### PR TITLE
Plugin System Phase 4: Notifier Slot (#9)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (347 symbols, 632 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (348 symbols, 633 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (349 symbols, 634 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (354 symbols, 639 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (354 symbols, 639 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (360 symbols, 647 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (369 symbols, 663 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (371 symbols, 668 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (368 symbols, 662 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (369 symbols, 663 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (360 symbols, 647 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (368 symbols, 662 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (371 symbols, 668 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (371 symbols, 670 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (348 symbols, 633 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (349 symbols, 634 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (347 symbols, 632 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (348 symbols, 633 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (349 symbols, 634 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (354 symbols, 639 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (354 symbols, 639 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (360 symbols, 647 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (369 symbols, 663 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (371 symbols, 668 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (368 symbols, 662 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (369 symbols, 663 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (360 symbols, 647 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (368 symbols, 662 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (371 symbols, 668 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (371 symbols, 670 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (348 symbols, 633 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (349 symbols, 634 relationships, 19 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ See `obsidian/plugins.md` for Dataview, Templater setup.
 | `cockpit tracker create-issue <project> <title>` | Create an issue in the project's tracker repo |
 | `cockpit tracker merge-pr <project> <num>` | Enable auto-merge on a PR |
 | `cockpit tracker get-checks <project> <num>` | Print PR check runs |
+| `cockpit notify <message>` | Send a message to the user via the configured notifier |
 | `cockpit shutdown [project]` | Graceful shutdown |
 | `cockpit feedback` | Open opt-in feedback issue |
 
@@ -109,6 +110,10 @@ Vault storage (hub + per-project spokes) runs behind a pluggable **workspace dri
 
 Issue/PR operations run behind a pluggable **tracker driver** (currently only `github`). One-shot ops — create-issue, merge-pr, get-checks, get-run-log, list-issues — go through the driver instead of `gh` CLI directly. Bash scripts call `cockpit tracker <op>`. Polling stays provider-specific (`scripts/poll-github.sh`); future providers add their own poll scripts. Each project may override the global default via its `tracker` field. New backends (Linear, Jira, GitLab) are added as driver files in `src/trackers/` — see `docs/specs/2026-04-21-plugin-system-tracker-design.md`.
 
+### Notifier Abstraction
+
+User-facing notifications run behind a pluggable **notifier driver** (currently only `cmux`). Escalations, reactor alerts, and other "tell the user" events go through `cockpit notify <message>`. The default `CmuxNotifier` delegates to `cockpit runtime send --command` — the abstraction exists as a swap-point for future Slack/Discord/email/pager drivers. Notifier is global (no per-project override). See `docs/specs/2026-04-21-plugin-system-notifier-design.md`.
+
 ### Obsidian Vaults (Hub-and-Spoke)
 
 - **Hub vault** (`~/cockpit-hub`) — cross-project dashboard + hub wiki
@@ -138,6 +143,7 @@ Issue/PR operations run behind a pluggable **tracker driver** (currently only `g
   "runtime": "cmux",
   "workspace": "obsidian",
   "tracker": "github",
+  "notifier": "cmux",
   "projects": {
     "brove": {
       "path": "~/projects/brove",

--- a/docs/specs/2026-04-21-plugin-system-notifier-design.md
+++ b/docs/specs/2026-04-21-plugin-system-notifier-design.md
@@ -1,0 +1,149 @@
+# Plugin/Extension System — Phase 4: Notifier Slot
+
+**Date:** 2026-04-21
+**Status:** Draft — design only, implementation in next sprint
+**Issue:** [#9](https://github.com/tu11aa/claude-cockpit/issues/9)
+**Phase:** 4 of N (notifier — last of the core 4 slots)
+**Depends on:** Phase 1 (runtime, PR #20), Phase 2 (workspace, PR #26), Phase 3 (tracker, PR #28)
+
+## Problem
+
+Cockpit's "tell the user something happened" layer hardcodes cmux as the channel. Every escalation path in `scripts/execute-reaction.sh` shells out to `cockpit runtime send --command` — fine today, but there's no seam for a future Slack/Discord/email notifier. Swapping to a different alert channel would require editing every escalation call-site.
+
+## Goal
+
+Abstract user-notification behind a `NotifierDriver` interface mirroring phases 1-3. Cmux remains the default and only shipped implementation. The abstraction:
+
+- Gives a single swap-point for future notifier providers (Slack, Discord, email, pager)
+- Keeps the implementation thin — `CmuxNotifier.notify()` delegates to existing `cockpit runtime send --command`
+- Exposes `cockpit notify <message>` CLI so bash scripts use one command for all escalations
+
+## Non-Goals
+
+- **Urgency levels** (`info`/`warn`/`error`) — no caller needs them today; add when a driver requires routing based on severity.
+- **Multi-sink fanout** — "escalations go to Slack AND cmux" is routing logic, out of scope for phase 4. Follow-up if/when real multi-channel needs arrive.
+- **Per-project notifier** — notifications go to the single user; scope is global only.
+- **Replacing `delegate-to-captain` / `send-to-captain`** — those are dispatch to internal workspaces, not notifications. Stay on `cockpit runtime send <project>`.
+- **Additional providers** (Slack, Discord, email, pager) — each is a follow-up PR.
+- **External plugin loading** — phase 5.
+- **Strict `NotifierScope` typing** — shipping loose, same pattern as prior phases.
+
+## Architecture: Notifier Driver (mirrors Runtime + Workspace + Tracker)
+
+```
+cockpit core
+  └── src/notifiers/
+        ├── types.ts         ← NotifierDriver interface
+        ├── cmux.ts          ← Cmux notifier (delegates to cockpit runtime send --command)
+        ├── registry.ts      ← NotifierRegistry — global, no per-project
+        ├── index.ts         ← re-exports
+        └── __tests__/
+```
+
+Callers (`execute-reaction.sh`, future TS) go through `cockpit notify <message>`. The registry returns the configured driver; `CmuxNotifier` is a thin delegate over `cockpit runtime send --command`.
+
+## 1. Notifier Driver Interface
+
+```typescript
+// src/notifiers/types.ts
+export interface NotifierProbeResult {
+  installed: boolean;   // provider deps present
+  reachable: boolean;   // this notifier can currently deliver (e.g., command workspace running)
+}
+
+export interface NotifierScope {
+  [key: string]: unknown;  // provider-specific (loose)
+}
+
+export interface NotifierDriver {
+  name: string;          // "cmux", "slack", ...
+
+  probe(): Promise<NotifierProbeResult>;
+  notify(message: string): Promise<void>;
+}
+
+export type NotifierFactory = (scope: NotifierScope) => NotifierDriver;
+```
+
+### Contract notes
+
+- **`notify()` must deliver and commit.** For cmux: the underlying `cockpit runtime send --command` already handles Enter-after-message per phase 1. For other providers: implementations are responsible for whatever "commit" means (Slack: message visible in channel; email: queued for send).
+- **`probe()` returns two flags.** `installed` = the provider dependencies are present (cmux binary, auth token, SDK). `reachable` = the configured scope is currently deliverable (command workspace running, API key valid, etc.).
+- **No scope for the default cmux notifier.** Scope parameter exists for future providers (Slack workspace ID, Discord webhook URL); cmux ignores it.
+
+## 2. Registry & Config
+
+```typescript
+// src/notifiers/registry.ts
+export class NotifierRegistry {
+  constructor(private factories: Record<string, NotifierFactory>) {}
+
+  get(config: CockpitConfig): NotifierDriver {
+    const name = config.notifier ?? DEFAULT_NOTIFIER;
+    return this.getFactory(name)({});
+  }
+
+  getFactory(name: string): NotifierFactory { /* throws on unknown */ }
+
+  async probeAll(): Promise<Record<string, NotifierProbeResult>> { /* ... */ }
+}
+```
+
+Config addition (single optional field, default `"cmux"`):
+
+```jsonc
+// ~/.config/cockpit/config.json
+{
+  "notifier": "cmux"  // NEW — global default (no per-project override)
+}
+```
+
+No per-project `notifier` field — notifications target the user, not a project.
+
+## 3. CLI Subcommand
+
+New command at `src/commands/notify.ts`:
+
+```
+cockpit notify <message>       # deliver to the configured notifier
+cockpit notify -               # read message from stdin
+```
+
+Single subcommand (notifier has one op). Exit 0 on success, 1 on failure. No `--help` subcommand tree needed — just this one command.
+
+## 4. Refactor Surface
+
+| File | Current | After |
+|------|---------|-------|
+| `scripts/execute-reaction.sh` `escalate` case | `cockpit runtime send --command "$MESSAGE"` | `cockpit notify "$MESSAGE"` |
+| `scripts/execute-reaction.sh` `send-to-command` case | `cockpit runtime send --command "$MESSAGE"` | `cockpit notify "$MESSAGE"` |
+| `scripts/execute-reaction.sh` `auto-fix-ci` max-retries escalation | `cockpit runtime send --command "$ESC_MSG"` | `cockpit notify "$ESC_MSG"` |
+| `src/commands/doctor.ts` | no notifier check today | probe configured notifier |
+
+Other call-sites remain on `cockpit runtime send <project>` — those dispatch to internal workspaces (captain command delivery), not notifications.
+
+## 5. Testing
+
+Mirror prior phases:
+
+- **Unit tests** for `CmuxNotifier` — mock `execSync` to verify it calls `cockpit runtime send --command "..."`; verify `probe()` calls `cockpit runtime status --command` and maps exit code to `reachable`.
+- **Unit tests** for `NotifierRegistry` — default provider returns cmux; override via `config.notifier`; unknown provider throws.
+- **In-memory test driver** — `createMemoryNotifier(state?)` backed by an array of delivered messages. Used for any future TS caller tests.
+- **Integration smoke** — `cockpit notify "hello"` against a running command workspace, gated behind `SKIP_INTEGRATION=1`.
+
+## 6. Rollout
+
+1. Land this spec and implementation plan.
+2. Implement `src/notifiers/` with only `CmuxNotifier`.
+3. Add `cockpit notify` CLI subcommand.
+4. Migrate three `execute-reaction.sh` call-sites.
+5. Add doctor probe.
+6. Document in README.
+7. Ship as single PR.
+
+## 7. Relationship to Other Work
+
+- **Builds on:** Phase 1 runtime (PR #20), Phase 2 workspace (PR #26), Phase 3 tracker (PR #28). Same driver+registry+CLI pattern.
+- **Unblocks:** Slack, Discord, email, pager notifier PRs — each is a self-contained future addition.
+- **Completes the core 4-slot plugin system.** Phase 5 (external plugin loading from `node_modules`) is the platform bet — deferred, optional, not blocking.
+- **Follow-ups may arise:** urgency levels, multi-sink routing — only when a driver or caller actually needs them.

--- a/docs/specs/2026-04-21-plugin-system-notifier-plan.md
+++ b/docs/specs/2026-04-21-plugin-system-notifier-plan.md
@@ -1,0 +1,743 @@
+# Plugin System Phase 4 — Notifier Slot Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Abstract user-notification behind a `NotifierDriver` interface mirroring phases 1-3; ship `CmuxNotifier` that delegates to `cockpit runtime send --command`; expose `cockpit notify` CLI; migrate 3 escalation call-sites in `execute-reaction.sh`.
+
+**Architecture:** New `src/notifiers/` parallel to `src/runtimes/`, `src/workspaces/`, `src/trackers/`. `CmuxNotifier` uses `execSync` to call `cockpit runtime send --command "$MSG"`. Global scope (no per-project); single-op interface (`notify`).
+
+**Tech Stack:** TypeScript, commander.js, vitest, Node 22 (`child_process`), bash.
+
+**Spec:** `docs/specs/2026-04-21-plugin-system-notifier-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `src/notifiers/types.ts` — `NotifierDriver`, `NotifierProbeResult`, `NotifierScope`, `NotifierFactory`
+- `src/notifiers/cmux.ts` — `createCmuxNotifier(scope)`
+- `src/notifiers/registry.ts` — `NotifierRegistry`
+- `src/notifiers/index.ts` — barrel
+- `src/notifiers/__tests__/cmux.test.ts`
+- `src/notifiers/__tests__/registry.test.ts`
+- `src/notifiers/__tests__/helpers/memory-notifier.ts` + `.test.ts`
+- `src/commands/notify.ts` — `cockpit notify` CLI
+
+**Modify:**
+- `src/config.ts` — add `notifier?: string` to `CockpitConfig` (no per-project field)
+- `src/index.ts` — register `notifyCommand`
+- `src/commands/doctor.ts` — probe configured notifier
+- `scripts/execute-reaction.sh` — 3 escalation call-sites → `cockpit notify`
+- `README.md` — document `notifier` config + CLI
+
+---
+
+## Task 1: Add `notifier?` field to CockpitConfig
+
+**Files:**
+- Modify: `src/config.ts`
+
+- [ ] **Step 1: Add `notifier?: string` to `CockpitConfig`**
+
+In `src/config.ts`, add `notifier?: string` to `CockpitConfig` right after the existing `tracker?: string` field. Do NOT add to `ProjectConfig` (notifier is global).
+
+```typescript
+export interface CockpitConfig {
+  commandName: string;
+  hubVault: string;
+  projects: Record<string, ProjectConfig>;
+  agents?: Record<string, AgentEntry>;
+  runtime?: string;
+  workspace?: string;
+  tracker?: string;
+  notifier?: string;  // NEW — global default ("cmux" when absent); no per-project
+  defaults: {
+    maxCrew: number;
+    worktreeDir: string;
+    teammateMode: string;
+    permissions: PermissionConfig;
+    models?: ModelRoutingConfig;
+    roles?: RoleConfig;
+  };
+  metrics: {
+    enabled: boolean;
+    path: string;
+  };
+}
+```
+
+- [ ] **Step 2: Verify lint**
+
+Run: `npm run lint`
+Expected: exit 0
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/config.ts
+git commit -m "feat(notifier): add optional notifier field to CockpitConfig"
+```
+
+---
+
+## Task 2: Define NotifierDriver interface
+
+**Files:**
+- Create: `src/notifiers/types.ts`
+
+- [ ] **Step 1: Write the types file**
+
+Create `src/notifiers/` directory. Write `src/notifiers/types.ts`:
+
+```typescript
+export interface NotifierProbeResult {
+  installed: boolean;
+  reachable: boolean;
+}
+
+export interface NotifierScope {
+  [key: string]: unknown;
+}
+
+export interface NotifierDriver {
+  name: string;
+
+  probe(): Promise<NotifierProbeResult>;
+  notify(message: string): Promise<void>;
+}
+
+export type NotifierFactory = (scope: NotifierScope) => NotifierDriver;
+```
+
+- [ ] **Step 2: Verify lint**
+
+Run: `npm run lint`
+Expected: exit 0
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/notifiers/types.ts
+git commit -m "feat(notifier): add NotifierDriver interface"
+```
+
+---
+
+## Task 3: Write failing tests for CmuxNotifier
+
+**Files:**
+- Create: `src/notifiers/__tests__/cmux.test.ts`
+
+- [ ] **Step 1: Write the test file**
+
+Create `src/notifiers/__tests__/cmux.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createCmuxNotifier } from "../cmux.js";
+
+const execMock = vi.hoisted(() => vi.fn());
+vi.mock("node:child_process", () => ({
+  execSync: execMock,
+}));
+
+describe("CmuxNotifier", () => {
+  beforeEach(() => {
+    execMock.mockReset();
+  });
+
+  it("has name 'cmux'", () => {
+    expect(createCmuxNotifier({}).name).toBe("cmux");
+  });
+
+  it("notify shells out to 'cockpit runtime send --command'", async () => {
+    execMock.mockReturnValue("");
+    await createCmuxNotifier({}).notify("hello world");
+    const calls = execMock.mock.calls.map((c) => c[0] as string);
+    expect(calls[0]).toContain("cockpit runtime send");
+    expect(calls[0]).toContain("--command");
+    expect(calls[0]).toContain("hello world");
+  });
+
+  it("notify escapes double-quotes in the message", async () => {
+    execMock.mockReturnValue("");
+    await createCmuxNotifier({}).notify('say "hi"');
+    const calls = execMock.mock.calls.map((c) => c[0] as string);
+    expect(calls[0]).toContain('\\"hi\\"');
+  });
+
+  it("notify throws when cockpit runtime send fails", async () => {
+    execMock.mockImplementation(() => { throw new Error("send failed"); });
+    await expect(createCmuxNotifier({}).notify("x")).rejects.toThrow(/send failed/);
+  });
+
+  it("probe returns installed+reachable=true when status succeeds (exit 0)", async () => {
+    execMock.mockImplementation((cmd: string) => {
+      if (cmd.includes("cockpit runtime status --command")) return "running";
+      return "";
+    });
+    const probe = await createCmuxNotifier({}).probe();
+    expect(probe.installed).toBe(true);
+    expect(probe.reachable).toBe(true);
+  });
+
+  it("probe returns reachable=false when status throws (non-zero exit)", async () => {
+    execMock.mockImplementation((cmd: string) => {
+      if (cmd.includes("cockpit runtime status --command")) {
+        const err: Error & { status?: number } = new Error("stopped");
+        err.status = 1;
+        throw err;
+      }
+      return "";
+    });
+    const probe = await createCmuxNotifier({}).probe();
+    expect(probe.installed).toBe(true);
+    expect(probe.reachable).toBe(false);
+  });
+
+  it("probe returns installed=false when cockpit binary is missing", async () => {
+    execMock.mockImplementation(() => {
+      const err: Error & { code?: string } = new Error("cockpit: command not found");
+      err.code = "ENOENT";
+      throw err;
+    });
+    const probe = await createCmuxNotifier({}).probe();
+    expect(probe.installed).toBe(false);
+    expect(probe.reachable).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/notifiers/__tests__/cmux.test.ts`
+Expected: FAIL with "Cannot find module '../cmux.js'"
+
+---
+
+## Task 4: Implement CmuxNotifier
+
+**Files:**
+- Create: `src/notifiers/cmux.ts`
+
+- [ ] **Step 1: Write the implementation**
+
+Create `src/notifiers/cmux.ts`:
+
+```typescript
+import { execSync } from "node:child_process";
+import type {
+  NotifierDriver,
+  NotifierProbeResult,
+  NotifierScope,
+} from "./types.js";
+
+function escape(s: string): string {
+  return s.replace(/"/g, '\\"');
+}
+
+export function createCmuxNotifier(_scope: NotifierScope): NotifierDriver {
+  return {
+    name: "cmux",
+
+    async probe(): Promise<NotifierProbeResult> {
+      try {
+        execSync("cockpit runtime status --command", { encoding: "utf-8", stdio: "pipe" });
+        return { installed: true, reachable: true };
+      } catch (err) {
+        const code = (err as { code?: string }).code;
+        if (code === "ENOENT") {
+          return { installed: false, reachable: false };
+        }
+        // Non-zero exit = cockpit binary works but command workspace not running
+        return { installed: true, reachable: false };
+      }
+    },
+
+    async notify(message: string): Promise<void> {
+      execSync(`cockpit runtime send --command "${escape(message)}"`, { encoding: "utf-8" });
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `npx vitest run src/notifiers/__tests__/cmux.test.ts`
+Expected: PASS, 7 tests
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/notifiers/cmux.ts src/notifiers/__tests__/cmux.test.ts
+git commit -m "feat(notifier): add CmuxNotifier (delegates to cockpit runtime send)"
+```
+
+---
+
+## Task 5: NotifierRegistry TDD
+
+**Files:**
+- Create: `src/notifiers/__tests__/registry.test.ts`
+- Create: `src/notifiers/registry.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/notifiers/__tests__/registry.test.ts`:
+
+```typescript
+import { describe, it, expect, vi } from "vitest";
+import { NotifierRegistry } from "../registry.js";
+import type { NotifierDriver, NotifierScope } from "../types.js";
+import type { CockpitConfig } from "../../config.js";
+
+function stubFactory(name: string): (scope: NotifierScope) => NotifierDriver {
+  return (_scope) => ({
+    name,
+    probe: vi.fn(async () => ({ installed: true, reachable: true })),
+    notify: vi.fn(async () => {}),
+  });
+}
+
+function baseConfig(overrides: Partial<CockpitConfig> = {}): CockpitConfig {
+  return {
+    commandName: "cmd",
+    hubVault: "~/hub",
+    projects: {},
+    defaults: {
+      maxCrew: 5,
+      worktreeDir: ".worktrees",
+      teammateMode: "in-process",
+      permissions: { command: "default", captain: "acceptEdits" },
+    },
+    metrics: { enabled: false, path: "" },
+    ...overrides,
+  };
+}
+
+describe("NotifierRegistry", () => {
+  it("returns cmux driver by default", () => {
+    const registry = new NotifierRegistry({ cmux: stubFactory("cmux") });
+    expect(registry.get(baseConfig()).name).toBe("cmux");
+  });
+
+  it("uses config.notifier override", () => {
+    const registry = new NotifierRegistry({
+      cmux: stubFactory("cmux"),
+      slack: stubFactory("slack"),
+    });
+    expect(registry.get(baseConfig({ notifier: "slack" })).name).toBe("slack");
+  });
+
+  it("throws when configured provider has no factory", () => {
+    const registry = new NotifierRegistry({ cmux: stubFactory("cmux") });
+    expect(() => registry.get(baseConfig({ notifier: "unknown" }))).toThrowError(/unknown/i);
+  });
+
+  it("probeAll returns results keyed by provider name", async () => {
+    const registry = new NotifierRegistry({
+      cmux: stubFactory("cmux"),
+      slack: stubFactory("slack"),
+    });
+    const results = await registry.probeAll();
+    expect(results.cmux.installed).toBe(true);
+    expect(results.slack.installed).toBe(true);
+  });
+});
+```
+
+Verify failing: `npx vitest run src/notifiers/__tests__/registry.test.ts`
+Expected: "Cannot find module '../registry.js'"
+
+- [ ] **Step 2: Implement registry**
+
+Create `src/notifiers/registry.ts`:
+
+```typescript
+import type { CockpitConfig } from "../config.js";
+import type {
+  NotifierDriver,
+  NotifierFactory,
+  NotifierProbeResult,
+} from "./types.js";
+
+const DEFAULT_NOTIFIER = "cmux";
+
+export class NotifierRegistry {
+  constructor(private factories: Record<string, NotifierFactory>) {}
+
+  get(config: CockpitConfig): NotifierDriver {
+    const name = config.notifier ?? DEFAULT_NOTIFIER;
+    return this.getFactory(name)({});
+  }
+
+  getFactory(name: string): NotifierFactory {
+    const factory = this.factories[name];
+    if (!factory) {
+      throw new Error(`Unknown notifier provider '${name}' — no factory registered`);
+    }
+    return factory;
+  }
+
+  async probeAll(): Promise<Record<string, NotifierProbeResult>> {
+    const results: Record<string, NotifierProbeResult> = {};
+    for (const [name, factory] of Object.entries(this.factories)) {
+      try {
+        results[name] = await factory({}).probe();
+      } catch {
+        results[name] = { installed: false, reachable: false };
+      }
+    }
+    return results;
+  }
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `npx vitest run src/notifiers/__tests__/registry.test.ts`
+Expected: PASS, 4 tests
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/notifiers/registry.ts src/notifiers/__tests__/registry.test.ts
+git commit -m "feat(notifier): add NotifierRegistry"
+```
+
+---
+
+## Task 6: Barrel + in-memory helper
+
+**Files:**
+- Create: `src/notifiers/index.ts`
+- Create: `src/notifiers/__tests__/helpers/memory-notifier.ts`
+- Create: `src/notifiers/__tests__/helpers/memory-notifier.test.ts`
+
+- [ ] **Step 1: Write barrel**
+
+Create `src/notifiers/index.ts`:
+
+```typescript
+export { createCmuxNotifier } from "./cmux.js";
+export { NotifierRegistry } from "./registry.js";
+export type {
+  NotifierDriver,
+  NotifierFactory,
+  NotifierProbeResult,
+  NotifierScope,
+} from "./types.js";
+```
+
+- [ ] **Step 2: Write in-memory helper**
+
+Create `src/notifiers/__tests__/helpers/memory-notifier.ts`:
+
+```typescript
+import type { NotifierDriver } from "../../types.js";
+
+export function createMemoryNotifier(): NotifierDriver & {
+  messages: string[];
+} {
+  const messages: string[] = [];
+  return {
+    name: "memory",
+    messages,
+    async probe() {
+      return { installed: true, reachable: true };
+    },
+    async notify(message: string) {
+      messages.push(message);
+    },
+  };
+}
+```
+
+- [ ] **Step 3: Write smoke test**
+
+Create `src/notifiers/__tests__/helpers/memory-notifier.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { createMemoryNotifier } from "./memory-notifier.js";
+
+describe("createMemoryNotifier", () => {
+  it("records notified messages in order", async () => {
+    const n = createMemoryNotifier();
+    await n.notify("first");
+    await n.notify("second");
+    expect(n.messages).toEqual(["first", "second"]);
+  });
+
+  it("probe returns installed+reachable=true", async () => {
+    const n = createMemoryNotifier();
+    expect(await n.probe()).toEqual({ installed: true, reachable: true });
+  });
+});
+```
+
+- [ ] **Step 4: Verify build + tests**
+
+Run: `npm run build && npx vitest run src/notifiers/__tests__/helpers/`
+Expected: build exits 0, tests 2/2 pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/notifiers/index.ts src/notifiers/__tests__/helpers/
+git commit -m "feat(notifier): add barrel and in-memory test notifier"
+```
+
+---
+
+## Task 7: `cockpit notify` CLI subcommand
+
+**Files:**
+- Create: `src/commands/notify.ts`
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Create the command file**
+
+Create `src/commands/notify.ts`:
+
+```typescript
+import { Command } from "commander";
+import chalk from "chalk";
+import { loadConfig } from "../config.js";
+import { createCmuxNotifier, NotifierRegistry } from "../notifiers/index.js";
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+export const notifyCommand = new Command("notify")
+  .description("Send a message to the user via the configured notifier")
+  .argument("<message>", "Message to send (use '-' to read from stdin)")
+  .action(async (message: string) => {
+    const config = loadConfig();
+    const registry = new NotifierRegistry({ cmux: createCmuxNotifier });
+    try {
+      const payload = message === "-" ? await readStdin() : message;
+      if (!payload) throw new Error("Empty message");
+      await registry.get(config).notify(payload);
+    } catch (err) {
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+  });
+```
+
+- [ ] **Step 2: Register in src/index.ts**
+
+Add import after `trackerCommand`:
+
+```typescript
+import { notifyCommand } from "./commands/notify.js";
+```
+
+And register after `program.addCommand(trackerCommand);`:
+
+```typescript
+program.addCommand(notifyCommand);
+```
+
+- [ ] **Step 3: Build and smoke**
+
+Run:
+```
+npm run build
+node dist/index.js notify --help
+```
+Expected: shows help for notify, single positional arg.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/commands/notify.ts src/index.ts
+git commit -m "feat(notifier): add 'cockpit notify' CLI subcommand"
+```
+
+---
+
+## Task 8: Migrate execute-reaction.sh escalations
+
+**Files:**
+- Modify: `scripts/execute-reaction.sh`
+
+- [ ] **Step 1: Read the file and identify the 3 call-sites**
+
+Run: `grep -n "cockpit runtime send --command" scripts/execute-reaction.sh`
+
+Expected: 3 matches in the `escalate`, `send-to-command`, and `auto-fix-ci` (max-retries) cases.
+
+- [ ] **Step 2: Replace each occurrence**
+
+For EACH match, replace:
+```bash
+cockpit runtime send --command "$MESSAGE"
+```
+with:
+```bash
+cockpit notify "$MESSAGE"
+```
+
+(Variable names may differ — `$ESC_MSG`, `$MSG`, etc. Use the same variable the original call used.)
+
+Do NOT modify any `cockpit runtime send "$PROJECT" "$MESSAGE"` calls — those dispatch to project captains, not notifications.
+
+Also remove any surrounding `if get_command_ws >/dev/null; then ...; fi` guards — `cockpit notify` handles offline-command gracefully (exits non-zero, caller already checks).
+
+Example transformation for the `escalate` case:
+
+Before:
+```bash
+escalate)
+  if get_command_ws >/dev/null && cockpit runtime send --command "$MESSAGE"; then
+    echo "✔ Escalated to command: ${RULE}"
+  else
+    echo "⚠️  Command workspace offline. Escalation: ${MESSAGE}"
+  fi
+  ;;
+```
+
+After:
+```bash
+escalate)
+  if cockpit notify "$MESSAGE"; then
+    echo "✔ Escalated to command: ${RULE}"
+  else
+    echo "⚠️  Command workspace offline. Escalation: ${MESSAGE}"
+  fi
+  ;;
+```
+
+Apply the same transformation to `send-to-command` and the `auto-fix-ci` max-retries escalation block.
+
+- [ ] **Step 3: Verify**
+
+Run:
+```bash
+bash -n scripts/execute-reaction.sh
+```
+Expected: no output, exit 0.
+
+Run: `grep -c "cockpit runtime send --command" scripts/execute-reaction.sh`
+Expected: 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/execute-reaction.sh
+git commit -m "refactor(reactor): migrate escalations to 'cockpit notify'"
+```
+
+---
+
+## Task 9: Doctor probe + README
+
+**Files:**
+- Modify: `src/commands/doctor.ts`
+- Modify: `README.md`
+
+- [ ] **Step 1: Add doctor probe**
+
+In `src/commands/doctor.ts`, add import at the top:
+
+```typescript
+import { createCmuxNotifier, NotifierRegistry } from "../notifiers/index.js";
+```
+
+Inside the action, after the tracker probe block, add:
+
+```typescript
+// Probe notifier providers
+const notifiers = new NotifierRegistry({ cmux: createCmuxNotifier });
+const notifierProbes = await notifiers.probeAll();
+for (const [name, probe] of Object.entries(notifierProbes)) {
+  results.push(check(
+    `Notifier '${name}' installed`,
+    probe.installed,
+  ));
+  if (probe.installed) {
+    results.push(check(
+      `Notifier '${name}' reachable`,
+      probe.reachable,
+    ));
+  }
+}
+```
+
+- [ ] **Step 2: Update README**
+
+In `README.md`:
+
+**2a.** After the existing `cockpit tracker get-checks` row in the Commands table, add:
+
+```markdown
+| `cockpit notify <message>` | Send a message to the user via the configured notifier |
+```
+
+**2b.** In the Config JSON example, add at top level (after `"tracker": "github",`):
+
+```json
+  "notifier": "cmux",
+```
+
+**2c.** After the `### Tracker Abstraction` subsection, add:
+
+```markdown
+### Notifier Abstraction
+
+User-facing notifications run behind a pluggable **notifier driver** (currently only `cmux`). Escalations, reactor alerts, and other "tell the user" events go through `cockpit notify <message>`. The default `CmuxNotifier` delegates to `cockpit runtime send --command` — the abstraction exists as a swap-point for future Slack/Discord/email/pager drivers. Notifier is global (no per-project override). See `docs/specs/2026-04-21-plugin-system-notifier-design.md`.
+```
+
+- [ ] **Step 3: Build + smoke**
+
+Run: `npm run build && node dist/index.js doctor`
+Expected: new `Notifier 'cmux' installed` + `Notifier 'cmux' reachable` lines.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/commands/doctor.ts README.md
+git commit -m "feat(notifier): doctor probe + README docs"
+```
+
+---
+
+## Task 10: Full-suite verification
+
+**Files:** none.
+
+- [ ] **Step 1: Test suite**
+
+Run: `npm run test -- --run`
+Expected: all new notifier tests pass (~13 total); baseline preserved.
+
+- [ ] **Step 2: Lint + build**
+
+Run: `npm run lint && npm run build`
+Expected: exits 0 on both.
+
+- [ ] **Step 3: CLI smoke**
+
+Run:
+- `node dist/index.js notify --help` — shows help
+- `node dist/index.js doctor` — shows Notifier checks
+- `echo "test" | node dist/index.js notify -` — reads stdin (if command workspace running, delivers; else fails gracefully)
+
+- [ ] **Step 4: No commit — verification only**
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** §1 Interface → T2; §2 Registry + Config → T1, T5; §3 CLI → T7; §4 Refactor → T8, T9 (README + doctor); §5 Testing → T3, T5, T6.
+- **Type consistency:** `NotifierDriver` methods (`probe`, `notify`) identical across types, cmux.ts, memory-notifier, registry tests, CLI.
+- **Deferred scope** (per spec §Non-Goals): no urgency levels, no multi-sink routing, no per-project notifier, no additional providers.
+- **Commit discipline:** 9 atomic commits across 10 tasks (Task 10 is verify-only).

--- a/scripts/execute-reaction.sh
+++ b/scripts/execute-reaction.sh
@@ -78,9 +78,7 @@ case "$ACTION_TYPE" in
     else
       echo "⚠️  Captain for '$PROJECT' offline — escalating to command"
       # Fallback: send to command
-      if get_command_ws >/dev/null; then
-        cockpit runtime send --command "⚠️ Reactor: ${PROJECT} captain offline. Pending action: ${MESSAGE}" || true
-      fi
+      cockpit notify "⚠️ Reactor: ${PROJECT} captain offline. Pending action: ${MESSAGE}" || true
     fi
     ;;
 
@@ -94,7 +92,7 @@ case "$ACTION_TYPE" in
     ;;
 
   escalate)
-    if get_command_ws >/dev/null && cockpit runtime send --command "$MESSAGE"; then
+    if cockpit notify "$MESSAGE"; then
       echo "✔ Escalated to command: ${RULE}"
     else
       # Last resort: print to reactor log
@@ -122,7 +120,7 @@ else:
     ;;
 
   send-to-command)
-    if get_command_ws >/dev/null && cockpit runtime send --command "$MESSAGE"; then
+    if cockpit notify "$MESSAGE"; then
       echo "✔ Sent to command: ${RULE}"
     fi
     ;;
@@ -135,7 +133,7 @@ else:
     if [ "$CURRENT" -ge "$MAX_RETRIES" ]; then
       # Escalate to command
       ESC_MSG="🚨 CI failed ${CURRENT}× on ${PROJECT} PR #${NUMBER} — auto-fix exhausted (max ${MAX_RETRIES}). Needs manual triage: ${URL}"
-      if get_command_ws >/dev/null && cockpit runtime send --command "$ESC_MSG"; then
+      if cockpit notify "$ESC_MSG"; then
         echo "✔ Escalated PR #${NUMBER} to command (retries: ${CURRENT}/${MAX_RETRIES})"
       else
         echo "⚠️  Command offline. Escalation: ${ESC_MSG}"

--- a/scripts/execute-reaction.sh
+++ b/scripts/execute-reaction.sh
@@ -77,8 +77,11 @@ case "$ACTION_TYPE" in
       echo "✔ Sent message to ${PROJECT} captain: ${RULE}"
     else
       echo "⚠️  Captain for '$PROJECT' offline — escalating to command"
-      # Fallback: send to command
-      cockpit notify "⚠️ Reactor: ${PROJECT} captain offline. Pending action: ${MESSAGE}" || true
+      if cockpit notify "⚠️ Reactor: ${PROJECT} captain offline. Pending action: ${MESSAGE}"; then
+        echo "✔ Escalated to command"
+      else
+        echo "⚠️  Command also offline. Escalation: ${MESSAGE}" >&2
+      fi
     fi
     ;;
 
@@ -122,6 +125,8 @@ else:
   send-to-command)
     if cockpit notify "$MESSAGE"; then
       echo "✔ Sent to command: ${RULE}"
+    else
+      echo "⚠️  Send-to-command failed: ${RULE}" >&2
     fi
     ;;
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -6,6 +6,7 @@ import { loadConfig } from "../config.js";
 import { createCmuxDriver, RuntimeRegistry } from "../runtimes/index.js";
 import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
 import { createGitHubDriver, TrackerRegistry } from "../trackers/index.js";
+import { createCmuxNotifier, NotifierRegistry } from "../notifiers/index.js";
 
 function commandExists(cmd: string): boolean {
   try {
@@ -150,6 +151,22 @@ export const doctorCommand = new Command("doctor")
         results.push(check(
           `Tracker '${name}' authenticated`,
           probe.authenticated,
+        ));
+      }
+    }
+
+    // Probe notifier providers
+    const notifiers = new NotifierRegistry({ cmux: createCmuxNotifier });
+    const notifierProbes = await notifiers.probeAll();
+    for (const [name, probe] of Object.entries(notifierProbes)) {
+      results.push(check(
+        `Notifier '${name}' installed`,
+        probe.installed,
+      ));
+      if (probe.installed) {
+        results.push(check(
+          `Notifier '${name}' reachable`,
+          probe.reachable,
         ));
       }
     }

--- a/src/commands/notify.ts
+++ b/src/commands/notify.ts
@@ -1,0 +1,28 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { loadConfig } from "../config.js";
+import { createCmuxNotifier, NotifierRegistry } from "../notifiers/index.js";
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+export const notifyCommand = new Command("notify")
+  .description("Send a message to the user via the configured notifier")
+  .argument("<message>", "Message to send (use '-' to read from stdin)")
+  .action(async (message: string) => {
+    const config = loadConfig();
+    const registry = new NotifierRegistry({ cmux: createCmuxNotifier });
+    try {
+      const payload = message === "-" ? await readStdin() : message;
+      if (!payload) throw new Error("Empty message");
+      await registry.get(config).notify(payload);
+    } catch (err) {
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+  });

--- a/src/config.ts
+++ b/src/config.ts
@@ -108,6 +108,7 @@ export interface CockpitConfig {
   runtime?: string;
   workspace?: string;
   tracker?: string;
+  notifier?: string;
   defaults: {
     maxCrew: number;
     worktreeDir: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { retroCommand } from "./commands/retro.js";
 import { runtimeCommand } from "./commands/runtime.js";
 import { workspaceCommand } from "./commands/workspace.js";
 import { trackerCommand } from "./commands/tracker.js";
+import { notifyCommand } from "./commands/notify.js";
 
 const program = new Command();
 
@@ -35,5 +36,6 @@ program.addCommand(retroCommand);
 program.addCommand(runtimeCommand);
 program.addCommand(workspaceCommand);
 program.addCommand(trackerCommand);
+program.addCommand(notifyCommand);
 
 program.parse();

--- a/src/notifiers/__tests__/cmux.test.ts
+++ b/src/notifiers/__tests__/cmux.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createCmuxNotifier } from "../cmux.js";
+
+const execMock = vi.hoisted(() => vi.fn());
+vi.mock("node:child_process", () => ({
+  execSync: execMock,
+}));
+
+describe("CmuxNotifier", () => {
+  beforeEach(() => {
+    execMock.mockReset();
+  });
+
+  it("has name 'cmux'", () => {
+    expect(createCmuxNotifier({}).name).toBe("cmux");
+  });
+
+  it("notify shells out to 'cockpit runtime send --command'", async () => {
+    execMock.mockReturnValue("");
+    await createCmuxNotifier({}).notify("hello world");
+    const calls = execMock.mock.calls.map((c) => c[0] as string);
+    expect(calls[0]).toContain("cockpit runtime send");
+    expect(calls[0]).toContain("--command");
+    expect(calls[0]).toContain("hello world");
+  });
+
+  it("notify escapes double-quotes in the message", async () => {
+    execMock.mockReturnValue("");
+    await createCmuxNotifier({}).notify('say "hi"');
+    const calls = execMock.mock.calls.map((c) => c[0] as string);
+    expect(calls[0]).toContain('\\"hi\\"');
+  });
+
+  it("notify throws when cockpit runtime send fails", async () => {
+    execMock.mockImplementation(() => { throw new Error("send failed"); });
+    await expect(createCmuxNotifier({}).notify("x")).rejects.toThrow(/send failed/);
+  });
+
+  it("probe returns installed+reachable=true when status succeeds (exit 0)", async () => {
+    execMock.mockImplementation((cmd: string) => {
+      if (cmd.includes("cockpit runtime status --command")) return "running";
+      return "";
+    });
+    const probe = await createCmuxNotifier({}).probe();
+    expect(probe.installed).toBe(true);
+    expect(probe.reachable).toBe(true);
+  });
+
+  it("probe returns reachable=false when status throws (non-zero exit)", async () => {
+    execMock.mockImplementation((cmd: string) => {
+      if (cmd.includes("cockpit runtime status --command")) {
+        const err: Error & { status?: number } = new Error("stopped");
+        err.status = 1;
+        throw err;
+      }
+      return "";
+    });
+    const probe = await createCmuxNotifier({}).probe();
+    expect(probe.installed).toBe(true);
+    expect(probe.reachable).toBe(false);
+  });
+
+  it("probe returns installed=false when cockpit binary is missing", async () => {
+    execMock.mockImplementation(() => {
+      const err: Error & { code?: string } = new Error("cockpit: command not found");
+      err.code = "ENOENT";
+      throw err;
+    });
+    const probe = await createCmuxNotifier({}).probe();
+    expect(probe.installed).toBe(false);
+    expect(probe.reachable).toBe(false);
+  });
+});

--- a/src/notifiers/__tests__/helpers/memory-notifier.test.ts
+++ b/src/notifiers/__tests__/helpers/memory-notifier.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { createMemoryNotifier } from "./memory-notifier.js";
+
+describe("createMemoryNotifier", () => {
+  it("records notified messages in order", async () => {
+    const n = createMemoryNotifier();
+    await n.notify("first");
+    await n.notify("second");
+    expect(n.messages).toEqual(["first", "second"]);
+  });
+
+  it("probe returns installed+reachable=true", async () => {
+    const n = createMemoryNotifier();
+    expect(await n.probe()).toEqual({ installed: true, reachable: true });
+  });
+});

--- a/src/notifiers/__tests__/helpers/memory-notifier.ts
+++ b/src/notifiers/__tests__/helpers/memory-notifier.ts
@@ -1,0 +1,17 @@
+import type { NotifierDriver } from "../../types.js";
+
+export function createMemoryNotifier(): NotifierDriver & {
+  messages: string[];
+} {
+  const messages: string[] = [];
+  return {
+    name: "memory",
+    messages,
+    async probe() {
+      return { installed: true, reachable: true };
+    },
+    async notify(message: string) {
+      messages.push(message);
+    },
+  };
+}

--- a/src/notifiers/__tests__/registry.test.ts
+++ b/src/notifiers/__tests__/registry.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from "vitest";
+import { NotifierRegistry } from "../registry.js";
+import type { NotifierDriver, NotifierScope } from "../types.js";
+import type { CockpitConfig } from "../../config.js";
+
+function stubFactory(name: string): (scope: NotifierScope) => NotifierDriver {
+  return (_scope) => ({
+    name,
+    probe: vi.fn(async () => ({ installed: true, reachable: true })),
+    notify: vi.fn(async () => {}),
+  });
+}
+
+function baseConfig(overrides: Partial<CockpitConfig> = {}): CockpitConfig {
+  return {
+    commandName: "cmd",
+    hubVault: "~/hub",
+    projects: {},
+    defaults: {
+      maxCrew: 5,
+      worktreeDir: ".worktrees",
+      teammateMode: "in-process",
+      permissions: { command: "default", captain: "acceptEdits" },
+    },
+    metrics: { enabled: false, path: "" },
+    ...overrides,
+  };
+}
+
+describe("NotifierRegistry", () => {
+  it("returns cmux driver by default", () => {
+    const registry = new NotifierRegistry({ cmux: stubFactory("cmux") });
+    expect(registry.get(baseConfig()).name).toBe("cmux");
+  });
+
+  it("uses config.notifier override", () => {
+    const registry = new NotifierRegistry({
+      cmux: stubFactory("cmux"),
+      slack: stubFactory("slack"),
+    });
+    expect(registry.get(baseConfig({ notifier: "slack" })).name).toBe("slack");
+  });
+
+  it("throws when configured provider has no factory", () => {
+    const registry = new NotifierRegistry({ cmux: stubFactory("cmux") });
+    expect(() => registry.get(baseConfig({ notifier: "unknown" }))).toThrowError(/unknown/i);
+  });
+
+  it("probeAll returns results keyed by provider name", async () => {
+    const registry = new NotifierRegistry({
+      cmux: stubFactory("cmux"),
+      slack: stubFactory("slack"),
+    });
+    const results = await registry.probeAll();
+    expect(results.cmux.installed).toBe(true);
+    expect(results.slack.installed).toBe(true);
+  });
+});

--- a/src/notifiers/cmux.ts
+++ b/src/notifiers/cmux.ts
@@ -1,0 +1,33 @@
+import { execSync } from "node:child_process";
+import type {
+  NotifierDriver,
+  NotifierProbeResult,
+  NotifierScope,
+} from "./types.js";
+
+function escape(s: string): string {
+  return s.replace(/"/g, '\\"');
+}
+
+export function createCmuxNotifier(_scope: NotifierScope): NotifierDriver {
+  return {
+    name: "cmux",
+
+    async probe(): Promise<NotifierProbeResult> {
+      try {
+        execSync("cockpit runtime status --command", { encoding: "utf-8", stdio: "pipe" });
+        return { installed: true, reachable: true };
+      } catch (err) {
+        const code = (err as { code?: string }).code;
+        if (code === "ENOENT") {
+          return { installed: false, reachable: false };
+        }
+        return { installed: true, reachable: false };
+      }
+    },
+
+    async notify(message: string): Promise<void> {
+      execSync(`cockpit runtime send --command "${escape(message)}"`, { encoding: "utf-8" });
+    },
+  };
+}

--- a/src/notifiers/cmux.ts
+++ b/src/notifiers/cmux.ts
@@ -22,6 +22,8 @@ export function createCmuxNotifier(_scope: NotifierScope): NotifierDriver {
         if (code === "ENOENT") {
           return { installed: false, reachable: false };
         }
+        // Any non-ENOENT error: cockpit shim crashed, workspace down, or
+        // config unreadable all collapse to "installed but not reachable".
         return { installed: true, reachable: false };
       }
     },

--- a/src/notifiers/index.ts
+++ b/src/notifiers/index.ts
@@ -1,0 +1,8 @@
+export { createCmuxNotifier } from "./cmux.js";
+export { NotifierRegistry } from "./registry.js";
+export type {
+  NotifierDriver,
+  NotifierFactory,
+  NotifierProbeResult,
+  NotifierScope,
+} from "./types.js";

--- a/src/notifiers/registry.ts
+++ b/src/notifiers/registry.ts
@@ -1,0 +1,37 @@
+import type { CockpitConfig } from "../config.js";
+import type {
+  NotifierDriver,
+  NotifierFactory,
+  NotifierProbeResult,
+} from "./types.js";
+
+const DEFAULT_NOTIFIER = "cmux";
+
+export class NotifierRegistry {
+  constructor(private factories: Record<string, NotifierFactory>) {}
+
+  get(config: CockpitConfig): NotifierDriver {
+    const name = config.notifier ?? DEFAULT_NOTIFIER;
+    return this.getFactory(name)({});
+  }
+
+  getFactory(name: string): NotifierFactory {
+    const factory = this.factories[name];
+    if (!factory) {
+      throw new Error(`Unknown notifier provider '${name}' — no factory registered`);
+    }
+    return factory;
+  }
+
+  async probeAll(): Promise<Record<string, NotifierProbeResult>> {
+    const results: Record<string, NotifierProbeResult> = {};
+    for (const [name, factory] of Object.entries(this.factories)) {
+      try {
+        results[name] = await factory({}).probe();
+      } catch {
+        results[name] = { installed: false, reachable: false };
+      }
+    }
+    return results;
+  }
+}

--- a/src/notifiers/types.ts
+++ b/src/notifiers/types.ts
@@ -1,0 +1,17 @@
+export interface NotifierProbeResult {
+  installed: boolean;
+  reachable: boolean;
+}
+
+export interface NotifierScope {
+  [key: string]: unknown;
+}
+
+export interface NotifierDriver {
+  name: string;
+
+  probe(): Promise<NotifierProbeResult>;
+  notify(message: string): Promise<void>;
+}
+
+export type NotifierFactory = (scope: NotifierScope) => NotifierDriver;


### PR DESCRIPTION
## Summary

Phase 4 of issue #9 — the **last of the core 4 slots**. Thin wrapper completing the plugin system: `NotifierDriver` abstracts "tell the user something" behind a driver boundary mirroring phases 1-3. \`CmuxNotifier\` delegates to \`cockpit runtime send --command\`; future Slack/Discord/email/pager drivers slot in by swapping this single call-point.

Spec: [\`docs/specs/2026-04-21-plugin-system-notifier-design.md\`](docs/specs/2026-04-21-plugin-system-notifier-design.md)
Plan: [\`docs/specs/2026-04-21-plugin-system-notifier-plan.md\`](docs/specs/2026-04-21-plugin-system-notifier-plan.md)

## What changed

**New:**
- \`src/notifiers/types.ts\` — \`NotifierDriver\` (2 methods: \`probe\`, \`notify\`)
- \`src/notifiers/cmux.ts\` — \`createCmuxNotifier\` (33 lines; delegates via \`execSync\`)
- \`src/notifiers/registry.ts\` — \`NotifierRegistry\` with \`get\`/\`getFactory\`/\`probeAll\`
- \`src/notifiers/index.ts\` — barrel
- \`src/notifiers/__tests__/\` — **13 new tests** (7 cmux, 4 registry, 2 memory-notifier)
- \`src/notifiers/__tests__/helpers/memory-notifier.ts\` — in-memory fixture
- \`src/commands/notify.ts\` — \`cockpit notify <message>\` CLI (single subcommand; \`-\` reads stdin)

**Migrated:**
- \`scripts/execute-reaction.sh\` — 4 escalation call-sites (\`escalate\`, \`send-to-command\`, \`send-to-captain\` fallback, \`auto-fix-ci\` max-retries) now call \`cockpit notify\`. Zero \`cockpit runtime send --command\` refs remain.
- \`src/commands/doctor.ts\` — probes notifier providers; reports installed + reachable.

**Config (backward compatible):**
- \`notifier?: string\` at top level only (global — no per-project override)

**Docs:**
- README — commands table + config JSON + Notifier Abstraction architecture subsection.

## Contract highlights

- **One method (\`notify\`).** No urgency levels, no multi-sink routing — YAGNI; add when a real driver requires them.
- **Global scope.** Notifier targets the user (singleton) not a project.
- **Thin delegation.** \`CmuxNotifier.notify()\` shells out to \`cockpit runtime send --command\`. The abstraction is the seam, not new logic.

## Test plan

- [x] \`npm run test -- --run\`: 120 pass / 2 pre-existing \`config.test.ts\` failures (emoji-prefix baseline, predates PR)
- [x] \`npm run lint\` exits 0
- [x] \`npm run build\` exits 0
- [x] \`grep -c \"cockpit runtime send --command\" scripts/execute-reaction.sh\` = **0**
- [x] \`cockpit doctor\` shows new \`Notifier 'cmux' installed\` + \`reachable\` lines
- [x] \`cockpit notify --help\` renders

## Pre-PR code review

Internal review (superpowers:code-reviewer) approved with 2 small shell-script regressions flagged and fixed in commit \`1bf72e5\`:
- **send-to-captain fallback** lost its else-arm warning when switching away from the \`get_command_ws\` guard — restored with \`Command also offline\` stderr message.
- **send-to-command** had no else path on notify failure — now prints \`Send-to-command failed\` to stderr.

Also added a clarifying comment on \`CmuxNotifier.probe()\`'s non-ENOENT branch documenting the accepted ambiguity (shim crash vs workspace down vs config unreadable all collapse to \`reachable=false\` — same tradeoff as prior phases).

## Plugin system status

With this PR, **all 4 core slots are shipped:**

| Slot | Status |
|------|--------|
| runtime | ✅ PR #20 |
| agent | ✅ PR #16 |
| workspace | ✅ PR #26 |
| tracker | ✅ PR #28 |
| **notifier** | **✅ this PR** |
| external plugin loading (node_modules) | 🔜 phase 5 (optional platform bet) |

## Open follow-ups (from prior phases, still open)

- #23 — Tighten WorkspaceScope typing when 2nd provider ships
- #24 — Migrate status.md reads in standup/retro
- #25 — Evaluate symlink traversal policy in ObsidianDriver
- #27 — Normalize cross-tracker vocabulary in reactions.json