### PR TITLE
fix(shutdown): match legacy un-anchored captain workspace names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (508 symbols, 984 relationships, 34 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (514 symbols, 990 relationships, 35 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (508 symbols, 984 relationships, 34 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (514 symbols, 990 relationships, 35 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/src/commands/shutdown.ts
+++ b/src/commands/shutdown.ts
@@ -2,6 +2,43 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { loadConfig } from "../config.js";
 import { createCmuxDriver, RuntimeRegistry } from "../runtimes/index.js";
+import type { RuntimeDriver } from "../runtimes/index.js";
+
+// Captain workspaces gained the leading "⚓ " prefix partway through cockpit's
+// life. Workspaces created before that convention persist with the un-prefixed
+// name and shutdown needs to match both shapes.
+function nameVariants(name: string): string[] {
+  const stripped = name.replace(/^⚓\s+/, "").trim();
+  return stripped === name ? [name] : [name, stripped];
+}
+
+async function closeMatching(
+  runtime: RuntimeDriver,
+  variants: string[],
+  label: string,
+): Promise<{ closed: string[]; failed: string[] }> {
+  const workspaces = await runtime.list();
+  const matches = workspaces.filter((w) => variants.includes(w.name));
+  const closed: string[] = [];
+  const failed: string[] = [];
+  if (matches.length === 0) {
+    console.log(
+      chalk.yellow(`  ⚠ Workspace '${label}' not found — already closed?`),
+    );
+    return { closed, failed };
+  }
+  for (const ws of matches) {
+    try {
+      await runtime.stop(ws.id);
+      console.log(chalk.green(`  ✔ Closed: ${ws.name}`));
+      closed.push(ws.name);
+    } catch {
+      console.log(chalk.red(`  ✘ Failed to close: ${ws.name}`));
+      failed.push(ws.name);
+    }
+  }
+  return { closed, failed };
+}
 
 export const shutdownCommand = new Command("shutdown")
   .description(
@@ -15,18 +52,24 @@ export const shutdownCommand = new Command("shutdown")
     if (!project) {
       const globalRuntime = runtimes.global(config);
       const workspaces = await globalRuntime.list();
-      const captainNames = Object.values(config.projects).map((p) => p.captainName);
-      const commandName = config.commandName || "command";
-      const cockpitWorkspaces = workspaces.filter(
-        (w) => w.name === commandName || captainNames.includes(w.name),
+      const captainVariants = Object.values(config.projects).flatMap((p) =>
+        nameVariants(p.captainName),
       );
+      const commandName = config.commandName || "command";
+      const commandVariants = nameVariants(commandName);
+      const allVariants = new Set([...captainVariants, ...commandVariants]);
+      const cockpitWorkspaces = workspaces.filter((w) => allVariants.has(w.name));
 
       if (cockpitWorkspaces.length === 0) {
         console.log(chalk.yellow("\nNo cockpit workspaces found to close.\n"));
         return;
       }
 
-      console.log(chalk.bold(`\nShutting down ${cockpitWorkspaces.length} workspace(s)...\n`));
+      console.log(
+        chalk.bold(
+          `\nShutting down ${cockpitWorkspaces.length} workspace(s)...\n`,
+        ),
+      );
       for (const ws of cockpitWorkspaces) {
         try {
           await globalRuntime.stop(ws.id);
@@ -50,19 +93,15 @@ export const shutdownCommand = new Command("shutdown")
 
     const captainName = config.projects[project].captainName;
     const runtime = runtimes.forProject(project, config);
-    console.log(chalk.bold(`\nShutting down captain workspace for '${project}'...\n`));
+    console.log(
+      chalk.bold(`\nShutting down captain workspace for '${project}'...\n`),
+    );
 
-    const ref = await runtime.status(captainName);
-    if (!ref) {
-      console.log(chalk.yellow(`  ⚠ Workspace '${captainName}' not found — already closed?\n`));
-      return;
-    }
-
-    try {
-      await runtime.stop(ref.id);
-      console.log(chalk.green(`  ✔ Closed: ${captainName}\n`));
-    } catch {
-      console.error(chalk.red(`  ✘ Failed to close workspace '${captainName}'\n`));
-      process.exit(1);
-    }
+    const { failed } = await closeMatching(
+      runtime,
+      nameVariants(captainName),
+      captainName,
+    );
+    console.log("");
+    if (failed.length > 0) process.exit(1);
   });


### PR DESCRIPTION
Closes #52

## What

Captain workspaces gained a leading `⚓ ` prefix partway through cockpit's life. Workspaces created before that convention persist with the un-prefixed name; `cockpit shutdown` only matched the current `captainName` exactly, so those legacy workspaces became orphans (had to be closed manually via `cmux close-workspace`).

## Fix

`src/commands/shutdown.ts`:
- Added `nameVariants(name)` helper — returns `[name, stripAnchor(name)]` (deduped if no anchor).
- Added `closeMatching()` helper — lists workspaces, filters by variant set, closes each match.
- Bulk path: builds variant set across all captain names + commandName, filters live workspace list.
- Single-project path: switched from `runtime.status(captainName)` (single match) to `closeMatching` so both anchored and legacy versions get closed in one shot.

## Verification

- `npm run lint` — clean.
- `npm test` — 268 passing, 2 pre-existing failures in `config.test.ts` (commandName default emoji mismatch — unrelated).
- Live repro from today:
  ```
  cmux list-workspaces | grep pact
    workspace:2  pact-network-captain        # legacy, no anchor
    workspace:8  ⚓ pact-network-captain      # current
  ```
  Old behavior: `cockpit shutdown pact-network` left `workspace:2` behind. New behavior: closes both.

## Out of scope (separate)

`--fresh` flag is still misleading (forces new chat session, not a new workspace). Consider as a follow-up issue.