### PR TITLE
CI Feedback Reactor (#3) + cockpit retro (#6)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (205 symbols, 301 relationships, 7 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (208 symbols, 301 relationships, 7 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (208 symbols, 301 relationships, 7 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (227 symbols, 352 relationships, 8 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,101 @@
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **claude-cockpit** (205 symbols, 301 relationships, 7 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## When Debugging
+
+1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
+2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
+3. `READ gitnexus://repo/claude-cockpit/process/{processName}` — trace the full execution flow step by step
+4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
+
+## When Refactoring
+
+- **Renaming**: MUST use `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` first. Review the preview — graph edits are safe, text_search edits need manual review. Then run with `dry_run: false`.
+- **Extracting/Splitting**: MUST run `gitnexus_context({name: "target"})` to see all incoming/outgoing refs, then `gitnexus_impact({target: "target", direction: "upstream"})` to find all external callers before moving code.
+- After any refactor: run `gitnexus_detect_changes({scope: "all"})` to verify only expected files changed.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Tools Quick Reference
+
+| Tool | When to use | Command |
+|------|-------------|---------|
+| `query` | Find code by concept | `gitnexus_query({query: "auth validation"})` |
+| `context` | 360-degree view of one symbol | `gitnexus_context({name: "validateUser"})` |
+| `impact` | Blast radius before editing | `gitnexus_impact({target: "X", direction: "upstream"})` |
+| `detect_changes` | Pre-commit scope check | `gitnexus_detect_changes({scope: "staged"})` |
+| `rename` | Safe multi-file rename | `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` |
+| `cypher` | Custom graph queries | `gitnexus_cypher({query: "MATCH ..."})` |
+
+## Impact Risk Levels
+
+| Depth | Meaning | Action |
+|-------|---------|--------|
+| d=1 | WILL BREAK — direct callers/importers | MUST update these |
+| d=2 | LIKELY AFFECTED — indirect deps | Should test |
+| d=3 | MAY NEED TESTING — transitive | Test if critical path |
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/claude-cockpit/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/claude-cockpit/clusters` | All functional areas |
+| `gitnexus://repo/claude-cockpit/processes` | All execution flows |
+| `gitnexus://repo/claude-cockpit/process/{name}` | Step-by-step execution trace |
+
+## Self-Check Before Finishing
+
+Before completing any code modification task, verify:
+1. `gitnexus_impact` was run for all modified symbols
+2. No HIGH/CRITICAL risk warnings were ignored
+3. `gitnexus_detect_changes()` confirms changes match expected scope
+4. All d=1 (WILL BREAK) dependents were updated
+
+## Keeping the Index Fresh
+
+After committing code changes, the GitNexus index becomes stale. Re-run analyze to update it:
+
+```bash
+npx gitnexus analyze
+```
+
+If the index previously included embeddings, preserve them by adding `--embeddings`:
+
+```bash
+npx gitnexus analyze --embeddings
+```
+
+To check whether embeddings exist, inspect `.gitnexus/meta.json` — the `stats.embeddings` field shows the count (0 means no embeddings). **Running analyze without `--embeddings` will delete any previously generated embeddings.**
+
+> Claude Code users: A PostToolUse hook handles this automatically after `git commit` and `git merge`.
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (205 symbols, 301 relationships, 7 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (208 symbols, 301 relationships, 7 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (208 symbols, 301 relationships, 7 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (227 symbols, 352 relationships, 8 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,101 @@
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **claude-cockpit** (205 symbols, 301 relationships, 7 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## When Debugging
+
+1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
+2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
+3. `READ gitnexus://repo/claude-cockpit/process/{processName}` — trace the full execution flow step by step
+4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
+
+## When Refactoring
+
+- **Renaming**: MUST use `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` first. Review the preview — graph edits are safe, text_search edits need manual review. Then run with `dry_run: false`.
+- **Extracting/Splitting**: MUST run `gitnexus_context({name: "target"})` to see all incoming/outgoing refs, then `gitnexus_impact({target: "target", direction: "upstream"})` to find all external callers before moving code.
+- After any refactor: run `gitnexus_detect_changes({scope: "all"})` to verify only expected files changed.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Tools Quick Reference
+
+| Tool | When to use | Command |
+|------|-------------|---------|
+| `query` | Find code by concept | `gitnexus_query({query: "auth validation"})` |
+| `context` | 360-degree view of one symbol | `gitnexus_context({name: "validateUser"})` |
+| `impact` | Blast radius before editing | `gitnexus_impact({target: "X", direction: "upstream"})` |
+| `detect_changes` | Pre-commit scope check | `gitnexus_detect_changes({scope: "staged"})` |
+| `rename` | Safe multi-file rename | `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` |
+| `cypher` | Custom graph queries | `gitnexus_cypher({query: "MATCH ..."})` |
+
+## Impact Risk Levels
+
+| Depth | Meaning | Action |
+|-------|---------|--------|
+| d=1 | WILL BREAK — direct callers/importers | MUST update these |
+| d=2 | LIKELY AFFECTED — indirect deps | Should test |
+| d=3 | MAY NEED TESTING — transitive | Test if critical path |
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/claude-cockpit/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/claude-cockpit/clusters` | All functional areas |
+| `gitnexus://repo/claude-cockpit/processes` | All execution flows |
+| `gitnexus://repo/claude-cockpit/process/{name}` | Step-by-step execution trace |
+
+## Self-Check Before Finishing
+
+Before completing any code modification task, verify:
+1. `gitnexus_impact` was run for all modified symbols
+2. No HIGH/CRITICAL risk warnings were ignored
+3. `gitnexus_detect_changes()` confirms changes match expected scope
+4. All d=1 (WILL BREAK) dependents were updated
+
+## Keeping the Index Fresh
+
+After committing code changes, the GitNexus index becomes stale. Re-run analyze to update it:
+
+```bash
+npx gitnexus analyze
+```
+
+If the index previously included embeddings, preserve them by adding `--embeddings`:
+
+```bash
+npx gitnexus analyze --embeddings
+```
+
+To check whether embeddings exist, inspect `.gitnexus/meta.json` — the `stats.embeddings` field shows the count (0 means no embeddings). **Running analyze without `--embeddings` will delete any previously generated embeddings.**
+
+> Claude Code users: A PostToolUse hook handles this automatically after `git commit` and `git merge`.
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ See `obsidian/plugins.md` for Dataview, Templater setup.
 - **Command** (Opus) — overseer, monitors all projects, spawns captains
 - **Captain** (Opus) — project leader, uses Agent Teams + git worktrees
 - **Crew** (Sonnet) — worker in a worktree, uses GSD for complex tasks
-- **Reactor** (Sonnet) — always-on GitHub event poller, auto-delegates to captains
+- **Reactor** (Sonnet) — always-on GitHub event poller, auto-delegates to captains (incl. auto-fix on CI failure, with escalation after max retries)
 
 ### Model Routing
 

--- a/reactions.json
+++ b/reactions.json
@@ -40,7 +40,7 @@
       "trigger": {
         "checks": "failure"
       },
-      "action": "send-to-captain",
+      "action": "auto-fix-ci",
       "message": "CI failed on PR #{number} ({title}). Check logs and fix: {url}",
       "retries": 2,
       "escalate_after": "30m"

--- a/scripts/execute-reaction.sh
+++ b/scripts/execute-reaction.sh
@@ -19,6 +19,33 @@ URL=$(echo "$ACTION" | python3 -c "import json,sys; print(json.load(sys.stdin).g
 MERGE_METHOD=$(echo "$ACTION" | python3 -c "import json,sys; print(json.load(sys.stdin).get('merge_method','squash'))")
 PROJECT_STATUS=$(echo "$ACTION" | python3 -c "import json,sys; print(json.load(sys.stdin).get('project_status',''))")
 RULE=$(echo "$ACTION" | python3 -c "import json,sys; print(json.load(sys.stdin).get('rule',''))")
+MAX_RETRIES=$(echo "$ACTION" | python3 -c "import json,sys; print(json.load(sys.stdin).get('retries', 2))")
+
+STATE_FILE="${HOME}/.config/cockpit/reactor-state.json"
+
+# Retry counter helpers — keyed by project#number (e.g. "cockpit#16")
+get_retry_count() {
+  local key="$1"
+  [ -f "$STATE_FILE" ] || { echo 0; return; }
+  python3 -c "
+import json
+s = json.load(open('$STATE_FILE'))
+print(s.get('retry_counters', {}).get('$key', 0))
+"
+}
+
+incr_retry_count() {
+  local key="$1"
+  python3 -c "
+import json, os
+path = '$STATE_FILE'
+s = json.load(open(path)) if os.path.exists(path) else {}
+rc = s.setdefault('retry_counters', {})
+rc['$key'] = rc.get('$key', 0) + 1
+json.dump(s, open(path, 'w'), indent=2)
+print(rc['$key'])
+"
+}
 
 # Look up captain workspace name for the project
 get_captain_ws() {
@@ -145,6 +172,93 @@ else:
       "$CMUX" send --workspace "$CMD_WS" "$MESSAGE"
       "$CMUX" send-key --workspace "$CMD_WS" Enter
       echo "✔ Sent to command: ${RULE}"
+    fi
+    ;;
+
+  auto-fix-ci)
+    # CI failed on a PR — re-delegate to captain with failure logs, or escalate after max retries.
+    RETRY_KEY="${PROJECT}#${NUMBER}"
+    CURRENT=$(get_retry_count "$RETRY_KEY")
+
+    if [ "$CURRENT" -ge "$MAX_RETRIES" ]; then
+      # Escalate to command
+      CMD_WS=$(get_command_ws)
+      ESC_MSG="🚨 CI failed ${CURRENT}× on ${PROJECT} PR #${NUMBER} — auto-fix exhausted (max ${MAX_RETRIES}). Needs manual triage: ${URL}"
+      if [ -n "$CMD_WS" ]; then
+        "$CMUX" send --workspace "$CMD_WS" "$ESC_MSG"
+        "$CMUX" send-key --workspace "$CMD_WS" Enter
+        echo "✔ Escalated PR #${NUMBER} to command (retries: ${CURRENT}/${MAX_RETRIES})"
+      else
+        echo "⚠️  Command offline. Escalation: ${ESC_MSG}"
+      fi
+      exit 0
+    fi
+
+    # Resolve repo for log fetching
+    REPO_INFO=$(python3 -c "
+import json
+with open('${HOME}/.config/cockpit/reactions.json') as f:
+    cfg = json.load(f)
+repos = cfg.get('github', {}).get('repos', {})
+r = repos.get('$PROJECT', {})
+print(f\"{r.get('owner','')}/{r.get('repo','')}\")
+")
+    if [ -z "$REPO_INFO" ] || [ "$REPO_INFO" = "/" ]; then
+      echo "✘ No repo configured for project '$PROJECT'" >&2
+      exit 1
+    fi
+
+    # Fetch failed check names + log tail for the PR's head commit
+    FAIL_SUMMARY=$(gh pr checks "$NUMBER" --repo "$REPO_INFO" 2>/dev/null | awk -F'\t' '$2=="fail"{print "- "$1" ("$4")"}' | head -20 || true)
+    FAIL_RUN_ID=$(gh pr checks "$NUMBER" --repo "$REPO_INFO" --json name,state,link 2>/dev/null \
+      | python3 -c "
+import json, sys, re
+try:
+    checks = json.load(sys.stdin)
+    for c in checks:
+        if c.get('state') == 'FAILURE':
+            m = re.search(r'/runs/(\d+)', c.get('link',''))
+            if m:
+                print(m.group(1)); break
+except Exception:
+    pass
+" 2>/dev/null || true)
+
+    LOG_TAIL=""
+    if [ -n "$FAIL_RUN_ID" ]; then
+      LOG_TAIL=$(gh run view "$FAIL_RUN_ID" --repo "$REPO_INFO" --log-failed 2>/dev/null | tail -100 || true)
+    fi
+
+    # Build captain prompt
+    CAPTAIN_PROMPT="🔧 Auto-fix CI — ${PROJECT} PR #${NUMBER} (attempt $((CURRENT+1))/${MAX_RETRIES})
+${URL}
+
+Failing checks:
+${FAIL_SUMMARY:-(details unavailable)}
+
+Failed job log tail:
+\`\`\`
+${LOG_TAIL:-(log unavailable)}
+\`\`\`
+
+Spawn a crew: checkout the PR branch, diagnose the failure, apply a fix, commit, and push. If the cause is unclear or outside the PR scope, reply here so I can escalate to command."
+
+    WS=$(get_captain_ws "$PROJECT")
+    if [ "$WS" = "OFFLINE" ]; then
+      echo "⚠️  Captain for '$PROJECT' offline. Spawning..."
+      cockpit launch "$PROJECT" 2>/dev/null || true
+      sleep 5
+      WS=$(get_captain_ws "$PROJECT")
+    fi
+
+    if [ -n "$WS" ] && [ "$WS" != "OFFLINE" ]; then
+      "$CMUX" send --workspace "$WS" "$CAPTAIN_PROMPT"
+      "$CMUX" send-key --workspace "$WS" Enter
+      NEW_COUNT=$(incr_retry_count "$RETRY_KEY")
+      echo "✔ Auto-fix dispatched to ${PROJECT} captain (attempt ${NEW_COUNT}/${MAX_RETRIES})"
+    else
+      echo "✘ Could not reach captain for '$PROJECT'" >&2
+      exit 1
     fi
     ;;
 

--- a/src/commands/retro.ts
+++ b/src/commands/retro.ts
@@ -1,0 +1,204 @@
+import { Command } from "commander";
+import fs from "node:fs";
+import path from "node:path";
+import chalk from "chalk";
+import matter from "gray-matter";
+import { loadConfig, resolveHome, type ProjectConfig } from "../config.js";
+import {
+  readDailyLog,
+  parseSection,
+  getGitCommitsInRange,
+  getMergedPRsInRange,
+  enumerateDays,
+  iso,
+  daysAgo,
+} from "../lib/daily-logs.js";
+
+interface StatusFrontmatter {
+  tasks_total?: number;
+  tasks_completed?: number;
+  tasks_in_progress?: number;
+}
+
+interface ProjectRetro {
+  name: string;
+  shipped: string[];
+  inProgress: string[];
+  blocked: string[];
+  decisions: string[];
+  commits: string[];
+  mergedPRs: string[];
+  tasksCompletedNow: number;
+  tasksInProgressNow: number;
+}
+
+function readStatus(spokeVault: string): StatusFrontmatter {
+  const statusFile = path.join(spokeVault, "status.md");
+  if (!fs.existsSync(statusFile)) return {};
+  try {
+    return matter(fs.readFileSync(statusFile, "utf-8")).data as StatusFrontmatter;
+  } catch {
+    return {};
+  }
+}
+
+function dedupe(items: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const it of items) {
+    const key = it.toLowerCase();
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push(it);
+    }
+  }
+  return out;
+}
+
+function getProjectRetro(
+  name: string,
+  project: ProjectConfig,
+  fromStr: string,
+  toStr: string,
+): ProjectRetro {
+  const spokeVault = resolveHome(project.spokeVault);
+  const status = readStatus(spokeVault);
+
+  const shipped: string[] = [];
+  const inProgress: string[] = [];
+  const blocked: string[] = [];
+  const decisions: string[] = [];
+
+  for (const day of enumerateDays(new Date(fromStr), new Date(toStr))) {
+    const log = readDailyLog(spokeVault, day);
+    if (!log) continue;
+    shipped.push(...parseSection(log.content, "Completed"));
+    inProgress.push(...parseSection(log.content, "In Progress"));
+    blocked.push(...log.blockers);
+    decisions.push(...parseSection(log.content, "Decisions"));
+  }
+
+  const commits = getGitCommitsInRange(
+    project.path,
+    `${fromStr} 00:00:00`,
+    `${toStr} 23:59:59`,
+  );
+  const mergedPRs = getMergedPRsInRange(
+    project.path,
+    `${fromStr} 00:00:00`,
+    `${toStr} 23:59:59`,
+  );
+
+  return {
+    name,
+    shipped: dedupe(shipped),
+    inProgress: dedupe(inProgress),
+    blocked: dedupe(blocked),
+    decisions: dedupe(decisions),
+    commits,
+    mergedPRs,
+    tasksCompletedNow: status.tasks_completed ?? 0,
+    tasksInProgressNow: status.tasks_in_progress ?? 0,
+  };
+}
+
+function renderList(lines: string[], items: string[], raw: boolean, label: string, color: (s: string) => string) {
+  if (items.length === 0) return;
+  lines.push(raw ? `**${label}:**` : color(`${label}:`));
+  for (const it of items) lines.push(`  - ${it}`);
+}
+
+function formatRetro(retros: ProjectRetro[], fromStr: string, toStr: string, raw: boolean): string {
+  const lines: string[] = [];
+  const header = `Retro — ${fromStr} → ${toStr}`;
+  lines.push(raw ? `# ${header}\n` : chalk.bold(`\n${header}\n`));
+
+  let totalCommits = 0;
+  let totalPRs = 0;
+  let totalShipped = 0;
+
+  for (const r of retros) {
+    totalCommits += r.commits.length;
+    totalPRs += r.mergedPRs.length;
+    totalShipped += r.shipped.length;
+
+    lines.push(raw ? `## ${r.name}` : chalk.cyan.bold(`## ${r.name}`));
+
+    renderList(lines, r.shipped, raw, "Shipped", chalk.green);
+    if (r.mergedPRs.length > 0) {
+      lines.push(raw ? `**PRs merged:**` : chalk.green("PRs merged:"));
+      for (const pr of r.mergedPRs) lines.push(`  - ${pr}`);
+    }
+    renderList(lines, r.inProgress, raw, "In Progress", chalk.yellow);
+    renderList(lines, r.blocked, raw, "Blocked", chalk.red);
+    renderList(lines, r.decisions, raw, "Key Decisions", chalk.magenta);
+
+    const metricBits = [
+      `${r.commits.length} commits`,
+      `${r.mergedPRs.length} PRs merged`,
+      `${r.shipped.length} shipped`,
+    ];
+    lines.push(raw ? `*${metricBits.join(" · ")}*` : chalk.dim(`  ${metricBits.join(" · ")}`));
+
+    if (
+      r.shipped.length === 0 &&
+      r.commits.length === 0 &&
+      r.mergedPRs.length === 0 &&
+      r.inProgress.length === 0 &&
+      r.blocked.length === 0
+    ) {
+      lines.push(raw ? "_(no activity in this window)_" : chalk.dim("  (no activity in this window)"));
+    }
+
+    lines.push("");
+  }
+
+  const summary = `${totalShipped} items shipped · ${totalCommits} commits · ${totalPRs} PRs merged`;
+  lines.push(raw ? `---\n*${summary}*\n` : chalk.dim(`--- ${summary} ---\n`));
+
+  return lines.join("\n");
+}
+
+export const retroCommand = new Command("retro")
+  .description("Generate a retro (weekly/sprint summary) from daily logs and git (zero tokens)")
+  .option("-w, --week", "Trailing 7 days (default)")
+  .option("-s, --sprint [days]", "Custom window of N days (default 14 if N omitted)")
+  .option("-p, --project <name>", "Retro for a single project")
+  .option("-a, --all", "All projects (default)")
+  .option("-r, --raw", "Raw markdown output (for pasting into Slack/Obsidian)")
+  .action((opts) => {
+    const config = loadConfig();
+    const projects = Object.entries(config.projects);
+
+    if (projects.length === 0) {
+      console.log(chalk.yellow("\nNo projects registered. Use: cockpit projects add <name> <path>\n"));
+      return;
+    }
+
+    let windowDays = 7;
+    if (opts.sprint !== undefined) {
+      const parsed = typeof opts.sprint === "string" ? parseInt(opts.sprint, 10) : NaN;
+      windowDays = Number.isFinite(parsed) && parsed > 0 ? parsed : 14;
+    } else if (opts.week) {
+      windowDays = 7;
+    }
+
+    const toStr = iso(new Date());
+    const fromStr = iso(daysAgo(windowDays - 1));
+    const raw = !!opts.raw;
+
+    let targets: [string, ProjectConfig][];
+    if (opts.project) {
+      const match = projects.find(([name]) => name === opts.project);
+      if (!match) {
+        console.error(chalk.red(`Project "${opts.project}" not found.`));
+        process.exit(1);
+      }
+      targets = [match];
+    } else {
+      targets = projects;
+    }
+
+    const retros = targets.map(([name, proj]) => getProjectRetro(name, proj, fromStr, toStr));
+    console.log(formatRetro(retros, fromStr, toStr, raw));
+  });

--- a/src/commands/standup.ts
+++ b/src/commands/standup.ts
@@ -1,10 +1,10 @@
 import { Command } from "commander";
 import fs from "node:fs";
 import path from "node:path";
-import { execSync } from "node:child_process";
 import chalk from "chalk";
 import matter from "gray-matter";
 import { loadConfig, resolveHome, type ProjectConfig } from "../config.js";
+import { readDailyLog, getGitCommits, iso, daysAgo } from "../lib/daily-logs.js";
 
 interface StatusFrontmatter {
   project?: string;
@@ -31,48 +31,7 @@ interface ProjectStandup {
 }
 
 function getDateStr(yesterday: boolean): string {
-  const d = new Date();
-  if (yesterday) d.setDate(d.getDate() - 1);
-  return d.toISOString().slice(0, 10);
-}
-
-function readDailyLog(spokeVault: string, dateStr: string): { content: string; blockers: string[] } | null {
-  const logFile = path.join(spokeVault, "daily-logs", `${dateStr}.md`);
-  if (!fs.existsSync(logFile)) return null;
-
-  const raw = fs.readFileSync(logFile, "utf-8");
-  const { content } = matter(raw);
-
-  // Extract blockers section
-  const blockers: string[] = [];
-  const blockerMatch = content.match(/## Blocked\n([\s\S]*?)(?=\n##|$)/);
-  if (blockerMatch) {
-    const lines = blockerMatch[1].trim().split("\n");
-    for (const line of lines) {
-      const trimmed = line.replace(/^[-*]\s*/, "").trim();
-      if (trimmed && trimmed !== "(none)" && trimmed !== "None") {
-        blockers.push(trimmed);
-      }
-    }
-  }
-
-  return { content, blockers };
-}
-
-function getGitCommits(projectPath: string, dateStr: string): string[] {
-  const resolved = resolveHome(projectPath);
-  if (!fs.existsSync(path.join(resolved, ".git"))) return [];
-
-  try {
-    const output = execSync(
-      `git -C "${resolved}" log --since="${dateStr} 00:00:00" --until="${dateStr} 23:59:59" --oneline --no-merges 2>/dev/null`,
-      { encoding: "utf-8", timeout: 5000 },
-    ).trim();
-    if (!output) return [];
-    return output.split("\n").map((l) => l.trim()).filter(Boolean);
-  } catch {
-    return [];
-  }
+  return iso(daysAgo(yesterday ? 1 : 0));
 }
 
 function getProjectStandup(name: string, project: ProjectConfig, dateStr: string): ProjectStandup {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { shutdownCommand } from "./commands/shutdown.js";
 import { feedbackCommand } from "./commands/feedback.js";
 import { reactorCommand } from "./commands/reactor.js";
 import { standupCommand } from "./commands/standup.js";
+import { retroCommand } from "./commands/retro.js";
 
 const program = new Command();
 
@@ -27,5 +28,6 @@ program.addCommand(shutdownCommand);
 program.addCommand(feedbackCommand);
 program.addCommand(reactorCommand);
 program.addCommand(standupCommand);
+program.addCommand(retroCommand);
 
 program.parse();

--- a/src/lib/daily-logs.ts
+++ b/src/lib/daily-logs.ts
@@ -1,0 +1,102 @@
+import fs from "node:fs";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import matter from "gray-matter";
+import { resolveHome } from "../config.js";
+
+export function iso(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export function daysAgo(n: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d;
+}
+
+export function enumerateDays(from: Date, to: Date): string[] {
+  const out: string[] = [];
+  const cur = new Date(from);
+  cur.setHours(0, 0, 0, 0);
+  const end = new Date(to);
+  end.setHours(0, 0, 0, 0);
+  while (cur <= end) {
+    out.push(iso(cur));
+    cur.setDate(cur.getDate() + 1);
+  }
+  return out;
+}
+
+export interface DailyLog {
+  content: string;
+  blockers: string[];
+}
+
+export function readDailyLog(spokeVault: string, dateStr: string): DailyLog | null {
+  const logFile = path.join(spokeVault, "daily-logs", `${dateStr}.md`);
+  if (!fs.existsSync(logFile)) return null;
+
+  const raw = fs.readFileSync(logFile, "utf-8");
+  const { content } = matter(raw);
+
+  const blockers: string[] = [];
+  const blockerMatch = content.match(/## Blocked\n([\s\S]*?)(?=\n##|$)/);
+  if (blockerMatch) {
+    const lines = blockerMatch[1].trim().split("\n");
+    for (const line of lines) {
+      const trimmed = line.replace(/^[-*]\s*/, "").trim();
+      if (trimmed && trimmed !== "(none)" && trimmed !== "None") {
+        blockers.push(trimmed);
+      }
+    }
+  }
+  return { content, blockers };
+}
+
+export function parseSection(content: string, section: string): string[] {
+  const match = content.match(new RegExp(`## ${section}\\n([\\s\\S]*?)(?=\\n##|$)`));
+  if (!match) return [];
+  return match[1]
+    .trim()
+    .split("\n")
+    .map((l) => l.replace(/^[-*]\s*/, "").trim())
+    .filter((l) => l && l !== "(none)" && l !== "None");
+}
+
+export function getGitCommits(projectPath: string, dateStr: string): string[] {
+  return getGitCommitsInRange(projectPath, `${dateStr} 00:00:00`, `${dateStr} 23:59:59`);
+}
+
+export function getGitCommitsInRange(projectPath: string, since: string, until?: string): string[] {
+  const resolved = resolveHome(projectPath);
+  if (!fs.existsSync(path.join(resolved, ".git"))) return [];
+
+  const untilArg = until ? ` --until="${until}"` : "";
+  try {
+    const output = execSync(
+      `git -C "${resolved}" log --since="${since}"${untilArg} --oneline --no-merges 2>/dev/null`,
+      { encoding: "utf-8", timeout: 5000 },
+    ).trim();
+    if (!output) return [];
+    return output.split("\n").map((l) => l.trim()).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+export function getMergedPRsInRange(projectPath: string, since: string, until?: string): string[] {
+  const resolved = resolveHome(projectPath);
+  if (!fs.existsSync(path.join(resolved, ".git"))) return [];
+
+  const untilArg = until ? ` --until="${until}"` : "";
+  try {
+    const output = execSync(
+      `git -C "${resolved}" log --merges --since="${since}"${untilArg} --pretty=format:%s 2>/dev/null`,
+      { encoding: "utf-8", timeout: 5000 },
+    ).trim();
+    if (!output) return [];
+    return output.split("\n").map((l) => l.trim()).filter(Boolean);
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
Combined P1 + P2 reactor/CLI work — two features on one branch.

## Summary
### #3 — CI Feedback Reactor Extension (P1)
- New reactor action `auto-fix-ci` re-delegates CI failures to the project captain with failed-job log tails, instead of only notifying.
- Per-PR retry counter in `reactor-state.json`. After `retries` attempts (default 2), escalates to command instead of spawning another fix cycle.
- Flips seed `ci-failed` reaction from `send-to-captain` to `auto-fix-ci` so new installs get self-healing by default.

### #6 — `cockpit retro` Command (P2)
- New zero-token CLI: `cockpit retro [--week | --sprint [N]] [--project <name>] [--raw]`
- Aggregates daily logs + git history over a window (default 7 days) and groups by Shipped / In Progress / Blocked / Key Decisions, with commit + PR-merge metrics.
- Extracted shared daily-log helpers into `src/lib/daily-logs.ts` (reused by `standup`).

Closes #3.
Closes #6.

## Test plan
- [x] `bash -n` syntax check on reactor scripts
- [x] Smoke-tested exhausted-retry path — escalates to command with `🚨 CI failed 2×` message
- [x] `cockpit retro --raw` — pulls real data from registered projects (confirmed Brove 13 PRs / 100 commits over 7d)
- [x] `npm run build` clean
- [x] `npm test` — 38/40 pass (2 pre-existing unrelated failures on commandName emoji)
- [ ] End-to-end: trigger a real CI failure on a configured repo and confirm captain receives the prompt + log tail