### PR TITLE
feat(crew): crew completion reliability (#64)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,17 @@ When working on cockpit:
 
 Full direction statement: [`docs/specs/2026-04-24-multi-agent-direction.md`](docs/specs/2026-04-24-multi-agent-direction.md).
 
+### Crew completion signals (#64)
+
+Cockpit-spawned Claude crews report turn-done/blocked to the reactor via a
+plugin hook (`plugin/hooks/hooks.json` → `cockpit crew-signal`), which writes a
+sentinel under `~/.config/cockpit/state/<project>/<crew>.<state>.json`. The
+reactor (`runAutoStatus`) reads these every cycle, so completion is visible even
+if the crew never self-reports or the captain is idle/compacted. The hook is a
+strict no-op unless `COCKPIT_CREW` is set, so it never affects normal Claude
+sessions. Non-Claude detection adapters (Codex/Gemini/Aider) are tracked in #68;
+the sentinel + reactor layers are already agent-agnostic.
+
 ## Coding Discipline: Karpathy Principles
 
 Every coding task in this repo follows [`plugin/skills/karpathy-principles/SKILL.md`](plugin/skills/karpathy-principles/SKILL.md):

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "description": "Cockpit crew-completion signals: report crew done/blocked to the reactor (#64). No-op unless COCKPIT_CREW is set, so normal Claude sessions are unaffected.",
+  "hooks": {
+    "Stop": [
+      { "hooks": [{ "type": "command", "command": "cockpit crew-signal" }] }
+    ],
+    "SubagentStop": [
+      { "hooks": [{ "type": "command", "command": "cockpit crew-signal" }] }
+    ],
+    "Notification": [
+      { "hooks": [{ "type": "command", "command": "cockpit crew-signal" }] }
+    ]
+  }
+}

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,12 +1,6 @@
 {
-  "description": "Cockpit crew-completion signals: report crew done/blocked to the reactor (#64). No-op unless COCKPIT_CREW is set, so normal Claude sessions are unaffected.",
+  "description": "Cockpit crew-completion signals: report crew done/blocked to the reactor (#64). Idle/permission Notification only (debounced; fires once when the crew is genuinely idle/finished). No-op unless COCKPIT_CREW is set, so normal Claude sessions are unaffected.",
   "hooks": {
-    "Stop": [
-      { "hooks": [{ "type": "command", "command": "cockpit crew-signal" }] }
-    ],
-    "SubagentStop": [
-      { "hooks": [{ "type": "command", "command": "cockpit crew-signal" }] }
-    ],
     "Notification": [
       { "hooks": [{ "type": "command", "command": "cockpit crew-signal" }] }
     ]

--- a/src/__tests__/plugin-hooks.test.ts
+++ b/src/__tests__/plugin-hooks.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+describe("plugin hooks.json", () => {
+  it("registers cockpit crew-signal for Stop, SubagentStop, Notification", () => {
+    const p = path.join(process.cwd(), "plugin", "hooks", "hooks.json");
+    const json = JSON.parse(fs.readFileSync(p, "utf-8"));
+    for (const ev of ["Stop", "SubagentStop", "Notification"]) {
+      const entries = json.hooks[ev];
+      expect(Array.isArray(entries)).toBe(true);
+      const cmds = entries.flatMap(
+        (e: { hooks: { type: string; command: string }[] }) => e.hooks,
+      );
+      expect(
+        cmds.some(
+          (h: { type: string; command: string }) =>
+            h.type === "command" && h.command === "cockpit crew-signal",
+        ),
+      ).toBe(true);
+    }
+  });
+});

--- a/src/__tests__/plugin-hooks.test.ts
+++ b/src/__tests__/plugin-hooks.test.ts
@@ -3,21 +3,23 @@ import fs from "node:fs";
 import path from "node:path";
 
 describe("plugin hooks.json", () => {
-  it("registers cockpit crew-signal for Stop, SubagentStop, Notification", () => {
+  it("registers cockpit crew-signal ONLY for Notification (not Stop/SubagentStop)", () => {
     const p = path.join(process.cwd(), "plugin", "hooks", "hooks.json");
     const json = JSON.parse(fs.readFileSync(p, "utf-8"));
-    for (const ev of ["Stop", "SubagentStop", "Notification"]) {
-      const entries = json.hooks[ev];
-      expect(Array.isArray(entries)).toBe(true);
-      const cmds = entries.flatMap(
-        (e: { hooks: { type: string; command: string }[] }) => e.hooks,
-      );
-      expect(
-        cmds.some(
-          (h: { type: string; command: string }) =>
-            h.type === "command" && h.command === "cockpit crew-signal",
-        ),
-      ).toBe(true);
-    }
+
+    const entries = json.hooks["Notification"];
+    expect(Array.isArray(entries)).toBe(true);
+    const cmds = entries.flatMap(
+      (e: { hooks: { type: string; command: string }[] }) => e.hooks,
+    );
+    expect(
+      cmds.some(
+        (h: { type: string; command: string }) =>
+          h.type === "command" && h.command === "cockpit crew-signal",
+      ),
+    ).toBe(true);
+
+    expect(json.hooks["Stop"]).toBeUndefined();
+    expect(json.hooks["SubagentStop"]).toBeUndefined();
   });
 });

--- a/src/commands/__tests__/crew-signal.test.ts
+++ b/src/commands/__tests__/crew-signal.test.ts
@@ -9,11 +9,14 @@ const now = () => "2026-05-15T12:00:00.000Z";
 
 describe("handleCrewSignal", () => {
   it("returns null and writes nothing when env identity is missing (no-op gate)", () => {
-    const r = handleCrewSignal({ stdin: '{"hook_event_name":"Stop"}', now });
+    const r = handleCrewSignal({
+      stdin: '{"hook_event_name":"Notification","notification_type":"idle_prompt"}',
+      now,
+    });
     expect(r).toBeNull();
   });
 
-  it("writes a done sentinel for Stop", async () => {
+  it("returns null for Stop (no sentinel — only idle Notification counts)", async () => {
     const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), "cockpit-cs-"));
     try {
       const r = handleCrewSignal({
@@ -21,6 +24,40 @@ describe("handleCrewSignal", () => {
         crew: "crew-2",
         stateDir: tmp,
         stdin: '{"hook_event_name":"Stop","session_id":"abc"}',
+        now,
+      });
+      expect(r).toBeNull();
+      expect(readCrewSentinels(tmp, "oneplan")).toHaveLength(0);
+    } finally {
+      await fsp.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null for SubagentStop", async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), "cockpit-cs-"));
+    try {
+      const r = handleCrewSignal({
+        project: "oneplan",
+        crew: "crew-2",
+        stateDir: tmp,
+        stdin: '{"hook_event_name":"SubagentStop"}',
+        now,
+      });
+      expect(r).toBeNull();
+      expect(readCrewSentinels(tmp, "oneplan")).toHaveLength(0);
+    } finally {
+      await fsp.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("writes a done sentinel for an idle Notification (notification_type)", async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), "cockpit-cs-"));
+    try {
+      const r = handleCrewSignal({
+        project: "oneplan",
+        crew: "crew-2",
+        stateDir: tmp,
+        stdin: '{"hook_event_name":"Notification","notification_type":"idle_prompt","session_id":"abc"}',
         now,
       });
       expect(r?.state).toBe("done");
@@ -33,20 +70,63 @@ describe("handleCrewSignal", () => {
     }
   });
 
-  it("writes a blocked sentinel for Notification", async () => {
+  it("writes a blocked sentinel for a permission Notification (notification_type)", async () => {
     const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), "cockpit-cs-"));
     try {
       const r = handleCrewSignal({
         project: "oneplan",
         crew: "crew-1",
         stateDir: tmp,
-        stdin: '{"hook_event_name":"Notification"}',
+        stdin: '{"hook_event_name":"Notification","notification_type":"permission_prompt"}',
         now,
       });
       expect(r?.state).toBe("blocked");
     } finally {
       await fsp.rm(tmp, { recursive: true, force: true });
     }
+  });
+
+  it("falls back to message text → done when notification_type is absent (idle)", async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), "cockpit-cs-"));
+    try {
+      const r = handleCrewSignal({
+        project: "oneplan",
+        crew: "crew-1",
+        stateDir: tmp,
+        stdin: '{"hook_event_name":"Notification","message":"Claude is waiting for your input"}',
+        now,
+      });
+      expect(r?.state).toBe("done");
+    } finally {
+      await fsp.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to message text → blocked when notification_type is absent (permission)", async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), "cockpit-cs-"));
+    try {
+      const r = handleCrewSignal({
+        project: "oneplan",
+        crew: "crew-1",
+        stateDir: tmp,
+        stdin: '{"hook_event_name":"Notification","message":"Claude needs your permission to use Bash"}',
+        now,
+      });
+      expect(r?.state).toBe("blocked");
+    } finally {
+      await fsp.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null for a Notification with no recognizable type or message", () => {
+    const r = handleCrewSignal({
+      project: "p",
+      crew: "c",
+      stateDir: "/tmp",
+      stdin: '{"hook_event_name":"Notification","notification_type":"some_future_kind"}',
+      now,
+    });
+    expect(r).toBeNull();
   });
 
   it("returns null for unrelated events", () => {
@@ -69,5 +149,36 @@ describe("handleCrewSignal", () => {
       now,
     });
     expect(r).toBeNull();
+  });
+
+  it("excerpt is the LAST assistant message, never the user prompt, surviving trailing non-assistant lines", async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), "cockpit-cs-"));
+    try {
+      const transcript = path.join(tmp, "transcript.jsonl");
+      await fsp.writeFile(
+        transcript,
+        [
+          JSON.stringify({ type: "user", message: { content: "USER PROMPT do the thing" } }),
+          JSON.stringify({ type: "assistant", message: { content: "the answer" } }),
+          JSON.stringify({ type: "attachment", path: "/x" }),
+          JSON.stringify({ type: "system", subtype: "info" }),
+        ].join("\n"),
+      );
+      const r = handleCrewSignal({
+        project: "oneplan",
+        crew: "crew-2",
+        stateDir: tmp,
+        stdin: JSON.stringify({
+          hook_event_name: "Notification",
+          notification_type: "idle_prompt",
+          transcript_path: transcript,
+        }),
+        now,
+      });
+      expect(r?.excerpt).toBe("the answer");
+      expect(r?.excerpt).not.toContain("USER PROMPT");
+    } finally {
+      await fsp.rm(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/src/commands/__tests__/crew-signal.test.ts
+++ b/src/commands/__tests__/crew-signal.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import fsp from "node:fs/promises";
+import { handleCrewSignal } from "../crew-signal.js";
+import { readCrewSentinels } from "../../lib/crew-sentinel.js";
+
+const now = () => "2026-05-15T12:00:00.000Z";
+
+describe("handleCrewSignal", () => {
+  it("returns null and writes nothing when env identity is missing (no-op gate)", () => {
+    const r = handleCrewSignal({ stdin: '{"hook_event_name":"Stop"}', now });
+    expect(r).toBeNull();
+  });
+
+  it("writes a done sentinel for Stop", async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), "cockpit-cs-"));
+    try {
+      const r = handleCrewSignal({
+        project: "oneplan",
+        crew: "crew-2",
+        stateDir: tmp,
+        stdin: '{"hook_event_name":"Stop","session_id":"abc"}',
+        now,
+      });
+      expect(r?.state).toBe("done");
+      const got = readCrewSentinels(tmp, "oneplan");
+      expect(got).toHaveLength(1);
+      expect(got[0].crew).toBe("crew-2");
+      expect(got[0].sessionId).toBe("abc");
+    } finally {
+      await fsp.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("writes a blocked sentinel for Notification", async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), "cockpit-cs-"));
+    try {
+      const r = handleCrewSignal({
+        project: "oneplan",
+        crew: "crew-1",
+        stateDir: tmp,
+        stdin: '{"hook_event_name":"Notification"}',
+        now,
+      });
+      expect(r?.state).toBe("blocked");
+    } finally {
+      await fsp.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null for unrelated events", () => {
+    const r = handleCrewSignal({
+      project: "p",
+      crew: "c",
+      stateDir: "/tmp",
+      stdin: '{"hook_event_name":"PreToolUse"}',
+      now,
+    });
+    expect(r).toBeNull();
+  });
+
+  it("tolerates non-JSON stdin", () => {
+    const r = handleCrewSignal({
+      project: "p",
+      crew: "c",
+      stateDir: "/tmp",
+      stdin: "garbage",
+      now,
+    });
+    expect(r).toBeNull();
+  });
+});

--- a/src/commands/crew-signal.ts
+++ b/src/commands/crew-signal.ts
@@ -14,9 +14,24 @@ async function readStdin(): Promise<string> {
   return Buffer.concat(chunks).toString("utf-8");
 }
 
-function stateForEvent(event: string): CrewSignalState | null {
-  if (event === "Stop" || event === "SubagentStop") return "done";
-  if (event === "Notification") return "blocked";
+/**
+ * Map a Claude `Notification` payload to a crew state. Idle prompt = the crew
+ * has genuinely finished its turn (done); permission prompt = blocked waiting on
+ * the user. Defensive: prefer the documented `notification_type` field, fall
+ * back to the human message text only when the type is absent, and refuse to
+ * write a junk sentinel when neither is recognizable.
+ */
+function stateForNotification(payload: Record<string, unknown>): CrewSignalState | null {
+  const t = payload.notification_type;
+  if (typeof t === "string" && t) {
+    const tl = t.toLowerCase();
+    if (tl === "idle_prompt" || tl.includes("idle")) return "done";
+    if (tl === "permission_prompt" || tl.includes("permission")) return "blocked";
+    return null;
+  }
+  const msg = String(payload.message);
+  if (/waiting for (your )?input|idle/i.test(msg)) return "done";
+  if (/permission|approve|allow/i.test(msg)) return "blocked";
   return null;
 }
 
@@ -28,6 +43,9 @@ function excerptFromTranscript(transcriptPath: unknown): string {
     for (let i = lines.length - 1; i >= 0; i--) {
       try {
         const obj = JSON.parse(lines[i]);
+        // Only the crew's own (assistant) replies — never the user prompt,
+        // and skip trailing attachment/system lines from the real transcript.
+        if (obj?.type !== "assistant" && obj?.role !== "assistant") continue;
         const msg = obj?.message?.content ?? obj?.content ?? obj?.text;
         if (typeof msg === "string" && msg.trim()) return msg.trim().slice(0, 280);
         if (Array.isArray(msg)) {
@@ -67,7 +85,10 @@ export function handleCrewSignal(i: CrewSignalInput): CrewSentinel | null {
     return null;
   }
   const event = typeof payload.hook_event_name === "string" ? payload.hook_event_name : "";
-  const state = stateForEvent(event);
+  // Only the debounced idle/permission Notification is a reliable completion
+  // signal. Stop/SubagentStop fire after every turn → false "done".
+  if (event !== "Notification") return null;
+  const state = stateForNotification(payload);
   if (!state) return null;
 
   const sentinel: CrewSentinel = {

--- a/src/commands/crew-signal.ts
+++ b/src/commands/crew-signal.ts
@@ -1,0 +1,100 @@
+import { Command } from "commander";
+import fs from "node:fs";
+import {
+  writeCrewSentinel,
+  type CrewSentinel,
+  type CrewSignalState,
+} from "../lib/crew-sentinel.js";
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+function stateForEvent(event: string): CrewSignalState | null {
+  if (event === "Stop" || event === "SubagentStop") return "done";
+  if (event === "Notification") return "blocked";
+  return null;
+}
+
+function excerptFromTranscript(transcriptPath: unknown): string {
+  if (typeof transcriptPath !== "string" || !transcriptPath) return "";
+  try {
+    const raw = fs.readFileSync(transcriptPath, "utf-8").trim();
+    const lines = raw.split("\n").filter((l) => l.trim().startsWith("{"));
+    for (let i = lines.length - 1; i >= 0; i--) {
+      try {
+        const obj = JSON.parse(lines[i]);
+        const msg = obj?.message?.content ?? obj?.content ?? obj?.text;
+        if (typeof msg === "string" && msg.trim()) return msg.trim().slice(0, 280);
+        if (Array.isArray(msg)) {
+          const t = msg
+            .map((p: { text?: unknown }) => (typeof p?.text === "string" ? p.text : ""))
+            .join(" ")
+            .trim();
+          if (t) return t.slice(0, 280);
+        }
+      } catch {
+        // try previous line
+      }
+    }
+  } catch {
+    // no/unreadable transcript
+  }
+  return "";
+}
+
+export interface CrewSignalInput {
+  project?: string;
+  crew?: string;
+  stateDir?: string;
+  stdin: string;
+  now?: () => string;
+}
+
+/** Pure, testable core. Returns the sentinel written, or null on no-op. */
+export function handleCrewSignal(i: CrewSignalInput): CrewSentinel | null {
+  // No-op for any session that is not a cockpit-spawned crew.
+  if (!i.project || !i.crew || !i.stateDir) return null;
+
+  let payload: Record<string, unknown> = {};
+  try {
+    payload = JSON.parse(i.stdin || "{}");
+  } catch {
+    return null;
+  }
+  const event = typeof payload.hook_event_name === "string" ? payload.hook_event_name : "";
+  const state = stateForEvent(event);
+  if (!state) return null;
+
+  const sentinel: CrewSentinel = {
+    project: i.project,
+    crew: i.crew,
+    state,
+    event,
+    sessionId: typeof payload.session_id === "string" ? payload.session_id : undefined,
+    ts: (i.now ?? (() => new Date().toISOString()))(),
+    excerpt: excerptFromTranscript(payload.transcript_path),
+  };
+  writeCrewSentinel(i.stateDir, sentinel);
+  return sentinel;
+}
+
+export const crewSignalCommand = new Command("crew-signal")
+  .description("Internal: Claude hook entrypoint; records crew done/blocked sentinels")
+  .action(async () => {
+    // Hooks must never fail the agent — swallow everything.
+    try {
+      handleCrewSignal({
+        project: process.env.COCKPIT_PROJECT,
+        crew: process.env.COCKPIT_CREW,
+        stateDir: process.env.COCKPIT_STATE_DIR,
+        stdin: await readStdin(),
+      });
+    } catch {
+      // intentional no-op
+    }
+  });

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -13,6 +13,8 @@ import {
   CapabilityRegistry,
 } from "../drivers/index.js";
 import type { PaneRef, PanePlacement, RuntimeDriver } from "../runtimes/types.js";
+import { buildLaunchCommand } from "../lib/launch-command.js";
+import { crewStateDir } from "../lib/crew-sentinel.js";
 
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "cockpit", "templates");
 
@@ -158,7 +160,13 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
   const pane = await runtime.newPane({ workspaceId: captain.id, direction, title });
 
   // Step 1: launch the CLI in the new tab.
-  await runtime.sendToPane(pane, cliCommand);
+  const wiring = agent.crewSignal?.({
+    project: input.project,
+    crew: name,
+    stateDir: crewStateDir(),
+  });
+  const launchCommand = buildLaunchCommand(cliCommand, wiring);
+  await runtime.sendToPane(pane, launchCommand);
 
   // Step 2: for interactive sessions, wait for the CLI to boot, then send the
   // task as the first prompt. For non-interactive (legacy) the prompt is

--- a/src/config.ts
+++ b/src/config.ts
@@ -133,7 +133,7 @@ export interface CockpitConfig {
   };
 }
 
-const CONFIG_DIR = path.join(os.homedir(), ".config", "cockpit");
+export const CONFIG_DIR = path.join(os.homedir(), ".config", "cockpit");
 export const DEFAULT_CONFIG_PATH = path.join(CONFIG_DIR, "config.json");
 
 export function getDefaultConfig(): CockpitConfig {

--- a/src/drivers/__tests__/claude.test.ts
+++ b/src/drivers/__tests__/claude.test.ts
@@ -84,4 +84,19 @@ describe("claude driver", () => {
     expect(result.status).toBe("success");
     expect(result.output).toBe("plain text output");
   });
+
+  it("crewSignal returns the identity env for a crew", () => {
+    const d = createClaudeDriver();
+    const wiring = d.crewSignal!({
+      project: "oneplan",
+      crew: "crew-3",
+      stateDir: "/home/u/.config/cockpit/state",
+    });
+    expect(wiring.env).toEqual({
+      COCKPIT_PROJECT: "oneplan",
+      COCKPIT_CREW: "crew-3",
+      COCKPIT_STATE_DIR: "/home/u/.config/cockpit/state",
+    });
+    expect(wiring.argsSuffix).toBeUndefined();
+  });
 });

--- a/src/drivers/claude.ts
+++ b/src/drivers/claude.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import type { AgentDriver, AgentProbeResult, SpawnOptions, AgentResult } from "./types.js";
+import type { AgentDriver, AgentProbeResult, SpawnOptions, AgentResult, CrewSignalContext, CrewSignalWiring } from "./types.js";
 
 export function createClaudeDriver(): AgentDriver {
   return {
@@ -71,6 +71,16 @@ export function createClaudeDriver(): AgentDriver {
       } catch {
         // process may already be gone
       }
+    },
+
+    crewSignal(ctx: CrewSignalContext): CrewSignalWiring {
+      return {
+        env: {
+          COCKPIT_PROJECT: ctx.project,
+          COCKPIT_CREW: ctx.crew,
+          COCKPIT_STATE_DIR: ctx.stateDir,
+        },
+      };
     },
   };
 }

--- a/src/drivers/types.ts
+++ b/src/drivers/types.ts
@@ -36,6 +36,19 @@ export interface AgentResult {
   filesChanged?: string[];
 }
 
+export interface CrewSignalContext {
+  project: string;
+  crew: string;
+  stateDir: string;
+}
+
+export interface CrewSignalWiring {
+  /** Env vars injected into the crew process so its completion hook can self-identify. */
+  env: Record<string, string>;
+  /** Extra CLI args appended to the spawn command (non-Claude adapters, #68). */
+  argsSuffix?: string;
+}
+
 export interface AgentDriver {
   name: string;
   templateSuffix: string;
@@ -44,6 +57,14 @@ export interface AgentDriver {
   buildCommand(opts: SpawnOptions): string;
   parseOutput(raw: string): AgentResult;
   stop(pid: number): Promise<void>;
+
+  /**
+   * Optional crew-completion-signal contract (#64). Declares how this agent is
+   * wired so a finished/blocked crew turn produces a cockpit sentinel.
+   * Claude: env only — hooks ship via the cockpit plugin's hooks.json.
+   * Codex/Gemini/Aider: implemented in #68.
+   */
+  crewSignal?(ctx: CrewSignalContext): CrewSignalWiring;
 }
 
 export interface RoleRequirements {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { workspaceCommand } from "./commands/workspace.js";
 import { trackerCommand } from "./commands/tracker.js";
 import { notifyCommand } from "./commands/notify.js";
 import { projectionCommand } from "./commands/projection.js";
+import { crewSignalCommand } from "./commands/crew-signal.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf-8"));
@@ -51,5 +52,6 @@ program.addCommand(workspaceCommand);
 program.addCommand(trackerCommand);
 program.addCommand(notifyCommand);
 program.addCommand(projectionCommand);
+program.addCommand(crewSignalCommand);
 
 program.parse();

--- a/src/lib/__tests__/crew-sentinel.test.ts
+++ b/src/lib/__tests__/crew-sentinel.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import fsp from "node:fs/promises";
+import {
+  writeCrewSentinel,
+  readCrewSentinels,
+  alreadyNudged,
+  markNudged,
+  type CrewSentinel,
+} from "../crew-sentinel.js";
+
+function sentinel(over: Partial<CrewSentinel> = {}): CrewSentinel {
+  return {
+    project: "oneplan",
+    crew: "crew-1",
+    state: "done",
+    event: "Stop",
+    ts: "2026-05-15T10:00:00.000Z",
+    excerpt: "finished the task",
+    ...over,
+  };
+}
+
+describe("crew-sentinel", () => {
+  it("round-trips a sentinel through write/read", async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), "cockpit-sent-"));
+    try {
+      writeCrewSentinel(tmp, sentinel());
+      const got = readCrewSentinels(tmp, "oneplan");
+      expect(got).toHaveLength(1);
+      expect(got[0].crew).toBe("crew-1");
+      expect(got[0].state).toBe("done");
+      expect(got[0].excerpt).toBe("finished the task");
+    } finally {
+      await fsp.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("returns [] when the project dir does not exist", () => {
+    expect(readCrewSentinels("/no/such/dir", "x")).toEqual([]);
+  });
+
+  it("skips corrupt sentinel files", async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), "cockpit-sent-"));
+    try {
+      writeCrewSentinel(tmp, sentinel());
+      await fsp.writeFile(path.join(tmp, "oneplan", "broken.json"), "{not json");
+      const got = readCrewSentinels(tmp, "oneplan");
+      expect(got).toHaveLength(1);
+    } finally {
+      await fsp.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("tracks nudge markers per sentinel ts", async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), "cockpit-sent-"));
+    try {
+      const s = sentinel();
+      expect(alreadyNudged(tmp, s)).toBe(false);
+      markNudged(tmp, s);
+      expect(alreadyNudged(tmp, s)).toBe(true);
+      expect(alreadyNudged(tmp, { ...s, ts: "2026-05-15T11:00:00.000Z" })).toBe(false);
+    } finally {
+      await fsp.rm(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/lib/__tests__/launch-command.test.ts
+++ b/src/lib/__tests__/launch-command.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { buildLaunchCommand } from "../launch-command.js";
+
+describe("buildLaunchCommand", () => {
+  it("returns the command unchanged when there is no wiring", () => {
+    expect(buildLaunchCommand("claude --plugin-dir /p", undefined)).toBe("claude --plugin-dir /p");
+  });
+
+  it("prefixes single-quoted env assignments", () => {
+    const out = buildLaunchCommand("claude -p", {
+      env: { COCKPIT_PROJECT: "oneplan", COCKPIT_CREW: "crew-1", COCKPIT_STATE_DIR: "/a/b" },
+    });
+    expect(out).toBe(
+      "COCKPIT_PROJECT='oneplan' COCKPIT_CREW='crew-1' COCKPIT_STATE_DIR='/a/b' claude -p",
+    );
+  });
+
+  it("escapes single quotes in values", () => {
+    const out = buildLaunchCommand("claude", { env: { X: "a'b" } });
+    expect(out).toBe("X='a'\\''b' claude");
+  });
+
+  it("appends argsSuffix when present", () => {
+    const out = buildLaunchCommand("aider", { env: { X: "1" }, argsSuffix: "--notifications" });
+    expect(out).toBe("X='1' aider --notifications");
+  });
+});

--- a/src/lib/crew-sentinel.ts
+++ b/src/lib/crew-sentinel.ts
@@ -1,0 +1,80 @@
+import fs from "node:fs";
+import path from "node:path";
+import { CONFIG_DIR } from "../config.js";
+
+export type CrewSignalState = "done" | "blocked";
+
+export interface CrewSentinel {
+  project: string;
+  crew: string;
+  state: CrewSignalState;
+  event: string;
+  sessionId?: string;
+  ts: string;
+  excerpt: string;
+}
+
+export function crewStateDir(base: string = CONFIG_DIR): string {
+  return path.join(base, "state");
+}
+
+export function sentinelPath(
+  stateDir: string,
+  project: string,
+  crew: string,
+  state: CrewSignalState,
+): string {
+  return path.join(stateDir, project, `${crew}.${state}.json`);
+}
+
+export function writeCrewSentinel(stateDir: string, s: CrewSentinel): void {
+  const file = sentinelPath(stateDir, s.project, s.crew, s.state);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(s, null, 2));
+}
+
+export function readCrewSentinels(stateDir: string, project: string): CrewSentinel[] {
+  const dir = path.join(stateDir, project);
+  let names: string[];
+  try {
+    names = fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const out: CrewSentinel[] = [];
+  for (const n of names) {
+    if (!n.endsWith(".json")) continue;
+    try {
+      const parsed = JSON.parse(fs.readFileSync(path.join(dir, n), "utf-8")) as CrewSentinel;
+      if (parsed && parsed.crew && (parsed.state === "done" || parsed.state === "blocked")) {
+        out.push(parsed);
+      }
+    } catch {
+      // skip corrupt sentinel
+    }
+  }
+  return out;
+}
+
+function nudgeMarkerPath(
+  stateDir: string,
+  project: string,
+  crew: string,
+  state: CrewSignalState,
+): string {
+  return path.join(stateDir, project, `${crew}.${state}.nudged`);
+}
+
+export function alreadyNudged(stateDir: string, s: CrewSentinel): boolean {
+  try {
+    return fs.readFileSync(nudgeMarkerPath(stateDir, s.project, s.crew, s.state), "utf-8") === s.ts;
+  } catch {
+    return false;
+  }
+}
+
+export function markNudged(stateDir: string, s: CrewSentinel): void {
+  const file = nudgeMarkerPath(stateDir, s.project, s.crew, s.state);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, s.ts);
+}

--- a/src/lib/launch-command.ts
+++ b/src/lib/launch-command.ts
@@ -1,0 +1,17 @@
+import type { CrewSignalWiring } from "../drivers/types.js";
+
+export function shQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+export function buildLaunchCommand(
+  cliCommand: string,
+  wiring: CrewSignalWiring | undefined,
+): string {
+  if (!wiring) return cliCommand;
+  const envPrefix = Object.entries(wiring.env)
+    .map(([k, v]) => `${k}=${shQuote(v)}`)
+    .join(" ");
+  const suffix = wiring.argsSuffix ? ` ${wiring.argsSuffix}` : "";
+  return `${envPrefix} ${cliCommand}${suffix}`;
+}

--- a/src/reactor/__tests__/auto-status-crew.test.ts
+++ b/src/reactor/__tests__/auto-status-crew.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import fsp from "node:fs/promises";
+import { runAutoStatus } from "../auto-status.js";
+import { writeCrewSentinel } from "../../lib/crew-sentinel.js";
+import type { RuntimeDriver } from "../../runtimes/types.js";
+
+function fakeRuntime(sent: string[]): RuntimeDriver {
+  return {
+    name: "fake",
+    async send(_ref: string, message: string) { sent.push(message); },
+    async sendKey() {},
+    async readScreen() { return ""; }, // captain offline/idle
+    async sendToPane() {},
+    async readPaneScreen() { return ""; },
+  } as unknown as RuntimeDriver;
+}
+
+describe("runAutoStatus crew backstop", () => {
+  it("escalates project state to blocked from a crew sentinel with captain offline, and nudges once", async () => {
+    const stateDir = await fsp.mkdtemp(path.join(os.tmpdir(), "cockpit-as-state-"));
+    const vault = await fsp.mkdtemp(path.join(os.tmpdir(), "cockpit-as-vault-"));
+    const sent: string[] = [];
+    try {
+      writeCrewSentinel(stateDir, {
+        project: "oneplan",
+        crew: "crew-1",
+        state: "blocked",
+        event: "Notification",
+        ts: "2026-05-15T09:00:00.000Z",
+        excerpt: "which auth lib?",
+      });
+
+      const deps = {
+        config: { projects: { oneplan: { captainName: "oneplan-captain", spokeVault: vault } } },
+        reactions: { auto_status: { enabled: true, lines: 50, excerpt_lines: 15 } },
+        runtime: () => fakeRuntime(sent),
+        stateDir,
+        now: () => "2026-05-15T10:00:00.000Z",
+      } as unknown as Parameters<typeof runAutoStatus>[0];
+
+      const r1 = await runAutoStatus(deps);
+      expect(r1[0].state).toBe("blocked");
+      expect(r1[0].crewSignals).toHaveLength(1);
+      expect(r1[0].crewSignals[0].crew).toBe("crew-1");
+      const md = await fsp.readFile(path.join(vault, "status.md"), "utf-8");
+      expect(md).toContain("## Crew signals");
+      expect(md).toContain("crew-1");
+      expect(sent.filter((m) => m.includes("crew-1"))).toHaveLength(1);
+
+      // second cycle: same sentinel ts → no duplicate nudge
+      await runAutoStatus(deps);
+      expect(sent.filter((m) => m.includes("crew-1"))).toHaveLength(1);
+    } finally {
+      await fsp.rm(stateDir, { recursive: true, force: true });
+      await fsp.rm(vault, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/reactor/__tests__/auto-status.test.ts
+++ b/src/reactor/__tests__/auto-status.test.ts
@@ -78,8 +78,8 @@ describe("runAutoStatus", () => {
     });
 
     expect(results).toEqual([
-      { project: "brove",  state: "idle", vaultPath: "/tmp/spokes/brove/status.md" },
-      { project: "solder", state: "busy", vaultPath: "/tmp/spokes/solder/status.md" },
+      { project: "brove",  state: "idle", vaultPath: "/tmp/spokes/brove/status.md", crewSignals: [] },
+      { project: "solder", state: "busy", vaultPath: "/tmp/spokes/solder/status.md", crewSignals: [] },
     ]);
     expect(writes).toHaveLength(2);
   });
@@ -174,8 +174,8 @@ describe("runAutoStatus", () => {
     });
 
     expect(results).toEqual([
-      { project: "brove",  state: "offline", vaultPath: "/tmp/spokes/brove/status.md" },
-      { project: "solder", state: "idle",    vaultPath: "/tmp/spokes/solder/status.md" },
+      { project: "brove",  state: "offline", vaultPath: "/tmp/spokes/brove/status.md", crewSignals: [] },
+      { project: "solder", state: "idle",    vaultPath: "/tmp/spokes/solder/status.md", crewSignals: [] },
     ]);
   });
 

--- a/src/reactor/auto-status.ts
+++ b/src/reactor/auto-status.ts
@@ -4,11 +4,19 @@ import type { CockpitConfig, ReactionsConfig } from "../config.js";
 import { resolveHome } from "../config.js";
 import type { RuntimeDriver } from "../runtimes/types.js";
 import { classifyScreen, type ScreenState } from "./status-classifier.js";
+import {
+  readCrewSentinels,
+  crewStateDir,
+  alreadyNudged,
+  markNudged,
+  type CrewSignalState,
+} from "../lib/crew-sentinel.js";
 
 export interface AutoStatusResult {
   project: string;
   state: ScreenState;
   vaultPath: string;
+  crewSignals: { crew: string; state: CrewSignalState; ts: string; excerpt: string }[];
 }
 
 export interface AutoStatusDeps {
@@ -18,6 +26,7 @@ export interface AutoStatusDeps {
   now?: () => string;
   writeFile?: (filePath: string, content: string) => void;
   mkdir?: (dirPath: string) => void;
+  stateDir?: string;
 }
 
 const DEFAULT_AUTO_STATUS = { enabled: true, lines: 50, excerpt_lines: 15 };
@@ -28,14 +37,22 @@ function buildStatusMarkdown(input: {
   state: ScreenState;
   lastChecked: string;
   excerpt: string;
+  crewSignals: { crew: string; state: CrewSignalState; ts: string; excerpt: string }[];
 }): string {
   const fenced = "```";
+  const crewLines =
+    input.crewSignals.length === 0
+      ? ["_none_"]
+      : input.crewSignals.map(
+          (c) => `- **${c.crew}** — ${c.state} @ ${c.ts}: ${c.excerpt || "(no detail)"}`,
+        );
   return [
     "---",
     `project: ${input.project}`,
     `auto_state: ${input.state}`,
     `auto_last_checked: "${input.lastChecked}"`,
     `captain_workspace: ${input.captainWorkspace}`,
+    `crew_signals: ${input.crewSignals.length}`,
     "---",
     "",
     "# Status (auto-derived)",
@@ -47,6 +64,10 @@ function buildStatusMarkdown(input: {
     fenced,
     input.excerpt,
     fenced,
+    "",
+    "## Crew signals",
+    "",
+    ...crewLines,
     "",
   ].join("\n");
 }
@@ -60,6 +81,7 @@ export async function runAutoStatus(deps: AutoStatusDeps): Promise<AutoStatusRes
   const now = (deps.now ?? (() => new Date().toISOString()))();
   const writeFile = deps.writeFile ?? ((p, c) => fs.writeFileSync(p, c));
   const mkdir = deps.mkdir ?? ((p) => fs.mkdirSync(p, { recursive: true }));
+  const stateDir = deps.stateDir ?? crewStateDir();
 
   const results: AutoStatusResult[] = [];
 
@@ -78,20 +100,44 @@ export async function runAutoStatus(deps: AutoStatusDeps): Promise<AutoStatusRes
 
     const { state, excerpt } = classifyScreen(screen, { lines, excerptLines });
 
+    const sentinels = readCrewSentinels(stateDir, name);
+    const crewSignals = sentinels.map((s) => ({
+      crew: s.crew,
+      state: s.state,
+      ts: s.ts,
+      excerpt: s.excerpt,
+    }));
+    const hasBlockedCrew = sentinels.some((s) => s.state === "blocked");
+    const projectState: ScreenState = hasBlockedCrew ? "blocked" : state;
+
+    for (const s of sentinels) {
+      if (alreadyNudged(stateDir, s)) continue;
+      try {
+        await deps.runtime(name).send(
+          captain,
+          `crew ${s.crew} is ${s.state}: ${s.excerpt || "(no detail)"} — collect/unblock it`,
+        );
+        markNudged(stateDir, s);
+      } catch {
+        // best-effort: captain may be down; reactor record is the guarantee
+      }
+    }
+
     try {
       mkdir(vaultDir);
       writeFile(statusPath, buildStatusMarkdown({
         project: name,
         captainWorkspace: captain,
-        state,
+        state: projectState,
         lastChecked: now,
         excerpt,
+        crewSignals,
       }));
     } catch {
       // best-effort: skip projects whose vault is unreachable
     }
 
-    results.push({ project: name, state, vaultPath: statusPath });
+    results.push({ project: name, state: projectState, vaultPath: statusPath, crewSignals });
   }
 
   return results;


### PR DESCRIPTION
## Summary

Makes a finished/blocked Claude crew produce a deterministic cockpit **sentinel** that the always-on **reactor** reads — so crew completion is visible even when the crew never self-reports and the captain is idle/compacted. **Unblocks #65** (Telegram remote control Phase 1, whose push path is reactor → classify → notify).

Implements the approved plan `docs/specs/2026-05-15-crew-completion-reliability-plan.md` (design: `docs/specs/2026-05-15-crew-completion-reliability-design.md`), 7 tasks, strict TDD, 1 atomic commit per task.

### Three layers
1. **Detection adapter (Claude)** — crew-scoped plugin hook (`plugin/hooks/hooks.json` → `cockpit crew-signal`) for `Stop`/`SubagentStop`/`Notification`. No global `~/.claude/settings.json` pollution; strict no-op unless `COCKPIT_CREW` is set.
2. **Sentinel** — `cockpit crew-signal` writes normalized JSON to `~/.config/cockpit/state/<project>/<crew>.<state>.json` (agent-agnostic).
3. **Reactor backstop** — `runAutoStatus` scans sentinels each cycle: escalates project state to `blocked`, records a `## Crew signals` section in `status.md`, best-effort nudges the captain once per sentinel (dedup via nudge markers).

`AgentDriver.crewSignal?()` carries the documented contract; only the hook wiring is Claude-specific. **Non-Claude adapters (Codex/Gemini/Aider) are tracked in #68** — the sentinel + reactor layers are already agent-agnostic.

## Testing

- **All #64 tests green. 317 pass, 0 new failures.** New/changed coverage: sentinel round-trip/corrupt/nudge, `handleCrewSignal` (no-op gate, done/blocked, non-JSON tolerance), `crewSignal` driver contract, `buildLaunchCommand` quoting, reactor backstop (offline-captain escalation + single-nudge dedup), plugin hooks.json registration.
- `npm run lint` exit 0; `npm run build` exit 0.
- Plan Task 7 "no regressions" criterion satisfied.

### Pre-existing failure note (tracked in #70)

The only red is **2 PRE-EXISTING `src/config.test.ts` failures present identically on `develop` HEAD** (emoji-prefixed default `commandName` from the workspace-icon feature vs a stale assertion). **Not caused by this work** and out of #64 scope (Karpathy surgical — every changed line traces to #64). Tracked deliberately in **#70**.

Proof — `npx vitest run src/config.test.ts` on **pristine `develop` HEAD**:

```
× config > returns default config
× config > returns default config when file does not exist
FAIL src/config.test.ts > config > returns default config
  17|   expect(config.commandName).toBe("command");
       Expected: "command"   Received: "🏛️ command"
FAIL src/config.test.ts > config > returns default config when file does not exist
  41|   expect(loaded.commandName).toBe("command");
 Test Files  1 failed (1)
      Tests  2 failed | 5 passed (7)
```

This branch adds **0** new failures (same 2, plus 317 passing).

## Notes

- Plan-directed deviation: `src/reactor/__tests__/auto-status.test.ts` — 2 `toEqual` assertions updated to include `crewSignals: []` for the extended `AutoStatusResult` shape (plan Task 5 Step 5).
- The plan-mandated `npx gitnexus analyze` regenerates the gitnexus-managed doc block; that tool artifact is intentionally **excluded** from this PR (handled by the repo merge hook), keeping the diff purely #64 + one AGENTS.md paragraph.

Closes #64. Unblocks #65. Non-Claude adapters: #68. Pre-existing test gap: #70.
