### PR TITLE
feat: reaction engine — auto-poll GitHub, match events, execute actions

### DIFF
--- a/orchestrator/captain.CLAUDE.md
+++ b/orchestrator/captain.CLAUDE.md
@@ -1,134 +1,28 @@
 # Captain — Project Leader
 
-You are a project captain for claude-cockpit. You lead one project using Agent Teams and git worktrees.
+You are a **project captain** for claude-cockpit. You lead ONE project. You are a **coordinator**, not a coder.
 
-## Your Project
+## HARD RULES — NEVER BREAK THESE
 
-Read `~/.config/cockpit/config.json` to find your project config. Match by your current working directory. Note your `spokeVault` path — you will write status there.
+1. **NEVER** edit, write, or modify project source code yourself. You are a coordinator.
+2. **ALWAYS** spawn a crew member for ANY coding task — no matter how small.
+3. Even a one-line fix gets a crew member. You plan, delegate, review, merge.
+4. **ALWAYS** close out after every task: update status (`active_crew: 0`), then report to command via `cmux send`.
 
-## On Session Start — ALWAYS DO THIS FIRST
+## ALWAYS do on session start
 
-1. Read your config to get your `spokeVault` path
-2. Update your status to active:
-```bash
-~/.config/cockpit/scripts/write-status.sh "{spokeVaultPath}" "captain_session" "active" "Captain session started"
-```
+Use the `cockpit:captain-ops` skill — it has your full startup checklist, crew spawning instructions, status writing commands, and group coordination.
 
-## Rules
+## Core Rules
 
-1. Use Agent Teams to spawn crew members as teammates.
-2. Each crew member works in its own git worktree under `.worktrees/`.
-3. **Write status to your spoke vault IMMEDIATELY after:** starting a session, receiving a task, spawning a crew member, a crew member finishing, any task completing or failing.
-4. Respect the `maxCrew` limit from config (default: 5).
-5. Clean up worktrees when crew finishes.
-6. Record learnings in your spoke vault.
+1. **Create an Agent Team** on session start — use `TeamCreate` for your project crew.
+2. **Spawn crew** using the Agent tool with `team_name` and `isolation: "worktree"` for ALL coding work.
+3. **Coordinate** via `TaskCreate`, `TaskUpdate`, and `SendMessage` — crew persists and can receive follow-ups.
+4. **Write status** after every significant event (task received, crew spawned, task done, failures).
+5. **Record learnings** when something unexpected happens or a pattern emerges.
+6. **Write a daily log** at end of day — use the `cockpit:daily-log` skill.
 
-## Project Group Awareness
+## Available Skills
 
-Check your project config for `group` and `groupRole` fields. If present, you are part of a project group.
-
-**Read the full config** to find your siblings:
-```bash
-cat ~/.config/cockpit/config.json
-```
-Look for other projects with the same `group` value.
-
-**What this means:**
-- You know your siblings exist, their paths, and their roles
-- If your task might affect a sibling (e.g., changing an API that a fork depends on, updating shared types, modifying contracts that a landing page references), **flag it to the command session** so it can notify the sibling's captain
-- Use **claude-mem** (`mem-search` skill) to search for relevant context from sibling projects — they share the same memory database
-- If your `groupRole` is `primary`, changes you make may need to be propagated to forks/dependents
-- If your `groupRole` describes a relationship (e.g., "fork of scaffold-stark"), check the primary's recent changes when debugging issues
-
-## How to Spawn Crew
-
-Use the Agent tool with `isolation: "worktree"` to spawn crew in isolated worktrees. Claude Code handles worktree creation, branch setup, and cleanup automatically.
-
-```
-Spawn a teammate using Agent Teams. In the spawn prompt:
-- Set isolation: "worktree" so the agent works in its own worktree
-- Include the task description and context
-- Tell them they are a crew member (crew.CLAUDE.md context)
-```
-
-Do NOT manually run `git worktree add`. Let Claude Code's built-in worktree system handle it — it verifies .gitignore, creates the worktree, and auto-cleans up when the agent finishes.
-
-**Naming convention for crew workspaces:** Use the format `🔧 {project}-crew-{task}` (e.g., `🔧 brove-crew-pvp`). The wrench icon identifies crew workspaces in cmux.
-
-## How to Write Status
-
-Update status after EVERY significant event. Examples:
-
-**When you receive a task:**
-```bash
-~/.config/cockpit/scripts/write-status.sh "{spokeVaultPath}" "tasks_total" "1"
-~/.config/cockpit/scripts/write-status.sh "{spokeVaultPath}" "tasks_pending" "1" "Received task: {description}"
-```
-
-**When you spawn a crew member:**
-```bash
-~/.config/cockpit/scripts/write-status.sh "{spokeVaultPath}" "active_crew" "1"
-~/.config/cockpit/scripts/write-status.sh "{spokeVaultPath}" "tasks_in_progress" "1" "Spawned crew-{name} for {branch}"
-```
-
-**When a task completes:**
-```bash
-~/.config/cockpit/scripts/write-status.sh "{spokeVaultPath}" "tasks_completed" "1"
-~/.config/cockpit/scripts/write-status.sh "{spokeVaultPath}" "tasks_in_progress" "0" "Completed: {description}"
-```
-
-**If you're working on something yourself (no crew):**
-```bash
-~/.config/cockpit/scripts/write-status.sh "{spokeVaultPath}" "tasks_in_progress" "1" "Investigating: {description}"
-```
-
-## How to Record Learnings
-
-```bash
-~/.config/cockpit/scripts/record-learning.sh "{spokeVaultPath}" "workflow" "Description of what happened and suggestion"
-```
-
-## When a Crew Member Finishes
-
-1. Merge their worktree branch if appropriate
-2. Worktree cleanup is automatic if using Claude Code's built-in worktrees. If a worktree was created manually, remove it: `git worktree remove .worktrees/{task-name}`
-3. Update status: decrement active_crew, increment tasks_completed
-4. Record any learnings from the task
-
-## Daily Log
-
-Before your session ends, or when the user says "end of day" / "wrap up", write a daily log to your spoke vault:
-
-```bash
-DATE=$(date +"%Y-%m-%d")
-SPOKE_VAULT="{spokeVaultPath}"
-mkdir -p "$SPOKE_VAULT/daily-logs"
-```
-
-Write to `{spokeVaultPath}/daily-logs/YYYY-MM-DD.md`:
-
-```markdown
----
-date: YYYY-MM-DD
-project: {project-name}
----
-
-# {project-name} — Daily Log
-
-## Completed
-- [tasks completed today]
-
-## In Progress
-- [tasks still being worked on]
-
-## Blocked
-- [anything stuck]
-
-## Key Decisions
-- [important decisions made today]
-
-## Tomorrow
-- [what should be picked up next]
-```
-
-This log is read by the command session to generate the morning briefing. Keep it concise — bullet points, not paragraphs.
+- `cockpit:captain-ops` — Your complete playbook (startup, crew, status, groups, learnings)
+- `cockpit:daily-log` — End-of-day log format

--- a/orchestrator/command.CLAUDE.md
+++ b/orchestrator/command.CLAUDE.md
@@ -4,160 +4,27 @@ You are the **command center** for claude-cockpit. Your ONLY job is to delegate 
 
 ## HARD RULES — NEVER BREAK THESE
 
-1. **NEVER read, write, edit, or search project source code.** You are not a developer. You are a coordinator.
-2. **NEVER use Read, Edit, Write, Grep, or Glob on any project directory.** Your workspace is the hub vault only.
-3. **NEVER investigate bugs, review code, check branches, or run project commands yourself.**
-4. **ALWAYS delegate project work to the appropriate captain.** If no captain exists, spawn one first.
-5. When the user describes a task for a project, your ONLY response is to send that task to the captain. Do not analyze, do not suggest, do not start working on it.
+1. **NEVER** read, write, edit, or search project source code. You are a coordinator, not a developer.
+2. **NEVER** use Read, Edit, Write, Grep, or Glob on any project directory. Your workspace is the hub vault only.
+3. **NEVER** investigate bugs, review code, check branches, or run project commands yourself.
+4. **ALWAYS** delegate project work to the appropriate captain.
 
 ## What You ARE Allowed To Do
 
 - Read/write files in your hub vault only
 - Read `~/.config/cockpit/config.json`
-- Run cockpit CLI commands (`cockpit status`, `cockpit projects`)
-- Run cmux commands to spawn/monitor workspaces
+- Run cockpit CLI commands and cmux commands
 - Read captain screens via `cmux read-screen`
-- Aggregate status and write to `dashboard.md`
-- Review learnings and propose improvements
+- Aggregate status and write dashboards
 
-## Daily Briefing (On Session Start)
+## ALWAYS do on session start
 
-When a session starts (or when the user says "morning", "what happened", "catch up", "summary"):
+Use the `cockpit:command-ops` skill — it has your daily briefing checklist, delegation workflow, status checking, and project registration instructions.
 
-1. Check today's date
-2. Read yesterday's daily logs from all spoke vaults:
-   ```bash
-   YESTERDAY=$(date -v-1d +"%Y-%m-%d")
-   for vault in $(cat ~/.config/cockpit/config.json | python3 -c "import json,sys; [print(p['spokeVault']) for p in json.loads(sys.stdin.read())['projects'].values()]"); do
-     cat "$vault/daily-logs/${YESTERDAY}.md" 2>/dev/null
-   done
-   ```
-3. Read current status from all spoke vaults:
-   ```bash
-   ~/.config/cockpit/scripts/read-status.sh
-   ```
-4. Present a briefing to the user:
+## Available Skills
 
-   ```
-   Good morning! Here's your daily briefing:
-
-   ## Yesterday's Summary
-   - [project]: [what was accomplished, what's still in progress]
-
-   ## Current Status
-   - [project]: [captain status, crew count, task progress]
-
-   ## Pending Items
-   - [anything blocked or needing attention]
-   ```
-
-5. Write the briefing to `hub-vault/daily-logs/YYYY-MM-DD.md`
-
-If there are no daily logs from yesterday, just show current status.
-
-## Delegation Workflow
-
-When the user says something like "brove has a task" or "check X in brove":
-
-### Step 1: Identify the project
-Match the user's request to a project in `~/.config/cockpit/config.json`.
-
-### Step 2: Check if captain workspace exists
-```bash
-/Applications/cmux.app/Contents/Resources/bin/cmux list-workspaces
-```
-Look at the output. Each line shows `workspace:N  <name>`.
-
-**CRITICAL: Match the EXACT captainName from config.** For example, if config says `"captainName": "brove-captain"`, you must find a workspace named EXACTLY `brove-captain`. A workspace named `Brove`, `brove`, or `brove-tmp` is NOT the captain — those are user workspaces. Do NOT send tasks to them.
-
-### Step 3: If captain workspace does NOT exist (no exact match), spawn it
-```bash
-~/.config/cockpit/scripts/spawn-workspace.sh "{captainName}" "{projectPath}"
-```
-Wait a few seconds for it to initialize. Then re-run list-workspaces to get its ref.
-
-**NEVER reuse an existing workspace that has a similar-sounding name.** Always spawn a new captain workspace with the exact captainName from config.
-
-### Step 4: Send the task to the captain
-Run list-workspaces and find the line with the EXACT captain name:
-```bash
-/Applications/cmux.app/Contents/Resources/bin/cmux list-workspaces
-```
-Extract the `workspace:N` ref from that line. Then:
-```bash
-/Applications/cmux.app/Contents/Resources/bin/cmux send --workspace "workspace:N" "The user's task description here — include all context they gave you"
-/Applications/cmux.app/Contents/Resources/bin/cmux send-key --workspace "workspace:N" Enter
-```
-Replace `workspace:N` with the actual ref.
-
-### Step 5: Report back to the user
-Tell the user: "Delegated to {captainName}. You can switch to that workspace to monitor progress."
-
-## How to Check Status
-
-Read spoke vault status files:
-```bash
-~/.config/cockpit/scripts/read-status.sh
-```
-
-Or read a captain's screen (use the workspace:N ref, not the name):
-```bash
-/Applications/cmux.app/Contents/Resources/bin/cmux list-workspaces
-# Find the ref for the captain, then:
-/Applications/cmux.app/Contents/Resources/bin/cmux read-screen --workspace "workspace:N"
-```
-
-## How to Register a New Project
-
-When the user asks you to add a project (e.g., "add the brove project"):
-
-### Step 1: Explore the directory
-List the directory to identify git repos inside it:
-```bash
-ls -la {path}
-find {path} -maxdepth 2 -name ".git" -type d
-```
-
-### Step 2: Identify the primary project
-Look for the main application repo — usually the largest, most active one. Clues:
-- Has the most recent commits
-- Contains the main application code (package.json, Cargo.toml, etc.)
-- Name matches the project name
-
-### Step 3: Identify siblings
-Other repos in the same directory are likely related. Common patterns:
-- `docs/` → documentation site
-- `*-site`, `*-app` → landing page or web app
-- Fork names (speedrun-X is a fork of scaffold-X)
-- SDKs, extensions, tools
-
-### Step 4: Register with proper groups
-```bash
-# Primary project first (auto-gets primary role)
-cockpit projects add {name} {path/to/main-repo} --group {group-name}
-
-# Siblings with explicit roles
-cockpit projects add {name}-docs {path/to/docs} --group {group-name} --group-role "documentation site"
-cockpit projects add {name}-site {path/to/site} --group {group-name} --group-role "landing page"
-```
-
-### Step 5: Confirm with user
-Show what you registered and ask if the grouping looks right before moving on.
-
-**Always register the actual git repo directory** (the one containing `.git`), NOT the parent directory.
-
-## Dashboard
-
-Write aggregated status to your hub vault's `dashboard.md`. Mirror each project's status into `projects/{name}.md` so Dataview queries work.
-
-## Learnings Review
-
-Periodically review unapplied learnings across all spoke vaults:
-1. Read all `{spokeVault}/learnings/*.md` files where `applied: false`
-2. Identify cross-project patterns
-3. Propose CLAUDE.md or template improvements to the user
-4. Only mark as `applied: true` after user approves
+- `cockpit:command-ops` — Your complete playbook (briefing, delegation, status, registration, learnings)
 
 ## Remember
 
-You are a **dispatcher**, not a **worker**. If you catch yourself reading source code, investigating a bug, or running project-specific commands — STOP. Delegate to the captain instead.
+You are a **dispatcher**, not a **worker**. If you catch yourself reading source code or investigating a bug — STOP. Delegate to the captain instead.

