### PR TITLE
feat(runtime): self-heal source-managed dirs on every invocation

### DIFF
--- a/docs/specs/2026-05-17-runtime-self-heal-sync-design.md
+++ b/docs/specs/2026-05-17-runtime-self-heal-sync-design.md
@@ -48,89 +48,142 @@ Success criteria:
 
 ## Approach
 
-**Source-fingerprint self-heal** (chosen over version-stamp, which misses
-same-version changes, and over mtime-watermark, which is marginally less
-robust under clock skew / file restores).
+**Cacheless idempotent mirror.** Every `cockpit` invocation mirrors each
+managed target (copy-if-different + prune). No fingerprint, no state file.
+
+A fingerprint/state-file design was implemented and rejected during
+development: a source-only fingerprint cache **can lie** — if the runtime
+dest is incomplete or corrupted while source is unchanged, the cache
+reports "synced" and the dest is never reconciled. That reintroduces the
+silent-drift bug one level up. Observed in practice: a poisoned
+`.sync-state.json` left `templates/` with 2 of 7 files and blocked
+self-heal until the state file was manually deleted.
+
+The managed dirs are tiny (dozens of small files); mirroring every run is
+sub-10ms, needs no crypto, and **cannot be poisoned** because the dest is
+always reconciled to source.
 
 ## Components
 
-### 1. `mirrorDir(src, dest)` — mirroring sync helper
+### 1. `copyIfDifferent(src, dest)` — idempotent file copy
+
+- Copy `src` → `dest` only if `dest` is missing or its **bytes differ**
+  (content comparison, not size+mtime — a same-size edit is always
+  detected, and an unchanged file is never rewritten ⇒ no mtime churn).
+- Returns whether a copy happened (drives `chmod`).
+
+### 1b. `mirrorDir(src, dest)` — recursive mirror
 
 Replaces additive `copyDirRecursive` for managed dirs:
 
-- Recursively copy files that are new or changed (size or mtime differs).
+- Recursively `copyIfDifferent` every file.
 - **Prune:** delete dest entries (files and dirs) absent from src.
-- `init` is refactored to call `mirrorDir`, so `init` and auto-sync share
-  one code path (no behavioral divergence).
+- Used for `mode: "tree"` targets (currently `plugin`).
+
+### 1c. `mirrorFlat(src, dest, match, chmod?)` — filtered flat sync
+
+For `mode: "flat"` targets where the runtime dir is a flat set of files
+copied from a differently-named, possibly mixed source dir:
+
+- `copyIfDifferent` only top-level files whose name matches `match`.
+- **Prune:** remove `dest` files whose name is not in the matched set.
+- Apply `chmod` to freshly copied files when specified (scripts → `0o755`).
+
+### 1d. Managed-target descriptors
+
+The source→runtime mapping is **not** same-name full-tree (discovered
+during implementation from `init.ts`):
+
+```ts
+MANAGED_TARGETS = [
+  { name: "plugin",    srcRel: "plugin",       mode: "tree" },
+  { name: "scripts",   srcRel: "scripts",      mode: "flat",
+    match: /\.sh$/,                              chmod: 0o755 },
+  { name: "templates", srcRel: "orchestrator", mode: "flat",
+    match: /\.(claude\.md|generic\.md|CLAUDE\.md)$/ },
+]
+```
+
+`name` = runtime dir under `~/.config/cockpit/`. `srcRel` = source dir
+relative to package root. Note `templates` ← `orchestrator/`.
 
 ### 2. `ensureRuntimeSynced()` — self-heal gate
 
-Called once at CLI entry (`src/index.ts`) before command dispatch.
+Called once at CLI entry (`src/index.ts`) before command dispatch, and
+reused by `cockpit init` (one code path; no divergence).
 
-- Resolve source root via existing `findPackageRoot()`.
-- For each managed subtree (`plugin/`, `templates/`, `scripts/`):
-  compute a fingerprint = hash over sorted `(relpath, size, mtimeMs)`.
-- Read recorded fingerprints from `~/.config/cockpit/.sync-state.json`
-  (`{ plugin, templates, scripts }`).
-- For each subtree whose fingerprint differs (or is missing): run
-  `mirrorDir` for that subtree, then rewrite that entry in the state file.
-- On match: read + compare only, no writes, no output.
-- On any error (source missing, FS error): write a one-line warning to
-  stderr and continue — the command must still run.
+- Resolve source root via package root (the dir containing the installed
+  `package.json`).
+- For each `MANAGED_TARGETS` entry: if its source dir exists, run
+  `mirrorDir` (tree) or `mirrorFlat` (flat). Unconditional — idempotent
+  copy-if-different makes the no-change case cheap and silent.
+- No fingerprint, no state file, no skip logic — the dest is always
+  reconciled, so nothing can claim "synced" while it is not.
+- On any per-target error (source missing, FS error): write a one-line
+  warning to stderr and continue — the command must still run. Never
+  throws.
 
