### PR TITLE
feat(crew): default crew spawn to a tab in the captain workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ cockpit launch <project>          → Captain (per project, in cmux)
 cockpit launch --all              → Reactor + every Captain
 cockpit command --task briefing   → One-shot Command session in a split pane
                                        (also: --task learnings-review | wiki-aggregate)
-Captain → cockpit crew spawn …    → Crew (split pane, fresh agent CLI session)
+Captain → cockpit crew spawn …    → Crew (new tab in the captain workspace, fresh agent CLI)
 ```
 
 1. **`cockpit init`** — first-time setup
@@ -88,7 +88,7 @@ See `obsidian/plugins.md` for Dataview, Templater setup.
 | `cockpit projection emit [--scope user\|project] [--project <name>] [--target <name>] [--all]` | Emit cockpit rules + skills to Cursor/Codex/Gemini config files |
 | `cockpit projection diff [same flags]` | Preview projection changes without writing |
 | `cockpit projection list` | Show registered projection targets and their destinations |
-| `cockpit crew spawn <project> <task> [--direction <d>] [--agent <a>]` | Spawn a crew session in a split pane next to the project's captain |
+| `cockpit crew spawn <project> <task> [--direction tab\|right\|left\|up\|down] [--agent <a>]` | Spawn a crew session as a tab in the captain workspace (default) or as a split pane via `--direction <d>` |
 | `cockpit shutdown [project]` | Graceful shutdown |
 | `cockpit feedback` | Open opt-in feedback issue |
 
@@ -98,7 +98,7 @@ See `obsidian/plugins.md` for Dataview, Templater setup.
 
 - **Command** (Opus) — *on-demand* cross-project session. Spawned by `cockpit command --task <briefing|learnings-review|wiki-aggregate>` in a split pane; exits when the task completes. No persistent Command process.
 - **Captain** (Opus) — project leader, uses Agent Teams + git worktrees
-- **Crew** (Sonnet by default) — fresh CLI session in a split pane next to the captain. Spawned via `cockpit crew spawn`. Works with any agent CLI (claude, codex, gemini, aider). Disposable; uses GSD for complex tasks.
+- **Crew** (Sonnet by default) — fresh CLI session as a new tab in the captain's workspace (or a split pane via `--direction`). Spawned via `cockpit crew spawn`. Works with any agent CLI (claude, codex, gemini, aider). Disposable; uses GSD for complex tasks.
 - **Reactor** (Sonnet) — always-on GitHub event poller, auto-delegates to captains (incl. auto-fix on CI failure, with escalation after max retries)
 
 ### Model Routing
@@ -124,9 +124,9 @@ Issue/PR operations run behind a pluggable **tracker driver** (currently only `g
 
 User-facing notifications run behind a pluggable **notifier driver** (currently only `cmux`). Escalations, reactor alerts, and other "tell the user" events go through `cockpit notify <message>`. The default `CmuxNotifier` delegates to `cockpit runtime send --command` — the abstraction exists as a swap-point for future Slack/Discord/email/pager drivers. Notifier is global (no per-project override). See `docs/specs/2026-04-21-plugin-system-notifier-design.md`.
 
-### Crew Spawn (Split-Pane CLI)
+### Crew Spawn (Tabbed CLI)
 
