### PR TITLE
fix(crew): honor configured model routing (v0.3.2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (527 symbols, 1048 relationships, 36 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (526 symbols, 1048 relationships, 36 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to claude-cockpit are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-05-06
+
+### Fixed
+
+- **Crew now honors configured model routing.** `cockpit crew spawn` was not
+  passing `--model` to the agent CLI, so Claude crews silently fell back to
+  the user's global default (typically opus) instead of the configured
+  `defaults.roles.crew.model` (sonnet by default). Read the model from
+  config and pass it through `buildCommand`. Token spend for crew sessions
+  drops accordingly.
+- Model passthrough is **agent-aware**: only applied when the spawn agent
+  matches the role's configured agent (`defaults.roles.crew.agent`). Cross-
+  agent crews (e.g. `--agent codex` while config routes crew to claude) skip
+  the model arg, since model names are agent-specific (`sonnet` is a Claude
+  alias and would be invalid for codex / aider / gemini).
+
 ## [0.3.1] - 2026-05-06
 
 Crew sessions become **interactive sub-sessions** instead of one-shot print

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (527 symbols, 1048 relationships, 36 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (526 symbols, 1048 relationships, 36 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-cockpit",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Multi-project agent orchestration for Claude Code",
   "type": "module",
   "bin": {

--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -158,6 +158,58 @@ describe("cockpit crew spawn", () => {
     expect(result.title).toBe("🔧 brove:crew-1");
   });
 
+  it("passes the configured crew model when spawn agent matches role agent", async () => {
+    loadConfig.mockReturnValue({
+      ...baseConfig,
+      defaults: {
+        ...baseConfig.defaults,
+        roles: {
+          command: { agent: "claude", model: "opus" },
+          captain: { agent: "claude", model: "opus" },
+          crew: { agent: "claude", model: "sonnet" },
+          reactor: { agent: "claude", model: "sonnet" },
+          exploration: { agent: "claude", model: "haiku" },
+        },
+      },
+    });
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude --model sonnet ...");
+
+    const promise = runCrewSpawn({ project: "brove", task: "task" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ model: "sonnet" }));
+  });
+
+  it("does NOT pass crew model when spawn agent differs from configured role agent", async () => {
+    // role config says crew=claude/sonnet, but user spawns with --agent codex.
+    // Model names are agent-specific, so we must NOT pass "sonnet" to codex.
+    loadConfig.mockReturnValue({
+      ...baseConfig,
+      defaults: {
+        ...baseConfig.defaults,
+        roles: {
+          command: { agent: "claude", model: "opus" },
+          captain: { agent: "claude", model: "opus" },
+          crew: { agent: "claude", model: "sonnet" },
+          reactor: { agent: "claude", model: "sonnet" },
+          exploration: { agent: "claude", model: "haiku" },
+        },
+      },
+    });
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("codex exec 'task'");
+
+    await runCrewSpawn({ project: "brove", task: "task", agent: "codex" });
+
+    expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ model: undefined }));
+  });
+
   it("respects --direction override", async () => {
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -135,12 +135,20 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
   // don't yet honor `interactive` will keep their existing print-mode shape —
   // a known limitation tracked for future work.
   const interactive = agent.name === "claude";
+  // Honor configured model routing only when the spawn agent matches the
+  // configured role agent — model names are agent-specific (e.g. "sonnet" is
+  // a Claude alias; aider expects a fully-qualified name; codex/gemini have
+  // their own routing). Cross-agent crews fall back to the agent's own
+  // default to avoid passing an invalid model arg.
+  const crewRole = config.defaults.roles?.crew;
+  const crewModel = crewRole && crewRole.agent === agent.name ? crewRole.model : undefined;
   const cliCommand = agent.buildCommand({
     prompt: input.task,
     workdir: proj.path,
     role: "crew",
     promptFile,
     interactive,
+    model: crewModel,
   });
 
   const direction: PanePlacement = input.direction ?? "tab";


### PR DESCRIPTION
Closes #58

## Summary

Crew was silently using opus because `cockpit crew spawn` didn't pass `--model` to the agent CLI. The configured `defaults.roles.crew.model` (`sonnet` by default) was read but never reached `buildCommand`. Token spend was inflated.

## Fix

`src/commands/crew.ts`:
- Read `config.defaults.roles?.crew?.model`.
- Pass it through `agent.buildCommand({ ..., model })`.
- **Agent-aware:** only pass when the spawn agent matches `defaults.roles.crew.agent`. Cross-agent crews (`--agent codex` while config routes crew to claude) skip `--model` since model names are agent-specific (`sonnet` is a Claude alias, invalid for codex/aider/gemini).

## Verification

- `npm run lint` — clean
- `npm test` — 283 pass (2 new model tests). 2 pre-existing config failures unchanged.
- `npm run build` — clean

## Release

Bumps 0.3.1 → 0.3.2. CHANGELOG entry under `[0.3.2] - 2026-05-06`.