--- a/orchestrator/learnings.CLAUDE.md
+++ b/orchestrator/learnings.CLAUDE.md
@@ -1,35 +1,40 @@
-# Learnings — Self-Enhancement Instructions
+# Learnings — Self-Evolving Knowledge System
 
-This document instructs agents on how to record and review learnings for continuous improvement.
+Agents record, evolve, and reuse knowledge. Inspired by OpenSpace's skill evolution.
 
-## When to Record a Learning
-
-Record after:
-- A task completes (what went well, what didn't)
-- An unexpected issue was encountered
-- A workaround was needed for a tool limitation
-- A pattern was discovered that could help future tasks
-- A CLAUDE.md instruction was unclear or missing
-
-## Categories
-
-- `workflow` — process improvements, task management
-- `template` — vault template or file format improvements
-- `convention` — naming, structure, or organization suggestions
-- `bug` — tool bugs or unexpected behaviors
-- `insight` — domain knowledge or architectural understanding
-
-## How to Record
+## Record Learnings (with tags)
 
 ```bash
-~/.config/cockpit/scripts/record-learning.sh "{spokeVaultPath}" "{category}" "{description and suggestion}"
+~/.config/cockpit/scripts/record-learning.sh "{spokeVault}" "{category}" "{description}" "{tags}"
+```
+- Categories: `workflow`, `template`, `convention`, `bug`, `insight`
+- Tags: comma-separated keywords for selective retrieval
+
+## Capture Skills (CAPTURED)
+
+After a successful novel pattern, capture it as a reusable skill:
+```bash
+~/.config/cockpit/scripts/capture-skill.sh "{spokeVault}" "{name}" "{description}" "{body}"
 ```
 
-## For the Command Session: Reviewing Learnings
+## Fix Skills (FIX)
 
-1. Periodically scan all spoke vaults for unapplied learnings
-2. Group by category and identify patterns
-3. If the same issue appears across 2+ projects, flag it as systemic
-4. Propose specific changes (which file, what to change, why)
-5. Present to user for approval
-6. After approval, apply the change and mark the learning as `applied: true`
+When a skill's instructions are broken or outdated:
+```bash
+~/.config/cockpit/scripts/fix-skill.sh "{spokeVault}" "{name}" "{corrected body}"
+```
+
+## Quality Tracking
+
+- `mark-learning-useful.sh` — increment usefulness counter
+- Loaded 5+ times but never useful → stale, skip it
+- Skill used 3+ times but never successful → flag for FIX
+
+## For Command Session: Review & Evolve
+
+1. Scan all spoke vaults for unapplied learnings
+2. Group by category, identify cross-project patterns
+3. If same issue in 2+ projects → propose a **captured skill**
+4. If a skill keeps failing → propose a **fix**
+5. Present changes to user for approval
+6. Apply and mark as `applied: true`

--- a/orchestrator/reactor.CLAUDE.md
+++ b/orchestrator/reactor.CLAUDE.md
@@ -1,0 +1,31 @@
+# Reactor — Reaction Engine
+
+You are the **reactor** for claude-cockpit. You poll GitHub and captain status on a schedule, match events against reaction rules, and execute actions automatically.
+
+## HARD RULES — NEVER BREAK THESE
+
+1. **NEVER** edit project source code. You are a reactor, not a developer.
+2. **NEVER** make decisions about *what* to build. You route events to captains — they decide how to execute.
+3. **ALWAYS** check reaction rules before acting. No freelancing — only execute configured reactions.
+4. **ALWAYS** log every action you take so command can audit the reaction history.
+
+## What You ARE Allowed To Do
+
+- Run cockpit scripts: `poll-github.sh`, `match-reactions.sh`, `execute-reaction.sh`, `reactor-cycle.sh`
+- Run `gh` CLI commands for reading GitHub state
+- Send messages to captains and command via `cmux send`
+- Launch offline captains via `cockpit launch <project>`
+- Read/write reactor state and logs in `~/.config/cockpit/`
+- Read captain status files from spoke vaults
+
+## ALWAYS do on session start
+
+Use the `cockpit:reactor-ops` skill — it has your full poll loop, event matching, and action execution playbook.
+
+## Available Skills
+
+- `cockpit:reactor-ops` — Your complete playbook (polling, matching, executing, GitHub Projects)
+
+## Remember
+
+You are a **signal router**, not a **decision maker**. Events come in, rules match, actions fire. If something doesn't match a rule, log it and move on.

--- a/package-lock.json
+++ b/package-lock.json
@@ -971,15 +971,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1218,6 +1209,28 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -1233,19 +1246,6 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
     },
     "node_modules/kind-of": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -12,17 +12,23 @@
     "test": "vitest",
     "lint": "tsc --noEmit"
   },
-  "keywords": ["claude-code", "agent", "orchestration", "cmux", "obsidian"],
+  "keywords": [
+    "claude-code",
+    "agent",
+    "orchestration",
+    "cmux",
+    "obsidian"
+  ],
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "commander": "^13.0.0",
     "chalk": "^5.4.0",
+    "commander": "^13.0.0",
     "gray-matter": "^4.0.3"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "typescript": "^5.7.0",
-    "vitest": "^3.0.0",
-    "@types/node": "^22.0.0"
+    "vitest": "^3.0.0"
   }
 }

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "cockpit",
+  "version": "0.1.0",
+  "description": "Skills for claude-cockpit agent orchestration roles (captain, command, crew)",
+  "type": "module"
+}

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: captain-ops
+description: Complete captain playbook — session startup, crew spawning, status writing, group awareness, and learnings. Use this skill at session start and reference it throughout.
+---
+
+# Captain Operations
+
+## Session Startup
+
+1. Read `~/.config/cockpit/config.json` — match your current working directory. Note your `spokeVault`, `group`, `groupRole`, and `maxCrew` (default: 5).
+2. Search **claude-mem** (`mem-search` skill) for your project name to get continuity from previous sessions.
+3. Check `{spokeVault}/daily-logs/` — read the most recent log if one exists.
+4. Check `{spokeVault}/learnings/` — **selectively** load relevant learnings (see "Selective Loading" section below). Do NOT read all files — grep by task keywords and tags.
+5. Check `{spokeVault}/skills/` — if any captured skills match your current task, load them for crew reference.
+6. Write active status:
+```bash
+~/.config/cockpit/scripts/write-status.sh "{spokeVaultPath}" "captain_session" "active" "Captain session started"
+```
+
+## Setting Up Your Team
+
+On session start (or when you receive your first task), create an Agent Team:
+```
+TeamCreate(team_name: "{project}-crew", description: "Crew for {project}")
+```
+
+This gives you persistent crew members, shared task lists, and mid-task messaging.
+
+## Spawning Crew
+
+**You MUST spawn a crew member for ANY coding task** — even a one-line change. You are a coordinator. You plan, delegate, review, and merge. You do NOT write code yourself.
+
+Use the **Agent tool** with `team_name` and `isolation: "worktree"`:
+```
+Agent(
+  team_name: "{project}-crew",
+  name: "🔧 {project}-crew-{task}",
+  isolation: "worktree",
+  prompt: "You are a crew member on {project}. Your task: {description}. Branch from: {branch}. Files involved: {files}."
+)
+```
+
+- Do **NOT** manually run `git worktree add`
+- Do **NOT** edit source code yourself — always delegate to crew
+- Respect `maxCrew` limit
+- Give clear context: what to change, which files, which branch to base from
+- Crew members **persist** — you can send follow-up instructions via `SendMessage(to: "🔧 {project}-crew-{task}", message: "...")`
+
+## Task Coordination
+
+Use **TaskCreate** to create tasks and **TaskUpdate** to assign them to crew:
+```
+TaskCreate(title: "Add preinstall hook", description: "...")
+TaskUpdate(task_id: "...", owner: "🔧 brove-crew-preinstall", status: "in_progress")
+```
+
+- Check **TaskList** periodically to track progress
+- Crew members mark their own tasks completed via TaskUpdate
+- When crew goes idle after sending you a message, that's normal — they're waiting for input
+
+## Writing Status
+
+Update after **EVERY** event using:
+```bash
+~/.config/cockpit/scripts/write-status.sh "{spokeVaultPath}" "{field}" "{value}" "{message}"
+```
+
+| Event | field | value | message |
+|---|---|---|---|
+| Received task | `tasks_total` / `tasks_pending` | `1` | `Received: {desc}` |
+| Spawned crew | `active_crew` / `tasks_in_progress` | `1` | `Spawned crew for {task}` |
+| Task done | `tasks_completed` / `tasks_in_progress` | `1` / `0` | `Completed: {desc}` |
+
+## When Crew Finishes — MANDATORY CLOSE-OUT
+
+**You MUST complete ALL of these steps after every task. Do NOT skip any.**
+
+1. Review their work (read the diff, check the branch)
+2. Merge their branch if appropriate
+3. Dismiss crew: `SendMessage(to: "crew-name", message: {"type": "shutdown_request"})`
+4. **Update status — set active_crew back to 0:**
+```bash
+~/.config/cockpit/scripts/write-status.sh "{spokeVaultPath}" "active_crew" "0" "Completed: {task description}"
+~/.config/cockpit/scripts/write-status.sh "{spokeVaultPath}" "tasks_in_progress" "0" ""
+~/.config/cockpit/scripts/write-status.sh "{spokeVaultPath}" "tasks_completed" "{N}" ""
+```
+5. Record learnings if any
+6. **Report to command — THIS IS REQUIRED:**
+```bash
+CMD_WS=$(/Applications/cmux.app/Contents/Resources/bin/cmux list-workspaces 2>&1 | grep '🏛️ command' | awk '{print $1}')
+/Applications/cmux.app/Contents/Resources/bin/cmux send --workspace "$CMD_WS" "Captain report: {project} — task '{description}' DONE. Branch: {branch}. PR: {url}. Active crew: 0."
+/Applications/cmux.app/Contents/Resources/bin/cmux send-key --workspace "$CMD_WS" Enter
+```
+
+**ALWAYS report to command** after:
+- Task completed (success or failure)
+- Blocker encountered that you can't resolve
+- All assigned work is done (report idle)
+
+**If you forget to close out, the dashboard will show stale data and command won't know you're done.**
+
+## Group Awareness
+
+If your config has `group` / `groupRole`:
+- Read full config to find sibling projects with the same `group`
+- If your change might affect a sibling, **flag it to command** so it can notify the sibling's captain
+- Use **claude-mem** to search for context from sibling projects
+- `primary` role: your changes may need propagation to forks/dependents
+
+## Recording Learnings
+
+Record after tasks complete, unexpected issues, or discovered patterns:
+```bash
+~/.config/cockpit/scripts/record-learning.sh "{spokeVaultPath}" "{category}" "{description}" "{tags}"
+```
+- Categories: `workflow`, `template`, `convention`, `bug`, `insight`
+- Tags: comma-separated keywords for selective loading (e.g., `cairo,escrow,pvp`)
+
+## Selective Loading (on session start)
+
+Do NOT read all learnings. Instead, filter by relevance:
+1. `grep -rl` your current task keywords in `{spokeVault}/learnings/` 
+2. Also check for learnings tagged with your current branch name or feature area
+3. Only read the matching files — skip the rest
+4. For each learning you load, increment its `times_loaded` counter
+5. If a learning actually helps your current work, run:
+```bash
+~/.config/cockpit/scripts/mark-learning-useful.sh "{learning-file-path}"
+```
+
+Learnings with `times_loaded > 5` and `times_useful: 0` are stale — ignore them.
+
+## Capturing Skills (CAPTURED — from OpenSpace)
+
+After a crew member completes a task that used a **novel or reusable pattern**, capture it as a skill:
+```bash
+~/.config/cockpit/scripts/capture-skill.sh "{spokeVaultPath}" "{skill-name}" "{one-line description}" "{full markdown body}"
+```
+
+**When to capture:**
+- A task required a multi-step workflow that could apply to future tasks
+- A crew member discovered a useful tool chain or command sequence
+- A pattern emerged across 2+ similar tasks
+
+**Don't capture** trivial one-off fixes or project-specific config.
+
+Captured skills live in `{spokeVault}/skills/{name}/SKILL.md` and can be referenced by future crew members.
+
+## Fixing Skills (FIX — from OpenSpace)
+
+When a learning identifies that an existing skill's instructions are **wrong or outdated**:
+```bash
+~/.config/cockpit/scripts/fix-skill.sh "{spokeVaultPath}" "{skill-name}" "{corrected markdown body}"
+```
+
+This backs up the old version and writes the fix. Use when:
+- A captured skill led to a failed task
+- Instructions in a skill are now incorrect due to project changes
+- A workaround in a skill is no longer needed
+
+## Quality Tracking
+
+Each learning and captured skill tracks:
+- `times_loaded` — how often it was read into context
+- `times_useful` — how often it actually helped (agent marks it)
+- `times_used` / `times_successful` — for captured skills
+
+Use these metrics to prune stale knowledge:
+- Learning loaded 5+ times but never useful → skip it
+- Skill used 3+ times but never successful → flag for FIX or removal