-### 3. State file — `~/.config/cockpit/.sync-state.json`
+### 3. No state file
 
-`{ "plugin": "<hash>", "templates": "<hash>", "scripts": "<hash>" }`.
-Created/updated by `ensureRuntimeSynced`. Absent/corrupt → treated as
-"all stale", triggering a full re-sync (self-correcting).
+Deliberately none. The earlier `.sync-state.json` cache was removed
+because it could report "synced" over an incomplete dest. Any leftover
+`.sync-state.json` from the old design is inert (never read or written)
+and safe to delete.
 
 ## Hard Boundary
 
-The sync touches **only** `plugin/`, `templates/`, `scripts/`. It must
-never write or prune `config.json`, `sessions.json`, `reactions.json`,
-`spokes/`, `reactor-events/`, or any other `~/.config/cockpit` entry.
-Pruning is scoped per managed subtree — never at the `~/.config/cockpit`
-root.
+The sync touches **only** the runtime dirs named in `MANAGED_TARGETS`
+(`plugin/`, `scripts/`, `templates/`). It must never write or prune
+`config.json`, `sessions.json`, `reactions.json`, `spokes/`,
+`reactor-events/`, or any other `~/.config/cockpit` entry. Pruning is
+scoped per managed target — never at the `~/.config/cockpit` root. The
+user's hub vault (scaffolded by `init`) is **not** a managed target and
+is never pruned.
 
 ## Data Flow
 
 ```
 cockpit <cmd>
   -> ensureRuntimeSynced()
-       -> for sub in [plugin, templates, scripts]:
-            fp = fingerprint(source/sub)
-            if fp != state[sub]:
-                 mirrorDir(source/sub, runtime/sub)   # copy + prune
-                 state[sub] = fp
-       -> persist .sync-state.json (only if changed)
+       -> for t in MANAGED_TARGETS:                 # plugin, scripts, templates
+            if exists(sourceRoot/t.srcRel):
+                 t.mode == "tree"  ? mirrorDir(srcDir, runtime/t.name)
+                 t.mode == "flat"  ? mirrorFlat(srcDir, runtime/t.name, t.match, t.chmod)
   -> dispatch command
 ```
 
 ## Error Handling
 
-- Source root unresolvable / managed dir missing in source → warn, skip
-  that subtree, continue command.
-- FS error during mirror → warn with the path, leave runtime as-is for
-  that subtree (last-known-good), continue command.
-- Corrupt `.sync-state.json` → treat as empty, full re-sync.
+- Managed source dir missing → skip that target, continue command.
+- FS error during mirror → warn with the target name, leave runtime as-is
+  for that target (last-known-good), continue command.
 - Never throw out of `ensureRuntimeSynced`; the CLI must remain usable.
 
 ## Testing
 
-`mirrorDir`:
+`mirrorDir` (tree targets):
 - copies a new file
-- overwrites a changed file (size and mtime cases)
+- overwrites a changed file
 - **prunes a file deleted from src**
 - **prunes a dir deleted from src**
-- leaves an unmanaged sibling in dest untouched
+- mirrors nested dirs including dotfiles (`.claude-plugin/`)
+- **idempotent** — an unchanged file is not rewritten (no mtime churn)
+
+`mirrorFlat` (flat filtered targets):
+- copies only files matching `match`, ignores non-matching
+- **prunes a dest file no longer in the matched set**
+- applies `chmod` to copied files when specified
+- **idempotent** — an unchanged matched file is not rewritten
 
 `ensureRuntimeSynced`:
-- no-op when fingerprints match (no FS writes, no output)
-- syncs only the changed subtree on partial mismatch
+- syncs all managed targets (filtering + chmod per descriptor)
+- idempotent: unchanged source ⇒ no runtime files rewritten
+- **self-heals an incomplete dest even when source is unchanged**
+  (the core property — proves no cache can lie)
+- writes no `.sync-state.json`
 - never touches user-state files (`config.json` etc.) even when present
   in the runtime dir
-- missing source dir → warns, command proceeds
-- corrupt/absent state file → full re-sync, then steady state
+- missing source dir → command proceeds (no throw)
 
 ## Out of Scope (YAGNI)
 

