### PR TITLE
fix(plugin): register cockpit skill namespace via plugin manifest

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "cockpit",
+  "description": "Skills for claude-cockpit agent orchestration roles (captain, command, crew)",
+  "skills": "./skills/"
+}


### PR DESCRIPTION
## Problem

Captain/command startup showed:

```
Skill(cockpit:captain-ops)  → Error: Unknown skill: cockpit:captain-ops
Skill(plugin:captain-ops)   → Successfully loaded skill
```

The plugin is loaded via `claude --plugin-dir <repo>/plugin` (`src/commands/launch.ts:150`), but `plugin/` had **no `.claude-plugin/plugin.json`**. Claude Code derives a plugin's skill namespace from that manifest's `name`; with none present it falls back to the **directory basename** (`plugin`), so skills registered as `plugin:captain-ops`. Every prompt, role template, and in-skill cross-ref in the repo (~23 refs) uses the `cockpit:` namespace instead.

Startup self-recovered by guessing `plugin:*`, but mid-task opt-in refs (`cockpit:daily-log`, `cockpit:wiki-ops` inside `captain-ops/SKILL.md`) errored with no retry — and the "skip if uneventful" framing let the model silently drop them.

## Fix

Add `plugin/.claude-plugin/plugin.json` with `"name": "cockpit"` so skills resolve under the namespace the codebase already expects. No `version` field — not required for namespacing, and avoids a third drift point (root `package.json` is `0.3.3`, `plugin/package.json` is `0.1.0`).

One new file. No code edits. `gitnexus detect_changes`: 0 symbols affected, risk none.

## Verification

Headless run with the exact launcher flag:

```
$ claude -p "List every available Skill whose name contains 'captain-ops' or 'command-ops'..." --plugin-dir <repo>/plugin
cockpit:captain-ops
cockpit:command-ops
```

## Out of scope (flagged, not changed)

`plugin/package.json` pinned at `0.1.0` while project is `0.3.3` — separate decision (sync vs. delete if unused as npm package).