-Crew is no longer a Claude Agent Team member. The captain spawns a crew session via `cockpit crew spawn <project> "<task>"`, which opens a split pane in the captain's cmux workspace and starts a fresh CLI session for the chosen agent (`--agent claude|codex|gemini|aider`). The crew session loads `crew.<agent>.md` as its system prompt and the task as its inline prompt — exactly the OpenAI-Swarm "handoff = next prompt" pattern. State lives in the pane buffer + git; the pane is disposable. See [`docs/specs/2026-05-05-cockpit-thin-redirect-design.md`](docs/specs/2026-05-05-cockpit-thin-redirect-design.md).
+Crew is no longer a Claude Agent Team member. The captain spawns a crew session via `cockpit crew spawn <project> "<task>"`, which opens a new tab in the captain's cmux workspace and starts a fresh CLI session for the chosen agent (`--agent claude|codex|gemini|aider`). Pass `--direction right|left|up|down` to use a split pane instead of a tab. The crew session loads `crew.<agent>.md` as its system prompt and the task as its inline prompt — exactly the OpenAI-Swarm "handoff = next prompt" pattern. State lives in the surface buffer + git; the tab is disposable. See [`docs/specs/2026-05-05-cockpit-thin-redirect-design.md`](docs/specs/2026-05-05-cockpit-thin-redirect-design.md).
 
 ### Projection (Cross-Agent Config Sync)
 

--- a/orchestrator/captain.claude.md
+++ b/orchestrator/captain.claude.md
@@ -7,7 +7,7 @@ You are a **project captain** for claude-cockpit. You lead ONE project. You are 
 1. **NEVER** edit, write, or modify project source code yourself. You are a coordinator.
 2. **ALWAYS** spawn a crew session for ANY coding task — no matter how small.
 3. Even a one-line fix gets a crew session. You plan, delegate, review, merge.
-4. **ALWAYS** spawn crew via `cockpit crew spawn` — never via the `Agent` tool, never via `TeamCreate`. The split-pane CLI works for any agent (claude, codex, gemini, aider).
+4. **ALWAYS** spawn crew via `cockpit crew spawn` — never via the `Agent` tool, never via `TeamCreate`. Crew opens as a new tab in your workspace and works for any agent (claude, codex, gemini, aider).
 
 ## ALWAYS do on session start
 
@@ -17,10 +17,10 @@ Use the `cockpit:captain-ops` skill — it has your full startup checklist, crew
 
 1. **Spawn crew with `cockpit crew spawn`**:
    ```bash
-   cockpit crew spawn <project> "<task description with context, files, branch>" [--direction right|down] [--agent claude|codex|gemini|aider]
+   cockpit crew spawn <project> "<task description with context, files, branch>" [--direction tab|right|left|up|down] [--agent claude|codex|gemini|aider]
    ```