--- a/docs/specs/2026-05-17-runtime-self-heal-sync-design.md
+++ b/docs/specs/2026-05-17-runtime-self-heal-sync-design.md
@@ -1,0 +1,140 @@
+# Runtime Self-Heal Sync — Design
+
+**Date:** 2026-05-17
+**Status:** Approved (design), pending implementation plan
+
+## Problem
+
+`cockpit init` deploys source `plugin/`, `templates/`, `scripts/` into
+`~/.config/cockpit/` via `copyDirRecursive` — a **one-shot additive copy**.
+The CLI then loads everything from `~/.config/cockpit/` at runtime
+(`TEMPLATES_DIR = ~/.config/cockpit/templates`,
+`pluginDir = ~/.config/cockpit/plugin`).
+
+Two latent failures, both hit in production on 2026-05-17:
+
+1. **No re-sync trigger.** Source changes (PRs #72/#73 added
+   `plugin/.claude-plugin/plugin.json` and deleted `plugin/package.json`)
+   never reached `~/.config/cockpit/plugin`. Captains launched with a
+   stale plugin dir that had no manifest, so Claude Code loaded **zero**
+   cockpit skills — `cockpit:captain-ops`, `plugin:captain-ops`, and
+   `captain-ops` all failed.
+2. **No prune.** `copyDirRecursive` only copies src→dest; it never
+   removes dest entries deleted from src. Re-running `cockpit init` would
+   have left the dead `package.json` behind, re-introducing the exact
+   drift #73 removed.
+
+A version-number check is **insufficient**: #72/#73 changed source
+without bumping the project version (still `0.3.3`), and the dev machine
+is npm-linked (`git pull + tsc`, no version bump). The trigger must be
+source **content**, not version.
+
+## Goal
+
+When cockpit's source-managed assets change, the runtime copy in
+`~/.config/cockpit/` self-heals automatically on the next `cockpit`
+invocation — including deletions — without any command to remember and
+without clobbering user/runtime state.
+
+Success criteria:
+
+- A source change to `plugin/`, `templates/`, or `scripts/` is reflected
+  in `~/.config/cockpit/` before the next command runs, with no manual step.
+- A file deleted from a managed source dir is removed from the runtime copy.
+- User/runtime state (`config.json`, `sessions.json`, `reactions.json`,
+  `spokes/`, `reactor-events/`) is never overwritten or pruned.
+- Happy path (no source change) adds negligible latency and is silent.
+- Sync failure degrades gracefully: warn, do not block the command.
+
+## Approach
+
+**Source-fingerprint self-heal** (chosen over version-stamp, which misses
+same-version changes, and over mtime-watermark, which is marginally less
+robust under clock skew / file restores).
+
+## Components
+
+### 1. `mirrorDir(src, dest)` — mirroring sync helper
+
+Replaces additive `copyDirRecursive` for managed dirs:
+
+- Recursively copy files that are new or changed (size or mtime differs).
+- **Prune:** delete dest entries (files and dirs) absent from src.
+- `init` is refactored to call `mirrorDir`, so `init` and auto-sync share
+  one code path (no behavioral divergence).
+
+### 2. `ensureRuntimeSynced()` — self-heal gate
+
+Called once at CLI entry (`src/index.ts`) before command dispatch.
+
+- Resolve source root via existing `findPackageRoot()`.
+- For each managed subtree (`plugin/`, `templates/`, `scripts/`):
+  compute a fingerprint = hash over sorted `(relpath, size, mtimeMs)`.
+- Read recorded fingerprints from `~/.config/cockpit/.sync-state.json`
+  (`{ plugin, templates, scripts }`).
+- For each subtree whose fingerprint differs (or is missing): run
+  `mirrorDir` for that subtree, then rewrite that entry in the state file.
+- On match: read + compare only, no writes, no output.
+- On any error (source missing, FS error): write a one-line warning to
+  stderr and continue — the command must still run.
+
+### 3. State file — `~/.config/cockpit/.sync-state.json`
+
+`{ "plugin": "<hash>", "templates": "<hash>", "scripts": "<hash>" }`.
+Created/updated by `ensureRuntimeSynced`. Absent/corrupt → treated as
+"all stale", triggering a full re-sync (self-correcting).
+
+## Hard Boundary
+
+The sync touches **only** `plugin/`, `templates/`, `scripts/`. It must
+never write or prune `config.json`, `sessions.json`, `reactions.json`,
+`spokes/`, `reactor-events/`, or any other `~/.config/cockpit` entry.
+Pruning is scoped per managed subtree — never at the `~/.config/cockpit`
+root.
+
+## Data Flow
+
+```
+cockpit <cmd>
+  -> ensureRuntimeSynced()
+       -> for sub in [plugin, templates, scripts]:
+            fp = fingerprint(source/sub)
+            if fp != state[sub]:
+                 mirrorDir(source/sub, runtime/sub)   # copy + prune
+                 state[sub] = fp
+       -> persist .sync-state.json (only if changed)
+  -> dispatch command
+```
+
+## Error Handling
+
+- Source root unresolvable / managed dir missing in source → warn, skip
+  that subtree, continue command.
+- FS error during mirror → warn with the path, leave runtime as-is for
+  that subtree (last-known-good), continue command.
+- Corrupt `.sync-state.json` → treat as empty, full re-sync.
+- Never throw out of `ensureRuntimeSynced`; the CLI must remain usable.
+
+## Testing
+
+`mirrorDir`:
+- copies a new file
+- overwrites a changed file (size and mtime cases)
+- **prunes a file deleted from src**
+- **prunes a dir deleted from src**
+- leaves an unmanaged sibling in dest untouched
+
+`ensureRuntimeSynced`:
+- no-op when fingerprints match (no FS writes, no output)
+- syncs only the changed subtree on partial mismatch
+- never touches user-state files (`config.json` etc.) even when present
+  in the runtime dir
+- missing source dir → warns, command proceeds
+- corrupt/absent state file → full re-sync, then steady state
+
+## Out of Scope (YAGNI)
+
+- No config flags / `--no-sync` escape hatch unless a concrete need arises.
+- No syncing of assets beyond the three managed dirs.
+- No background watcher — the per-invocation check is sufficient and
+  matches the "self-improving, prompted-at-key-moments" model.

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -11,6 +11,7 @@ import {
   resolveHome,
 } from "../config.js";
 import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
