### PR TITLE
fix(command-ops): add freshness gate before reusing captain workspace

### DIFF
--- a/plugin/skills/command-ops/SKILL.md
+++ b/plugin/skills/command-ops/SKILL.md
@@ -44,19 +44,34 @@ Match to `~/.config/cockpit/config.json`.
 ```
 **CRITICAL:** Match the EXACT `captainName` from config. `Brove` ≠ `⚓ brove-captain`.
 
-### 3. Spawn captain if missing
+### 3. Freshness gate (run BEFORE deciding to reuse)
+A name match is **not** sufficient — the workspace may be holding a session from a previous day. Check `sessions.json` against today before reusing:
+```bash
+TODAY=$(date +%Y-%m-%d)
+LAST=$(python3 -c "import json; d=json.load(open('$HOME/.config/cockpit/sessions.json')); print(d.get('workspaces',{}).get('{captainName}',{}).get('lastLaunched',''))" 2>/dev/null)
+[ "$LAST" = "$TODAY" ] && echo "fresh" || echo "stale"
+```
+- `fresh` → reuse the existing workspace, proceed to step 5.
+- `stale` (or no entry) → close the existing workspace, then go to step 4 to respawn so `spawn-workspace.sh` runs its `↻ new day — starting fresh session` path:
+  ```bash
+  /Applications/cmux.app/Contents/Resources/bin/cmux close-workspace --workspace "workspace:N"
+  ```
+
+Never skip this gate when a workspace was found by name — that's how stale captains get reused.
+
+### 4. Spawn captain (missing or stale)
 ```bash
 ~/.config/cockpit/scripts/spawn-workspace.sh "{captainName}" "{projectPath}"
 ```
-Wait a few seconds, then `list-workspaces` again to get its ref.
+Wait a few seconds, then `list-workspaces` again to get its ref. Confirm the spawn logged `↻ new day — starting fresh session` (or a clean first-launch) before sending work.
 
-### 4. Send the task
+### 5. Send the task
 ```bash
 /Applications/cmux.app/Contents/Resources/bin/cmux send --workspace "workspace:N" "Task description with all context"
 /Applications/cmux.app/Contents/Resources/bin/cmux send-key --workspace "workspace:N" Enter
 ```
 
-### 5. Report back
+### 6. Report back
 "Delegated to {captainName}."
 
 ## Checking Status


### PR DESCRIPTION
## Summary

- Inserts an explicit freshness-check step into the `command-ops` delegation workflow so a name-matched captain workspace isn't reused on a new day.
- The check reads `~/.config/cockpit/sessions.json` and compares `lastLaunched` to today; on stale, command closes the workspace and respawns via `spawn-workspace.sh` (which already logs `↻ new day — starting fresh session`).
- Renumbers the trailing "Report back" step from 5 → 6 to accommodate the new gate.

`spawn-workspace.sh` already handled new-day freshness correctly; the bug was that `command-ops/SKILL.md` could bypass it whenever step 2 (`list-workspaces`) found a matching name. This PR closes that gap by making the freshness check part of the delegation contract.

Fixes #37

## Test plan

- [ ] On a new day with a captain workspace left over from a previous session, run delegation and confirm the freshness gate produces `stale` and triggers a respawn.
- [ ] Same-day reuse case: confirm the gate produces `fresh` and the existing workspace is reused without respawn.
- [ ] No `sessions.json` entry for the captain (first-ever launch path): confirm the gate treats it as `stale` so step 4 spawns cleanly.