### PR TITLE
feat(crew): interactive sub-sessions with named lifecycle (v0.3.1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (515 symbols, 990 relationships, 35 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (527 symbols, 1048 relationships, 36 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (514 symbols, 990 relationships, 35 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (515 symbols, 990 relationships, 35 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to claude-cockpit are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-05-06
+
+Crew sessions become **interactive sub-sessions** instead of one-shot print
+runs — the captain's equivalent of a Claude Agent Team subagent. Each crew is
+named, addressable, stays idle between turns, and is driven by new
+`cockpit crew send/read/close/list` verbs. Closes #56.
+
+### Added
+
+- **Interactive Claude crews** — `cockpit crew spawn` boots Claude without
+  `-p`, then sends the task as the first turn after the CLI is ready. The
+  session stays alive between turns waiting for the captain's next message.
+- **Named crews** — `--name <n>` (or auto-generated `crew-1`, `crew-2`, …
+  picking the next free slot from existing tabs in the captain workspace).
+  Tab title becomes `🔧 <project>:<name>` so the surface itself is the
+  registry — no state file.
+- **`cockpit crew send <project> <name> "<message>"`** — send a follow-up
+  turn to an existing crew. Replaces the "spawn a new tab for every turn"
+  pattern.
+- **`cockpit crew read <project> <name>`** — read the crew's current screen
+  from the CLI (no need to flip into the cmux UI).
+- **`cockpit crew close <project> <name>`** — shutdown a crew (closes its
+  tab).
+- **`cockpit crew list <project>`** — list live crews for a project.
+- **`SpawnOptions.interactive`** flag — Claude driver omits `-p` when set so
+  callers can deliver the prompt over runtime.send.
+- **`RuntimeDriver.listSurfaces(workspaceId)`** — enumerate surfaces (tabs /
+  panes) inside a workspace with their titles. Cmux driver parses
+  `cmux tree --workspace`.
+
+### Changed
+
+- **Captain templates + `captain-ops` SKILL** rewritten — teach the new
+  spawn-once / send-follow-ups / close-when-done pattern. Stops the "tons of
+  tabs" growth seen pre-0.3.1.
+- **README + CLI help** updated with the new verbs.
+
+### Known limitations
+
+- Non-Claude agents (codex / gemini / aider) still launch in print-mode;
+  full interactive support per agent is a follow-up.
+- Crew tabs do not persist across `cockpit shutdown <project>` — they're
+  surfaces inside the captain workspace and die with it. Matches Agent Team
+  semantics.
+
 ## [0.3.0] - 2026-05-05
 
 The thin-redirect release. Cockpit becomes a thin multi-agent orchestration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (515 symbols, 990 relationships, 35 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (527 symbols, 1048 relationships, 36 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (514 symbols, 990 relationships, 35 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (515 symbols, 990 relationships, 35 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,11 @@ See `obsidian/plugins.md` for Dataview, Templater setup.
 | `cockpit projection emit [--scope user\|project] [--project <name>] [--target <name>] [--all]` | Emit cockpit rules + skills to Cursor/Codex/Gemini config files |
 | `cockpit projection diff [same flags]` | Preview projection changes without writing |
 | `cockpit projection list` | Show registered projection targets and their destinations |
-| `cockpit crew spawn <project> <task> [--direction tab\|right\|left\|up\|down] [--agent <a>]` | Spawn a crew session as a tab in the captain workspace (default) or as a split pane via `--direction <d>` |
+| `cockpit crew spawn <project> <task> [--name <n>] [--direction tab\|right\|left\|up\|down] [--agent <a>]` | Spawn an interactive crew sub-session (tab in the captain workspace by default; `--direction` for a pane) |
+| `cockpit crew send <project> <name> <message>` | Send a follow-up turn to an existing crew |
+| `cockpit crew read <project> <name>` | Read a crew session's current screen |
+| `cockpit crew close <project> <name>` | Shutdown a crew session (closes its tab) |
+| `cockpit crew list <project>` | List live crews for a project |
 | `cockpit shutdown [project]` | Graceful shutdown |
 | `cockpit feedback` | Open opt-in feedback issue |
 
@@ -98,7 +102,7 @@ See `obsidian/plugins.md` for Dataview, Templater setup.
 
 - **Command** (Opus) — *on-demand* cross-project session. Spawned by `cockpit command --task <briefing|learnings-review|wiki-aggregate>` in a split pane; exits when the task completes. No persistent Command process.
 - **Captain** (Opus) — project leader, uses Agent Teams + git worktrees
-- **Crew** (Sonnet by default) — fresh CLI session as a new tab in the captain's workspace (or a split pane via `--direction`). Spawned via `cockpit crew spawn`. Works with any agent CLI (claude, codex, gemini, aider). Disposable; uses GSD for complex tasks.
+- **Crew** (Sonnet by default) — interactive sub-session running as a new tab in the captain's workspace (or a split pane via `--direction`). Each crew is named (`crew-1`, `crew-2`, …) and stays idle between turns waiting for the captain's next message — same model as a Claude Agent Team subagent. Spawn with `cockpit crew spawn`, send follow-ups with `cockpit crew send`, close when done. Works with any agent CLI (claude is fully interactive; codex/gemini/aider currently print-mode). Uses GSD for complex tasks.
 - **Reactor** (Sonnet) — always-on GitHub event poller, auto-delegates to captains (incl. auto-fix on CI failure, with escalation after max retries)
 
 ### Model Routing
@@ -124,9 +128,11 @@ Issue/PR operations run behind a pluggable **tracker driver** (currently only `g
 
 User-facing notifications run behind a pluggable **notifier driver** (currently only `cmux`). Escalations, reactor alerts, and other "tell the user" events go through `cockpit notify <message>`. The default `CmuxNotifier` delegates to `cockpit runtime send --command` — the abstraction exists as a swap-point for future Slack/Discord/email/pager drivers. Notifier is global (no per-project override). See `docs/specs/2026-04-21-plugin-system-notifier-design.md`.
 
-### Crew Spawn (Tabbed CLI)
+### Crew Spawn (Interactive Sub-Sessions)
 
-Crew is no longer a Claude Agent Team member. The captain spawns a crew session via `cockpit crew spawn <project> "<task>"`, which opens a new tab in the captain's cmux workspace and starts a fresh CLI session for the chosen agent (`--agent claude|codex|gemini|aider`). Pass `--direction right|left|up|down` to use a split pane instead of a tab. The crew session loads `crew.<agent>.md` as its system prompt and the task as its inline prompt — exactly the OpenAI-Swarm "handoff = next prompt" pattern. State lives in the surface buffer + git; the tab is disposable. See [`docs/specs/2026-05-05-cockpit-thin-redirect-design.md`](docs/specs/2026-05-05-cockpit-thin-redirect-design.md).
+Crew is the captain's equivalent of an Agent Team subagent — but runtime-agnostic. The captain spawns a crew via `cockpit crew spawn <project> "<task>" [--name <n>]`, which opens a new tab in the captain's cmux workspace, boots an interactive Claude session (no `-p`), and sends the task as the first turn. The crew works on it and **stays idle** waiting for follow-ups. The captain drives the session with `cockpit crew send/read/close/list`, addressing each crew by its tab title (`🔧 <project>:<name>`).
+
+Pass `--direction right|left|up|down` to use a split pane instead of a tab. State lives in the surface buffer + git; tabs die with the captain workspace on `cockpit shutdown`. Non-Claude agents (codex/gemini/aider) currently still launch in print-mode; full interactive support is a follow-up. See [`docs/specs/2026-05-05-cockpit-thin-redirect-design.md`](docs/specs/2026-05-05-cockpit-thin-redirect-design.md).
 
 ### Projection (Cross-Agent Config Sync)
 

--- a/orchestrator/captain.claude.md
+++ b/orchestrator/captain.claude.md
@@ -15,12 +15,23 @@ Use the `cockpit:captain-ops` skill — it has your full startup checklist, crew
 
 ## Core Rules
 
-1. **Spawn crew with `cockpit crew spawn`**:
+1. **Crew = interactive sub-session.** Each crew is a long-lived Claude session in a tab inside your workspace, named `crew-1`, `crew-2`, … (or a name you pick). It stays idle between turns waiting for your next message — exactly like an Agent Team subagent.
+2. **Spawn a NEW crew** with `cockpit crew spawn`:
    ```bash
-   cockpit crew spawn <project> "<task description with context, files, branch>" [--direction tab|right|left|up|down] [--agent claude|codex|gemini|aider]
+   cockpit crew spawn <project> "<task description>" [--name <n>] [--direction tab|right|left|up|down] [--agent claude|codex|gemini|aider]
    ```
-   By default the crew opens as a **new tab** in your workspace (use `--direction right|down|...` to split into a pane instead). You can preview live; the crew can report back via `cockpit runtime send <project> "<message>"`.
-2. **Read crew progress** by inspecting their tab/pane visually in cmux (the spawn output prints the new surface ref so you can find it). The CLI does not yet target individual surfaces for read-screen / send — that's a follow-up improvement; for now use the cmux UI to inspect crew surfaces mid-task.
+   Opens a new tab titled `🔧 <project>:<name>`, boots an interactive Claude (no `-p`), then sends the task as the first turn. `--name` is optional; auto-picks the next free `crew-N`.
+3. **Send a follow-up turn** to an existing crew:
+   ```bash
+   cockpit crew send <project> <name> "<message>"
+   ```
+   Use this for follow-ups, corrections, "now do X" — DO NOT spawn a new crew for every turn. That's how you get tab pollution.
+4. **Inspect & manage:**
+   ```bash
+   cockpit crew list <project>                 # see live crews
+   cockpit crew read <project> <name>          # read its screen
+   cockpit crew close <project> <name>         # shutdown when done
+   ```
 3. **Record learnings** when something unexpected happens or a pattern emerges (`cockpit:captain-ops` shows the script).
 4. **Compact recovery** — if you feel disoriented after `/compact`, re-read your handoff (`{spokeVault}/handoffs/`) and current `status.md` to restore work context. Role itself survives compact via `--append-system-prompt-file`.
 

--- a/orchestrator/captain.generic.md
+++ b/orchestrator/captain.generic.md
@@ -4,16 +4,22 @@ You are a project captain coordinating work via cmux workspaces. You are a coord
 
 ## Rules
 
-1. You coordinate crew sessions running in tabs alongside your workspace (one per task; pass `--direction` to split into a pane instead).
-2. **Spawn crew with `cockpit crew spawn`**:
+1. Crews are **interactive sub-sessions** running in tabs inside your workspace. Each one stays idle between turns waiting for your next message.
+2. **Spawn a NEW crew** with `cockpit crew spawn`:
    ```bash
-   cockpit crew spawn <project> "<task description>" [--direction tab|right|left|up|down] [--agent claude|codex|gemini|aider]
+   cockpit crew spawn <project> "<task>" [--name <n>] [--direction tab|right|left|up|down] [--agent claude|codex|gemini|aider]
    ```
-3. Communicate with the project's captain workspace via:
+3. **Send a follow-up turn** to an existing crew (don't spawn a new tab for every turn):
+   ```bash
+   cockpit crew send <project> <name> "<message>"
+   cockpit crew read <project> <name>          # read screen
+   cockpit crew close <project> <name>         # shutdown when done
+   cockpit crew list <project>                 # all live crews
+   ```
+4. Communicate with the project's captain workspace via:
    ```bash
    cockpit runtime send <project> "<message>"
    ```
-4. Inspect crew surfaces (tabs / panes) visually in cmux (the spawn output prints the surface ref so you can locate them). Per-surface CLI read/send is a follow-up improvement.
 5. When a crew task completes, review the diff and merge if appropriate.
 6. Record learnings (script: `~/.config/cockpit/scripts/record-learning.sh`).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-cockpit",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Multi-project agent orchestration for Claude Code",
   "type": "module",
   "bin": {

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -78,57 +78,81 @@ mcp__task-master-ai__expand_task(id: "1", projectRoot: "{projectPath}")
 
 **You MUST spawn a crew session for ANY coding task** — even a one-line change. You are a coordinator. You plan, delegate, review, and merge. You do NOT write code yourself.
 
-Use `cockpit crew spawn`:
+A crew is an **interactive Claude sub-session** running in a tab inside your workspace, named `crew-1`, `crew-2`, … (or a name you pick). It stays idle between turns waiting for your next message — same model as a Claude Agent Team subagent.
+
+### Spawn a NEW crew
 
 ```bash
 cockpit crew spawn <project> "<task description>" \
+    [--name <name>] \
     [--direction tab|right|left|up|down] \
     [--agent claude|codex|gemini|aider]
 ```
 
 What it does:
-1. Opens a new **tab** in the project's captain workspace (use `--direction right|left|up|down` to split into a pane instead).
-2. Renames the tab to `🔧 <project>-crew` so you can identify it visually.
-3. Starts a fresh CLI session for the chosen agent (default: `claude`) with `crew.<agent>.md` loaded as the system prompt and the task as the inline prompt.
-4. Prints the new surface ref — capture it if you want to read its screen later.
+1. Opens a new **tab** in the captain workspace (use `--direction right|left|up|down` to split into a pane instead).
+2. Names the tab `🔧 <project>:<name>` — `--name` is optional; auto-picks the next free `crew-N`.
+3. Boots an interactive Claude session (no `-p`) with `crew.<agent>.md` loaded as system prompt.
+4. Sends your task as the first turn. The crew works on it and then **stays idle** waiting for follow-ups.
 
-**Examples:**
+### Send a FOLLOW-UP to an existing crew
 
-Simple coding task (default agent claude, opens a new tab):
+DO NOT spawn a new crew for every turn — that's how you get tab pollution. Use `send`:
+
+```bash
+cockpit crew send <project> <name> "<message>"
+```
+
+### Inspect & shutdown
+
+```bash
+cockpit crew list <project>                 # see all live crews for the project
+cockpit crew read <project> <name>          # read the crew's current screen
+cockpit crew close <project> <name>         # shutdown the crew (closes its tab)
+```
+
+### Examples
+
+Spawn a fresh crew (auto-named `crew-1`):
 ```bash
 cockpit crew spawn brove "Add preinstall hook to package.json. Branch: feat/preinstall."
 ```
 
-Use Codex for a complex refactor:
+Named crew for a specific work track:
 ```bash
-cockpit crew spawn brove "Refactor src/api/handlers.ts: extract validation into validators.ts. Branch: refactor/handlers." --agent codex
+cockpit crew spawn brove "Refactor src/api/handlers.ts" --name api-refactor --agent codex
 ```
 
-Open as a side-by-side pane instead of a tab when you want live preview:
+Send a follow-up turn:
+```bash
+cockpit crew send brove crew-1 "Also wire that into the install script"
+```
+
+Open as a side-by-side pane when you want live preview:
 ```bash
 cockpit crew spawn brove "Fix typo in README" --direction right
 ```
 
-**Rules:**
-- Do NOT manually run `git worktree add`. The crew operates in the captain's checkout — the CLI does not create worktrees by default. If a task genuinely requires worktree isolation, ask the user before doing so.
+### Rules
+
+- **Reuse with `send` before spawning a new one.** Same task track, same crew. New track = new crew.
+- **Close crews you're done with** (`cockpit crew close ...`) so they don't accumulate.
+- Do NOT manually run `git worktree add`. The crew operates in the captain's checkout. If a task genuinely requires worktree isolation, ask the user.
 - Do NOT edit source code yourself — always delegate to crew.
 - Respect `maxCrew` — don't exceed the configured concurrent crew count.
-- **Model routing is per-agent:** the agent driver decides; if you want a specific model, pass it through the agent's CLI flags inside the task prompt.
-- **For complex multi-step tasks** (3+ steps, multiple files), tell the crew to use GSD inside the spawn prompt — add to the prompt: *"This is a complex task. Use `/gsd:plan-phase` and `/gsd:execute-phase` for wave-based execution with fresh context per step."*
+- **For complex multi-step tasks** (3+ steps, multiple files), tell the crew to use GSD inside the task prompt: *"This is a complex task. Use `/gsd:plan-phase` and `/gsd:execute-phase` for wave-based execution with fresh context per step."*
 - **For simple tasks**, don't mention GSD — the crew will handle it directly.
 
-## Sending Follow-up Instructions
-
-The crew session keeps running in its tab (or pane) until it exits. There is no per-surface CLI send yet — multi-turn follow-up is a follow-up improvement. For now, either:
-- Send the entire context up front in the initial `cockpit crew spawn` task prompt, or
-- Type follow-up instructions directly into the crew's tab via the cmux UI.
+> Non-Claude agents (codex / gemini / aider) currently still launch in print-mode (one-shot) rather than as interactive sessions; `send` won't reach them yet. Prefer Claude crews when you want multi-turn dialogue.
 
 ## Task Coordination
 
 You don't have an Agent Team or `TaskCreate`/`TaskUpdate` tools — those were Claude-specific. Track crew progress by:
-1. Inspecting the crew tab visually in cmux (you have its surface ref from the spawn output).
-2. Watching the auto-poller's `{spokeVault}/status.md` (written by the reactor — see issue #43).
-3. Asking the user to check the dashboard if you need a cross-project view (see issue #44).
+1. `cockpit crew read <project> <name>` — read the crew's screen directly from CLI.
+2. `cockpit crew list <project>` — see all live crews and pick the right one.
+3. Inspecting the crew tab visually in cmux when you want richer context (you have its surface ref from the spawn output).
+4. Watching the auto-poller's `{spokeVault}/status.md` (written by the reactor — see issue #43).
+5. Asking the user to check the dashboard if you need a cross-project view (see issue #44).
 
 When a crew sends you a status message via `cockpit runtime send <project> "<message>"`, it lands in your captain pane. Acknowledge, then update your handoff if a meaningful decision was made.
 
@@ -138,7 +162,7 @@ After a crew task completes:
 
 1. Review the work — read the diff, check the branch.
 2. Merge their branch if appropriate.
-3. Close the crew surface: it closes naturally when the agent session exits. If you need to force-close, use the cmux UI directly. (A `cockpit runtime close-surface` CLI is a follow-up improvement.)
+3. Close the crew with `cockpit crew close <project> <name>` once the work track is done. (Or let the crew exit itself — the tab closes when the CLI ends.)
 4. Record learnings if any (see "Recording Learnings" below).
 5. Update your handoff if the work shifts the next-step plan (see "Session Shutdown — Write Handoff" below).
 

--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -1,7 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const newPane = vi.hoisted(() => vi.fn());
 const sendToPane = vi.hoisted(() => vi.fn());
+const closePane = vi.hoisted(() => vi.fn());
+const readPaneScreen = vi.hoisted(() => vi.fn());
+const listSurfaces = vi.hoisted(() => vi.fn());
 const status = vi.hoisted(() => vi.fn());
 const buildCommand = vi.hoisted(() => vi.fn());
 const probe = vi.hoisted(() => vi.fn());
@@ -18,9 +21,10 @@ vi.mock("../../runtimes/index.js", () => ({
     readScreen: vi.fn(),
     stop: vi.fn(),
     newPane,
-    closePane: vi.fn(),
+    closePane,
     sendToPane,
-    readPaneScreen: vi.fn(),
+    readPaneScreen,
+    listSurfaces,
   }),
   RuntimeRegistry: class {
     constructor(private drivers: Record<string, unknown>) {}
@@ -55,94 +59,200 @@ vi.mock("../../drivers/index.js", () => ({
   },
 }));
 
-import { runCrewSpawn } from "../crew.js";
+import { runCrewSpawn, runCrewSend, runCrewRead, runCrewClose, runCrewList } from "../crew.js";
+
+const baseConfig = {
+  commandName: "command",
+  hubVault: "~/hub",
+  projects: {
+    brove: { path: "/tmp/brove", captainName: "brove-captain", spokeVault: "~/hub/spokes/brove", host: "local" },
+  },
+  defaults: { maxCrew: 5, worktreeDir: ".worktrees", teammateMode: "in-process", permissions: {} },
+  metrics: { enabled: false, path: "" },
+};
 
 describe("cockpit crew spawn", () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     newPane.mockReset();
     sendToPane.mockReset();
+    closePane.mockReset();
+    readPaneScreen.mockReset();
+    listSurfaces.mockReset();
     status.mockReset();
     buildCommand.mockReset();
     loadConfig.mockReset();
   });
 
-  it("opens a tab in the captain workspace and sends the agent command", async () => {
-    loadConfig.mockReturnValue({
-      commandName: "command",
-      hubVault: "~/hub",
-      projects: {
-        brove: { path: "/tmp/brove", captainName: "brove-captain", spokeVault: "~/hub/spokes/brove", host: "local" },
-      },
-      defaults: { maxCrew: 5, worktreeDir: ".worktrees", teammateMode: "in-process", permissions: {} },
-      metrics: { enabled: false, path: "" },
-    });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("spawns a Claude crew interactively, names it crew-1, then sends the task after the boot delay", async () => {
+    loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
     newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
-    buildCommand.mockReturnValue('claude --append-system-prompt-file /tmp/crew.md "do the thing"');
+    buildCommand.mockReturnValue("claude --append-system-prompt-file /tmp/crew.md");
 
-    const result = await runCrewSpawn({ project: "brove", task: "do the thing" });
+    const promise = runCrewSpawn({ project: "brove", task: "do the thing" });
+    await vi.advanceTimersByTimeAsync(3000);
+    const result = await promise;
 
-    expect(status).toHaveBeenCalledWith("brove-captain");
+    expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ interactive: true }));
     expect(newPane).toHaveBeenCalledWith(expect.objectContaining({
       workspaceId: "workspace:5",
       direction: "tab",
+      title: "🔧 brove:crew-1",
     }));
-    expect(sendToPane).toHaveBeenCalledWith(
+    expect(sendToPane.mock.calls[0]).toEqual([
       { workspaceId: "workspace:5", surfaceId: "surface:9" },
-      'claude --append-system-prompt-file /tmp/crew.md "do the thing"',
-    );
-    expect(result).toEqual({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+      "claude --append-system-prompt-file /tmp/crew.md",
+    ]);
+    expect(sendToPane.mock.calls[1]).toEqual([
+      { workspaceId: "workspace:5", surfaceId: "surface:9" },
+      "do the thing",
+    ]);
+    expect(result.title).toBe("🔧 brove:crew-1");
+  });
+
+  it("auto-names the next crew based on existing tabs (crew-1 + crew-3 → crew-2)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([
+      { workspaceId: "workspace:5", surfaceId: "surface:10", title: "🔧 brove:crew-1" },
+      { workspaceId: "workspace:5", surfaceId: "surface:12", title: "🔧 brove:crew-3" },
+    ]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:13" });
+    buildCommand.mockReturnValue("claude ...");
+
+    const promise = runCrewSpawn({ project: "brove", task: "task" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(newPane).toHaveBeenCalledWith(expect.objectContaining({ title: "🔧 brove:crew-2" }));
+  });
+
+  it("respects --name and refuses if a crew with that name already exists", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([
+      { workspaceId: "workspace:5", surfaceId: "surface:10", title: "🔧 brove:fix-typos" },
+    ]);
+
+    await expect(runCrewSpawn({ project: "brove", task: "x", name: "fix-typos" }))
+      .rejects.toThrow(/already exists/);
+  });
+
+  it("non-Claude agent crews stay print-mode (no boot delay, no second send)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("codex exec 'task'");
+
+    const result = await runCrewSpawn({ project: "brove", task: "task", agent: "codex" });
+
+    expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ interactive: false }));
+    expect(sendToPane).toHaveBeenCalledTimes(1);
+    expect(result.title).toBe("🔧 brove:crew-1");
+  });
+
+  it("respects --direction override", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude ...");
+
+    const promise = runCrewSpawn({ project: "brove", task: "task", direction: "down" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(newPane).toHaveBeenCalledWith(expect.objectContaining({ direction: "down" }));
   });
 
   it("throws when project is not registered", async () => {
-    loadConfig.mockReturnValue({
-      commandName: "command",
-      hubVault: "~/hub",
-      projects: {},
-      defaults: { maxCrew: 5, worktreeDir: ".worktrees", teammateMode: "in-process", permissions: {} },
-      metrics: { enabled: false, path: "" },
-    });
-
+    loadConfig.mockReturnValue({ ...baseConfig, projects: {} });
     await expect(runCrewSpawn({ project: "ghost", task: "x" }))
       .rejects.toThrow(/Project 'ghost' not found/);
   });
 
   it("throws when captain workspace is not running", async () => {
-    loadConfig.mockReturnValue({
-      commandName: "command",
-      hubVault: "~/hub",
-      projects: {
-        brove: { path: "/tmp/brove", captainName: "brove-captain", spokeVault: "~/hub/spokes/brove", host: "local" },
-      },
-      defaults: { maxCrew: 5, worktreeDir: ".worktrees", teammateMode: "in-process", permissions: {} },
-      metrics: { enabled: false, path: "" },
-    });
+    loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue(null);
-
     await expect(runCrewSpawn({ project: "brove", task: "x" }))
       .rejects.toThrow(/captain workspace 'brove-captain' is not running/i);
   });
+});
 
-  it("respects --direction and --agent overrides", async () => {
-    loadConfig.mockReturnValue({
-      commandName: "command",
-      hubVault: "~/hub",
-      projects: {
-        brove: { path: "/tmp/brove", captainName: "brove-captain", spokeVault: "~/hub/spokes/brove", host: "local" },
-      },
-      defaults: { maxCrew: 5, worktreeDir: ".worktrees", teammateMode: "in-process", permissions: {} },
-      metrics: { enabled: false, path: "" },
-    });
+describe("cockpit crew send/read/close/list", () => {
+  beforeEach(() => {
+    listSurfaces.mockReset();
+    status.mockReset();
+    sendToPane.mockReset();
+    closePane.mockReset();
+    readPaneScreen.mockReset();
+    loadConfig.mockReset();
+    loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
-    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
-    buildCommand.mockReturnValue("codex 'task'");
+  });
 
-    await runCrewSpawn({ project: "brove", task: "task", direction: "down", agent: "codex" });
+  it("send delivers a message to the matching crew tab", async () => {
+    listSurfaces.mockResolvedValue([
+      { workspaceId: "workspace:5", surfaceId: "surface:10", title: "🔧 brove:crew-1" },
+    ]);
 
-    expect(newPane).toHaveBeenCalledWith(expect.objectContaining({ direction: "down" }));
+    await runCrewSend("brove", "crew-1", "follow up");
+
     expect(sendToPane).toHaveBeenCalledWith(
-      expect.anything(),
-      "codex 'task'",
+      { workspaceId: "workspace:5", surfaceId: "surface:10", title: "🔧 brove:crew-1" },
+      "follow up",
     );
+  });
+
+  it("send throws when crew name is not found", async () => {
+    listSurfaces.mockResolvedValue([]);
+    await expect(runCrewSend("brove", "ghost", "msg"))
+      .rejects.toThrow(/Crew 'ghost' not found/);
+  });
+
+  it("read returns the crew's screen content", async () => {
+    listSurfaces.mockResolvedValue([
+      { workspaceId: "workspace:5", surfaceId: "surface:10", title: "🔧 brove:crew-1" },
+    ]);
+    readPaneScreen.mockResolvedValue("crew screen text");
+
+    const text = await runCrewRead("brove", "crew-1");
+    expect(text).toBe("crew screen text");
+  });
+
+  it("close shuts the crew tab", async () => {
+    listSurfaces.mockResolvedValue([
+      { workspaceId: "workspace:5", surfaceId: "surface:10", title: "🔧 brove:crew-1" },
+    ]);
+
+    await runCrewClose("brove", "crew-1");
+
+    expect(closePane).toHaveBeenCalledWith({
+      workspaceId: "workspace:5",
+      surfaceId: "surface:10",
+      title: "🔧 brove:crew-1",
+    });
+  });
+
+  it("list returns all crews for the project, ignoring non-crew tabs", async () => {
+    listSurfaces.mockResolvedValue([
+      { workspaceId: "workspace:5", surfaceId: "surface:9", title: "captain shell" },
+      { workspaceId: "workspace:5", surfaceId: "surface:10", title: "🔧 brove:crew-1" },
+      { workspaceId: "workspace:5", surfaceId: "surface:11", title: "🔧 brove:fix-typos" },
+      { workspaceId: "workspace:5", surfaceId: "surface:12", title: "🔧 other:crew-1" },
+    ]);
+
+    const crews = await runCrewList("brove");
+    expect(crews).toEqual([
+      { name: "crew-1", surfaceId: "surface:10" },
+      { name: "fix-typos", surfaceId: "surface:11" },
+    ]);
   });
 });

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -11,31 +11,111 @@ import {
   createAiderDriver,
   CapabilityRegistry,
 } from "../drivers/index.js";
-import type { PaneRef, PanePlacement } from "../runtimes/types.js";
+import type { PaneRef, PanePlacement, RuntimeDriver } from "../runtimes/types.js";
 
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "cockpit", "templates");
+
+// Time to wait between launching the crew CLI and sending the first prompt.
+// The CLI needs a moment to initialize plugins / load the system prompt before
+// it's ready to accept input. 3s matches the captain launch path.
+const CLI_BOOT_DELAY_MS = 3000;
+
+function titleFor(project: string, name: string): string {
+  return `🔧 ${project}:${name}`;
+}
+
+function isCrewTitle(project: string, title: string): boolean {
+  return title.startsWith(`🔧 ${project}:`);
+}
+
+function nameFromTitle(project: string, title: string): string {
+  return title.slice(`🔧 ${project}:`.length);
+}
+
+async function listProjectCrews(
+  runtime: RuntimeDriver,
+  workspaceId: string,
+  project: string,
+): Promise<PaneRef[]> {
+  const surfaces = await runtime.listSurfaces(workspaceId);
+  return surfaces.filter((s) => s.title && isCrewTitle(project, s.title));
+}
+
+async function findCrew(
+  runtime: RuntimeDriver,
+  workspaceId: string,
+  project: string,
+  name: string,
+): Promise<PaneRef | null> {
+  const want = titleFor(project, name);
+  const surfaces = await runtime.listSurfaces(workspaceId);
+  return surfaces.find((s) => s.title === want) ?? null;
+}
+
+function nextAutoName(existingTitles: string[], project: string): string {
+  const used = new Set<number>();
+  for (const title of existingTitles) {
+    const n = nameFromTitle(project, title).match(/^crew-(\d+)$/);
+    if (n) used.add(Number(n[1]));
+  }
+  let i = 1;
+  while (used.has(i)) i++;
+  return `crew-${i}`;
+}
+
+async function resolveCaptainWorkspace(project: string): Promise<{
+  runtime: RuntimeDriver;
+  workspaceId: string;
+}> {
+  const config = loadConfig();
+  const proj = config.projects[project];
+  if (!proj) {
+    throw new Error(`Project '${project}' not found. Run 'cockpit projects list'.`);
+  }
+  const runtime = new RuntimeRegistry({ cmux: createCmuxDriver() }).forProject(project, config);
+  const captain = await runtime.status(proj.captainName);
+  if (!captain) {
+    throw new Error(
+      `Captain workspace '${proj.captainName}' is not running. Run 'cockpit launch ${project}' first.`,
+    );
+  }
+  return { runtime, workspaceId: captain.id };
+}
 
 export interface CrewSpawnInput {
   project: string;
   task: string;
+  name?: string;
   direction?: PanePlacement;
   agent?: string;
 }
 
 export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
   const config = loadConfig();
-  const project = config.projects[input.project];
-  if (!project) {
+  const proj = config.projects[input.project];
+  if (!proj) {
     throw new Error(`Project '${input.project}' not found. Run 'cockpit projects list'.`);
   }
 
-  const runtime = new RuntimeRegistry({ cmux: createCmuxDriver() })
-    .forProject(input.project, config);
-
-  const captain = await runtime.status(project.captainName);
+  const runtime = new RuntimeRegistry({ cmux: createCmuxDriver() }).forProject(input.project, config);
+  const captain = await runtime.status(proj.captainName);
   if (!captain) {
-    throw new Error(`Captain workspace '${project.captainName}' is not running. Run 'cockpit launch ${input.project}' first.`);
+    throw new Error(
+      `Captain workspace '${proj.captainName}' is not running. Run 'cockpit launch ${input.project}' first.`,
+    );
   }
+
+  const existing = await listProjectCrews(runtime, captain.id, input.project);
+  const existingTitles = existing.map((s) => s.title!);
+  if (input.name) {
+    const wantTitle = titleFor(input.project, input.name);
+    if (existingTitles.includes(wantTitle)) {
+      throw new Error(
+        `Crew '${input.name}' already exists for ${input.project}. Use 'cockpit crew send ${input.project} ${input.name}' to send a follow-up, or pick a different --name.`,
+      );
+    }
+  }
+  const name = input.name ?? nextAutoName(existingTitles, input.project);
 
   const agents = new CapabilityRegistry({
     claude: createClaudeDriver(),
@@ -50,33 +130,169 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
   }
 
   const promptFile = path.join(TEMPLATES_DIR, `crew.${agent.templateSuffix}.md`);
-  const command = agent.buildCommand({
+  // Claude crews run interactively (no -p) so the session stays alive between
+  // turns; the task is sent via cmux after the CLI boots. Other agents that
+  // don't yet honor `interactive` will keep their existing print-mode shape —
+  // a known limitation tracked for future work.
+  const interactive = agent.name === "claude";
+  const cliCommand = agent.buildCommand({
     prompt: input.task,
-    workdir: project.path,
+    workdir: proj.path,
     role: "crew",
     promptFile,
+    interactive,
   });
 
   const direction: PanePlacement = input.direction ?? "tab";
-  const title = `🔧 ${input.project}-crew`;
+  const title = titleFor(input.project, name);
   const pane = await runtime.newPane({ workspaceId: captain.id, direction, title });
-  await runtime.sendToPane(pane, command);
-  return pane;
+
+  // Step 1: launch the CLI in the new tab.
+  await runtime.sendToPane(pane, cliCommand);
+
+  // Step 2: for interactive sessions, wait for the CLI to boot, then send the
+  // task as the first prompt. For non-interactive (legacy) the prompt is
+  // already baked into cliCommand, so we're done.
+  if (interactive) {
+    await new Promise((r) => setTimeout(r, CLI_BOOT_DELAY_MS));
+    await runtime.sendToPane(pane, input.task);
+  }
+
+  return { ...pane, title };
 }
 
-export const crewCommand = new Command("crew").description("Spawn and manage crew sessions next to the project's captain");
+export async function runCrewSend(project: string, name: string, message: string): Promise<void> {
+  const { runtime, workspaceId } = await resolveCaptainWorkspace(project);
+  const crew = await findCrew(runtime, workspaceId, project, name);
+  if (!crew) {
+    throw new Error(`Crew '${name}' not found for ${project}. Run 'cockpit crew list ${project}'.`);
+  }
+  await runtime.sendToPane(crew, message);
+}
+
+export async function runCrewRead(project: string, name: string): Promise<string> {
+  const { runtime, workspaceId } = await resolveCaptainWorkspace(project);
+  const crew = await findCrew(runtime, workspaceId, project, name);
+  if (!crew) {
+    throw new Error(`Crew '${name}' not found for ${project}. Run 'cockpit crew list ${project}'.`);
+  }
+  return runtime.readPaneScreen(crew);
+}
+
+export async function runCrewClose(project: string, name: string): Promise<void> {
+  const { runtime, workspaceId } = await resolveCaptainWorkspace(project);
+  const crew = await findCrew(runtime, workspaceId, project, name);
+  if (!crew) {
+    throw new Error(`Crew '${name}' not found for ${project}. Run 'cockpit crew list ${project}'.`);
+  }
+  await runtime.closePane(crew);
+}
+
+export async function runCrewList(project: string): Promise<Array<{ name: string; surfaceId: string }>> {
+  const { runtime, workspaceId } = await resolveCaptainWorkspace(project);
+  const crews = await listProjectCrews(runtime, workspaceId, project);
+  return crews.map((c) => ({
+    name: nameFromTitle(project, c.title!),
+    surfaceId: c.surfaceId,
+  }));
+}
+
+export const crewCommand = new Command("crew").description(
+  "Spawn and manage interactive crew sessions next to the project's captain",
+);
 
 crewCommand
   .command("spawn")
-  .description("Spawn a crew session as a tab in the project's captain workspace (use --direction to split into a pane instead)")
+  .description(
+    "Spawn an interactive crew session as a tab in the captain's workspace (use --direction to split into a pane instead)",
+  )
   .argument("<project>", "Project name (must be registered)")
-  .argument("<task>", "Task prompt for the crew session")
+  .argument("<task>", "Initial task prompt for the crew session")
+  .option("--name <name>", "Crew name (default: auto-generated crew-N)")
   .option("--direction <dir>", "Placement: tab (default) or split direction (right|left|up|down)", "tab")
   .option("--agent <name>", "Agent CLI to use (claude|codex|gemini|aider)", "claude")
-  .action(async (project: string, task: string, opts: { direction: PanePlacement; agent: string }) => {
+  .action(
+    async (
+      project: string,
+      task: string,
+      opts: { name?: string; direction: PanePlacement; agent: string },
+    ) => {
+      try {
+        const pane = await runCrewSpawn({
+          project,
+          task,
+          name: opts.name,
+          direction: opts.direction,
+          agent: opts.agent,
+        });
+        console.log(chalk.green(`✔ Crew '${pane.title}' spawned (${pane.surfaceId})`));
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    },
+  );
+
+crewCommand
+  .command("list")
+  .description("List live crew sessions for a project")
+  .argument("<project>", "Project name")
+  .action(async (project: string) => {
     try {
-      const pane = await runCrewSpawn({ project, task, direction: opts.direction, agent: opts.agent });
-      console.log(chalk.green(`✔ Crew spawned in ${pane.workspaceId} ${pane.surfaceId}`));
+      const crews = await runCrewList(project);
+      if (crews.length === 0) {
+        console.log(chalk.yellow(`No live crew sessions for ${project}.`));
+        return;
+      }
+      for (const c of crews) {
+        console.log(`  ${c.name}  (${c.surfaceId})`);
+      }
+    } catch (err) {
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+  });
+
+crewCommand
+  .command("send")
+  .description("Send a follow-up message to an existing crew session")
+  .argument("<project>", "Project name")
+  .argument("<name>", "Crew name (e.g. crew-1)")
+  .argument("<message>", "Message to send")
+  .action(async (project: string, name: string, message: string) => {
+    try {
+      await runCrewSend(project, name, message);
+      console.log(chalk.green(`✔ Sent to ${project}:${name}`));
+    } catch (err) {
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+  });
+
+crewCommand
+  .command("read")
+  .description("Read the current screen of a crew session")
+  .argument("<project>", "Project name")
+  .argument("<name>", "Crew name")
+  .action(async (project: string, name: string) => {
+    try {
+      const screen = await runCrewRead(project, name);
+      console.log(screen);
+    } catch (err) {
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+  });
+
+crewCommand
+  .command("close")
+  .description("Shutdown a crew session (closes its tab)")
+  .argument("<project>", "Project name")
+  .argument("<name>", "Crew name")
+  .action(async (project: string, name: string) => {
+    try {
+      await runCrewClose(project, name);
+      console.log(chalk.green(`✔ Closed ${project}:${name}`));
     } catch (err) {
       console.error(chalk.red((err as Error).message));
       process.exit(1);

--- a/src/drivers/claude.ts
+++ b/src/drivers/claude.ts
@@ -46,7 +46,9 @@ export function createClaudeDriver(): AgentDriver {
       const pluginDir = `${process.env.HOME}/.config/cockpit/plugin`;
       cmd += ` --plugin-dir ${pluginDir}`;
 
-      cmd += ` -p "${opts.prompt.replace(/"/g, '\\"')}"`;
+      if (!opts.interactive) {
+        cmd += ` -p "${opts.prompt.replace(/"/g, '\\"')}"`;
+      }
       return cmd;
     },
 

--- a/src/drivers/types.ts
+++ b/src/drivers/types.ts
@@ -24,6 +24,10 @@ export interface SpawnOptions {
   autoApprove?: boolean;
   jsonOutput?: boolean;
   promptFile?: string;
+  // Interactive crew sessions: drivers should NOT bake the prompt into the
+  // command (no `-p`). Caller will deliver the prompt via runtime.send after
+  // the CLI is ready, so the session stays alive between turns.
+  interactive?: boolean;
 }
 
 export interface AgentResult {

--- a/src/reactor/__tests__/auto-status.test.ts
+++ b/src/reactor/__tests__/auto-status.test.ts
@@ -50,6 +50,7 @@ function makeRuntime(screens: Record<string, string>): RuntimeDriver {
     closePane: vi.fn(),
     sendToPane: vi.fn(),
     readPaneScreen: vi.fn(),
+    listSurfaces: vi.fn(),
   };
 }
 

--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -223,4 +223,32 @@ describe("cmux driver", () => {
     const text = await driver.readPaneScreen({ workspaceId: "workspace:1", surfaceId: "surface:9" });
     expect(text).toBe("");
   });
+
+  it("listSurfaces parses cmux tree output and returns surfaces with titles", async () => {
+    execMock.mockImplementation((cmd: string) => {
+      if (cmd.includes("tree")) {
+        return [
+          'window window:1 [current] ◀ active',
+          '└── workspace workspace:10 "⚓ pact-network-captain"',
+          '    └── pane pane:29 [focused]',
+          '        ├── surface surface:29 [terminal] "✳ Run startup checklist" [selected]',
+          '        ├── surface surface:30 [terminal] "🔧 pact-network:crew-1"',
+          '        └── surface surface:31 [terminal] "🔧 pact-network:crew-2"',
+        ].join("\n");
+      }
+      return "";
+    });
+    const surfaces = await driver.listSurfaces("workspace:10");
+    expect(surfaces).toEqual([
+      { workspaceId: "workspace:10", surfaceId: "surface:29", title: "✳ Run startup checklist" },
+      { workspaceId: "workspace:10", surfaceId: "surface:30", title: "🔧 pact-network:crew-1" },
+      { workspaceId: "workspace:10", surfaceId: "surface:31", title: "🔧 pact-network:crew-2" },
+    ]);
+  });
+
+  it("listSurfaces returns empty array when cmux throws", async () => {
+    execMock.mockImplementation(() => { throw new Error("workspace not found"); });
+    const surfaces = await driver.listSurfaces("workspace:99");
+    expect(surfaces).toEqual([]);
+  });
 });

--- a/src/runtimes/__tests__/registry.test.ts
+++ b/src/runtimes/__tests__/registry.test.ts
@@ -18,6 +18,7 @@ function stubDriver(name: string): RuntimeDriver {
     closePane: vi.fn(async () => {}),
     sendToPane: vi.fn(async () => {}),
     readPaneScreen: vi.fn(async () => ""),
+    listSurfaces: vi.fn(async () => []),
   };
 }
 

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -129,5 +129,25 @@ export function createCmuxDriver(): RuntimeDriver {
         return "";
       }
     },
+
+    async listSurfaces(workspaceId: string): Promise<PaneRef[]> {
+      let output: string;
+      try {
+        output = cmux(`tree --workspace "${workspaceId}"`);
+      } catch {
+        return [];
+      }
+      const surfaces: PaneRef[] = [];
+      // tree output line example:
+      //     ├── surface surface:30 [terminal] "🔧 pact-network:crew-1" [selected]
+      const re = /surface\s+(surface:\d+)\s+\[\w+\]\s+"([^"]*)"/;
+      for (const line of output.split("\n")) {
+        const match = line.match(re);
+        if (match) {
+          surfaces.push({ workspaceId, surfaceId: match[1], title: match[2] });
+        }
+      }
+      return surfaces;
+    },
   };
 }