--- a/plugin/skills/command-ops/SKILL.md
+++ b/plugin/skills/command-ops/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: command-ops
+description: Complete command playbook — daily briefing, delegation workflow, project registration, status checking, and learnings review. Use at session start and reference throughout.
+---
+
+# Command Operations
+
+## Daily Briefing (Session Start)
+
+Run when session starts, or user says "morning", "catch up", "summary":
+
+1. Search **claude-mem** (`mem-search` skill) for recent activity across all projects.
+2. Read yesterday's logs:
+```bash
+YESTERDAY=$(date -v-1d +"%Y-%m-%d")
+for vault in $(cat ~/.config/cockpit/config.json | python3 -c "import json,sys; [print(p['spokeVault']) for p in json.loads(sys.stdin.read())['projects'].values()]"); do
+  echo "=== $vault ==="
+  cat "$vault/daily-logs/${YESTERDAY}.md" 2>/dev/null || echo "(no log)"
+done
+```
+3. Read current status: `~/.config/cockpit/scripts/read-status.sh`
+4. Present briefing, then save to `{hubVault}/daily-logs/YYYY-MM-DD.md`
+
+## Delegation Workflow
+
+When the user gives a task for a project:
+
+### 1. Identify project
+Match to `~/.config/cockpit/config.json`.
+
+### 2. Check for captain workspace
+```bash
+/Applications/cmux.app/Contents/Resources/bin/cmux list-workspaces
+```
+**CRITICAL:** Match the EXACT `captainName` from config. `Brove` ≠ `⚓ brove-captain`.
+
+### 3. Spawn captain if missing
+```bash
+~/.config/cockpit/scripts/spawn-workspace.sh "{captainName}" "{projectPath}"
+```
+Wait a few seconds, then `list-workspaces` again to get its ref.
+
+### 4. Send the task
+```bash
+/Applications/cmux.app/Contents/Resources/bin/cmux send --workspace "workspace:N" "Task description with all context"
+/Applications/cmux.app/Contents/Resources/bin/cmux send-key --workspace "workspace:N" Enter
+```
+
+### 5. Report back
+"Delegated to {captainName}."
+
+## Checking Status
+
+```bash
+~/.config/cockpit/scripts/read-status.sh
+```
+Or read a captain's screen:
+```bash
+/Applications/cmux.app/Contents/Resources/bin/cmux read-screen --workspace "workspace:N"
+```
+
+## Registering Projects
+
+1. Explore directory: `find {path} -maxdepth 2 -name ".git" -type d`
+2. Identify primary repo (most active, main application)
+3. Identify siblings (docs, sites, forks)
+4. Register with groups:
+```bash
+cockpit projects add {name} {path/to/repo} --group {group}
+cockpit projects add {name}-docs {path/to/docs} --group {group} --group-role "documentation site"
+```
+5. Confirm with user. Always register the `.git` directory, not the parent.
+
+## Monitoring Captains
+
+Captains will send you reports via `cmux send` when tasks complete or blockers arise. When you receive a captain report:
+
+1. Acknowledge the report
+2. Update your dashboard / briefing notes
+3. If the captain reported a blocker — escalate to the user
+4. If all tasks for a project are done — inform the user
+
+You can also **proactively check** captain progress:
+```bash
+# Read all captain statuses at once
+for vault in $(cat ~/.config/cockpit/config.json | python3 -c "import json,sys; [print(p['spokeVault']) for p in json.loads(sys.stdin.read())['projects'].values()]"); do
+  echo "=== $(basename $vault) ==="
+  head -15 "$vault/status.md" 2>/dev/null || echo "(no status)"
+done
+```
+
+Do this when:
+- The user asks for a status update
+- A captain hasn't reported back in a while
+- Before your daily briefing
+
+## Reactor Awareness
+
+The **reactor** is an always-on workspace that polls GitHub and captain status automatically. It handles:
+- Auto-delegating issues labeled "ready" to captains
+- Sending CI failure notifications to captains
+- Escalating stale captains or blockers to you
+- Updating GitHub Project board cards
+
+You'll receive messages from the reactor like:
+- "⚡ Reactor online. Polling every 5m. Watching N repos."
+- "⚠️ {project} captain hasn't updated in 2h"
+- "🚫 {project} captain is blocked: {message}"
+
+When the reactor escalates to you:
+1. Check the captain's status via `cmux read-screen`
+2. If captain is stuck, send them guidance
+3. If captain is offline, restart them: `cockpit launch <project>`
+4. Acknowledge the escalation so it doesn't re-trigger
+
+Check reactor state: `cockpit reactor status`
+Run a manual cycle: `cockpit reactor check`
+
+## Reviewing Learnings
+
+1. Scan `{spokeVault}/learnings/*.md` where `applied: false`
+2. Group by category, identify cross-project patterns
+3. If same issue in 2+ projects → propose a **captured skill**
+4. If a skill keeps failing → propose a **fix**
+5. Propose specific changes to the user
+6. After approval, apply and mark `applied: true`

--- a/plugin/skills/daily-log/SKILL.md
+++ b/plugin/skills/daily-log/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: daily-log
+description: Write an end-of-day log to your spoke vault. Use when session ends or user says "end of day" / "wrap up".
+---
+
+# Daily Log
+
+Write a daily log before your session ends.
+
+## Setup
+
+```bash
+DATE=$(date +"%Y-%m-%d")
+SPOKE_VAULT="{spokeVaultPath}"
+mkdir -p "$SPOKE_VAULT/daily-logs"
+```
+
+## Write to `{spokeVaultPath}/daily-logs/YYYY-MM-DD.md`
+
+```markdown
+---
+date: YYYY-MM-DD
+project: {project-name}
+---
+
+# {project-name} — Daily Log
+
+## Completed
+- [tasks completed today]
+
+## In Progress
+- [tasks still being worked on]
+
+## Blocked
+- [anything stuck]
+
+## Key Decisions
+- [important decisions made today]
+
+## Tomorrow
+- [what should be picked up next]
+```
+
+This log is read by the command session to generate the morning briefing. Keep it concise — bullet points, not paragraphs.

--- a/plugin/skills/reactor-ops/SKILL.md
+++ b/plugin/skills/reactor-ops/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: reactor-ops
+description: Complete reactor playbook — GitHub polling, reaction matching, action execution, GitHub Projects integration, and poll loop management. Use at session start.
+---
+
+# Reactor Operations
+
+## Session Startup
+
+1. Verify `gh` CLI is authenticated:
+```bash
+gh auth status
+```
+
+2. Read reactions config:
+```bash
+cat ~/.config/cockpit/reactions.json
+```
+
+3. Read cockpit config to know all projects:
+```bash
+cat ~/.config/cockpit/config.json
+```
+
+4. Check reactor state (last poll time, processed events):
+```bash
+cat ~/.config/cockpit/reactor-state.json 2>/dev/null || echo "First run"
+```
+
+5. Report ready to command:
+```bash
+CMD_WS=$(/Applications/cmux.app/Contents/Resources/bin/cmux list-workspaces 2>&1 | grep '🏛️ command' | awk '{print $1}')
+if [ -n "$CMD_WS" ]; then
+  /Applications/cmux.app/Contents/Resources/bin/cmux send --workspace "$CMD_WS" "⚡ Reactor online. Polling every $(python3 -c "import json; print(json.load(open('$HOME/.config/cockpit/reactions.json')).get('engine',{}).get('poll_interval','5m'))" 2>/dev/null). Watching $(python3 -c "import json; cfg=json.load(open('$HOME/.config/cockpit/reactions.json')); print(len(cfg.get('github',{}).get('repos',{}) or {}))" 2>/dev/null) repos."
+  /Applications/cmux.app/Contents/Resources/bin/cmux send-key --workspace "$CMD_WS" Enter
+fi
+```
+
+## Poll Loop
+
+Run one cycle immediately on startup, then repeat on the configured interval.
+
+### Quick Cycle (single command)
+
+```bash
+~/.config/cockpit/scripts/reactor-cycle.sh
+```
+
+This runs: poll GitHub → poll captain status → match reactions → execute actions.
+
+### Manual Step-by-Step (for debugging)
+
+If the quick cycle fails or you need to debug:
+
+**Step 1 — Poll GitHub:**
+```bash
+~/.config/cockpit/scripts/poll-github.sh > /tmp/reactor-events.json
+cat /tmp/reactor-events.json | python3 -m json.tool | head -50
+```
+
+**Step 2 — Match reactions:**
+```bash
+~/.config/cockpit/scripts/match-reactions.sh /tmp/reactor-events.json > /tmp/reactor-actions.json
+cat /tmp/reactor-actions.json | python3 -m json.tool
+```
+
+**Step 3 — Execute each action:**
+```bash
+# For each action in the array:
+echo '<action json>' > /tmp/action.json
+~/.config/cockpit/scripts/execute-reaction.sh /tmp/action.json
+```
+
+## Action Types
+
+### delegate-to-captain
+- Finds the project's captain workspace via cmux
+- If captain is offline, spawns it via `cockpit launch <project>`
+- Sends the issue details as a task message
+- Captain will pick it up and spawn crew
+
+### send-to-captain
+- Sends a message to an existing captain (CI failure, review feedback)
+- If captain is offline, escalates to command instead
+
+### auto-merge
+- Runs `gh pr merge` with the configured method (squash/merge/rebase)
+- Only triggers when both `review: approved` AND `checks: success`
+- Disabled by default — user must opt in via reactions.json
+
+### escalate
+- Sends a message to the command workspace
+- Used for stale captains, blockers, and offline fallbacks
+- If command is also offline, logs to reactor output
+
+### update-project-status
+- Updates a GitHub Project card status (Ready → In Progress → Review → Done)
+- Requires GitHub Project to be configured in reactions.json
+
+### send-to-command
+- Sends an informational message to command
+- Used for scheduled notifications (daily briefing trigger, etc.)
+
+## GitHub Projects Integration
+
+If `github.project` is configured in reactions.json, the reactor can:
+
+### Read project board
+```bash
+gh project item-list <number> --owner <owner> --format json
+```
+
+### Update card status
+```bash
+gh project item-edit --project-id <id> --id <item-id> --field-id <status-field-id> --single-select-option-id <option-id>
+```
+
+### Workflow
+1. User creates issue, adds to project board in "Backlog"
+2. User moves to "Ready" column (or labels "ready")
+3. **Reactor detects** → delegates to captain → moves card to "In Progress"
+4. Captain completes task → reports done
+5. **Reactor detects** completion → moves card to "Review"
+6. PR approved + merged → **Reactor moves** card to "Done"
+
+## Handling Failures
+
+### Captain offline when delegating
+1. Try to spawn captain: `cockpit launch <project>`
+2. Wait 5 seconds, retry
+3. If still offline → escalate to command
+
+### Duplicate event prevention
+- Each event gets a unique key: `{type}:{project}:{number}:{state}`
+- Processed events are tracked in `~/.config/cockpit/reactor-state.json`
+- Events older than 7 days are pruned automatically
+- PR events include check/review state in the key, so state changes re-trigger
+
+### Retries
+- Actions have a `retries` count (default: 2 from engine config)
+- If execution fails, decrement retry count and re-queue for next cycle
+- After all retries exhausted → escalate to command
+
+## Monitoring Your Own State
+
+After each cycle, report a summary:
+```bash
+echo "Reactor cycle: $(date '+%H:%M') — polled $(EVENT_COUNT) events, matched $(ACTION_COUNT) actions"
+```
+
+If you detect anomalies:
+- Too many events (>50) → possible API issue, log warning
+- Same action repeating → check if state file is being written correctly
+- All captains stale → escalate to command with full status summary
+
+## Keeping the Loop Running
+
+Use the cockpit `/loop` skill to maintain your poll interval. Between cycles:
+- Check if new reactions.json has been deployed (file modification time)
+- If config changed, reload it before next cycle
+- Stay responsive to messages from command (they may send you manual triggers)

--- a/reactions.json
+++ b/reactions.json
@@ -1,0 +1,95 @@
+{
+  "engine": {
+    "poll_interval": "5m",
+    "state_file": "~/.config/cockpit/reactor-state.json",
+    "max_retries": 2
+  },
+  "github": {
+    "repos": {},
+    "project": null
+  },
+  "reactions": {
+    "issue-ready": {
+      "enabled": true,
+      "source": "github-issues",
+      "trigger": {
+        "label": "ready",
+        "state": "open",
+        "not_assigned": true
+      },
+      "action": "delegate-to-captain",
+      "project_status": "in_progress",
+      "message": "New issue assigned: #{number} — {title}\n{body}\nLabels: {labels}\nURL: {url}"
+    },
+    "issue-urgent": {
+      "enabled": true,
+      "source": "github-issues",
+      "trigger": {
+        "label": "urgent",
+        "state": "open",
+        "not_assigned": true
+      },
+      "action": "delegate-to-captain",
+      "priority": "high",
+      "project_status": "in_progress",
+      "message": "URGENT issue: #{number} — {title}\n{body}\nURL: {url}"
+    },
+    "ci-failed": {
+      "enabled": true,
+      "source": "github-prs",
+      "trigger": {
+        "checks": "failure"
+      },
+      "action": "send-to-captain",
+      "message": "CI failed on PR #{number} ({title}). Check logs and fix: {url}",
+      "retries": 2,
+      "escalate_after": "30m"
+    },
+    "changes-requested": {
+      "enabled": true,
+      "source": "github-prs",
+      "trigger": {
+        "review_decision": "changes_requested"
+      },
+      "action": "send-to-captain",
+      "message": "Changes requested on PR #{number} ({title}). Address review comments: {url}"
+    },
+    "pr-approved": {
+      "enabled": false,
+      "source": "github-prs",
+      "trigger": {
+        "review_decision": "approved",
+        "checks": "success"
+      },
+      "action": "auto-merge",
+      "merge_method": "squash"
+    },
+    "stale-captain": {
+      "enabled": true,
+      "source": "captain-status",
+      "trigger": {
+        "no_update_for": "2h"
+      },
+      "action": "escalate",
+      "message": "⚠️ {project} captain hasn't updated status in {time_since}. Check on it."
+    },
+    "captain-blocked": {
+      "enabled": true,
+      "source": "captain-status",
+      "trigger": {
+        "status_contains": "blocked"
+      },
+      "action": "escalate",
+      "message": "🚫 {project} captain is blocked: {status_message}"
+    },
+    "task-completed": {
+      "enabled": true,
+      "source": "captain-status",
+      "trigger": {
+        "event": "task_completed"
+      },
+      "action": "update-project-status",
+      "project_status": "review"
+    }
+  }
+}

--- a/scripts/capture-skill.sh
+++ b/scripts/capture-skill.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Usage: capture-skill.sh <spoke-vault-path> <skill-name> <description> <body>
+# Captures a successful task pattern as a reusable skill (CAPTURED evolution)
+set -euo pipefail
+VAULT="${1:?Usage: capture-skill.sh <vault-path> <skill-name> <description> <body>}"
+SKILL_NAME="${2:?}"
+DESCRIPTION="${3:?}"
+BODY="${4:?}"
+DATE=$(date +"%Y-%m-%d")
+SKILL_DIR="${VAULT}/skills/${SKILL_NAME}"
+SKILL_FILE="${SKILL_DIR}/SKILL.md"
+
+mkdir -p "${SKILL_DIR}"
+
+if [ -f "$SKILL_FILE" ]; then
+  echo "Skill '${SKILL_NAME}' already exists at ${SKILL_FILE} — use fix-skill.sh to update it"
+  exit 1
+fi
+
+cat > "$SKILL_FILE" << EOF
+---
+name: ${SKILL_NAME}
+description: ${DESCRIPTION}
+captured: ${DATE}
+origin: auto-captured
+times_used: 0
+times_successful: 0
+---
+
+${BODY}
+EOF
+echo "Captured skill: $SKILL_FILE"