+import { ensureRuntimeSynced } from "../lib/runtime-sync.js";
 
 function findPackageRoot(): string {
   let dir = path.dirname(new URL(import.meta.url).pathname);
@@ -90,50 +91,11 @@ export const initCommand = new Command("init")
     const projectsDir = path.join(hubPath, "projects");
     fs.mkdirSync(projectsDir, { recursive: true });
 
-    // 3. Copy scripts to ~/.config/cockpit/scripts/ and make executable
-    const scriptsTemplate = path.join(pkgRoot, "scripts");
-    const scriptsTarget = path.join(configDir, "scripts");
-    if (fs.existsSync(scriptsTemplate)) {
-      fs.mkdirSync(scriptsTarget, { recursive: true });
-      for (const file of fs.readdirSync(scriptsTemplate)) {
-        if (file.endsWith(".sh")) {
-          const src = path.join(scriptsTemplate, file);
-          const dest = path.join(scriptsTarget, file);
-          fs.copyFileSync(src, dest);
-          fs.chmodSync(dest, 0o755);
-        }
-      }
-      console.log(chalk.green(`  ✔ Scripts copied to ${scriptsTarget}`));
-    } else {
-      console.log(chalk.yellow("  ⚠ Scripts directory not found in package"));
-    }
-
-    // 4. Copy CLAUDE.md role templates to ~/.config/cockpit/templates/
-    const orchestratorDir = path.join(pkgRoot, "orchestrator");
-    const templatesTarget = path.join(configDir, "templates");
-    if (fs.existsSync(orchestratorDir)) {
-      fs.mkdirSync(templatesTarget, { recursive: true });
-      for (const file of fs.readdirSync(orchestratorDir)) {
-        if (file.endsWith(".claude.md") || file.endsWith(".generic.md") || file.endsWith(".CLAUDE.md")) {
-          const src = path.join(orchestratorDir, file);
-          const dest = path.join(templatesTarget, file);
-          fs.copyFileSync(src, dest);
-        }
-      }
-      console.log(chalk.green(`  ✔ Role templates copied to ${templatesTarget}`));
-    } else {
-      console.log(chalk.yellow("  ⚠ Orchestrator templates not found in package"));
-    }
-
-    // 5. Copy cockpit plugin (skills) to ~/.config/cockpit/plugin/
-    const pluginSrc = path.join(pkgRoot, "plugin");
-    const pluginTarget = path.join(configDir, "plugin");
-    if (fs.existsSync(pluginSrc)) {
-      copyDirRecursive(pluginSrc, pluginTarget);
-      console.log(chalk.green(`  ✔ Cockpit plugin (skills) copied to ${pluginTarget}`));
-    } else {
-      console.log(chalk.yellow("  ⚠ Plugin directory not found in package"));
-    }
+    // 3. Sync source-managed runtime dirs (plugin, scripts, templates) via
+    // the same self-heal path the CLI runs on every invocation: copy +
+    // prune + chmod, so a re-init never leaves stale files behind.
+    ensureRuntimeSynced({ sourceRoot: pkgRoot, runtimeRoot: configDir });
+    console.log(chalk.green(`  ✔ Runtime assets synced to ${configDir}`));
 
     // 6. Enable Agent Teams in settings.json if not set
     const settingsPath = path.join(os.homedir(), ".claude", "settings.json");

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import { Command } from "commander";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+import { ensureRuntimeSynced } from "./lib/runtime-sync.js";
 import { doctorCommand } from "./commands/doctor.js";
 import { initCommand } from "./commands/init.js";
 import { projectsCommand } from "./commands/projects.js";
@@ -25,6 +27,14 @@ import { projectionCommand } from "./commands/projection.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf-8"));
+
+// Self-heal the runtime copy of source-managed dirs before any command runs,
+// so source changes (skills, role templates, scripts) can never silently
+// drift from ~/.config/cockpit. Never throws.
+ensureRuntimeSynced({
+  sourceRoot: join(__dirname, ".."),
+  runtimeRoot: join(homedir(), ".config", "cockpit"),
+});
 
 const program = new Command();
 

