### PR TITLE
feat: GSD integration for crew wave-based execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,20 @@ cockpit doctor
 - [Claude Code](https://claude.ai/code) >= 2.1.32
 - [cmux](https://cmux.dev) (macOS terminal for coding agents)
 - [Obsidian](https://obsidian.md) (status tracking)
-- Node.js >= 18
+- Node.js >= 22
 
-### Claude Code Plugins
+### Required Integrations
 
-```
+```bash
+# Claude Memory — cross-session continuity
 /plugin marketplace add thedotmack/claude-mem
 /plugin install claude-mem
+
+# Task Master — PRD decomposition (works via Max subscription)
+npm install -g task-master-ai
+
+# GSD — wave-based execution for crew (fresh context per step)
+npx get-shit-done-cc@latest --claude --global
 ```
 
 See `core/plugins.md` for full plugin setup.
@@ -53,11 +60,15 @@ See `obsidian/plugins.md` for Dataview, Templater setup.
 | `cockpit init` | First-time setup — config, hub vault, scripts |
 | `cockpit launch` | Start the command workspace |
 | `cockpit launch <project>` | Start a specific project captain |
+| `cockpit launch --all` | Launch command + reactor + all captains |
 | `cockpit status` | Show all project status (no Claude needed) |
+| `cockpit standup` | Daily standup summary (zero LLM tokens) |
 | `cockpit doctor` | Health check — verify dependencies |
 | `cockpit projects list` | List registered projects |
 | `cockpit projects add <name> <path>` | Register a project |
 | `cockpit projects remove <name>` | Unregister a project |
+| `cockpit reactor check` | Run one reactor poll cycle |
+| `cockpit reactor status` | Show reactor state |
 | `cockpit shutdown [project]` | Graceful shutdown |
 | `cockpit feedback` | Open opt-in feedback issue |
 
@@ -65,18 +76,35 @@ See `obsidian/plugins.md` for Dataview, Templater setup.
 
 ### Roles
 
-- **Command** — overseer, monitors all projects, spawns captains
-- **Captain** — project leader, uses Agent Teams + git worktrees
-- **Crew** — worker in a worktree, can spawn subagents for parallel work
+- **Command** (Opus) — overseer, monitors all projects, spawns captains
+- **Captain** (Opus) — project leader, uses Agent Teams + git worktrees
+- **Crew** (Sonnet) — worker in a worktree, uses GSD for complex tasks
+- **Reactor** (Sonnet) — always-on GitHub event poller, auto-delegates to captains
+
+### Model Routing
+
+Each role runs on the optimal model for cost/quality tradeoff. Configured in `config.json`:
+- Command/Captain/Review: Opus (coordination + quality)
+- Crew/Reactor: Sonnet (execution)
+- Exploration: Haiku (cheap lookups)
 
 ### Obsidian Vaults (Hub-and-Spoke)
 
-- **Hub vault** (`~/cockpit-hub`) — cross-project dashboard
-- **Spoke vaults** (`{project}/.cockpit-vault/`) — per-project status
+- **Hub vault** (`~/cockpit-hub`) — cross-project dashboard + hub wiki
+- **Spoke vaults** — per-project status, learnings, and wiki
 
-### Self-Enhancement
+### Knowledge System
 
-Agents record learnings. The command session reviews them, identifies patterns, and proposes improvements. Changes only apply after user approval.
+- **Learnings** — raw observations recorded by captains after tasks
+- **Wiki** — compiled, indexed knowledge pages in spoke vaults (`wiki/pages/`)
+- **Hub Wiki** — cross-project knowledge aggregated by command
+- Scripts: `wiki-ingest.sh`, `wiki-query.sh`, `wiki-log.sh`
+
+### Session Continuity
+
+- **Handoff files** — captain writes context on shutdown, reads on startup
+- **Session freshness** — auto-detects new day or template changes, forces fresh context
+- **claude-mem** — cross-session memory via MCP plugin
 
 ## Config
 
@@ -90,14 +118,26 @@ Agents record learnings. The command session reviews them, identifies patterns, 
     "brove": {
       "path": "~/projects/brove",
       "captainName": "brove-captain",
-      "spokeVault": "~/projects/.cockpit-vault",
+      "spokeVault": "~/cockpit-hub/spokes/brove",
       "host": "local"
     }
   },
   "defaults": {
     "maxCrew": 5,
     "worktreeDir": ".worktrees",
-    "teammateMode": "in-process"
+    "teammateMode": "in-process",
+    "permissions": {
+      "command": "default",
+      "captain": "acceptEdits"
+    },
+    "models": {
+      "command": "opus",
+      "captain": "opus",
+      "crew": "sonnet",
+      "reactor": "sonnet",
+      "exploration": "haiku",
+      "review": "opus"
+    }
   }
 }
 ```

--- a/orchestrator/crew.CLAUDE.md
+++ b/orchestrator/crew.CLAUDE.md
@@ -15,6 +15,21 @@ You are a crew member working on a specific task within a git worktree.
 
 Your working directory is a git worktree. Your branch is isolated from main. Work freely without affecting other crew members.
 
+## GSD for Complex Tasks
+
+When your captain assigns a **multi-step implementation task** (3+ distinct steps, multiple files, or significant scope), use GSD's wave-based execution for fresh context per step:
+
+1. `/gsd:plan-phase 1` — break the task into atomic plans with verification steps
+2. `/gsd:execute-phase 1` — GSD spawns subagents per task in parallel waves, each with fresh 200K context
+3. Each subagent makes atomic git commits — progress is never lost
+
+**When NOT to use GSD:**
+- Simple one-file changes or bug fixes — just do them directly
+- Tasks your captain marked as "quick" or "simple"
+- If you're unsure, just start coding — you can always switch to GSD if it gets complex
+
+GSD creates a `.planning/` directory in your worktree — this is normal and expected.
+
 ## Parallel Subagents
 
 When your task has independent sub-components (e.g., client + server), dispatch subagents:

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -120,6 +120,8 @@ Agent(
 - **Model routing**: `sonnet` for coding, `opus` for reviews, `haiku` for exploration
 - Give clear context: what to change, which files, which branch to base from
 - Crew members **persist** — you can send follow-up instructions via `SendMessage(to: "🔧 {project}-crew-{task}", message: "...")`
+- **For complex multi-step tasks** (3+ steps, multiple files): tell crew to use GSD — add to the prompt: "This is a complex task. Use `/gsd:plan-phase` and `/gsd:execute-phase` for wave-based execution with fresh context per step."
+- **For simple tasks**: don't mention GSD — crew will handle it directly
 
 ## Task Coordination
 


### PR DESCRIPTION
## Summary
- Crew template updated with GSD section: when to use `/gsd:plan-phase` + `/gsd:execute-phase`, when NOT to
- Captain-ops skill updated: instructs captain to tell crew to use GSD for complex multi-step tasks (3+ steps), skip for simple ones
- GSD v1.34.2 installed globally — already available to all Claude sessions

## Design
GSD is opt-in per task. Captain decides complexity, crew decides execution method. No changes to agent hierarchy — GSD subagents are ephemeral within crew sessions.

## Test plan
- [ ] Crew session can run `/gsd:help` and see available commands
- [ ] Captain spawns crew with GSD prompt for complex task → crew uses wave execution
- [ ] Captain spawns crew without GSD prompt for simple task → crew works directly
- [ ] GSD `.planning/` dir stays in worktree, doesn't leak to main

Closes #4