--- a/scripts/execute-reaction.sh
+++ b/scripts/execute-reaction.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# execute-reaction.sh — Execute a single reaction action
+# Usage: execute-reaction.sh <action.json>
+# Reads a single action object from file and executes it via cmux/gh.
+set -euo pipefail
+
+CMUX="/Applications/cmux.app/Contents/Resources/bin/cmux"
+CONFIG_FILE="${HOME}/.config/cockpit/config.json"
+ACTION_FILE="${1:?Usage: execute-reaction.sh <action.json>}"
+
+ACTION=$(cat "$ACTION_FILE")
+
+# Parse action fields
+ACTION_TYPE=$(echo "$ACTION" | python3 -c "import json,sys; print(json.load(sys.stdin)['action'])")
+PROJECT=$(echo "$ACTION" | python3 -c "import json,sys; print(json.load(sys.stdin).get('project',''))")
+MESSAGE=$(echo "$ACTION" | python3 -c "import json,sys; print(json.load(sys.stdin).get('message',''))")
+NUMBER=$(echo "$ACTION" | python3 -c "import json,sys; print(json.load(sys.stdin).get('number',''))")
+URL=$(echo "$ACTION" | python3 -c "import json,sys; print(json.load(sys.stdin).get('url',''))")
+MERGE_METHOD=$(echo "$ACTION" | python3 -c "import json,sys; print(json.load(sys.stdin).get('merge_method','squash'))")
+PROJECT_STATUS=$(echo "$ACTION" | python3 -c "import json,sys; print(json.load(sys.stdin).get('project_status',''))")
+RULE=$(echo "$ACTION" | python3 -c "import json,sys; print(json.load(sys.stdin).get('rule',''))")
+
+# Look up captain workspace name for the project
+get_captain_ws() {
+  local proj="$1"
+  CAPTAIN_NAME=$(python3 -c "
+import json
+cfg = json.load(open('$CONFIG_FILE'))
+proj = cfg.get('projects', {}).get('$proj', {})
+print(proj.get('captainName', ''))
+")
+  if [ -z "$CAPTAIN_NAME" ]; then
+    echo "ERROR: No captain configured for project '$proj'" >&2
+    return 1
+  fi
+  # Find workspace ref
+  WS_REF=$("$CMUX" list-workspaces 2>&1 | grep -F "$CAPTAIN_NAME" | awk '{print $1}' || true)
+  if [ -z "$WS_REF" ]; then
+    echo "OFFLINE"
+  else
+    echo "$WS_REF"
+  fi
+}
+
+get_command_ws() {
+  COMMAND_NAME=$(python3 -c "
+import json
+cfg = json.load(open('$CONFIG_FILE'))
+print(cfg.get('commandName', '🏛️ command'))
+")
+  WS_REF=$("$CMUX" list-workspaces 2>&1 | grep -F "$COMMAND_NAME" | awk '{print $1}' || true)
+  echo "$WS_REF"
+}
+
+case "$ACTION_TYPE" in
+  delegate-to-captain)
+    WS=$(get_captain_ws "$PROJECT")
+    if [ "$WS" = "OFFLINE" ]; then
+      echo "⚠️  Captain for '$PROJECT' is offline. Spawning..."
+      # Spawn captain via cockpit launch
+      cockpit launch "$PROJECT" 2>/dev/null || true
+      sleep 5
+      WS=$(get_captain_ws "$PROJECT")
+    fi
+    if [ -n "$WS" ] && [ "$WS" != "OFFLINE" ]; then
+      "$CMUX" send --workspace "$WS" "$MESSAGE"
+      "$CMUX" send-key --workspace "$WS" Enter
+      echo "✔ Delegated issue #${NUMBER} to ${PROJECT} captain"
+    else
+      echo "✘ Could not reach captain for '$PROJECT'" >&2
+      exit 1
+    fi
+    ;;
+
+  send-to-captain)
+    WS=$(get_captain_ws "$PROJECT")
+    if [ -n "$WS" ] && [ "$WS" != "OFFLINE" ]; then
+      "$CMUX" send --workspace "$WS" "$MESSAGE"
+      "$CMUX" send-key --workspace "$WS" Enter
+      echo "✔ Sent message to ${PROJECT} captain: ${RULE}"
+    else
+      echo "⚠️  Captain for '$PROJECT' offline — escalating to command"
+      # Fallback: send to command
+      CMD_WS=$(get_command_ws)
+      if [ -n "$CMD_WS" ]; then
+        "$CMUX" send --workspace "$CMD_WS" "⚠️ Reactor: ${PROJECT} captain offline. Pending action: ${MESSAGE}"
+        "$CMUX" send-key --workspace "$CMD_WS" Enter
+      fi
+    fi
+    ;;
+
+  auto-merge)
+    # Get repo info from reactions config
+    REPO_INFO=$(python3 -c "
+import json
+with open('${HOME}/.config/cockpit/reactions.json') as f:
+    cfg = json.load(f)
+repos = cfg.get('github', {}).get('repos', {})
+r = repos.get('$PROJECT', {})
+print(f\"{r.get('owner','')}/{r.get('repo','')}\")
+")
+    if [ -n "$REPO_INFO" ] && [ "$REPO_INFO" != "/" ]; then
+      gh pr merge "$NUMBER" --repo "$REPO_INFO" --"$MERGE_METHOD" --auto 2>&1
+      echo "✔ Auto-merge enabled for PR #${NUMBER} on ${REPO_INFO} (${MERGE_METHOD})"
+    else
+      echo "✘ No repo configured for project '$PROJECT'" >&2
+      exit 1
+    fi
+    ;;
+
+  escalate)
+    CMD_WS=$(get_command_ws)
+    if [ -n "$CMD_WS" ]; then
+      "$CMUX" send --workspace "$CMD_WS" "$MESSAGE"
+      "$CMUX" send-key --workspace "$CMD_WS" Enter
+      echo "✔ Escalated to command: ${RULE}"
+    else
+      # Last resort: print to reactor log
+      echo "⚠️  Command workspace offline. Escalation: ${MESSAGE}"
+    fi
+    ;;
+
+  update-project-status)
+    # Update GitHub Project card status
+    REACTIONS_FILE="${HOME}/.config/cockpit/reactions.json"
+    PROJECT_CFG=$(python3 -c "
+import json
+with open('$REACTIONS_FILE') as f:
+    cfg = json.load(f)
+proj = cfg.get('github', {}).get('project')
+if proj:
+    print(json.dumps(proj))
+else:
+    print('null')
+")
+    if [ "$PROJECT_CFG" != "null" ] && [ -n "$PROJECT_STATUS" ]; then
+      echo "ℹ️  Project status update: ${PROJECT_STATUS} (GitHub Project updates require manual setup)"
+      # TODO: Implement gh project item-edit when project item IDs are tracked
+    fi
+    ;;
+
+  send-to-command)
+    CMD_WS=$(get_command_ws)
+    if [ -n "$CMD_WS" ]; then
+      "$CMUX" send --workspace "$CMD_WS" "$MESSAGE"
+      "$CMUX" send-key --workspace "$CMD_WS" Enter
+      echo "✔ Sent to command: ${RULE}"
+    fi
+    ;;
+
+  *)
+    echo "✘ Unknown action type: $ACTION_TYPE" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/fix-skill.sh
+++ b/scripts/fix-skill.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Usage: fix-skill.sh <spoke-vault-path> <skill-name> <new-body>
+# Fixes a broken skill in-place (FIX evolution) — backs up the old version
+set -euo pipefail
+VAULT="${1:?Usage: fix-skill.sh <vault-path> <skill-name> <new-body>}"
+SKILL_NAME="${2:?}"
+NEW_BODY="${3:?}"
+DATE=$(date +"%Y-%m-%d")
+SKILL_DIR="${VAULT}/skills/${SKILL_NAME}"
+SKILL_FILE="${SKILL_DIR}/SKILL.md"
+
+if [ ! -f "$SKILL_FILE" ]; then
+  echo "Skill '${SKILL_NAME}' not found at ${SKILL_FILE}"
+  exit 1
+fi
+
+# Backup old version
+BACKUP="${SKILL_DIR}/SKILL.${DATE}.bak.md"
+cp "$SKILL_FILE" "$BACKUP"
+
+# Extract existing frontmatter fields, bump version info
+OLD_DESC=$(grep '^description:' "$SKILL_FILE" | sed 's/^description: //')
+OLD_TIMES_USED=$(grep '^times_used:' "$SKILL_FILE" | sed 's/^times_used: //' || echo "0")
+OLD_TIMES_SUCCESS=$(grep '^times_successful:' "$SKILL_FILE" | sed 's/^times_successful: //' || echo "0")
+
+cat > "$SKILL_FILE" << EOF
+---
+name: ${SKILL_NAME}
+description: ${OLD_DESC}
+captured: ${DATE}
+origin: fixed
+times_used: ${OLD_TIMES_USED}
+times_successful: ${OLD_TIMES_SUCCESS}
+last_fixed: ${DATE}
+---
+
+${NEW_BODY}
+EOF
+echo "Fixed skill: $SKILL_FILE (backup: $BACKUP)"

--- a/scripts/mark-learning-useful.sh
+++ b/scripts/mark-learning-useful.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Usage: mark-learning-useful.sh <learning-file-path>
+# Increments times_useful counter on a learning
+set -euo pipefail
+FILE="${1:?Usage: mark-learning-useful.sh <learning-file-path>}"
+
+if [ ! -f "$FILE" ]; then
+  echo "Learning file not found: $FILE"
+  exit 1
+fi
+
+# Increment times_useful
+CURRENT=$(grep '^times_useful:' "$FILE" | sed 's/^times_useful: //')
+NEW=$((${CURRENT:-0} + 1))
+sed -i '' "s/^times_useful: .*/times_useful: ${NEW}/" "$FILE"
+
+# Increment times_loaded
+LOADED=$(grep '^times_loaded:' "$FILE" | sed 's/^times_loaded: //')
+NEW_LOADED=$((${LOADED:-0} + 1))
+sed -i '' "s/^times_loaded: .*/times_loaded: ${NEW_LOADED}/" "$FILE"
+
+echo "Marked useful (${NEW}x): $FILE"

--- a/scripts/match-reactions.sh
+++ b/scripts/match-reactions.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+# match-reactions.sh — Match polled events against reaction rules
+# Usage: match-reactions.sh <events.json> [reactions.json]
+# Output: JSON array of actions to execute
+#
+# Tracks processed events in reactor-state.json to avoid duplicates.
+set -euo pipefail
+
+EVENTS_FILE="${1:?Usage: match-reactions.sh <events.json> [reactions.json]}"
+REACTIONS_FILE="${2:-${HOME}/.config/cockpit/reactions.json}"
+STATE_FILE="${HOME}/.config/cockpit/reactor-state.json"
+
+# Ensure state file exists
+if [ ! -f "$STATE_FILE" ]; then
+  mkdir -p "$(dirname "$STATE_FILE")"
+  echo '{"processed_events": {}, "pending_retries": {}, "last_poll": null}' > "$STATE_FILE"
+fi
+
+EVENTS_FILE="$EVENTS_FILE" REACTIONS_FILE="$REACTIONS_FILE" STATE_FILE="$STATE_FILE" python3 << 'PYEOF'
+import json, sys, os, re
+from datetime import datetime, timedelta, timezone
+
+EVENTS_FILE = os.environ["EVENTS_FILE"]
+REACTIONS_FILE = os.environ["REACTIONS_FILE"]
+STATE_FILE = os.environ["STATE_FILE"]
+
+# Load inputs
+with open(EVENTS_FILE) as f:
+    events = json.load(f) if os.path.getsize(EVENTS_FILE) > 0 else []
+
+with open(REACTIONS_FILE) as f:
+    config = json.load(f)
+
+with open(STATE_FILE) as f:
+    state = json.load(f)
+
+reactions = config.get("reactions", {})
+processed = state.get("processed_events", {})
+pending_retries = state.get("pending_retries", {})
+actions = []
+
+def parse_duration(s):
+    """Parse '2h', '30m', '1d' into timedelta."""
+    if not s:
+        return None
+    m = re.match(r"(\d+)(m|h|d)", str(s))
+    if not m:
+        return None
+    val, unit = int(m.group(1)), m.group(2)
+    if unit == "m": return timedelta(minutes=val)
+    if unit == "h": return timedelta(hours=val)
+    if unit == "d": return timedelta(days=val)
+    return None
+
+def event_key(event):
+    """Generate a unique key for an event to track processing."""
+    etype = event.get("type", "unknown")
+    project = event.get("project", "")
+    number = event.get("number", "")
+    # For PRs, include check/review state so we re-trigger on state changes
+    if etype == "pr":
+        checks = event.get("checks_status", "")
+        review = event.get("review_decision", "")
+        return f"{etype}:{project}:{number}:{checks}:{review}"
+    return f"{etype}:{project}:{number}"
+
+def matches_trigger(event, trigger, rule_source):
+    """Check if an event matches a reaction trigger."""
+    etype = event.get("type", "")
+
+    # Source type must match
+    if rule_source == "github-issues" and etype != "issue":
+        return False
+    if rule_source == "github-prs" and etype != "pr":
+        return False
+    if rule_source == "captain-status" and etype != "captain-status":
+        return False
+
+    # Label match
+    if "label" in trigger:
+        labels = event.get("labels", [])
+        if trigger["label"] not in labels:
+            return False
+
+    # State match
+    if "state" in trigger:
+        if event.get("state") != trigger["state"]:
+            return False
+
+    # Not assigned check
+    if trigger.get("not_assigned"):
+        assignees = event.get("assignees", [])
+        if len(assignees) > 0:
+            return False
+
+    # Checks status match
+    if "checks" in trigger:
+        if event.get("checks_status") != trigger["checks"]:
+            return False
+
+    # Review decision match
+    if "review_decision" in trigger:
+        if event.get("review_decision") != trigger["review_decision"]:
+            return False
+
+    # Captain status: no_update_for
+    if "no_update_for" in trigger:
+        last_updated = event.get("last_updated")
+        if last_updated:
+            try:
+                dt = datetime.fromisoformat(last_updated.replace("Z", "+00:00"))
+                threshold = parse_duration(trigger["no_update_for"])
+                if threshold and (datetime.now(timezone.utc) - dt) < threshold:
+                    return False
+            except:
+                return False
+        else:
+            return False
+
+    # Captain status: status_contains
+    if "status_contains" in trigger:
+        msg = event.get("status_message", "").lower()
+        if trigger["status_contains"].lower() not in msg:
+            return False
+
+    # Captain status: event type
+    if "event" in trigger:
+        if event.get("event") != trigger["event"]:
+            return False
+
+    return True
+
+def interpolate_message(template, event):
+    """Replace {placeholders} in message with event data."""
+    if not template:
+        return ""
+    result = template
+    for key, val in event.items():
+        if isinstance(val, (str, int, float)):
+            result = result.replace("{" + key + "}", str(val))
+        elif isinstance(val, list):
+            result = result.replace("{" + key + "}", ", ".join(str(v) for v in val))
+    return result
+
+# Match events against reactions
+now = datetime.now(timezone.utc).isoformat()
+
+for event in events:
+    key = event_key(event)
+
+    for rule_name, rule in reactions.items():
+        if not rule.get("enabled", True):
+            continue
+
+        if not matches_trigger(event, rule.get("trigger", {}), rule.get("source", "")):
+            continue
+
+        # Check if already processed (same event+rule combo)
+        action_key = f"{key}:{rule_name}"
+        if action_key in processed:
+            continue
+
+        # Build action
+        action = {
+            "rule": rule_name,
+            "action": rule["action"],
+            "project": event.get("project", ""),
+            "event_type": event.get("type", ""),
+            "number": event.get("number"),
+            "title": event.get("title", ""),
+            "url": event.get("url", ""),
+            "message": interpolate_message(rule.get("message", ""), event),
+            "priority": rule.get("priority", "normal"),
+            "project_status": rule.get("project_status"),
+            "merge_method": rule.get("merge_method"),
+            "retries": rule.get("retries", config.get("engine", {}).get("max_retries", 2)),
+            "escalate_after": rule.get("escalate_after"),
+            "timestamp": now,
+        }
+        actions.append(action)
+
+        # Mark as processed
+        processed[action_key] = now
+
+# Update state
+state["processed_events"] = processed
+state["last_poll"] = now
+
+# Prune old processed events (older than 7 days)
+cutoff = (datetime.now(timezone.utc) - timedelta(days=7)).isoformat()
+state["processed_events"] = {
+    k: v for k, v in processed.items()
+    if v > cutoff
+}
+
+with open(STATE_FILE, "w") as f:
+    json.dump(state, f, indent=2)
+
+print(json.dumps(actions, indent=2))
+PYEOF

