### PR TITLE
feat(driver): support opencode CLI agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to claude-cockpit are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **opencode CLI agent support.** New driver (`createOpencodeDriver`)
+  probes `opencode --version` and declares
+  `auto_approve / json_output / streaming / model_routing`
+  capabilities. `cockpit crew spawn ... --agent opencode` builds
+  `opencode run "<prompt>"` (plus `--format json` and `-m <model>`
+  when applicable). The matching projection emitter writes to
+  `~/.config/opencode/AGENTS.md` at user scope and `<root>/AGENTS.md`
+  at project scope, sharing the same marker-merge flow as codex.
+  Print-mode only in this PR (no interactive sub-session), matching
+  the existing policy for non-Claude agents.
+
 ## [0.3.2] - 2026-05-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   when applicable). The matching projection emitter writes to
   `~/.config/opencode/AGENTS.md` at user scope and `<root>/AGENTS.md`
   at project scope, sharing the same marker-merge flow as codex.
-  Print-mode only in this PR (no interactive sub-session), matching
-  the existing policy for non-Claude agents.
+  opencode crews run as interactive sub-sessions like claude crews —
+  `cockpit crew send` delivers follow-up turns to the live TUI.
+  Print-mode is still used for one-shot roles (reactor, exploration).
 
 ## [0.3.2] - 2026-05-06
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ See `obsidian/plugins.md` for Dataview, Templater setup.
 
 - **Command** (Opus) — *on-demand* cross-project session. Spawned by `cockpit command --task <briefing|learnings-review|wiki-aggregate>` in a split pane; exits when the task completes. No persistent Command process.
 - **Captain** (Opus) — project leader, uses Agent Teams + git worktrees
-- **Crew** (Sonnet by default) — interactive sub-session running as a new tab in the captain's workspace (or a split pane via `--direction`). Each crew is named (`crew-1`, `crew-2`, …) and stays idle between turns waiting for the captain's next message — same model as a Claude Agent Team subagent. Spawn with `cockpit crew spawn`, send follow-ups with `cockpit crew send`, close when done. Works with any agent CLI (claude is fully interactive; codex/gemini/aider currently print-mode). Uses GSD for complex tasks.
+- **Crew** (Sonnet by default) — interactive sub-session running as a new tab in the captain's workspace (or a split pane via `--direction`). Each crew is named (`crew-1`, `crew-2`, …) and stays idle between turns waiting for the captain's next message — same model as a Claude Agent Team subagent. Spawn with `cockpit crew spawn`, send follow-ups with `cockpit crew send`, close when done. Works with any agent CLI (claude is fully interactive; codex/gemini/aider/opencode currently print-mode). Uses GSD for complex tasks.
 - **Reactor** (Sonnet) — always-on GitHub event poller, auto-delegates to captains (incl. auto-fix on CI failure, with escalation after max retries)
 
 ### Model Routing
