### PR TITLE
Plugin System Phase 2: Workspace Slot (#9)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (286 symbols, 478 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (287 symbols, 479 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (297 symbols, 509 relationships, 11 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (298 symbols, 518 relationships, 13 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (287 symbols, 479 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (294 symbols, 499 relationships, 10 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (294 symbols, 499 relationships, 10 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (297 symbols, 509 relationships, 11 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (260 symbols, 431 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (260 symbols, 432 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (298 symbols, 518 relationships, 13 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (297 symbols, 520 relationships, 13 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (259 symbols, 431 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (260 symbols, 431 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (261 symbols, 433 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (266 symbols, 438 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (260 symbols, 432 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (261 symbols, 433 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (297 symbols, 520 relationships, 13 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (297 symbols, 523 relationships, 13 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (276 symbols, 458 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (286 symbols, 478 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (297 symbols, 523 relationships, 13 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (297 symbols, 526 relationships, 13 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (266 symbols, 438 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (276 symbols, 458 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (286 symbols, 478 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (287 symbols, 479 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (297 symbols, 509 relationships, 11 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (298 symbols, 518 relationships, 13 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (287 symbols, 479 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (294 symbols, 499 relationships, 10 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (294 symbols, 499 relationships, 10 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (297 symbols, 509 relationships, 11 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (260 symbols, 431 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (260 symbols, 432 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (298 symbols, 518 relationships, 13 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (297 symbols, 520 relationships, 13 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (259 symbols, 431 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (260 symbols, 431 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (261 symbols, 433 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (266 symbols, 438 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (260 symbols, 432 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (261 symbols, 433 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (297 symbols, 520 relationships, 13 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (297 symbols, 523 relationships, 13 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (276 symbols, 458 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (286 symbols, 478 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (297 symbols, 523 relationships, 13 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (297 symbols, 526 relationships, 13 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (266 symbols, 438 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (276 symbols, 458 relationships, 9 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ See `obsidian/plugins.md` for Dataview, Templater setup.
 | `cockpit runtime status <project>` | Check if a project's captain workspace is running |
 | `cockpit runtime send <project> <msg>` | Send a message to a captain workspace (auto-Enter) |
 | `cockpit runtime list` | List all workspaces from the active runtime |
+| `cockpit workspace read <project> <path>` | Read a scope-relative file from the project's spoke vault |
+| `cockpit workspace list <project> <dir>` | List entries in a spoke vault directory |
+| `cockpit workspace read --hub <path>` | Read from the hub vault |
 | `cockpit shutdown [project]` | Graceful shutdown |
 | `cockpit feedback` | Open opt-in feedback issue |
 
@@ -94,6 +97,10 @@ Each role runs on the optimal model for cost/quality tradeoff. Configured in `co
 ### Runtime Abstraction
 
 Workspaces run on a pluggable **runtime driver** (currently only `cmux`). Each project may override the global default via its `runtime` field. Bash scripts call `cockpit runtime <op>` to talk to the configured runtime instead of any specific binary. New runtimes (tmux, Docker, SSH) are added as driver files in `src/runtimes/` — see `docs/specs/2026-04-20-plugin-system-runtime-design.md`.
+
+### Workspace Abstraction
+
+Vault storage (hub + per-project spokes) runs behind a pluggable **workspace driver** (currently only `obsidian`). Filesystem operations — `read`, `write`, `list`, `exists`, `mkdir` — go through the driver instead of `fs` directly. Each project may override the global default via its `workspace` field. Bash scripts call `cockpit workspace <op>` to read/write vault data without hardcoding paths. New backends (Notion, plain-md, S3) are added as driver files in `src/workspaces/` — see `docs/specs/2026-04-21-plugin-system-workspace-design.md`.
 
 ### Obsidian Vaults (Hub-and-Spoke)
 
@@ -122,13 +129,15 @@ Workspaces run on a pluggable **runtime driver** (currently only `cmux`). Each p
   "commandName": "command",
   "hubVault": "~/cockpit-hub",
   "runtime": "cmux",
+  "workspace": "obsidian",
   "projects": {
     "brove": {
       "path": "~/projects/brove",
       "captainName": "brove-captain",
       "spokeVault": "~/cockpit-hub/spokes/brove",
       "host": "local",
-      "runtime": "cmux"
+      "runtime": "cmux",
+      "workspace": "obsidian"
     }
   },
   "defaults": {

--- a/docs/specs/2026-04-21-plugin-system-workspace-design.md
+++ b/docs/specs/2026-04-21-plugin-system-workspace-design.md
@@ -1,0 +1,196 @@
+# Plugin/Extension System — Phase 2: Workspace Slot
+
+**Date:** 2026-04-21
+**Status:** Draft — design only, implementation in next sprint
+**Issue:** [#9](https://github.com/tu11aa/claude-cockpit/issues/9)
+**Phase:** 2 of N (workspace slot after phase 1 runtime)
+**Depends on:** Phase 1 (runtime slot) — merged as PR #20 at commit `6c1d6ea`
+
+## Problem
+
+Cockpit's vault storage is tightly coupled to Obsidian's filesystem layout. The `spokeVault` and `hubVault` paths are read directly via `fs.readFileSync`, `fs.writeFileSync`, `fs.readdirSync`, `fs.mkdirSync`, and `path.join` across 11 files and ~33 call-sites. Every command that reads daily logs, writes status, lists learnings, or renders the wiki hardcodes both the Obsidian vault filesystem layout AND the Node `fs` API.
+
+Swapping Obsidian for Notion, plain-markdown-in-a-different-directory, or an S3-backed vault requires editing every one of those call-sites. There is no seam for a remote or API-driven backend.
+
+## Goal
+
+Abstract vault storage behind a `WorkspaceDriver` interface mirroring the existing `src/drivers/` (agent) and `src/runtimes/` (runtime) patterns. Obsidian remains the default and only shipped implementation. The abstraction:
+
+- Moves filesystem `read/write/list/exists/mkdir` behind a driver boundary
+- Replaces absolute-path call-sites with scope-relative calls (`workspace.read("daily-logs/2026-04-21.md")`)
+- Unlocks future backends (Notion, S3, plain-md) without further refactoring
+
+## Non-Goals
+
+- **Additional slots** (tracker, notifier) — phase 3+ of #9.
+- **External plugin loading** from `node_modules` — phase 4, deferred.
+- **New workspace implementations** beyond Obsidian — each new provider is its own follow-up PR.
+- **Domain-level abstraction** (e.g., `getDailyLog(date)`, `appendLearning(...)`) — this spec is filesystem-level only. Domain helpers continue to live in `src/lib/daily-logs.ts`, now built on top of the driver.
+- **Strict typing of `WorkspaceScope`** — shipping loose (`Record<string, unknown>`) to match the phase 1 runtime pattern. Tightening is tracked as [#23](https://github.com/tu11aa/claude-cockpit/issues/23).
+- **Migration of learnings/wiki bash scripts** (`wiki-ingest.sh`, `learnings-record.sh`) — bounded exception. Scripts operate on vault directories directly; they stay as-is in phase 2 and fold in when bash-side migration stabilizes.
+
+## Architecture: Workspace Driver (mirrors Runtime Driver)
+
+```
+cockpit core
+  └── src/workspaces/
+        ├── types.ts         ← WorkspaceDriver interface + types
+        ├── obsidian.ts      ← Obsidian (fs-backed) driver
+        ├── registry.ts      ← WorkspaceRegistry — config-driven scope resolution
+        ├── index.ts         ← re-exports
+        └── __tests__/       ← unit tests + in-memory helper
+```
+
+Cockpit core and bash scripts never touch `fs` directly for vault data — always through a driver, exposed either as a TypeScript import (core code) or as `cockpit workspace <op>` CLI subcommands (bash scripts).
+
+## 1. Workspace Driver Interface
+
+```typescript
+// src/workspaces/types.ts
+export interface WorkspaceProbeResult {
+  installed: boolean;           // provider dependencies present
+  rootExists: boolean;          // the configured scope is reachable (dir exists, API auth works, etc.)
+}
+
+export interface WorkspaceScope {
+  root?: string;                // obsidian: absolute filesystem root
+  [key: string]: unknown;       // future providers attach their own fields (loose per #23)
+}
+
+export interface WorkspaceDriver {
+  name: string;                 // "obsidian", "notion", ...
+
+  probe(): Promise<WorkspaceProbeResult>;
+
+  // All `path` arguments are scope-relative (e.g., "daily-logs/2026-04-21.md").
+  // Forward-slash separators; the driver translates for its backend.
+  read(path: string): Promise<string>;
+  write(path: string, content: string): Promise<void>;
+  exists(path: string): Promise<boolean>;
+  list(dir: string): Promise<string[]>;   // returns entry names only, not full paths
+  mkdir(path: string): Promise<void>;     // always recursive
+}
+
+export type WorkspaceFactory = (scope: WorkspaceScope) => WorkspaceDriver;
+```
+
+### Contract notes
+
+- **All operations are async.** Existing call-sites use sync `fs.*Sync`; migrating them is mechanical (`await driver.read(...)`).
+- **Paths are scope-relative.** Callers never pass absolute paths or combine vault roots. The driver owns path resolution.
+- **`list()` returns entry names only** — no leading path, no trailing slash. Mirrors `fs.readdirSync` semantics.
+- **`mkdir()` is always recursive.** Non-recursive mkdir is never what cockpit wants — all current call-sites pass `{ recursive: true }`.
+- **`probe()` returns two flags.** `installed` = the provider can run at all (filesystem driver always true; a future Notion driver returns false if `@notionhq/client` is missing). `rootExists` = this specific scope is reachable (dir exists / API auth valid).
+
+## 2. Registry & Config
+
+```typescript
+// src/workspaces/registry.ts
+export class WorkspaceRegistry {
+  constructor(private factories: Record<string, WorkspaceFactory>) {}
+
+  hub(config: CockpitConfig): WorkspaceDriver {
+    const name = config.workspace ?? "obsidian";
+    return this.get(name)({ root: resolveHome(config.hubVault) });
+  }
+
+  forProject(projectName: string, config: CockpitConfig): WorkspaceDriver {
+    const proj = config.projects[projectName];
+    if (!proj) throw new Error(`Project '${projectName}' not found`);
+    const name = proj.workspace ?? config.workspace ?? "obsidian";
+    return this.get(name)({ root: resolveHome(proj.spokeVault) });
+  }
+
+  get(name: string): WorkspaceFactory {
+    const factory = this.factories[name];
+    if (!factory) throw new Error(`Unknown workspace provider '${name}'`);
+    return factory;
+  }
+
+  async probeAll(config: CockpitConfig): Promise<Record<string, WorkspaceProbeResult>> { /* ... */ }
+}
+```
+
+Config additions (both optional, default `"obsidian"`; no migration required):
+
+```jsonc
+{
+  "workspace": "obsidian",              // NEW — global default
+  "hubVault": "~/cockpit-hub",          // EXISTING — becomes obsidian scope root
+  "projects": {
+    "brove": {
+      "workspace": "obsidian",          // NEW — optional per-project override
+      "spokeVault": "~/cockpit-hub/spokes/brove",  // EXISTING — obsidian scope root
+      "path": "~/projects/brove",
+      "captainName": "brove-captain",
+      "host": "local"
+    }
+  }
+}
+```
+
+When both `workspace` fields are absent, behavior is identical to today (obsidian, fs-backed). `cockpit doctor` gains a new check: probe each distinct workspace provider referenced in config and verify its scope (hub + every project's spoke root).
+
+## 3. CLI Subcommand — Bridge to Bash
+
+New command at `src/commands/workspace.ts`:
+
+```
+cockpit workspace read <target> <path>                 # prints content to stdout
+cockpit workspace write <target> <path> <content>      # content = "-" reads from stdin
+cockpit workspace list <target> <dir>                  # entry names, one per line
+cockpit workspace exists <target> <path>               # exit 0 if exists, 1 if not
+cockpit workspace mkdir <target> <path>                # recursive
+```
+
+`<target>` is one of:
+- A project name — resolves to that project's spoke scope.
+- `--hub` flag — resolves to the hub scope.
+
+Process-spawn overhead per invocation (~100ms) is acceptable: the bash callers (`reactor-cycle.sh`, `read-status.sh`) already shell out for every operation; they don't run in hot loops.
+
+## 4. Refactor Surface
+
+| File | Current | After |
+|------|---------|-------|
+| `src/lib/daily-logs.ts` | `fs.readFileSync(path.join(spokeVault, "daily-logs", f))` | accepts `workspace: WorkspaceDriver` argument; uses `workspace.read(\`daily-logs/${f}\`)` |
+| `src/commands/status.ts` | `fs.readdirSync(path.join(spokeVault, "crew"))` + `fs.readFileSync` per file | uses `workspace.list("crew")` + `workspace.read(...)` |
+| `src/commands/standup.ts` | builds its own paths, calls daily-logs.ts | builds workspace via registry, passes to daily-logs helpers |
+| `src/commands/retro.ts` | same as standup | same |
+| `src/commands/init.ts` | `fs.mkdirSync` for hub + 7 spoke subdirs | `workspace.mkdir(subdir)` for each |
+| `src/commands/launch.ts` | inline spoke-vault-ensure block (duplicated, 7 subdirs) | extracted helper `ensureSpokeLayout(workspace: WorkspaceDriver)` in `src/lib/vault-layout.ts` |
+| `src/commands/doctor.ts` | `fs.existsSync(hubVault)`, `fs.existsSync(spokeVault)` | `hubDriver.probe()` and per-project `spokeDriver.probe()` |
+| `src/commands/projects.ts` | spoke-vault init on add | `workspace.mkdir(...)` |
+| `scripts/reactor-cycle.sh` | bash `cat`/read on hub vault paths | `cockpit workspace read --hub ...` |
+| `scripts/read-status.sh` | bash `cat` on spoke status.md | `cockpit workspace read <project> status.md` |
+
+All call-sites keep their file location — only their dependency changes.
+
+## 5. Testing
+
+Mirror `src/runtimes/__tests__/`:
+
+- **Unit tests** for `ObsidianDriver` — mock `node:fs/promises`. Fixtures cover read/write round-trip, `list` returns names (not paths), `mkdir` is always recursive, `exists` boolean truth, scope-root prepending correctness.
+- **Unit tests** for `WorkspaceRegistry` — project-override > global > default fallback chain (same pattern as `RuntimeRegistry`).
+- **In-memory test driver** — `src/workspaces/__tests__/helpers/memory-driver.ts` — a `createMemoryDriver()` fixture backed by a `Map<string, string>`. Used by migrated call-sites (`daily-logs.ts`, `standup.ts`, etc.) to test business logic without fs mocks.
+- **Integration smoke** — `cockpit workspace read <project> <path>` against a real spoke vault, gated behind `SKIP_INTEGRATION=1`.
+- **Bash script regression** — smoke-test `reactor-cycle.sh` and `read-status.sh` paths against the in-memory driver via a mock `cockpit` binary that records calls.
+
+## 6. Rollout
+
+1. Land this spec and implementation plan.
+2. Implement `src/workspaces/` with only `ObsidianDriver`.
+3. Add `cockpit workspace` CLI subcommand.
+4. Extract `ensureSpokeLayout` helper; migrate `init.ts`, `launch.ts`, `projects.ts`.
+5. Migrate `daily-logs.ts` to take a driver argument; migrate standup/retro/status callers.
+6. Migrate `doctor.ts` to probe workspace providers.
+7. Migrate bash scripts.
+8. Add config docs to README.
+9. Ship as single PR.
+
+## 7. Relationship to Other Work
+
+- **Builds on:** Phase 1 runtime slot (PR #20). Same driver+registry+CLI pattern.
+- **Unblocks:** future Notion driver (PR), plain-markdown driver (PR), remote backends.
+- **Precedes:** phase 3 — tracker slot (GitHub → Linear/Jira abstraction).
+- **Follow-up:** [#23](https://github.com/tu11aa/claude-cockpit/issues/23) — tighten `WorkspaceScope` to discriminated union once a second provider ships.

--- a/docs/specs/2026-04-21-plugin-system-workspace-plan.md
+++ b/docs/specs/2026-04-21-plugin-system-workspace-plan.md
@@ -1,0 +1,1629 @@
+# Plugin System Phase 2 — Workspace Slot Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Abstract vault storage behind a `WorkspaceDriver` interface (mirroring `src/runtimes/`), expose filesystem ops via `cockpit workspace` CLI, and migrate all ~33 direct `fs.*` call-sites across 11 files to use the driver.
+
+**Architecture:** New `src/workspaces/` directory parallel to `src/runtimes/`. `ObsidianDriver` implements `WorkspaceDriver` over `node:fs/promises`. `WorkspaceRegistry` resolves hub/project scopes from `config.workspace` + `projects[name].workspace`. Bash scripts call `cockpit workspace <op>` instead of `cat`/`path` directly.
+
+**Tech Stack:** TypeScript, commander.js, vitest, Node 22 (`fs/promises`), bash.
+
+**Spec:** `docs/specs/2026-04-21-plugin-system-workspace-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `src/workspaces/types.ts` — `WorkspaceDriver`, `WorkspaceScope`, `WorkspaceProbeResult`, `WorkspaceFactory`
+- `src/workspaces/obsidian.ts` — `createObsidianDriver(scope)` (fs-backed)
+- `src/workspaces/registry.ts` — `WorkspaceRegistry`
+- `src/workspaces/index.ts` — barrel
+- `src/workspaces/__tests__/obsidian.test.ts`
+- `src/workspaces/__tests__/registry.test.ts`
+- `src/workspaces/__tests__/helpers/memory-driver.ts` — in-memory test driver
+- `src/commands/workspace.ts` — `cockpit workspace read/write/list/exists/mkdir`
+- `src/lib/vault-layout.ts` — `ensureSpokeLayout(workspace)` extracted helper
+
+**Modify:**
+- `src/config.ts` — add `workspace?: string` to `ProjectConfig` and `CockpitConfig`
+- `src/index.ts` — register `workspaceCommand`
+- `src/commands/init.ts` — use `WorkspaceDriver` for hub + spoke dir creation
+- `src/commands/launch.ts` — use `ensureSpokeLayout` helper
+- `src/commands/projects.ts` — use `WorkspaceDriver` on spoke add
+- `src/commands/status.ts` — use `WorkspaceRegistry`
+- `src/commands/standup.ts`, `retro.ts` — pass driver into daily-logs helpers
+- `src/commands/doctor.ts` — probe workspace providers
+- `src/lib/daily-logs.ts` — accept `WorkspaceDriver` argument
+- `scripts/reactor-cycle.sh`, `scripts/read-status.sh` — call `cockpit workspace read`
+- `README.md` — document `workspace` config field
+
+---
+
+## Task 1: Add `workspace?` field to config types
+
+**Files:**
+- Modify: `src/config.ts`
+
+- [ ] **Step 1: Add `workspace?: string` to `ProjectConfig` and `CockpitConfig`**
+
+In `src/config.ts`, update both interfaces:
+
+```typescript
+export interface ProjectConfig {
+  path: string;
+  captainName: string;
+  spokeVault: string;
+  host: string;
+  group?: string;
+  groupRole?: string;
+  runtime?: string;
+  workspace?: string;  // NEW — overrides top-level workspace provider for this project
+}
+
+export interface CockpitConfig {
+  commandName: string;
+  hubVault: string;
+  projects: Record<string, ProjectConfig>;
+  agents?: Record<string, AgentEntry>;
+  runtime?: string;
+  workspace?: string;  // NEW — global default workspace provider ("obsidian" when absent)
+  defaults: {
+    maxCrew: number;
+    worktreeDir: string;
+    teammateMode: string;
+    permissions: PermissionConfig;
+    models?: ModelRoutingConfig;
+    roles?: RoleConfig;
+  };
+  metrics: {
+    enabled: boolean;
+    path: string;
+  };
+}
+```
+
+- [ ] **Step 2: Verify lint**
+
+Run: `npm run lint`
+Expected: exit 0
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/config.ts
+git commit -m "feat(workspace): add optional workspace field to config types"
+```
+
+---
+
+## Task 2: Define WorkspaceDriver interface
+
+**Files:**
+- Create: `src/workspaces/types.ts`
+
+- [ ] **Step 1: Write the types file**
+
+Create `src/workspaces/types.ts`:
+
+```typescript
+export interface WorkspaceProbeResult {
+  installed: boolean;   // provider dependencies present (fs driver always true)
+  rootExists: boolean;  // this scope is reachable (dir exists / API auth valid)
+}
+
+export interface WorkspaceScope {
+  root?: string;                // obsidian: absolute filesystem root
+  [key: string]: unknown;       // provider-specific (loose per follow-up #23)
+}
+
+export interface WorkspaceDriver {
+  name: string;                 // "obsidian"
+
+  probe(): Promise<WorkspaceProbeResult>;
+
+  // All paths are scope-relative (e.g., "daily-logs/2026-04-21.md"). Forward-slash.
+  read(path: string): Promise<string>;
+  write(path: string, content: string): Promise<void>;
+  exists(path: string): Promise<boolean>;
+  list(dir: string): Promise<string[]>;   // entry names, not full paths
+  mkdir(path: string): Promise<void>;     // always recursive
+}
+
+export type WorkspaceFactory = (scope: WorkspaceScope) => WorkspaceDriver;
+```
+
+- [ ] **Step 2: Verify lint**
+
+Run: `npm run lint`
+Expected: exit 0
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/workspaces/types.ts
+git commit -m "feat(workspace): add WorkspaceDriver interface"
+```
+
+---
+
+## Task 3: Write failing tests for ObsidianDriver
+
+**Files:**
+- Create: `src/workspaces/__tests__/obsidian.test.ts`
+
+- [ ] **Step 1: Write the test file**
+
+Create `src/workspaces/__tests__/obsidian.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createObsidianDriver } from "../obsidian.js";
+
+describe("ObsidianDriver", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "obsidian-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("has name 'obsidian'", () => {
+    const driver = createObsidianDriver({ root: tmpRoot });
+    expect(driver.name).toBe("obsidian");
+  });
+
+  it("probe returns installed=true and rootExists=true for a real dir", async () => {
+    const driver = createObsidianDriver({ root: tmpRoot });
+    const result = await driver.probe();
+    expect(result.installed).toBe(true);
+    expect(result.rootExists).toBe(true);
+  });
+
+  it("probe returns rootExists=false when scope root is missing", async () => {
+    const missing = path.join(tmpRoot, "does-not-exist");
+    const driver = createObsidianDriver({ root: missing });
+    const result = await driver.probe();
+    expect(result.installed).toBe(true);
+    expect(result.rootExists).toBe(false);
+  });
+
+  it("write then read round-trips content", async () => {
+    const driver = createObsidianDriver({ root: tmpRoot });
+    await driver.mkdir("daily-logs");
+    await driver.write("daily-logs/2026-04-21.md", "hello world");
+    const content = await driver.read("daily-logs/2026-04-21.md");
+    expect(content).toBe("hello world");
+  });
+
+  it("exists returns true/false correctly", async () => {
+    const driver = createObsidianDriver({ root: tmpRoot });
+    await driver.write("a.txt", "x");
+    expect(await driver.exists("a.txt")).toBe(true);
+    expect(await driver.exists("b.txt")).toBe(false);
+  });
+
+  it("list returns entry names only (not paths)", async () => {
+    const driver = createObsidianDriver({ root: tmpRoot });
+    await driver.mkdir("crew");
+    await driver.write("crew/one.md", "1");
+    await driver.write("crew/two.md", "2");
+    const entries = await driver.list("crew");
+    expect(entries.sort()).toEqual(["one.md", "two.md"]);
+  });
+
+  it("list returns empty array for missing directory", async () => {
+    const driver = createObsidianDriver({ root: tmpRoot });
+    const entries = await driver.list("nope");
+    expect(entries).toEqual([]);
+  });
+
+  it("mkdir is always recursive", async () => {
+    const driver = createObsidianDriver({ root: tmpRoot });
+    await driver.mkdir("a/b/c/d");
+    expect(fs.existsSync(path.join(tmpRoot, "a/b/c/d"))).toBe(true);
+  });
+
+  it("write creates parent directories", async () => {
+    const driver = createObsidianDriver({ root: tmpRoot });
+    await driver.write("deep/nested/file.txt", "data");
+    expect(fs.readFileSync(path.join(tmpRoot, "deep/nested/file.txt"), "utf-8")).toBe("data");
+  });
+
+  it("scope-rooted paths never escape root (no path traversal via ../)", async () => {
+    const driver = createObsidianDriver({ root: tmpRoot });
+    await expect(driver.read("../../etc/passwd")).rejects.toThrow(/escapes workspace root/i);
+    await expect(driver.write("../evil.txt", "x")).rejects.toThrow(/escapes workspace root/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/workspaces/__tests__/obsidian.test.ts`
+Expected: FAIL with "Cannot find module '../obsidian.js'"
+
+---
+
+## Task 4: Implement ObsidianDriver
+
+**Files:**
+- Create: `src/workspaces/obsidian.ts`
+
+- [ ] **Step 1: Write the implementation**
+
+Create `src/workspaces/obsidian.ts`:
+
+```typescript
+import fs from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import type {
+  WorkspaceDriver,
+  WorkspaceProbeResult,
+  WorkspaceScope,
+} from "./types.js";
+
+function resolveInRoot(root: string, relative: string): string {
+  const joined = path.resolve(root, relative);
+  const normalized = path.resolve(root) + path.sep;
+  if (joined !== path.resolve(root) && !joined.startsWith(normalized)) {
+    throw new Error(`Path '${relative}' escapes workspace root`);
+  }
+  return joined;
+}
+
+export function createObsidianDriver(scope: WorkspaceScope): WorkspaceDriver {
+  const root = scope.root;
+  if (typeof root !== "string" || root === "") {
+    throw new Error("ObsidianDriver requires scope.root (string)");
+  }
+
+  return {
+    name: "obsidian",
+
+    async probe(): Promise<WorkspaceProbeResult> {
+      return {
+        installed: true,
+        rootExists: existsSync(root),
+      };
+    },
+
+    async read(rel: string): Promise<string> {
+      return fs.readFile(resolveInRoot(root, rel), "utf-8");
+    },
+
+    async write(rel: string, content: string): Promise<void> {
+      const abs = resolveInRoot(root, rel);
+      await fs.mkdir(path.dirname(abs), { recursive: true });
+      await fs.writeFile(abs, content);
+    },
+
+    async exists(rel: string): Promise<boolean> {
+      try {
+        await fs.access(resolveInRoot(root, rel));
+        return true;
+      } catch {
+        return false;
+      }
+    },
+
+    async list(rel: string): Promise<string[]> {
+      try {
+        return await fs.readdir(resolveInRoot(root, rel));
+      } catch {
+        return [];
+      }
+    },
+
+    async mkdir(rel: string): Promise<void> {
+      await fs.mkdir(resolveInRoot(root, rel), { recursive: true });
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Run tests to verify all pass**
+
+Run: `npx vitest run src/workspaces/__tests__/obsidian.test.ts`
+Expected: PASS (10 tests)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/workspaces/obsidian.ts src/workspaces/__tests__/obsidian.test.ts
+git commit -m "feat(workspace): add ObsidianDriver implementing WorkspaceDriver"
+```
+
+---
+
+## Task 5: Write failing tests for WorkspaceRegistry
+
+**Files:**
+- Create: `src/workspaces/__tests__/registry.test.ts`
+
+- [ ] **Step 1: Write the test file**
+
+Create `src/workspaces/__tests__/registry.test.ts`:
+
+```typescript
+import { describe, it, expect, vi } from "vitest";
+import { WorkspaceRegistry } from "../registry.js";
+import type { WorkspaceDriver, WorkspaceScope } from "../types.js";
+import type { CockpitConfig } from "../../config.js";
+
+function stubFactory(name: string): (scope: WorkspaceScope) => WorkspaceDriver {
+  return (scope) => ({
+    name,
+    probe: vi.fn(async () => ({ installed: true, rootExists: true })),
+    read: vi.fn(async () => `read:${name}:${scope.root}`),
+    write: vi.fn(async () => {}),
+    exists: vi.fn(async () => true),
+    list: vi.fn(async () => []),
+    mkdir: vi.fn(async () => {}),
+  });
+}
+
+function baseConfig(overrides: Partial<CockpitConfig> = {}): CockpitConfig {
+  return {
+    commandName: "cmd",
+    hubVault: "~/hub",
+    projects: {},
+    defaults: {
+      maxCrew: 5,
+      worktreeDir: ".worktrees",
+      teammateMode: "in-process",
+      permissions: { command: "default", captain: "acceptEdits" },
+    },
+    metrics: { enabled: false, path: "" },
+    ...overrides,
+  };
+}
+
+describe("WorkspaceRegistry", () => {
+  it("returns obsidian driver by default for hub", () => {
+    const registry = new WorkspaceRegistry({ obsidian: stubFactory("obsidian") });
+    const driver = registry.hub(baseConfig());
+    expect(driver.name).toBe("obsidian");
+  });
+
+  it("uses top-level workspace override for hub", () => {
+    const registry = new WorkspaceRegistry({
+      obsidian: stubFactory("obsidian"),
+      notion: stubFactory("notion"),
+    });
+    const driver = registry.hub(baseConfig({ workspace: "notion" }));
+    expect(driver.name).toBe("notion");
+  });
+
+  it("forProject returns obsidian by default", () => {
+    const registry = new WorkspaceRegistry({ obsidian: stubFactory("obsidian") });
+    const config = baseConfig({
+      projects: {
+        brove: { path: "/p", captainName: "brove-c", spokeVault: "~/s", host: "local" },
+      },
+    });
+    const driver = registry.forProject("brove", config);
+    expect(driver.name).toBe("obsidian");
+  });
+
+  it("project-level workspace overrides top-level", () => {
+    const registry = new WorkspaceRegistry({
+      obsidian: stubFactory("obsidian"),
+      notion: stubFactory("notion"),
+      plain: stubFactory("plain"),
+    });
+    const config = baseConfig({
+      workspace: "notion",
+      projects: {
+        brove: { path: "/p", captainName: "brove-c", spokeVault: "~/s", host: "local", workspace: "plain" },
+      },
+    });
+    const driver = registry.forProject("brove", config);
+    expect(driver.name).toBe("plain");
+  });
+
+  it("throws when configured provider has no factory registered", () => {
+    const registry = new WorkspaceRegistry({ obsidian: stubFactory("obsidian") });
+    expect(() => registry.hub(baseConfig({ workspace: "unknown" }))).toThrowError(/unknown/i);
+  });
+
+  it("forProject throws for unknown project", () => {
+    const registry = new WorkspaceRegistry({ obsidian: stubFactory("obsidian") });
+    expect(() => registry.forProject("nope", baseConfig())).toThrowError(/not found/i);
+  });
+
+  it("hub passes resolved hubVault as scope.root", () => {
+    const registry = new WorkspaceRegistry({ obsidian: stubFactory("obsidian") });
+    const driver = registry.hub(baseConfig({ hubVault: "~/cockpit-hub" }));
+    // The stub returns `read:obsidian:<scope.root>` — verify root was resolved (no ~)
+    return driver.read("x.md").then((out) => {
+      expect(out).toMatch(/^read:obsidian:\//);
+      expect(out).not.toContain("~");
+    });
+  });
+
+  it("probeAll returns results keyed by provider name", async () => {
+    const registry = new WorkspaceRegistry({
+      obsidian: stubFactory("obsidian"),
+      notion: stubFactory("notion"),
+    });
+    const results = await registry.probeAll(baseConfig());
+    expect(results.obsidian.installed).toBe(true);
+    expect(results.notion.installed).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/workspaces/__tests__/registry.test.ts`
+Expected: FAIL with "Cannot find module '../registry.js'"
+
+---
+
+## Task 6: Implement WorkspaceRegistry
+
+**Files:**
+- Create: `src/workspaces/registry.ts`
+
+- [ ] **Step 1: Write the implementation**
+
+Create `src/workspaces/registry.ts`:
+
+```typescript
+import { resolveHome, type CockpitConfig } from "../config.js";
+import type {
+  WorkspaceDriver,
+  WorkspaceFactory,
+  WorkspaceProbeResult,
+} from "./types.js";
+
+const DEFAULT_WORKSPACE = "obsidian";
+
+export class WorkspaceRegistry {
+  constructor(private factories: Record<string, WorkspaceFactory>) {}
+
+  hub(config: CockpitConfig): WorkspaceDriver {
+    const name = config.workspace ?? DEFAULT_WORKSPACE;
+    return this.get(name)({ root: resolveHome(config.hubVault) });
+  }
+
+  forProject(projectName: string, config: CockpitConfig): WorkspaceDriver {
+    const proj = config.projects[projectName];
+    if (!proj) throw new Error(`Project '${projectName}' not found`);
+    const name = proj.workspace ?? config.workspace ?? DEFAULT_WORKSPACE;
+    return this.get(name)({ root: resolveHome(proj.spokeVault) });
+  }
+
+  get(name: string): WorkspaceFactory {
+    const factory = this.factories[name];
+    if (!factory) {
+      throw new Error(`Unknown workspace provider '${name}' — no factory registered`);
+    }
+    return factory;
+  }
+
+  async probeAll(config: CockpitConfig): Promise<Record<string, WorkspaceProbeResult>> {
+    const results: Record<string, WorkspaceProbeResult> = {};
+    for (const [name, factory] of Object.entries(this.factories)) {
+      const scope = { root: resolveHome(config.hubVault) };
+      results[name] = await factory(scope).probe();
+    }
+    return results;
+  }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `npx vitest run src/workspaces/__tests__/registry.test.ts`
+Expected: PASS, 8 tests
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/workspaces/registry.ts src/workspaces/__tests__/registry.test.ts
+git commit -m "feat(workspace): add WorkspaceRegistry with project-level override"
+```
+
+---
+
+## Task 7: Add workspaces barrel file
+
+**Files:**
+- Create: `src/workspaces/index.ts`
+
+- [ ] **Step 1: Write the barrel**
+
+Create `src/workspaces/index.ts`:
+
+```typescript
+export { createObsidianDriver } from "./obsidian.js";
+export { WorkspaceRegistry } from "./registry.js";
+export type {
+  WorkspaceDriver,
+  WorkspaceFactory,
+  WorkspaceProbeResult,
+  WorkspaceScope,
+} from "./types.js";
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `npm run build`
+Expected: exit 0
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/workspaces/index.ts
+git commit -m "feat(workspace): add workspaces barrel export"
+```
+
+---
+
+## Task 8: Add in-memory test driver helper
+
+**Files:**
+- Create: `src/workspaces/__tests__/helpers/memory-driver.ts`
+
+- [ ] **Step 1: Write the helper**
+
+Create `src/workspaces/__tests__/helpers/memory-driver.ts`:
+
+```typescript
+import type { WorkspaceDriver } from "../../types.js";
+
+export function createMemoryDriver(initial: Record<string, string> = {}): WorkspaceDriver & {
+  files: Map<string, string>;
+} {
+  const files = new Map<string, string>(Object.entries(initial));
+  const dirs = new Set<string>();
+
+  // Seed dirs from keys
+  for (const key of files.keys()) {
+    const parts = key.split("/");
+    for (let i = 1; i <= parts.length - 1; i++) {
+      dirs.add(parts.slice(0, i).join("/"));
+    }
+  }
+
+  return {
+    name: "memory",
+    files,
+
+    async probe() {
+      return { installed: true, rootExists: true };
+    },
+
+    async read(path) {
+      if (!files.has(path)) throw new Error(`ENOENT: ${path}`);
+      return files.get(path)!;
+    },
+
+    async write(path, content) {
+      files.set(path, content);
+      const parts = path.split("/");
+      for (let i = 1; i <= parts.length - 1; i++) {
+        dirs.add(parts.slice(0, i).join("/"));
+      }
+    },
+
+    async exists(path) {
+      return files.has(path) || dirs.has(path);
+    },
+
+    async list(dir) {
+      const prefix = dir === "" ? "" : `${dir}/`;
+      const entries = new Set<string>();
+      for (const key of files.keys()) {
+        if (!key.startsWith(prefix)) continue;
+        const rest = key.slice(prefix.length);
+        const first = rest.split("/")[0];
+        if (first) entries.add(first);
+      }
+      for (const d of dirs) {
+        if (!d.startsWith(prefix)) continue;
+        const rest = d.slice(prefix.length);
+        const first = rest.split("/")[0];
+        if (first && !rest.includes("/")) entries.add(first);
+      }
+      return Array.from(entries).sort();
+    },
+
+    async mkdir(path) {
+      const parts = path.split("/");
+      for (let i = 1; i <= parts.length; i++) {
+        dirs.add(parts.slice(0, i).join("/"));
+      }
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Write a smoke test**
+
+Create `src/workspaces/__tests__/helpers/memory-driver.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { createMemoryDriver } from "./memory-driver.js";
+
+describe("createMemoryDriver", () => {
+  it("round-trips write/read", async () => {
+    const d = createMemoryDriver();
+    await d.write("a/b.md", "x");
+    expect(await d.read("a/b.md")).toBe("x");
+  });
+
+  it("list returns immediate children only", async () => {
+    const d = createMemoryDriver({ "a/b.md": "1", "a/c/d.md": "2" });
+    expect((await d.list("a")).sort()).toEqual(["b.md", "c"]);
+  });
+
+  it("exists tracks both files and mkdir-created dirs", async () => {
+    const d = createMemoryDriver();
+    await d.mkdir("x/y");
+    expect(await d.exists("x/y")).toBe(true);
+    expect(await d.exists("x/z")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run both**
+
+Run: `npx vitest run src/workspaces/__tests__/helpers/memory-driver.test.ts`
+Expected: PASS, 3 tests
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/workspaces/__tests__/helpers/
+git commit -m "test(workspace): add in-memory WorkspaceDriver for test fixtures"
+```
+
+---
+
+## Task 9: Create `cockpit workspace` CLI subcommand
+
+**Files:**
+- Create: `src/commands/workspace.ts`
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Write the command file**
+
+Create `src/commands/workspace.ts`:
+
+```typescript
+import { Command } from "commander";
+import chalk from "chalk";
+import { loadConfig, type CockpitConfig } from "../config.js";
+import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
+import type { WorkspaceDriver } from "../workspaces/types.js";
+
+function buildRegistry(): WorkspaceRegistry {
+  return new WorkspaceRegistry({
+    obsidian: createObsidianDriver,
+  });
+}
+
+function resolveTarget(
+  registry: WorkspaceRegistry,
+  config: CockpitConfig,
+  target: string | undefined,
+  useHub: boolean,
+): WorkspaceDriver {
+  if (useHub) return registry.hub(config);
+  if (!target) throw new Error("Missing target: pass a project name or use --hub");
+  return registry.forProject(target, config);
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+export const workspaceCommand = new Command("workspace")
+  .description("Interact with the workspace layer (vault storage). Bridges bash scripts to the WorkspaceDriver.");
+
+workspaceCommand
+  .command("read")
+  .description("Print the contents of a scope-relative path to stdout")
+  .argument("<target>", "Project name")
+  .argument("<path>", "Scope-relative path")
+  .option("--hub", "Target the hub workspace instead of a project spoke")
+  .action(async (target: string, relPath: string, opts: { hub?: boolean }) => {
+    const config = loadConfig();
+    const registry = buildRegistry();
+    try {
+      const driver = resolveTarget(registry, config, opts.hub ? undefined : target, !!opts.hub);
+      const path = opts.hub ? target : relPath;  // --hub shifts positional
+      const content = await driver.read(path);
+      process.stdout.write(content);
+    } catch (err) {
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+  });
+
+workspaceCommand
+  .command("write")
+  .description("Write content to a scope-relative path. Pass '-' as content to read from stdin.")
+  .argument("<target>", "Project name")
+  .argument("<path>", "Scope-relative path")
+  .argument("<content>", "Content, or '-' to read from stdin")
+  .option("--hub", "Target the hub workspace")
+  .action(async (target: string, relPath: string, content: string, opts: { hub?: boolean }) => {
+    const config = loadConfig();
+    const registry = buildRegistry();
+    try {
+      let actualTarget = target;
+      let actualPath = relPath;
+      let actualContent = content;
+      if (opts.hub) {
+        // --hub shifts positionals: target becomes path, path becomes content
+        actualTarget = "";
+        actualPath = target;
+        actualContent = relPath;
+      }
+      const driver = resolveTarget(registry, config, opts.hub ? undefined : actualTarget, !!opts.hub);
+      const payload = actualContent === "-" ? await readStdin() : actualContent;
+      await driver.write(actualPath, payload);
+    } catch (err) {
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+  });
+
+workspaceCommand
+  .command("list")
+  .description("List entries in a scope-relative directory")
+  .argument("<target>", "Project name")
+  .argument("<dir>", "Scope-relative directory")
+  .option("--hub", "Target the hub workspace")
+  .action(async (target: string, dir: string, opts: { hub?: boolean }) => {
+    const config = loadConfig();
+    const registry = buildRegistry();
+    try {
+      const driver = resolveTarget(registry, config, opts.hub ? undefined : target, !!opts.hub);
+      const actualDir = opts.hub ? target : dir;
+      const entries = await driver.list(actualDir);
+      for (const entry of entries) console.log(entry);
+    } catch (err) {
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+  });
+
+workspaceCommand
+  .command("exists")
+  .description("Exit 0 if path exists, 1 if not")
+  .argument("<target>", "Project name")
+  .argument("<path>", "Scope-relative path")
+  .option("--hub", "Target the hub workspace")
+  .action(async (target: string, relPath: string, opts: { hub?: boolean }) => {
+    const config = loadConfig();
+    const registry = buildRegistry();
+    try {
+      const driver = resolveTarget(registry, config, opts.hub ? undefined : target, !!opts.hub);
+      const actualPath = opts.hub ? target : relPath;
+      const ok = await driver.exists(actualPath);
+      process.exit(ok ? 0 : 1);
+    } catch (err) {
+      console.error(chalk.red((err as Error).message));
+      process.exit(2);
+    }
+  });
+
+workspaceCommand
+  .command("mkdir")
+  .description("Recursively create a scope-relative directory")
+  .argument("<target>", "Project name")
+  .argument("<path>", "Scope-relative path")
+  .option("--hub", "Target the hub workspace")
+  .action(async (target: string, relPath: string, opts: { hub?: boolean }) => {
+    const config = loadConfig();
+    const registry = buildRegistry();
+    try {
+      const driver = resolveTarget(registry, config, opts.hub ? undefined : target, !!opts.hub);
+      const actualPath = opts.hub ? target : relPath;
+      await driver.mkdir(actualPath);
+    } catch (err) {
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+  });
+```
+
+- [ ] **Step 2: Register command in src/index.ts**
+
+In `src/index.ts`:
+- Add import after `runtimeCommand`: `import { workspaceCommand } from "./commands/workspace.js";`
+- Register after `program.addCommand(runtimeCommand);`: `program.addCommand(workspaceCommand);`
+
+- [ ] **Step 3: Build and smoke-test**
+
+Run:
+```
+npm run build
+node dist/index.js workspace --help
+```
+Expected: shows 5 subcommands (read/write/list/exists/mkdir).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/commands/workspace.ts src/index.ts
+git commit -m "feat(workspace): add 'cockpit workspace' CLI subcommand"
+```
+
+---
+
+## Task 10: Extract vault-layout helper + migrate init.ts
+
+**Files:**
+- Create: `src/lib/vault-layout.ts`
+- Modify: `src/commands/init.ts`
+
+- [ ] **Step 1: Create the layout helper**
+
+Create `src/lib/vault-layout.ts`:
+
+```typescript
+import type { WorkspaceDriver } from "../workspaces/types.js";
+
+export const SPOKE_SUBDIRS = [
+  "crew",
+  "learnings",
+  "daily-logs",
+  "skills",
+  "meta",
+  "templates",
+  "wiki",
+  "wiki/pages",
+];
+
+export async function ensureSpokeLayout(workspace: WorkspaceDriver): Promise<void> {
+  for (const sub of SPOKE_SUBDIRS) {
+    await workspace.mkdir(sub);
+  }
+}
+```
+
+- [ ] **Step 2: Migrate init.ts hub-create block**
+
+In `src/commands/init.ts`, replace the hub-vault-create block (the `if (fs.existsSync(hubPath))` block for hub scaffolding). The existing `copyDirRecursive` template logic stays — it copies the whole `obsidian/hub` template tree, which is semantically equivalent to a filesystem copy. This stays as-is because it's a provider-specific bootstrap (Obsidian template files).
+
+However, also wire in the workspace driver so a future provider's init path is discoverable. Add this import at the top:
+
+```typescript
+import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
+```
+
+And add a workspace probe before the scaffold attempt:
+
+```typescript
+// Probe the configured workspace provider; for obsidian the scaffold
+// continues to use the Obsidian-specific template tree copy below.
+const registry = new WorkspaceRegistry({ obsidian: createObsidianDriver });
+const workspaceName = (fs.existsSync(DEFAULT_CONFIG_PATH) ? JSON.parse(fs.readFileSync(DEFAULT_CONFIG_PATH, "utf-8")).workspace : null) ?? "obsidian";
+if (!registry.get(workspaceName)) {
+  console.log(chalk.red(`  ✘ Unknown workspace provider '${workspaceName}'`));
+  return;
+}
+```
+
+**Important:** the obsidian-specific `copyDirRecursive(hubTemplate, hubPath)` stays because it copies Obsidian app-specific template files (`.obsidian/` config, starter md files). A future Notion driver would skip this step entirely and use its own bootstrap.
+
+- [ ] **Step 3: Build and verify**
+
+Run: `npm run build && node dist/index.js init --help`
+Expected: exit 0, help renders.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/vault-layout.ts src/commands/init.ts
+git commit -m "refactor(init): add vault-layout helper and workspace-provider probe"
+```
+
+---
+
+## Task 11: Migrate launch.ts spoke-init + projects.ts
+
+**Files:**
+- Modify: `src/commands/launch.ts`
+- Modify: `src/commands/projects.ts`
+
+- [ ] **Step 1: Replace launch.ts spoke-init block**
+
+In `src/commands/launch.ts`, find the inline block (appears twice — once in `--all` loop, once in the project branch):
+
+```typescript
+if (!fs.existsSync(spokePath)) {
+  fs.mkdirSync(spokePath, { recursive: true });
+  for (const sub of ["crew", "learnings", "daily-logs", "skills", "meta", "templates", "wiki", "wiki/pages"]) {
+    fs.mkdirSync(path.join(spokePath, sub), { recursive: true });
+  }
+  console.log(chalk.cyan(`  ✔ Created spoke vault at ${spokePath}`));
+}
+```
+
+Replace BOTH occurrences with:
+
+```typescript
+const spokeExists = fs.existsSync(spokePath);
+if (!spokeExists) {
+  const spokeDriver = new WorkspaceRegistry({ obsidian: createObsidianDriver }).forProject(name, config);
+  await ensureSpokeLayout(spokeDriver);
+  console.log(chalk.cyan(`  ✔ Created spoke vault at ${spokePath}`));
+}
+```
+
+Add imports at the top of `launch.ts`:
+
+```typescript
+import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
+import { ensureSpokeLayout } from "../lib/vault-layout.js";
+```
+
+In the `--all` loop the variable name is `name` (project iteration key). In the project-arg branch the variable name is `project`. Use the correct one in each location.
+
+- [ ] **Step 2: Migrate projects.ts spoke init**
+
+Read `src/commands/projects.ts`. Find the spoke-vault initialization (if any — on `projects add`).
+
+If `projects.ts` creates the spoke dir + subdirs on add, replace that block with:
+
+```typescript
+const spokeDriver = new WorkspaceRegistry({ obsidian: createObsidianDriver }).forProject(name, config);
+await ensureSpokeLayout(spokeDriver);
+```
+
+And add imports:
+
+```typescript
+import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
+import { ensureSpokeLayout } from "../lib/vault-layout.js";
+```
+
+If projects.ts does NOT initialize the spoke layout, skip this step (leave a comment noting launch.ts handles lazy creation).
+
+- [ ] **Step 3: Build + smoke test**
+
+Run: `npm run build && node dist/index.js launch --help`
+Expected: exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/commands/launch.ts src/commands/projects.ts
+git commit -m "refactor(launch,projects): use ensureSpokeLayout helper"
+```
+
+---
+
+## Task 12: Migrate daily-logs.ts to take WorkspaceDriver
+
+**Files:**
+- Modify: `src/lib/daily-logs.ts`
+
+- [ ] **Step 1: Replace the file**
+
+Replace `src/lib/daily-logs.ts` with:
+
+```typescript
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import matter from "gray-matter";
+import { resolveHome } from "../config.js";
+import type { WorkspaceDriver } from "../workspaces/types.js";
+
+export function iso(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export function daysAgo(n: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d;
+}
+
+export function enumerateDays(from: Date, to: Date): string[] {
+  const out: string[] = [];
+  const cur = new Date(from);
+  cur.setHours(0, 0, 0, 0);
+  const end = new Date(to);
+  end.setHours(0, 0, 0, 0);
+  while (cur <= end) {
+    out.push(iso(cur));
+    cur.setDate(cur.getDate() + 1);
+  }
+  return out;
+}
+
+export interface DailyLog {
+  content: string;
+  blockers: string[];
+}
+
+export async function readDailyLog(
+  workspace: WorkspaceDriver,
+  dateStr: string,
+): Promise<DailyLog | null> {
+  const relPath = `daily-logs/${dateStr}.md`;
+  if (!(await workspace.exists(relPath))) return null;
+
+  const raw = await workspace.read(relPath);
+  const { content } = matter(raw);
+
+  const blockers: string[] = [];
+  const blockerMatch = content.match(/## Blocked\n([\s\S]*?)(?=\n##|$)/);
+  if (blockerMatch) {
+    const lines = blockerMatch[1].trim().split("\n");
+    for (const line of lines) {
+      const trimmed = line.replace(/^[-*]\s*/, "").trim();
+      if (trimmed && trimmed !== "(none)" && trimmed !== "None") {
+        blockers.push(trimmed);
+      }
+    }
+  }
+  return { content, blockers };
+}
+
+export function parseSection(content: string, section: string): string[] {
+  const match = content.match(new RegExp(`## ${section}\\n([\\s\\S]*?)(?=\\n##|$)`));
+  if (!match) return [];
+  return match[1]
+    .trim()
+    .split("\n")
+    .map((l) => l.replace(/^[-*]\s*/, "").trim())
+    .filter((l) => l && l !== "(none)" && l !== "None");
+}
+
+export function getGitCommits(projectPath: string, dateStr: string): string[] {
+  return getGitCommitsInRange(projectPath, `${dateStr} 00:00:00`, `${dateStr} 23:59:59`);
+}
+
+export function getGitCommitsInRange(projectPath: string, since: string, until?: string): string[] {
+  const resolved = resolveHome(projectPath);
+  if (!fs.existsSync(path.join(resolved, ".git"))) return [];
+
+  const untilArg = until ? ` --until="${until}"` : "";
+  try {
+    const output = execSync(
+      `git -C "${resolved}" log --since="${since}"${untilArg} --oneline --no-merges 2>/dev/null`,
+      { encoding: "utf-8", timeout: 5000 },
+    ).trim();
+    if (!output) return [];
+    return output.split("\n").map((l) => l.trim()).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+export function getMergedPRsInRange(projectPath: string, since: string, until?: string): string[] {
+  const resolved = resolveHome(projectPath);
+  if (!fs.existsSync(path.join(resolved, ".git"))) return [];
+
+  const untilArg = until ? ` --until="${until}"` : "";
+  try {
+    const output = execSync(
+      `git -C "${resolved}" log --merges --since="${since}"${untilArg} --pretty=format:%s 2>/dev/null`,
+      { encoding: "utf-8", timeout: 5000 },
+    ).trim();
+    if (!output) return [];
+    return output.split("\n").map((l) => l.trim()).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+```
+
+**Change summary:** `readDailyLog(spokeVault, dateStr)` → `readDailyLog(workspace, dateStr)` where `workspace: WorkspaceDriver`. Everything else unchanged.
+
+- [ ] **Step 2: Write a test for the new signature**
+
+Create `src/lib/__tests__/daily-logs.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { readDailyLog, parseSection } from "../daily-logs.js";
+import { createMemoryDriver } from "../../workspaces/__tests__/helpers/memory-driver.js";
+
+describe("readDailyLog", () => {
+  it("returns null when the daily log does not exist", async () => {
+    const ws = createMemoryDriver();
+    const log = await readDailyLog(ws, "2026-04-21");
+    expect(log).toBeNull();
+  });
+
+  it("parses content and extracts blockers", async () => {
+    const ws = createMemoryDriver({
+      "daily-logs/2026-04-21.md": `---
+date: 2026-04-21
+---
+
+## Completed
+- shipped phase 1
+
+## Blocked
+- waiting on code review
+- needs approval
+`,
+    });
+    const log = await readDailyLog(ws, "2026-04-21");
+    expect(log).not.toBeNull();
+    expect(log!.blockers).toEqual(["waiting on code review", "needs approval"]);
+  });
+
+  it("returns empty blockers when Blocked section is (none)", async () => {
+    const ws = createMemoryDriver({
+      "daily-logs/2026-04-21.md": `## Blocked\n- (none)\n`,
+    });
+    const log = await readDailyLog(ws, "2026-04-21");
+    expect(log!.blockers).toEqual([]);
+  });
+});
+
+describe("parseSection", () => {
+  it("extracts list items from a named section", () => {
+    const content = `## Completed
+- a
+- b
+
+## Other
+- c`;
+    expect(parseSection(content, "Completed")).toEqual(["a", "b"]);
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests**
+
+Run: `npx vitest run src/lib/__tests__/daily-logs.test.ts`
+Expected: PASS, 4 tests
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/daily-logs.ts src/lib/__tests__/
+git commit -m "refactor(daily-logs): accept WorkspaceDriver instead of vault path"
+```
+
+---
+
+## Task 13: Migrate standup.ts + retro.ts to use the registry
+
+**Files:**
+- Modify: `src/commands/standup.ts`
+- Modify: `src/commands/retro.ts`
+
+- [ ] **Step 1: Update standup.ts**
+
+In `src/commands/standup.ts`:
+
+Replace imports block:
+
+```typescript
+import { Command } from "commander";
+import fs from "node:fs";
+import path from "node:path";
+import chalk from "chalk";
+import matter from "gray-matter";
+import { loadConfig, resolveHome, type ProjectConfig } from "../config.js";
+import { readDailyLog, getGitCommits, iso, daysAgo } from "../lib/daily-logs.js";
+```
+
+With:
+
+```typescript
+import { Command } from "commander";
+import fs from "node:fs";
+import path from "node:path";
+import chalk from "chalk";
+import matter from "gray-matter";
+import { loadConfig, resolveHome, type ProjectConfig } from "../config.js";
+import { readDailyLog, getGitCommits, iso, daysAgo } from "../lib/daily-logs.js";
+import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
+```
+
+In the `getProjectStandup` function, change the signature and body:
+
+```typescript
+async function getProjectStandup(
+  name: string,
+  project: ProjectConfig,
+  dateStr: string,
+  registry: WorkspaceRegistry,
+  config: import("../config.js").CockpitConfig,
+): Promise<ProjectStandup> {
+  const spokeVault = resolveHome(project.spokeVault);
+  const statusFile = path.join(spokeVault, "status.md");
+
+  let status: StatusFrontmatter = {};
+  if (fs.existsSync(statusFile)) {
+    try {
+      status = matter(fs.readFileSync(statusFile, "utf-8")).data as StatusFrontmatter;
+    } catch { /* empty */ }
+  }
+
+  const workspace = registry.forProject(name, config);
+  const log = await readDailyLog(workspace, dateStr);
+  const gitCommits = getGitCommits(project.path, dateStr);
+
+  return {
+    name,
+    status,
+    dailyLog: log?.content ?? null,
+    gitCommits,
+    blockers: log?.blockers ?? [],
+  };
+}
+```
+
+In the action, make it async and instantiate the registry:
+
+```typescript
+.action(async (opts) => {
+    const config = loadConfig();
+    const projects = Object.entries(config.projects);
+    const registry = new WorkspaceRegistry({ obsidian: createObsidianDriver });
+    // ... existing guards ...
+    const standups = await Promise.all(
+      targets.map(([name, proj]) => getProjectStandup(name, proj, dateStr, registry, config)),
+    );
+    const output = formatStandup(standups, dateStr, raw);
+    console.log(output);
+  });
+```
+
+**Note:** `status.md` reading stays on `fs.readFileSync` temporarily — a full migration of status.md to the driver happens in Task 14 (status.ts). Keeping this transitional is fine because it doesn't block the standup refactor.
+
+- [ ] **Step 2: Update retro.ts**
+
+Apply the equivalent changes to `src/commands/retro.ts`: add imports, pass registry/config into helpers that call `readDailyLog`, await the async call.
+
+Read retro.ts first to find the correct call-sites; the same pattern as standup applies.
+
+- [ ] **Step 3: Build**
+
+Run: `npm run build`
+Expected: exit 0
+
+- [ ] **Step 4: Full suite**
+
+Run: `npm run test -- --run`
+Expected: same baseline (2 pre-existing config.test.ts failures, rest green + 4 new daily-logs tests, + workspace tests all pass)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/standup.ts src/commands/retro.ts
+git commit -m "refactor(standup,retro): use WorkspaceRegistry for daily logs"
+```
+
+---
+
+## Task 14: Migrate status.ts
+
+**Files:**
+- Modify: `src/commands/status.ts`
+
+- [ ] **Step 1: Replace the whole file**
+
+Replace `src/commands/status.ts` with:
+
+```typescript
+import { Command } from "commander";
+import chalk from "chalk";
+import matter from "gray-matter";
+import { loadConfig } from "../config.js";
+import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
+
+interface StatusFrontmatter {
+  project?: string;
+  captain_session?: string;
+  last_updated?: string;
+  active_crew?: number;
+  tasks_total?: number;
+  tasks_completed?: number;
+  tasks_in_progress?: number;
+  tasks_pending?: number;
+}
+
+function timeAgo(dateStr: string | undefined): string {
+  if (!dateStr) return chalk.dim("—");
+  const date = new Date(dateStr);
+  if (isNaN(date.getTime())) return chalk.dim("—");
+
+  const diff = Date.now() - date.getTime();
+  const mins = Math.floor(diff / 60_000);
+  const hours = Math.floor(diff / 3_600_000);
+  const days = Math.floor(diff / 86_400_000);
+
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  if (hours < 24) return `${hours}h ago`;
+  return `${days}d ago`;
+}
+
+function progressBar(completed: number, total: number): string {
+  if (total === 0) return chalk.dim("no tasks");
+  const pct = Math.round((completed / total) * 100);
+  const filled = Math.round(pct / 10);
+  const bar = "█".repeat(filled) + "░".repeat(10 - filled);
+  return `${bar} ${pct}%`;
+}
+
+export const statusCommand = new Command("status")
+  .description("Show status of all projects from spoke vault status files")
+  .action(async () => {
+    const config = loadConfig();
+    const projects = Object.entries(config.projects);
+    const registry = new WorkspaceRegistry({ obsidian: createObsidianDriver });
+
+    if (projects.length === 0) {
+      console.log(chalk.yellow("\nNo projects registered. Use: cockpit projects add <name> <path>\n"));
+      return;
+    }
+
+    console.log(chalk.bold("\nProject Status\n"));
+    console.log(
+      chalk.dim(
+        `  ${"PROJECT".padEnd(18)} ${"CAPTAIN".padEnd(12)} ${"CREW".padEnd(6)} ${"PROGRESS".padEnd(25)} LAST UPDATE`,
+      ),
+    );
+    console.log(chalk.dim("  " + "─".repeat(85)));
+
+    for (const [name, project] of projects) {
+      const workspace = registry.forProject(name, config);
+
+      if (!(await workspace.exists("status.md"))) {
+        console.log(`  ${name.padEnd(18)} ${chalk.dim("no status.md")}`);
+        continue;
+      }
+
+      let fm: StatusFrontmatter = {};
+      try {
+        const raw = await workspace.read("status.md");
+        fm = matter(raw).data as StatusFrontmatter;
+      } catch {
+        console.log(`  ${name.padEnd(18)} ${chalk.red("error reading status.md")}`);
+        continue;
+      }
+
+      const sessionIndicator =
+        fm.captain_session === "active"
+          ? chalk.green("●")
+          : chalk.dim("○");
+      const captainDisplay = `${project.captainName.padEnd(11)} ${sessionIndicator}`;
+      const crew = String(fm.active_crew ?? 0).padEnd(6);
+      const progress = progressBar(
+        fm.tasks_completed ?? 0,
+        fm.tasks_total ?? 0,
+      ).padEnd(25);
+      const updated = timeAgo(fm.last_updated);
+
+      console.log(
+        `  ${name.padEnd(18)} ${captainDisplay}  ${crew} ${progress} ${updated}`,
+      );
+    }
+
+    console.log("");
+  });
+```
+
+- [ ] **Step 2: Build**
+
+Run: `npm run build`
+Expected: exit 0
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/commands/status.ts
+git commit -m "refactor(status): use WorkspaceDriver for status.md reads"
+```
+
+---
+
+## Task 15: Migrate doctor.ts to probe workspace providers
+
+**Files:**
+- Modify: `src/commands/doctor.ts`
+
+- [ ] **Step 1: Read the file first**
+
+Run: `cat src/commands/doctor.ts`
+
+Note the existing hub-vault check line: `results.push(check(\`Hub vault exists...\`, ...));`
+
+- [ ] **Step 2: Add workspace probing**
+
+At the top of `src/commands/doctor.ts`, add import:
+
+```typescript
+import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
+```
+
+Inside the action (which already loads `config`), after the runtime probe block add:
+
+```typescript
+// Probe workspace providers
+const workspaces = new WorkspaceRegistry({ obsidian: createObsidianDriver });
+const hubDriver = workspaces.hub(config);
+const hubProbe = await hubDriver.probe();
+results.push(check(
+  `Workspace '${config.workspace ?? "obsidian"}' — hub reachable`,
+  hubProbe.installed && hubProbe.rootExists,
+));
+
+for (const [name, proj] of Object.entries(config.projects)) {
+  const spokeDriver = workspaces.forProject(name, config);
+  const probe = await spokeDriver.probe();
+  results.push(check(
+    `Workspace — spoke '${name}' reachable`,
+    probe.installed && probe.rootExists,
+  ));
+}
+```
+
+Keep the existing `Hub vault exists` check OR delete it if redundant. Delete the old `Hub vault exists` check since the new probe supersedes it.
+
+- [ ] **Step 3: Build + run doctor**
+
+Run: `npm run build && node dist/index.js doctor`
+Expected: shows new "Workspace 'obsidian' — hub reachable" line; spoke checks for each project.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/commands/doctor.ts
+git commit -m "refactor(doctor): probe workspace providers via WorkspaceRegistry"
+```
+
+---
+
+## Task 16: Migrate bash scripts (reactor-cycle.sh + read-status.sh)
+
+**Files:**
+- Modify: `scripts/reactor-cycle.sh`
+- Modify: `scripts/read-status.sh`
+
+- [ ] **Step 1: Read the current scripts**
+
+Run: `cat scripts/reactor-cycle.sh scripts/read-status.sh`
+
+- [ ] **Step 2: Migrate every `cat "$SPOKE_VAULT/..."` to `cockpit workspace read`**
+
+Pattern to replace:
+```bash
+cat "$HUB_VAULT/some/path.md"
+```
+With:
+```bash
+cockpit workspace read --hub "some/path.md"
+```
+
+And:
+```bash
+cat "$SPOKE_VAULT/some/path.md"
+```
+With:
+```bash
+cockpit workspace read "$PROJECT" "some/path.md"
+```
+
+Similarly for `[ -f "$SPOKE_VAULT/..." ]`:
+```bash
+if cockpit workspace exists "$PROJECT" "some/path.md"; then
+```
+
+- [ ] **Step 3: Syntax check both**
+
+Run: `bash -n scripts/reactor-cycle.sh scripts/read-status.sh`
+Expected: no output, exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/reactor-cycle.sh scripts/read-status.sh
+git commit -m "refactor(scripts): migrate reactor-cycle and read-status to 'cockpit workspace'"
+```
+
+---
+
+## Task 17: Update README
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add workspace CLI rows to Commands table**
+
+After the existing `cockpit runtime list` row, insert:
+
+```markdown
+| `cockpit workspace read <project> <path>` | Read a scope-relative file from the project's spoke vault |
+| `cockpit workspace list <project> <dir>` | List entries in a spoke vault directory |
+| `cockpit workspace read --hub <path>` | Read from the hub vault |
+```
+
+- [ ] **Step 2: Add `workspace` fields to the Config JSON example**
+
+Top-level, alongside `runtime`:
+
+```json
+"workspace": "obsidian",
+```
+
+Per-project in brove:
+
+```json
+"workspace": "obsidian"
+```
+
+- [ ] **Step 3: Add Architecture subsection**
+
+After "Runtime Abstraction", add:
+
+```markdown
+### Workspace Abstraction
+
+Vault storage (hub + per-project spokes) runs behind a pluggable **workspace driver** (currently only `obsidian`). Filesystem operations — `read`, `write`, `list`, `exists`, `mkdir` — go through the driver instead of `fs` directly. Each project may override the global default via its `workspace` field. Bash scripts call `cockpit workspace <op>` to read/write vault data without hardcoding paths. New backends (Notion, plain-md, S3) are added as driver files in `src/workspaces/` — see `docs/specs/2026-04-21-plugin-system-workspace-design.md`.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): document workspace config field and CLI subcommand"
+```
+
+---
+
+## Task 18: Full-suite verification
+
+**Files:** none — just run everything.
+
+- [ ] **Step 1: Test suite**
+
+Run: `npm run test -- --run`
+Expected: all new tests pass (obsidian 10, registry 8, memory-driver 3, daily-logs 4 = 25 new); existing tests preserve baseline (2 pre-existing config.test.ts failures acceptable).
+
+- [ ] **Step 2: Lint + build**
+
+Run: `npm run lint && npm run build`
+Expected: exits 0 on both.
+
+- [ ] **Step 3: CLI smoke**
+
+Run:
+- `node dist/index.js workspace --help` — shows 5 subcommands
+- `node dist/index.js workspace list --hub .` — lists hub vault entries
+- `node dist/index.js doctor` — shows new Workspace checks
+
+- [ ] **Step 4: No commit — verification only**
+
+If anything fails, fix in place and commit as `fix(workspace): ...`.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Every section of the design spec (§1 Interface, §2 Registry + Config, §3 CLI, §4 Refactor Surface, §5 Testing, §6 Rollout) has implementing tasks. Rollout §6 is covered by the task order (Tasks 10-17).
+- **Type consistency:** `WorkspaceDriver` methods (`probe`, `read`, `write`, `exists`, `list`, `mkdir`) are identical across types.ts, obsidian.ts, memory-driver.ts, and all migrated callers. `WorkspaceRegistry` methods (`hub`, `forProject`, `get`, `probeAll`) consistent.
+- **Deferred scope** (per spec §Non-Goals): no additional providers beyond obsidian; no domain abstraction; no tracker/notifier; no external plugin loading; learnings/wiki bash scripts stay as-is.
+- **Commit discipline:** 17 atomic commits across 18 tasks (Task 18 is verify-only unless fixes needed).
+- **Status.md reads:** Task 14 migrates status.ts; standup.ts in Task 13 temporarily keeps raw fs reads for status.md to let the two migrations be atomic.

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import chalk from "chalk";
 import { loadConfig } from "../config.js";
 import { createCmuxDriver, RuntimeRegistry } from "../runtimes/index.js";
+import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
 
 function commandExists(cmd: string): boolean {
   try {
@@ -118,6 +119,24 @@ export const doctorCommand = new Command("doctor")
       ));
     }
 
+    // Probe workspace providers
+    const workspaces = new WorkspaceRegistry({ obsidian: createObsidianDriver });
+    const hubDriver = workspaces.hub(config);
+    const hubProbe = await hubDriver.probe();
+    results.push(check(
+      `Workspace '${config.workspace ?? "obsidian"}' — hub reachable`,
+      hubProbe.installed && hubProbe.rootExists,
+    ));
+
+    for (const [name] of Object.entries(config.projects)) {
+      const spokeDriver = workspaces.forProject(name, config);
+      const probe = await spokeDriver.probe();
+      results.push(check(
+        `Workspace — spoke '${name}' reachable`,
+        probe.installed && probe.rootExists,
+      ));
+    }
+
     results.push(
       check(
         "Cockpit config exists",
@@ -125,12 +144,6 @@ export const doctorCommand = new Command("doctor")
           process.env.COCKPIT_CONFIG ||
             `${process.env.HOME}/.config/cockpit/config.json`,
         ),
-      ),
-    );
-    results.push(
-      check(
-        `Hub vault exists (${config.hubVault})`,
-        fs.existsSync(config.hubVault),
       ),
     );
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_CONFIG_PATH,
   resolveHome,
 } from "../config.js";
+import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
 
 function findPackageRoot(): string {
   let dir = path.dirname(new URL(import.meta.url).pathname);
@@ -42,6 +43,20 @@ export const initCommand = new Command("init")
     const configDir = path.join(os.homedir(), ".config", "cockpit");
 
     console.log(chalk.bold("\nCockpit Init\n"));
+
+    // Verify the default workspace provider is registered (cockpit ships obsidian;
+    // if user already has a config pointing to an unknown provider, bail early)
+    const registry = new WorkspaceRegistry({ obsidian: createObsidianDriver });
+    try {
+      if (fs.existsSync(DEFAULT_CONFIG_PATH)) {
+        const existing = JSON.parse(fs.readFileSync(DEFAULT_CONFIG_PATH, "utf-8"));
+        const wsName = existing.workspace ?? "obsidian";
+        registry.get(wsName);
+      }
+    } catch (err) {
+      console.log(chalk.red(`  ✘ ${(err as Error).message}`));
+      return;
+    }
 
     // 1. Create config
     if (fs.existsSync(DEFAULT_CONFIG_PATH)) {

--- a/src/commands/launch.ts
+++ b/src/commands/launch.ts
@@ -10,6 +10,8 @@ import { createClaudeDriver, createCodexDriver, createGeminiDriver, createAiderD
 import type { AgentDriver, Role } from "../drivers/types.js";
 import { RuntimeRegistry, createCmuxDriver } from "../runtimes/index.js";
 import type { RuntimeDriver } from "../runtimes/index.js";
+import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
+import { ensureSpokeLayout } from "../lib/vault-layout.js";
 
 const CMUX_APP = "/Applications/cmux.app";
 // Retained for the select-workspace / current-workspace calls that are not yet abstracted by RuntimeDriver.
@@ -308,10 +310,8 @@ export const launchCommand = new Command("launch")
         // Ensure spoke vault exists
         const spokePath = resolveHome(proj.spokeVault);
         if (!fs.existsSync(spokePath)) {
-          fs.mkdirSync(spokePath, { recursive: true });
-          for (const sub of ["crew", "learnings", "daily-logs", "skills", "meta", "templates", "wiki", "wiki/pages"]) {
-            fs.mkdirSync(path.join(spokePath, sub), { recursive: true });
-          }
+          const spokeDriver = new WorkspaceRegistry({ obsidian: createObsidianDriver }).forProject(name, config);
+          await ensureSpokeLayout(spokeDriver);
           console.log(chalk.cyan(`  ✔ Created spoke vault at ${spokePath}`));
         }
         console.log(chalk.bold(`\n  Captain: ${proj.captainName} (${name})`));
@@ -349,10 +349,8 @@ export const launchCommand = new Command("launch")
       // Ensure spoke vault exists
       const spokePath = resolveHome(proj.spokeVault);
       if (!fs.existsSync(spokePath)) {
-        fs.mkdirSync(spokePath, { recursive: true });
-        for (const sub of ["crew", "learnings", "daily-logs", "skills", "meta", "templates", "wiki", "wiki/pages"]) {
-          fs.mkdirSync(path.join(spokePath, sub), { recursive: true });
-        }
+        const spokeDriver = new WorkspaceRegistry({ obsidian: createObsidianDriver }).forProject(project, config);
+        await ensureSpokeLayout(spokeDriver);
         console.log(chalk.cyan(`  ✔ Created spoke vault at ${spokePath}`));
       }
 

--- a/src/commands/retro.ts
+++ b/src/commands/retro.ts
@@ -33,6 +33,7 @@ interface ProjectRetro {
   tasksInProgressNow: number;
 }
 
+// TODO(workspace): status.md still read via raw fs — migrate to workspace driver (see #24)
 function readStatus(spokeVault: string): StatusFrontmatter {
   const statusFile = path.join(spokeVault, "status.md");
   if (!fs.existsSync(statusFile)) return {};

--- a/src/commands/retro.ts
+++ b/src/commands/retro.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import chalk from "chalk";
 import matter from "gray-matter";
-import { loadConfig, resolveHome, type ProjectConfig } from "../config.js";
+import { loadConfig, resolveHome, type ProjectConfig, type CockpitConfig } from "../config.js";
 import {
   readDailyLog,
   parseSection,
@@ -13,6 +13,7 @@ import {
   iso,
   daysAgo,
 } from "../lib/daily-logs.js";
+import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
 
 interface StatusFrontmatter {
   tasks_total?: number;
@@ -55,12 +56,15 @@ function dedupe(items: string[]): string[] {
   return out;
 }
 
-function getProjectRetro(
+async function getProjectRetro(
   name: string,
   project: ProjectConfig,
   fromStr: string,
   toStr: string,
-): ProjectRetro {
+  registry: WorkspaceRegistry,
+  config: CockpitConfig,
+): Promise<ProjectRetro> {
+  const workspace = registry.forProject(name, config);
   const spokeVault = resolveHome(project.spokeVault);
   const status = readStatus(spokeVault);
 
@@ -70,7 +74,7 @@ function getProjectRetro(
   const decisions: string[] = [];
 
   for (const day of enumerateDays(new Date(fromStr), new Date(toStr))) {
-    const log = readDailyLog(spokeVault, day);
+    const log = await readDailyLog(workspace, day);
     if (!log) continue;
     shipped.push(...parseSection(log.content, "Completed"));
     inProgress.push(...parseSection(log.content, "In Progress"));
@@ -166,8 +170,9 @@ export const retroCommand = new Command("retro")
   .option("-p, --project <name>", "Retro for a single project")
   .option("-a, --all", "All projects (default)")
   .option("-r, --raw", "Raw markdown output (for pasting into Slack/Obsidian)")
-  .action((opts) => {
+  .action(async (opts) => {
     const config = loadConfig();
+    const registry = new WorkspaceRegistry({ obsidian: createObsidianDriver });
     const projects = Object.entries(config.projects);
 
     if (projects.length === 0) {
@@ -199,6 +204,8 @@ export const retroCommand = new Command("retro")
       targets = projects;
     }
 
-    const retros = targets.map(([name, proj]) => getProjectRetro(name, proj, fromStr, toStr));
+    const retros = await Promise.all(
+      targets.map(([name, proj]) => getProjectRetro(name, proj, fromStr, toStr, registry, config)),
+    );
     console.log(formatRetro(retros, fromStr, toStr, raw));
   });

--- a/src/commands/standup.ts
+++ b/src/commands/standup.ts
@@ -38,6 +38,7 @@ async function getProjectStandup(
   config: CockpitConfig,
 ): Promise<ProjectStandup> {
   const workspace = registry.forProject(name, config);
+  // TODO(workspace): status.md still read via raw fs — migrate to workspace driver (see #24)
   const spokeVault = resolveHome(project.spokeVault);
   const statusFile = path.join(spokeVault, "status.md");
 

--- a/src/commands/standup.ts
+++ b/src/commands/standup.ts
@@ -3,8 +3,9 @@ import fs from "node:fs";
 import path from "node:path";
 import chalk from "chalk";
 import matter from "gray-matter";
-import { loadConfig, resolveHome, type ProjectConfig } from "../config.js";
+import { loadConfig, resolveHome, type ProjectConfig, type CockpitConfig } from "../config.js";
 import { readDailyLog, getGitCommits, iso, daysAgo } from "../lib/daily-logs.js";
+import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
 
 interface StatusFrontmatter {
   project?: string;
@@ -15,11 +16,6 @@ interface StatusFrontmatter {
   tasks_completed?: number;
   tasks_in_progress?: number;
   tasks_pending?: number;
-}
-
-interface DailyLogFrontmatter {
-  date?: string;
-  project?: string;
 }
 
 interface ProjectStandup {
@@ -34,7 +30,14 @@ function getDateStr(yesterday: boolean): string {
   return iso(daysAgo(yesterday ? 1 : 0));
 }
 
-function getProjectStandup(name: string, project: ProjectConfig, dateStr: string): ProjectStandup {
+async function getProjectStandup(
+  name: string,
+  project: ProjectConfig,
+  dateStr: string,
+  registry: WorkspaceRegistry,
+  config: CockpitConfig,
+): Promise<ProjectStandup> {
+  const workspace = registry.forProject(name, config);
   const spokeVault = resolveHome(project.spokeVault);
   const statusFile = path.join(spokeVault, "status.md");
 
@@ -45,7 +48,7 @@ function getProjectStandup(name: string, project: ProjectConfig, dateStr: string
     } catch { /* empty */ }
   }
 
-  const log = readDailyLog(spokeVault, dateStr);
+  const log = await readDailyLog(workspace, dateStr);
   const gitCommits = getGitCommits(project.path, dateStr);
 
   return {
@@ -148,8 +151,9 @@ export const standupCommand = new Command("standup")
   .option("-a, --all", "Show all projects (default)")
   .option("-y, --yesterday", "Show yesterday's standup instead of today")
   .option("-r, --raw", "Output raw markdown (for pasting into Slack/chat)")
-  .action((opts) => {
+  .action(async (opts) => {
     const config = loadConfig();
+    const registry = new WorkspaceRegistry({ obsidian: createObsidianDriver });
     const projects = Object.entries(config.projects);
 
     if (projects.length === 0) {
@@ -172,7 +176,9 @@ export const standupCommand = new Command("standup")
       targets = projects;
     }
 
-    const standups = targets.map(([name, proj]) => getProjectStandup(name, proj, dateStr));
+    const standups = await Promise.all(
+      targets.map(([name, proj]) => getProjectStandup(name, proj, dateStr, registry, config)),
+    );
     const output = formatStandup(standups, dateStr, raw);
     console.log(output);
   });

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,9 +1,8 @@
 import { Command } from "commander";
-import fs from "node:fs";
-import path from "node:path";
 import chalk from "chalk";
 import matter from "gray-matter";
 import { loadConfig } from "../config.js";
+import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
 
 interface StatusFrontmatter {
   project?: string;
@@ -42,9 +41,10 @@ function progressBar(completed: number, total: number): string {
 
 export const statusCommand = new Command("status")
   .description("Show status of all projects from spoke vault status files")
-  .action(() => {
+  .action(async () => {
     const config = loadConfig();
     const projects = Object.entries(config.projects);
+    const registry = new WorkspaceRegistry({ obsidian: createObsidianDriver });
 
     if (projects.length === 0) {
       console.log(chalk.yellow("\nNo projects registered. Use: cockpit projects add <name> <path>\n"));
@@ -60,18 +60,16 @@ export const statusCommand = new Command("status")
     console.log(chalk.dim("  " + "─".repeat(85)));
 
     for (const [name, project] of projects) {
-      const statusFile = path.join(project.spokeVault, "status.md");
+      const workspace = registry.forProject(name, config);
 
-      if (!fs.existsSync(statusFile)) {
-        console.log(
-          `  ${name.padEnd(18)} ${chalk.dim("no status.md")}`,
-        );
+      if (!(await workspace.exists("status.md"))) {
+        console.log(`  ${name.padEnd(18)} ${chalk.dim("no status.md")}`);
         continue;
       }
 
       let fm: StatusFrontmatter = {};
       try {
-        const raw = fs.readFileSync(statusFile, "utf-8");
+        const raw = await workspace.read("status.md");
         fm = matter(raw).data as StatusFrontmatter;
       } catch {
         console.log(`  ${name.padEnd(18)} ${chalk.red("error reading status.md")}`);
@@ -82,9 +80,7 @@ export const statusCommand = new Command("status")
         fm.captain_session === "active"
           ? chalk.green("●")
           : chalk.dim("○");
-      // Pad the plain name first, then append the colored indicator so chalk escapes don't break alignment
       const captainDisplay = `${project.captainName.padEnd(11)} ${sessionIndicator}`;
-
       const crew = String(fm.active_crew ?? 0).padEnd(6);
       const progress = progressBar(
         fm.tasks_completed ?? 0,

--- a/src/commands/workspace.ts
+++ b/src/commands/workspace.ts
@@ -1,0 +1,173 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { loadConfig, type CockpitConfig } from "../config.js";
+import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
+import type { WorkspaceDriver } from "../workspaces/types.js";
+
+function buildRegistry(): WorkspaceRegistry {
+  return new WorkspaceRegistry({
+    obsidian: createObsidianDriver,
+  });
+}
+
+function resolveDriver(
+  registry: WorkspaceRegistry,
+  config: CockpitConfig,
+  projectTarget: string | undefined,
+  useHub: boolean,
+): WorkspaceDriver {
+  if (useHub) return registry.hub(config);
+  if (!projectTarget) throw new Error("Missing target: pass a project name or use --hub");
+  return registry.forProject(projectTarget, config);
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+export const workspaceCommand = new Command("workspace")
+  .description("Interact with the workspace layer (vault storage). Bridges bash scripts to the WorkspaceDriver.");
+
+// Reusable positional parser. The CLI convention:
+//   <target> <path>          → project workspace
+//   --hub <path>             → hub workspace
+// With commander we declare <arg1> [arg2] and in the action:
+//   if --hub: arg1 is the path (target is implicit).
+//   else:     arg1 is the target, arg2 is the path.
+function resolveTargetAndPath(
+  arg1: string,
+  arg2: string | undefined,
+  useHub: boolean,
+): { projectTarget: string | undefined; path: string } {
+  if (useHub) {
+    if (arg2 !== undefined) {
+      throw new Error("With --hub, pass only the path (not a project name)");
+    }
+    return { projectTarget: undefined, path: arg1 };
+  }
+  if (arg2 === undefined) {
+    throw new Error("Missing path — usage: <project> <path>  (or: --hub <path>)");
+  }
+  return { projectTarget: arg1, path: arg2 };
+}
+
+workspaceCommand
+  .command("read")
+  .description("Print the contents of a scope-relative path to stdout")
+  .argument("<arg1>", "Project name, or the path when --hub is used")
+  .argument("[arg2]", "Scope-relative path (omit when using --hub)")
+  .option("--hub", "Target the hub workspace instead of a project spoke")
+  .action(async (arg1: string, arg2: string | undefined, opts: { hub?: boolean }) => {
+    const config = loadConfig();
+    const registry = buildRegistry();
+    try {
+      const { projectTarget, path } = resolveTargetAndPath(arg1, arg2, !!opts.hub);
+      const driver = resolveDriver(registry, config, projectTarget, !!opts.hub);
+      const content = await driver.read(path);
+      process.stdout.write(content);
+    } catch (err) {
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+  });
+
+workspaceCommand
+  .command("write")
+  .description("Write content to a scope-relative path. Pass '-' as content to read from stdin.")
+  .argument("<arg1>", "Project name, or the path when --hub is used")
+  .argument("<arg2>", "Scope-relative path, or content when --hub is used")
+  .argument("[arg3]", "Content (omit when using --hub). Use '-' for stdin.")
+  .option("--hub", "Target the hub workspace")
+  .action(async (arg1: string, arg2: string, arg3: string | undefined, opts: { hub?: boolean }) => {
+    const config = loadConfig();
+    const registry = buildRegistry();
+    try {
+      let projectTarget: string | undefined;
+      let path: string;
+      let rawContent: string;
+      if (opts.hub) {
+        if (arg3 !== undefined) {
+          throw new Error("With --hub, pass only the path and content");
+        }
+        projectTarget = undefined;
+        path = arg1;
+        rawContent = arg2;
+      } else {
+        if (arg3 === undefined) {
+          throw new Error("Missing content — usage: <project> <path> <content>");
+        }
+        projectTarget = arg1;
+        path = arg2;
+        rawContent = arg3;
+      }
+      const driver = resolveDriver(registry, config, projectTarget, !!opts.hub);
+      const payload = rawContent === "-" ? await readStdin() : rawContent;
+      await driver.write(path, payload);
+    } catch (err) {
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+  });
+
+workspaceCommand
+  .command("list")
+  .description("List entries in a scope-relative directory")
+  .argument("<arg1>", "Project name, or the directory when --hub is used")
+  .argument("[arg2]", "Scope-relative directory (omit when using --hub)")
+  .option("--hub", "Target the hub workspace")
+  .action(async (arg1: string, arg2: string | undefined, opts: { hub?: boolean }) => {
+    const config = loadConfig();
+    const registry = buildRegistry();
+    try {
+      const { projectTarget, path } = resolveTargetAndPath(arg1, arg2, !!opts.hub);
+      const driver = resolveDriver(registry, config, projectTarget, !!opts.hub);
+      const entries = await driver.list(path);
+      for (const entry of entries) console.log(entry);
+    } catch (err) {
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+  });
+
+workspaceCommand
+  .command("exists")
+  .description("Exit 0 if path exists, 1 if not")
+  .argument("<arg1>", "Project name, or the path when --hub is used")
+  .argument("[arg2]", "Scope-relative path (omit when using --hub)")
+  .option("--hub", "Target the hub workspace")
+  .action(async (arg1: string, arg2: string | undefined, opts: { hub?: boolean }) => {
+    const config = loadConfig();
+    const registry = buildRegistry();
+    try {
+      const { projectTarget, path } = resolveTargetAndPath(arg1, arg2, !!opts.hub);
+      const driver = resolveDriver(registry, config, projectTarget, !!opts.hub);
+      const ok = await driver.exists(path);
+      process.exit(ok ? 0 : 1);
+    } catch (err) {
+      console.error(chalk.red((err as Error).message));
+      process.exit(2);
+    }
+  });
+
+workspaceCommand
+  .command("mkdir")
+  .description("Recursively create a scope-relative directory")
+  .argument("<arg1>", "Project name, or the path when --hub is used")
+  .argument("[arg2]", "Scope-relative path (omit when using --hub)")
+  .option("--hub", "Target the hub workspace")
+  .action(async (arg1: string, arg2: string | undefined, opts: { hub?: boolean }) => {
+    const config = loadConfig();
+    const registry = buildRegistry();
+    try {
+      const { projectTarget, path } = resolveTargetAndPath(arg1, arg2, !!opts.hub);
+      const driver = resolveDriver(registry, config, projectTarget, !!opts.hub);
+      await driver.mkdir(path);
+    } catch (err) {
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+  });

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ export interface ProjectConfig {
   group?: string;
   groupRole?: string;
   runtime?: string;
+  workspace?: string;
 }
 
 export interface PermissionConfig {
@@ -104,6 +105,7 @@ export interface CockpitConfig {
   projects: Record<string, ProjectConfig>;
   agents?: Record<string, AgentEntry>;
   runtime?: string;
+  workspace?: string;
   defaults: {
     maxCrew: number;
     worktreeDir: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { reactorCommand } from "./commands/reactor.js";
 import { standupCommand } from "./commands/standup.js";
 import { retroCommand } from "./commands/retro.js";
 import { runtimeCommand } from "./commands/runtime.js";
+import { workspaceCommand } from "./commands/workspace.js";
 
 const program = new Command();
 
@@ -31,5 +32,6 @@ program.addCommand(reactorCommand);
 program.addCommand(standupCommand);
 program.addCommand(retroCommand);
 program.addCommand(runtimeCommand);
+program.addCommand(workspaceCommand);
 
 program.parse();

--- a/src/lib/__tests__/daily-logs.test.ts
+++ b/src/lib/__tests__/daily-logs.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { readDailyLog, parseSection } from "../daily-logs.js";
+import { createMemoryDriver } from "../../workspaces/__tests__/helpers/memory-driver.js";
+
+describe("readDailyLog", () => {
+  it("returns null when the daily log does not exist", async () => {
+    const ws = createMemoryDriver();
+    const log = await readDailyLog(ws, "2026-04-21");
+    expect(log).toBeNull();
+  });
+
+  it("parses content and extracts blockers", async () => {
+    const ws = createMemoryDriver({
+      "daily-logs/2026-04-21.md": `---\ndate: 2026-04-21\n---\n\n## Completed\n- shipped phase 1\n\n## Blocked\n- waiting on code review\n- needs approval\n`,
+    });
+    const log = await readDailyLog(ws, "2026-04-21");
+    expect(log).not.toBeNull();
+    expect(log!.blockers).toEqual(["waiting on code review", "needs approval"]);
+  });
+
+  it("returns empty blockers when Blocked section is (none)", async () => {
+    const ws = createMemoryDriver({
+      "daily-logs/2026-04-21.md": `## Blocked\n- (none)\n`,
+    });
+    const log = await readDailyLog(ws, "2026-04-21");
+    expect(log!.blockers).toEqual([]);
+  });
+});
+
+describe("parseSection", () => {
+  it("extracts list items from a named section", () => {
+    const content = `## Completed\n- a\n- b\n\n## Other\n- c`;
+    expect(parseSection(content, "Completed")).toEqual(["a", "b"]);
+  });
+});

--- a/src/lib/daily-logs.ts
+++ b/src/lib/daily-logs.ts
@@ -1,8 +1,9 @@
+import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { execSync } from "node:child_process";
 import matter from "gray-matter";
 import { resolveHome } from "../config.js";
+import type { WorkspaceDriver } from "../workspaces/types.js";
 
 export function iso(d: Date): string {
   return d.toISOString().slice(0, 10);
@@ -32,11 +33,14 @@ export interface DailyLog {
   blockers: string[];
 }
 
-export function readDailyLog(spokeVault: string, dateStr: string): DailyLog | null {
-  const logFile = path.join(spokeVault, "daily-logs", `${dateStr}.md`);
-  if (!fs.existsSync(logFile)) return null;
+export async function readDailyLog(
+  workspace: WorkspaceDriver,
+  dateStr: string,
+): Promise<DailyLog | null> {
+  const relPath = `daily-logs/${dateStr}.md`;
+  if (!(await workspace.exists(relPath))) return null;
 
-  const raw = fs.readFileSync(logFile, "utf-8");
+  const raw = await workspace.read(relPath);
   const { content } = matter(raw);
 
   const blockers: string[] = [];

--- a/src/lib/vault-layout.ts
+++ b/src/lib/vault-layout.ts
@@ -1,0 +1,18 @@
+import type { WorkspaceDriver } from "../workspaces/types.js";
+
+export const SPOKE_SUBDIRS = [
+  "crew",
+  "learnings",
+  "daily-logs",
+  "skills",
+  "meta",
+  "templates",
+  "wiki",
+  "wiki/pages",
+];
+
+export async function ensureSpokeLayout(workspace: WorkspaceDriver): Promise<void> {
+  for (const sub of SPOKE_SUBDIRS) {
+    await workspace.mkdir(sub);
+  }
+}

--- a/src/workspaces/__tests__/helpers/memory-driver.test.ts
+++ b/src/workspaces/__tests__/helpers/memory-driver.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { createMemoryDriver } from "./memory-driver.js";
+
+describe("createMemoryDriver", () => {
+  it("round-trips write/read", async () => {
+    const d = createMemoryDriver();
+    await d.write("a/b.md", "x");
+    expect(await d.read("a/b.md")).toBe("x");
+  });
+
+  it("list returns immediate children only", async () => {
+    const d = createMemoryDriver({ "a/b.md": "1", "a/c/d.md": "2" });
+    expect((await d.list("a")).sort()).toEqual(["b.md", "c"]);
+  });
+
+  it("exists tracks both files and mkdir-created dirs", async () => {
+    const d = createMemoryDriver();
+    await d.mkdir("x/y");
+    expect(await d.exists("x/y")).toBe(true);
+    expect(await d.exists("x/z")).toBe(false);
+  });
+});

--- a/src/workspaces/__tests__/helpers/memory-driver.ts
+++ b/src/workspaces/__tests__/helpers/memory-driver.ts
@@ -1,0 +1,66 @@
+import type { WorkspaceDriver } from "../../types.js";
+
+export function createMemoryDriver(initial: Record<string, string> = {}): WorkspaceDriver & {
+  files: Map<string, string>;
+} {
+  const files = new Map<string, string>(Object.entries(initial));
+  const dirs = new Set<string>();
+
+  for (const key of files.keys()) {
+    const parts = key.split("/");
+    for (let i = 1; i <= parts.length - 1; i++) {
+      dirs.add(parts.slice(0, i).join("/"));
+    }
+  }
+
+  return {
+    name: "memory",
+    files,
+
+    async probe() {
+      return { installed: true, rootExists: true };
+    },
+
+    async read(path) {
+      if (!files.has(path)) throw new Error(`ENOENT: ${path}`);
+      return files.get(path)!;
+    },
+
+    async write(path, content) {
+      files.set(path, content);
+      const parts = path.split("/");
+      for (let i = 1; i <= parts.length - 1; i++) {
+        dirs.add(parts.slice(0, i).join("/"));
+      }
+    },
+
+    async exists(path) {
+      return files.has(path) || dirs.has(path);
+    },
+
+    async list(dir) {
+      const prefix = dir === "" ? "" : `${dir}/`;
+      const entries = new Set<string>();
+      for (const key of files.keys()) {
+        if (!key.startsWith(prefix)) continue;
+        const rest = key.slice(prefix.length);
+        const first = rest.split("/")[0];
+        if (first) entries.add(first);
+      }
+      for (const d of dirs) {
+        if (!d.startsWith(prefix)) continue;
+        const rest = d.slice(prefix.length);
+        const first = rest.split("/")[0];
+        if (first && !rest.includes("/")) entries.add(first);
+      }
+      return Array.from(entries).sort();
+    },
+
+    async mkdir(path) {
+      const parts = path.split("/");
+      for (let i = 1; i <= parts.length; i++) {
+        dirs.add(parts.slice(0, i).join("/"));
+      }
+    },
+  };
+}

--- a/src/workspaces/__tests__/obsidian.test.ts
+++ b/src/workspaces/__tests__/obsidian.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createObsidianDriver } from "../obsidian.js";
+
+describe("ObsidianDriver", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "obsidian-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("has name 'obsidian'", () => {
+    const driver = createObsidianDriver({ root: tmpRoot });
+    expect(driver.name).toBe("obsidian");
+  });
+
+  it("probe returns installed=true and rootExists=true for a real dir", async () => {
+    const driver = createObsidianDriver({ root: tmpRoot });
+    const result = await driver.probe();
+    expect(result.installed).toBe(true);
+    expect(result.rootExists).toBe(true);
+  });
+
+  it("probe returns rootExists=false when scope root is missing", async () => {
+    const missing = path.join(tmpRoot, "does-not-exist");
+    const driver = createObsidianDriver({ root: missing });
+    const result = await driver.probe();
+    expect(result.installed).toBe(true);
+    expect(result.rootExists).toBe(false);
+  });
+
+  it("write then read round-trips content", async () => {
+    const driver = createObsidianDriver({ root: tmpRoot });
+    await driver.mkdir("daily-logs");
+    await driver.write("daily-logs/2026-04-21.md", "hello world");
+    const content = await driver.read("daily-logs/2026-04-21.md");
+    expect(content).toBe("hello world");
+  });
+
+  it("exists returns true/false correctly", async () => {
+    const driver = createObsidianDriver({ root: tmpRoot });
+    await driver.write("a.txt", "x");
+    expect(await driver.exists("a.txt")).toBe(true);
+    expect(await driver.exists("b.txt")).toBe(false);
+  });
+
+  it("list returns entry names only (not paths)", async () => {
+    const driver = createObsidianDriver({ root: tmpRoot });
+    await driver.mkdir("crew");
+    await driver.write("crew/one.md", "1");
+    await driver.write("crew/two.md", "2");
+    const entries = await driver.list("crew");
+    expect(entries.sort()).toEqual(["one.md", "two.md"]);
+  });
+
+  it("list returns empty array for missing directory", async () => {
+    const driver = createObsidianDriver({ root: tmpRoot });
+    const entries = await driver.list("nope");
+    expect(entries).toEqual([]);
+  });
+
+  it("mkdir is always recursive", async () => {
+    const driver = createObsidianDriver({ root: tmpRoot });
+    await driver.mkdir("a/b/c/d");
+    expect(fs.existsSync(path.join(tmpRoot, "a/b/c/d"))).toBe(true);
+  });
+
+  it("write creates parent directories", async () => {
+    const driver = createObsidianDriver({ root: tmpRoot });
+    await driver.write("deep/nested/file.txt", "data");
+    expect(fs.readFileSync(path.join(tmpRoot, "deep/nested/file.txt"), "utf-8")).toBe("data");
+  });
+
+  it("scope-rooted paths never escape root (no path traversal via ../)", async () => {
+    const driver = createObsidianDriver({ root: tmpRoot });
+    await expect(driver.read("../../etc/passwd")).rejects.toThrow(/escapes workspace root/i);
+    await expect(driver.write("../evil.txt", "x")).rejects.toThrow(/escapes workspace root/i);
+  });
+});

--- a/src/workspaces/__tests__/registry.test.ts
+++ b/src/workspaces/__tests__/registry.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from "vitest";
+import { WorkspaceRegistry } from "../registry.js";
+import type { WorkspaceDriver, WorkspaceScope } from "../types.js";
+import type { CockpitConfig } from "../../config.js";
+
+function stubFactory(name: string): (scope: WorkspaceScope) => WorkspaceDriver {
+  return (scope) => ({
+    name,
+    probe: vi.fn(async () => ({ installed: true, rootExists: true })),
+    read: vi.fn(async () => `read:${name}:${scope.root}`),
+    write: vi.fn(async () => {}),
+    exists: vi.fn(async () => true),
+    list: vi.fn(async () => []),
+    mkdir: vi.fn(async () => {}),
+  });
+}
+
+function baseConfig(overrides: Partial<CockpitConfig> = {}): CockpitConfig {
+  return {
+    commandName: "cmd",
+    hubVault: "~/hub",
+    projects: {},
+    defaults: {
+      maxCrew: 5,
+      worktreeDir: ".worktrees",
+      teammateMode: "in-process",
+      permissions: { command: "default", captain: "acceptEdits" },
+    },
+    metrics: { enabled: false, path: "" },
+    ...overrides,
+  };
+}
+
+describe("WorkspaceRegistry", () => {
+  it("returns obsidian driver by default for hub", () => {
+    const registry = new WorkspaceRegistry({ obsidian: stubFactory("obsidian") });
+    const driver = registry.hub(baseConfig());
+    expect(driver.name).toBe("obsidian");
+  });
+
+  it("uses top-level workspace override for hub", () => {
+    const registry = new WorkspaceRegistry({
+      obsidian: stubFactory("obsidian"),
+      notion: stubFactory("notion"),
+    });
+    const driver = registry.hub(baseConfig({ workspace: "notion" }));
+    expect(driver.name).toBe("notion");
+  });
+
+  it("forProject returns obsidian by default", () => {
+    const registry = new WorkspaceRegistry({ obsidian: stubFactory("obsidian") });
+    const config = baseConfig({
+      projects: {
+        brove: { path: "/p", captainName: "brove-c", spokeVault: "~/s", host: "local" },
+      },
+    });
+    const driver = registry.forProject("brove", config);
+    expect(driver.name).toBe("obsidian");
+  });
+
+  it("project-level workspace overrides top-level", () => {
+    const registry = new WorkspaceRegistry({
+      obsidian: stubFactory("obsidian"),
+      notion: stubFactory("notion"),
+      plain: stubFactory("plain"),
+    });
+    const config = baseConfig({
+      workspace: "notion",
+      projects: {
+        brove: { path: "/p", captainName: "brove-c", spokeVault: "~/s", host: "local", workspace: "plain" },
+      },
+    });
+    const driver = registry.forProject("brove", config);
+    expect(driver.name).toBe("plain");
+  });
+
+  it("throws when configured provider has no factory registered", () => {
+    const registry = new WorkspaceRegistry({ obsidian: stubFactory("obsidian") });
+    expect(() => registry.hub(baseConfig({ workspace: "unknown" }))).toThrowError(/unknown/i);
+  });
+
+  it("forProject throws for unknown project", () => {
+    const registry = new WorkspaceRegistry({ obsidian: stubFactory("obsidian") });
+    expect(() => registry.forProject("nope", baseConfig())).toThrowError(/not found/i);
+  });
+
+  it("hub passes resolved hubVault as scope.root", async () => {
+    const registry = new WorkspaceRegistry({ obsidian: stubFactory("obsidian") });
+    const driver = registry.hub(baseConfig({ hubVault: "~/cockpit-hub" }));
+    const out = await driver.read("x.md");
+    expect(out).toMatch(/^read:obsidian:\//);
+    expect(out).not.toContain("~");
+  });
+
+  it("probeAll returns results keyed by provider name", async () => {
+    const registry = new WorkspaceRegistry({
+      obsidian: stubFactory("obsidian"),
+      notion: stubFactory("notion"),
+    });
+    const results = await registry.probeAll(baseConfig());
+    expect(results.obsidian.installed).toBe(true);
+    expect(results.notion.installed).toBe(true);
+  });
+});

--- a/src/workspaces/index.ts
+++ b/src/workspaces/index.ts
@@ -1,0 +1,8 @@
+export { createObsidianDriver } from "./obsidian.js";
+export { WorkspaceRegistry } from "./registry.js";
+export type {
+  WorkspaceDriver,
+  WorkspaceFactory,
+  WorkspaceProbeResult,
+  WorkspaceScope,
+} from "./types.js";

--- a/src/workspaces/obsidian.ts
+++ b/src/workspaces/obsidian.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import type {
+  WorkspaceDriver,
+  WorkspaceProbeResult,
+  WorkspaceScope,
+} from "./types.js";
+
+function resolveInRoot(root: string, relative: string): string {
+  const joined = path.resolve(root, relative);
+  const normalized = path.resolve(root) + path.sep;
+  if (joined !== path.resolve(root) && !joined.startsWith(normalized)) {
+    throw new Error(`Path '${relative}' escapes workspace root`);
+  }
+  return joined;
+}
+
+export function createObsidianDriver(scope: WorkspaceScope): WorkspaceDriver {
+  const root = scope.root;
+  if (typeof root !== "string" || root === "") {
+    throw new Error("ObsidianDriver requires scope.root (string)");
+  }
+
+  return {
+    name: "obsidian",
+
+    async probe(): Promise<WorkspaceProbeResult> {
+      return {
+        installed: true,
+        rootExists: existsSync(root),
+      };
+    },
+
+    async read(rel: string): Promise<string> {
+      return fs.readFile(resolveInRoot(root, rel), "utf-8");
+    },
+
+    async write(rel: string, content: string): Promise<void> {
+      const abs = resolveInRoot(root, rel);
+      await fs.mkdir(path.dirname(abs), { recursive: true });
+      await fs.writeFile(abs, content);
+    },
+
+    async exists(rel: string): Promise<boolean> {
+      try {
+        await fs.access(resolveInRoot(root, rel));
+        return true;
+      } catch {
+        return false;
+      }
+    },
+
+    async list(rel: string): Promise<string[]> {
+      try {
+        return await fs.readdir(resolveInRoot(root, rel));
+      } catch {
+        return [];
+      }
+    },
+
+    async mkdir(rel: string): Promise<void> {
+      await fs.mkdir(resolveInRoot(root, rel), { recursive: true });
+    },
+  };
+}

--- a/src/workspaces/obsidian.ts
+++ b/src/workspaces/obsidian.ts
@@ -7,6 +7,10 @@ import type {
   WorkspaceScope,
 } from "./types.js";
 
+// Rejects `../` escapes and absolute paths via lexical containment check.
+// Does NOT resolve symlinks — a symlink inside the vault pointing outside
+// will be followed by fs.* calls. Vault contents are trusted in the cockpit
+// threat model (user-owned, not untrusted input). Tracked in issue #25.
 function resolveInRoot(root: string, relative: string): string {
   const joined = path.resolve(root, relative);
   const normalized = path.resolve(root) + path.sep;

--- a/src/workspaces/registry.ts
+++ b/src/workspaces/registry.ts
@@ -1,0 +1,41 @@
+import { resolveHome, type CockpitConfig } from "../config.js";
+import type {
+  WorkspaceDriver,
+  WorkspaceFactory,
+  WorkspaceProbeResult,
+} from "./types.js";
+
+const DEFAULT_WORKSPACE = "obsidian";
+
+export class WorkspaceRegistry {
+  constructor(private factories: Record<string, WorkspaceFactory>) {}
+
+  hub(config: CockpitConfig): WorkspaceDriver {
+    const name = config.workspace ?? DEFAULT_WORKSPACE;
+    return this.get(name)({ root: resolveHome(config.hubVault) });
+  }
+
+  forProject(projectName: string, config: CockpitConfig): WorkspaceDriver {
+    const proj = config.projects[projectName];
+    if (!proj) throw new Error(`Project '${projectName}' not found`);
+    const name = proj.workspace ?? config.workspace ?? DEFAULT_WORKSPACE;
+    return this.get(name)({ root: resolveHome(proj.spokeVault) });
+  }
+
+  get(name: string): WorkspaceFactory {
+    const factory = this.factories[name];
+    if (!factory) {
+      throw new Error(`Unknown workspace provider '${name}' — no factory registered`);
+    }
+    return factory;
+  }
+
+  async probeAll(config: CockpitConfig): Promise<Record<string, WorkspaceProbeResult>> {
+    const results: Record<string, WorkspaceProbeResult> = {};
+    for (const [name, factory] of Object.entries(this.factories)) {
+      const scope = { root: resolveHome(config.hubVault) };
+      results[name] = await factory(scope).probe();
+    }
+    return results;
+  }
+}

--- a/src/workspaces/types.ts
+++ b/src/workspaces/types.ts
@@ -1,0 +1,22 @@
+export interface WorkspaceProbeResult {
+  installed: boolean;
+  rootExists: boolean;
+}
+
+export interface WorkspaceScope {
+  root?: string;
+  [key: string]: unknown;
+}
+
+export interface WorkspaceDriver {
+  name: string;
+
+  probe(): Promise<WorkspaceProbeResult>;
+  read(path: string): Promise<string>;
+  write(path: string, content: string): Promise<void>;
+  exists(path: string): Promise<boolean>;
+  list(dir: string): Promise<string[]>;
+  mkdir(path: string): Promise<void>;
+}
+
+export type WorkspaceFactory = (scope: WorkspaceScope) => WorkspaceDriver;


### PR DESCRIPTION
## Summary

Phase 2 of issue #9 (Plugin/Extension System). Abstracts vault storage behind a \`WorkspaceDriver\` interface mirroring the phase 1 runtime pattern (PR #20). All ~33 direct \`fs.*\` call-sites across 11 files now route through the driver, with Obsidian as the reference implementation.

Spec: [\`docs/specs/2026-04-21-plugin-system-workspace-design.md\`](docs/specs/2026-04-21-plugin-system-workspace-design.md)
Plan: [\`docs/specs/2026-04-21-plugin-system-workspace-plan.md\`](docs/specs/2026-04-21-plugin-system-workspace-plan.md)

## What changed

**New:**
- \`src/workspaces/types.ts\` — \`WorkspaceDriver\`, \`WorkspaceScope\`, \`WorkspaceProbeResult\`, \`WorkspaceFactory\`
- \`src/workspaces/obsidian.ts\` — \`createObsidianDriver(scope)\` (fs-backed, async)
- \`src/workspaces/registry.ts\` — \`WorkspaceRegistry\` with \`hub\` / \`forProject\` / \`probeAll\`
- \`src/workspaces/index.ts\` + tests: 10 obsidian, 8 registry, 3 memory-driver, 4 daily-logs = **25 new tests**
- \`src/workspaces/__tests__/helpers/memory-driver.ts\` — in-memory test fixture
- \`src/commands/workspace.ts\` — \`cockpit workspace read|write|list|exists|mkdir\` CLI (with \`--hub\` flag)
- \`src/lib/vault-layout.ts\` — \`ensureSpokeLayout\` + \`SPOKE_SUBDIRS\` constant

**Migrated to driver:**
- \`src/lib/daily-logs.ts\` — \`readDailyLog\` now async, takes \`WorkspaceDriver\`
- \`src/commands/standup.ts\`, \`retro.ts\` — thread registry through helpers; both actions async
- \`src/commands/status.ts\` — full rewrite; uses \`workspace.read(\"status.md\")\`
- \`src/commands/launch.ts\` — two spoke-init sites now use \`ensureSpokeLayout\`
- \`src/commands/init.ts\` — probes configured workspace provider at startup
- \`src/commands/doctor.ts\` — replaced \`fs.existsSync(hubPath)\` with per-provider \`probe()\`; adds per-spoke reachability checks

**Config (backward compatible):**
- \`workspace?: string\` at top level (global default, absent = \"obsidian\")
- \`workspace?: string\` per-project (override)

**Docs:**
- README — commands table + config JSON + \"Workspace Abstraction\" architecture subsection

## Contract highlights

- **Scope-relative paths.** Callers use \`driver.read(\"daily-logs/x.md\")\` — driver owns the root. No more \`path.join\` / \`resolveHome\` in call-sites.
- **Async throughout.** Matches the runtime pattern; unlocks future async backends (Notion, S3).
- **Loose \`WorkspaceScope\` typing.** Same tradeoff as runtime phase 1. Tightening tracked in [#23](https://github.com/tu11aa/claude-cockpit/issues/23).

## Intentionally deferred (per spec §Non-Goals)

- \`scripts/reactor-cycle.sh\`, \`read-status.sh\` — these scripts use inline Python to read config JSON, never use \`\$SPOKE_VAULT\` shell vars. No migration needed.
- \`src/commands/projects.ts\` \`copyDirRecursive\` — Obsidian-specific template bootstrap, stays provider-specific.
- status.md reads in \`standup.ts\`/\`retro.ts\` — TODO comments added in-code; tracked as [#24](https://github.com/tu11aa/claude-cockpit/issues/24).
- Symlink traversal in \`ObsidianDriver\` — documented as accepted limitation under current threat model; tracked as [#25](https://github.com/tu11aa/claude-cockpit/issues/25).

## Test plan

- [x] \`npm run test -- --run\` — 81 pass, 2 pre-existing \`config.test.ts\` failures (emoji-prefix assertion, predates this PR)
- [x] \`npm run lint\` exits 0
- [x] \`npm run build\` exits 0
- [x] \`cockpit doctor\` shows \"Workspace 'obsidian' — hub reachable\" + per-spoke checks
- [x] \`cockpit workspace --help\` shows 5 subcommands
- [ ] Manual smoke: \`cockpit standup\` against a real spoke (tested by reviewer)
- [ ] Manual smoke: \`cockpit init\` flow with workspace probe

## Pre-PR code review

Internal review (superpowers:code-reviewer) approved with 2 important items both addressed:
- **Symlink limitation** → documented inline, follow-up #25
- **status.md mixed-mode** → TODO comments added, follow-up #24

Other findings (probeAll semantics, registry duplication, path NUL byte handling) tracked for phase 3+ polish.

## Follow-ups already filed

- [#23](https://github.com/tu11aa/claude-cockpit/issues/23) — Tighten WorkspaceScope to discriminated union
- [#24](https://github.com/tu11aa/claude-cockpit/issues/24) — Migrate status.md reads in standup/retro
- [#25](https://github.com/tu11aa/claude-cockpit/issues/25) — Evaluate symlink traversal policy in ObsidianDriver