--- a/src/lib/__tests__/runtime-sync.test.ts
+++ b/src/lib/__tests__/runtime-sync.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { mirrorDir, mirrorFlat, ensureRuntimeSynced } from "../runtime-sync.js";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cockpit-sync-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function write(p: string, content: string): void {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, content);
+}
+
+describe("mirrorDir", () => {
+  it("copies a new file from src into a non-existent dest", () => {
+    const src = path.join(tmp, "src");
+    const dest = path.join(tmp, "dest");
+    write(path.join(src, "a.txt"), "hello");
+
+    mirrorDir(src, dest);
+
+    expect(fs.readFileSync(path.join(dest, "a.txt"), "utf-8")).toBe("hello");
+  });
+
+  it("overwrites a file whose content changed in src", () => {
+    const src = path.join(tmp, "src");
+    const dest = path.join(tmp, "dest");
+    write(path.join(src, "a.txt"), "new");
+    write(path.join(dest, "a.txt"), "old");
+
+    mirrorDir(src, dest);
+
+    expect(fs.readFileSync(path.join(dest, "a.txt"), "utf-8")).toBe("new");
+  });
+
+  it("prunes a file present in dest but absent in src", () => {
+    const src = path.join(tmp, "src");
+    const dest = path.join(tmp, "dest");
+    write(path.join(src, "keep.txt"), "keep");
+    write(path.join(dest, "keep.txt"), "keep");
+    write(path.join(dest, "stale.txt"), "stale");
+
+    mirrorDir(src, dest);
+
+    expect(fs.existsSync(path.join(dest, "stale.txt"))).toBe(false);
+    expect(fs.existsSync(path.join(dest, "keep.txt"))).toBe(true);
+  });
+
+  it("prunes a directory present in dest but absent in src", () => {
+    const src = path.join(tmp, "src");
+    const dest = path.join(tmp, "dest");
+    write(path.join(src, "a.txt"), "a");
+    write(path.join(dest, "a.txt"), "a");
+    write(path.join(dest, "gone", "nested.txt"), "x");
+
+    mirrorDir(src, dest);
+
+    expect(fs.existsSync(path.join(dest, "gone"))).toBe(false);
+  });
+
+  it("mirrors nested directories including dotfiles", () => {
+    const src = path.join(tmp, "src");
+    const dest = path.join(tmp, "dest");
+    write(path.join(src, ".claude-plugin", "plugin.json"), "{}");
+
+    mirrorDir(src, dest);
+
+    expect(
+      fs.readFileSync(path.join(dest, ".claude-plugin", "plugin.json"), "utf-8"),
+    ).toBe("{}");
+  });
+
+  it("does not rewrite an unchanged file (idempotent, no mtime churn)", () => {
+    const src = path.join(tmp, "src");
+    const dest = path.join(tmp, "dest");
+    write(path.join(src, "a.txt"), "same");
+    mirrorDir(src, dest);
+    const before = fs.statSync(path.join(dest, "a.txt")).mtimeMs;
+
+    mirrorDir(src, dest);
+
+    expect(fs.statSync(path.join(dest, "a.txt")).mtimeMs).toBe(before);
+  });
+});
+
+describe("mirrorFlat", () => {
+  it("copies only files matching the pattern, ignoring others", () => {
+    const src = path.join(tmp, "src");
+    const dest = path.join(tmp, "dest");
+    write(path.join(src, "a.sh"), "sh");
+    write(path.join(src, "README.md"), "readme");
+    write(path.join(src, "b.sh"), "sh2");
+
+    mirrorFlat(src, dest, /\.sh$/);
+
+    expect(fs.existsSync(path.join(dest, "a.sh"))).toBe(true);
+    expect(fs.existsSync(path.join(dest, "b.sh"))).toBe(true);
+    expect(fs.existsSync(path.join(dest, "README.md"))).toBe(false);
+  });
+
+  it("prunes a dest file no longer in the matched source set", () => {
+    const src = path.join(tmp, "src");
+    const dest = path.join(tmp, "dest");
+    write(path.join(src, "keep.sh"), "k");
+    write(path.join(dest, "keep.sh"), "k");
+    write(path.join(dest, "gone.sh"), "g");
+
+    mirrorFlat(src, dest, /\.sh$/);
+
+    expect(fs.existsSync(path.join(dest, "keep.sh"))).toBe(true);
+    expect(fs.existsSync(path.join(dest, "gone.sh"))).toBe(false);
+  });
+
+  it("applies chmod to copied files when specified", () => {
+    const src = path.join(tmp, "src");
+    const dest = path.join(tmp, "dest");
+    write(path.join(src, "x.sh"), "echo");
+
+    mirrorFlat(src, dest, /\.sh$/, 0o755);
+
+    expect(fs.statSync(path.join(dest, "x.sh")).mode & 0o777).toBe(0o755);
+  });
+
+  it("does not rewrite an unchanged matched file (idempotent)", () => {
+    const src = path.join(tmp, "src");
+    const dest = path.join(tmp, "dest");
+    write(path.join(src, "a.sh"), "x");
+    mirrorFlat(src, dest, /\.sh$/);
+    const before = fs.statSync(path.join(dest, "a.sh")).mtimeMs;
+
+    mirrorFlat(src, dest, /\.sh$/);
+
+    expect(fs.statSync(path.join(dest, "a.sh")).mtimeMs).toBe(before);
+  });
+});
+
+describe("ensureRuntimeSynced", () => {
+  function setupSource(): { sourceRoot: string; runtimeRoot: string } {
+    const sourceRoot = path.join(tmp, "src-root");
+    const runtimeRoot = path.join(tmp, "rt-root");
+    // plugin: tree target
+    write(path.join(sourceRoot, "plugin", "skills", "captain-ops", "SKILL.md"), "captain");
+    write(path.join(sourceRoot, "plugin", ".claude-plugin", "plugin.json"), '{"name":"cockpit"}');
+    // templates: flat target sourced from orchestrator/, filtered by extension
+    write(path.join(sourceRoot, "orchestrator", "captain.claude.md"), "tmpl");
+    write(path.join(sourceRoot, "orchestrator", "notes.txt"), "ignore me");
+    // scripts: flat target, only *.sh, chmod 0o755
+    write(path.join(sourceRoot, "scripts", "learn.sh"), "echo");
+    write(path.join(sourceRoot, "scripts", "README.md"), "ignore me");
+    fs.mkdirSync(runtimeRoot, { recursive: true });
+    return { sourceRoot, runtimeRoot };
+  }
+
+  it("syncs all managed subtrees on first run (no state file)", () => {
+    const { sourceRoot, runtimeRoot } = setupSource();
+
+    ensureRuntimeSynced({ sourceRoot, runtimeRoot });
+
+    expect(
+      fs.readFileSync(path.join(runtimeRoot, "plugin", ".claude-plugin", "plugin.json"), "utf-8"),
+    ).toBe('{"name":"cockpit"}');
+    // templates sourced from orchestrator/, filtered
+    expect(fs.existsSync(path.join(runtimeRoot, "templates", "captain.claude.md"))).toBe(true);
+    expect(fs.existsSync(path.join(runtimeRoot, "templates", "notes.txt"))).toBe(false);
+    // scripts filtered to *.sh and made executable
+    expect(fs.existsSync(path.join(runtimeRoot, "scripts", "learn.sh"))).toBe(true);
+    expect(fs.existsSync(path.join(runtimeRoot, "scripts", "README.md"))).toBe(false);
+    expect(fs.statSync(path.join(runtimeRoot, "scripts", "learn.sh")).mode & 0o777).toBe(0o755);
+  });
+
+  it("is a no-op when source is unchanged (does not rewrite runtime files)", () => {
+    const { sourceRoot, runtimeRoot } = setupSource();
+    ensureRuntimeSynced({ sourceRoot, runtimeRoot });
+    const target = path.join(runtimeRoot, "plugin", "skills", "captain-ops", "SKILL.md");
+    const mtimeBefore = fs.statSync(target).mtimeMs;
+
+    ensureRuntimeSynced({ sourceRoot, runtimeRoot });
+
+    expect(fs.statSync(target).mtimeMs).toBe(mtimeBefore);
+  });
+
+  it("syncs only the subtree whose source changed", () => {
+    const { sourceRoot, runtimeRoot } = setupSource();
+    ensureRuntimeSynced({ sourceRoot, runtimeRoot });
+    const tmplTarget = path.join(runtimeRoot, "templates", "captain.claude.md");
+    const tmplMtime = fs.statSync(tmplTarget).mtimeMs;
+
+    // change only the plugin subtree in source
+    write(path.join(sourceRoot, "plugin", "skills", "new-skill", "SKILL.md"), "new");
+    ensureRuntimeSynced({ sourceRoot, runtimeRoot });
+
+    expect(fs.existsSync(path.join(runtimeRoot, "plugin", "skills", "new-skill", "SKILL.md"))).toBe(true);
+    expect(fs.statSync(tmplTarget).mtimeMs).toBe(tmplMtime);
+  });
+
+  it("never touches user/runtime state files outside managed subtrees", () => {
+    const { sourceRoot, runtimeRoot } = setupSource();
+    write(path.join(runtimeRoot, "config.json"), '{"user":"data"}');
+    write(path.join(runtimeRoot, "sessions.json"), '{"s":1}');
+    fs.mkdirSync(path.join(runtimeRoot, "spokes", "oneplan"), { recursive: true });
+
+    ensureRuntimeSynced({ sourceRoot, runtimeRoot });
+
+    expect(fs.readFileSync(path.join(runtimeRoot, "config.json"), "utf-8")).toBe('{"user":"data"}');
+    expect(fs.readFileSync(path.join(runtimeRoot, "sessions.json"), "utf-8")).toBe('{"s":1}');
+    expect(fs.existsSync(path.join(runtimeRoot, "spokes", "oneplan"))).toBe(true);
+  });
+
+  it("does not throw when a managed source dir is missing", () => {
+    const { sourceRoot, runtimeRoot } = setupSource();
+    fs.rmSync(path.join(sourceRoot, "scripts"), { recursive: true, force: true });
+
+    expect(() => ensureRuntimeSynced({ sourceRoot, runtimeRoot })).not.toThrow();
+    expect(fs.existsSync(path.join(runtimeRoot, "plugin", ".claude-plugin"))).toBe(true);
+  });
+
+  it("self-heals an incomplete dest even when source is unchanged", () => {
+    const { sourceRoot, runtimeRoot } = setupSource();
+    ensureRuntimeSynced({ sourceRoot, runtimeRoot });
+    // simulate runtime corruption: a synced file goes missing
+    const victim = path.join(runtimeRoot, "plugin", ".claude-plugin", "plugin.json");
+    fs.rmSync(victim);
+    expect(fs.existsSync(victim)).toBe(false);
+
+    // source is unchanged — must still repair (no state cache that can lie)
+    ensureRuntimeSynced({ sourceRoot, runtimeRoot });
+
+    expect(fs.readFileSync(victim, "utf-8")).toBe('{"name":"cockpit"}');
+  });
+
+  it("does not write a .sync-state.json (no cache)", () => {
+    const { sourceRoot, runtimeRoot } = setupSource();
+    ensureRuntimeSynced({ sourceRoot, runtimeRoot });
+    expect(fs.existsSync(path.join(runtimeRoot, ".sync-state.json"))).toBe(false);
+  });
+});