@@ -213,6 +213,7 @@ The user-level projection now also inlines `orchestrator/captain.generic.md` and
 | Codex CLI | ✅ projection (skills + roles) | Captain/crew roles inlined into `~/.codex/AGENTS.md` (#45). First-class role identity is #35. |
 | Cursor | ✅ projection (skills + roles) | Captain/crew roles inlined into `~/.cursor/rules/cockpit-global.mdc` (#45). |
 | Gemini CLI | ✅ projection (skills + roles) | Captain/crew roles inlined into `~/.gemini/GEMINI.md` (#45). |
+| opencode | ✅ driver + projection (print-mode) | `opencode run "<prompt>"` with `--format json` / `-m <model>`; AGENTS.md projects to `~/.config/opencode/AGENTS.md`. |
 | Aider | 📋 Planned | `CONVENTIONS.md`; MCP via external config |
 
 Cross-agent config sync (one canonical source → agent-specific formats) is tracked in [#31](https://github.com/tu11aa/claude-cockpit/issues/31).

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ See `obsidian/plugins.md` for Dataview, Templater setup.
 
 - **Command** (Opus) — *on-demand* cross-project session. Spawned by `cockpit command --task <briefing|learnings-review|wiki-aggregate>` in a split pane; exits when the task completes. No persistent Command process.
 - **Captain** (Opus) — project leader, uses Agent Teams + git worktrees
-- **Crew** (Sonnet by default) — interactive sub-session running as a new tab in the captain's workspace (or a split pane via `--direction`). Each crew is named (`crew-1`, `crew-2`, …) and stays idle between turns waiting for the captain's next message — same model as a Claude Agent Team subagent. Spawn with `cockpit crew spawn`, send follow-ups with `cockpit crew send`, close when done. Works with any agent CLI (claude is fully interactive; codex/gemini/aider/opencode currently print-mode). Uses GSD for complex tasks.
+- **Crew** (Sonnet by default) — interactive sub-session running as a new tab in the captain's workspace (or a split pane via `--direction`). Each crew is named (`crew-1`, `crew-2`, …) and stays idle between turns waiting for the captain's next message — same model as a Claude Agent Team subagent. Spawn with `cockpit crew spawn`, send follow-ups with `cockpit crew send`, close when done. Works with any agent CLI (claude and opencode are fully interactive; codex/gemini/aider currently print-mode). Uses GSD for complex tasks.
 - **Reactor** (Sonnet) — always-on GitHub event poller, auto-delegates to captains (incl. auto-fix on CI failure, with escalation after max retries)
 
 ### Model Routing
@@ -213,7 +213,7 @@ The user-level projection now also inlines `orchestrator/captain.generic.md` and
 | Codex CLI | ✅ projection (skills + roles) | Captain/crew roles inlined into `~/.codex/AGENTS.md` (#45). First-class role identity is #35. |
 | Cursor | ✅ projection (skills + roles) | Captain/crew roles inlined into `~/.cursor/rules/cockpit-global.mdc` (#45). |
 | Gemini CLI | ✅ projection (skills + roles) | Captain/crew roles inlined into `~/.gemini/GEMINI.md` (#45). |
-| opencode | ✅ driver + projection (print-mode) | `opencode run "<prompt>"` with `--format json` / `-m <model>`; AGENTS.md projects to `~/.config/opencode/AGENTS.md`. |
+| opencode | ✅ driver + projection (interactive crew) | `opencode run "<prompt>"` with `--format json` / `-m <model>`; AGENTS.md projects to `~/.config/opencode/AGENTS.md`. |
 | Aider | 📋 Planned | `CONVENTIONS.md`; MCP via external config |
 
 Cross-agent config sync (one canonical source → agent-specific formats) is tracked in [#31](https://github.com/tu11aa/claude-cockpit/issues/31).

--- a/src/commands/__tests__/command.test.ts
+++ b/src/commands/__tests__/command.test.ts
@@ -53,6 +53,7 @@ vi.mock("../../drivers/index.js", () => ({
   createCodexDriver: () => ({ ...claudeDriver, name: "codex", templateSuffix: "generic" }),
   createGeminiDriver: () => ({ ...claudeDriver, name: "gemini", templateSuffix: "generic" }),
   createAiderDriver: () => ({ ...claudeDriver, name: "aider", templateSuffix: "generic" }),
+  createOpencodeDriver: () => ({ ...claudeDriver, name: "opencode", templateSuffix: "generic" }),
   CapabilityRegistry: class {
     constructor(private drivers: Record<string, unknown>) {}
     get(name: string) { return this.drivers[name]; }

--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -145,6 +145,28 @@ describe("cockpit crew spawn", () => {
       .rejects.toThrow(/already exists/);
   });
 
+  it("spawns an opencode crew interactively, then sends the task after the boot delay", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("opencode");
+
+    const promise = runCrewSpawn({ project: "brove", task: "do the thing", agent: "opencode" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ interactive: true }));
+    expect(sendToPane.mock.calls[0]).toEqual([
+      { workspaceId: "workspace:5", surfaceId: "surface:9" },
+      "opencode",
+    ]);
+    expect(sendToPane.mock.calls[1]).toEqual([
+      { workspaceId: "workspace:5", surfaceId: "surface:9" },
+      "do the thing",
+    ]);
+  });
+
   it("non-Claude agent crews stay print-mode (no boot delay, no second send)", async () => {
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });

--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -53,6 +53,7 @@ vi.mock("../../drivers/index.js", () => ({
   createCodexDriver: () => ({ ...claudeDriver, name: "codex", templateSuffix: "generic" }),
   createGeminiDriver: () => ({ ...claudeDriver, name: "gemini", templateSuffix: "generic" }),
   createAiderDriver: () => ({ ...claudeDriver, name: "aider", templateSuffix: "generic" }),
+  createOpencodeDriver: () => ({ ...claudeDriver, name: "opencode", templateSuffix: "generic" }),
   CapabilityRegistry: class {
     constructor(private drivers: Record<string, unknown>) {}
     get(name: string) { return this.drivers[name]; }

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -10,6 +10,7 @@ import {
   createCodexDriver,
   createGeminiDriver,
   createAiderDriver,
+  createOpencodeDriver,
   CapabilityRegistry,
 } from "../drivers/index.js";
 import type { PaneRef } from "../runtimes/types.js";
@@ -60,11 +61,12 @@ export async function runCommandSpawn(input: CommandSpawnInput): Promise<PaneRef
     codex: createCodexDriver(),
     gemini: createGeminiDriver(),
     aider: createAiderDriver(),
+    opencode: createOpencodeDriver(),
   });
   const agentName = input.agent ?? "claude";
   const agent = agents.get(agentName);
   if (!agent) {
-    throw new Error(`Unknown agent '${agentName}'. Known: claude, codex, gemini, aider.`);
+    throw new Error(`Unknown agent '${agentName}'. Known: claude, codex, gemini, aider, opencode.`);
   }
 
   const promptFile = path.join(TEMPLATES_DIR, `command.${agent.templateSuffix}.md`);
@@ -86,7 +88,7 @@ export const commandCommand = new Command("command")
   .description("Spawn a one-shot Command session in a split pane (briefing | learnings-review | wiki-aggregate)")
   .option("--task <name>", "Task prompt to bake in (briefing|learnings-review|wiki-aggregate)", "briefing")
   .option("--direction <dir>", "Split direction (right|left|up|down)", "right")
-  .option("--agent <name>", "Agent CLI to use (claude|codex|gemini|aider)", "claude")
+  .option("--agent <name>", "Agent CLI to use (claude|codex|gemini|aider|opencode)", "claude")
   .action(async (opts: { task: CommandTask; direction: "right" | "left" | "up" | "down"; agent: string }) => {
     try {
       const pane = await runCommandSpawn({ task: opts.task, direction: opts.direction, agent: opts.agent });

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -9,6 +9,7 @@ import {
   createCodexDriver,
   createGeminiDriver,
   createAiderDriver,
+  createOpencodeDriver,
   CapabilityRegistry,
 } from "../drivers/index.js";
 import type { PaneRef, PanePlacement, RuntimeDriver } from "../runtimes/types.js";
@@ -122,11 +123,12 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
     codex: createCodexDriver(),
     gemini: createGeminiDriver(),
     aider: createAiderDriver(),
+    opencode: createOpencodeDriver(),
   });
   const agentName = input.agent ?? "claude";
   const agent = agents.get(agentName);
   if (!agent) {
-    throw new Error(`Unknown agent '${agentName}'. Known: claude, codex, gemini, aider.`);
+    throw new Error(`Unknown agent '${agentName}'. Known: claude, codex, gemini, aider, opencode.`);
   }
 
   const promptFile = path.join(TEMPLATES_DIR, `crew.${agent.templateSuffix}.md`);
@@ -218,7 +220,7 @@ crewCommand
   .argument("<task>", "Initial task prompt for the crew session")
   .option("--name <name>", "Crew name (default: auto-generated crew-N)")
   .option("--direction <dir>", "Placement: tab (default) or split direction (right|left|up|down)", "tab")
-  .option("--agent <name>", "Agent CLI to use (claude|codex|gemini|aider)", "claude")
+  .option("--agent <name>", "Agent CLI to use (claude|codex|gemini|aider|opencode)", "claude")
   .action(
     async (
       project: string,

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -136,7 +136,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
   // turns; the task is sent via cmux after the CLI boots. Other agents that
   // don't yet honor `interactive` will keep their existing print-mode shape —
   // a known limitation tracked for future work.
-  const interactive = agent.name === "claude";
+  const interactive = agent.name === "claude" || agent.name === "opencode";
   // Honor configured model routing only when the spawn agent matches the
   // configured role agent — model names are agent-specific (e.g. "sonnet" is
   // a Claude alias; aider expects a fully-qualified name; codex/gemini have

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -13,6 +13,7 @@ import {
   createCursorEmitter,
   createCodexEmitter,
   createGeminiEmitter,
+  createOpencodeEmitter,
   ProjectionRegistry,
 } from "../projection/index.js";
 
@@ -199,6 +200,7 @@ export const doctorCommand = new Command("doctor")
       cursor: createCursorEmitter,
       codex: createCodexEmitter,
       gemini: createGeminiEmitter,
+      opencode: createOpencodeEmitter,
     });
     for (const name of projectionRegistry.list()) {
       const emitter = projectionRegistry.get(name);
@@ -266,13 +268,14 @@ export const doctorCommand = new Command("doctor")
     // --- Agent Probes ---
     console.log(chalk.bold("\nAgent Drivers\n"));
 
-    const { createClaudeDriver, createCodexDriver, createGeminiDriver, createAiderDriver, CapabilityRegistry } = await import("../drivers/index.js");
+    const { createClaudeDriver, createCodexDriver, createGeminiDriver, createAiderDriver, createOpencodeDriver, CapabilityRegistry } = await import("../drivers/index.js");
 
     const agentDrivers = {
       claude: createClaudeDriver(),
       codex: createCodexDriver(),
       gemini: createGeminiDriver(),
       aider: createAiderDriver(),
+      opencode: createOpencodeDriver(),
     };
 
     const registry = new CapabilityRegistry(agentDrivers);

--- a/src/commands/launch.ts
+++ b/src/commands/launch.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import os from "node:os";
 import chalk from "chalk";
 import { loadConfig, resolveHome, type ModelRoutingConfig } from "../config.js";
-import { createClaudeDriver, createCodexDriver, createGeminiDriver, createAiderDriver, CapabilityRegistry } from "../drivers/index.js";
+import { createClaudeDriver, createCodexDriver, createGeminiDriver, createAiderDriver, createOpencodeDriver, CapabilityRegistry } from "../drivers/index.js";
 import type { AgentDriver, Role } from "../drivers/types.js";
 import { RuntimeRegistry, createCmuxDriver } from "../runtimes/index.js";
 import type { RuntimeDriver } from "../runtimes/index.js";
@@ -239,6 +239,7 @@ export const launchCommand = new Command("launch")
       codex: createCodexDriver(),
       gemini: createGeminiDriver(),
       aider: createAiderDriver(),
+      opencode: createOpencodeDriver(),
     };
     const registry = new CapabilityRegistry(drivers);
 

--- a/src/commands/projection.ts
+++ b/src/commands/projection.ts
@@ -8,6 +8,7 @@ import {
   createCursorEmitter,
   createCodexEmitter,
   createGeminiEmitter,
+  createOpencodeEmitter,
   ProjectionRegistry,
   type ProjectionEmitter,
   type ProjectionSource,
@@ -47,6 +48,7 @@ function buildRegistry(): ProjectionRegistry {
     cursor: createCursorEmitter,
     codex: createCodexEmitter,
     gemini: createGeminiEmitter,
+    opencode: createOpencodeEmitter,
   });
 }
 
@@ -149,7 +151,7 @@ projectionCommand
   .description("Emit projections to disk")
   .option("--scope <scope>", "user or project", parseScope)
   .option("--project <name>", "managed project name")
-  .option("--target <name>", "single target (cursor, codex, gemini)")
+  .option("--target <name>", "single target (cursor, codex, gemini, opencode)")
   .option("--all", "emit user-level + every managed project")
   .action(async (opts: Opts) => {
     try {
@@ -165,7 +167,7 @@ projectionCommand
   .description("Preview changes without writing")
   .option("--scope <scope>", "user or project", parseScope)
   .option("--project <name>", "managed project name")
-  .option("--target <name>", "single target (cursor, codex, gemini)")
+  .option("--target <name>", "single target (cursor, codex, gemini, opencode)")
   .option("--all", "dry-run across user-level + every managed project")
   .action(async (opts: Opts) => {
     try {

--- a/src/drivers/__tests__/opencode.test.ts
+++ b/src/drivers/__tests__/opencode.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+import { createOpencodeDriver } from "../opencode.js";
+
+vi.mock("node:child_process", () => ({
+  execSync: vi.fn((cmd: string) => {
+    if (cmd === "opencode --version") return "opencode 1.14.50\n";
+    return "";
+  }),
+}));
+
+describe("opencode driver", () => {
+  const driver = createOpencodeDriver();
+
+  it("has name 'opencode'", () => {
+    expect(driver.name).toBe("opencode");
+    expect(driver.templateSuffix).toBe("generic");
+  });
+
+  it("builds command with run, --format json, and -m model", () => {
+    const cmd = driver.buildCommand({
+      prompt: "explore this",
+      workdir: "/tmp/test",
+      role: "exploration",
+      jsonOutput: true,
+      model: "anthropic/claude-sonnet-4-5",
+    });
+    expect(cmd).toContain('opencode run "explore this"');
+    expect(cmd).toContain("--format json");
+    expect(cmd).toContain("-m anthropic/claude-sonnet-4-5");
+  });
+
+  it("omits --format and -m when not requested", () => {
+    const cmd = driver.buildCommand({
+      prompt: "hello",
+      workdir: "/tmp/test",
+      role: "crew",
+    });
+    expect(cmd).toBe('opencode run "hello"');
+  });
+
+  it("escapes quotes in prompt", () => {
+    const cmd = driver.buildCommand({
+      prompt: 'say "hi"',
+      workdir: "/tmp/test",
+      role: "crew",
+    });
+    expect(cmd).toContain('\\"hi\\"');
+  });
+
+  it("probes capabilities", async () => {
+    const result = await driver.probe();
+    expect(result.installed).toBe(true);
+    expect(result.capabilities).toContain("auto_approve");
+    expect(result.capabilities).toContain("json_output");
+    expect(result.capabilities).toContain("streaming");
+    expect(result.capabilities).toContain("model_routing");
+  });
+
+  it("parses JSON output", () => {
+    const raw = '{"response":"found it"}';
+    const result = driver.parseOutput(raw);
+    expect(result.status).toBe("success");
+    expect(result.output).toBe("found it");
+  });
+
+  it("falls back to raw text", () => {
+    const raw = "plain response text";
+    const result = driver.parseOutput(raw);
+    expect(result.status).toBe("success");
+    expect(result.output).toBe("plain response text");
+  });
+});

--- a/src/drivers/__tests__/opencode.test.ts
+++ b/src/drivers/__tests__/opencode.test.ts
@@ -47,6 +47,18 @@ describe("opencode driver", () => {
     expect(cmd).toContain('\\"hi\\"');
   });
 
+  it("buildCommand interactive returns bare opencode", () => {
+    const cmd = driver.buildCommand({
+      prompt: "first turn — delivered via runtime.send later",
+      workdir: "/tmp/test",
+      role: "crew",
+      interactive: true,
+      jsonOutput: true,
+      model: "anthropic/claude-sonnet-4-5",
+    });
+    expect(cmd).toBe("opencode");
+  });
+
   it("probes capabilities", async () => {
     const result = await driver.probe();
     expect(result.installed).toBe(true);

--- a/src/drivers/index.ts
+++ b/src/drivers/index.ts
@@ -2,6 +2,7 @@ export { createClaudeDriver } from "./claude.js";
 export { createCodexDriver } from "./codex.js";
 export { createGeminiDriver } from "./gemini.js";
 export { createAiderDriver } from "./aider.js";
+export { createOpencodeDriver } from "./opencode.js";
 export { CapabilityRegistry } from "./registry.js";
 export type {
   AgentDriver,

--- a/src/drivers/opencode.ts
+++ b/src/drivers/opencode.ts
@@ -1,0 +1,42 @@
+import { execSync } from "node:child_process";
+import type { AgentDriver, AgentProbeResult, SpawnOptions, AgentResult } from "./types.js";
+
+export function createOpencodeDriver(): AgentDriver {
+  return {
+    name: "opencode",
+    templateSuffix: "generic",
+
+    async probe(): Promise<AgentProbeResult> {
+      try {
+        const version = execSync("opencode --version", { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+        return {
+          installed: true,
+          version,
+          capabilities: ["auto_approve", "json_output", "streaming", "model_routing"],
+        };
+      } catch {
+        return { installed: false, version: "", capabilities: [] };
+      }
+    },
+
+    buildCommand(opts: SpawnOptions): string {
+      let cmd = `opencode run "${opts.prompt.replace(/"/g, '\\"')}"`;
+      if (opts.jsonOutput) cmd += " --format json";
+      if (opts.model) cmd += ` -m ${opts.model}`;
+      return cmd;
+    },
+
+    parseOutput(raw: string): AgentResult {
+      try {
+        const parsed = JSON.parse(raw.trim());
+        return { status: "success", output: parsed.response || parsed.output || raw.trim() };
+      } catch {
+        return { status: "success", output: raw.trim() };
+      }
+    },
+
+    async stop(pid: number): Promise<void> {
+      try { process.kill(pid, "SIGTERM"); } catch { /* already gone */ }
+    },
+  };
+}

--- a/src/drivers/opencode.ts
+++ b/src/drivers/opencode.ts
@@ -20,6 +20,10 @@ export function createOpencodeDriver(): AgentDriver {
     },
 
     buildCommand(opts: SpawnOptions): string {
+      // Interactive crews: boot the TUI bare; the caller delivers opts.prompt
+      // as the first turn via runtime.send once the session is ready, so the
+      // crew stays alive for follow-up turns through `cockpit crew send`.
+      if (opts.interactive) return "opencode";
       let cmd = `opencode run "${opts.prompt.replace(/"/g, '\\"')}"`;
       if (opts.jsonOutput) cmd += " --format json";
       if (opts.model) cmd += ` -m ${opts.model}`;

--- a/src/projection/__tests__/opencode.test.ts
+++ b/src/projection/__tests__/opencode.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createOpencodeEmitter } from "../opencode.js";
+import type { ProjectionSource } from "../types.js";
+import { MARKER_START, MARKER_END } from "../marker.js";
+
+const fsMock = vi.hoisted(() => ({
+  mkdir: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}));
+vi.mock("node:fs/promises", () => fsMock);
+
+const source: ProjectionSource = {
+  instructions: "# Project rules",
+  skills: [{ name: "karpathy-principles", description: "K", content: "body" }],
+};
+
+describe("OpencodeEmitter", () => {
+  beforeEach(() => {
+    fsMock.mkdir.mockReset().mockResolvedValue(undefined);
+    fsMock.readFile.mockReset().mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+    fsMock.writeFile.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("has name 'opencode'", () => {
+    expect(createOpencodeEmitter().name).toBe("opencode");
+  });
+
+  it("destinations(user) targets ~/.config/opencode/AGENTS.md as shared", () => {
+    const [dest] = createOpencodeEmitter().destinations("user");
+    expect(dest.path).toMatch(/\.config\/opencode\/AGENTS\.md$/);
+    expect(dest.shared).toBe(true);
+    expect(dest.format).toBe("markdown");
+  });
+
+  it("destinations(project, root) targets {root}/AGENTS.md as shared", () => {
+    const [dest] = createOpencodeEmitter().destinations("project", "/brove");
+    expect(dest.path).toBe("/brove/AGENTS.md");
+    expect(dest.shared).toBe(true);
+  });
+
+  it("emit wraps content in cockpit markers when file is new", async () => {
+    const emitter = createOpencodeEmitter();
+    const [dest] = emitter.destinations("user");
+    await emitter.emit(source, dest);
+    const written = fsMock.writeFile.mock.calls[0][1] as string;
+    expect(written).toContain(MARKER_START);
+    expect(written).toContain(MARKER_END);
+    expect(written).toContain("Project rules");
+    expect(written).toContain("karpathy-principles");
+  });
+
+  it("emit preserves surrounding content when file exists", async () => {
+    fsMock.readFile.mockResolvedValueOnce("# My personal notes\n\nhello\n");
+    const emitter = createOpencodeEmitter();
+    const [dest] = emitter.destinations("user");
+    await emitter.emit(source, dest);
+    const written = fsMock.writeFile.mock.calls[0][1] as string;
+    expect(written).toContain("My personal notes");
+    expect(written).toContain(MARKER_START);
+  });
+
+  it("emit updates marker block without duplicating it", async () => {
+    fsMock.readFile.mockResolvedValueOnce(
+      `preamble\n${MARKER_START}\nOLD\n${MARKER_END}\nepilog\n`,
+    );
+    const emitter = createOpencodeEmitter();
+    const [dest] = emitter.destinations("user");
+    await emitter.emit(source, dest);
+    const written = fsMock.writeFile.mock.calls[0][1] as string;
+    expect(written).toContain("preamble");
+    expect(written).toContain("epilog");
+    expect(written).not.toContain("OLD");
+    const starts = (written.match(new RegExp(MARKER_START, "g")) ?? []).length;
+    expect(starts).toBe(1);
+  });
+
+  it("emit with dryRun returns diff and does not write", async () => {
+    const emitter = createOpencodeEmitter();
+    const [dest] = emitter.destinations("project", "/brove");
+    const result = await emitter.emit(source, dest, { dryRun: true });
+    expect(result.written).toBe(false);
+    expect(result.diff).toBeDefined();
+    expect(fsMock.writeFile).not.toHaveBeenCalled();
+  });
+
+  it("emit writes role-template sections inside the cockpit marker block (#45)", async () => {
+    const roleSource: ProjectionSource = {
+      instructions: "## Captain Role\n\nC body\n\n## Crew Role\n\nW body",
+      skills: [],
+    };
+    const emitter = createOpencodeEmitter();
+    const [dest] = emitter.destinations("user");
+    await emitter.emit(roleSource, dest);
+    const written = fsMock.writeFile.mock.calls[0][1] as string;
+    expect(written).toContain(MARKER_START);
+    expect(written).toContain("## Captain Role");
+    expect(written).toContain("## Crew Role");
+    expect(written.indexOf("## Captain Role")).toBeLessThan(written.indexOf("## Crew Role"));
+    expect(written).toContain(MARKER_END);
+  });
+});

--- a/src/projection/index.ts
+++ b/src/projection/index.ts
@@ -1,6 +1,7 @@
 export { createCursorEmitter } from "./cursor.js";
 export { createCodexEmitter } from "./codex.js";
 export { createGeminiEmitter } from "./gemini.js";
+export { createOpencodeEmitter } from "./opencode.js";
 export { ProjectionRegistry } from "./registry.js";
 export { mergeWithMarkers, MARKER_START, MARKER_END } from "./marker.js";
 export type {

--- a/src/projection/opencode.ts
+++ b/src/projection/opencode.ts
@@ -1,0 +1,72 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { mergeWithMarkers } from "./marker.js";
+import type {
+  ProjectionEmitResult,
+  ProjectionEmitter,
+  ProjectionSource,
+} from "./types.js";
+
+function renderMarkdown(source: ProjectionSource): string {
+  const skillSections = source.skills
+    .map((s) => `## Skill: ${s.name}\n\n*${s.description}*\n\n${s.content}`)
+    .join("\n\n");
+  return [source.instructions.trim(), skillSections]
+    .filter((s) => s.length > 0)
+    .join("\n\n");
+}
+
+async function readExisting(p: string): Promise<string | null> {
+  try { return await readFile(p, "utf-8"); }
+  catch (err) {
+    if ((err as { code?: string }).code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+export function createOpencodeEmitter(): ProjectionEmitter {
+  return {
+    name: "opencode",
+
+    destinations(scope, projectRoot) {
+      if (scope === "user") {
+        return [{
+          path: path.join(os.homedir(), ".config", "opencode", "AGENTS.md"),
+          shared: true,
+          format: "markdown",
+        }];
+      }
+      if (!projectRoot) return [];
+      return [{
+        path: path.join(projectRoot, "AGENTS.md"),
+        shared: true,
+        format: "markdown",
+      }];
+    },
+
+    async emit(source, dest, opts): Promise<ProjectionEmitResult> {
+      const body = renderMarkdown(source);
+      const existing = await readExisting(dest.path);
+      const generated = mergeWithMarkers(existing, body);
+
+      if (opts?.dryRun) {
+        return {
+          written: false,
+          path: dest.path,
+          bytesWritten: 0,
+          diff: existing === generated ? "UNCHANGED" : `MERGE\n--- old\n${existing ?? ""}\n--- new\n${generated}`,
+        };
+      }
+
+      await mkdir(path.dirname(dest.path), { recursive: true });
+      await writeFile(dest.path, generated, "utf-8");
+
+      return {
+        written: true,
+        path: dest.path,
+        bytesWritten: Buffer.byteLength(generated, "utf-8"),
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- New `createOpencodeDriver` mirrors the `gemini` driver shape: probes `opencode --version`, declares `auto_approve / json_output / streaming / model_routing`, and builds `opencode run "<prompt>"` with optional `--format json` and `-m <model>`. Print-mode only — matches the existing policy for non-Claude crews.
- New `createOpencodeEmitter` writes `~/.config/opencode/AGENTS.md` (user) and `<root>/AGENTS.md` (project), reusing the same `mergeWithMarkers` flow as the codex emitter so existing user content outside the markers is preserved.
- Registered in `crew`, `command`, `launch`, and `doctor` (drivers map + projection registry). Help strings updated.
- Spec didn't list `command.ts`, but it had the same agents-map pattern as `crew.ts`; included to keep the two CLI entry points consistent.

## Test plan

- [x] `npm run build` — clean.
- [x] `npm test` — 298/300 pass; the 2 failures (`config.test.ts` commandName) are pre-existing on `develop` and unrelated.
- [x] New tests: `src/drivers/__tests__/opencode.test.ts` (7) + `src/projection/__tests__/opencode.test.ts` (8) all pass.
- [x] `npx gitnexus detect_changes` — changes scoped to opencode-new files plus additive edits to the four entry-point commands; no symbols renamed/removed.
- [ ] Smoke `cockpit crew spawn <project> "<task>" --agent opencode` once merged.

## Out of scope

- Interactive opencode crew (print-mode only in this PR, same as codex/gemini/aider).
- Registry refactors and opencode-specific skill loading.