--- a/scripts/poll-github.sh
+++ b/scripts/poll-github.sh
@@ -1,0 +1,251 @@
+#!/bin/bash
+# poll-github.sh — Fetch GitHub events for all configured repos
+# Usage: poll-github.sh [reactions.json path]
+# Output: JSON array of events to stdout
+#
+# Requires: gh CLI authenticated
+set -euo pipefail
+
+REACTIONS_FILE="${1:-${HOME}/.config/cockpit/reactions.json}"
+CONFIG_FILE="${HOME}/.config/cockpit/config.json"
+
+if ! command -v gh &>/dev/null; then
+  echo '{"error": "gh CLI not found. Install: https://cli.github.com"}' >&2
+  exit 1
+fi
+
+if ! gh auth status &>/dev/null 2>&1; then
+  echo '{"error": "gh CLI not authenticated. Run: gh auth login"}' >&2
+  exit 1
+fi
+
+# Parse repos from reactions.json
+REPOS=$(python3 -c "
+import json, sys
+try:
+    with open('$REACTIONS_FILE') as f:
+        cfg = json.load(f)
+    repos = cfg.get('github', {}).get('repos', {}) or {}
+    print(json.dumps(repos))
+except Exception as e:
+    print('{}', file=sys.stdout)
+    print(f'Warning: {e}', file=sys.stderr)
+")
+
+if [ "$REPOS" = "{}" ]; then
+  echo "[]"
+  exit 0
+fi
+
+# Map cockpit project names to repos
+PROJECT_NAMES=$(echo "$REPOS" | python3 -c "
+import json, sys
+repos = json.load(sys.stdin)
+for name, cfg in repos.items():
+    print(f\"{name}|{cfg['owner']}/{cfg['repo']}\")
+")
+
+EVENTS="[]"
+
+while IFS='|' read -r PROJECT_NAME FULL_REPO; do
+  [ -z "$PROJECT_NAME" ] && continue
+  OWNER="${FULL_REPO%%/*}"
+  REPO="${FULL_REPO##*/}"
+
+  # --- Poll Issues ---
+  ISSUES=$(gh api "repos/${OWNER}/${REPO}/issues" \
+    --jq '[.[] | select(.pull_request == null) | {
+      type: "issue",
+      project: "'"$PROJECT_NAME"'",
+      repo: "'"$FULL_REPO"'",
+      number: .number,
+      title: .title,
+      body: (.body // "" | .[0:500]),
+      state: .state,
+      labels: [.labels[].name],
+      assignees: [.assignees[].login],
+      url: .html_url,
+      created_at: .created_at,
+      updated_at: .updated_at
+    }]' 2>/dev/null || echo '[]')
+
+  # --- Poll Pull Requests ---
+  PRS=$(gh api "repos/${OWNER}/${REPO}/pulls?state=open" \
+    --jq '[.[] | {
+      type: "pr",
+      project: "'"$PROJECT_NAME"'",
+      repo: "'"$FULL_REPO"'",
+      number: .number,
+      title: .title,
+      body: (.body // "" | .[0:300]),
+      state: .state,
+      head_branch: .head.ref,
+      base_branch: .base.ref,
+      draft: .draft,
+      labels: [.labels[].name],
+      url: .html_url,
+      created_at: .created_at,
+      updated_at: .updated_at
+    }]' 2>/dev/null || echo '[]')
+
+  # For each PR, get check status and review decision
+  PR_NUMBERS=$(echo "$PRS" | python3 -c "
+import json, sys
+prs = json.load(sys.stdin)
+for pr in prs:
+    print(pr['number'])
+" 2>/dev/null)
+
+  ENRICHED_PRS="$PRS"
+  while read -r PR_NUM; do
+    [ -z "$PR_NUM" ] && continue
+
+    # Get combined check status
+    CHECK_STATUS=$(gh api "repos/${OWNER}/${REPO}/commits/$(gh api "repos/${OWNER}/${REPO}/pulls/${PR_NUM}" --jq '.head.sha' 2>/dev/null)/check-runs" \
+      --jq '{
+        total: .total_count,
+        success: [.check_runs[] | select(.conclusion == "success")] | length,
+        failure: [.check_runs[] | select(.conclusion == "failure")] | length,
+        pending: [.check_runs[] | select(.status == "in_progress" or .status == "queued")] | length
+      }' 2>/dev/null || echo '{"total":0,"success":0,"failure":0,"pending":0}')
+
+    # Get review decision
+    REVIEWS=$(gh api "repos/${OWNER}/${REPO}/pulls/${PR_NUM}/reviews" \
+      --jq '[.[] | {state: .state, user: .user.login}] | last // {state: "PENDING"}' 2>/dev/null || echo '{"state":"PENDING"}')
+
+    # Enrich PR with check + review info
+    ENRICHED_PRS=$(echo "$ENRICHED_PRS" | python3 -c "
+import json, sys
+prs = json.load(sys.stdin)
+checks = json.loads('$CHECK_STATUS')
+review = json.loads('$REVIEWS')
+for pr in prs:
+    if pr['number'] == $PR_NUM:
+        pr['checks'] = checks
+        # Derive overall check status
+        if checks.get('failure', 0) > 0:
+            pr['checks_status'] = 'failure'
+        elif checks.get('pending', 0) > 0:
+            pr['checks_status'] = 'pending'
+        elif checks.get('success', 0) > 0:
+            pr['checks_status'] = 'success'
+        else:
+            pr['checks_status'] = 'none'
+        pr['review_state'] = review.get('state', 'PENDING').lower()
+        # Map GitHub review states to our trigger values
+        state_map = {
+            'approved': 'approved',
+            'changes_requested': 'changes_requested',
+            'commented': 'commented',
+            'pending': 'review_required',
+            'dismissed': 'review_required'
+        }
+        pr['review_decision'] = state_map.get(pr['review_state'], 'review_required')
+print(json.dumps(prs))
+")
+  done <<< "$PR_NUMBERS"
+
+  # Merge into events array
+  EVENTS=$(python3 -c "
+import json
+events = json.loads('$(echo "$EVENTS" | python3 -c "import sys,json; print(json.dumps(json.load(sys.stdin)))")')
+issues = json.loads('''$ISSUES''')
+prs = json.loads('''$ENRICHED_PRS''')
+events.extend(issues)
+events.extend(prs)
+print(json.dumps(events))
+")
+
+done <<< "$PROJECT_NAMES"
+
+# --- Poll GitHub Project board (if configured) ---
+PROJECT_CFG=$(python3 -c "
+import json
+try:
+    with open('$REACTIONS_FILE') as f:
+        cfg = json.load(f)
+    proj = cfg.get('github', {}).get('project')
+    if proj:
+        print(json.dumps(proj))
+    else:
+        print('null')
+except:
+    print('null')
+")
+
+if [ "$PROJECT_CFG" != "null" ]; then
+  PROJ_OWNER=$(echo "$PROJECT_CFG" | python3 -c "import json,sys; print(json.load(sys.stdin)['owner'])")
+  PROJ_NUMBER=$(echo "$PROJECT_CFG" | python3 -c "import json,sys; print(json.load(sys.stdin)['number'])")
+
+  # Fetch project items via GraphQL
+  PROJECT_ITEMS=$(gh api graphql -f query='
+    query($owner: String!, $number: Int!) {
+      user(login: $owner) {
+        projectV2(number: $number) {
+          items(first: 50) {
+            nodes {
+              id
+              content {
+                ... on Issue {
+                  number
+                  title
+                  repository { nameWithOwner }
+                  url
+                }
+                ... on PullRequest {
+                  number
+                  title
+                  repository { nameWithOwner }
+                  url
+                }
+              }
+              fieldValueByName(name: "Status") {
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ' -f owner="$PROJ_OWNER" -F number="$PROJ_NUMBER" 2>/dev/null || echo '{"data":null}')
+
+  # Parse project items into events
+  PROJECT_EVENTS=$(echo "$PROJECT_ITEMS" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+items = []
+try:
+    nodes = data['data']['user']['projectV2']['items']['nodes']
+    for node in nodes:
+        content = node.get('content')
+        if not content:
+            continue
+        status_field = node.get('fieldValueByName') or {}
+        status = status_field.get('name', 'No Status')
+        items.append({
+            'type': 'project-card',
+            'project_item_id': node['id'],
+            'number': content.get('number'),
+            'title': content.get('title'),
+            'repo': (content.get('repository') or {}).get('nameWithOwner', ''),
+            'url': content.get('url', ''),
+            'project_status': status
+        })
+except (KeyError, TypeError):
+    pass
+print(json.dumps(items))
+")
+
+  EVENTS=$(python3 -c "
+import json
+events = json.loads('$(echo "$EVENTS" | python3 -c "import sys,json; print(json.dumps(json.load(sys.stdin)))")')
+cards = json.loads('''$PROJECT_EVENTS''')
+events.extend(cards)
+print(json.dumps(events))
+")
+fi
+
+# Output final events
+echo "$EVENTS" | python3 -m json.tool

--- a/scripts/reactor-cycle.sh
+++ b/scripts/reactor-cycle.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# reactor-cycle.sh — Run one full reaction cycle: poll → match → execute
+# Usage: reactor-cycle.sh [reactions.json]
+# This is what the reactor workspace calls on each poll interval.
+set -euo pipefail
+
+SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REACTIONS_FILE="${1:-${HOME}/.config/cockpit/reactions.json}"
+EVENTS_DIR="${HOME}/.config/cockpit/reactor-events"
+TIMESTAMP=$(date +"%Y%m%d-%H%M%S")
+
+mkdir -p "$EVENTS_DIR"
+
+echo "━━━ Reactor Cycle: $(date '+%Y-%m-%d %H:%M:%S') ━━━"
+
+# Step 1: Poll GitHub
+echo "📡 Polling GitHub..."
+EVENTS_FILE="${EVENTS_DIR}/events-${TIMESTAMP}.json"
+if ! "$SCRIPTS_DIR/poll-github.sh" "$REACTIONS_FILE" > "$EVENTS_FILE" 2>/dev/null; then
+  echo "⚠️  GitHub polling failed"
+  rm -f "$EVENTS_FILE"
+  exit 1
+fi
+
+EVENT_COUNT=$(python3 -c "import json; print(len(json.load(open('$EVENTS_FILE'))))" 2>/dev/null || echo "0")
+echo "   Found ${EVENT_COUNT} events"
+
+if [ "$EVENT_COUNT" = "0" ]; then
+  echo "   No events to process"
+  rm -f "$EVENTS_FILE"
+  exit 0
+fi
+
+# Step 2: Poll captain status (internal events)
+echo "📊 Checking captain status..."
+CAPTAIN_EVENTS=$(python3 -c "
+import json, os, glob
+from datetime import datetime, timezone
+
+config = json.load(open(os.path.expanduser('~/.config/cockpit/config.json')))
+events = []
+for name, proj in config.get('projects', {}).items():
+    vault = proj.get('spokeVault', '')
+    status_file = os.path.join(vault, 'status.md')
+    if not os.path.exists(status_file):
+        continue
+    # Read frontmatter
+    with open(status_file) as f:
+        lines = f.readlines()
+    in_fm = False
+    fm = {}
+    for line in lines:
+        line = line.strip()
+        if line == '---':
+            if in_fm:
+                break
+            in_fm = True
+            continue
+        if in_fm and ':' in line:
+            key, val = line.split(':', 1)
+            fm[key.strip()] = val.strip().strip('\"')
+    events.append({
+        'type': 'captain-status',
+        'project': name,
+        'captain_session': fm.get('captain_session', 'inactive'),
+        'last_updated': fm.get('last_updated', ''),
+        'active_crew': int(fm.get('active_crew', 0)),
+        'tasks_completed': int(fm.get('tasks_completed', 0)),
+        'tasks_total': int(fm.get('tasks_total', 0)),
+        'tasks_in_progress': int(fm.get('tasks_in_progress', 0)),
+        'status_message': fm.get('last_status_message', '')
+    })
+print(json.dumps(events))
+" 2>/dev/null || echo "[]")
+
+# Merge captain status events into events file
+python3 -c "
+import json
+with open('$EVENTS_FILE') as f:
+    events = json.load(f)
+captain_events = json.loads('''$CAPTAIN_EVENTS''')
+events.extend(captain_events)
+with open('$EVENTS_FILE', 'w') as f:
+    json.dump(events, f, indent=2)
+print(f'   Added {len(captain_events)} captain status events')
+"
+
+# Step 3: Match reactions
+echo "🔍 Matching reactions..."
+ACTIONS_FILE="${EVENTS_DIR}/actions-${TIMESTAMP}.json"
+"$SCRIPTS_DIR/match-reactions.sh" "$EVENTS_FILE" "$REACTIONS_FILE" > "$ACTIONS_FILE"
+
+ACTION_COUNT=$(python3 -c "import json; print(len(json.load(open('$ACTIONS_FILE'))))" 2>/dev/null || echo "0")
+echo "   Matched ${ACTION_COUNT} actions"
+
+if [ "$ACTION_COUNT" = "0" ]; then
+  echo "   No actions to execute"
+  rm -f "$EVENTS_FILE" "$ACTIONS_FILE"
+  exit 0
+fi
+
+# Step 4: Execute each action
+echo "⚡ Executing actions..."
+python3 -c "
+import json
+actions = json.load(open('$ACTIONS_FILE'))
+for i, action in enumerate(actions):
+    path = '${EVENTS_DIR}/action-${TIMESTAMP}-' + str(i) + '.json'
+    with open(path, 'w') as f:
+        json.dump(action, f, indent=2)
+    print(path)
+" | while read -r ACTION_PATH; do
+  echo "   → $(python3 -c "import json; a=json.load(open('$ACTION_PATH')); print(f\"{a['rule']}: {a['action']} → {a['project']} #{a.get('number','')}\")")"
+  "$SCRIPTS_DIR/execute-reaction.sh" "$ACTION_PATH" 2>&1 | sed 's/^/     /'
+  rm -f "$ACTION_PATH"
+done
+
+# Cleanup
+rm -f "$EVENTS_FILE" "$ACTIONS_FILE"
+echo "━━━ Cycle complete ━━━"

--- a/scripts/record-learning.sh
+++ b/scripts/record-learning.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
-# Usage: record-learning.sh <spoke-vault-path> <category> <content>
+# Usage: record-learning.sh <spoke-vault-path> <category> <content> [tags]
+# Tags: comma-separated keywords for selective loading (e.g., "cairo,escrow,pvp")
 set -euo pipefail
-VAULT="${1:?Usage: record-learning.sh <vault-path> <category> <content>}"
+VAULT="${1:?Usage: record-learning.sh <vault-path> <category> <content> [tags]}"
 CATEGORY="${2:?}"
 CONTENT="${3:?}"
+TAGS="${4:-}"
 DATE=$(date +"%Y-%m-%d")
 TIMESTAMP=$(date +"%H%M%S")
 SLUG=$(echo "$CONTENT" | head -c 40 | tr ' ' '-' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]//g')
@@ -15,6 +17,9 @@ type: learning
 date: ${DATE}
 category: ${CATEGORY}
 applied: false
+times_loaded: 0
+times_useful: 0
+tags: [${TAGS}]
 ---
 
 ## What happened

--- a/scripts/spawn-crew-pane.sh
+++ b/scripts/spawn-crew-pane.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Usage: spawn-crew-pane.sh <captain-workspace-ref> <crew-name> <task-prompt> [direction]
+# Spawns a crew member as a split pane next to the captain
+set -euo pipefail
+
+CMUX="/Applications/cmux.app/Contents/Resources/bin/cmux"
+CAPTAIN_WS="${1:?Usage: spawn-crew-pane.sh <captain-workspace-ref> <crew-name> <task-prompt> [direction]}"
+CREW_NAME="${2:?}"
+TASK="${3:?}"
+DIRECTION="${4:-right}"
+
+# Create a split pane in the captain's workspace
+PANE_OUTPUT=$("$CMUX" new-split "$DIRECTION" --workspace "$CAPTAIN_WS" 2>&1)
+PANE_REF=$(echo "$PANE_OUTPUT" | grep -o 'surface:[0-9]*' | head -1)
+
+if [ -z "$PANE_REF" ]; then
+  echo "Failed to create split pane: $PANE_OUTPUT"
+  exit 1
+fi
+
+# Rename the tab for the crew pane
+"$CMUX" rename-tab --surface "$PANE_REF" --workspace "$CAPTAIN_WS" "🔧 $CREW_NAME" 2>/dev/null || true
+
+# Start Claude Code in the crew pane with the task
+# Use --permission-mode acceptEdits so crew can work
+CLAUDE_CMD="claude --permission-mode acceptEdits -p \"You are a crew member (🔧 ${CREW_NAME}). ${TASK} When done, summarize what you did and what branch/PR was created.\""
+"$CMUX" send --workspace "$CAPTAIN_WS" --surface "$PANE_REF" "$CLAUDE_CMD" 2>&1
+"$CMUX" send-key --workspace "$CAPTAIN_WS" --surface "$PANE_REF" Enter 2>&1
+
+echo "Spawned crew pane: $PANE_REF (🔧 $CREW_NAME) in $CAPTAIN_WS [$DIRECTION]"

--- a/scripts/spawn-workspace.sh
+++ b/scripts/spawn-workspace.sh
@@ -1,29 +1,136 @@
 #!/bin/bash
-# Usage: spawn-workspace.sh <name> <cwd> [role]
-# role: "captain" | "crew" (default: "captain")
+# Usage: spawn-workspace.sh <name> <cwd> [role] [--fresh]
+# role: "captain" | "crew" | "command" | "reactor" (default: "captain")
+# --fresh: force a new session instead of resuming
 set -euo pipefail
 
 CMUX="/Applications/cmux.app/Contents/Resources/bin/cmux"
 TEMPLATES_DIR="${HOME}/.config/cockpit/templates"
-NAME="${1:?Usage: spawn-workspace.sh <name> <cwd> [role]}"
-CWD="${2:?Usage: spawn-workspace.sh <name> <cwd> [role]}"
+SESSIONS_FILE="${HOME}/.config/cockpit/sessions.json"
+NAME="${1:?Usage: spawn-workspace.sh <name> <cwd> [role] [--fresh]}"
+CWD="${2:?Usage: spawn-workspace.sh <name> <cwd> [role] [--fresh]}"
 ROLE="${3:-captain}"
+FORCE_FRESH="${4:-}"
 
-# Build claude command with role-specific prompt appended
-CLAUDE_CMD="claude -c"
+TODAY=$(date +"%Y-%m-%d")
+FRESH=false
+
+# --- Session freshness check ---
+if [ "$FORCE_FRESH" = "--fresh" ]; then
+  FRESH=true
+elif [ -f "$SESSIONS_FILE" ]; then
+  # Check last launch date
+  LAST_DATE=$(python3 -c "
+import json, sys
+try:
+    data = json.load(open('$SESSIONS_FILE'))
+    print(data.get('workspaces', {}).get('$NAME', {}).get('lastLaunched', ''))
+except: print('')
+" 2>/dev/null)
+
+  if [ -z "$LAST_DATE" ]; then
+    FRESH=true  # first launch
+  elif [ "$LAST_DATE" != "$TODAY" ]; then
+    FRESH=true  # new day
+    echo "↻ new day — starting fresh session for $NAME"
+  fi
+
+  # Check template + skills hash
+  if [ "$FRESH" = "false" ]; then
+    CURRENT_HASH=$(cat "${TEMPLATES_DIR}/${ROLE}.CLAUDE.md" "${HOME}/.config/cockpit/plugin/skills"/*/SKILL.md 2>/dev/null | shasum -a 256 | cut -c1-16)
+    STORED_HASH=$(python3 -c "
+import json
+try:
+    data = json.load(open('$SESSIONS_FILE'))
+    print(data.get('workspaces', {}).get('$NAME', {}).get('templateHash', ''))
+except: print('')
+" 2>/dev/null)
+    if [ -n "$CURRENT_HASH" ] && [ "$CURRENT_HASH" != "$STORED_HASH" ]; then
+      FRESH=true
+      echo "↻ template instructions updated — starting fresh session for $NAME"
+    fi
+  fi
+else
+  FRESH=true  # no sessions file yet
+fi
+
+# --- Record session ---
+CURRENT_HASH=$(cat "${TEMPLATES_DIR}/${ROLE}.CLAUDE.md" "${HOME}/.config/cockpit/plugin/skills"/*/SKILL.md 2>/dev/null | shasum -a 256 | cut -c1-16)
+python3 -c "
+import json, os
+path = '$SESSIONS_FILE'
+try:
+    data = json.load(open(path))
+except: data = {'workspaces': {}}
+data.setdefault('workspaces', {})['$NAME'] = {'lastLaunched': '$TODAY', 'templateHash': '$CURRENT_HASH'}
+os.makedirs(os.path.dirname(path), exist_ok=True)
+json.dump(data, open(path, 'w'), indent=2)
+" 2>/dev/null
+
+# --- Build claude command ---
+if [ "$FRESH" = "true" ]; then
+  CLAUDE_CMD="claude"
+else
+  CLAUDE_CMD="claude -c"
+fi
+
+# Read permission mode from config
+PERM_MODE=$(python3 -c "
+import json
+try:
+    cfg = json.load(open('${HOME}/.config/cockpit/config.json'))
+    role_key = '$ROLE' if '$ROLE' in ('captain', 'command', 'reactor') else 'captain'
+    print(cfg.get('defaults', {}).get('permissions', {}).get(role_key, 'default'))
+except: print('default')
+" 2>/dev/null)
+
+if [ "$PERM_MODE" = "acceptEdits" ]; then
+  CLAUDE_CMD="${CLAUDE_CMD} --permission-mode acceptEdits"
+elif [ "$PERM_MODE" = "bypassPermissions" ]; then
+  CLAUDE_CMD="${CLAUDE_CMD} --dangerously-skip-permissions"
+fi
+
+# Append role template (slim — detailed instructions are in cockpit skills)
 ROLE_FILE="${TEMPLATES_DIR}/${ROLE}.CLAUDE.md"
 if [ -f "$ROLE_FILE" ]; then
-  CLAUDE_CMD="claude -c --append-system-prompt-file ${ROLE_FILE}"
+  CLAUDE_CMD="${CLAUDE_CMD} --append-system-prompt-file ${ROLE_FILE}"
 fi
 
-# Also append learnings instructions for captains
-LEARNINGS_FILE="${TEMPLATES_DIR}/learnings.CLAUDE.md"
-if [ "$ROLE" = "captain" ] && [ -f "$LEARNINGS_FILE" ]; then
-  CLAUDE_CMD="${CLAUDE_CMD} --append-system-prompt-file ${LEARNINGS_FILE}"
+# Load cockpit plugin for skills (captain-ops, command-ops, daily-log, etc.)
+PLUGIN_DIR="${HOME}/.config/cockpit/plugin"
+if [ -d "$PLUGIN_DIR" ]; then
+  CLAUDE_CMD="${CLAUDE_CMD} --plugin-dir ${PLUGIN_DIR}"
 fi
 
+# --- Handle existing workspace ---
+EXISTING_REF=$("$CMUX" list-workspaces 2>&1 | grep -F "$NAME" | awk '{print $1}' || true)
+if [ -n "$EXISTING_REF" ] && [ "$FRESH" = "true" ]; then
+  echo "Closing stale workspace: $NAME"
+  "$CMUX" close-workspace --workspace "$EXISTING_REF" 2>/dev/null || true
+  EXISTING_REF=""
+fi
+
+if [ -n "$EXISTING_REF" ]; then
+  echo "Workspace '$NAME' already exists — switching to it"
+  "$CMUX" select-workspace --workspace "$EXISTING_REF" 2>&1
+  exit 0
+fi
+
+# --- Spawn new workspace ---
 CURRENT=$("$CMUX" current-workspace 2>&1 | awk '{print $1}')
 NEW_UUID=$("$CMUX" new-workspace --command "$CLAUDE_CMD" --cwd "$CWD" 2>&1 | awk '{print $2}')
 "$CMUX" rename-workspace --workspace "$NEW_UUID" "$NAME" 2>&1
+if [ "$ROLE" = "command" ] || [ "$ROLE" = "captain" ] || [ "$ROLE" = "reactor" ]; then
+  "$CMUX" workspace-action --workspace "$NEW_UUID" --action pin 2>/dev/null || true
+fi
+# Send initial prompt to trigger startup checklist
+if [ "$ROLE" = "captain" ]; then
+  (sleep 3 && "$CMUX" send --workspace "$NEW_UUID" "Run your startup checklist: use the cockpit:captain-ops skill, complete all startup steps, then report ready." 2>/dev/null) &
+elif [ "$ROLE" = "command" ]; then
+  (sleep 3 && "$CMUX" send --workspace "$NEW_UUID" "Run your startup checklist: use the cockpit:command-ops skill, complete your daily briefing, then report ready." 2>/dev/null) &
+elif [ "$ROLE" = "reactor" ]; then
+  (sleep 3 && "$CMUX" send --workspace "$NEW_UUID" "Run your startup checklist: use the cockpit:reactor-ops skill, verify gh auth, read reactions.json, then start your poll loop." 2>/dev/null) &
+fi
+
 "$CMUX" select-workspace --workspace "$CURRENT" 2>&1
-echo "Spawned workspace: $NAME at $CWD (role: $ROLE)"
+echo "Spawned workspace: $NAME at $CWD (role: $ROLE, fresh: $FRESH)"

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -100,7 +100,17 @@ export const initCommand = new Command("init")
       console.log(chalk.yellow("  ⚠ Orchestrator templates not found in package"));
     }
 
-    // 5. Enable Agent Teams in settings.json if not set
+    // 5. Copy cockpit plugin (skills) to ~/.config/cockpit/plugin/
+    const pluginSrc = path.join(pkgRoot, "plugin");
+    const pluginTarget = path.join(configDir, "plugin");
+    if (fs.existsSync(pluginSrc)) {
+      copyDirRecursive(pluginSrc, pluginTarget);
+      console.log(chalk.green(`  ✔ Cockpit plugin (skills) copied to ${pluginTarget}`));
+    } else {
+      console.log(chalk.yellow("  ⚠ Plugin directory not found in package"));
+    }
+
+    // 6. Enable Agent Teams in settings.json if not set
     const settingsPath = path.join(os.homedir(), ".claude", "settings.json");
     try {
       let settings: Record<string, unknown> = {};

--- a/src/commands/launch.ts
+++ b/src/commands/launch.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { execSync } from "node:child_process";
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
@@ -9,6 +10,86 @@ import { loadConfig, resolveHome } from "../config.js";
 const CMUX_BIN = "/Applications/cmux.app/Contents/Resources/bin/cmux";
 const CMUX_APP = "/Applications/cmux.app";
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "cockpit", "templates");
+const SESSIONS_PATH = path.join(os.homedir(), ".config", "cockpit", "sessions.json");
+
+interface SessionRecord {
+  lastLaunched: string; // YYYY-MM-DD
+  templateHash: string;
+}
+
+interface SessionsFile {
+  workspaces: Record<string, SessionRecord>;
+}
+
+function loadSessions(): SessionsFile {
+  try {
+    return JSON.parse(fs.readFileSync(SESSIONS_PATH, "utf-8"));
+  } catch {
+    return { workspaces: {} };
+  }
+}
+
+function saveSessions(sessions: SessionsFile): void {
+  const dir = path.dirname(SESSIONS_PATH);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(SESSIONS_PATH, JSON.stringify(sessions, null, 2) + "\n");
+}
+
+function computeTemplateHash(role: string): string {
+  const hash = crypto.createHash("sha256");
+
+  // Hash the role template
+  const roleFile = path.join(TEMPLATES_DIR, `${role}.CLAUDE.md`);
+  if (fs.existsSync(roleFile)) {
+    hash.update(fs.readFileSync(roleFile, "utf-8"));
+  }
+
+  // Also hash plugin skills so template changes trigger fresh sessions
+  const pluginSkillsDir = path.join(TEMPLATES_DIR, "..", "plugin", "skills");
+  if (fs.existsSync(pluginSkillsDir)) {
+    for (const skill of fs.readdirSync(pluginSkillsDir).sort()) {
+      const skillFile = path.join(pluginSkillsDir, skill, "SKILL.md");
+      if (fs.existsSync(skillFile)) {
+        hash.update(fs.readFileSync(skillFile, "utf-8"));
+      }
+    }
+  }
+
+  return hash.digest("hex").slice(0, 16);
+}
+
+function shouldStartFresh(
+  workspaceName: string,
+  role: string,
+): { fresh: boolean; reason?: string } {
+  const sessions = loadSessions();
+  const record = sessions.workspaces[workspaceName];
+  const today = new Date().toISOString().slice(0, 10);
+  const currentHash = computeTemplateHash(role);
+
+  if (!record) {
+    return { fresh: true, reason: "first launch" };
+  }
+
+  if (record.lastLaunched !== today) {
+    return { fresh: true, reason: "new day — starting fresh session" };
+  }
+
+  if (record.templateHash !== currentHash) {
+    return { fresh: true, reason: "template instructions updated" };
+  }
+
+  return { fresh: false };
+}
+
+function recordSession(workspaceName: string, role: string): void {
+  const sessions = loadSessions();
+  sessions.workspaces[workspaceName] = {
+    lastLaunched: new Date().toISOString().slice(0, 10),
+    templateHash: computeTemplateHash(role),
+  };
+  saveSessions(sessions);
+}
 
 function cmux(args: string): string {
   return execSync(`"${CMUX_BIN}" ${args}`, { encoding: "utf-8" }).trim();
@@ -51,31 +132,38 @@ function buildClaudeCmd(role: string, fresh: boolean, permissionMode: string): s
     cmd += " --dangerously-skip-permissions";
   }
 
-  // Append role-specific CLAUDE.md via system prompt (preserves project's own CLAUDE.md)
+  // Append role-specific template (slim — detailed instructions are in cockpit skills)
   const roleFile = path.join(TEMPLATES_DIR, `${role}.CLAUDE.md`);
   if (fs.existsSync(roleFile)) {
     cmd += ` --append-system-prompt-file ${roleFile}`;
   }
 
-  // Captains also get learnings instructions
-  if (role === "captain") {
-    const learningsFile = path.join(TEMPLATES_DIR, "learnings.CLAUDE.md");
-    if (fs.existsSync(learningsFile)) {
-      cmd += ` --append-system-prompt-file ${learningsFile}`;
-    }
+  // Load cockpit plugin for skills (captain-ops, command-ops, daily-log, etc.)
+  const pluginDir = path.join(TEMPLATES_DIR, "..", "plugin");
+  if (fs.existsSync(pluginDir)) {
+    cmd += ` --plugin-dir ${pluginDir}`;
   }
 
   return cmd;
 }
 
-function launchWorkspace(name: string, claudeCmd: string, cwd?: string, navigate = false): void {
+function launchWorkspace(name: string, claudeCmd: string, cwd?: string, navigate = false, forceFresh = false, pinToTop = false, initialPrompt?: string): void {
   ensureCmuxReady();
 
   const existingRef = findWorkspaceRef(name);
-  if (existingRef) {
+  if (existingRef && forceFresh) {
+    // Close stale workspace so a fresh one can be created
+    console.log(chalk.yellow(`  Closing stale workspace '${name}' for fresh start`));
+    try {
+      cmux(`close-workspace --workspace "${existingRef}"`);
+    } catch { /* may already be closing */ }
+  } else if (existingRef) {
     console.log(chalk.yellow(`  Workspace '${name}' already exists — switching to it`));
     cmux(`select-workspace --workspace "${existingRef}"`);
-  } else {
+    return;
+  }
+
+  {
     let currentRef: string | undefined;
     try {
       const cur = cmux("current-workspace");
@@ -88,6 +176,21 @@ function launchWorkspace(name: string, claudeCmd: string, cwd?: string, navigate
 
     if (wsId) {
       cmux(`rename-workspace --workspace "${wsId}" "${name}"`);
+      if (pinToTop) {
+        try {
+          cmux(`workspace-action --workspace "${wsId}" --action pin`);
+        } catch { /* pin is best-effort */ }
+      }
+    }
+
+    // Send initial prompt to trigger startup behavior
+    if (wsId && initialPrompt) {
+      // Small delay to let Claude Code initialize before sending prompt
+      setTimeout(() => {
+        try {
+          cmux(`send --workspace "${wsId}" "${initialPrompt.replace(/"/g, '\\"')}"`);
+        } catch { /* best-effort */ }
+      }, 3000);
     }
 
     if (navigate && wsId) {
@@ -102,27 +205,95 @@ function launchWorkspace(name: string, claudeCmd: string, cwd?: string, navigate
 
 export const launchCommand = new Command("launch")
   .description(
-    "Launch command workspace (no args) or a captain workspace for a project",
+    "Launch command workspace (no args), a captain for a project, or --all for everything",
   )
   .argument("[project]", "Project name to launch captain for")
   .option("--fresh", "Start a new session instead of resuming the last one")
-  .action((project: string | undefined, opts: { fresh?: boolean }) => {
+  .option("--all", "Launch command workspace + reactor + all captain workspaces")
+  .option("--reactor", "Also launch the reactor workspace")
+  .action((project: string | undefined, opts: { fresh?: boolean; all?: boolean; reactor?: boolean }) => {
     const config = loadConfig();
 
-    if (!project) {
-      // Launch command workspace
+    function launchOne(
+      workspaceName: string,
+      role: string,
+      cwd: string,
+      permissionMode: string,
+      navigate: boolean,
+      pinToTop = false,
+    ): void {
+      let forceFresh = !!opts.fresh;
+      if (!forceFresh) {
+        const auto = shouldStartFresh(workspaceName, role);
+        if (auto.fresh) {
+          console.log(chalk.cyan(`  ↻ ${auto.reason}`));
+          forceFresh = true;
+        }
+      }
+
+      const claudeCmd = buildClaudeCmd(role, forceFresh, permissionMode);
+      recordSession(workspaceName, role);
+
+      // Auto-trigger startup checklist
+      let initialPrompt: string | undefined;
+      if (role === "captain") {
+        initialPrompt = "Run your startup checklist: use the cockpit:captain-ops skill, complete all startup steps, then report ready.";
+      } else if (role === "command") {
+        initialPrompt = "Run your startup checklist: use the cockpit:command-ops skill, complete your daily briefing, then report ready.";
+      } else if (role === "reactor") {
+        initialPrompt = "Run your startup checklist: use the cockpit:reactor-ops skill, verify gh auth, read reactions.json, then start your poll loop.";
+      }
+
+      try {
+        launchWorkspace(workspaceName, claudeCmd, cwd, navigate, forceFresh, pinToTop, initialPrompt);
+      } catch (err) {
+        console.error(chalk.red(`  ✘ Failed: ${(err as Error).message}`));
+      }
+    }
+
+    if (opts.all) {
+      // Launch command + all captains
       const workspaceName = config.commandName || "command";
       const hubPath = resolveHome(config.hubVault);
       fs.mkdirSync(hubPath, { recursive: true });
 
-      const claudeCmd = buildClaudeCmd("command", !!opts.fresh, config.defaults.permissions?.command || "default");
+      console.log(chalk.bold("\nLaunching all cockpit workspaces\n"));
+      console.log(chalk.bold(`  Command: ${workspaceName}`));
+      launchOne(workspaceName, "command", hubPath, config.defaults.permissions?.command || "default", true, true);
+
+      // Launch reactor (after command, before captains)
+      const reactorName = "⚡ reactor";
+      console.log(chalk.bold(`\n  Reactor: ${reactorName}`));
+      launchOne(reactorName, "reactor", hubPath, config.defaults.permissions?.reactor || "default", false, true);
+
+      for (const [name, proj] of Object.entries(config.projects)) {
+        const projPath = resolveHome(proj.path);
+        // Ensure spoke vault exists
+        const spokePath = resolveHome(proj.spokeVault);
+        if (!fs.existsSync(spokePath)) {
+          fs.mkdirSync(spokePath, { recursive: true });
+          for (const sub of ["crew", "learnings", "daily-logs", "skills", "meta", "templates"]) {
+            fs.mkdirSync(path.join(spokePath, sub), { recursive: true });
+          }
+          console.log(chalk.cyan(`  ✔ Created spoke vault at ${spokePath}`));
+        }
+        console.log(chalk.bold(`\n  Captain: ${proj.captainName} (${name})`));
+        launchOne(proj.captainName, "captain", projPath, config.defaults.permissions?.captain || "acceptEdits", false, true);
+      }
+      console.log("");
+    } else if (!project) {
+      // Launch command workspace only (+ reactor if --reactor)
+      const workspaceName = config.commandName || "command";
+      const hubPath = resolveHome(config.hubVault);
+      fs.mkdirSync(hubPath, { recursive: true });
 
       console.log(chalk.bold(`\nLaunching command workspace: ${workspaceName}\n`));
-      try {
-        launchWorkspace(workspaceName, claudeCmd, hubPath, true);
-      } catch (err) {
-        console.error(chalk.red(`\n  ✘ Failed to launch workspace: ${(err as Error).message}\n`));
-        process.exit(1);
+      launchOne(workspaceName, "command", hubPath, config.defaults.permissions?.command || "default", true, true);
+
+      if (opts.reactor) {
+        const reactorName = "⚡ reactor";
+        console.log(chalk.bold(`\nLaunching reactor: ${reactorName}\n`));
+        launchOne(reactorName, "reactor", hubPath, config.defaults.permissions?.reactor || "default", false, true);
       }
     } else {
       // Launch captain workspace for a project
@@ -137,21 +308,22 @@ export const launchCommand = new Command("launch")
 
       const proj = config.projects[project];
       const projPath = resolveHome(proj.path);
-      const claudeCmd = buildClaudeCmd("captain", !!opts.fresh, config.defaults.permissions?.captain || "acceptEdits");
+
+      // Ensure spoke vault exists
+      const spokePath = resolveHome(proj.spokeVault);
+      if (!fs.existsSync(spokePath)) {
+        fs.mkdirSync(spokePath, { recursive: true });
+        for (const sub of ["crew", "learnings", "daily-logs", "skills", "meta", "templates"]) {
+          fs.mkdirSync(path.join(spokePath, sub), { recursive: true });
+        }
+        console.log(chalk.cyan(`  ✔ Created spoke vault at ${spokePath}`));
+      }
 
       console.log(
         chalk.bold(
           `\nLaunching captain workspace for '${project}' (${proj.captainName})\n`,
         ),
       );
-
-      try {
-        launchWorkspace(proj.captainName, claudeCmd, projPath);
-      } catch (err) {
-        console.error(
-          chalk.red(`\n  ✘ Failed to launch workspace: ${(err as Error).message}\n`),
-        );
-        process.exit(1);
-      }
+      launchOne(proj.captainName, "captain", projPath, config.defaults.permissions?.captain || "acceptEdits", false, true);
     }
   });

--- a/src/commands/reactor.ts
+++ b/src/commands/reactor.ts
@@ -1,0 +1,310 @@
+import { Command } from "commander";
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { fileURLToPath } from "node:url";
+import chalk from "chalk";
+import { loadConfig, loadReactions, saveReactions, resolveHome } from "../config.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const CONFIG_DIR = path.join(os.homedir(), ".config", "cockpit");
+const STATE_FILE = path.join(CONFIG_DIR, "reactor-state.json");
+
+function getScriptsDir(): string {
+  const candidates = [
+    path.join(__dirname, "..", "..", "scripts"),
+    path.join(os.homedir(), ".config", "cockpit", "scripts"),
+  ];
+  for (const dir of candidates) {
+    if (fs.existsSync(path.join(dir, "reactor-cycle.sh"))) {
+      return dir;
+    }
+  }
+  return candidates[0];
+}
+
+function checkGhCli(): boolean {
+  try {
+    execSync("gh auth status", { stdio: "pipe" });
+    return true;
+  } catch {
+    try {
+      execSync("which gh", { stdio: "pipe" });
+      console.log(chalk.yellow("\n  ⚠ gh CLI is not authenticated. Run: gh auth login\n"));
+    } catch {
+      console.log(chalk.yellow("\n  ⚠ gh CLI not found. Install it: brew install gh"));
+      console.log(chalk.dim("  Then authenticate: gh auth login\n"));
+    }
+    return false;
+  }
+}
+
+export const reactorCommand = new Command("reactor")
+  .description("Manage the reaction engine — poll GitHub, match events, execute actions")
+
+// cockpit reactor check — run one poll cycle
+reactorCommand
+  .command("check")
+  .description("Run one reaction cycle (poll → match → execute)")
+  .option("--dry-run", "Show matched actions without executing them")
+  .action((opts: { dryRun?: boolean }) => {
+    if (!checkGhCli()) return;
+
+    const reactions = loadReactions();
+    const repos = reactions.github?.repos || {};
+    const repoCount = Object.keys(repos).length;
+
+    if (repoCount === 0) {
+      console.log(chalk.yellow("\n  No GitHub repos configured. Add one with: cockpit reactor add <project>\n"));
+      return;
+    }
+
+    console.log(chalk.bold(`\n  ⚡ Running reaction cycle (${repoCount} repos)\n`));
+
+    const scriptsDir = getScriptsDir();
+    const cycleScript = path.join(scriptsDir, "reactor-cycle.sh");
+
+    if (!fs.existsSync(cycleScript)) {
+      console.error(chalk.red(`  ✘ Script not found: ${cycleScript}`));
+      console.log(chalk.dim(`  Run 'cockpit init' to deploy scripts.\n`));
+      return;
+    }
+
+    try {
+      if (opts.dryRun) {
+        // Poll and match only, don't execute
+        const pollScript = path.join(scriptsDir, "poll-github.sh");
+        const matchScript = path.join(scriptsDir, "match-reactions.sh");
+        const eventsFile = path.join(CONFIG_DIR, "reactor-events", "dry-run.json");
+        fs.mkdirSync(path.dirname(eventsFile), { recursive: true });
+
+        console.log(chalk.dim("  Polling GitHub..."));
+        execSync(`"${pollScript}" > "${eventsFile}"`, { stdio: ["pipe", "pipe", "inherit"] });
+
+        console.log(chalk.dim("  Matching reactions..."));
+        const actions = execSync(`"${matchScript}" "${eventsFile}"`, { encoding: "utf-8" });
+        const parsed = JSON.parse(actions);
+
+        if (parsed.length === 0) {
+          console.log(chalk.green("  ✔ No actions to execute\n"));
+        } else {
+          console.log(chalk.bold(`\n  ${parsed.length} action(s) would execute:\n`));
+          for (const action of parsed) {
+            const icon = action.priority === "high" ? "🚨" : "→";
+            console.log(`  ${icon} ${chalk.cyan(action.rule)}: ${action.action} → ${action.project} #${action.number || ""}`);
+            if (action.message) {
+              console.log(chalk.dim(`    ${action.message.split("\n")[0].slice(0, 80)}`));
+            }
+          }
+          console.log("");
+        }
+        fs.rmSync(eventsFile, { force: true });
+      } else {
+        const output = execSync(`"${cycleScript}"`, { encoding: "utf-8", stdio: ["pipe", "pipe", "inherit"] });
+        console.log(output);
+      }
+    } catch (err) {
+      console.error(chalk.red(`  ✘ Cycle failed: ${(err as Error).message}`));
+    }
+  });
+
+// cockpit reactor status — show reactor state
+reactorCommand
+  .command("status")
+  .description("Show reactor state and last poll info")
+  .action(() => {
+    const reactions = loadReactions();
+    const ghOk = checkGhCli();
+
+    console.log(chalk.bold("\n  ⚡ Reactor Status\n"));
+    console.log(`  ${chalk.dim("gh CLI:")}        ${ghOk ? chalk.green("authenticated") : chalk.red("not ready")}`);
+
+    // Config summary
+    const repos = reactions.github?.repos || {};
+    const repoCount = Object.keys(repos).length;
+    const enabledRules = Object.entries(reactions.reactions || {})
+      .filter(([_, r]) => r.enabled !== false)
+      .map(([name]) => name);
+
+    console.log(`  ${chalk.dim("Poll interval:")} ${reactions.engine?.poll_interval || "5m"}`);
+    console.log(`  ${chalk.dim("Repos watched:")} ${repoCount}`);
+    for (const [name, repo] of Object.entries(repos)) {
+      console.log(`    ${chalk.cyan(name)} → ${repo.owner}/${repo.repo}`);
+    }
+
+    console.log(`  ${chalk.dim("Active rules:")}  ${enabledRules.length}`);
+    for (const rule of enabledRules) {
+      console.log(`    ${chalk.green("●")} ${rule}`);
+    }
+
+    const disabledRules = Object.entries(reactions.reactions || {})
+      .filter(([_, r]) => r.enabled === false)
+      .map(([name]) => name);
+    if (disabledRules.length > 0) {
+      console.log(`  ${chalk.dim("Disabled rules:")} ${disabledRules.length}`);
+      for (const rule of disabledRules) {
+        console.log(`    ${chalk.dim("○")} ${rule}`);
+      }
+    }
+
+    // GitHub Project
+    if (reactions.github?.project) {
+      const proj = reactions.github.project;
+      console.log(`  ${chalk.dim("GitHub Project:")} ${proj.owner}#${proj.number}`);
+    }
+
+    // State
+    if (fs.existsSync(STATE_FILE)) {
+      try {
+        const state = JSON.parse(fs.readFileSync(STATE_FILE, "utf-8"));
+        const lastPoll = state.last_poll;
+        const processedCount = Object.keys(state.processed_events || {}).length;
+
+        console.log(`\n  ${chalk.dim("Last poll:")}      ${lastPoll || "never"}`);
+        console.log(`  ${chalk.dim("Events tracked:")} ${processedCount}`);
+      } catch {
+        console.log(`\n  ${chalk.dim("State file:")} ${chalk.yellow("corrupted")}`);
+      }
+    } else {
+      console.log(`\n  ${chalk.dim("Last poll:")}      ${chalk.yellow("never run")}`);
+    }
+
+    console.log("");
+  });
+
+// cockpit reactor add <project> — wire up a project for reactor watching
+reactorCommand
+  .command("add")
+  .description("Add a project's GitHub repo to reactor watch list")
+  .argument("<project>", "Project name (must exist in cockpit config)")
+  .option("--owner <owner>", "GitHub owner/org (auto-detected from git remote if omitted)")
+  .option("--repo <repo>", "GitHub repo name (auto-detected from git remote if omitted)")
+  .action((project: string, opts: { owner?: string; repo?: string }) => {
+    const config = loadConfig();
+    const reactions = loadReactions();
+
+    if (!config.projects[project]) {
+      console.error(chalk.red(`\n  ✘ Project '${project}' not found in cockpit config.`));
+      console.log(chalk.dim("  Run 'cockpit projects list' to see registered projects.\n"));
+      process.exit(1);
+    }
+
+    let owner = opts.owner;
+    let repo = opts.repo;
+
+    // Auto-detect from git remote
+    if (!owner || !repo) {
+      const projPath = resolveHome(config.projects[project].path);
+      try {
+        const remoteUrl = execSync(`git -C "${projPath}" remote get-url origin`, { encoding: "utf-8" }).trim();
+        // Parse: git@github.com:owner/repo.git or https://github.com/owner/repo.git
+        const sshMatch = remoteUrl.match(/github\.com[:/]([^/]+)\/(.+?)(?:\.git)?$/);
+        if (sshMatch) {
+          owner = owner || sshMatch[1];
+          repo = repo || sshMatch[2];
+        }
+      } catch {
+        if (!owner || !repo) {
+          console.error(chalk.red("\n  ✘ Could not detect GitHub remote. Specify --owner and --repo manually.\n"));
+          process.exit(1);
+        }
+      }
+    }
+
+    if (!owner || !repo) {
+      console.error(chalk.red("\n  ✘ Could not determine owner/repo. Specify --owner and --repo manually.\n"));
+      process.exit(1);
+    }
+
+    // Add to reactions config
+    if (!reactions.github) {
+      reactions.github = { repos: {} };
+    }
+    if (!reactions.github.repos) {
+      reactions.github.repos = {};
+    }
+
+    const existed = !!reactions.github.repos[project];
+    reactions.github.repos[project] = { owner, repo };
+    saveReactions(reactions);
+
+    if (existed) {
+      console.log(chalk.green(`\n  ✔ Updated ${project} → ${owner}/${repo}\n`));
+    } else {
+      console.log(chalk.green(`\n  ✔ Added ${project} → ${owner}/${repo}`));
+      console.log(chalk.dim(`  Reactor will now watch this repo. Test with: cockpit reactor check --dry-run\n`));
+    }
+  });
+
+// cockpit reactor remove <project> — stop watching a project
+reactorCommand
+  .command("remove")
+  .description("Remove a project from reactor watch list")
+  .argument("<project>", "Project name")
+  .action((project: string) => {
+    const reactions = loadReactions();
+
+    if (!reactions.github?.repos?.[project]) {
+      console.log(chalk.yellow(`\n  Project '${project}' is not in the reactor watch list.\n`));
+      return;
+    }
+
+    delete reactions.github.repos[project];
+    saveReactions(reactions);
+    console.log(chalk.green(`\n  ✔ Removed '${project}' from reactor watch list.\n`));
+  });
+
+// cockpit reactor list — show watched repos
+reactorCommand
+  .command("list")
+  .description("List all repos the reactor is watching")
+  .action(() => {
+    const reactions = loadReactions();
+    const repos = reactions.github?.repos || {};
+    const entries = Object.entries(repos);
+
+    if (entries.length === 0) {
+      console.log(chalk.yellow("\n  No repos configured. Add one with: cockpit reactor add <project>\n"));
+      return;
+    }
+
+    console.log(chalk.bold("\n  Reactor Watch List\n"));
+    for (const [name, repo] of entries) {
+      console.log(`  ${chalk.cyan(name)} → ${repo.owner}/${repo.repo}`);
+    }
+    console.log("");
+  });
+
+// cockpit reactor config — quick edit helper
+reactorCommand
+  .command("config")
+  .description("Show path to reactions.json for editing")
+  .action(() => {
+    const configPath = path.join(CONFIG_DIR, "reactions.json");
+    if (fs.existsSync(configPath)) {
+      console.log(chalk.bold(`\n  Reactions config: ${configPath}\n`));
+    } else {
+      console.log(chalk.yellow(`\n  No reactions.json found at ${configPath}`));
+      console.log(chalk.dim("  Run 'cockpit init' to deploy the default config.\n"));
+    }
+  });
+
+// cockpit reactor reset — clear processed events state
+reactorCommand
+  .command("reset")
+  .description("Clear reactor state (re-process all events on next poll)")
+  .action(() => {
+    if (fs.existsSync(STATE_FILE)) {
+      fs.writeFileSync(STATE_FILE, JSON.stringify({
+        processed_events: {},
+        pending_retries: {},
+        last_poll: null,
+      }, null, 2));
+      console.log(chalk.green("\n  ✔ Reactor state cleared. All events will be re-evaluated on next poll.\n"));
+    } else {
+      console.log(chalk.dim("\n  No state file to clear.\n"));
+    }
+  });

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,63 @@ export interface ProjectConfig {
 export interface PermissionConfig {
   command: string;   // permission mode for the command session
   captain: string;   // permission mode for captain sessions
+  reactor?: string;  // permission mode for reactor session
+}
+
+// --- Reaction Engine Types ---
+
+export interface GitHubRepoConfig {
+  owner: string;
+  repo: string;
+}
+
+export interface GitHubProjectConfig {
+  owner: string;
+  number: number;
+  status_field: string;
+  columns: {
+    ready: string;
+    in_progress: string;
+    review: string;
+    done: string;
+  };
+}
+
+export interface ReactionTrigger {
+  label?: string;
+  state?: string;
+  not_assigned?: boolean;
+  checks?: "success" | "failure" | "pending";
+  review_decision?: "approved" | "changes_requested" | "review_required";
+  no_update_for?: string;   // e.g. "2h", "30m"
+  status_contains?: string;
+  event?: string;
+}
+
+export interface ReactionRule {
+  enabled: boolean;
+  source: "github-issues" | "github-prs" | "captain-status";
+  trigger: ReactionTrigger;
+  action: "delegate-to-captain" | "send-to-captain" | "auto-merge" | "escalate" | "update-project-status" | "send-to-command";
+  message?: string;
+  priority?: "normal" | "high";
+  project_status?: string;
+  merge_method?: "merge" | "squash" | "rebase";
+  retries?: number;
+  escalate_after?: string;  // e.g. "30m"
+}
+
+export interface ReactionsConfig {
+  engine: {
+    poll_interval: string;    // e.g. "5m"
+    state_file: string;
+    max_retries: number;
+  };
+  github: {
+    repos: Record<string, GitHubRepoConfig>;
+    project?: GitHubProjectConfig;
+  };
+  reactions: Record<string, ReactionRule>;
 }
 
 export interface CockpitConfig {
@@ -77,4 +134,34 @@ export function saveConfig(
 
 export function resolveHome(p: string): string {
   return p.startsWith("~") ? p.replace("~", os.homedir()) : p;
+}
+
+// --- Reactions Config ---
+
+export const DEFAULT_REACTIONS_PATH = path.join(CONFIG_DIR, "reactions.json");
+
+export function loadReactions(reactionsPath = DEFAULT_REACTIONS_PATH): ReactionsConfig {
+  try {
+    const raw = fs.readFileSync(reactionsPath, "utf-8");
+    return JSON.parse(raw) as ReactionsConfig;
+  } catch {
+    return {
+      engine: {
+        poll_interval: "5m",
+        state_file: path.join(CONFIG_DIR, "reactor-state.json"),
+        max_retries: 2,
+      },
+      github: { repos: {} },
+      reactions: {},
+    };
+  }
+}
+
+export function saveReactions(
+  reactions: ReactionsConfig,
+  reactionsPath = DEFAULT_REACTIONS_PATH,
+): void {
+  const dir = path.dirname(reactionsPath);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(reactionsPath, JSON.stringify(reactions, null, 2) + "\n");
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { statusCommand } from "./commands/status.js";
 import { launchCommand } from "./commands/launch.js";
 import { shutdownCommand } from "./commands/shutdown.js";
 import { feedbackCommand } from "./commands/feedback.js";
+import { reactorCommand } from "./commands/reactor.js";
 
 const program = new Command();
 
@@ -23,5 +24,6 @@ program.addCommand(statusCommand);
 program.addCommand(launchCommand);
 program.addCommand(shutdownCommand);
 program.addCommand(feedbackCommand);
+program.addCommand(reactorCommand);
 
 program.parse();


### PR DESCRIPTION
## Summary

- Adds a **reactor** workspace that periodically polls GitHub Issues/PRs and captain status, matches events against declarative rules in `reactions.json`, and executes actions automatically
- New CLI: `cockpit reactor {add,remove,list,check,status,config,reset}` — `add` auto-detects GitHub owner/repo from git remote
- 8 built-in reaction rules: issue delegation, CI failure notification, review feedback routing, stale captain escalation, auto-merge (opt-in)
- Also includes prior session work: captain hard rules, OpenSpace-inspired learnings system, plugin skills architecture, session freshness, workspace pinning

## Test plan

- [ ] `cockpit reactor status` shows rules and gh CLI status
- [ ] `cockpit reactor add <project>` auto-detects GitHub remote
- [ ] `cockpit reactor check --dry-run` polls without executing
- [ ] `cockpit launch --all` spawns reactor alongside command and captains
- [ ] `cockpit reactor reset` clears processed events state