### PR TITLE
feat: default cockpit roles to auto permission mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 *.tsbuildinfo
 .DS_Store
+.worktrees/

--- a/scripts/spawn-crew-pane.sh
+++ b/scripts/spawn-crew-pane.sh
@@ -22,8 +22,8 @@ fi
 "$CMUX" rename-tab --surface "$PANE_REF" --workspace "$CAPTAIN_WS" "🔧 $CREW_NAME" 2>/dev/null || true
 
 # Start Claude Code in the crew pane with the task
-# Use --permission-mode acceptEdits so crew can work
-CLAUDE_CMD="claude --permission-mode acceptEdits -p \"You are a crew member (🔧 ${CREW_NAME}). ${TASK} When done, summarize what you did and what branch/PR was created.\""
+# Use --permission-mode auto so crew can work without repeated prompts
+CLAUDE_CMD="claude --permission-mode auto -p \"You are a crew member (🔧 ${CREW_NAME}). ${TASK} When done, summarize what you did and what branch/PR was created.\""
 "$CMUX" send --workspace "$CAPTAIN_WS" --surface "$PANE_REF" "$CLAUDE_CMD" 2>&1
 "$CMUX" send-key --workspace "$CAPTAIN_WS" --surface "$PANE_REF" Enter 2>&1
 

--- a/scripts/spawn-workspace.sh
+++ b/scripts/spawn-workspace.sh
@@ -116,6 +116,8 @@ case "$AGENT" in
 
     if [ "$PERM_MODE" = "acceptEdits" ]; then
       AGENT_CMD="${AGENT_CMD} --permission-mode acceptEdits"
+    elif [ "$PERM_MODE" = "auto" ]; then
+      AGENT_CMD="${AGENT_CMD} --permission-mode auto"
     elif [ "$PERM_MODE" = "bypassPermissions" ]; then
       AGENT_CMD="${AGENT_CMD} --dangerously-skip-permissions"
     fi

--- a/src/commands/launch.ts
+++ b/src/commands/launch.ts
@@ -128,6 +128,8 @@ function buildAgentCmd(
 
     if (permissionMode === "acceptEdits") {
       cmd += " --permission-mode acceptEdits";
+    } else if (permissionMode === "auto") {
+      cmd += " --permission-mode auto";
     } else if (permissionMode === "bypassPermissions") {
       cmd += " --dangerously-skip-permissions";
     }
@@ -294,7 +296,7 @@ export const launchCommand = new Command("launch")
 
       console.log(chalk.bold("\nLaunching all cockpit workspaces\n"));
       console.log(chalk.bold(`  Command: ${workspaceName}`));
-      await launchOne(workspaceName, "command", hubPath, config.defaults.permissions?.command || "default", true, true);
+      await launchOne(workspaceName, "command", hubPath, config.defaults.permissions?.command || "auto", true, true);
 
       // Launch reactor (after command, before captains)
       const reactorName = "⚡ reactor";
@@ -313,7 +315,7 @@ export const launchCommand = new Command("launch")
           console.log(chalk.cyan(`  ✔ Created spoke vault at ${spokePath}`));
         }
         console.log(chalk.bold(`\n  Captain: ${proj.captainName} (${name})`));
-        await launchOne(proj.captainName, "captain", projPath, config.defaults.permissions?.captain || "acceptEdits", false, true, name);
+        await launchOne(proj.captainName, "captain", projPath, config.defaults.permissions?.captain || "auto", false, true, name);
       }
       console.log("");
     } else if (!project) {
@@ -323,7 +325,7 @@ export const launchCommand = new Command("launch")
       fs.mkdirSync(hubPath, { recursive: true });
 
       console.log(chalk.bold(`\nLaunching command workspace: ${workspaceName}\n`));
-      await launchOne(workspaceName, "command", hubPath, config.defaults.permissions?.command || "default", true, true);
+      await launchOne(workspaceName, "command", hubPath, config.defaults.permissions?.command || "auto", true, true);
 
       if (opts.reactor) {
         const reactorName = "⚡ reactor";
@@ -359,6 +361,6 @@ export const launchCommand = new Command("launch")
           `\nLaunching captain workspace for '${project}' (${proj.captainName})\n`,
         ),
       );
-      await launchOne(proj.captainName, "captain", projPath, config.defaults.permissions?.captain || "acceptEdits", false, true, project);
+      await launchOne(proj.captainName, "captain", projPath, config.defaults.permissions?.captain || "auto", false, true, project);
     }
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -134,8 +134,8 @@ export function getDefaultConfig(): CockpitConfig {
       worktreeDir: ".worktrees",
       teammateMode: "in-process",
       permissions: {
-        command: "default",
-        captain: "acceptEdits",
+        command: "auto",
+        captain: "auto",
       },
       models: {
         command: "opus",


### PR DESCRIPTION
Closes #21.

## Summary
- Default `permissions.command` and `permissions.captain` changed from `default`/`acceptEdits` → `auto` in `src/config.ts` and fallback defaults in `src/commands/launch.ts`
- `launch.ts` and `scripts/spawn-workspace.sh` now emit `--permission-mode auto` when the resolved permission mode is `auto`
- `scripts/spawn-crew-pane.sh` crew command switched from `--permission-mode acceptEdits` → `--permission-mode auto`
- `.gitignore`: added `.worktrees/` so isolated worktrees stop showing up in git status

## Why
`~/.claude/settings.json` already sets `defaultMode: "auto"` globally, but cockpit-spawned sessions were overriding that with `acceptEdits`, forcing per-session reconfiguration. `auto` is a better fit for unattended captain/crew work.

## Out of scope
Runtime config at `~/.config/cockpit/config.json` stays user-local; existing installs can keep `acceptEdits` or migrate manually. This PR just moves the out-of-the-box default.

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — same 2 pre-existing `commandName` failures on develop; no new failures
- [ ] Manual: spawn a captain and confirm `ps` shows `--permission-mode auto`
- [ ] Manual: spawn a crew pane via `spawn-crew-pane.sh` and confirm same