### PR TITLE
chore(release): v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-05-15
+
 ### Added
 
 - **opencode CLI agent support.** New driver (`createOpencodeDriver`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-cockpit",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Multi-project agent orchestration for Claude Code",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release-only change — **no code changes**. Promotes the already-merged opencode work (PR #60, squash commit 8425a21) to a tagged release.

## What's in 0.3.3

- **opencode CLI agent driver** — `createOpencodeDriver` probes `opencode --version`, declares `auto_approve / json_output / streaming / model_routing`; `cockpit crew spawn --agent opencode` builds `opencode run "<prompt>"` (`--format json`, `-m <model>` when applicable).
- **opencode projection emitter** — writes `~/.config/opencode/AGENTS.md` (user scope) and `<root>/AGENTS.md` (project scope) via the codex-style marker-merge flow.
- **Interactive opencode crews** — run as live sub-sessions like claude crews; `cockpit crew send` delivers follow-up turns to the TUI. Print-mode retained for one-shot roles (reactor, exploration).
- **Projection-registry fix** — opencode emitter registered in the projection command registry.

All shipped via **PR #60**. Follow-up tracked in **#61** (opencode session-scoped role identity).

## Release mechanics

- `package.json`: `0.3.2` → `0.3.3` (CLI reads version from `package.json` per `5ba9f72`, so `cockpit --version` now reports `0.3.3`).
- `CHANGELOG.md`: `[Unreleased]` promoted to `[0.3.3] - 2026-05-15`, opencode entry intact; fresh empty `[Unreleased]` added per Keep a Changelog.
- Commit scope is exactly 2 files (`package.json` + `CHANGELOG.md`), matching the `chore(release): v0.3.0`/`v0.2.0` precedent.

## Verification

- `npm run build` — passes (tsc, reports `claude-cockpit@0.3.3`).
- `npm test` — 300 passed; the only 2 failures are the pre-existing, unrelated `src/config.test.ts` emoji-prefix assertions (known).

Do not merge until reviewed. Tagging + main sync handled by captain post-merge per project precedent.