### PR TITLE
fix(projection): read project canonical source outside cwd sandbox

### DIFF
--- a/src/commands/projection.ts
+++ b/src/commands/projection.ts
@@ -122,7 +122,9 @@ async function runEmit(opts: Opts & { dryRun?: boolean }) {
         console.error(chalk.yellow(`⚠ unknown project: ${projectName}`));
         continue;
       }
-      const source = await readProjectLevelSource(workspace, proj.path);
+      const source = await readProjectLevelSource(
+        createObsidianDriver({ root: proj.path }),
+      );
       if (!source) {
         console.log(chalk.gray(`- ${projectName}: no AGENTS.md, skipping`));
         continue;

--- a/src/lib/__tests__/canonical-source.test.ts
+++ b/src/lib/__tests__/canonical-source.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
+import os from "node:os";
+import fsp from "node:fs/promises";
+import path from "node:path";
 import { readUserLevelSource, readProjectLevelSource } from "../canonical-source.js";
+import { createObsidianDriver } from "../../workspaces/index.js";
 import type { WorkspaceDriver } from "../../workspaces/types.js";
 
 function memDriver(files: Record<string, string>): WorkspaceDriver {
@@ -70,27 +74,52 @@ describe("canonical-source", () => {
 
   it("readProjectLevelSource returns null when AGENTS.md is absent", async () => {
     const driver = memDriver({});
-    const src = await readProjectLevelSource(driver, "/brove");
+    const src = await readProjectLevelSource(driver);
     expect(src).toBeNull();
   });
 
   it("readProjectLevelSource reads AGENTS.md when present", async () => {
     const driver = memDriver({
-      "/brove/AGENTS.md": "# Brove rules\nuse design tokens",
+      "AGENTS.md": "# Brove rules\nuse design tokens",
     });
-    const src = await readProjectLevelSource(driver, "/brove");
+    const src = await readProjectLevelSource(driver);
     expect(src).not.toBeNull();
     expect(src!.instructions).toContain("Brove rules");
   });
 
   it("readProjectLevelSource inlines project-local plugin/skills if present", async () => {
     const driver = memDriver({
-      "/brove/AGENTS.md": "# Brove",
-      "/brove/plugin/skills/brove-style/SKILL.md":
+      "AGENTS.md": "# Brove",
+      "plugin/skills/brove-style/SKILL.md":
         "---\nname: brove-style\ndescription: BS\n---\n\nBS body",
     });
-    const src = await readProjectLevelSource(driver, "/brove");
+    const src = await readProjectLevelSource(driver);
     expect(src!.skills.map((s) => s.name)).toEqual(["brove-style"]);
+  });
+
+  // Regression: project-scope projection silently skipped every managed project
+  // whose path was not under the cockpit repo, because the source-reading driver
+  // was rooted at process.cwd() and the obsidian sandbox guard rejected the
+  // absolute out-of-cwd project path. readProjectLevelSource must read a project
+  // whose directory lives OUTSIDE process.cwd().
+  it("readProjectLevelSource reads a project rooted outside process.cwd()", async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), "cockpit-proj-"));
+    try {
+      await fsp.writeFile(path.join(tmp, "AGENTS.md"), "# OnePlan rules\nuse design tokens");
+      await fsp.mkdir(path.join(tmp, "plugin/skills/op-style"), { recursive: true });
+      await fsp.writeFile(
+        path.join(tmp, "plugin/skills/op-style/SKILL.md"),
+        "---\nname: op-style\ndescription: OP\n---\n\nOP body",
+      );
+      expect(tmp.startsWith(process.cwd())).toBe(false);
+      const driver = createObsidianDriver({ root: tmp });
+      const src = await readProjectLevelSource(driver);
+      expect(src).not.toBeNull();
+      expect(src!.instructions).toContain("OnePlan rules");
+      expect(src!.skills.map((s) => s.name)).toEqual(["op-style"]);
+    } finally {
+      await fsp.rm(tmp, { recursive: true, force: true });
+    }
   });
 
   it("skips SKILL.md files with missing frontmatter", async () => {

--- a/src/lib/canonical-source.ts
+++ b/src/lib/canonical-source.ts
@@ -76,13 +76,15 @@ export async function readUserLevelSource(
   return { instructions, skills };
 }
 
+// `driver` must be rooted at the project directory itself (createObsidianDriver
+// with root: proj.path). Reading via a driver rooted at process.cwd() — as the
+// projection command previously did — made the sandbox guard reject every
+// managed project living outside the cockpit repo, silently skipping them.
 export async function readProjectLevelSource(
   driver: WorkspaceDriver,
-  projectRoot: string,
 ): Promise<ProjectionSource | null> {
-  const agentsPath = `${projectRoot}/AGENTS.md`;
-  if (!(await driver.exists(agentsPath))) return null;
-  const instructions = await driver.read(agentsPath);
-  const skills = await readSkills(driver, `${projectRoot}/plugin/skills`);
+  if (!(await driver.exists("AGENTS.md"))) return null;
+  const instructions = await driver.read("AGENTS.md");
+  const skills = await readSkills(driver, "plugin/skills");
   return { instructions, skills };
 }


### PR DESCRIPTION
## Bug

Project-scope projection (`cockpit projection emit/diff --scope project`) silently skipped **every managed project whose path is not under the cockpit repo**, printing `<project>: no AGENTS.md, skipping` even when `AGENTS.md` existed.

### Root cause (the cwd-root bug)

- `src/commands/projection.ts` created the source-reading driver as `createObsidianDriver({ root: process.cwd() })`.
- For project scope it called `readProjectLevelSource(workspace, proj.path)`, which built an **absolute** path (`${proj.path}/AGENTS.md`) and passed it to the cwd-rooted driver.
- The obsidian driver's `resolveInRoot()` sandbox guard (correctly) throws `Path escapes workspace root` for any absolute path outside `root` (= cwd).
- `exists()` catches the throw and returns `false` → `readProjectLevelSource` returns `null` → the command prints `no AGENTS.md, skipping`.

Proof: from the cockpit repo `projection diff --scope project --project oneplan` printed `oneplan: no AGENTS.md, skipping`; the same command run *from inside* the OnePlanApp dir worked. The only difference was `process.cwd()`.

## Fix

Root a **per-project driver at `proj.path`** and read **relative** paths (`AGENTS.md`, `plugin/skills`). The driver stays sandboxed — to the project itself, not cwd — so the escape guard never bites and arbitrary managed-project paths are read correctly.

- `WorkspaceDriver` interface and the obsidian sandbox guard are **untouched** (the guard is correct and still protects vault writes).
- `readUserLevelSource` behavior is **unchanged**.
- The now-unused `projectRoot` param is removed from `readProjectLevelSource`; the sole production caller (`projection.ts`) is updated. `readSkills` is reused as-is — no duplication.

Chosen over the raw-`fs` alternative because it is the smaller surgical diff, reuses existing code, and matches `canonical-source.ts`'s existing driver-based style (Karpathy: surgical, no speculative refactor).

## Regression test

`src/lib/__tests__/canonical-source.test.ts` adds a test that reads a project rooted in a **tmpdir outside `process.cwd()`**. It **fails on the pre-fix code** (`expected null not to be null`) and **passes after**. The 3 existing `readProjectLevelSource` tests are adapted to the new signature.

## Verification

- `npm run build` — clean (tsc).
- `npm test` — 301 passed; the only 2 failures are the pre-existing, unrelated `config.test.ts` failures.
- Functional: from the cockpit repo root, `node dist/index.js projection diff --scope project --project oneplan` now resolves the OnePlanApp path and lists targets instead of `no AGENTS.md, skipping`:
  ```
  [cursor] /Users/q3labsadmin/me/LumiLabs/OnePlanApp/.cursor/rules/cockpit.mdc
  [codex]  /Users/q3labsadmin/me/LumiLabs/OnePlanApp/AGENTS.md
  [gemini] /Users/q3labsadmin/me/LumiLabs/OnePlanApp/GEMINI.md
  ```
- `gitnexus detect_changes` — scope is `canonical-source.ts` + `projection.ts` + the test file (the AGENTS.md/CLAUDE.md entries are pre-existing uncommitted changes, not part of this PR).

This unblocks project-scope projection for **all** managed projects (surfaced via `oneplan`).

## Out of scope (untouched)

User-scope projection, the obsidian sandbox guard, emitter logic, the opencode work, and version bump.