### PR TITLE
feat: model routing config for cost-optimized agent spawning

### DIFF
--- a/orchestrator/captain.CLAUDE.md
+++ b/orchestrator/captain.CLAUDE.md
@@ -21,6 +21,7 @@ Use the `cockpit:captain-ops` skill — it has your full startup checklist, crew
 4. **Write status** after every significant event (task received, crew spawned, task done, failures).
 5. **Record learnings** when something unexpected happens or a pattern emerges.
 6. **Write a daily log** at end of day — use the `cockpit:daily-log` skill.
+7. **Model routing**: Spawn crew with `model: "sonnet"`, reviews with `model: "opus"`, exploration with `model: "haiku"`. See captain-ops for examples.
 
 ## Available Skills
 

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -79,19 +79,40 @@ mcp__task-master-ai__expand_task(id: "1", projectRoot: "{projectPath}")
 
 **You MUST spawn a crew member for ANY coding task** — even a one-line change. You are a coordinator. You plan, delegate, review, and merge. You do NOT write code yourself.
 
-Use the **Agent tool** with `team_name` and `isolation: "worktree"`:
+Use the **Agent tool** with `team_name`, `isolation: "worktree"`, and the appropriate `model`:
 ```
 Agent(
   team_name: "{project}-crew",
   name: "🔧 {project}-crew-{task}",
   isolation: "worktree",
+  model: "sonnet",
   prompt: "You are a crew member on {project}. Your task: {description}. Branch from: {branch}. Files involved: {files}."
+)
+```
+
+For **review tasks**, use Opus for higher quality:
+```
+Agent(
+  team_name: "{project}-crew",
+  name: "🔍 {project}-review-{task}",
+  model: "opus",
+  prompt: "Review the changes on branch {branch}. Check for: correctness, edge cases, test coverage, style."
+)
+```
+
+For **exploration/research**, use Haiku for cost efficiency:
+```
+Agent(
+  name: "explore-{topic}",
+  model: "haiku",
+  prompt: "Quickly find: {question}. Return a concise answer."
 )
 ```
 
 - Do **NOT** manually run `git worktree add`
 - Do **NOT** edit source code yourself — always delegate to crew
 - Respect `maxCrew` limit
+- **Model routing**: `sonnet` for coding, `opus` for reviews, `haiku` for exploration
 - Give clear context: what to change, which files, which branch to base from
 - Crew members **persist** — you can send follow-up instructions via `SendMessage(to: "🔧 {project}-crew-{task}", message: "...")`
 

--- a/scripts/spawn-workspace.sh
+++ b/scripts/spawn-workspace.sh
@@ -90,6 +90,20 @@ elif [ "$PERM_MODE" = "bypassPermissions" ]; then
   CLAUDE_CMD="${CLAUDE_CMD} --dangerously-skip-permissions"
 fi
 
+# Read model routing from config
+MODEL=$(python3 -c "
+import json
+try:
+    cfg = json.load(open('${HOME}/.config/cockpit/config.json'))
+    models = cfg.get('defaults', {}).get('models', {})
+    print(models.get('$ROLE', ''))
+except: print('')
+" 2>/dev/null)
+
+if [ -n "$MODEL" ]; then
+  CLAUDE_CMD="${CLAUDE_CMD} --model ${MODEL}"
+fi
+
 # Append role template (slim — detailed instructions are in cockpit skills)
 ROLE_FILE="${TEMPLATES_DIR}/${ROLE}.CLAUDE.md"
 if [ -f "$ROLE_FILE" ]; then

--- a/src/commands/launch.ts
+++ b/src/commands/launch.ts
@@ -5,7 +5,7 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import chalk from "chalk";
-import { loadConfig, resolveHome } from "../config.js";
+import { loadConfig, resolveHome, type ModelRoutingConfig } from "../config.js";
 
 const CMUX_BIN = "/Applications/cmux.app/Contents/Resources/bin/cmux";
 const CMUX_APP = "/Applications/cmux.app";
@@ -123,13 +123,17 @@ function findWorkspaceRef(name: string): string | null {
   }
 }
 
-function buildClaudeCmd(role: string, fresh: boolean, permissionMode: string): string {
+function buildClaudeCmd(role: string, fresh: boolean, permissionMode: string, model?: string): string {
   let cmd = fresh ? "claude" : "claude -c";
 
   if (permissionMode === "acceptEdits") {
     cmd += " --permission-mode acceptEdits";
   } else if (permissionMode === "bypassPermissions") {
     cmd += " --dangerously-skip-permissions";
+  }
+
+  if (model) {
+    cmd += ` --model ${model}`;
   }
 
   // Append role-specific template (slim — detailed instructions are in cockpit skills)
@@ -231,7 +235,8 @@ export const launchCommand = new Command("launch")
         }
       }
 
-      const claudeCmd = buildClaudeCmd(role, forceFresh, permissionMode);
+      const model = config.defaults.models?.[role as keyof ModelRoutingConfig];
+      const claudeCmd = buildClaudeCmd(role, forceFresh, permissionMode, model);
       recordSession(workspaceName, role);
 
       // Auto-trigger startup checklist

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,17 @@ export interface PermissionConfig {
   reactor?: string;  // permission mode for reactor session
 }
 
+export type ModelAlias = "opus" | "sonnet" | "haiku";
+
+export interface ModelRoutingConfig {
+  command: ModelAlias;
+  captain: ModelAlias;
+  crew: ModelAlias;
+  reactor: ModelAlias;
+  exploration: ModelAlias;
+  review: ModelAlias;
+}
+
 // --- Reaction Engine Types ---
 
 export interface GitHubRepoConfig {
@@ -83,6 +94,7 @@ export interface CockpitConfig {
     worktreeDir: string;
     teammateMode: string;
     permissions: PermissionConfig;
+    models?: ModelRoutingConfig;
   };
   metrics: {
     enabled: boolean;
@@ -105,6 +117,14 @@ export function getDefaultConfig(): CockpitConfig {
       permissions: {
         command: "default",
         captain: "acceptEdits",
+      },
+      models: {
+        command: "opus",
+        captain: "opus",
+        crew: "sonnet",
+        reactor: "sonnet",
+        exploration: "haiku",
+        review: "opus",
       },
     },
     metrics: {


### PR DESCRIPTION
## Summary
- Adds `ModelRoutingConfig` to cockpit config with per-role model assignments (command=opus, captain=opus, crew=sonnet, reactor=sonnet, exploration=haiku, review=opus)
- `launch.ts` passes `--model` flag when building claude CLI commands
- `spawn-workspace.sh` reads model config and applies the same flag
- Captain-ops skill updated with model-aware Agent() examples for crew/review/exploration

## Test plan
- [ ] `npm run build` passes cleanly
- [ ] Existing configs without `models` field continue to work (backward compat)
- [ ] `cockpit launch` generates claude commands with `--model` flag
- [ ] Captain Agent() spawning examples include model parameter

Closes #2