--- a/src/lib/runtime-sync.ts
+++ b/src/lib/runtime-sync.ts
@@ -1,0 +1,146 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Copy `src` → `dest` only if `dest` is missing or its bytes differ. Content
+ * comparison (not size+mtime) makes this both correct — a same-size edit is
+ * always detected — and idempotent: an unchanged file is never rewritten, so
+ * there is no mtime churn across runs. Managed files are small; reading them
+ * per invocation is sub-millisecond. Returns true if a copy happened.
+ */
+function copyIfDifferent(src: string, dest: string): boolean {
+  if (fs.existsSync(dest)) {
+    if (fs.readFileSync(src).equals(fs.readFileSync(dest))) return false;
+  }
+  fs.copyFileSync(src, dest);
+  return true;
+}
+
+/**
+ * Mirror `src` into `dest`: recursively copy new/changed files AND prune any
+ * dest entry that no longer exists in src. Idempotent — unchanged files are
+ * left untouched. After this returns, `dest` is a structural copy of `src`.
+ * Caller is responsible for only pointing this at source-managed trees — it
+ * WILL delete dest entries absent from src.
+ */
+export function mirrorDir(src: string, dest: string): void {
+  fs.mkdirSync(dest, { recursive: true });
+
+  const srcEntries = fs.readdirSync(src, { withFileTypes: true });
+  const srcNames = new Set(srcEntries.map((e) => e.name));
+
+  for (const entry of srcEntries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      mirrorDir(srcPath, destPath);
+    } else {
+      copyIfDifferent(srcPath, destPath);
+    }
+  }
+
+  for (const entry of fs.readdirSync(dest, { withFileTypes: true })) {
+    if (!srcNames.has(entry.name)) {
+      fs.rmSync(path.join(dest, entry.name), { recursive: true, force: true });
+    }
+  }
+}
+
+/**
+ * Copy the top-level (non-recursive) files of `src` matching `match` into a
+ * flat `dest`, prune dest entries no longer in the matched set, and apply
+ * `chmod` to freshly copied files when given. Idempotent — unchanged files
+ * are left untouched. For runtime dirs whose source is a differently-named,
+ * mixed directory (templates ← orchestrator/, scripts).
+ */
+export function mirrorFlat(
+  src: string,
+  dest: string,
+  match: RegExp,
+  chmod?: number,
+): void {
+  fs.mkdirSync(dest, { recursive: true });
+
+  const matched = fs
+    .readdirSync(src, { withFileTypes: true })
+    .filter((e) => e.isFile() && match.test(e.name))
+    .map((e) => e.name);
+  const matchedSet = new Set(matched);
+
+  for (const name of matched) {
+    const destPath = path.join(dest, name);
+    const copied = copyIfDifferent(path.join(src, name), destPath);
+    if (copied && chmod !== undefined) fs.chmodSync(destPath, chmod);
+  }
+
+  for (const entry of fs.readdirSync(dest, { withFileTypes: true })) {
+    if (!matchedSet.has(entry.name)) {
+      fs.rmSync(path.join(dest, entry.name), { recursive: true, force: true });
+    }
+  }
+}
+
+/**
+ * A source-managed runtime dir. `name` is the dir under the runtime root;
+ * `srcRel` is its source dir relative to the package root (note: the
+ * runtime `templates/` is sourced from `orchestrator/`).
+ */
+export type ManagedTarget =
+  | { name: string; srcRel: string; mode: "tree" }
+  | {
+      name: string;
+      srcRel: string;
+      mode: "flat";
+      match: RegExp;
+      chmod?: number;
+    };
+
+export const MANAGED_TARGETS: ManagedTarget[] = [
+  { name: "plugin", srcRel: "plugin", mode: "tree" },
+  { name: "scripts", srcRel: "scripts", mode: "flat", match: /\.sh$/, chmod: 0o755 },
+  {
+    name: "templates",
+    srcRel: "orchestrator",
+    mode: "flat",
+    match: /\.(claude\.md|generic\.md|CLAUDE\.md)$/,
+  },
+];
+
+export interface EnsureRuntimeSyncedOptions {
+  /** Package root containing the source dirs (`plugin/`, `orchestrator/`, …). */
+  sourceRoot: string;
+  /** Runtime root, normally ~/.config/cockpit. */
+  runtimeRoot: string;
+  /** Override the managed-target list (defaults to MANAGED_TARGETS). */
+  targets?: ManagedTarget[];
+}
+
+/**
+ * Self-heal the runtime copy of source-managed dirs. Every invocation
+ * mirrors each managed target (mirrorDir for tree, mirrorFlat for flat) —
+ * idempotent copy-if-different + prune, so the runtime is always reconciled
+ * to source. There is no cached state: nothing can claim "synced" while the
+ * dest is actually wrong. Only ever touches the runtime dirs named in the
+ * target list — never user/runtime state. Never throws — a sync failure
+ * degrades to a stderr warning so the CLI stays usable.
+ */
+export function ensureRuntimeSynced(opts: EnsureRuntimeSyncedOptions): void {
+  const targets = opts.targets ?? MANAGED_TARGETS;
+
+  for (const t of targets) {
+    const srcDir = path.join(opts.sourceRoot, t.srcRel);
+    try {
+      if (!fs.existsSync(srcDir)) continue;
+      const destDir = path.join(opts.runtimeRoot, t.name);
+      if (t.mode === "tree") {
+        mirrorDir(srcDir, destDir);
+      } else {
+        mirrorFlat(srcDir, destDir, t.match, t.chmod);
+      }
+    } catch (err) {
+      process.stderr.write(
+        `cockpit: runtime sync skipped for ${t.name}: ${(err as Error).message}\n`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Problem

The CLI loads `plugin/`, `templates/`, `scripts/` from `~/.config/cockpit`, deployed by a one-shot **additive** `cockpit init` copy (`copyDirRecursive`). Two production failures:

1. **No re-sync** — source changes never reach runtime. PRs #72/#73 fixed the plugin manifest in source but captains kept launching with a stale, manifest-less `~/.config/cockpit/plugin` → `cockpit:captain-ops` / `plugin:captain-ops` / `captain-ops` all failed to resolve.
2. **No prune** — `copyDirRecursive` never removed deletions, so a re-`init` left stale files (e.g. the dead `package.json`).

Root-caused this session; see `docs/specs/2026-05-17-runtime-self-heal-sync-design.md`.

## Change

`src/lib/runtime-sync.ts`: `ensureRuntimeSynced()` runs at CLI entry (`src/index.ts`) and is reused by `cockpit init` — **one code path**.

- `mirrorDir` (tree) / `mirrorFlat` (flat, filtered, chmod) — `copyIfDifferent` by **content** + prune. Idempotent: unchanged files not rewritten (no mtime churn).
- `MANAGED_TARGETS` descriptors map the real layout (discovered from `init.ts`): `templates` ← `orchestrator/` filtered; `scripts` ← `*.sh` +`0755`; `plugin` ← full tree.
- **Cacheless by design.** A fingerprint/`.sync-state.json` cache was implemented then **rejected**: a source-only cache can report "synced" over an incomplete dest and block self-heal (observed: `templates/` left 2 of 7 files). Mirroring tiny dirs every run is sub-10ms and cannot be poisoned. Any leftover `.sync-state.json` is inert.
- Only ever touches managed dirs — never `config.json`/`sessions.json`/`spokes/`/etc. Never throws (per-target warn + continue).
- `init` drops its bespoke plugin/scripts/templates copy blocks; the hub-vault scaffold stays **additive** (a user vault must never be pruned).

## Verification

- 17 new tests: `mirrorDir`/`mirrorFlat`/`ensureRuntimeSynced`, incl. **self-heal of a corrupted dest with unchanged source**, never-touch-user-state, idempotence, filtering, chmod, prune.
- Full suite: 318 pass. The only 2 failures (`config.test.ts`) are **pre-existing on develop** (workspace-icon emoji vs stale assertion) — untouched by this branch, flagged separately.
- `gitnexus detect_changes`: LOW, 0 processes affected.
- **End-to-end:** `cockpit init` then fresh `cockpit launch oneplan` → captain screen shows `Skill(cockpit:captain-ops)` → "Successfully loaded skill" on first try, no Unknown-skill error; proceeded into the real startup checklist using synced scripts.
- Real-runtime self-heal proven: deleting the manifest + a template, then any `cockpit` command, restored them with source unchanged.

## Follow-ups (not in this PR)

- Pre-existing `config.test.ts` failures on develop (stale assertion vs `🏛️` default `commandName`).