--- a/src/runtimes/types.ts
+++ b/src/runtimes/types.ts
@@ -7,6 +7,7 @@ export interface WorkspaceRef {
 export interface PaneRef {
   workspaceId: string; // parent workspace ref ("workspace:42")
   surfaceId: string;   // runtime-native surface ref (cmux: "surface:7")
+  title?: string;      // tab title — populated by listSurfaces, optional on spawn
 }
 
 export interface RuntimeSpawnOptions {
@@ -50,4 +51,7 @@ export interface RuntimeDriver {
   closePane(pane: PaneRef): Promise<void>;
   sendToPane(pane: PaneRef, message: string): Promise<void>; // sends text + Enter
   readPaneScreen(pane: PaneRef): Promise<string>;
+  // List all surfaces (tabs/panes) inside a workspace, with their titles.
+  // Used to find named crews by tab title (#56).
+  listSurfaces(workspaceId: string): Promise<PaneRef[]>;
 }


### PR DESCRIPTION
Closes #56

## Summary

Crew was `claude -p "<task>"` — print mode, one-shot, dies after the task. The captain couldn't send follow-ups, monitor, or interject; new work meant a new tab every turn → tab pollution.

This makes each crew an **interactive Claude sub-session** — the captain's runtime-agnostic equivalent of an Agent Team subagent. Each crew is named, addressable via tab title, stays idle between turns, and is driven by new CLI verbs.

## What changed

**Runtime / driver layer**
- `SpawnOptions.interactive` — Claude driver omits `-p` when set.
- `RuntimeDriver.listSurfaces(workspaceId)` — enumerate surfaces with titles. Cmux driver parses `cmux tree --workspace`.
- `PaneRef.title` — populated by `listSurfaces`.

**CLI (`cockpit crew ...`)**
- `spawn` — boots interactive Claude, sends the task after a 3s boot delay (matches captain launch path). Auto-names `crew-N` from the next free slot. `--name <n>` for explicit naming; collisions error out with a redirect to `send`.
- `send <project> <name> "<message>"` — deliver a follow-up turn.
- `read <project> <name>` — read crew's screen.
- `close <project> <name>` — shutdown a crew.
- `list <project>` — show live crews.

**Templates + SKILL**
- `captain.claude.md`, `captain.generic.md`, captain-ops SKILL rewritten — teach the new spawn-once / send-follow-ups / close-when-done pattern. Discourages spawning a new tab per turn.
- README updated with new verbs in the command table + crew architecture section.

## Verification

- `npm run lint` — clean
- `npm test` — 281 pass, 2 pre-existing failures (config.test.ts commandName default emoji mismatch — unrelated)
- `npm run build` — clean
- New tests: 8 fresh unit tests for spawn (auto-name, --name conflict, interactive flow, non-Claude print fallback), send/read/close/list, plus listSurfaces in the cmux driver.

## Known limitations (called out in docs)

- Non-Claude agents (codex / gemini / aider) still launch in print-mode; full interactive support per agent is a follow-up.
- Crew tabs die with the captain workspace on `cockpit shutdown` — same lifetime as Agent Team subagents (intentional).

## Release

Bumps `package.json` 0.3.0 → 0.3.1. CHANGELOG entry under `[0.3.1] - 2026-05-06`.