### PR TITLE
chore(plugin): remove dead plugin/package.json

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "cockpit",
-  "version": "0.1.0",
-  "description": "Skills for claude-cockpit agent orchestration roles (captain, command, crew)",
-  "type": "module"
-}


### PR DESCRIPTION
Follow-up to #72.

`plugin/package.json` (`name: cockpit`, `version: 0.1.0`) was the original attempt to name the Claude Code plugin. Claude Code never reads npm `package.json` for plugin naming — that's precisely why the skill-namespace bug existed until `.claude-plugin/plugin.json` was added in #72.

It is now fully dead:
- not an npm workspace, not in root `files`, not published
- imported/referenced by nothing in `src/` or `scripts/`
- only non-trivial field (`"type": "module"`) is inert — zero `.js` files under `plugin/`

Removing it eliminates the version drift point (`0.1.0` vs project `0.3.3`) and the misleading manifest. The real plugin manifest is `plugin/.claude-plugin/plugin.json`.

`gitnexus detect_changes`: 0 symbols, risk none.