-   The crew opens in a split pane next to your workspace. You can preview live; it can report back via `cockpit runtime send <project> "<message>"`.
-2. **Read crew progress** by inspecting their pane visually in cmux (the spawn output prints the new pane's surface ref so you can find it). The CLI does not yet target individual panes for read-screen / send — that's a follow-up improvement; for now use the cmux UI to inspect crew panes mid-task.
+   By default the crew opens as a **new tab** in your workspace (use `--direction right|down|...` to split into a pane instead). You can preview live; the crew can report back via `cockpit runtime send <project> "<message>"`.
+2. **Read crew progress** by inspecting their tab/pane visually in cmux (the spawn output prints the new surface ref so you can find it). The CLI does not yet target individual surfaces for read-screen / send — that's a follow-up improvement; for now use the cmux UI to inspect crew surfaces mid-task.
 3. **Record learnings** when something unexpected happens or a pattern emerges (`cockpit:captain-ops` shows the script).
 4. **Compact recovery** — if you feel disoriented after `/compact`, re-read your handoff (`{spokeVault}/handoffs/`) and current `status.md` to restore work context. Role itself survives compact via `--append-system-prompt-file`.
 

--- a/orchestrator/captain.generic.md
+++ b/orchestrator/captain.generic.md
@@ -4,16 +4,16 @@ You are a project captain coordinating work via cmux workspaces. You are a coord
 
 ## Rules
 
-1. You coordinate crew sessions working in split panes (one per task).
+1. You coordinate crew sessions running in tabs alongside your workspace (one per task; pass `--direction` to split into a pane instead).
 2. **Spawn crew with `cockpit crew spawn`**:
    ```bash
-   cockpit crew spawn <project> "<task description>" [--direction right|down] [--agent claude|codex|gemini|aider]
+   cockpit crew spawn <project> "<task description>" [--direction tab|right|left|up|down] [--agent claude|codex|gemini|aider]
    ```
 3. Communicate with the project's captain workspace via:
    ```bash
    cockpit runtime send <project> "<message>"
    ```
-4. Inspect crew panes visually in cmux (the spawn output prints the surface ref so you can locate the pane). Per-pane CLI read/send is a follow-up improvement.
+4. Inspect crew surfaces (tabs / panes) visually in cmux (the spawn output prints the surface ref so you can locate them). Per-surface CLI read/send is a follow-up improvement.
 5. When a crew task completes, review the diff and merge if appropriate.
 6. Record learnings (script: `~/.config/cockpit/scripts/record-learning.sh`).
 

--- a/orchestrator/crew.claude.md
+++ b/orchestrator/crew.claude.md
@@ -5,7 +5,7 @@ You are a crew member working on a specific task within a git worktree.
 ## Rules
 
 1. You are in a worktree, NOT the main branch. Do not modify files outside your worktree.
-2. You operate as a single fresh CLI session in a split pane. You do NOT spawn nested Agent Team subagents. For complex multi-step work, use GSD slash commands (`/gsd:plan-phase`, `/gsd:execute-phase`) which fork their own subagents within your session.
+2. You operate as a single fresh CLI session in a tab (or split pane) inside the captain's workspace. You do NOT spawn nested Agent Team subagents. For complex multi-step work, use GSD slash commands (`/gsd:plan-phase`, `/gsd:execute-phase`) which fork their own subagents within your session.
 3. You do NOT write status files — your captain handles that.
 4. You do NOT create Agent Teams (no nested teams).
 5. When your task is complete, report back to your captain.

--- a/orchestrator/crew.generic.md
+++ b/orchestrator/crew.generic.md
@@ -21,7 +21,7 @@ When done:
 
 ## How You Were Spawned
 
-You were started by `cockpit crew spawn` as a split pane in the captain's workspace. Your task is in your initial prompt. When you finish, exit cleanly — the pane is disposable.
+You were started by `cockpit crew spawn` as a new tab in the captain's workspace (or as a split pane if `--direction` was passed). Your task is in your initial prompt. When you finish, exit cleanly — the surface is disposable.
 
 ## Coding Discipline (Karpathy Principles)
 

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -32,9 +32,9 @@ If relevant pages exist, read them for context before starting work.
 
 ## Crew Setup
 
-You do NOT create an Agent Team. You spawn each crew session on demand as a split pane next to your workspace via `cockpit crew spawn`. The pane is a fresh CLI session with the crew template loaded as system prompt — disposable, restartable, runtime-agnostic.
+You do NOT create an Agent Team. You spawn each crew session on demand as a **new tab** in your workspace via `cockpit crew spawn` (use `--direction right|down|...` to split into a pane instead). The surface is a fresh CLI session with the crew template loaded as system prompt — disposable, restartable, runtime-agnostic.
 
-You don't need to create or persist anything up front. Each `cockpit crew spawn` call creates the pane.
+You don't need to create or persist anything up front. Each `cockpit crew spawn` call creates a new surface.
 
 ## Task Decomposition with Task Master
 
@@ -82,19 +82,19 @@ Use `cockpit crew spawn`:
 
 ```bash
 cockpit crew spawn <project> "<task description>" \
-    [--direction right|left|up|down] \
+    [--direction tab|right|left|up|down] \
     [--agent claude|codex|gemini|aider]
 ```
 
 What it does:
-1. Opens a split pane next to the project's captain workspace.
+1. Opens a new **tab** in the project's captain workspace (use `--direction right|left|up|down` to split into a pane instead).
 2. Renames the tab to `🔧 <project>-crew` so you can identify it visually.
 3. Starts a fresh CLI session for the chosen agent (default: `claude`) with `crew.<agent>.md` loaded as the system prompt and the task as the inline prompt.
-4. Prints the new pane's surface ref — capture it if you want to read its screen later.
+4. Prints the new surface ref — capture it if you want to read its screen later.
 
 **Examples:**
 
-Simple coding task (default agent claude, default direction right):
+Simple coding task (default agent claude, opens a new tab):
 ```bash
 cockpit crew spawn brove "Add preinstall hook to package.json. Branch: feat/preinstall."
 ```
@@ -104,9 +104,9 @@ Use Codex for a complex refactor:
 cockpit crew spawn brove "Refactor src/api/handlers.ts: extract validation into validators.ts. Branch: refactor/handlers." --agent codex
 ```
 
-Use a downward split when the workspace is already busy on the right:
+Open as a side-by-side pane instead of a tab when you want live preview:
 ```bash
-cockpit crew spawn brove "Fix typo in README" --direction down
+cockpit crew spawn brove "Fix typo in README" --direction right
 ```
 
 **Rules:**
@@ -119,14 +119,14 @@ cockpit crew spawn brove "Fix typo in README" --direction down
 
 ## Sending Follow-up Instructions
 
-The crew session keeps running in its split pane until it exits. There is no per-pane CLI send yet — multi-turn follow-up is a follow-up improvement. For now, either:
+The crew session keeps running in its tab (or pane) until it exits. There is no per-surface CLI send yet — multi-turn follow-up is a follow-up improvement. For now, either:
 - Send the entire context up front in the initial `cockpit crew spawn` task prompt, or
-- Type follow-up instructions directly into the crew's pane via the cmux UI.
+- Type follow-up instructions directly into the crew's tab via the cmux UI.
 
 ## Task Coordination
 
 You don't have an Agent Team or `TaskCreate`/`TaskUpdate` tools — those were Claude-specific. Track crew progress by:
-1. Inspecting the crew pane visually in cmux (you have its surface ref from the spawn output).
+1. Inspecting the crew tab visually in cmux (you have its surface ref from the spawn output).
 2. Watching the auto-poller's `{spokeVault}/status.md` (written by the reactor — see issue #43).
 3. Asking the user to check the dashboard if you need a cross-project view (see issue #44).
 
@@ -138,7 +138,7 @@ After a crew task completes:
 
 1. Review the work — read the diff, check the branch.
 2. Merge their branch if appropriate.
-3. Close the crew pane: it closes naturally when the agent session exits. If you need to force-close, use the cmux UI directly. (A `cockpit runtime close-pane` CLI is a follow-up improvement.)
+3. Close the crew surface: it closes naturally when the agent session exits. If you need to force-close, use the cmux UI directly. (A `cockpit runtime close-surface` CLI is a follow-up improvement.)
 4. Record learnings if any (see "Recording Learnings" below).
 5. Update your handoff if the work shifts the next-step plan (see "Session Shutdown — Write Handoff" below).
 

--- a/scripts/spawn-crew-pane.sh
+++ b/scripts/spawn-crew-pane.sh
@@ -11,7 +11,7 @@ fi
 
 PROJECT="$1"
 TASK="$2"
-DIRECTION="${3:-right}"
+DIRECTION="${3:-tab}"
 AGENT="${4:-claude}"
 
 exec cockpit crew spawn "$PROJECT" "$TASK" --direction "$DIRECTION" --agent "$AGENT"

--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -66,7 +66,7 @@ describe("cockpit crew spawn", () => {
     loadConfig.mockReset();
   });
 
-  it("opens a split pane in the captain workspace and sends the agent command", async () => {
+  it("opens a tab in the captain workspace and sends the agent command", async () => {
     loadConfig.mockReturnValue({
       commandName: "command",
       hubVault: "~/hub",
@@ -85,7 +85,7 @@ describe("cockpit crew spawn", () => {
     expect(status).toHaveBeenCalledWith("brove-captain");
     expect(newPane).toHaveBeenCalledWith(expect.objectContaining({
       workspaceId: "workspace:5",
-      direction: "right",
+      direction: "tab",
     }));
     expect(sendToPane).toHaveBeenCalledWith(
       { workspaceId: "workspace:5", surfaceId: "surface:9" },

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -11,14 +11,14 @@ import {
   createAiderDriver,
   CapabilityRegistry,
 } from "../drivers/index.js";
-import type { PaneRef } from "../runtimes/types.js";
+import type { PaneRef, PanePlacement } from "../runtimes/types.js";
 
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "cockpit", "templates");
 
 export interface CrewSpawnInput {
   project: string;
   task: string;
-  direction?: "right" | "left" | "up" | "down";
+  direction?: PanePlacement;
   agent?: string;
 }
 
@@ -57,23 +57,23 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
     promptFile,
   });
 
-  const direction = input.direction ?? "right";
+  const direction: PanePlacement = input.direction ?? "tab";
   const title = `🔧 ${input.project}-crew`;
   const pane = await runtime.newPane({ workspaceId: captain.id, direction, title });
   await runtime.sendToPane(pane, command);
   return pane;
 }
 
-export const crewCommand = new Command("crew").description("Spawn and manage crew sessions in split panes");
+export const crewCommand = new Command("crew").description("Spawn and manage crew sessions next to the project's captain");
 
 crewCommand
   .command("spawn")
-  .description("Spawn a crew session in a split pane next to the project's captain")
+  .description("Spawn a crew session as a tab in the project's captain workspace (use --direction to split into a pane instead)")
   .argument("<project>", "Project name (must be registered)")
   .argument("<task>", "Task prompt for the crew session")
-  .option("--direction <dir>", "Split direction (right|left|up|down)", "right")
+  .option("--direction <dir>", "Placement: tab (default) or split direction (right|left|up|down)", "tab")
   .option("--agent <name>", "Agent CLI to use (claude|codex|gemini|aider)", "claude")
-  .action(async (project: string, task: string, opts: { direction: "right" | "left" | "up" | "down"; agent: string }) => {
+  .action(async (project: string, task: string, opts: { direction: PanePlacement; agent: string }) => {
     try {
       const pane = await runCrewSpawn({ project, task, direction: opts.direction, agent: opts.agent });
       console.log(chalk.green(`✔ Crew spawned in ${pane.workspaceId} ${pane.surfaceId}`));

--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -134,6 +134,35 @@ describe("cmux driver", () => {
     expect(calls.some((c) => c.includes("new-pane") && c.includes("--direction right") && c.includes("--workspace \"workspace:1\""))).toBe(true);
   });
 
+  it("newPane with direction=tab calls cmux new-surface instead of new-pane", async () => {
+    execMock.mockImplementation((cmd: string) => {
+      if (cmd.includes("new-surface")) return "OK surface:31 workspace:1";
+      return "";
+    });
+    const pane = await driver.newPane({ workspaceId: "workspace:1", direction: "tab" });
+    expect(pane).toEqual({ workspaceId: "workspace:1", surfaceId: "surface:31" });
+    const calls = execMock.mock.calls.map((c) => c[0] as string);
+    expect(calls.some((c) => c.includes("new-surface") && c.includes("--workspace \"workspace:1\""))).toBe(true);
+    expect(calls.every((c) => !c.includes("new-pane"))).toBe(true);
+    expect(calls.every((c) => !c.includes("--direction"))).toBe(true);
+  });
+
+  it("newPane with direction=tab and title renames the new surface", async () => {
+    execMock.mockImplementation((cmd: string) => {
+      if (cmd.includes("new-surface")) return "OK surface:42 workspace:7";
+      return "";
+    });
+    await driver.newPane({ workspaceId: "workspace:7", direction: "tab", title: "🔧 brove-crew" });
+    const calls = execMock.mock.calls.map((c) => c[0] as string);
+    expect(calls.some((c) => c.includes("rename-tab") && c.includes("--surface \"surface:42\"") && c.includes("\"🔧 brove-crew\""))).toBe(true);
+  });
+
+  it("newPane with direction=tab throws when output has no surface id", async () => {
+    execMock.mockReturnValue("garbage");
+    await expect(driver.newPane({ workspaceId: "workspace:1", direction: "tab" }))
+      .rejects.toThrow(/new-surface did not return a surface/);
+  });
+
   it("newPane with title also calls rename-tab on the new surface", async () => {
     execMock.mockImplementation((cmd: string) => {
       if (cmd.includes("new-pane")) return "OK surface:9 pane:3 workspace:2";

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -94,10 +94,14 @@ export function createCmuxDriver(): RuntimeDriver {
 
     async newPane(opts: RuntimePaneOptions): Promise<PaneRef> {
       const titleArg = opts.title ? ` --title "${escape(opts.title)}"` : "";
-      const output = cmux(`new-pane --type terminal --direction ${opts.direction} --workspace "${opts.workspaceId}"`);
+      const cmd = opts.direction === "tab"
+        ? `new-surface --type terminal --workspace "${opts.workspaceId}"`
+        : `new-pane --type terminal --direction ${opts.direction} --workspace "${opts.workspaceId}"`;
+      const output = cmux(cmd);
       const surfaceId = output.match(/surface:\d+/)?.[0];
       if (!surfaceId) {
-        throw new Error(`cmux new-pane did not return a surface id: ${output}`);
+        const verb = opts.direction === "tab" ? "new-surface" : "new-pane";
+        throw new Error(`cmux ${verb} did not return a surface id: ${output}`);
       }
       if (opts.title) {
         try {

--- a/src/runtimes/types.ts
+++ b/src/runtimes/types.ts
@@ -17,9 +17,14 @@ export interface RuntimeSpawnOptions {
   pinToTop?: boolean;
 }
 
+// "tab" creates a new top-level surface (cmux: new-surface) inside the
+// workspace; the cardinal directions split the current surface into a pane
+// (cmux: new-pane). Both produce a PaneRef with a fresh surfaceId.
+export type PanePlacement = "tab" | "right" | "left" | "up" | "down";
+
 export interface RuntimePaneOptions {
   workspaceId: string;
-  direction: "right" | "left" | "up" | "down";
+  direction: PanePlacement;
   title?: string;
 }
 


### PR DESCRIPTION
Closes #54

## What

`cockpit crew spawn` defaulted to a split pane next to the captain. Crowded the captain's column and was inconvenient in practice. Default flips to a **tab** in the captain's workspace; `--direction right|left|up|down` opts into a pane.

## Changes

**Runtime layer (`src/runtimes/`)**
- New `PanePlacement` type: `"tab" | "right" | "left" | "up" | "down"`
- `CmuxDriver.newPane`: dispatch `cmux new-surface` when direction === `"tab"`, else existing `cmux new-pane`. Same `PaneRef` shape either way; `rename-tab` still runs to title the surface.
- New tests: tab path (new-surface call, no `--direction` flag, rename-tab applied, missing-surface-id error path).

**CLI**
- `cockpit crew spawn`: `--direction` default is now `tab`. Help text updated.
- `scripts/spawn-crew-pane.sh` shim default direction also `tab`.

**Docs/templates**
- README, `captain.claude.md`, `captain.generic.md`, `crew.claude.md`, `crew.generic.md`, `captain-ops` SKILL: language flipped from "split pane" → "tab"; pane opt-in documented via `--direction`.
- CHANGELOG and historical specs left as-is (history of what shipped at the time).

## Verification

- `npm run lint` — clean
- `npm test` — 271 pass (3 new tab tests). Same 2 pre-existing `config.test.ts` failures (commandName default emoji mismatch — unrelated).
- `npm run build` — clean

## Out of scope

- Dashboard / `cockpit command` keep their pane defaults (intentional — sidebar grid + one-shot Command session both want side-by-side).
- Per-surface CLI read/send remains a follow-up improvement.