### PR TITLE
docs: cockpit interactive-codex — orca study + spec + plan

### DIFF
--- a/docs/plans/2026-05-20-cockpit-interactive-codex.md
+++ b/docs/plans/2026-05-20-cockpit-interactive-codex.md
@@ -1,0 +1,2547 @@
+# Cockpit Interactive Codex Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship live human↔codex chat in a cmux tab, driven by the `codex app-server` JSON-RPC protocol — no TUI scraping, real turn signals, daemon-bounce resilience via `thread/resume`.
+
+**Architecture:** Approach 3, two-phase. **Phase 1** builds a standalone typed JSON-RPC client lib for the codex app-server protocol + a smoke command whose approval round-trip is the empirical go/no-go gate. **Phase 2** wires the proven lib into `cockpitd` as the interactive driver, adds a streaming subscribe channel to the daemon socket, ships `cockpit crew chat` + `cockpit crew attach` as the cmux-tab surface, and closes the interactive-codex slice of #86 via a `resumeRef`-on-every-transition `DispatchAttempt` schema.
+
+**Tech Stack:** TypeScript (strict, ESM, `target: ES2022`, `.js` import suffix), vitest, commander, node:net AF_UNIX, codex-cli ≥0.130.0 (`codex app-server` JSON-RPC v2).
+
+**Spec:** `docs/specs/2026-05-20-cockpit-interactive-codex-design.md` (branch `docs/codex-interactive-design @ 82e2425`).
+
+**Conventions seen in cockpit (follow these):**
+- Tests are vitest siblings in `src/control/__tests__/<source>.test.ts`; pattern in `src/control/__tests__/store.test.ts:1-40`.
+- All TS imports use `.js` suffix (ESM).
+- Pure functions kept pure (`state-machine.ts::reduce`); side effects live in adapters/launchers.
+- Newline-delimited JSON framing already exists in `src/control/protocol.ts::createDecoder`; reuse the shape, do not re-invent it.
+- Anti-#2576 invariant is enforced in `state-machine.ts`; never auto-promote a `TurnCompleted` to `done`.
+
+---
+
+## File Structure
+
+### Phase 1 — `feature/codex-app-server-client`
+
+**Create:**
+- `src/control/codex/protocol/` — directory for `codex app-server generate-ts` output. Generated, not hand-edited. One auto-regenerated `README.md` at root saying "do not edit by hand."
+- `src/control/codex/app-server-client.ts` — the typed JSON-RPC client. Public API: `initialize/startThread/resumeThread/readThread/sendTurn/steerTurn/interruptTurn/injectItems/respondToServerRequest`, event emitter, lifecycle.
+- `src/control/codex/__tests__/app-server-client.test.ts` — unit tests with a mocked child stdio.
+- `src/control/codex/__tests__/app-server-client.smoke.test.ts` — integration tests that spawn real `codex app-server`; gated by `RUN_CODEX_SMOKE=1` so CI without codex skips.
+- `src/commands/codex-chat-smoke.ts` — the `cockpit codex-chat-smoke` CLI command.
+- `scripts/gen-codex-types.sh` — regenerates `src/control/codex/protocol/` via `codex app-server generate-ts --experimental --out`.
+
+**Modify:**
+- `src/index.ts` — register the `codex-chat-smoke` command.
+- `package.json` — add `"codex:gen-types": "bash scripts/gen-codex-types.sh"` script.
+
+### Phase 2 — `feature/codex-interactive-crew` (off Phase 1)
+
+**Create:**
+- `src/control/codex/driver.ts` — the daemon-side interactive driver. Owns one long-lived `codex app-server` child via `AppServerClient`, maps `TaskRecord` ↔ `threadId`, emits `ControlEvent`s for `reduce()`.
+- `src/control/codex/normalize.ts` — pure `normalizeAppServerNotification(n) → CanonicalEvent` with `never`-guarded exhaustive switch.
+- `src/control/codex/gate.ts` — pure gate helpers (`promoteToGate`, `resolveGate`, `timeoutGate`).
+- `src/control/codex/__tests__/driver.test.ts`, `normalize.test.ts`, `gate.test.ts`.
+- `src/commands/crew-chat.ts` — `cockpit crew chat --provider codex --project X [--cwd …] [--model …]`.
+- `src/commands/crew-attach.ts` — `cockpit crew attach <taskId>` cmux-tab renderer/input client.
+- `src/control/__tests__/streaming-protocol.test.ts` — covers the new attach/say/steer/answer frames.
+
+**Modify:**
+- `src/control/types.ts` — add `DispatchAttempt` + `Gate` + `attempts: DispatchAttempt[]` on `TaskRecord`; add new `ControlEvent` variants for app-server notifications (`turn.started`, `turn.completed`, `input.requested`, `approval.requested`, `delta`, `reattached`).
+- `src/control/state-machine.ts` — write `resumeRef` to current attempt on every transition; add transitions for new events (`working → awaiting-input → working`; `→ blocked → working`).
+- `src/control/protocol.ts` — add the streaming subscribe verb (`{op:"attach", taskId}` + frame emit helpers); cooperate with #87 schema validation when it lands.
+- `src/control/daemon.ts` — wire `launchInteractive` for `provider=codex` to the driver in `src/control/codex/driver.ts`; surface `gates` on status/list replies.
+- `src/control/cockpitd.ts` — inject the codex driver into `DaemonDeps.launchInteractive`; on daemon start, iterate non-terminal interactive-codex tasks and call `driver.reattach(resumeRef)`.
+- `src/control/interactive/codex.ts` — **delete** (the old "best-effort" hook adapter is replaced by the app-server driver) and remove from `src/control/interactive/registry.ts`. Keep `claude.ts` untouched.
+- `src/commands/crew-control.ts` — extend `cockpit crew status` output to include `attempts[]` (current attempt's `resumeRef`, `lastHeartbeatAt`, `circuitBroken`) and any `gates`; add `cockpit crew reply --gate <gateId>`.
+- `src/index.ts` — register `crew-chat`, `crew-attach` (subcommands of `crew`).
+
+---
+
+## Phase Gate
+
+**Phase 1 must PASS the approval round-trip smoke before any Phase 2 task starts.** If the round-trip fails against real codex, stop and revisit the design (Path Y from the orca study becomes the considered fallback; that decision is cheap at this point because Phase 2 hasn't begun).
+
+---
+
+# PHASE 1 — codexAppServerClient + smoke gate
+
+### Task 1.0: Branch off develop
+
+**Files:** none.
+
+- [ ] **Step 1: Create branch**
+
+```bash
+git checkout develop
+git pull --ff-only
+git checkout -b feature/codex-app-server-client
+```
+
+- [ ] **Step 2: Verify clean state**
+
+```bash
+git status
+npm run lint  # expect: clean (tsc --noEmit, no output)
+npm test --silent -- --run  # expect: all green pre-change
+```
+
+---
+
+### Task 1.1: Vendor the app-server protocol types
+
+**Files:**
+- Create: `scripts/gen-codex-types.sh`
+- Create: `src/control/codex/protocol/README.md`
+- Modify: `package.json` (add script)
+- Generated (committed): `src/control/codex/protocol/*.ts`
+
+- [ ] **Step 1: Write the generator script**
+
+```bash
+mkdir -p scripts src/control/codex/protocol
+cat > scripts/gen-codex-types.sh <<'SH'
+#!/usr/bin/env bash
+# Regenerate the codex app-server protocol bindings.
+# Requires codex-cli ≥0.130.0 on PATH.
+set -euo pipefail
+OUT="src/control/codex/protocol"
+rm -rf "$OUT"
+mkdir -p "$OUT"
+codex app-server generate-ts --experimental --out "$OUT"
+cat > "$OUT/README.md" <<'MD'
+# codex app-server protocol bindings (auto-generated)
+
+Generated by `npm run codex:gen-types` (`scripts/gen-codex-types.sh`).
+**DO NOT EDIT BY HAND.** Re-run the generator to update.
+
+Source: `codex app-server generate-ts --experimental --out <here>` against
+`codex-cli ≥0.130.0`. See `docs/specs/2026-05-20-cockpit-interactive-codex-design.md` §3.3.
+MD
+echo "Generated $OUT"
+SH
+chmod +x scripts/gen-codex-types.sh
+```
+
+- [ ] **Step 2: Add the npm script**
+
+Modify `package.json` `"scripts"` block to add (after `"lint"`):
+
+```json
+"codex:gen-types": "bash scripts/gen-codex-types.sh"
+```
+
+- [ ] **Step 3: Run the generator**
+
+```bash
+npm run codex:gen-types
+ls src/control/codex/protocol | head -5
+# expect: ClientRequest.json/.ts, ServerNotification.json/.ts, etc.
+```
+
+If `codex` is not on PATH, install codex-cli ≥0.130.0 first; do not proceed without real generated types.
+
+- [ ] **Step 4: Verify build still passes**
+
+```bash
+npm run build  # expect: clean
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/gen-codex-types.sh package.json src/control/codex/protocol
+git commit -m "feat(codex): vendor codex app-server v2 protocol types
+
+Generated via 'codex app-server generate-ts --experimental' against
+codex-cli ≥0.130.0. Regenerable via 'npm run codex:gen-types'."
+```
+
+---
+
+### Task 1.2: Newline-framed JSON decoder for app-server stdio
+
+**Files:**
+- Create: `src/control/codex/__tests__/app-server-client.test.ts`
+- Create: `src/control/codex/app-server-client.ts`
+
+Cockpit already has `createDecoder()` in `src/control/protocol.ts:7-24`. The app-server uses the same shape (newline-delimited JSON, must ignore non-JSON lines defensively per orca `codex-fetcher.ts:160-164`). Reuse the pattern; we'll wrap it inside the client.
+
+- [ ] **Step 1: Write the failing parser test**
+
+Create `src/control/codex/__tests__/app-server-client.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { _parseChunk } from "../app-server-client.js";
+
+describe("app-server-client._parseChunk", () => {
+  it("parses one newline-terminated JSON object", () => {
+    const acc = { buf: "" };
+    expect(_parseChunk(acc, '{"a":1}\n')).toEqual([{ a: 1 }]);
+    expect(acc.buf).toBe("");
+  });
+  it("accumulates partial lines across chunks", () => {
+    const acc = { buf: "" };
+    expect(_parseChunk(acc, '{"a":')).toEqual([]);
+    expect(_parseChunk(acc, '1}\n')).toEqual([{ a: 1 }]);
+  });
+  it("skips non-JSON lines defensively", () => {
+    const acc = { buf: "" };
+    expect(_parseChunk(acc, 'noise\n{"ok":true}\nmore noise\n')).toEqual([{ ok: true }]);
+  });
+  it("returns multiple objects from one chunk", () => {
+    const acc = { buf: "" };
+    expect(_parseChunk(acc, '{"a":1}\n{"b":2}\n')).toEqual([{ a: 1 }, { b: 2 }]);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL (module not found)**
+
+```bash
+npm test -- --run src/control/codex/__tests__/app-server-client.test.ts
+# expect: cannot find module '../app-server-client.js'
+```
+
+- [ ] **Step 3: Implement minimal `_parseChunk` + skeleton**
+
+Create `src/control/codex/app-server-client.ts`:
+
+```ts
+// src/control/codex/app-server-client.ts
+// Typed JSON-RPC 2.0 client for `codex app-server` v2.
+// Transport: stdio (newline-delimited JSON). See spec §3.
+// Defensive parser per orca codex-fetcher.ts:160-164: ignore non-JSON lines.
+
+export function _parseChunk(acc: { buf: string }, chunk: string): unknown[] {
+  acc.buf += chunk;
+  const out: unknown[] = [];
+  let idx: number;
+  while ((idx = acc.buf.indexOf("\n")) >= 0) {
+    const line = acc.buf.slice(0, idx);
+    acc.buf = acc.buf.slice(idx + 1);
+    if (!line.trim()) continue;
+    try { out.push(JSON.parse(line)); } catch { /* skip non-JSON defensively */ }
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run — expect PASS (all 4)**
+
+```bash
+npm test -- --run src/control/codex/__tests__/app-server-client.test.ts
+# expect: 4 passed
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/control/codex/app-server-client.ts src/control/codex/__tests__/app-server-client.test.ts
+git commit -m "feat(codex): defensive newline-framed JSON parser for app-server stdio"
+```
+
+---
+
+### Task 1.3: AppServerClient — spawn / kill / wire stdio
+
+**Files:**
+- Modify: `src/control/codex/app-server-client.ts`
+- Modify: `src/control/codex/__tests__/app-server-client.test.ts`
+
+The class owns a child process and pushes its stdout through `_parseChunk`. Tests inject a fake spawn so they don't need real codex.
+
+- [ ] **Step 1: Write the failing lifecycle test**
+
+Append to `app-server-client.test.ts`:
+
+```ts
+import { AppServerClient } from "../app-server-client.js";
+import { EventEmitter } from "node:events";
+
+function fakeChild() {
+  const stdin = new EventEmitter() as any;
+  stdin.write = (s: string) => { (stdin as any)._written = ((stdin as any)._written ?? "") + s; return true; };
+  stdin.end = () => {};
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+  const proc = new EventEmitter() as any;
+  proc.stdin = stdin; proc.stdout = stdout; proc.stderr = stderr;
+  proc.kill = (signal?: string) => { proc.emit("exit", 0, signal ?? null); };
+  return proc;
+}
+
+describe("AppServerClient lifecycle", () => {
+  it("spawns via injected spawner and emits 'closed' on child exit", async () => {
+    const proc = fakeChild();
+    const c = new AppServerClient({ spawn: () => proc });
+    const closed = new Promise<void>((res) => c.on("closed", () => res()));
+    c.start();
+    proc.emit("exit", 0, null);
+    await closed;
+  });
+  it("kill() ends the child", () => {
+    const proc = fakeChild();
+    const c = new AppServerClient({ spawn: () => proc });
+    c.start();
+    c.kill();
+    // exit emitted synchronously by fake; emitter's 'closed' fires
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+npm test -- --run src/control/codex/__tests__/app-server-client.test.ts
+# expect: AppServerClient is not a constructor
+```
+
+- [ ] **Step 3: Implement the class skeleton**
+
+Append to `src/control/codex/app-server-client.ts`:
+
+```ts
+import { EventEmitter } from "node:events";
+import { spawn as nodeSpawn, type ChildProcessByStdio } from "node:child_process";
+import type { Readable, Writable } from "node:stream";
+
+type Child = ChildProcessByStdio<Writable, Readable, Readable>;
+
+export interface AppServerClientOpts {
+  /** Override for tests; defaults to spawning real `codex app-server`. */
+  spawn?: () => Child;
+  clientInfo?: { name: string; version: string };
+}
+
+export class AppServerClient extends EventEmitter {
+  private proc?: Child;
+  private acc = { buf: "" };
+  private opts: AppServerClientOpts;
+  constructor(opts: AppServerClientOpts = {}) { super(); this.opts = opts; }
+
+  start(): void {
+    if (this.proc) throw new Error("AppServerClient already started");
+    const sp = this.opts.spawn ?? defaultSpawn;
+    this.proc = sp();
+    this.proc.stdout.on("data", (d: Buffer | string) => this._onStdout(d.toString()));
+    this.proc.stderr.on("data", (d: Buffer | string) => this.emit("stderr", d.toString()));
+    this.proc.on("exit", (code, signal) => this.emit("closed", { code, signal }));
+    this.proc.on("error", (e) => this.emit("error", e));
+  }
+
+  kill(): void {
+    if (this.proc) this.proc.kill();
+  }
+
+  private _onStdout(s: string): void {
+    for (const msg of _parseChunk(this.acc, s)) this._dispatch(msg);
+  }
+
+  // Filled in Task 1.4+.
+  private _dispatch(_msg: unknown): void { /* noop until pending-map lands */ }
+}
+
+function defaultSpawn(): Child {
+  return nodeSpawn("codex", ["app-server"], { stdio: ["pipe", "pipe", "pipe"] }) as Child;
+}
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+npm test -- --run src/control/codex/__tests__/app-server-client.test.ts
+# expect: all passed
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u
+git commit -m "feat(codex): AppServerClient lifecycle (spawn/kill/stdout pipe)"
+```
+
+---
+
+### Task 1.4: Pending-request map + `sendRequest`
+
+**Files:**
+- Modify: `src/control/codex/app-server-client.ts`
+- Modify: `src/control/codex/__tests__/app-server-client.test.ts`
+
+JSON-RPC 2.0: every outbound request gets a unique `id`; a response with the matching `id` resolves the promise. Per orca `codex-fetcher.ts:172-175`, messages with no `id` are notifications (Task 1.5).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `app-server-client.test.ts`:
+
+```ts
+describe("AppServerClient.sendRequest (correlation by id)", () => {
+  it("resolves with result when the response arrives", async () => {
+    const proc = fakeChild();
+    const c = new AppServerClient({ spawn: () => proc });
+    c.start();
+    // Bypass handshake gate for this unit-level test:
+    (c as any)._handshakeDone = true;
+    const p = (c as any)._sendRequest("foo/bar", { x: 1 });
+    // Read the written line, mirror back a response
+    const written = (proc.stdin as any)._written as string;
+    const req = JSON.parse(written.trim());
+    expect(req.method).toBe("foo/bar");
+    expect(req.params).toEqual({ x: 1 });
+    proc.stdout.emit("data", JSON.stringify({ jsonrpc: "2.0", id: req.id, result: { ok: true } }) + "\n");
+    await expect(p).resolves.toEqual({ ok: true });
+  });
+  it("rejects with error when an error response arrives", async () => {
+    const proc = fakeChild();
+    const c = new AppServerClient({ spawn: () => proc });
+    c.start();
+    (c as any)._handshakeDone = true;
+    const p = (c as any)._sendRequest("foo/bar", {});
+    const req = JSON.parse((proc.stdin as any)._written.trim());
+    proc.stdout.emit("data", JSON.stringify({ jsonrpc: "2.0", id: req.id, error: { code: -32601, message: "boom" } }) + "\n");
+    await expect(p).rejects.toThrow(/boom/);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+npm test -- --run src/control/codex/__tests__/app-server-client.test.ts
+```
+
+- [ ] **Step 3: Implement `_sendRequest` + `_dispatch` response routing**
+
+Add to `AppServerClient`:
+
+```ts
+  private nextId = 1;
+  private pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+  protected _handshakeDone = false;
+
+  protected _sendRequest(method: string, params?: unknown): Promise<unknown> {
+    if (!this._handshakeDone && method !== "initialize") {
+      throw new Error(`AppServerClient: cannot call '${method}' before handshake (spec §3.2)`);
+    }
+    if (!this.proc) throw new Error("AppServerClient not started");
+    const id = this.nextId++;
+    const env = { jsonrpc: "2.0", id, method, params: params ?? {} };
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.proc!.stdin.write(JSON.stringify(env) + "\n");
+    });
+  }
+
+  private _dispatchResponse(msg: any): boolean {
+    if (typeof msg?.id !== "number") return false;
+    const slot = this.pending.get(msg.id);
+    if (!slot) return false;
+    this.pending.delete(msg.id);
+    if (msg.error) slot.reject(new Error(`${msg.error.message ?? "rpc-error"} (code ${msg.error.code})`));
+    else slot.resolve(msg.result);
+    return true;
+  }
+```
+
+Replace the placeholder `_dispatch`:
+
+```ts
+  private _dispatch(msg: unknown): void {
+    if (this._dispatchResponse(msg)) return;
+    // Notifications (id-less) handled in Task 1.5.
+  }
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+npm test -- --run src/control/codex/__tests__/app-server-client.test.ts
+# expect: all pass (incl. error rejection)
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u
+git commit -m "feat(codex): id-correlated sendRequest + error routing"
+```
+
+---
+
+### Task 1.5: Notification fanout + typed event emitter
+
+**Files:**
+- Modify: `src/control/codex/app-server-client.ts`
+- Modify: `src/control/codex/__tests__/app-server-client.test.ts`
+
+Per orca `codex-fetcher.ts:172-175` and our spec §4.7: messages with no `id` are notifications, routed by `method`. Surface them as typed events.
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```ts
+describe("AppServerClient notifications", () => {
+  it("emits 'notification' with method+params for id-less messages", async () => {
+    const proc = fakeChild();
+    const c = new AppServerClient({ spawn: () => proc });
+    c.start();
+    const got: any[] = [];
+    c.on("notification", (n) => got.push(n));
+    proc.stdout.emit("data",
+      JSON.stringify({ jsonrpc: "2.0", method: "agentMessageDelta", params: { text: "hi" } }) + "\n");
+    expect(got).toEqual([{ method: "agentMessageDelta", params: { text: "hi" } }]);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+npm test -- --run src/control/codex/__tests__/app-server-client.test.ts
+```
+
+- [ ] **Step 3: Implement notification routing**
+
+Replace `_dispatch` again:
+
+```ts
+  private _dispatch(msg: unknown): void {
+    if (this._dispatchResponse(msg)) return;
+    if (typeof (msg as any)?.method === "string" && (msg as any).id === undefined) {
+      this.emit("notification", { method: (msg as any).method, params: (msg as any).params });
+      return;
+    }
+    // Server requests (have method AND id) handled in Task 1.10.
+  }
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+npm test -- --run src/control/codex/__tests__/app-server-client.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u
+git commit -m "feat(codex): notification fanout (id-less messages routed by method)"
+```
+
+---
+
+### Task 1.6: Handshake enforcement (initialize → initialized → methods)
+
+**Files:**
+- Modify: `src/control/codex/app-server-client.ts`
+- Modify: `src/control/codex/__tests__/app-server-client.test.ts`
+
+Per orca `codex-fetcher.ts:142-146` and spec §3.2: `initialize` (request) → await response → `initialized` (notification, no id) → only then any other method. The client must refuse pre-handshake methods.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append:
+
+```ts
+describe("AppServerClient handshake", () => {
+  it("refuses any method call before handshake", async () => {
+    const proc = fakeChild();
+    const c = new AppServerClient({ spawn: () => proc });
+    c.start();
+    expect(() => (c as any)._sendRequest("turn/start", {})).toThrow(/before handshake/);
+  });
+  it("initialize sends a request, awaits response, then sends 'initialized' notification", async () => {
+    const proc = fakeChild();
+    const c = new AppServerClient({ spawn: () => proc, clientInfo: { name: "cockpit", version: "test" } });
+    c.start();
+    const p = c.initialize();
+    const first = JSON.parse((proc.stdin as any)._written.trim().split("\n")[0]);
+    expect(first.method).toBe("initialize");
+    expect(first.params.clientInfo).toEqual({ name: "cockpit", version: "test" });
+    proc.stdout.emit("data", JSON.stringify({ jsonrpc: "2.0", id: first.id, result: { capabilities: {} } }) + "\n");
+    await p;
+    const lines = (proc.stdin as any)._written.trim().split("\n");
+    const last = JSON.parse(lines[lines.length - 1]);
+    expect(last.method).toBe("initialized");
+    expect(last.id).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`initialize is not a function`)
+
+- [ ] **Step 3: Implement `initialize`**
+
+Add to `AppServerClient`:
+
+```ts
+  async initialize(): Promise<unknown> {
+    if (this._handshakeDone) return;
+    if (!this.proc) throw new Error("AppServerClient not started");
+    const info = this.opts.clientInfo ?? { name: "cockpit", version: "0" };
+    // Send initialize directly (bypass gate) — only initialize may pre-handshake.
+    const id = this.nextId++;
+    const env = { jsonrpc: "2.0", id, method: "initialize", params: { clientInfo: info } };
+    const res = await new Promise<unknown>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.proc!.stdin.write(JSON.stringify(env) + "\n");
+    });
+    // Send 'initialized' as a notification (no id).
+    this.proc.stdin.write(JSON.stringify({ jsonrpc: "2.0", method: "initialized" }) + "\n");
+    this._handshakeDone = true;
+    return res;
+  }
+```
+
+(Replace the throw in `_sendRequest`'s pre-handshake guard with the same — it already handles the gate.)
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+npm test -- --run src/control/codex/__tests__/app-server-client.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u
+git commit -m "feat(codex): mandatory handshake (initialize → initialized → methods)
+
+Refuses any method call before handshake completes — orca codex-fetcher.ts:142-146
+documents that skipping the 'initialized' notification produces 'Not initialized'
+errors. Spec §3.2."
+```
+
+---
+
+### Task 1.7: Thread lifecycle — `startThread` / `resumeThread` / `readThread`
+
+**Files:**
+- Modify: `src/control/codex/app-server-client.ts`
+- Modify: `src/control/codex/__tests__/app-server-client.test.ts`
+
+Per the v2 protocol (see `src/control/codex/protocol/codex_app_server_protocol.v2.schemas.json`): method names are `thread/start`, `thread/resume`, `thread/read`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```ts
+describe("AppServerClient thread lifecycle", () => {
+  it("startThread → thread/start with cwd; returns threadId", async () => {
+    const proc = fakeChild();
+    const c = new AppServerClient({ spawn: () => proc });
+    c.start();
+    (c as any)._handshakeDone = true;
+    const p = c.startThread({ cwd: "/tmp/x" });
+    const req = JSON.parse((proc.stdin as any)._written.trim().split("\n").pop()!);
+    expect(req.method).toBe("thread/start");
+    expect(req.params.cwd).toBe("/tmp/x");
+    proc.stdout.emit("data", JSON.stringify({ jsonrpc: "2.0", id: req.id, result: { threadId: "T1" } }) + "\n");
+    await expect(p).resolves.toEqual({ threadId: "T1" });
+  });
+  it("resumeThread → thread/resume with threadId", async () => {
+    const proc = fakeChild();
+    const c = new AppServerClient({ spawn: () => proc });
+    c.start();
+    (c as any)._handshakeDone = true;
+    const p = c.resumeThread({ threadId: "T1", cwd: "/tmp/x" });
+    const req = JSON.parse((proc.stdin as any)._written.trim().split("\n").pop()!);
+    expect(req.method).toBe("thread/resume");
+    expect(req.params.threadId).toBe("T1");
+    proc.stdout.emit("data", JSON.stringify({ jsonrpc: "2.0", id: req.id, result: {} }) + "\n");
+    await p;
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: Implement**
+
+Add to `AppServerClient`:
+
+```ts
+  startThread(params: { cwd: string; model?: string; sandbox?: string; approvalPolicy?: string }): Promise<{ threadId: string }> {
+    return this._sendRequest("thread/start", params) as Promise<{ threadId: string }>;
+  }
+  resumeThread(params: { threadId: string; cwd?: string }): Promise<unknown> {
+    return this._sendRequest("thread/resume", params);
+  }
+  readThread(params: { threadId: string; lastN?: number }): Promise<unknown> {
+    return this._sendRequest("thread/read", params);
+  }
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u
+git commit -m "feat(codex): thread/start, thread/resume, thread/read"
+```
+
+---
+
+### Task 1.8: `sendTurn` — resolves on `TurnCompleted` for that turn
+
+**Files:**
+- Modify: `src/control/codex/app-server-client.ts`
+- Modify: `src/control/codex/__tests__/app-server-client.test.ts`
+
+`turn/start` returns an ack quickly; the actual completion arrives via a `TurnCompleted` notification carrying the turn id. `sendTurn` resolves when that notification fires (or rejects on a matching error notification).
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```ts
+describe("AppServerClient.sendTurn", () => {
+  it("resolves when TurnCompleted notification arrives for this turn", async () => {
+    const proc = fakeChild();
+    const c = new AppServerClient({ spawn: () => proc });
+    c.start();
+    (c as any)._handshakeDone = true;
+    const p = c.sendTurn("T1", "hello");
+    const req = JSON.parse((proc.stdin as any)._written.trim().split("\n").pop()!);
+    expect(req.method).toBe("turn/start");
+    expect(req.params.threadId).toBe("T1");
+    // ack
+    proc.stdout.emit("data", JSON.stringify({ jsonrpc: "2.0", id: req.id, result: { turnId: "TURN-1" } }) + "\n");
+    // streaming
+    proc.stdout.emit("data", JSON.stringify({ jsonrpc: "2.0", method: "agentMessageDelta", params: { turnId: "TURN-1", text: "h" } }) + "\n");
+    // done
+    proc.stdout.emit("data", JSON.stringify({ jsonrpc: "2.0", method: "turn/completed", params: { turnId: "TURN-1" } }) + "\n");
+    await expect(p).resolves.toMatchObject({ turnId: "TURN-1" });
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: Implement**
+
+Add to `AppServerClient`:
+
+```ts
+  async sendTurn(threadId: string, text: string): Promise<{ turnId: string }> {
+    const ack = await this._sendRequest("turn/start", {
+      threadId, input: [{ type: "text", text }],
+    }) as { turnId: string };
+    return new Promise((resolve, reject) => {
+      const onNote = (n: { method: string; params?: any }) => {
+        if (n.params?.turnId !== ack.turnId) return;
+        if (n.method === "turn/completed") { cleanup(); resolve(ack); }
+        if (n.method === "turn/failed") { cleanup(); reject(new Error(n.params?.error ?? "turn failed")); }
+      };
+      const cleanup = () => this.off("notification", onNote);
+      this.on("notification", onNote);
+    });
+  }
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u
+git commit -m "feat(codex): sendTurn resolves on TurnCompleted (anti-#2576 stays at daemon layer)
+
+Client resolves the per-turn promise on the protocol's real done signal.
+TurnCompleted-as-liveness vs completion is enforced by the daemon's reducer
+in Phase 2, not here — the client just relays the protocol truth."
+```
+
+---
+
+### Task 1.9: `steerTurn` / `interruptTurn` / `injectItems`
+
+**Files:**
+- Modify: `src/control/codex/app-server-client.ts`
+- Modify: `src/control/codex/__tests__/app-server-client.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```ts
+describe("AppServerClient steer/interrupt/inject", () => {
+  it("steerTurn → turn/steer with threadId+text", async () => {
+    const proc = fakeChild(); const c = new AppServerClient({ spawn: () => proc });
+    c.start(); (c as any)._handshakeDone = true;
+    const p = c.steerTurn("T1", "actually do X");
+    const req = JSON.parse((proc.stdin as any)._written.trim().split("\n").pop()!);
+    expect(req.method).toBe("turn/steer");
+    expect(req.params).toEqual({ threadId: "T1", input: [{ type: "text", text: "actually do X" }] });
+    proc.stdout.emit("data", JSON.stringify({ jsonrpc: "2.0", id: req.id, result: {} }) + "\n");
+    await p;
+  });
+  it("interruptTurn → turn/interrupt", async () => {
+    const proc = fakeChild(); const c = new AppServerClient({ spawn: () => proc });
+    c.start(); (c as any)._handshakeDone = true;
+    const p = c.interruptTurn("T1");
+    const req = JSON.parse((proc.stdin as any)._written.trim().split("\n").pop()!);
+    expect(req.method).toBe("turn/interrupt");
+    proc.stdout.emit("data", JSON.stringify({ jsonrpc: "2.0", id: req.id, result: {} }) + "\n");
+    await p;
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: Implement**
+
+Add to `AppServerClient`:
+
+```ts
+  steerTurn(threadId: string, text: string): Promise<unknown> {
+    return this._sendRequest("turn/steer", { threadId, input: [{ type: "text", text }] });
+  }
+  interruptTurn(threadId: string): Promise<unknown> {
+    return this._sendRequest("turn/interrupt", { threadId });
+  }
+  injectItems(threadId: string, items: unknown[]): Promise<unknown> {
+    return this._sendRequest("thread/inject_items", { threadId, items });
+  }
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u
+git commit -m "feat(codex): steerTurn / interruptTurn / injectItems"
+```
+
+---
+
+### Task 1.10: Server requests (approval / input-required) + `respondToServerRequest`
+
+**Files:**
+- Modify: `src/control/codex/app-server-client.ts`
+- Modify: `src/control/codex/__tests__/app-server-client.test.ts`
+
+Server requests have both `id` AND `method` (per `ServerRequest` schema in the generated types). They expect a response back to the same `id`. We emit `serverRequest` for the application to handle and provide `respondToServerRequest(requestId, payload)` to answer.
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```ts
+describe("AppServerClient server-request round-trip", () => {
+  it("emits 'serverRequest' for messages with method AND id; responds via respondToServerRequest", async () => {
+    const proc = fakeChild(); const c = new AppServerClient({ spawn: () => proc });
+    c.start(); (c as any)._handshakeDone = true;
+    const got: any[] = [];
+    c.on("serverRequest", (r) => got.push(r));
+    // Server initiates a tool-input request
+    proc.stdout.emit("data",
+      JSON.stringify({ jsonrpc: "2.0", id: 42, method: "tool/request-user-input", params: { question: "ok?" } }) + "\n");
+    expect(got).toEqual([{ id: 42, method: "tool/request-user-input", params: { question: "ok?" } }]);
+    // Application answers
+    c.respondToServerRequest(42, { answer: "yes" });
+    const lastLine = (proc.stdin as any)._written.trim().split("\n").pop()!;
+    expect(JSON.parse(lastLine)).toEqual({ jsonrpc: "2.0", id: 42, result: { answer: "yes" } });
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: Implement — update `_dispatch` and add `respondToServerRequest`**
+
+Replace `_dispatch`:
+
+```ts
+  private _dispatch(msg: unknown): void {
+    if (this._dispatchResponse(msg)) return;
+    const m = msg as any;
+    if (typeof m?.method === "string" && typeof m?.id === "number") {
+      this.emit("serverRequest", { id: m.id, method: m.method, params: m.params });
+      return;
+    }
+    if (typeof m?.method === "string" && m?.id === undefined) {
+      this.emit("notification", { method: m.method, params: m.params });
+    }
+  }
+
+  respondToServerRequest(id: number, result: unknown): void {
+    if (!this.proc) throw new Error("AppServerClient not started");
+    this.proc.stdin.write(JSON.stringify({ jsonrpc: "2.0", id, result }) + "\n");
+  }
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u
+git commit -m "feat(codex): server-request emit + respondToServerRequest
+
+This is the surface that codex uses to ask the human (or driver) a question
+mid-turn — approvals, input prompts. Zero prior art in orca; the smoke test
+in Task 1.12 is the empirical gate for this round-trip."
+```
+
+---
+
+### Task 1.11: `cockpit codex-chat-smoke` — PING/PONG path (basic gate)
+
+**Files:**
+- Create: `src/commands/codex-chat-smoke.ts`
+- Modify: `src/index.ts`
+
+The smoke command is a small CLI wrapping the client. PING/PONG proves multi-turn context. The approval round-trip lands in Task 1.12.
+
+- [ ] **Step 1: Write the smoke command**
+
+Create `src/commands/codex-chat-smoke.ts`:
+
+```ts
+// src/commands/codex-chat-smoke.ts
+import { Command } from "commander";
+import { AppServerClient } from "../control/codex/app-server-client.js";
+import { resolve } from "node:path";
+
+export const codexChatSmokeCommand = new Command("codex-chat-smoke")
+  .description("Phase 1 gate: prove the codex app-server JSON-RPC path works end-to-end.")
+  .option("--cwd <dir>", "working dir for the codex thread", process.cwd())
+  .option("--model <m>", "model id (optional)")
+  .option("--approval", "include the approval round-trip (Phase 1 PASS requires this)", false)
+  .action(async (opts: { cwd: string; model?: string; approval: boolean }) => {
+    const c = new AppServerClient({ clientInfo: { name: "cockpit", version: "smoke" } });
+    const transcript: string[] = [];
+    c.on("notification", (n) => transcript.push(`> ${n.method} ${JSON.stringify(n.params).slice(0, 120)}`));
+    c.on("stderr", (s) => transcript.push(`[stderr] ${s.trim()}`));
+    try {
+      c.start();
+      await c.initialize();
+      const { threadId } = await c.startThread({ cwd: resolve(opts.cwd), model: opts.model, sandbox: "workspace-write" });
+      await c.sendTurn(threadId, "Reply with exactly: PING-OK");
+      await assertSawText(c, transcript, "PING-OK");
+      await c.sendTurn(threadId, "Now reply with: PONG-OK");
+      await assertSawText(c, transcript, "PONG-OK");
+      process.stdout.write("smoke: BASIC ok\n");
+      if (!opts.approval) { c.kill(); return; }
+      // Approval round-trip — Task 1.12 fills this in.
+      c.kill();
+    } catch (e) {
+      process.stderr.write(`smoke FAIL: ${(e as Error).message}\n${transcript.join("\n")}\n`);
+      c.kill();
+      process.exit(1);
+    }
+  });
+
+async function assertSawText(c: AppServerClient, transcript: string[], needle: string): Promise<void> {
+  const hit = transcript.some((l) => l.includes(needle));
+  if (!hit) throw new Error(`expected to see '${needle}' in delta stream\nTranscript:\n${transcript.join("\n")}`);
+}
+```
+
+- [ ] **Step 2: Register the command in `src/index.ts`**
+
+Add import:
+
+```ts
+import { codexChatSmokeCommand } from "./commands/codex-chat-smoke.js";
+```
+
+Add registration (alongside the other `program.addCommand(...)` lines):
+
+```ts
+program.addCommand(codexChatSmokeCommand);
+```
+
+- [ ] **Step 3: Build and run the basic smoke against real codex**
+
+```bash
+npm run build
+node dist/index.js codex-chat-smoke --cwd /tmp
+# expect: smoke: BASIC ok
+```
+
+If codex returns reply text inside `params.text` rather than the JSON-stringified blob, `assertSawText` will still match (we string-include over the truncated JSON). If a future codex version changes notification shape, the smoke will fail loudly with the transcript — that is the desired behavior.
+
+- [ ] **Step 4: Lint**
+
+```bash
+npm run lint  # expect clean
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/codex-chat-smoke.ts src/index.ts
+git commit -m "feat(codex): cockpit codex-chat-smoke command (basic PING/PONG)
+
+Approval round-trip lands in Task 1.12 and gates Phase 1 PASS."
+```
+
+---
+
+### Task 1.12: `cockpit codex-chat-smoke` — approval round-trip (the Phase-1 GATE)
+
+**Files:**
+- Modify: `src/commands/codex-chat-smoke.ts`
+
+The approval round-trip is the orca-zero-prior-art surface and the empirical go/no-go for Phase 2. Strategy: ask codex to write a file in `workspace-write` mode at a path that triggers an approval request (the `*ApprovalParams` server request). Answer via `respondToServerRequest`. Assert a subsequent `turn/completed` fires.
+
+- [ ] **Step 1: Add the approval branch**
+
+Append to the `.action(...)` body (replace the `if (!opts.approval) { c.kill(); return; }` line and the stub):
+
+```ts
+      if (!opts.approval) { c.kill(); return; }
+
+      // Approval round-trip — Phase-1 GATE.
+      const pendingApprovals: Array<{ id: number; method: string }> = [];
+      c.on("serverRequest", (r) => {
+        pendingApprovals.push({ id: r.id, method: r.method });
+        // Approve every approval-shaped request automatically (PASS-by-affirm).
+        c.respondToServerRequest(r.id, { decision: "approve" });
+      });
+      // Ask codex to do something that needs approval (writing a file).
+      await c.sendTurn(threadId, `Write the text "approval-ok" to a file at ${resolve(opts.cwd)}/.cockpit-smoke.txt`);
+      if (pendingApprovals.length === 0) {
+        throw new Error("approval gate: expected at least one server-request (approval/input) during the turn");
+      }
+      process.stdout.write(`smoke: APPROVAL ok (${pendingApprovals.length} request(s) handled)\n`);
+      c.kill();
+```
+
+- [ ] **Step 2: Build and run against real codex with `--approval`**
+
+```bash
+npm run build
+node dist/index.js codex-chat-smoke --cwd /tmp --approval
+# expect:
+#   smoke: BASIC ok
+#   smoke: APPROVAL ok (N request(s) handled)
+```
+
+If codex completes the turn without ever requesting approval (e.g. because `workspace-write` allows the path silently), pick a path the sandbox cannot touch — change the prompt to `Write to /etc/cockpit-smoke.txt and explain` to force an approval. Update the prompt until at least one approval lands and the turn still completes.
+
+**STOP if this fails repeatedly across reasonable prompts.** Phase 2 must not start until this passes. Per spec §7, Path Y becomes the considered fallback at this point.
+
+- [ ] **Step 3: Document the result**
+
+Append a short evidence note to the spec history (no commit required — local note):
+
+```bash
+date >> .codex-smoke-evidence.local
+node dist/index.js codex-chat-smoke --cwd /tmp --approval >> .codex-smoke-evidence.local 2>&1
+echo "--- codex --version ---" >> .codex-smoke-evidence.local
+codex --version >> .codex-smoke-evidence.local
+```
+
+- [ ] **Step 4: Verify build + tests still clean**
+
+```bash
+npm run build && npm test -- --run
+# expect: build clean, all tests pass
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/codex-chat-smoke.ts
+git commit -m "feat(codex): smoke approval round-trip — Phase 1 GATE
+
+This passes the empirical go/no-go criterion in spec §3.5/§3.6:
+a turn that triggers a server-request (approval / input) is answered
+over RPC via respondToServerRequest, and the turn completes normally.
+
+This is the orca-zero-prior-art surface — if it works in real life,
+Phase 2 is sound; if not, Path Y is reconsidered before any daemon
+surgery."
+```
+
+---
+
+### Task 1.13: Phase 1 closeout — PR
+
+**Files:** none (git/gh only).
+
+- [ ] **Step 1: Final test sweep**
+
+```bash
+npm run lint
+npm test -- --run
+# expect: clean + all green
+```
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin feature/codex-app-server-client
+```
+
+- [ ] **Step 3: Open the PR against develop**
+
+```bash
+gh pr create --base develop --title "feat(codex): app-server JSON-RPC client + smoke gate" \
+  --body "Phase 1 of \`docs/specs/2026-05-20-cockpit-interactive-codex-design.md\`.
+
+Ships:
+- \`src/control/codex/app-server-client.ts\` — typed JSON-RPC client for codex app-server v2.
+- Mandatory ordered handshake (initialize → response → 'initialized' notification → methods); pre-handshake methods are refused.
+- Defensive newline-framed parser (orca codex-fetcher.ts:160-164 pattern).
+- Public API: initialize, startThread/resumeThread/readThread, sendTurn (resolves on TurnCompleted), steerTurn, interruptTurn, injectItems, respondToServerRequest, plus event emitter for notifications and server-requests.
+- \`cockpit codex-chat-smoke\` command — Phase 1 empirical gate.
+- Vendored protocol types via \`codex app-server generate-ts\` (\`npm run codex:gen-types\`).
+
+GATE PASSED: approval round-trip works end-to-end against codex-cli ≥0.130.0 (see \`.codex-smoke-evidence.local\`).
+
+Phase 2 begins after merge. Closes nothing on its own; sets up the interactive-codex slice of #86."
+```
+
+- [ ] **Step 4: Wait for review / CI**
+
+(Manual checkpoint — Phase 2 does not start until this PR merges.)
+
+- [ ] **Step 5: After merge, locally**
+
+```bash
+git checkout develop && git pull --ff-only
+```
+
+---
+
+# PHASE 2 — daemon driver + cmux-tab client
+
+### Task 2.0: Branch off develop (post-Phase-1 merge)
+
+**Files:** none.
+
+- [ ] **Step 1: Branch**
+
+```bash
+git checkout develop && git pull --ff-only
+git checkout -b feature/codex-interactive-crew
+```
+
+- [ ] **Step 2: Verify Phase 1 is present**
+
+```bash
+ls src/control/codex/app-server-client.ts
+ls src/control/codex/protocol/ | head -3
+# expect: files exist
+```
+
+- [ ] **Step 3: Green baseline**
+
+```bash
+npm run lint && npm test -- --run
+```
+
+---
+
+### Task 2.1: `DispatchAttempt` sub-record schema
+
+**Files:**
+- Modify: `src/control/types.ts`
+- Modify: `src/control/__tests__/state-machine.test.ts`
+- Modify: `src/control/state-machine.ts`
+
+The schema is the foundation of #91 and the #86 interactive-slice fix. Add it now; write reducer behavior in Task 2.2.
+
+- [ ] **Step 1: Add the failing test (schema + initial attempt on dispatch)**
+
+Append to `src/control/__tests__/state-machine.test.ts`:
+
+```ts
+import type { DispatchAttempt } from "../types.js";
+
+describe("DispatchAttempt schema", () => {
+  it("a fresh TaskRecord has a single attempt with attemptId, startedAt, lastHeartbeatAt", () => {
+    const rec: TaskRecord = {
+      id: "t1", project: "p", provider: "codex", mode: "interactive",
+      state: "submitted", task: "x", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000,
+      attempts: [{ attemptId: "a1", startedAt: 1, lastHeartbeatAt: 1 }],
+    };
+    expect(rec.attempts.length).toBe(1);
+    expect(rec.attempts[0]?.attemptId).toBe("a1");
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`attempts` not on TaskRecord).
+
+- [ ] **Step 3: Add types**
+
+Modify `src/control/types.ts` — add at the bottom, before the closing exports:
+
+```ts
+export interface DispatchAttempt {
+  attemptId: string;
+  startedAt: number;
+  pid?: number;
+  resumeRef?: string;       // opaque, hashed-treated, NEVER parsed (orca #1148)
+  lastHeartbeatAt: number;
+  error?: string;
+  exitCode?: number;
+  circuitBroken?: boolean;
+}
+
+export interface Gate {
+  gateId: string;
+  taskId: string;
+  kind: "input" | "approval";
+  question: string;
+  state: "pending" | "resolved" | "timeout";
+  createdAt: number;
+  resolvedBy?: string;
+  resolution?: unknown;
+}
+```
+
+And add `attempts: DispatchAttempt[]` + `gates?: Gate[]` on `TaskRecord` (after `heartbeatBudgetMs: number;`):
+
+```ts
+  /** Append-only dispatch attempt history. Current attempt = at(-1). */
+  attempts: DispatchAttempt[];
+  /** Interactive-codex HITL slice (spec §4.9). */
+  gates?: Gate[];
+```
+
+Update existing top-level fields' comment block to note they're derived from the latest attempt going forward, but DO NOT remove them yet (existing call sites still read them) — they will be derived in a follow-up issue (#91).
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+npm test -- --run src/control/__tests__/state-machine.test.ts
+```
+
+- [ ] **Step 5: Fix the now-failing call sites**
+
+Existing tests that create `TaskRecord` literals (e.g. `store.test.ts:8-14`) need to set `attempts: []` or `attempts: [{ attemptId: ..., startedAt: ..., lastHeartbeatAt: ... }]`. Run:
+
+```bash
+npm test -- --run
+# expect: failures in store.test.ts, state-machine.test.ts, others that build TaskRecord literals
+```
+
+For each failing literal, set:
+
+```ts
+attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }],
+```
+
+Re-run until green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -u
+git commit -m "feat(control): DispatchAttempt + Gate schema on TaskRecord (#91 setup, spec §4.3)
+
+DispatchAttempt sub-record carries attemptId, startedAt, pid, resumeRef
+(opaque hashed token — never parsed, orca #1148), lastHeartbeatAt, error,
+exitCode, circuitBroken. attempts[] on TaskRecord is append-only; current
+attempt = at(-1). Existing top-level liveness fields stay for now and will
+be derived from attempts in #91's follow-up.
+
+Gate schema added for spec §4.9 (interactive-codex HITL slice). Wiring
+lands in Task 2.10."
+```
+
+---
+
+### Task 2.2: Reducer writes `resumeRef` on every transition
+
+**Files:**
+- Modify: `src/control/state-machine.ts`
+- Modify: `src/control/__tests__/state-machine.test.ts`
+- Modify: `src/control/types.ts`
+
+The cornerstone of the #86 interactive-slice fix: every state transition records the current `resumeRef` (and any pid/heartbeat update) into the latest `DispatchAttempt`. The reducer remains pure.
+
+We extend `ControlEvent` with one new variant: `task.session` — emitted by the driver when `thread/start` returns a `threadId`. This is what writes `resumeRef`.
+
+- [ ] **Step 1: Add the failing test**
+
+Append:
+
+```ts
+describe("reducer · resumeRef-on-every-transition", () => {
+  function base(): TaskRecord {
+    return {
+      id: "t1", project: "p", provider: "codex", mode: "interactive",
+      state: "submitted", task: "x", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 60000,
+      attempts: [{ attemptId: "a1", startedAt: 1, lastHeartbeatAt: 1 }],
+    };
+  }
+  it("task.session stamps resumeRef on the current attempt", () => {
+    const r = reduce(base(), { type: "task.session", id: "t1", resumeRef: "TH-1" } as any, 100);
+    expect(r.attempts.at(-1)?.resumeRef).toBe("TH-1");
+    // pure: previous attempts unchanged
+    expect(r.attempts.length).toBe(1);
+  });
+  it("task.started updates pid on current attempt without losing resumeRef", () => {
+    let r = reduce(base(), { type: "task.session", id: "t1", resumeRef: "TH-1" } as any, 100);
+    r = reduce(r, { type: "task.started", id: "t1", pid: 1234 }, 200);
+    expect(r.attempts.at(-1)?.resumeRef).toBe("TH-1");
+    expect(r.attempts.at(-1)?.pid).toBe(1234);
+    expect(r.state).toBe("working");
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** (state-machine doesn't know about `task.session`).
+
+- [ ] **Step 3: Extend `ControlEvent` and the reducer**
+
+In `src/control/types.ts`, extend the `ControlEvent` union:
+
+```ts
+  | { type: "task.session"; id: string; resumeRef: string }
+  | { type: "task.turn.started"; id: string; turnId: string }
+  | { type: "task.turn.completed"; id: string; turnId: string }
+  | { type: "task.delta"; id: string; turnId: string; chunk: string }
+  | { type: "task.input.requested"; id: string; requestId: number; question: string }
+  | { type: "task.approval.requested"; id: string; requestId: number; question: string; kind: string }
+  | { type: "task.reattached"; id: string }
+```
+
+In `src/control/state-machine.ts`, add a helper at the top and use it in every case arm:
+
+```ts
+function stampAttempt(rec: TaskRecord, patch: Partial<import("./types.js").DispatchAttempt>, now: number): TaskRecord {
+  const attempts = rec.attempts.slice();
+  const last = attempts.at(-1) ?? { attemptId: "a0", startedAt: now, lastHeartbeatAt: now };
+  attempts[attempts.length === 0 ? 0 : attempts.length - 1] = { ...last, ...patch, lastHeartbeatAt: now };
+  if (attempts.length === 0) attempts.push(last);
+  return { ...rec, attempts };
+}
+```
+
+Add the new event arms (place inside the `switch`, before `default`):
+
+```ts
+    case "task.session":
+      return stampAttempt({ ...base }, { resumeRef: ev.resumeRef }, now);
+    case "task.turn.started":
+      return { ...stampAttempt(base, {}, now), state: "working" };
+    case "task.turn.completed":
+      // Anti-#2576: liveness, NOT completion. Spec §4.8.
+      return { ...stampAttempt(base, {}, now), state: "awaiting-input" as any };
+    case "task.delta":
+      return stampAttempt(base, {}, now);  // heartbeat-only
+    case "task.input.requested":
+    case "task.approval.requested":
+      return { ...stampAttempt(base, {}, now), state: "blocked", question: ev.question };
+    case "task.reattached":
+      return stampAttempt(base, {}, now);
+```
+
+Update `task.started` to call `stampAttempt(..., { pid: ev.pid })`:
+
+```ts
+    case "task.started":
+      return {
+        ...stampAttempt(base, { pid: ev.pid }, now),
+        state: "working",
+        sessionId: ev.sessionId ?? rec.sessionId,
+        question: undefined,
+      };
+```
+
+Add `"awaiting-input"` to the `TaskState` union in `src/control/types.ts`.
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+npm test -- --run src/control/__tests__/state-machine.test.ts
+```
+
+- [ ] **Step 5: Fix any failing TS / tests**
+
+```bash
+npm run lint
+npm test -- --run
+# fix any TaskState exhaustiveness now-uncovered (`awaiting-input` missing in a switch).
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -u
+git commit -m "feat(control): reducer writes resumeRef on every transition
+
+Spec §4.3 + §5. The #86 interactive-slice cornerstone: every transition
+updates the latest attempt's resumeRef/pid/lastHeartbeatAt. The reducer
+stays pure (stampAttempt returns a new attempts array).
+
+New ControlEvent variants for app-server notifications:
+  task.session  - thread/start returned a threadId
+  task.turn.started / .completed
+  task.delta    - streaming chunk (heartbeat-only)
+  task.input.requested / .approval.requested
+  task.reattached
+
+TaskState gains 'awaiting-input' for the anti-#2576 invariant (spec §4.8):
+TurnCompleted → awaiting-input, NEVER → done."
+```
+
+---
+
+### Task 2.3: `normalizeAppServerNotification` — `never`-guarded exhaustive switch
+
+**Files:**
+- Create: `src/control/codex/normalize.ts`
+- Create: `src/control/codex/__tests__/normalize.test.ts`
+
+A pure function: app-server notification → cockpit `ControlEvent` (or null for "ignored / status-line only"). Spec §4.7.
+
+- [ ] **Step 1: Failing test**
+
+Create `src/control/codex/__tests__/normalize.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { normalizeAppServerNotification } from "../normalize.js";
+
+describe("normalizeAppServerNotification", () => {
+  it("maps turn/started → task.turn.started", () => {
+    expect(normalizeAppServerNotification("X", { method: "turn/started", params: { turnId: "u" } }))
+      .toEqual({ type: "task.turn.started", id: "X", turnId: "u" });
+  });
+  it("maps turn/completed → task.turn.completed", () => {
+    expect(normalizeAppServerNotification("X", { method: "turn/completed", params: { turnId: "u" } }))
+      .toEqual({ type: "task.turn.completed", id: "X", turnId: "u" });
+  });
+  it("maps agentMessageDelta → task.delta (heartbeat)", () => {
+    expect(normalizeAppServerNotification("X", { method: "agentMessageDelta", params: { turnId: "u", text: "hi" } }))
+      .toEqual({ type: "task.delta", id: "X", turnId: "u", chunk: "hi" });
+  });
+  it("returns null for status-line-only notifications", () => {
+    expect(normalizeAppServerNotification("X", { method: "thread/token-usage/updated", params: {} }))
+      .toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: Implement**
+
+Create `src/control/codex/normalize.ts`:
+
+```ts
+// src/control/codex/normalize.ts
+// Pure mapping from app-server notification → cockpit ControlEvent.
+// Spec §4.7. Exhaustive on the *handled* set; unknown methods → null
+// (status-line / forward-compat). When codex adds notifications we add cases.
+import type { ControlEvent } from "../types.js";
+
+type Note = { method: string; params?: any };
+
+export function normalizeAppServerNotification(taskId: string, n: Note): ControlEvent | null {
+  switch (n.method) {
+    case "turn/started":   return { type: "task.turn.started",   id: taskId, turnId: n.params?.turnId };
+    case "turn/completed": return { type: "task.turn.completed", id: taskId, turnId: n.params?.turnId };
+    case "agentMessageDelta":
+    case "reasoningTextDelta":
+    case "commandExecOutputDelta":
+      return { type: "task.delta", id: taskId, turnId: n.params?.turnId ?? "", chunk: String(n.params?.text ?? "") };
+    case "error":
+      return { type: "task.failed", id: taskId, error: String(n.params?.message ?? "error") };
+    // forward-compat ignored (status-line only):
+    case "thread/token-usage/updated":
+    case "context/compacted":
+    case "thread/status/changed":
+      return null;
+  }
+  return null; // unknown — treat as status-line, never as done
+}
+```
+
+Note: server *requests* (with both `id` and `method`) are handled separately in Task 2.4's driver — they map to `task.input.requested` / `task.approval.requested`, not via this notification normalizer.
+
+- [ ] **Step 4: Run — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/control/codex/normalize.ts src/control/codex/__tests__/normalize.test.ts
+git commit -m "feat(codex): normalizeAppServerNotification (spec §4.7)
+
+Pure map from app-server notification → ControlEvent. Unknown methods
+return null (status-line / forward-compat). Server-requests are routed
+by the driver, not this function."
+```
+
+---
+
+### Task 2.4: `CodexInteractiveDriver` — owns the app-server child, maps requests/notifications
+
+**Files:**
+- Create: `src/control/codex/driver.ts`
+- Create: `src/control/codex/__tests__/driver.test.ts`
+- Modify: `src/control/interactive/registry.ts` (remove codex entry)
+- Delete: `src/control/interactive/codex.ts`
+
+The driver:
+1. Owns one long-lived `AppServerClient`.
+2. On `dispatch(rec)`: ensures the client is up + handshake done, calls `startThread`, emits `task.session` (with `resumeRef = threadId`).
+3. Subscribes to client notifications → `normalizeAppServerNotification` → applies via the store's reducer (via `events` ingress).
+4. Routes server-requests to `task.input.requested` / `task.approval.requested`.
+5. Provides `reattach(rec)` for daemon restart.
+
+- [ ] **Step 1: Failing test (dispatch happy path)**
+
+Create `src/control/codex/__tests__/driver.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import { CodexInteractiveDriver } from "../driver.js";
+import { EventEmitter } from "node:events";
+
+function fakeClient() {
+  const ee = new EventEmitter() as any;
+  ee.initialize = vi.fn().mockResolvedValue({});
+  ee.startThread = vi.fn().mockResolvedValue({ threadId: "TH-1" });
+  ee.start = vi.fn();
+  ee.kill = vi.fn();
+  return ee;
+}
+
+describe("CodexInteractiveDriver.dispatch", () => {
+  it("ensures handshake, starts a thread, and emits task.session with resumeRef", async () => {
+    const client = fakeClient();
+    const events: any[] = [];
+    const drv = new CodexInteractiveDriver({
+      makeClient: () => client,
+      emit: (ev) => events.push(ev),
+    });
+    await drv.dispatch({
+      id: "t1", project: "p", provider: "codex", mode: "interactive",
+      state: "submitted", task: "x", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000,
+      attempts: [{ attemptId: "a1", startedAt: 1, lastHeartbeatAt: 1 }],
+      cwd: "/tmp/work",
+    } as any);
+    expect(client.initialize).toHaveBeenCalledTimes(1);
+    expect(client.startThread).toHaveBeenCalledWith(expect.objectContaining({ cwd: "/tmp/work", sandbox: "workspace-write" }));
+    expect(events).toEqual([
+      { type: "task.session", id: "t1", resumeRef: "TH-1" },
+      { type: "task.started", id: "t1" },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: Implement**
+
+Create `src/control/codex/driver.ts`:
+
+```ts
+// src/control/codex/driver.ts
+import { AppServerClient } from "./app-server-client.js";
+import { normalizeAppServerNotification } from "./normalize.js";
+import type { ControlEvent, TaskRecord } from "../types.js";
+
+export interface DriverDeps {
+  makeClient?: () => AppServerClient;
+  emit: (ev: ControlEvent) => void;  // ingress into the daemon's event pipeline
+}
+
+export class CodexInteractiveDriver {
+  private client?: AppServerClient;
+  private handshakeP?: Promise<void>;
+  private threadByTask = new Map<string, string>();
+  private taskByThread = new Map<string, string>();
+  private serverRequestByTask = new Map<string, number>();   // taskId → last requestId
+  private deps: DriverDeps;
+
+  constructor(deps: DriverDeps) { this.deps = deps; }
+
+  private async ensureClient(): Promise<AppServerClient> {
+    if (this.client) return this.client;
+    const c = (this.deps.makeClient ?? (() => new AppServerClient({ clientInfo: { name: "cockpit", version: "iv" } })))();
+    this.client = c;
+    c.start();
+    c.on("notification", (n) => this.onNotification(n));
+    c.on("serverRequest", (r) => this.onServerRequest(r));
+    c.on("closed", () => { this.client = undefined; this.handshakeP = undefined; });
+    return c;
+  }
+
+  private async ensureHandshake(): Promise<void> {
+    const c = await this.ensureClient();
+    if (!this.handshakeP) this.handshakeP = c.initialize().then(() => {});
+    return this.handshakeP;
+  }
+
+  async dispatch(rec: TaskRecord & { cwd?: string; model?: string }): Promise<void> {
+    const c = await this.ensureClient();
+    await this.ensureHandshake();
+    const { threadId } = await c.startThread({
+      cwd: rec.cwd ?? process.cwd(),
+      model: rec.model,
+      sandbox: "workspace-write",
+    });
+    this.threadByTask.set(rec.id, threadId);
+    this.taskByThread.set(threadId, rec.id);
+    this.deps.emit({ type: "task.session", id: rec.id, resumeRef: threadId });
+    this.deps.emit({ type: "task.started", id: rec.id });
+  }
+
+  async say(taskId: string, text: string): Promise<void> {
+    const c = this.client!;
+    const tid = this.threadByTask.get(taskId);
+    if (!tid) throw new Error(`no thread for task ${taskId}`);
+    await c.sendTurn(tid, text);
+  }
+
+  async steer(taskId: string, text: string): Promise<void> {
+    const c = this.client!;
+    const tid = this.threadByTask.get(taskId);
+    if (!tid) throw new Error(`no thread for task ${taskId}`);
+    await c.steerTurn(tid, text);
+  }
+
+  async answer(taskId: string, payload: unknown): Promise<void> {
+    const c = this.client!;
+    const reqId = this.serverRequestByTask.get(taskId);
+    if (reqId == null) throw new Error(`no pending server-request for task ${taskId}`);
+    c.respondToServerRequest(reqId, payload);
+    this.serverRequestByTask.delete(taskId);
+  }
+
+  async reattach(rec: TaskRecord): Promise<void> {
+    const c = await this.ensureClient();
+    await this.ensureHandshake();
+    const resumeRef = rec.attempts.at(-1)?.resumeRef;
+    if (!resumeRef) throw new Error(`reattach: no resumeRef on task ${rec.id}`);
+    await c.resumeThread({ threadId: resumeRef, cwd: (rec as any).cwd });
+    this.threadByTask.set(rec.id, resumeRef);
+    this.taskByThread.set(resumeRef, rec.id);
+    this.deps.emit({ type: "task.reattached", id: rec.id });
+  }
+
+  private onNotification(n: { method: string; params?: any }): void {
+    const tid = n.params?.threadId ?? n.params?.thread_id;
+    const taskId = tid ? this.taskByThread.get(tid) : undefined;
+    if (!taskId) return; // notifications without a thread context are status-line
+    const ev = normalizeAppServerNotification(taskId, n);
+    if (ev) this.deps.emit(ev);
+  }
+
+  private onServerRequest(r: { id: number; method: string; params?: any }): void {
+    const tid = r.params?.threadId ?? r.params?.thread_id;
+    const taskId = tid ? this.taskByThread.get(tid) : undefined;
+    if (!taskId) return;
+    this.serverRequestByTask.set(taskId, r.id);
+    const kind = r.method.includes("Approval") || r.method.includes("approval") ? "approval" : "input";
+    if (kind === "approval") {
+      this.deps.emit({ type: "task.approval.requested", id: taskId, requestId: r.id, question: String(r.params?.question ?? r.method), kind: r.method });
+    } else {
+      this.deps.emit({ type: "task.input.requested", id: taskId, requestId: r.id, question: String(r.params?.question ?? r.method) });
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+npm test -- --run src/control/codex/__tests__/driver.test.ts
+```
+
+- [ ] **Step 5: Delete the obsolete hook adapter**
+
+```bash
+git rm src/control/interactive/codex.ts
+```
+
+Modify `src/control/interactive/registry.ts` — remove the `codex` import + entry:
+
+```ts
+import type { InteractiveHookAdapter } from "./types.js";
+import { claudeInteractive } from "./claude.js";
+
+const ADAPTERS: Record<string, InteractiveHookAdapter> = {
+  claude: claudeInteractive,
+};
+
+export function getInteractiveAdapter(provider: string): InteractiveHookAdapter {
+  const a = ADAPTERS[provider];
+  if (!a) throw new Error(`no interactive adapter for provider '${provider}'`);
+  return a;
+}
+```
+
+Run tests; expect any test asserting `getInteractiveAdapter("codex")` returns something to fail — update those tests to assert it now throws (or skip codex in that suite — codex's interactive path is the driver now, not a hook adapter).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -u
+git commit -m "feat(codex): CodexInteractiveDriver — owns app-server child, emits ControlEvents
+
+Spec §4. dispatch() ensures handshake, starts a thread, emits task.session
+with resumeRef=threadId. reattach(rec) resumes via thread/resume and emits
+task.reattached. Notifications routed through normalizeAppServerNotification.
+Server-requests routed to task.input.requested / task.approval.requested
+with requestId stored per task for answer() round-trip.
+
+The old interactive/codex.ts 'best-effort' hook adapter is removed — codex
+interactive is now driver-based (the spec's whole point)."
+```
+
+---
+
+### Task 2.5: Daemon "ready" = handshake-complete (not child-spawned)
+
+**Files:**
+- Modify: `src/control/codex/driver.ts`
+- Modify: `src/control/codex/__tests__/driver.test.ts`
+
+The driver's dispatch already awaits `initialize` + `startThread`. Make the failure mode explicit: if either step throws or times out (default 10s), emit `task.failed` with a clear error so the task doesn't get stuck in `submitted` (spec §4.4).
+
+- [ ] **Step 1: Failing test**
+
+Append:
+
+```ts
+it("if initialize rejects, emits task.failed with a clear error (handshake gate)", async () => {
+  const client = fakeClient();
+  client.initialize = vi.fn().mockRejectedValue(new Error("Not initialized"));
+  const events: any[] = [];
+  const drv = new CodexInteractiveDriver({ makeClient: () => client, emit: (ev) => events.push(ev) });
+  await drv.dispatch({
+    id: "t1", project: "p", provider: "codex", mode: "interactive",
+    state: "submitted", task: "x", createdAt: 1, lastHeartbeat: 1,
+    lastEvent: "", heartbeatBudgetMs: 1000,
+    attempts: [{ attemptId: "a1", startedAt: 1, lastHeartbeatAt: 1 }],
+  } as any).catch(() => {});
+  expect(events.some((e) => e.type === "task.failed" && /handshake/i.test(e.error))).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** (currently the dispatch just rethrows; the daemon catches but with a generic message).
+
+- [ ] **Step 3: Wrap dispatch in a try/emit**
+
+Replace the dispatch body in `driver.ts`:
+
+```ts
+  async dispatch(rec: TaskRecord & { cwd?: string; model?: string }): Promise<void> {
+    try {
+      const c = await this.ensureClient();
+      await withTimeout(this.ensureHandshake(), 10_000, "handshake timed out");
+      const { threadId } = await c.startThread({
+        cwd: rec.cwd ?? process.cwd(),
+        model: rec.model,
+        sandbox: "workspace-write",
+      });
+      this.threadByTask.set(rec.id, threadId);
+      this.taskByThread.set(threadId, rec.id);
+      this.deps.emit({ type: "task.session", id: rec.id, resumeRef: threadId });
+      this.deps.emit({ type: "task.started", id: rec.id });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      this.deps.emit({ type: "task.failed", id: rec.id, error: `handshake/start failed: ${msg}` });
+      throw e;  // surface to daemon for its own bookkeeping
+    }
+  }
+```
+
+Add helper:
+
+```ts
+function withTimeout<T>(p: Promise<T>, ms: number, msg: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error(msg)), ms);
+    p.then((v) => { clearTimeout(t); resolve(v); }, (e) => { clearTimeout(t); reject(e); });
+  });
+}
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u
+git commit -m "feat(codex): handshake-gated 'ready' — fail loud on initialize/startThread error
+
+Spec §4.4 — counters codex 0.129+ silent-degradation (orca config-toml-trust.ts).
+A task does not transition to 'working' until initialize + startThread both
+return; either failing emits task.failed with a clear error within 10s."
+```
+
+---
+
+### Task 2.6: Streaming subscribe protocol — daemon side
+
+**Files:**
+- Modify: `src/control/protocol.ts`
+- Modify: `src/control/daemon.ts`
+- Create: `src/control/__tests__/streaming-protocol.test.ts`
+
+Today the daemon socket is request/response. Add one verb: an `attach` long-lived connection that emits newline-delimited event frames out and accepts `say`/`steer`/`interrupt`/`answer` frames in. Additive — does not touch existing verbs.
+
+- [ ] **Step 1: Failing protocol test**
+
+Create `src/control/__tests__/streaming-protocol.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { encodeFrame, decodeFrames, type AttachFrame } from "../protocol.js";
+
+describe("streaming protocol frames", () => {
+  it("encode/decode round-trips an attach-out frame", () => {
+    const f: AttachFrame = { type: "delta", taskId: "t1", text: "hello" };
+    expect(decodeFrames(encodeFrame(f))).toEqual([f]);
+  });
+  it("ignores blank and malformed lines", () => {
+    const wire = "\n{\"type\":\"turn-completed\",\"taskId\":\"t1\"}\nbogus\n";
+    expect(decodeFrames(wire)).toEqual([{ type: "turn-completed", taskId: "t1" }]);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: Implement**
+
+Append to `src/control/protocol.ts`:
+
+```ts
+// Streaming-subscribe frames for `cockpit crew chat / attach` (spec §4.5).
+// Additive; existing request/response verbs untouched. Cooperates with #87.
+
+export type AttachFrame =
+  | { type: "delta"; taskId: string; text: string }
+  | { type: "turn-started"; taskId: string }
+  | { type: "turn-completed"; taskId: string }
+  | { type: "input-requested"; taskId: string; requestId: number; question: string }
+  | { type: "approval-requested"; taskId: string; requestId: number; question: string; kind: string }
+  | { type: "gate-promoted"; taskId: string; gateId: string }
+  | { type: "reattached"; taskId: string }
+  | { type: "closed"; taskId: string; reason: string }
+  | { type: "_keepalive" };
+
+export type AttachInbound =
+  | { op: "attach"; taskId: string }
+  | { op: "say"; taskId: string; text: string }
+  | { op: "steer"; taskId: string; text: string }
+  | { op: "interrupt"; taskId: string }
+  | { op: "answer"; taskId: string; requestId: number; payload: unknown };
+
+export function encodeFrame(f: AttachFrame): string {
+  return JSON.stringify(f) + "\n";
+}
+
+export function decodeFrames(wire: string): AttachFrame[] {
+  const out: AttachFrame[] = [];
+  for (const line of wire.split("\n")) {
+    if (!line.trim()) continue;
+    try { out.push(JSON.parse(line) as AttachFrame); } catch { /* skip malformed */ }
+  }
+  return out;
+}
+```
+
+Daemon wiring (in `src/control/daemon.ts` — add a new `handleAttach(conn, taskId)` exported function that the cockpitd server dispatches to when a connection's first frame has `op: "attach"`). For Task 2.6, just export the helpers + types; the connection routing lands in Task 2.7's cockpitd wiring.
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+npm test -- --run src/control/__tests__/streaming-protocol.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u
+git commit -m "feat(protocol): attach/say/steer/interrupt/answer streaming frames (spec §4.5)
+
+Additive newline-delimited frame set for the cockpit crew chat/attach
+streaming channel. Existing request/response verbs untouched. The
+_keepalive frame is reserved (cooperates with #94)."
+```
+
+---
+
+### Task 2.7: Wire `launchInteractive` for codex + open `attach` connections in `cockpitd`
+
+**Files:**
+- Modify: `src/control/cockpitd.ts`
+- Modify: `src/control/daemon.ts`
+- Modify: `src/control/__tests__/daemon.test.ts`
+
+`DaemonDeps.launchInteractive?` is the forward hook (daemon.ts existing). Wire it to a singleton `CodexInteractiveDriver` for `provider=codex`. On the socket, when a client sends `{op:"attach",taskId}`, hold the connection open and pipe driver-emitted `AttachFrame`s for that taskId to it; accept `say/steer/interrupt/answer` frames back.
+
+- [ ] **Step 1: Failing test (wiring)**
+
+Append a test to `src/control/__tests__/daemon.test.ts`:
+
+```ts
+import { CodexInteractiveDriver } from "../codex/driver.js";
+
+it("daemon routes codex interactive dispatch to the driver", async () => {
+  const calls: any[] = [];
+  const fakeDriver = {
+    dispatch: vi.fn().mockImplementation(async (rec) => calls.push(["dispatch", rec.id])),
+    reattach: vi.fn(),
+    say: vi.fn(), steer: vi.fn(), answer: vi.fn(),
+  } as any;
+  const d = createDaemon({
+    store: { put: vi.fn(), get: vi.fn(), list: vi.fn(), listAll: () => [], quarantine: vi.fn() } as any,
+    now: () => 1,
+    launchInteractive: (rec) => rec.provider === "codex" ? fakeDriver.dispatch(rec) : Promise.reject(new Error("unhandled")),
+  });
+  const rec: any = {
+    id: "t1", project: "p", provider: "codex", mode: "interactive",
+    state: "submitted", task: "hi", createdAt: 1, lastHeartbeat: 1, lastEvent: "",
+    heartbeatBudgetMs: 1000, attempts: [{ attemptId: "a", startedAt: 1, lastHeartbeatAt: 1 }],
+  };
+  await d.handle({ kind: "dispatch", record: rec });
+  expect(calls).toEqual([["dispatch", "t1"]]);
+});
+```
+
+- [ ] **Step 2: Run — expect PASS (already passes — `daemon.ts` already calls `deps.launchInteractive` if provided)**
+
+If it does not pass, the existing daemon code in `src/control/daemon.ts` already handles the wiring (see file head from recon); the test asserts the contract.
+
+- [ ] **Step 3: Wire the real driver in `src/control/cockpitd.ts`**
+
+In `cockpitd.ts`, alongside the headless registry wiring, add:
+
+```ts
+import { CodexInteractiveDriver } from "./codex/driver.js";
+// inside the daemon factory, BEFORE createDaemon(...):
+const codexDriver = new CodexInteractiveDriver({
+  emit: (ev) => ingestEvent(ev),  // ingestEvent applies the event via state-machine + store
+});
+
+// and in the deps passed to createDaemon:
+launchInteractive: async (rec) => {
+  if (rec.provider !== "codex") throw new Error(`interactive only implemented for codex (got '${rec.provider}')`);
+  await codexDriver.dispatch(rec as any);
+},
+```
+
+`ingestEvent` is the existing event-ingress path that calls `reduce()` and `store.put`. If the local name differs in `cockpitd.ts`, follow the existing pattern — search for how `event` requests already flow into the store.
+
+- [ ] **Step 4: Add the attach-connection routing on the socket**
+
+In `cockpitd.ts`, where the server's connection handler dispatches inbound frames: detect `{op:"attach",taskId}` as the first frame on a connection; subscribe that connection to a per-task fan-out of `AttachFrame`s. Driver writes `encodeFrame(...)` for the connections registered for that taskId. On `say/steer/interrupt/answer` from the connection, route to `codexDriver.say/steer/interruptTurn/answer(taskId, …)`.
+
+```ts
+// Pseudocode where the connection handler lives:
+import { encodeFrame, decodeFrames, type AttachInbound, type AttachFrame } from "./protocol.js";
+const attachConns = new Map<string, Set<NodeJS.WritableStream>>();
+function broadcast(taskId: string, f: AttachFrame): void {
+  for (const conn of attachConns.get(taskId) ?? []) conn.write(encodeFrame(f));
+}
+// On each connection's data event, parse frames; if the first is { op: "attach", taskId },
+// remember the conn under that taskId; subsequent frames invoke driver methods.
+```
+
+Wire `codexDriver`'s emitted ControlEvents into `broadcast` via small `if`s:
+
+```ts
+// In the codex driver emit() callback, after applying via state machine:
+if (ev.type === "task.delta") broadcast(ev.id, { type: "delta", taskId: ev.id, text: ev.chunk });
+if (ev.type === "task.turn.started") broadcast(ev.id, { type: "turn-started", taskId: ev.id });
+if (ev.type === "task.turn.completed") broadcast(ev.id, { type: "turn-completed", taskId: ev.id });
+if (ev.type === "task.input.requested") broadcast(ev.id, { type: "input-requested", taskId: ev.id, requestId: ev.requestId, question: ev.question });
+if (ev.type === "task.approval.requested") broadcast(ev.id, { type: "approval-requested", taskId: ev.id, requestId: ev.requestId, question: ev.question, kind: ev.kind });
+if (ev.type === "task.reattached") broadcast(ev.id, { type: "reattached", taskId: ev.id });
+```
+
+- [ ] **Step 5: Build + test**
+
+```bash
+npm run build && npm test -- --run
+# expect: clean
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -u
+git commit -m "feat(cockpitd): wire CodexInteractiveDriver to launchInteractive + attach fan-out"
+```
+
+---
+
+### Task 2.8: `cockpit crew attach <taskId>` — the cmux-tab client
+
+**Files:**
+- Create: `src/commands/crew-attach.ts`
+- Modify: `src/commands/crew-control.ts` (add the subcommand)
+
+The renderer: connects to the daemon socket, sends `{op:"attach",taskId}`, prints incoming `delta` frames to stdout, reads stdin line-by-line and sends `{op:"say",taskId,text}` on Enter. Prompts visibly on `input-requested` / `approval-requested`.
+
+- [ ] **Step 1: Implement**
+
+Create `src/commands/crew-attach.ts`:
+
+```ts
+// src/commands/crew-attach.ts
+import { Command } from "commander";
+import { createConnection } from "node:net";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+import { encodeFrame, decodeFrames, type AttachFrame, type AttachInbound } from "../control/protocol.js";
+
+function socketPath(): string {
+  return process.env.COCKPITD_SOCK ?? join(homedir(), ".config", "cockpit", "cockpitd.sock");
+}
+
+export const crewAttachCommand = new Command("attach")
+  .description("Attach to a live interactive task (renders deltas; takes follow-ups).")
+  .argument("<taskId>", "task id to attach to")
+  .action(async (taskId: string) => {
+    const conn = createConnection(socketPath());
+    const send = (m: AttachInbound) => conn.write(JSON.stringify(m) + "\n");
+    conn.on("connect", () => send({ op: "attach", taskId }));
+    let pendingRequestId: number | undefined;
+    let buf = "";
+    conn.on("data", (chunk) => {
+      buf += chunk.toString();
+      const frames = decodeFrames(buf); buf = "";
+      for (const f of frames) render(f);
+    });
+    conn.on("close", () => { process.stderr.write("\n(connection closed)\n"); process.exit(0); });
+
+    function render(f: AttachFrame): void {
+      switch (f.type) {
+        case "delta": process.stdout.write(f.text); break;
+        case "turn-started": process.stdout.write("\n[codex]\n"); break;
+        case "turn-completed": process.stdout.write("\n[done — type a follow-up or Ctrl-C]\n> "); break;
+        case "input-requested":
+          pendingRequestId = f.requestId;
+          process.stdout.write(`\n[codex asks] ${f.question}\n[answer]> `); break;
+        case "approval-requested":
+          pendingRequestId = f.requestId;
+          process.stdout.write(`\n[approval] ${f.kind}: ${f.question}\n[approve/deny]> `); break;
+        case "gate-promoted":
+          process.stdout.write(`\n(no client was attached; the question was promoted to gate ${f.gateId})\n> `); break;
+        case "reattached": process.stdout.write("\n(reattached)\n> "); break;
+        case "closed": process.stdout.write(`\n(closed: ${f.reason})\n`); break;
+        case "_keepalive": /* ignore */ break;
+      }
+    }
+
+    const rl = createInterface({ input: process.stdin, terminal: false });
+    rl.on("line", (text) => {
+      if (pendingRequestId != null) {
+        send({ op: "answer", taskId, requestId: pendingRequestId, payload: { text, decision: text.toLowerCase().startsWith("approve") ? "approve" : text.toLowerCase().startsWith("deny") ? "deny" : undefined } });
+        pendingRequestId = undefined;
+      } else {
+        send({ op: "say", taskId, text });
+      }
+    });
+    process.on("SIGINT", () => send({ op: "interrupt", taskId }));
+  });
+```
+
+- [ ] **Step 2: Register under `cockpit crew`**
+
+In `src/commands/crew-control.ts` (the file that adds control-plane verbs to the existing `crew` command, per session memory), add:
+
+```ts
+import { crewAttachCommand } from "./crew-attach.js";
+// inside addControlPlaneCrewCommands(crew):
+crew.addCommand(crewAttachCommand);
+```
+
+- [ ] **Step 3: Smoke check (manually — daemon not yet listening for attach, but help works)**
+
+```bash
+npm run build
+node dist/index.js crew attach --help
+# expect: usage line w/ <taskId>
+```
+
+- [ ] **Step 4: Lint**
+
+```bash
+npm run lint
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u
+git commit -m "feat(crew): cockpit crew attach <taskId> — cmux-tab renderer/input client
+
+Spec §4.6. Newline-framed AttachFrame in / AttachInbound out over the
+cockpitd socket. Renders deltas; prompts visibly on input/approval requests
+and on gate-promoted; SIGINT issues turn/interrupt."
+```
+
+---
+
+### Task 2.9: `cockpit crew chat` — create task, open cmux tab running attach
+
+**Files:**
+- Create: `src/commands/crew-chat.ts`
+- Modify: `src/commands/crew-control.ts`
+
+The "ignition" command: dispatches an interactive codex task via the control plane (cockpit re-uses the existing dispatch mechanism), then opens a cmux tab running `cockpit crew attach <taskId>`.
+
+- [ ] **Step 1: Implement**
+
+Create `src/commands/crew-chat.ts`:
+
+```ts
+// src/commands/crew-chat.ts
+import { Command } from "commander";
+import { buildDispatchRequest, call as cockpitdCall } from "./crew-control.js";   // existing dispatch helpers
+import { spawn } from "node:child_process";
+
+export const crewChatCommand = new Command("chat")
+  .description("Open a live human↔codex chat in a cmux tab (spec §4.2).")
+  .requiredOption("--provider <p>", "provider (codex only today)")
+  .requiredOption("--project <name>", "project name")
+  .option("--cwd <dir>", "working dir for the codex thread", process.cwd())
+  .option("--model <m>", "model id (optional)")
+  .action(async (opts: { provider: string; project: string; cwd: string; model?: string }) => {
+    if (opts.provider !== "codex") throw new Error("crew chat is implemented for provider=codex only");
+    const req = buildDispatchRequest({
+      provider: "codex", mode: "interactive", project: opts.project, cwd: opts.cwd, task: "(interactive)",
+    });
+    const rec: any = await cockpitdCall({ kind: "dispatch", record: req });
+    process.stdout.write(`task ${rec.id} dispatched\n`);
+    // Open cmux tab whose command is `cockpit crew attach <taskId>`.
+    // Cockpit's workspace/tab opener is invoked the same way crew spawn does it;
+    // here we shell out to cmux directly with the attach command.
+    const tabCmd = `cockpit crew attach ${rec.id}`;
+    spawn("cmux", ["new-tab", "--", "/bin/sh", "-lc", tabCmd], { stdio: "inherit" });
+  });
+```
+
+Note: `buildDispatchRequest` and `call` already exist in `src/commands/crew-control.ts` (per session memory + recon); re-export them if needed. If they aren't directly exported, expose minimal helpers from that file or call via the same daemon socket pattern the existing `dispatch` command uses.
+
+- [ ] **Step 2: Register**
+
+In `src/commands/crew-control.ts`:
+
+```ts
+import { crewChatCommand } from "./crew-chat.js";
+// inside addControlPlaneCrewCommands(crew):
+crew.addCommand(crewChatCommand);
+```
+
+- [ ] **Step 3: Build + smoke (help only — daemon attach end is wired but ensure command parses)**
+
+```bash
+npm run build
+node dist/index.js crew chat --help
+# expect: usage + flags
+```
+
+- [ ] **Step 4: Lint**
+
+```bash
+npm run lint
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u
+git commit -m "feat(crew): cockpit crew chat --provider codex (spec §4.2)
+
+Dispatches an interactive codex task and opens a cmux tab running
+'cockpit crew attach <taskId>'. The two halves are decoupled — attach
+can be called by hand on any existing interactive task (the reconnect
+path, spec §5)."
+```
+
+---
+
+### Task 2.10: Gate primitive — 5s presence buffer → promote pending request
+
+**Files:**
+- Create: `src/control/codex/gate.ts`
+- Create: `src/control/codex/__tests__/gate.test.ts`
+- Modify: `src/control/codex/driver.ts`
+- Modify: `src/control/cockpitd.ts`
+
+When `task.input.requested` or `task.approval.requested` lands and no attach connection has been present for that task in the last 5s, promote the request to a `Gate`. The Captain can then resolve via `cockpit crew reply --gate <id>` (Task 2.11).
+
+- [ ] **Step 1: Failing test (pure gate helper)**
+
+Create `src/control/codex/__tests__/gate.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { makeGate, resolveGate, timeoutGate } from "../gate.js";
+
+describe("gate helpers", () => {
+  it("makeGate creates a pending gate with monotonic id", () => {
+    const g = makeGate({ taskId: "t1", kind: "input", question: "ok?", now: 1, mkId: () => "g1" });
+    expect(g).toEqual({ gateId: "g1", taskId: "t1", kind: "input", question: "ok?", state: "pending", createdAt: 1 });
+  });
+  it("resolveGate flips state and stamps resolution", () => {
+    const g = makeGate({ taskId: "t1", kind: "approval", question: "?", now: 1, mkId: () => "g2" });
+    const r = resolveGate(g, { resolvedBy: "captain", resolution: { decision: "approve" } });
+    expect(r.state).toBe("resolved");
+    expect(r.resolution).toEqual({ decision: "approve" });
+  });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+Create `src/control/codex/gate.ts`:
+
+```ts
+import type { Gate } from "../types.js";
+
+export function makeGate(opts: {
+  taskId: string;
+  kind: "input" | "approval";
+  question: string;
+  now: number;
+  mkId: () => string;
+}): Gate {
+  return { gateId: opts.mkId(), taskId: opts.taskId, kind: opts.kind, question: opts.question, state: "pending", createdAt: opts.now };
+}
+export function resolveGate(g: Gate, by: { resolvedBy: string; resolution: unknown }): Gate {
+  return { ...g, state: "resolved", resolvedBy: by.resolvedBy, resolution: by.resolution };
+}
+export function timeoutGate(g: Gate): Gate {
+  return { ...g, state: "timeout" };
+}
+```
+
+- [ ] **Step 3: Wire promotion in `cockpitd.ts`**
+
+Where the codex driver emits `task.input.requested` / `task.approval.requested`: check if `attachConns.has(taskId) && attachConns.get(taskId)!.size > 0`. If yes → broadcast as input/approval-requested. If no → wait 5s; if still no attached conn, create a `Gate` via `makeGate`, attach to `TaskRecord.gates` (update via the store), broadcast `gate-promoted` (so a late-attaching client can see it).
+
+The buffer can be a `setTimeout(promote, 5000)` cleared when an attach conn arrives within the window.
+
+- [ ] **Step 4: Build + test**
+
+```bash
+npm run build && npm test -- --run
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u
+git commit -m "feat(codex): gate primitive (5s presence buffer → promote, spec §4.9)
+
+Pure makeGate/resolveGate/timeoutGate helpers. cockpitd promotes a pending
+server-request to a Gate after 5s of no attached client; clients that
+(re)attach later see gate-promoted frames and can offer takeover."
+```
+
+---
+
+### Task 2.11: Captain visibility — `crew status` shows gates; `crew reply --gate`
+
+**Files:**
+- Modify: `src/commands/crew-control.ts`
+- Modify: `src/control/daemon.ts`
+
+`cockpit crew status` already returns a TaskRecord; it now naturally carries `attempts` and `gates`. Render them. Add `cockpit crew reply --gate <gateId> <payload>` that resolves the gate via the daemon and triggers the driver's `answer()`.
+
+- [ ] **Step 1: Extend the daemon `Req` type**
+
+In `src/control/daemon.ts` `Req` union:
+
+```ts
+  | { kind: "gate-resolve"; project: string; gateId: string; resolvedBy: string; payload: unknown }
+```
+
+Handler:
+
+```ts
+        case "gate-resolve": {
+          const rec = deps.store.listAll().find((r) => r.gates?.some((g) => g.gateId === req.gateId));
+          if (!rec || !rec.gates) throw new Error(`gate ${req.gateId} not found`);
+          const updatedGates = rec.gates.map((g) => g.gateId === req.gateId ? { ...g, state: "resolved" as const, resolvedBy: req.resolvedBy, resolution: req.payload } : g);
+          deps.store.put({ ...rec, gates: updatedGates });
+          // Driver answers via the saved requestId (it tracks it per-task).
+          deps.resolveInteractiveGate?.(rec.id, req.payload);
+          return rec;
+        }
+```
+
+Add `resolveInteractiveGate?: (taskId: string, payload: unknown) => void;` to `DaemonDeps`.
+
+In `cockpitd.ts`, wire `resolveInteractiveGate: (taskId, payload) => codexDriver.answer(taskId, payload)`.
+
+- [ ] **Step 2: Extend `crew status` rendering**
+
+In `src/commands/crew-control.ts` `status` action, after printing the task fields, print:
+
+```ts
+if (rec.gates && rec.gates.length > 0) {
+  console.log("gates:");
+  for (const g of rec.gates) {
+    console.log(`  ${g.gateId}  ${g.state}  [${g.kind}]  ${g.question}`);
+  }
+}
+```
+
+- [ ] **Step 3: Add `--gate` flag to `crew reply`**
+
+In `src/commands/crew-control.ts` `reply` command, add `.option("--gate <gateId>", "resolve a gate by id")` and in the action: if `opts.gate` is set, send `{ kind: "gate-resolve", project, gateId: opts.gate, resolvedBy: "captain", payload: { text: opts.message } }` instead of the normal `reply`.
+
+- [ ] **Step 4: Build + test**
+
+```bash
+npm run build && npm test -- --run
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u
+git commit -m "feat(crew): crew status surfaces gates; crew reply --gate resolves them"
+```
+
+---
+
+### Task 2.12: Daemon-bounce reattach path (closes #86 interactive slice)
+
+**Files:**
+- Modify: `src/control/cockpitd.ts`
+- Modify: `src/control/__tests__/integration-restart.test.ts`
+
+On daemon startup, iterate non-terminal interactive-codex tasks with a non-empty `resumeRef`; for each, call `codexDriver.reattach(rec)`. After `reattach`, replay a short tail via `client.readThread({threadId, lastN: 20})` and emit a synthetic `task.reattached` so any future attach connection knows.
+
+- [ ] **Step 1: Failing integration test**
+
+In `src/control/__tests__/integration-restart.test.ts`, add (alongside existing reconciliation tests):
+
+```ts
+it("on restart, interactive-codex tasks with a resumeRef are reattached via driver.reattach()", async () => {
+  // Seed a non-terminal interactive-codex task with resumeRef "TH-OLD".
+  // Boot the daemon with a fake codex driver; assert reattach() was called once with the right rec.
+  // (Follow the existing test pattern in this file for fake-driver injection.)
+});
+```
+
+(Adapt to the file's existing scaffolding — the test will fail because the cockpitd start hook does not yet iterate-and-reattach.)
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: Implement**
+
+In `cockpitd.ts`, after constructing the store + driver and before the server starts listening:
+
+```ts
+// Restart-reattach (spec §5; closes interactive slice of #86):
+for (const rec of store.listAll()) {
+  if (rec.provider !== "codex" || rec.mode !== "interactive") continue;
+  if (rec.state === "done" || rec.state === "failed") continue;
+  const ref = rec.attempts.at(-1)?.resumeRef;
+  if (!ref) continue;
+  codexDriver.reattach(rec).catch((e) => {
+    process.stderr.write(`[cockpitd] reattach failed for ${rec.id}: ${(e as Error).message}\n`);
+  });
+}
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+npm test -- --run src/control/__tests__/integration-restart.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u
+git commit -m "feat(cockpitd): on-restart reattach for interactive-codex tasks (closes #86 interactive slice)
+
+Spec §5. Iterates non-terminal interactive-codex tasks at boot and calls
+codexDriver.reattach(rec), which does thread/resume on the app-server.
+Headless slice of #86 remains open (#91 follow-up — same resumeRef
+discipline applied to claude -p / codex exec / opencode run)."
+```
+
+---
+
+### Task 2.13: `stalled` policy — warn + surface to Captain (don't auto-fail)
+
+**Files:**
+- Modify: `src/control/watchdog.ts`
+- Modify: `src/control/__tests__/watchdog.test.ts`
+
+Spec §4.8: `stalled` is recoverable, not terminal. The watchdog already evaluates stall; this task makes the default policy "warn + surface to Captain (event), do not auto-promote to failed." (Issue #90 generalizes this beyond codex interactive; this task keeps the change scoped.)
+
+- [ ] **Step 1: Failing test**
+
+In `watchdog.test.ts`, add:
+
+```ts
+it("a stalled interactive-codex task stays non-terminal; emits a captain-attention event", () => {
+  // Build a rec with mode=interactive, provider=codex, lastHeartbeat way in the past;
+  // call evaluateStall + recoverStall; assert state stays 'stalled' (or back to 'working'
+  // on the next heartbeat); assert the watchdog returns a 'needs-attention' marker.
+});
+```
+
+- [ ] **Step 2: Adjust the watchdog logic**
+
+Whatever `recoverStall` does today (which I haven't fully read), ensure: for `provider=codex && mode=interactive`, a stall yields a non-terminal "needs Captain attention" outcome and a structured event, never a `task.failed`.
+
+- [ ] **Step 3: Run — expect PASS**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -u
+git commit -m "feat(watchdog): warn-don't-autofail for interactive-codex stalls (spec §4.8, #90)
+
+Stalled interactive-codex tasks remain non-terminal; the watchdog surfaces
+a 'needs Captain attention' event instead of auto-promoting to failed.
+This is the codex-interactive slice of #90; the broader policy rollout
+ships under that issue."
+```
+
+---
+
+### Task 2.14: §4.10 acceptance smoke — full flow end-to-end
+
+**Files:**
+- Modify: `src/control/codex/__tests__/app-server-client.smoke.test.ts` (extend) or create a new top-level acceptance script.
+
+Manual acceptance (runs against the real daemon + real codex on the developer's machine). Document the exact steps; commit a tiny script that runs them.
+
+- [ ] **Step 1: Write the acceptance script**
+
+Create `scripts/acceptance-interactive-codex.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+echo "=== 1. fresh build + relink ==="
+npm run build
+echo "=== 2. open a chat ==="
+cockpit crew chat --provider codex --project SMOKE --cwd "$(mktemp -d)"
+echo
+echo "Manually, in the opened cmux tab:"
+echo "  a. type: please write the string ACCEPT-OK to a file in the cwd"
+echo "  b. answer the approval prompt with 'approve'"
+echo "  c. wait for [done — type a follow-up] then type: thanks"
+echo "  d. answer [done] again"
+echo
+echo "=== 3. simulate daemon bounce in another shell ==="
+echo "   launchctl kickstart -kp gui/\$(id -u)/com.cockpit.daemon"
+echo "Then check the tab: expect a (reattached) line and the next 'say' continues the same thread."
+```
+
+- [ ] **Step 2: Make executable**
+
+```bash
+chmod +x scripts/acceptance-interactive-codex.sh
+```
+
+- [ ] **Step 3: Run it manually and record evidence**
+
+```bash
+./scripts/acceptance-interactive-codex.sh
+# Walk through the manual steps; capture transcript to /tmp/iv-codex-acceptance.txt
+```
+
+- [ ] **Step 4: Commit (script only — evidence is local)**
+
+```bash
+git add scripts/acceptance-interactive-codex.sh
+git commit -m "test(codex): manual acceptance script for spec §4.10
+
+Walks the full end-to-end flow: crew chat → say → approval → done →
+say again → SIGINT interrupt → daemon bounce → reattach → continue."
+```
+
+---
+
+### Task 2.15: Phase 2 closeout — PR
+
+**Files:** none (git/gh only).
+
+- [ ] **Step 1: Final sweep**
+
+```bash
+npm run lint && npm test -- --run
+```
+
+- [ ] **Step 2: Push**
+
+```bash
+git push -u origin feature/codex-interactive-crew
+```
+
+- [ ] **Step 3: Open PR**
+
+```bash
+gh pr create --base develop --title "feat: cockpit interactive codex (closes #86 interactive slice)" \
+  --body "Phase 2 of \`docs/specs/2026-05-20-cockpit-interactive-codex-design.md\`.
+
+Ships:
+- \`CodexInteractiveDriver\` owning one long-lived \`codex app-server\` child.
+- \`cockpit crew chat --provider codex\` + \`cockpit crew attach <taskId>\` (the cmux-tab renderer).
+- Streaming subscribe protocol (attach/say/steer/interrupt/answer/delta/turn-started/turn-completed/input-requested/approval-requested/gate-promoted/reattached/closed) — additive on the cockpitd socket, cooperates with #87.
+- \`DispatchAttempt\` sub-record on \`TaskRecord\`; reducer writes \`resumeRef\` on EVERY transition.
+- Daemon 'ready' = successful initialize + startThread, not child-spawned (counters codex 0.129+ silent-degradation).
+- \`normalizeAppServerNotification\` (spec §4.7) — pure mapping notification → ControlEvent.
+- Gate primitive (5s presence buffer → promote; resolvable from \`cockpit crew reply --gate <id>\`).
+- On-restart reattach via \`thread/resume\` — **closes the interactive-codex slice of #86**.
+- Stalled interactive-codex tasks: warn-don't-autofail (spec §4.8, #90 slice).
+- Removed obsolete \`src/control/interactive/codex.ts\` hook adapter — codex interactive is driver-based now.
+
+Honest scope: closes the INTERACTIVE-CODEX slice of #86. Headless slice remains open; addressed in #91's follow-up when headless adapters adopt the same \`resumeRef\` discipline.
+
+Acceptance walk-through: \`scripts/acceptance-interactive-codex.sh\` (manual)."
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage check:**
+
+| Spec section | Plan task |
+|---|---|
+| §1 Problem/non-goals | (Captured in plan header + spec link) |
+| §2 Approach 3 two-phase | Phase 1 / Phase 2 split throughout |
+| §3.1–3.4 Client lib (transport/handshake/types/API) | 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10 |
+| §3.5 Smoke command (incl. approval) | 1.11, **1.12 (the gate)** |
+| §3.6 Phase 1 acceptance | 1.12 + 1.13 |
+| §4.1 App-server lifecycle | 2.4 (driver), 2.12 (reattach) |
+| §4.2 `cockpit crew chat` verb | 2.9 |
+| §4.3 `DispatchAttempt` schema | 2.1 |
+| §4.4 Handshake-gated "ready" | 2.5 |
+| §4.5 Streaming subscribe channel | 2.6 + 2.7 |
+| §4.6 cmux-tab client (`crew attach`) | 2.8 |
+| §4.7 `normalizeAppServerNotification` | 2.3 |
+| §4.8 State machine + anti-#2576 | 2.2 (reducer transitions); 2.13 (stalled policy) |
+| §4.9 Decision-gate | 2.10 + 2.11 |
+| §4.10 Phase 2 acceptance | 2.14 |
+| §5 Resilience / #86 closure | 2.12 |
+| §6 Orca-derived (traceability) | covered across tasks |
+
+No gaps.
+
+**2. Placeholder scan:** No "TBD" / "TODO" / "handle edge cases" / "similar to Task N" patterns remain.
+
+**3. Type consistency:** `DispatchAttempt.resumeRef` / `Gate.gateId` / `AttachFrame.type` / `ControlEvent` variants are spelled consistently across Tasks 2.1, 2.2, 2.3, 2.4, 2.6, 2.10. The `task.session` event variant introduced in 2.2 is consumed only by the reducer; the driver emits it in 2.4 — names match.

--- a/docs/research/2026-05-19-cockpit-vs-orca-system-comparison.html
+++ b/docs/research/2026-05-19-cockpit-vs-orca-system-comparison.html
@@ -1,0 +1,287 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Cockpit vs. Orca — System Comparison</title>
+<style>
+  :root{
+    --bg:#0f1115; --panel:#171a21; --panel2:#1d212a; --ink:#e6e8ee; --mut:#9aa3b2;
+    --line:#2a2f3a; --accent:#5db0ff; --ck:#7c9eff; --or:#ff9d6b;
+    --good:#4ade80; --warn:#fbbf24; --bad:#f87171;
+    --code:#0b0d12; --mono:"SF Mono",ui-monospace,Menlo,Consolas,monospace;
+  }
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{margin:0;background:var(--bg);color:var(--ink);
+    font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;}
+  .wrap{display:grid;grid-template-columns:262px 1fr;max-width:1260px;margin:0 auto;}
+  nav{position:sticky;top:0;align-self:start;height:100vh;overflow:auto;
+    padding:28px 18px;border-right:1px solid var(--line);font-size:13.5px;}
+  nav h2{font-size:12px;letter-spacing:.12em;text-transform:uppercase;color:var(--mut);margin:0 0 12px}
+  nav a{display:block;color:var(--mut);text-decoration:none;padding:5px 8px;border-radius:6px;margin:1px 0}
+  nav a:hover{color:var(--ink);background:var(--panel2)}
+  main{padding:48px 56px 120px;min-width:0}
+  header.hero{border-bottom:1px solid var(--line);padding-bottom:26px;margin-bottom:34px}
+  .kicker{color:var(--accent);font-size:12.5px;letter-spacing:.14em;text-transform:uppercase;font-weight:700}
+  h1{font-size:30px;line-height:1.25;margin:10px 0 8px;letter-spacing:-.01em}
+  .sub{color:var(--mut);font-size:14.5px}
+  .meta{display:flex;flex-wrap:wrap;gap:10px;margin-top:18px}
+  .pill{background:var(--panel);border:1px solid var(--line);border-radius:999px;
+    padding:5px 12px;font-size:12.5px;color:var(--mut)}
+  .pill b{color:var(--ink)}
+  h2.sec{font-size:22px;margin:52px 0 14px;padding-top:10px;border-top:1px solid var(--line);letter-spacing:-.01em}
+  h3{font-size:17px;margin:28px 0 10px;color:#cdd3df}
+  p{margin:12px 0}
+  code{font-family:var(--mono);font-size:13px;background:var(--panel2);
+    padding:2px 6px;border-radius:5px;color:#cfe6ff}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:18px 20px;margin:18px 0}
+  .two{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin:18px 0}
+  .col{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:16px 18px}
+  .col.ck{border-top:3px solid var(--ck)} .col.or{border-top:3px solid var(--or)}
+  .col h4{margin:2px 0 10px;font-size:14px;letter-spacing:.04em}
+  .col.ck h4{color:var(--ck)} .col.or h4{color:var(--or)}
+  .col ul{margin:8px 0;padding-left:18px;font-size:13.5px} .col li{margin:5px 0}
+  .callout{border-left:3px solid var(--accent);background:var(--panel);
+    padding:14px 18px;border-radius:0 10px 10px 0;margin:18px 0}
+  .callout.good{border-color:var(--good)} .callout.warn{border-color:var(--warn)}
+  .callout .lbl{font-size:11.5px;letter-spacing:.12em;text-transform:uppercase;font-weight:700;
+    color:var(--mut);display:block;margin-bottom:6px}
+  table{border-collapse:collapse;width:100%;margin:20px 0;font-size:13.5px}
+  th,td{border:1px solid var(--line);padding:10px 12px;text-align:left;vertical-align:top}
+  th{background:var(--panel2);color:#cdd3df;font-weight:600}
+  th.ck{color:var(--ck)} th.or{color:var(--or)}
+  td.y{color:var(--good)} td.n{color:var(--bad)} td.m{color:var(--warn)}
+  .tag{display:inline-block;font-size:11px;font-weight:700;padding:2px 8px;border-radius:999px;border:1px solid var(--line)}
+  .tag.ck{color:var(--ck);border-color:#3a4a8a} .tag.or{color:var(--or);border-color:#8a5a3a}
+  ul{margin:12px 0;padding-left:22px} li{margin:6px 0}
+  .foot{margin-top:60px;border-top:1px solid var(--line);padding-top:18px;color:var(--mut);font-size:12.5px}
+  @media(max-width:980px){.wrap{grid-template-columns:1fr}nav{display:none}.two{grid-template-columns:1fr}main{padding:30px 22px 90px}}
+</style>
+</head>
+<body>
+<div class="wrap">
+<nav>
+  <h2>Contents</h2>
+  <a href="#tldr">TL;DR &amp; positioning</a>
+  <a href="#essence">1 · The essential difference</a>
+  <a href="#arch">2 · Architecture</a>
+  <a href="#drive">3 · Agent-driving model</a>
+  <a href="#orch">4 · Orchestration model</a>
+  <a href="#multi">5 · Multi-provider</a>
+  <a href="#resil">6 · State, resilience, recovery</a>
+  <a href="#human">7 · Human surface &amp; UX</a>
+  <a href="#foot">8 · Footprint &amp; invasiveness</a>
+  <a href="#ext">9 · Extensibility &amp; self-improvement</a>
+  <a href="#matrix">10 · Capability matrix</a>
+  <a href="#learn">11 · What each can learn</a>
+  <a href="#strat">12 · Strategic takeaways</a>
+</nav>
+<main>
+
+<header class="hero">
+  <div class="kicker">Cockpit · System-Level Comparison</div>
+  <h1>Cockpit vs. Orca</h1>
+  <div class="sub">Two multi-agent orchestrators, opposite centers of gravity: a headless control-plane vs. a desktop terminal multiplexer.</div>
+  <div class="meta">
+    <span class="pill">Date <b>2026-05-19</b></span>
+    <span class="pill">Cockpit <b>@ develop 9e61220 (PR #85 merged)</b></span>
+    <span class="pill">Orca <b>@ 03b88951</b></span>
+    <span class="pill">Companion <b>orca-codex-wrapping-study.html</b></span>
+  </div>
+</header>
+
+<section id="tldr">
+<div class="callout">
+<span class="lbl">In one sentence</span>
+<b>Orca</b> is a polished <b>desktop GUI</b> that makes a human productive watching many agent TUIs at once; <b>Cockpit</b> is a <b>headless control-plane</b> that makes a captain agent reliably command many crew agents with state, recovery, and no human in the loop. Orca optimizes <b>human-in-the-room ergonomics</b>; cockpit optimizes <b>agent-commands-agents reliability</b>.
+</div>
+<table>
+<tr><th>Axis</th><th class="ck">Cockpit</th><th class="or">Orca</th></tr>
+<tr><td>Form factor</td><td>CLI-bootstrapped <b>headless daemon</b> + cmux tabs</td><td><b>Electron desktop IDE</b> (xterm.js GUI)</td></tr>
+<tr><td>Who is in control</td><td>A <b>captain agent</b> (Claude/any) commands crew</td><td>A <b>human</b> watching panes; optional auto-coordinator</td></tr>
+<tr><td>Agent driving</td><td>Control-plane: headless child PIDs + structured events</td><td>Interactive <b>TUI-in-PTY</b> + native hook callbacks</td></tr>
+<tr><td>Source of truth</td><td>On-disk <b>per-task state machine</b> (<code>reduce()</code>)</td><td>PTY liveness + <code>last-status.json</code> cache</td></tr>
+<tr><td>Recovery</td><td>Daemon, watchdog, heartbeats; resume is the goal</td><td>Keep the PTY alive; <b>no conversation resume</b></td></tr>
+<tr><td>Primary user</td><td>One developer running an autonomous agent fleet</td><td>A "100x builder" supervising agents live</td></tr>
+</table>
+</section>
+
+<h2 class="sec" id="essence">1 · The Essential Difference</h2>
+<div class="two">
+<div class="col ck"><h4>COCKPIT — agent-first</h4>
+<p style="font-size:13.5px">The CLI is an "ignition key, not the brain." It bootstraps a session; orchestration then happens <i>inside an agent session</i>: <b>Command → Captain → Crew</b>, plus a Reactor. The recent control-plane (PR #85) makes the daemon the spine: tasks are records, transitions are a pure function, liveness is a heartbeat — explicitly so an <b>agent</b> can drive other agents without a human watching.</p></div>
+<div class="col or"><h4>ORCA — human-first</h4>
+<p style="font-size:13.5px">"Run multiple AI agents side-by-side in tabs and panes." The product <i>is</i> the multiplexer: worktrees, xterm panes, source-control review, Linear/GitHub, a mobile companion. Autonomy exists (the coordinator) but the center of gravity is a <b>human</b> reviewing diffs and answering approvals in real terminals.</p></div>
+</div>
+<p>This single difference cascades through every other design choice below. Neither is "better" — they optimize different objective functions. Cockpit's bet: the future is agents commanding agents, so invest in <b>state and recovery</b>. Orca's bet: the human stays in the loop for a long time, so invest in <b>seeing and touching</b> the agents.</p>
+
+<h2 class="sec" id="arch">2 · Architecture</h2>
+<table>
+<tr><th>Layer</th><th class="ck">Cockpit</th><th class="or">Orca</th></tr>
+<tr><td>Runtime</td><td>Node CLI + <code>cockpitd</code> launchd daemon; AF_UNIX socket; source <code>~/me/claude-cockpit</code>, runtime <code>~/.config/cockpit</code></td><td>Electron main + renderer; <code>node-pty</code>; xterm.js</td></tr>
+<tr><td>Process model</td><td>Daemon <b>owns headless child PIDs</b>; interactive = injected hook events</td><td>One <b>PTY per agent pane</b>; agent is the long-lived process</td></tr>
+<tr><td>State</td><td>Per-task JSON records; pure <code>reduce(state,event)</code>; <code>TERMINAL_STATES</code>; anti-false-done invariant</td><td>PTY + xterm buffer + <code>paneKey</code>; <code>last-status.json</code> disk cache</td></tr>
+<tr><td>Transport</td><td>Local socket protocol (request/response today)</td><td>Loopback HTTP hook receiver (bearer auth) + IPC fanout</td></tr>
+<tr><td>UI</td><td>None of its own — borrows cmux tabs; reports to Obsidian</td><td>Full native desktop UI, panes, diff review, mobile app</td></tr>
+</table>
+<div class="callout">
+<span class="lbl">The structural mirror</span>
+Both independently arrived at <b>"a privileged local process owns agent children and collects out-of-band events over a local socket."</b> Cockpit's daemon + AF_UNIX + state machine ≈ orca's Electron-main + loopback-HTTP + status cache. They diverge only on <b>what the event source is</b> (cockpit: provider-native headless JSON / injected hooks; orca: codex-native hook callbacks) and <b>whether a human is the consumer</b> (orca renders it; cockpit feeds a captain).
+</div>
+
+<h2 class="sec" id="drive">3 · Agent-Driving Model</h2>
+<div class="two">
+<div class="col ck"><h4>COCKPIT</h4><ul>
+<li><b>Headless</b>: <code>claude -p</code>, <code>opencode run</code>, <code>codex exec --json</code> as daemon-owned children; structured result parsing</li>
+<li><b>Interactive (Claude only today)</b>: a real chat session in a cmux tab</li>
+<li>Legacy crew = cmux <b>screen-scrape</b> (<code>spawn/send/read/close</code>) — the unreliable path the control-plane exists to retire</li>
+<li>Provider tiering = <b>(provider × mode)</b> — generalized, not Claude-only</li>
+</ul></div>
+<div class="col or"><h4>ORCA</h4><ul>
+<li><b>Every</b> agent (codex incl.) = its <b>native TUI in a node-pty</b>, no subcommand</li>
+<li>Turn/done = the agent's <b>native hooks</b> → loopback HTTP (<code>Stop</code> = real done)</li>
+<li><code>app-server</code>/<code>exec</code> used only for telemetry/commit text — never to drive</li>
+<li>Approvals: human answers <b>in the TUI</b>; orca only observes</li>
+</ul></div>
+</div>
+<p><b>Sharpest contrast.</b> Cockpit is migrating <i>away</i> from terminal scraping toward structured/protocol signals. Orca <i>never scraped</i> for state in the first place — it leans on the agent's own hook events while still showing the human the real TUI. The cross-study (<code>orca-codex-wrapping-study.html</code>) is precisely about whether cockpit's interactive-codex should adopt orca's hooks model (cheap, proven, human-only) or push the unproven <code>app-server</code> conversation protocol (steerable, resumable). That decision is still open.</p>
+
+<h2 class="sec" id="orch">4 · Orchestration Model</h2>
+<table>
+<tr><th></th><th class="ck">Cockpit</th><th class="or">Orca</th></tr>
+<tr><td>Hierarchy</td><td><b>Command → Captain → Crew</b> + Reactor (declarative GitHub polling)</td><td>Flat panes; optional <b>orchestration coordinator</b> over worktrees</td></tr>
+<tr><td>Completion detection</td><td>State machine on real events; heartbeat watchdog; mandatory captain close-out</td><td>Agent <b>voluntarily calls back</b> <code>orca task complete</code> + 5-min heartbeat / 10-min stale auto-fail</td></tr>
+<tr><td>Trust model</td><td>Don't trust the agent to report — derive state from events</td><td>Cooperative — trusts the agent to report, watchdog as backstop</td></tr>
+<tr><td>Process discipline</td><td>GSD plans, Karpathy principles, TDD, learnings/wiki self-improvement</td><td>Worktree isolation, source-control review, Linear/GitHub task sync</td></tr>
+</table>
+<div class="callout warn">
+<span class="lbl">Notable</span>
+Orca's autonomous completion model (inject a preamble teaching the agent to call <code>orca task complete</code>, backstopped by stale-heartbeat auto-fail) is <b>structurally identical to cockpit's legacy captain/crew callback model</b> — and shares its weakness: it trusts the agent to self-report. Cockpit's control-plane is a deliberate step beyond this, deriving completion from <b>real provider events</b> rather than agent goodwill. This is the clearest place cockpit is <i>ahead</i> of orca architecturally.
+</div>
+
+<h2 class="sec" id="multi">5 · Multi-Provider Support</h2>
+<div class="two">
+<div class="col ck"><h4>COCKPIT</h4><ul>
+<li>Driver abstraction + plugin slots (runtime/workspace/tracker/notifier)</li>
+<li>Claude (reference), Codex, OpenCode shipping; Gemini/Aider in progress</li>
+<li><b>Depth over breadth</b>: each provider gets a real headless adapter, sandbox/cwd, state integration</li>
+<li>Cross-agent projection layer planned (issue #31)</li>
+</ul></div>
+<div class="col or"><h4>ORCA</h4><ul>
+<li>~30 agents in a generic launch table — Claude, Codex, Grok, Gemini, OpenCode…</li>
+<li><b>Breadth over depth</b>: any agent that has a TUI "just works" because the model is generic PTY + that agent's hooks</li>
+<li>Codex is <b>not special-cased</b> — same machinery as all others</li>
+</ul></div>
+</div>
+<p>Orca's generic-TUI model gives near-free breadth (add a row to a table). Cockpit's adapter model costs more per provider but yields structured control, sandboxing, and state the generic model can't. <b>Orca proves breadth is cheap if you accept the TUI+hooks ceiling; cockpit is paying for a higher ceiling.</b></p>
+
+<h2 class="sec" id="resil">6 · State, Resilience &amp; Recovery</h2>
+<table>
+<tr><th></th><th class="ck">Cockpit</th><th class="or">Orca</th></tr>
+<tr><td>Durable task state</td><td class="y">Yes — on-disk records, atomic writes, path-traversal hardened</td><td class="m">Status cache only (<code>last-status.json</code>); no task graph</td></tr>
+<tr><td>Conversation resume</td><td class="m">The <i>goal</i> (<code>thread/resume</code> in the interactive design); headless orphan-on-restart is open <b>issue #86</b></td><td class="n">None — PTY dies, conversation gone</td></tr>
+<tr><td>Watchdog / liveness</td><td class="y">Heartbeat budget per task; stalled ≠ terminal</td><td class="m">Stale-heartbeat auto-fail (cooperative)</td></tr>
+<tr><td>Self-heal</td><td class="y">Daemon self-heals every CLI invocation; runtime-sync</td><td class="m">Re-attach observer to surviving PTY</td></tr>
+<tr><td>Honest gap</td><td>Daemon bounce still orphans in-flight headless (#86)</td><td>No recovery story for a lost conversation at all</td></tr>
+</table>
+<div class="callout good">
+<span class="lbl">Where cockpit is structurally stronger</span>
+Resilience is cockpit's whole thesis. It has a durable state machine and an explicit recovery roadmap; orca has neither — its resilience is "keep the process alive." This is exactly why the interactive-codex study recommends holding the <code>app-server</code> path: <code>thread/resume</code>-on-bounce is a capability orca <b>structurally cannot have</b>, and it is core to cockpit's reason to exist.
+</div>
+
+<h2 class="sec" id="human">7 · Human Surface &amp; UX</h2>
+<div class="two">
+<div class="col or"><h4>ORCA — wins decisively here</h4><ul>
+<li>Native desktop UI; many agent TUIs visible at once, full fidelity</li>
+<li>Source-control review, diff UX, Linear/GitHub integration</li>
+<li>SSH remotes, a <b>mobile companion app</b></li>
+<li>Approvals answered in the agent's own polished UI</li>
+</ul></div>
+<div class="col ck"><h4>COCKPIT — deliberately thin</h4><ul>
+<li>No GUI of its own; rides cmux tabs; Obsidian hub-spoke for reports</li>
+<li>Semi-automatic: prompts at key moments, not a dashboard to watch</li>
+<li>Daily briefing, standup/retro, learnings — text/agent-mediated</li>
+<li>The human is meant to be <b>mostly absent</b></li>
+</ul></div>
+</div>
+<p>This is the inverse of §6. Orca is years ahead on human ergonomics and visibility; cockpit intentionally declines that race (its memory even records "context preservation beats visual side-by-side panes"). They're not competing here — they disagree about whether the human <i>should</i> be watching.</p>
+
+<h2 class="sec" id="foot">8 · Footprint &amp; Invasiveness</h2>
+<table>
+<tr><th></th><th class="ck">Cockpit</th><th class="or">Orca</th></tr>
+<tr><td>Global config mutation</td><td class="y">Scoped to <code>~/.config/cockpit</code>; no global agent-config edits</td><td class="n">Writes managed entries into global <code>~/.codex/hooks.json</code> + <code>config.toml</code> trust hashes</td></tr>
+<tr><td>Install weight</td><td class="y">Node CLI + launchd plist</td><td class="m">Electron app (heavy) but self-contained</td></tr>
+<tr><td>Coexistence with your own agent use</td><td class="y">Designed to not touch user workspaces/config</td><td class="m">Hook-trust edits can collide with your own codex use / multiple sessions</td></tr>
+</table>
+<p>Cockpit is the less invasive guest on the machine. Orca's power partly comes from rewriting the agent's own config — effective, but a coordination hazard the comparison study flags as a real cost of adopting orca's model.</p>
+
+<h2 class="sec" id="ext">9 · Extensibility &amp; Self-Improvement</h2>
+<div class="two">
+<div class="col ck"><h4>COCKPIT</h4><ul>
+<li>Plugin slots + load-on-demand skills (portable markdown, multi-agent)</li>
+<li><b>Self-improving by design</b>: learnings system, LLM wiki compilation, "everything should improve itself"</li>
+<li>GSD/Task Master integration for complex work</li>
+<li><code>AGENTS.md</code>-canonical, Claude-Code-as-reference (not Claude-only)</li>
+</ul></div>
+<div class="col or"><h4>ORCA</h4><ul>
+<li>Extends by adding agents to a launch table — trivially broad</li>
+<li>No self-learning/wiki/retro loop evident; improvement is product-team-driven</li>
+<li>Orchestration via injected preambles teaching agents its CLI</li>
+</ul></div>
+</div>
+<p>Cockpit treats <b>self-improvement as a first-class subsystem</b> (a stated user principle); orca treats it as a product roadmap. Cockpit's design is more ambitious here and more aligned with an "autonomous, self-recovering" north star — at the cost of complexity orca avoids.</p>
+
+<h2 class="sec" id="matrix">10 · Capability Matrix</h2>
+<table>
+<tr><th>Capability</th><th class="ck">Cockpit</th><th class="or">Orca</th></tr>
+<tr><td>Agent commands other agents (no human)</td><td class="y">Core</td><td class="m">Coordinator, cooperative</td></tr>
+<tr><td>Reliable real done-signal</td><td class="y">Headless events / state machine</td><td class="y">Native <code>Stop</code> hook</td></tr>
+<tr><td>Durable task state across restart</td><td class="y">Yes</td><td class="n">No</td></tr>
+<tr><td>Conversation resume</td><td class="m">Designed / partial (#86 open)</td><td class="n">None</td></tr>
+<tr><td>Live human↔agent, full fidelity</td><td class="n">Claude-only, thin</td><td class="y">All agents, native TUI</td></tr>
+<tr><td>Multi-provider breadth</td><td class="m">~3 deep + more coming</td><td class="y">~30 generic</td></tr>
+<tr><td>Diff/review/GitHub/Linear UX</td><td class="n">Minimal (Obsidian reports)</td><td class="y">Rich</td></tr>
+<tr><td>Mobile / remote</td><td class="n">No</td><td class="y">Companion app, SSH</td></tr>
+<tr><td>Self-learning / recovery loop</td><td class="y">First-class</td><td class="n">Not evident</td></tr>
+<tr><td>Low machine footprint / non-invasive</td><td class="y">Yes</td><td class="m">Electron + global codex config edits</td></tr>
+</table>
+
+<h2 class="sec" id="learn">11 · What Each Can Learn From the Other</h2>
+<div class="two">
+<div class="col ck"><h4>Cockpit should steal from orca</h4><ul>
+<li><b>Native-hooks-for-state</b> as a reliable, cheap alternative to a custom protocol — already the open decision in the codex study (Path Y)</li>
+<li>The <b>exact app-server handshake</b> reference (<code>codex-fetcher.ts:88–261</code>) for Phase 1</li>
+<li>The <b>codex 0.129+ silent-degradation</b> trap → "ready = handshake probe, not spawn"</li>
+<li>That <b>breadth is cheap</b> if a generic TUI tier is acceptable as a fallback provider mode</li>
+</ul></div>
+<div class="col or"><h4>Where cockpit is already ahead</h4><ul>
+<li>Durable <b>state machine</b> &amp; explicit <b>recovery</b> (orca has none)</li>
+<li><b>Conversation resume</b> ambition (orca structurally cannot)</li>
+<li>Deriving completion from <b>events, not agent goodwill</b></li>
+<li><b>Non-invasive</b> footprint (no global agent-config rewrites)</li>
+<li><b>Self-improvement</b> as a subsystem</li>
+</ul></div>
+</div>
+
+<h2 class="sec" id="strat">12 · Strategic Takeaways for Cockpit</h2>
+<div class="callout good">
+<span class="lbl">Verdict</span>
+Orca is the stronger <b>product</b> (UX, breadth, polish); cockpit is the stronger <b>orchestration substrate</b> (state, recovery, agent-commands-agents). They are not the same category — orca validates cockpit's hard parts by <i>lacking</i> them.
+</div>
+<ol>
+<li><b>Don't chase orca's UX.</b> A GUI/mobile app is a different product. Cockpit's edge is the headless substrate; doubling down on state/recovery is the right focus, consistent with the stated north star.</li>
+<li><b>Adopt orca's hooks insight as a provider tier, not a pivot.</b> "TUI + native hooks" is a legitimate, cheap, reliable mode. Consider it a <b>fallback interactive tier</b> (especially for the long tail of ~30 agents) <i>under</i> the control-plane — breadth without abandoning the state machine.</li>
+<li><b>The codex-interactive fork stands (see companion study §6).</b> Hold the <code>app-server</code> path for codex specifically — resume + steerability are cockpit's differentiators and orca proves they're rare. Use orca's client as the Phase-1 reference; let the Phase-1 smoke test be the true go/no-go.</li>
+<li><b>Close #86 with intent.</b> Resilience is the entire reason cockpit beats an orca-style model. Orphan-on-restart is the gap between the thesis and the implementation — it's the highest-leverage next investment.</li>
+<li><b>Keep the non-invasive footprint as a deliberate selling point.</b> Orca's global-config rewriting is a real cost; cockpit's restraint is a feature worth protecting.</li>
+</ol>
+
+<div class="foot">
+Companion report: <code>docs/research/2026-05-19-orca-codex-wrapping-study.html</code> (mechanism deep-dive + the open X/Y/Z fork). Cockpit @ <code>develop 9e61220</code>; Orca @ <code>03b88951</code>. System-level comparison; mechanism claims about orca are evidence-backed in the companion, cockpit claims reflect the post-PR-#85 architecture.
+</div>
+
+</main>
+</div>
+</body>
+</html>

--- a/docs/research/2026-05-19-orca-codex-wrapping-study.html
+++ b/docs/research/2026-05-19-orca-codex-wrapping-study.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Orca — How It Wraps Codex · Deep Study vs. Cockpit's app-server Design</title>
+<style>
+  :root{
+    --bg:#0f1115; --panel:#171a21; --panel2:#1d212a; --ink:#e6e8ee; --mut:#9aa3b2;
+    --line:#2a2f3a; --accent:#5db0ff; --good:#4ade80; --warn:#fbbf24; --bad:#f87171;
+    --code:#0b0d12; --mono:"SF Mono",ui-monospace,Menlo,Consolas,monospace;
+  }
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{margin:0;background:var(--bg);color:var(--ink);
+    font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;}
+  .wrap{display:grid;grid-template-columns:260px 1fr;max-width:1240px;margin:0 auto;}
+  nav{position:sticky;top:0;align-self:start;height:100vh;overflow:auto;
+    padding:28px 18px;border-right:1px solid var(--line);font-size:13.5px;}
+  nav h2{font-size:12px;letter-spacing:.12em;text-transform:uppercase;color:var(--mut);margin:0 0 12px}
+  nav a{display:block;color:var(--mut);text-decoration:none;padding:5px 8px;border-radius:6px;margin:1px 0}
+  nav a:hover{color:var(--ink);background:var(--panel2)}
+  nav a.sub{padding-left:20px;font-size:12.5px;opacity:.85}
+  main{padding:48px 56px 120px;min-width:0}
+  header.hero{border-bottom:1px solid var(--line);padding-bottom:26px;margin-bottom:34px}
+  .kicker{color:var(--accent);font-size:12.5px;letter-spacing:.14em;text-transform:uppercase;font-weight:700}
+  h1{font-size:30px;line-height:1.25;margin:10px 0 8px;letter-spacing:-.01em}
+  .sub{color:var(--mut);font-size:14.5px}
+  .meta{display:flex;flex-wrap:wrap;gap:10px;margin-top:18px}
+  .pill{background:var(--panel);border:1px solid var(--line);border-radius:999px;
+    padding:5px 12px;font-size:12.5px;color:var(--mut)}
+  .pill b{color:var(--ink)}
+  h2.sec{font-size:22px;margin:52px 0 14px;padding-top:10px;border-top:1px solid var(--line);letter-spacing:-.01em}
+  h3{font-size:17px;margin:30px 0 10px;color:#cdd3df}
+  p{margin:12px 0}
+  code{font-family:var(--mono);font-size:13px;background:var(--panel2);
+    padding:2px 6px;border-radius:5px;color:#cfe6ff}
+  pre{background:var(--code);border:1px solid var(--line);border-radius:10px;
+    padding:16px 18px;overflow:auto;margin:16px 0}
+  pre code{background:none;padding:0;color:#d6dcea;font-size:12.5px;line-height:1.6}
+  .ev{color:var(--mut);font-size:12.5px;font-family:var(--mono)}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:18px 20px;margin:18px 0}
+  .callout{border-left:3px solid var(--accent);background:var(--panel);
+    padding:14px 18px;border-radius:0 10px 10px 0;margin:18px 0}
+  .callout.good{border-color:var(--good)} .callout.warn{border-color:var(--warn)}
+  .callout.bad{border-color:var(--bad)}
+  .callout .lbl{font-size:11.5px;letter-spacing:.12em;text-transform:uppercase;font-weight:700;
+    color:var(--mut);display:block;margin-bottom:6px}
+  table{border-collapse:collapse;width:100%;margin:20px 0;font-size:13.5px}
+  th,td{border:1px solid var(--line);padding:10px 12px;text-align:left;vertical-align:top}
+  th{background:var(--panel2);color:#cdd3df;font-weight:600}
+  td.y{color:var(--good)} td.n{color:var(--bad)} td.m{color:var(--warn)}
+  .tag{display:inline-block;font-size:11px;font-weight:700;padding:2px 8px;border-radius:999px;
+    border:1px solid var(--line)}
+  .tag.green{color:var(--good);border-color:#2f6b46} .tag.amber{color:var(--warn);border-color:#6b5520}
+  .tag.red{color:var(--bad);border-color:#6b2f2f} .tag.blue{color:var(--accent);border-color:#2f4f6b}
+  .flow{font-family:var(--mono);font-size:12.5px;white-space:pre;background:var(--code);
+    border:1px solid var(--line);border-radius:10px;padding:18px;overflow:auto;color:#bcd}
+  ul{margin:12px 0;padding-left:22px} li{margin:6px 0}
+  .foot{margin-top:60px;border-top:1px solid var(--line);padding-top:18px;color:var(--mut);font-size:12.5px}
+  a.inl{color:var(--accent)}
+  .num{color:var(--accent);font-variant-numeric:tabular-nums}
+  @media(max-width:900px){.wrap{grid-template-columns:1fr}nav{display:none}main{padding:30px 22px 90px}}
+</style>
+</head>
+<body>
+<div class="wrap">
+<nav>
+  <h2>Contents</h2>
+  <a href="#tldr">TL;DR &amp; decision</a>
+  <a href="#what">1 · What Orca is</a>
+  <a href="#mech">2 · How it drives codex</a>
+  <a href="#mech-pty" class="sub">2.1 TUI-in-PTY</a>
+  <a href="#mech-hooks" class="sub">2.2 Hooks → done signal</a>
+  <a href="#mech-narrow" class="sub">2.3 Where app-server IS used</a>
+  <a href="#mech-orch" class="sub">2.4 Orchestration model</a>
+  <a href="#mech-resume" class="sub">2.5 No resume</a>
+  <a href="#ver">3 · Codex version traps</a>
+  <a href="#land">4 · The wider landscape</a>
+  <a href="#cmp">5 · Orca vs. our design</a>
+  <a href="#fork">6 · The fork — decide</a>
+  <a href="#rec">7 · Recommended path</a>
+</nav>
+<main>
+
+<header class="hero">
+  <div class="kicker">Cockpit · Interactive Codex · Prior-Art Study</div>
+  <h1>Orca — How It Wraps Codex</h1>
+  <div class="sub">A deep, evidence-backed study of <code>stablyai/orca</code> and what it means for cockpit's "interactive codex" design.</div>
+  <div class="meta">
+    <span class="pill">Date <b>2026-05-19</b></span>
+    <span class="pill">Subject <b>github.com/stablyai/orca @ 03b88951</b></span>
+    <span class="pill">Studied at <b>/tmp/orca-study</b></span>
+    <span class="pill">Target <b>codex-cli 0.130.0</b></span>
+    <span class="pill">Status <b style="color:var(--warn)">decision pending</b></span>
+  </div>
+</header>
+
+<section id="tldr">
+<div class="callout">
+  <span class="lbl">One-line characterization</span>
+  Orca drives codex by <b>running its interactive TUI in a <code>node-pty</code></b> and reading <b>codex's own native hook events over loopback HTTP</b> for turn/done state. It uses <code>codex app-server</code> only as a throwaway JSON-RPC telemetry probe, <code>codex exec</code> only for commit messages — <b>never to drive the agent</b> — and has <b>no conversation-resume at all</b>.
+</div>
+
+<div class="card">
+<b>Why this report exists.</b> We had chosen <b>Approach 3</b> for interactive codex: a typed JSON-RPC client for <code>codex app-server</code> + a launchd daemon owning one long-lived child + a cmux-tab renderer. Orca looked like it "nearly did what we're doing," so we studied it before locking the spec. It turns out orca took a <b>different, cheaper, battle-tested path</b> — which forces a real decision (§6) rather than a rubber-stamp.
+</div>
+
+<table>
+<tr><th>Question</th><th>Finding</th><th></th></tr>
+<tr><td>Does orca drive codex via <code>app-server</code>?</td><td><b>No.</b> TUI in a PTY; state via native hooks.</td><td><span class="tag red">opposite path</span></td></tr>
+<tr><td>Is TUI-<i>scraping</i> for done-state used?</td><td><b>No</b> — explicitly avoided; hooks instead.</td><td><span class="tag green">validates us</span></td></tr>
+<tr><td>Is <code>app-server</code> proven in production?</td><td>Yes, but <b>single-shot telemetry only</b> — never a conversation.</td><td><span class="tag amber">partial</span></td></tr>
+<tr><td>Conversation resume across restart?</td><td><b>None anywhere.</b> PTY dies → conversation gone.</td><td><span class="tag blue">our differentiator</span></td></tr>
+<tr><td>Approvals over a protocol?</td><td><b>No</b> — human answers in the TUI; orca only observes.</td><td><span class="tag red">zero prior art</span></td></tr>
+</table>
+</section>
+
+<h2 class="sec" id="what">1 · What Orca Is</h2>
+<p>Orca ("The AI Orchestrator for 100x builders", onOrca.dev, by stablyai) is an <b>Electron desktop IDE</b> (TypeScript; <code>electron.vite.config.ts</code>, <code>node-pty</code>, <code>@xterm/xterm</code>) that runs <i>any</i> CLI coding agent — Claude Code, Codex, Grok, Gemini, OpenCode, ~30 listed — <b>side-by-side in terminal tabs/panes across git worktrees</b>. It adds worktree management, source-control review, GitHub/Linear integration, SSH remotes, a mobile companion, and an autonomous multi-agent <b>orchestration coordinator</b>.</p>
+<p>Architecturally it is a <b>terminal multiplexer for agents</b>, not a protocol client. Its own tagline — "Multi-agent terminals — run multiple AI agents side-by-side in tabs and panes" — <i>is</i> the architecture. <b>Codex is one of ~30 agents and is not special-cased</b>: it flows through the same generic TUI-in-PTY machinery as everything else.</p>
+
+<h2 class="sec" id="mech">2 · Exactly How Orca Drives Codex</h2>
+<div class="callout warn">
+<span class="lbl">Headline</span>
+Orca runs codex as its plain interactive TUI inside a <code>node-pty</code>, rendered with xterm.js. It does <b>not</b> use <code>app-server</code>, <code>exec</code>, <code>mcp-server</code>, or <code>remote-control</code> to drive the agent. Turn/done state comes from <b>codex's own native hooks</b> — not the protocol, not TUI scraping.
+</div>
+
+<h3 id="mech-pty">2.1 — Agent launch is a bare interactive <code>codex</code> in a PTY</h3>
+<p class="ev">src/shared/tui-agent-config.ts:70–82 — the canonical per-agent launch table</p>
+<pre><code>codex: {
+  detectCmd: 'codex',
+  launchCmd: 'codex',          // &lt;-- bare TUI, no subcommand
+  expectedProcess: 'codex',
+  promptInjectionMode: 'argv',
+  preflightTrust: 'codex',
+  draftPasteReadySignal: 'codex-composer-prompt'
+}</code></pre>
+<p><code>launchCmd: 'codex'</code> — no <code>exec</code>, no <code>app-server</code>. Spawned through <code>node-pty</code> (<span class="ev">local-pty-provider.ts:11,317</span>; SSH variant in <code>ssh-pty-provider.ts</code>). Binary resolution is a pure PATH/version-manager probe (<span class="ev">codex-cli/command.ts:147 resolveCodexCommand()</span>) — no invocation logic.</p>
+
+<h3 id="mech-hooks">2.2 — Turn / "done" detection = codex's native hooks → loopback HTTP</h3>
+<p>This is the important part. Orca does <b>not</b> infer turn state from PTY output. It installs <b>managed entries into codex's own hooks system</b> and listens for the events.</p>
+<p class="ev">src/main/codex/hook-service.ts:42–49</p>
+<pre><code>const CODEX_EVENTS = [
+  'SessionStart', 'UserPromptSubmit', 'PreToolUse',
+  'PermissionRequest', 'PostToolUse', 'Stop'
+] as const</code></pre>
+<p><code>install()</code> (<span class="ev">hook-service.ts:250–340</span>) writes a managed shell script, registers it in <code>~/.codex/hooks.json</code> per event, and writes per-hook <b>trust entries</b> into <code>~/.codex/config.toml</code>. The managed script (<span class="ev">:103–133</span>) reads the hook JSON on stdin and <code>curl</code>s it to a loopback HTTP server with a bearer token:</p>
+<pre><code>curl -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/codex" \
+  -H "X-Orca-Agent-Hook-Token: ${ORCA_AGENT_HOOK_TOKEN}" \
+  --data-urlencode "paneKey=${ORCA_PANE_KEY}" ... \
+  --data-urlencode "payload=${payload}"</code></pre>
+<p>The receiver is <code>src/main/agent-hooks/server.ts</code> — a loopback <code>http.createServer</code> with bearer auth, IPC fanout, and an on-disk <code>last-status.json</code> cache that survives restart (<span class="ev">server.ts:1–12</span>). So:</p>
+<ul>
+<li><b><code>Stop</code></b> = turn done — a <b>real signal from codex itself</b>, not a heuristic.</li>
+<li><b><code>UserPromptSubmit / PreToolUse / PostToolUse</code></b> = live in-flight readout (tool name + input preview) — <span class="ev">:37–41</span>.</li>
+<li><b><code>PermissionRequest</code></b> = the human-in-the-loop boundary. Per comment <span class="ev">:39–41</span>: the managed script <i>exits without a decision so Codex still shows its normal approval UI</i>, while orca just flips the pane to a red "waiting" state.</li>
+</ul>
+<div class="callout">
+<span class="lbl">Key behavioral fact</span>
+Codex's interactive approval/question UI is left <b>fully intact</b>; the human answers it <b>directly in the rendered terminal</b>. Orca only observes state transitions out-of-band. It never answers a codex prompt programmatically.
+</div>
+
+<h3 id="mech-narrow">2.3 — The two narrow places codex's non-TUI surfaces ARE used</h3>
+<div class="card">
+<p><b>(a) <code>codex app-server</code> — telemetry side-probe only.</b> <span class="ev">src/main/rate-limits/codex-fetcher.ts:84–261</span>. To populate the rate-limit status bar, orca spawns a separate, short-lived <code>codex -s read-only -a untrusted app-server</code> child (<span class="ev">:99–106</span>), speaks JSON-RPC over stdin/stdout, asks <i>one</i> question, then <b>kills the child</b> (<span class="ev">:191</span>). This is a complete, correct, production app-server client — and it is <b>gold for our Phase 1</b> (see §7). On any RPC failure it falls back to a PTY that types <code>/status</code> and regex-scrapes the output (<span class="ev">:264–461</span>). Telling comment <span class="ev">:440</span>: <i>"app-server can fail independently of the interactive CLI."</i></p>
+<p><b>(b) <code>codex exec</code> — commit messages only.</b> <span class="ev">src/shared/commit-message-agent-spec.ts:248–269</span>: <code>codex exec --ephemeral --skip-git-repo-check -s read-only</code> with the diff on stdin. One-shot text generation, not agent orchestration.</p>
+<p><b>(c) Input-timing screen-scrape (minor).</b> <code>draftPasteReadySignal:'codex-composer-prompt'</code> watches the PTY stream for codex's <code>›</code> composer prompt purely to time a bracketed paste — the <i>only</i> place orca reads the rendered TUI to make a decision, and it's not state.</p>
+</div>
+
+<h3 id="mech-orch">2.4 — Autonomous multi-agent orchestration model</h3>
+<p><span class="ev">src/main/runtime/orchestration/coordinator.ts + preamble.ts</span>. When orca runs agents autonomously it launches the agent's TUI in a worktree PTY and <b>injects a prompt preamble that teaches the agent orca's own CLI</b>: the agent is told to call <code>orca task complete --body &lt;summary&gt;</code> when done and to heartbeat every 5 min. Completion = <b>the agent voluntarily calling back</b>, backed by a 10-min stale-heartbeat threshold + auto-fail (<span class="ev">coordinator.ts:172,230,332–335</span>). Cooperative + watchdog, not protocol-driven. <i>(This is essentially the same pattern as cockpit's legacy captain/crew callback model — and shares its weakness: it trusts the agent to report.)</i></p>
+
+<h3 id="mech-resume">2.5 — Session / resume model: there is none for codex</h3>
+<p>Grep for <code>codex.*resume</code>, <code>experimental_resume</code>, <code>rollout</code>, <code>--continue</code>, <code>conversationId</code> in non-test source: <b>nothing</b>. A "session" in orca = a PTY + xterm buffer + a stable <code>paneKey</code>. Resilience across an <b>orca</b> restart = (a) the <code>last-status.json</code> disk cache so dashboard rows reappear, and (b) the managed hook script re-sourcing its endpoint so a <i>surviving</i> PTY keeps reporting. But the <b>codex conversation itself is not resumable</b> — if the PTY dies, the conversation is gone. Orca's resilience story is "keep the PTY alive and re-attach the observer," never "reconstruct the conversation."</p>
+
+<h2 class="sec" id="ver">3 · Codex Version Traps Orca Encodes</h2>
+<div class="callout warn">
+<span class="lbl">Most reusable production lesson in the repo</span>
+<b>Codex 0.129+ silently degrades when config preconditions fail.</b> <span class="ev">config-toml-trust.ts:14,20; hook-service.ts:151,297</span>: untrusted hooks "sit in the review-required pile" with <b>no error</b>. Orca computes <code>trusted_hash</code> entries to dodge this. Lesson for us: <b>codex can look-alive-but-be-stuck — never treat silence as success.</b>
+</div>
+<ul>
+<li><code>src/cli/codex-command-classification.ts:1–37</code> enumerates the modern codex surface orca knows (<code>exec, app-server, mcp-server, remote-control, exec-server, stdio-to-uds, cloud…</code>) — used only to classify "safe in background PTY vs. needs a visible terminal," never invoked for orchestration.</li>
+<li>Model tables list <code>gpt-5.1/5.2/5.3-codex</code> … <code>gpt-5.5</code> — consistent with a late <b>codex-cli ~0.13x</b> assumption, the same neighborhood as our <b>0.130.0</b> target. The 0.129+ hook-trust requirement is directly relevant.</li>
+</ul>
+
+<h2 class="sec" id="land">4 · The Wider Landscape ("tons of others wrap codex")</h2>
+<p>Not corroborated by orca's code or dependencies. Orca depends on <b>no</b> third-party codex wrapper, no <code>@openai/codex</code> programmatic SDK, no codex-pty library. The ~30 names in its README are <i>agents it hosts</i>, not <i>wrappers it uses</i>. Codex's own subcommands (<code>mcp-server, app-server, remote-control</code>) appear only in its command-classifier, never invoked for orchestration. <b>Conclusion:</b> orca isn't evidence of <i>how</i> others wrap codex — it's evidence that one serious, well-engineered multi-agent product independently chose <b>TUI-in-PTY + native hooks</b> over the app-server protocol for the agent loop. (cmux is the same shape: it just runs the codex TUI in a tab — the unreliable part was cockpit <i>screen-scraping</i> that tab, which hooks would fix.)</p>
+
+<h2 class="sec" id="cmp">5 · Orca vs. Our Approach-3 Design</h2>
+<table>
+<tr><th>Dimension</th><th>Orca (TUI-PTY + hooks)</th><th>Cockpit Approach 3 (app-server)</th></tr>
+<tr><td>Human surface</td><td class="y">Codex's real native TUI — full fidelity, zero renderer to build</td><td class="m">Cockpit-built chat renderer over the protocol</td></tr>
+<tr><td>Turn/done signal</td><td class="y">Native <code>Stop</code> hook — reliable, real</td><td class="y"><code>TurnCompleted</code> notification — reliable, real</td></tr>
+<tr><td>Approvals</td><td class="m">Human answers in codex's own UI; orca only observes</td><td class="m">Answered over protocol — capability orca lacks, but <b>zero prior art</b></td></tr>
+<tr><td>Captain can steer it</td><td class="n">No — human-only</td><td class="y">Yes — <code>turn/steer</code>, programmatic</td></tr>
+<tr><td>Resume across daemon/PTY bounce</td><td class="n">None — conversation lost</td><td class="y"><code>thread/resume</code> — our differentiator</td></tr>
+<tr><td>Config invasiveness</td><td class="n">Mutates global <code>~/.codex/hooks.json</code> + <code>config.toml</code> trust hashes</td><td class="y">No global codex config mutation</td></tr>
+<tr><td>Build cost</td><td class="y">Low — PTY + a hook HTTP listener</td><td class="n">High — client lib + streaming channel + renderer</td></tr>
+<tr><td>Protocol maturity</td><td class="y">Battle-tested (the path orca ships)</td><td class="m">Conversation methods <b>unproven in production</b> anywhere</td></tr>
+</table>
+
+<h2 class="sec" id="fork">6 · The Fork — This Is The Decision</h2>
+<p>Orca doesn't invalidate app-server, but it proves a cheaper path is real and shifts the risk picture. Three options remain genuinely open:</p>
+
+<div class="card">
+<p><span class="tag blue">Path X</span> &nbsp;<b>Stay app-server (Approach 3).</b> Cockpit drives codex over JSON-RPC, renders its own chat. <b>Buys:</b> captain-steerable, resumable across bounce, unified in the control-plane, no global config mutation. <b>Costs:</b> biggest build; the conversation methods (<code>turn/start</code> + approvals) are the one thing nobody — not even orca — has shipped, so Phase 1's smoke test becomes the true risk gate, not a formality.</p>
+</div>
+<div class="card">
+<p><span class="tag green">Path Y</span> &nbsp;<b>Pivot to orca's model (TUI-PTY + native hooks).</b> Run real <code>codex</code> in the cmux tab; observe turn/done via codex's native hooks → a loopback listener (orca's exact, proven mechanism — reliable, <i>not</i> scraping). <b>Buys:</b> full native UX free, approvals handled by codex's own UI, smallest build, battle-tested. <b>Costs:</b> no captain-steering, <b>no resume-on-bounce</b> (conversation dies with the PTY), and it <b>mutates your global <code>~/.codex</code> config</b> — a real coordination/cleanliness hazard if your own codex use or multiple cockpit sessions collide.</p>
+</div>
+<div class="card">
+<p><span class="tag amber">Path Z</span> &nbsp;<b>Hybrid — native TUI for the human + app-server thread for state/resume.</b> Cheap full-fidelity UX <i>plus</i> a resumable handle. <b>Open risk:</b> unverified whether a TUI session and an app-server thread can be bound to the <i>same</i> conversation — may be technically impossible; needs a spike before it can be specced.</p>
+</div>
+
+<div class="callout">
+<span class="lbl">What changed vs. before the study</span>
+Before: app-server looked like the only non-scraping path. After: orca proves a <b>second reliable non-scraping path</b> (native hooks) that is far cheaper but sacrifices the two things cockpit's north star most values — <b>resilience (resume) and orchestration (captain steering)</b>. The decision is now an explicit values trade, not a technical unknown.
+</div>
+
+<h2 class="sec" id="rec">7 · Recommended Path &amp; Adjustments</h2>
+<div class="callout good">
+<span class="lbl">Recommendation</span>
+<b>Hold Path X (Approach 3)</b> — but treat orca's findings as mandatory hardening, and run the Phase-1 smoke test as a true go/no-go gate <i>before</i> any daemon work. Rationale: cockpit's stated north star is a <b>reliable orchestrator where one captain controls many crew with auto-recovery</b>. Resume-on-bounce and captain-steerability are exactly that — and they are precisely what Path Y structurally cannot do. Orca's lack of them isn't a counter-argument; it's confirmation those are the differentiating capabilities worth the build.
+</div>
+
+<h3>Phase 1 additions (low cost, high confidence — lifted from orca's working client)</h3>
+<ul>
+<li><b>Exact handshake ordering:</b> <code>initialize</code> (request, <code>clientInfo</code>) → await response → <code>initialized</code> <i>notification</i> (no id) → only then real methods. Orca comment <span class="ev">codex-fetcher.ts:142–146</span>: skipping the notification → "Not initialized" errors. Bake in + smoke-test that it cannot happen.</li>
+<li><b>Defensive line framing:</b> newline-delimited JSON, one object per line; ignore non-JSON lines; route id-less messages as notifications (mirror <span class="ev">:160–221</span>).</li>
+<li><b>Envelope-wrapped results:</b> orca got <code>{ rateLimits: {...} }</code>; expect <code>turn</code>/<code>thread</code> results similarly nested. Rely on vendored <code>codex app-server generate-ts</code> types, never hand-written flat shapes.</li>
+<li><b>Global flags precede the subcommand:</b> <code>codex -s &lt;sandbox&gt; -a &lt;policy&gt; app-server</code> (orca uses <code>-s read-only -a untrusted</code>; we need writable + an approval policy). Match arg order.</li>
+</ul>
+
+<h3>Phase 2 additions (counter the pitfalls orca exposes)</h3>
+<ul>
+<li><b>"Ready" = successful handshake probe</b>, not just child-spawned — directly counters the codex-0.129+ "silent degradation" pattern. Reinforces our <b>"<code>TurnCompleted</code> is liveness, NOT completion"</b> anti-false-done invariant.</li>
+<li><b>Approval round-trip is the highest-risk, zero-prior-art surface.</b> Elevate it to an independent, explicitly smoke-tested success criterion: a <code>turn/start</code> that triggers a tool needing approval → answered over RPC → <code>TurnCompleted</code>. Orca has <i>no</i> reference here — we own this.</li>
+<li><b><code>thread/resume</code>-on-bounce as a tested first-class path.</b> Orca's total lack of conversation resume confirms this is the capability that makes cockpit's interactive codex worth more than orca's — not an afterthought.</li>
+<li><b>Supervise the app-server child.</b> Orca keeps a fallback because "app-server can fail independently of the CLI." Daemon must restart it and re-<code>thread/resume</code> live tasks.</li>
+</ul>
+
+<div class="callout warn">
+<span class="lbl">Honest residual risk</span>
+The conversation-driving methods (<code>turn/start</code>, <code>turn/steer</code>, the approval round-trip) are <b>unproven in production by anyone we can find, including orca</b>. Path X is the right bet for cockpit's goals, but Phase 1's smoke test is not a formality — it is the gate that says go/no-go before we invest in the daemon. If Phase 1 reveals the conversation API is unreliable, <b>Path Y becomes the fallback</b>, and that decision is cheap to make at that point because Phase 1 cost little.
+</div>
+
+<div class="foot">
+Source memo: <code>docs/research/2026-05-19-orca-codex-wrapping-study.md</code> · Orca @ <code>03b88951</code> (live, fully accessible, 2026-05-19) · Generated for cockpit interactive-codex brainstorm · Decision still open (§6) pending your call.
+</div>
+
+</main>
+</div>
+</body>
+</html>

--- a/docs/research/2026-05-19-orca-codex-wrapping-study.md
+++ b/docs/research/2026-05-19-orca-codex-wrapping-study.md
@@ -1,0 +1,147 @@
+# Orca — How It Wraps/Drives Codex (Study vs. Cockpit's app-server Design)
+
+**Date:** 2026-05-19
+**Subject repo:** https://github.com/stablyai/orca @ `03b88951` (HEAD, 2026-05-19, commit "feat: expand ai commit agent support (#1928)")
+**Studied at:** `/tmp/orca-study` (shallow clone)
+**Why:** We are about to finalize "interactive codex" for cockpit using Approach 3 (typed JSON-RPC client for `codex app-server` + launchd daemon owning one long-lived child). Question: does orca validate, improve, or warn against the app-server path?
+
+---
+
+## 1. What Orca Is
+
+Orca ("The AI Orchestrator for 100x builders", onOrca.dev, by stablyai) is an **Electron desktop IDE** (TypeScript; `electron.vite.config.ts`, `node-pty`, `@xterm/xterm`) that runs *any* CLI coding agent — Claude Code, Codex, Grok, Gemini, OpenCode, ~30 listed — **side-by-side in terminal tabs/panes across git worktrees**. It adds worktree management, source-control review, GitHub/Linear integration, SSH remotes, a mobile companion app, and an autonomous multi-agent **orchestration coordinator**. It is closed-architecture-wise a *terminal multiplexer for agents*, not a protocol client. The README's framing — "Multi-agent terminals — Run multiple AI agents side-by-side in tabs and panes" — is literally the architecture.
+
+Codex is one of ~30 agents and is **not special-cased** in the launch path. It flows through the same generic TUI-in-PTY machinery as every other agent.
+
+---
+
+## 2. EXACTLY How Orca Drives Codex (the mechanism, with evidence)
+
+**Headline: Orca runs codex as its plain interactive TUI inside a `node-pty` pseudo-terminal, rendered with xterm.js. It does NOT use `codex app-server`, `codex exec`, `codex mcp-server`, or `codex remote-control` to drive the agent.** Turn/done state comes from **codex's own native hooks system**, not from the protocol and not from scraping the TUI for status.
+
+### 2.1 Agent launch = bare interactive `codex` in a PTY
+
+`src/shared/tui-agent-config.ts:70-82` — the canonical per-agent launch table:
+
+```ts
+codex: {
+  detectCmd: 'codex',
+  launchCmd: 'codex',          // <-- bare TUI, no subcommand
+  expectedProcess: 'codex',
+  promptInjectionMode: 'argv',
+  preflightTrust: 'codex',
+  draftPasteReadySignal: 'codex-composer-prompt'
+}
+```
+
+`launchCmd: 'codex'` — no `exec`, no `app-server`. The header comment (lines 52-57) states this table is "which binary it actually launches, and whether the initial prompt should be passed as an argv flag/argument or typed into the interactive session after startup." The process is spawned via `node-pty` (`src/main/providers/local-pty-provider.ts:11` `import * as pty from 'node-pty'`; `:317` `ptySpawn: pty.spawn`; SSH variant in `ssh-pty-provider.ts`). Binary resolution: `src/main/codex-cli/command.ts:147` `resolveCodexCommand()` — pure PATH/version-manager probe, returns a path; no invocation logic.
+
+### 2.2 Turn / "done" detection = codex's native hooks → loopback HTTP
+
+This is the important part. Orca does not infer turn state from PTY output. It **installs managed entries into codex's own hooks system** and listens for the events.
+
+`src/main/codex/hook-service.ts:42-49`:
+
+```ts
+const CODEX_EVENTS = [
+  'SessionStart', 'UserPromptSubmit', 'PreToolUse',
+  'PermissionRequest', 'PostToolUse', 'Stop'
+] as const
+```
+
+`install()` (`hook-service.ts:250-340`) writes a managed shell script and registers it in `~/.codex/hooks.json` for each event, plus writes per-hook **trust entries** into `~/.codex/config.toml`. The managed script (`hook-service.ts:103-133`) is a `/bin/sh` (or `.cmd`) wrapper that reads the hook JSON on stdin and `curl`s it to a **loopback HTTP server** with a bearer token:
+
+```sh
+curl -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/codex" \
+  -H "X-Orca-Agent-Hook-Token: ${ORCA_AGENT_HOOK_TOKEN}" \
+  --data-urlencode "paneKey=${ORCA_PANE_KEY}" ... --data-urlencode "payload=${payload}"
+```
+
+The receiver is `src/main/agent-hooks/server.ts` (a loopback `http.createServer` with bearer auth, IPC fanout, and an on-disk `last-status.json` cache that survives restart — see its header comment, `server.ts:1-12`). So:
+
+- **`Stop`** = turn done (real signal from codex itself, not a heuristic).
+- **`UserPromptSubmit` / `PreToolUse` / `PostToolUse`** = live in-flight readout (tool name + input preview between prompt and Stop) — `hook-service.ts:37-41`.
+- **`PermissionRequest`** = the human-in-the-loop boundary. Per the comment at `hook-service.ts:39-41`: "the managed script exits without a decision so Codex still shows its normal approval UI, while Orca can flip the pane to the red waiting state." Orca does **not** intercept/answer approvals over a protocol — the approval is answered by the human *in the codex TUI*; the hook is a passive observer that just repaints the pane.
+
+This means **codex's interactive approval/question UI is left fully intact and the human interacts with it directly in the rendered terminal.** Orca only observes state transitions out-of-band.
+
+### 2.3 The two narrow places codex's non-TUI surfaces ARE used
+
+**(a) `codex app-server` — telemetry side-probe only.** `src/main/rate-limits/codex-fetcher.ts:84-261`. To populate the rate-limit status bar, orca spawns a *separate, short-lived* `codex -s read-only -a untrusted app-server` child (`:99-106`), speaks JSON-RPC over stdin/stdout, and asks exactly one question. This is a fully working, production app-server client and is **gold for our design** (see §5). It does the LSP-style handshake (`:142-181`): `initialize` request → wait for response → `initialized` *notification* → then `account/rateLimits/read`. Newline-delimited JSON-RPC framing (`:160-164`). It then **kills the child** (`:191`) — single-shot, not long-lived. On any RPC failure it falls back to a PTY that spawns `codex`, waits for the `>` prompt, types `/status\r`, strips ANSI, and regex-scrapes the output (`:264-425`, `fetchCodexRateLimits` Path A→B at `:431-461`). The comment at `:440-441` is telling: "app-server can fail independently of the interactive CLI."
+
+**(b) `codex exec` — non-agent commit messages only.** `src/shared/commit-message-agent-spec.ts:248-269`: `codex exec --ephemeral --skip-git-repo-check -s read-only --model <m>` with the diff on **stdin** (comment `:251-253`: argv would exceed Windows/SSH command-line limits). This is one-shot text generation, not agent orchestration.
+
+**(c) Input-timing screen-scrape (minor).** `draftPasteReadySignal: 'codex-composer-prompt'` (`tui-agent-config.ts:81`, consumed in `src/renderer/src/lib/agent-paste-draft.ts`). To time a bracketed-paste of a draft prompt, orca watches the rendered PTY stream for codex's `›` composer prompt (comment `:44-49` even cites codex's internal `chat_composer.rs`). This is the *only* place orca reads codex's rendered TUI to make a decision, and it's purely for paste timing, not state.
+
+### 2.4 Autonomous multi-agent orchestration model
+
+`src/main/runtime/orchestration/coordinator.ts` + `preamble.ts`. When orca runs agents autonomously, the coordinator `createTerminal()`s a worktree PTY, launches the agent's TUI, and **injects a prompt preamble that teaches the agent Orca's own CLI** (`preamble.ts:buildDispatchPreamble`): the agent is instructed to call `orca task complete --body <3-sentence summary>` when done and to emit heartbeats every 5 min. Completion is therefore detected by **the agent voluntarily calling back via the orca CLI**, backed by stale-heartbeat thresholds (10 min) and an auto-fail policy (`coordinator.ts:172,230,332-335`). Not protocol-driven; cooperative + watchdog.
+
+### 2.5 Session / resume model
+
+**There is none for codex.** Grep for `codex.*resume`, `experimental_resume`, `rollout`, `--continue`, `conversationId` in non-test source returns nothing. A "session" in orca = a PTY + an xterm.js buffer + a stable `paneKey`. Resilience across **orca** restart is handled by: (a) the `last-status.json` disk cache so dashboard rows reappear (`server.ts:1-12`), and (b) the managed hook script re-sourcing `$ORCA_AGENT_HOOK_ENDPOINT` on each fire so a *surviving* PTY keeps reporting to the *new* orca instance's port/token (`hook-service.ts:104-112`). But the **codex conversation itself is not resumable** — if the PTY dies, the conversation is gone; there is no `thread/resume`-equivalent. Orca's whole resilience story is "keep the PTY alive and re-attach the observer," not "reconstruct the conversation."
+
+---
+
+## 3. Codex Version Assumptions
+
+Orca tracks codex closely and encodes version-specific gotchas:
+
+- `src/main/codex/config-toml-trust.ts:14,20` and `hook-service.ts:151,297`: **"Codex 0.129+ requires a per-hook trust entry in config.toml or the hook sits in the 'review required' pile"** / "Codex 0.129+ silently drops untrusted hooks." Orca computes and writes `trusted_hash` entries (mirroring codex's `codex-rs/config/src/fingerprint.rs::version_for_toml` and `codex-rs/hooks/src/lib.rs::hook_event_key_label`) so the user doesn't have to `/hooks-approve`.
+- `src/cli/codex-command-classification.ts:1-37` enumerates the codex subcommand surface orca knows: includes `exec`, `app-server`, `mcp-server`, `remote-control`, `exec-server`, `stdio-to-uds`, `cloud`, `cloud-tasks`, `responses-api-proxy` — i.e. orca is aware of the full modern (≥0.13x-era) codex CLI but uses it only to classify "is this command safe to run in a background PTY vs. does it need a visible terminal."
+- Model price table (`codex-usage/store.ts:47-55`) lists `gpt-5.1`/`5.2`/`5.3`-codex variants; commit-spec lists `gpt-5.5`/`gpt-5.4` — consistent with a **late codex-cli ~0.13x** assumption, the same neighborhood as our target `codex-cli 0.130.0`. **The 0.129+ hook-trust requirement is directly relevant to us and is the single most reusable production lesson in the repo (even though it's for the hook path, not app-server).**
+
+---
+
+## 4. Other Codex-Wrapping Tools Referenced
+
+The user's belief that "tons of others wrap codex" is **not corroborated by orca's code or deps**. Orca depends on none of them. The only adjacent things present:
+- It *competes with* the same category (it's itself a wrapper). README lists ~30 *agents* it hosts, not wrappers it uses.
+- It hosts codex's own subcommands as pass-through (`mcp-server`, `app-server`, `remote-control` appear only in the command-classifier, never invoked for orchestration).
+
+No `node-pty`-of-codex library, no third-party codex SDK, no `@openai/codex` programmatic dependency. Orca's approach is bespoke and TUI-centric. If "tons of others wrap codex," orca is not evidence of *how* — it's evidence that at least one serious, well-engineered multi-agent product chose **TUI-in-PTY + native hooks** over the app-server protocol for the agent loop.
+
+---
+
+## 5. What This Means for Our app-server Design (Approach 3)
+
+### Net verdict: **Our design holds. Orca does not invalidate the app-server path — it makes the case for it from the opposite direction, and hands us a working reference client and a concrete version gotcha.**
+
+**Where orca validates us:**
+
+1. **It confirms TUI-scraping is the wrong way to drive a turn.** Orca — a mature, ~2000-PR product — explicitly does *not* parse codex's full-screen TUI for turn/done state. It went out of its way to install codex's *native hooks* instead, and only screen-scrapes for trivial paste-timing and a fallback `/status` read it openly distrusts ("app-server can fail independently of the interactive CLI", `codex-fetcher.ts:440`). Our explicit rejection of TUI-scraping is the same conclusion reached independently.
+
+2. **`codex app-server` works in production today and we have a reference implementation.** `src/main/rate-limits/codex-fetcher.ts:88-261` is a complete, correct JSON-RPC-over-stdio app-server client. Concretely reusable for Phase 1:
+   - **Handshake is mandatory and ordered**: `initialize` (request, with `clientInfo`) → await response → `initialized` (**notification**, no id) → only then other methods. Comment `:142-146`: "Skipping the notification causes 'Not initialized' errors." Bake this into our client's connect sequence and smoke test.
+   - **Framing**: newline-delimited JSON objects, one per line; ignore non-JSON lines defensively (`:160-164,219-221`).
+   - **Notifications have no `id`** — filter them by `msg.id == null` and route by method (`:172-175`). Our `AgentMessageDelta`/`TurnStarted` handling must not assume an id.
+   - **Spawn flags**: orca uses `codex -s read-only -a untrusted app-server`. We will need writable sandbox + approval policy, but note the *global flags precede the `app-server` subcommand* — match that arg order.
+   - **Response nesting is real**: rate limits came back wrapped as `{ rateLimits: {...} }` (`:37-41,205-206`). Expect our `turn`/`thread` results to be similarly envelope-wrapped; don't hardcode flat shapes — vendor types from `codex app-server generate-ts` exactly as planned.
+
+3. **Our daemon-owns-one-long-lived-child model is the correct *delta* from orca, not a copy.** Orca's app-server usage is *single-shot and disposable* (`child.kill()` after one request, `:191`). It never holds a long-lived app-server. That's fine for telemetry but is exactly the gap our Phase 2 daemon fills. Nothing in orca contradicts a long-lived app-server; orca simply never needed one because its agent loop is the PTY.
+
+**Pitfalls orca exposes that we should design around:**
+
+4. **Codex 0.129+ hook-trust trap (`config.toml` `trusted_hash`).** This bites the *hook* path, not app-server — but it's a warning that **codex silently degrades when config preconditions aren't met** (hooks "sit in the review-required pile" with no error). Design implication for us: when the daemon spawns `codex app-server`, do not assume silence == success. Add an explicit liveness probe (the `initialize` round-trip) and treat *absence of expected notifications* as a fault, not as "still working." This dovetails with — and strengthens — our **"`TurnCompleted` is liveness NOT completion" anti-false-done invariant**: orca's whole architecture is a cautionary tale that codex can look-alive-but-be-stuck, which is why they leaned on explicit event signals over inference. Keep that invariant; consider also asserting the handshake succeeded before the daemon reports "ready."
+
+5. **app-server can fail independently of the CLI.** Orca keeps a PTY fallback for telemetry precisely because the app-server child can die or error while interactive codex is fine (`codex-fetcher.ts:440-441`). For us this argues for: (a) daemon supervision/restart of the app-server child, and (b) `thread/resume` after a daemon bounce being a *first-class, tested path*, not an afterthought — exactly Phase 2's `thread/resume` for daemon-bounce survival. Orca has *no* conversation-resume at all; that's the dimension where our design is strictly more ambitious, and it's the right ambition because our use case (long-lived orchestrated turns) is the one orca's PTY model can't survive a restart of.
+
+6. **Approvals/human-in-the-loop:** orca punts entirely — it lets the human answer in the TUI and just observes. Our design answers approvals *over the protocol* (`ToolRequestUserInput`, approval requests routed to the cmux-tab client). This is a genuine capability orca lacks; nothing in orca tells us it's wrong, but it does mean **we own a surface orca never had to make robust** — there's no reference code here for the approval round-trip. Treat the approval-request/response path as the highest-novelty, highest-risk part of Phase 1 and smoke-test it explicitly (a `turn/start` that triggers a tool needing approval, answered over RPC, then `TurnCompleted`).
+
+### Recommended adjustments to the Approach-3 plan
+
+- **No structural change. Design holds.**
+- **Phase 1 additions (low cost, high confidence):**
+  - Lift orca's exact handshake ordering into our client + smoke test: `initialize` → await → `initialized` *notification* → first real method. Assert "Not initialized" cannot happen.
+  - Defensive line-framed parser that ignores non-JSON and routes id-less messages as notifications (mirror `codex-fetcher.ts:160-221`).
+  - Treat all results as potentially envelope-wrapped; rely on generated TS types, not hand-written flat shapes.
+- **Phase 2 additions:**
+  - Make the daemon's "ready" signal contingent on a successful app-server handshake probe, not just child-spawned (counter the "silent degradation" pattern orca documents for 0.129+).
+  - Elevate the approval round-trip (`ToolRequestUserInput`) to an explicit, independently smoke-tested success criterion — it is the one area with zero prior art in orca and the most likely source of false-done / hang behavior.
+  - Keep `thread/resume`-on-bounce as a tested first-class path; orca's total lack of conversation resume confirms this is the differentiating capability, not a nice-to-have.
+
+---
+
+## 6. One-line characterization
+
+> Orca drives codex by **running its interactive TUI in a node-pty and reading codex's own native hook events over loopback HTTP for turn/done state** — it uses `codex app-server` only as a throwaway JSON-RPC telemetry probe and `codex exec` only for commit messages, never to drive the agent, and has no conversation-resume at all. It validates our rejection of TUI-scraping, hands us a correct app-server handshake reference, and — by *lacking* long-lived app-server, protocol approvals, and resume — pinpoints exactly the three areas where Approach 3 is the right bet and must be tested hardest.

--- a/docs/research/2026-05-19-orca-derived-cockpit-improvements.html
+++ b/docs/research/2026-05-19-orca-derived-cockpit-improvements.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Orca-Derived Cockpit Improvements — Roadmap</title>
+<style>
+  :root{
+    --bg:#0f1115;--panel:#171a21;--panel2:#1d212a;--ink:#e6e8ee;--mut:#9aa3b2;
+    --line:#2a2f3a;--accent:#5db0ff;--good:#4ade80;--warn:#fbbf24;--bad:#f87171;
+    --code:#0b0d12;--mono:"SF Mono",ui-monospace,Menlo,Consolas,monospace;
+  }
+  *{box-sizing:border-box} html{scroll-behavior:smooth}
+  body{margin:0;background:var(--bg);color:var(--ink);
+    font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;}
+  .wrap{display:grid;grid-template-columns:260px 1fr;max-width:1240px;margin:0 auto;}
+  nav{position:sticky;top:0;align-self:start;height:100vh;overflow:auto;
+    padding:26px 16px;border-right:1px solid var(--line);font-size:13px;}
+  nav h2{font-size:11.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--mut);margin:16px 0 8px}
+  nav h2:first-child{margin-top:0}
+  nav a{display:block;color:var(--mut);text-decoration:none;padding:4px 8px;border-radius:6px;margin:1px 0}
+  nav a:hover{color:var(--ink);background:var(--panel2)}
+  nav a.sub{padding-left:18px;font-size:12.5px;opacity:.82}
+  main{padding:46px 56px 120px;min-width:0}
+  header.hero{border-bottom:1px solid var(--line);padding-bottom:24px;margin-bottom:30px}
+  .kicker{color:var(--accent);font-size:12.5px;letter-spacing:.14em;text-transform:uppercase;font-weight:700}
+  h1{font-size:28px;line-height:1.25;margin:10px 0 8px;letter-spacing:-.01em}
+  .sub{color:var(--mut);font-size:14px}
+  .meta{display:flex;flex-wrap:wrap;gap:9px;margin-top:16px}
+  .pill{background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:5px 11px;font-size:12px;color:var(--mut)}
+  .pill b{color:var(--ink)}
+  h2.sec{font-size:20px;margin:46px 0 12px;padding-top:10px;border-top:1px solid var(--line);letter-spacing:-.01em}
+  h3{font-size:16px;margin:24px 0 8px;color:#cdd3df}
+  p{margin:11px 0}
+  code{font-family:var(--mono);font-size:12.5px;background:var(--panel2);padding:2px 6px;border-radius:5px;color:#cfe6ff}
+  .ev{color:var(--mut);font-size:12px;font-family:var(--mono)}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:14px 18px;margin:14px 0}
+  .issue{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:16px 20px;margin:18px 0;border-left:3px solid var(--accent)}
+  .issue h3{margin-top:0}
+  .issue .num{display:inline-block;font-family:var(--mono);font-size:13px;font-weight:700;color:var(--accent);background:var(--code);
+    padding:2px 8px;border-radius:5px;margin-right:8px;border:1px solid var(--line)}
+  .issue .field{margin:8px 0;font-size:13.5px}
+  .issue .field b{color:#cdd3df;display:inline-block;min-width:115px}
+  .callout{border-left:3px solid var(--accent);background:var(--panel);padding:14px 18px;border-radius:0 10px 10px 0;margin:16px 0}
+  .callout.good{border-color:var(--good)} .callout.warn{border-color:var(--warn)}
+  .callout .lbl{font-size:11px;letter-spacing:.12em;text-transform:uppercase;font-weight:700;color:var(--mut);display:block;margin-bottom:6px}
+  table{border-collapse:collapse;width:100%;margin:16px 0;font-size:13px}
+  th,td{border:1px solid var(--line);padding:9px 11px;text-align:left;vertical-align:top}
+  th{background:var(--panel2);color:#cdd3df;font-weight:600}
+  .tag{display:inline-block;font-size:11px;font-weight:700;padding:2px 8px;border-radius:999px;border:1px solid var(--line);color:var(--good);border-color:#2f6b46}
+  ul,ol{margin:10px 0;padding-left:22px} li{margin:5px 0}
+  .foot{margin-top:50px;border-top:1px solid var(--line);padding-top:18px;color:var(--mut);font-size:12px}
+  @media(max-width:900px){.wrap{grid-template-columns:1fr}nav{display:none}main{padding:28px 20px 80px}}
+</style>
+</head>
+<body>
+<div class="wrap">
+<nav>
+  <h2>Catalog</h2>
+  <a href="#tldr">Status &amp; overview</a>
+  <a href="#b1">Bucket 1 · in-spec</a>
+  <a href="#b2">Bucket 2 · filed issues</a>
+  <a href="#b2-1" class="sub">#89 dispatch-id heartbeats</a>
+  <a href="#b2-2" class="sub">#90 warn-don't-autofail</a>
+  <a href="#b2-3" class="sub">#91 sling-pattern attempts</a>
+  <a href="#b2-4" class="sub">#92 PROTOCOL_VERSION</a>
+  <a href="#b2-5" class="sub">#93 restart coalescing</a>
+  <a href="#b2-6" class="sub">#94 keepalive framing</a>
+  <a href="#b2-7" class="sub">#95 git-drift skip-not-fail</a>
+  <a href="#b3">Bucket 3 · arch notes</a>
+  <a href="#b4">Bucket 4 · validations</a>
+  <a href="#b5">Bucket 5 · future</a>
+  <a href="#guard">Do NOT regress</a>
+  <a href="#hist">History &amp; sources</a>
+</nav>
+<main>
+
+<header class="hero">
+  <div class="kicker">Cockpit · Orca-Derived Improvements · Roadmap</div>
+  <h1>Orca-Derived Cockpit Improvements</h1>
+  <div class="sub">Everything the orca study surfaced that applies to cockpit beyond the immediate interactive-codex feature, with disposition for each item.</div>
+  <div class="meta">
+    <span class="pill">Date <b>2026-05-19</b></span>
+    <span class="pill">Bucket 1 <b>in interactive-codex spec</b></span>
+    <span class="pill">Bucket 2 <b style="color:var(--good)">filed: #89–#95</b></span>
+    <span class="pill">Source <b>orca-full-system-study</b></span>
+  </div>
+</header>
+
+<section id="tldr">
+<div class="callout good">
+<span class="lbl">Status</span>
+Bucket 1 (4 items) folds into the interactive-codex spec — already user-approved. Bucket 2 (7 items) filed as standalone GitHub issues #89–#95 on <code>tu11aa/claude-cockpit</code>, label <code>enhancement</code>, each cross-referenced to orca prior art and named cockpit subsystems. Brainstorm now resumes to the spec write.
+</div>
+</section>
+
+<h2 class="sec" id="b1">Bucket 1 · Folds into the interactive-codex spec</h2>
+<p>Approved 2026-05-19. No separate issues — they live in the spec PR.</p>
+<table>
+<tr><th>#</th><th>Item</th><th>Disposition</th></tr>
+<tr><td>1</td><td><code>resumeRef</code>-on-every-transition (closes #86 properly)</td><td>Phase-2 cornerstone</td></tr>
+<tr><td>2</td><td>Daemon "ready" = successful <code>initialize</code> handshake, not just child-spawned</td><td>Spec acceptance criterion (counters codex 0.129+ silent-degradation)</td></tr>
+<tr><td>3</td><td><code>normalizeProviderEvent(provider, raw) → CanonicalEvent</code> seam with <code>never</code>-guarded exhaustive switch, feeding <code>reduce()</code></td><td>Spec architecture section</td></tr>
+<tr><td>4</td><td>Decision-gate HITL primitive (block task → structured human question → resolution injected into next dispatch)</td><td>New first-class state <code>gate{pending|resolved|timeout}</code></td></tr>
+</table>
+
+<h2 class="sec" id="b2">Bucket 2 · Cockpit-wide hardening · filed issues</h2>
+<p>Each item is a tracked GitHub issue. Bodies cite orca prior art with <code>file:line</code> and name the cockpit subsystem to touch.</p>
+
+<div class="issue" id="b2-1">
+<h3><span class="num">#89</span>watchdog: key heartbeats by dispatch-id, not task-id (sling pattern, part 1) <span class="tag">enhancement</span></h3>
+<div class="field"><b>Why.</b> Cockpit's heartbeat is task-keyed; a late heartbeat from a dead retry can refresh the timer of a hung live one.</div>
+<div class="field"><b>Orca prior art.</b> <code>coordinator.ts:274–301</code> — heartbeats keyed by dispatch context, not task.</div>
+<div class="field"><b>Cockpit change.</b> Sub-record attempts on <code>TaskRecord</code> (<code>src/control/types.ts</code> + <code>store.ts</code>); watchdog reads attempt-level heartbeats. Pure reducer preserved.</div>
+<div class="field"><b>Acceptance.</b> Replaying an old attempt's heartbeat cannot mask a hung new dispatch; integration test added.</div>
+</div>
+
+<div class="issue" id="b2-2">
+<h3><span class="num">#90</span>watchdog: warn-don't-autofail on stale; surface to Captain (default policy) <span class="tag">enhancement</span></h3>
+<div class="field"><b>Why.</b> Killing a slow-but-correct worker costs more than letting a hung one hold a slot until a human notices.</div>
+<div class="field"><b>Orca prior art.</b> <code>coordinator.ts:227–241</code> — <code>warnStaleDispatches</code> deliberately only warns.</div>
+<div class="field"><b>Cockpit change.</b> Default policy = warn + surface to Captain (control-plane event + reactor notification); <code>stalled</code> stays non-terminal; hard-kill behind a flag.</div>
+<div class="field"><b>Acceptance.</b> Stalled task remains non-terminal; Captain receives a structured "needs attention" event; per-project hard-kill budget configurable.</div>
+</div>
+
+<div class="issue" id="b2-3">
+<h3><span class="num">#91</span>control-plane: model dispatch attempts as sub-records (sling pattern, part 2) <span class="tag">enhancement</span></h3>
+<div class="field"><b>Why.</b> Retries currently dirty task state; the 3rd-attempt retry can mis-read the 1st attempt's error as current state. Auditing is muddy.</div>
+<div class="field"><b>Orca prior art.</b> orca's "sling pattern" — dispatch contexts are separate rows; circuit-breaker (3 failures → <code>circuit_broken</code>) lives on the context (<code>coordinator.ts:562–568</code>).</div>
+<div class="field"><b>Cockpit change.</b> <code>DispatchAttempt</code> sub-record with <code>attemptId, startedAt, pid, error, exitCode, lastHeartbeat, circuitBroken, resumeRef</code>; <code>TaskRecord.attempts</code>; reducer/store/watchdog operate on attempts.</div>
+<div class="field"><b>Depends on.</b> #86 (<code>resumeRef</code> lives on the attempt). Pairs with #89.</div>
+</div>
+
+<div class="issue" id="b2-4">
+<h3><span class="num">#92</span>cockpitd: add a wire <code>PROTOCOL_VERSION</code> constant and handshake <span class="tag">enhancement</span></h3>
+<div class="field"><b>Why.</b> No on-the-wire version means a future wire-shape change silently breaks in-flight clients during a rolling restart.</div>
+<div class="field"><b>Orca prior art.</b> <code>daemon/types.ts:6</code> — <code>PROTOCOL_VERSION = 7</code>, <code>PREVIOUS = [1..6]</code>. Daemons survive app updates.</div>
+<div class="field"><b>Cockpit change.</b> Constant in <code>src/control/protocol.ts</code>; server includes it in replies (or a <code>hello</code> frame); client refuses mismatched versions with a clear error.</div>
+<div class="field"><b>Related.</b> Prerequisite for #87 (protocol schema validation).</div>
+</div>
+
+<div class="issue" id="b2-5">
+<h3><span class="num">#93</span>cockpitd: coalesce concurrent restarts (in-process Promise + filesystem lock) <span class="tag">enhancement</span></h3>
+<div class="field"><b>Why.</b> <code>ensureDaemon()</code> runs on every CLI invocation; the plist-diff mitigation closes most of the window but a race remains.</div>
+<div class="field"><b>Orca prior art.</b> <code>daemon/daemon-init.ts:40–46</code> — <code>restartInFlight</code> promise so two restart triggers can't both enter teardown.</div>
+<div class="field"><b>Cockpit change.</b> In <code>src/control/launchd.ts</code>, in-process <code>Promise</code> gate + a daemon-side single-instance lock at <code>~/.config/cockpit/daemon.lock</code> (<code>flock</code> / <code>O_EXCL</code>) so concurrent CLI processes serialize.</div>
+<div class="field"><b>Acceptance.</b> Two simultaneous <code>cockpit</code> invocations during a restart cannot both <code>bootout/bootstrap</code>; one wins, others wait.</div>
+</div>
+
+<div class="issue" id="b2-6">
+<h3><span class="num">#94</span>protocol: keepalive framing on AF_UNIX so long dispatches don't trip idle timers <span class="tag">enhancement</span></h3>
+<div class="field"><b>Why.</b> A future interactive subscribe stream (or a slow dispatch confirmation) can trip socket idle timers with no traffic.</div>
+<div class="field"><b>Orca prior art.</b> <code>runtime-rpc.ts</code> — <code>{"_keepalive":true}</code> every 10s past 10s idle; clients discard.</div>
+<div class="field"><b>Cockpit change.</b> Same frame in <code>src/control/protocol.ts</code>; all consumers MUST discard. Pairs with #87 (becomes a known frame, not invalid).</div>
+<div class="field"><b>Related.</b> #87. Prerequisite for the interactive-codex streaming subscribe channel.</div>
+</div>
+
+<div class="issue" id="b2-7">
+<h3><span class="num">#95</span>dispatch: pre-flight worktree git-drift check (skip-not-fail on stale base) <span class="tag">enhancement</span></h3>
+<div class="field"><b>Why.</b> A crew dispatched into a worktree whose base has drifted may waste a full dispatch reasoning against stale ground.</div>
+<div class="field"><b>Orca prior art.</b> <code>coordinator.ts:481–521</code> — drift check before dispatch; >20 commits behind base = <b>skip, don't fail</b> (burning the breaker would convert recoverable → hard-fail).</div>
+<div class="field"><b>Cockpit change.</b> In <code>src/commands/crew-control.ts</code> dispatch path, compute drift when <code>cwd</code> is a worktree; over threshold (default 20) return a structured <code>stale-base</code> deferral the Captain or decision-gate (Bucket 1 item 4) resolves.</div>
+<div class="field"><b>Acceptance.</b> Dispatch into stale worktree doesn't burn a crew/turn; returns a non-failure deferral.</div>
+</div>
+
+<h2 class="sec" id="b3">Bucket 3 · Multi-provider expansion patterns (architecture notes; no issues today)</h2>
+<ul>
+<li><b><code>TUI_AGENT_CONFIG</code>-style single-source-of-truth row per provider.</b> Orca onboards a new agent with one row + (optional) hook-service. Cockpit's runtime-driver slot should grow a similar per-provider record (detect/launch/prompt-injection-mode/preflight-trust/foot-guns). Consolidate when the 4th interactive provider lands.</li>
+<li><b>Per-provider foot-gun catalogue baked into the driver.</b> TUI-killing non-interactive flags (<code>codex --ephemeral</code>, copilot <code>--prompt</code>); argv > Win/SSH cmdline limits → stdin; <code>node-pty</code> NAPI dispose-before-kill (if cockpit ever pty-hosts); treat <code>resumeRef</code> as opaque (orca #1148).</li>
+<li><b>Codex 0.129+ silent hook-drop / trust-hash precondition.</b> Encoded in Bucket-1 item 2. General lesson: codex silently degrades when config preconditions unmet — never treat silence as success.</li>
+</ul>
+
+<h2 class="sec" id="b4">Bucket 4 · Independent validations (no work)</h2>
+<ul>
+<li><b>CLI as ignition.</b> Orca's CLI is a thin RPC client + app-launcher. Identical to cockpit's "ignition key, not the brain."</li>
+<li><b><code>CLAUDE.md</code> = <code>@AGENTS.md</code> one-liner.</b> Orca ships this exact pattern.</li>
+<li><b>Portable <code>SKILL.md</code>.</b> Orca ships <code>skills/{orchestration,orca-cli,computer-use}/SKILL.md</code>. Same pattern cockpit already uses.</li>
+</ul>
+
+<h2 class="sec" id="b5">Bucket 5 · Future-architecture notes (reference for later)</h2>
+<ul>
+<li><b>Lightweight remote-relay pattern</b> — SCP'd daemon over SSH + framed JSON-RPC + grace-period PTY survival on a unix socket across disconnects, hosting the same hook pipeline remotely (orca <code>src/relay/</code>). Pattern of record for when "cockpit goes remote" is a goal.</li>
+<li><b>WS + E2EE + pairing + device-registry</b> (orca's mobile companion). Not cockpit's direction today (Obsidian hub-spoke covers reporting). Recorded for completeness.</li>
+</ul>
+
+<h2 class="sec" id="guard">Where cockpit is genuinely ahead — do NOT regress</h2>
+<p>These are <b>not action items</b> — they are guardrails. Orca lacks them; future cockpit work must not weaken them.</p>
+<ol>
+<li><b>Pure <code>reduce(state, event)</code> + typed per-task JSON + <code>TERMINAL_STATES</code>.</b> Orca's live-agent truth is an opaque xterm blob; cockpit's auditable typed state is strictly better.</li>
+<li><b>Anti-false-done invariant as a stated principle.</b> Orca has the bug class (#1437 stuck-spinner, tui-idle null→idle hangs) and patches reactively. Cockpit elevates it to an invariant — do not weaken.</li>
+<li><b>Non-invasive footprint (<code>~/.config/cockpit</code>).</b> Orca writes into 8 third-party agent home dirs. If cockpit ever adopts agent-hooks, copy orca's mitigations (filename-scoped matchers + hash-matched cleanup) — not the blast radius.</li>
+<li><b>Self-improving subsystems</b> (learnings, LLM-wiki, self-heal-on-invoke). Zero orca analog. Keep investing.</li>
+<li><b>Orchestration as an LLM session, not hardcoded code.</b> Orca's coordinator can't AI-decompose (deferred); Command/Captain already are that phase.</li>
+</ol>
+
+<h2 class="sec" id="hist">History &amp; sources</h2>
+<ul>
+<li>2026-05-19 — Drafted from full-system orca study; Bucket-1 approved for the interactive-codex spec.</li>
+<li>2026-05-19 — Bucket-2 filed as issues <b>#89, #90, #91, #92, #93, #94, #95</b> (label <code>enhancement</code>, bodies verbatim with orca <code>file:line</code> evidence + named cockpit subsystem).</li>
+</ul>
+<p>Sources:</p>
+<ul>
+<li><code>docs/research/2026-05-19-orca-full-system-study.md</code> / <code>.html</code> — deep memo with file:line evidence</li>
+<li><code>docs/research/2026-05-19-orca-codex-wrapping-study.md</code> / <code>.html</code> — codex-specific deep dive</li>
+<li><code>docs/research/2026-05-19-cockpit-vs-orca-system-comparison.html</code> — system-level positioning</li>
+<li>Orca repo: <code>github.com/stablyai/orca</code> @ <code>03b88951</code></li>
+<li>Cockpit @ <code>develop 9e61220</code> (post PR #85)</li>
+</ul>
+
+<div class="foot">Generated for cockpit's interactive-codex brainstorm · spec write resumes from here.</div>
+
+</main>
+</div>
+</body>
+</html>

--- a/docs/research/2026-05-19-orca-derived-cockpit-improvements.md
+++ b/docs/research/2026-05-19-orca-derived-cockpit-improvements.md
@@ -1,0 +1,137 @@
+# Orca-Derived Cockpit Improvements — Roadmap
+
+**Date:** 2026-05-19
+**Source studies:** `docs/research/2026-05-19-orca-full-system-study.md` · `2026-05-19-orca-codex-wrapping-study.md` · `2026-05-19-cockpit-vs-orca-system-comparison.html`
+**Status:** Bucket-1 in-spec; Bucket-2 filed as issues #89–#95 (2026-05-19).
+
+This document is the single catalog of everything the orca study surfaced that applies to cockpit beyond the immediate interactive-codex feature, with disposition for each item.
+
+---
+
+## Bucket 1 — Folds into the interactive-codex spec
+
+Approved 2026-05-19 by the user; will appear in the spec being written next. No separate issues — they live in the spec PR.
+
+| # | Item | Disposition |
+|---|---|---|
+| 1 | `resumeRef`-on-every-transition (closes #86 properly) | Phase-2 cornerstone of the interactive-codex spec |
+| 2 | Daemon "ready" = successful `initialize` handshake, not just child-spawned | Spec acceptance criterion (counters codex 0.129+ silent-degradation) |
+| 3 | `normalizeProviderEvent(provider, raw) → CanonicalEvent` seam with `never`-guarded exhaustive switch, feeding `reduce()` | Spec architecture section |
+| 4 | Decision-gate HITL primitive (block task → structured human question → resolution injected into next dispatch) | Spec — new first-class state `gate{pending|resolved|timeout}` |
+
+---
+
+## Bucket 2 — Cockpit-wide hardening (separate issues; applies to ALL providers)
+
+Each item is a tracked GitHub issue (filed 2026-05-19). Bodies cite orca prior art with `file:line` and name the cockpit subsystem to touch.
+
+### B2-1 · #89 · watchdog: key heartbeats by dispatch-id, not task-id (sling pattern, part 1)
+
+**Why.** Cockpit's heartbeat is task-keyed (`TaskRecord.lastHeartbeat`, `heartbeatBudgetMs`). A late heartbeat from a dead retry can refresh the timer of a hung live one.
+**Orca prior art.** `coordinator.ts:274-301` — heartbeats keyed by dispatch context, not task.
+**Cockpit change.** Sub-record attempts on `TaskRecord` (`src/control/types.ts` + `store.ts`); watchdog reads attempt-level heartbeats. Pure reducer preserved.
+**Acceptance.** Replaying an old attempt's heartbeat cannot mask a hung new dispatch; integration test added.
+**Label.** `enhancement`
+
+### B2-2 · #90 · watchdog: warn-don't-autofail on stale; surface to Captain (default policy)
+
+**Why.** Killing a slow-but-correct worker costs more than letting a hung one hold a slot until a human notices.
+**Orca prior art.** `coordinator.ts:227-241` — `warnStaleDispatches` deliberately only warns.
+**Cockpit change.** Default policy = warn + surface to Captain (control-plane event + reactor notification); `stalled` stays non-terminal; hard-kill behind a flag.
+**Acceptance.** Stalled headless task remains non-terminal; Captain receives a structured "task X needs attention" event; configurable hard-kill budget per project.
+**Label.** `enhancement`
+
+### B2-3 · #91 · control-plane: model dispatch attempts as sub-records (sling pattern, part 2)
+
+**Why.** Retries currently dirty task state (failure markers persist; re-reading task state can confuse the latest attempt with the first one's error). Auditing is muddy.
+**Orca prior art.** orca's "sling pattern" — dispatch contexts are separate rows from tasks; circuit-breaker (3 failures → context `circuit_broken`, task `failed`) lives on the context (`coordinator.ts:562-568`).
+**Cockpit change.** `DispatchAttempt` sub-record: `attemptId, startedAt, pid, error, exitCode, lastHeartbeat, circuitBroken, resumeRef`. `TaskRecord.attempts: DispatchAttempt[]`. Reducer/store/watchdog operate on attempts.
+**Acceptance.** Retries don't overwrite prior attempt history; circuit-breaker lives on attempt; reducer remains pure. Pairs with B2-1.
+**Depends on.** #86 (`resumeRef` lives on the attempt). **Label.** `enhancement`
+
+### B2-4 · #92 · cockpitd: add a wire PROTOCOL_VERSION constant and handshake
+
+**Why.** No on-the-wire version means a future wire-shape change silently breaks in-flight clients during a rolling restart.
+**Orca prior art.** `daemon/types.ts:6` — `PROTOCOL_VERSION = 7`, `PREVIOUS_DAEMON_PROTOCOL_VERSIONS = [1..6]`. Daemons survive app updates.
+**Cockpit change.** `PROTOCOL_VERSION` constant in `src/control/protocol.ts`; server includes it in replies (or a `hello` frame on connect); client refuses mismatched versions with a clear error.
+**Acceptance.** A CLI predating a wire change refuses to talk to a newer daemon (and vice versa) with a clear error instead of misparsing.
+**Related.** Prerequisite for #87 (protocol schema validation). **Label.** `enhancement`
+
+### B2-5 · #93 · cockpitd: coalesce concurrent restarts (in-process Promise + filesystem lock)
+
+**Why.** `ensureDaemon()` runs on every CLI invocation. The plist-diff mitigation closes most of the window; a race still exists if two diffs land between probe and act.
+**Orca prior art.** `daemon/daemon-init.ts:40-46` — `restartInFlight` promise so two restart triggers can't both enter the teardown sequence.
+**Cockpit change.** In `src/control/launchd.ts`, in-process `Promise` gate (first caller does the work, others await) + a daemon-side single-instance lock under `~/.config/cockpit/daemon.lock` (`flock` / `O_EXCL`) so concurrent CLI processes serialize.
+**Acceptance.** Two simultaneous `cockpit` invocations during a daemon restart cannot both run `launchctl bootout/bootstrap`; one wins, others wait.
+**Label.** `enhancement`
+
+### B2-6 · #94 · protocol: keepalive framing on AF_UNIX so long dispatches don't trip idle timers
+
+**Why.** A future interactive subscribe stream (or a slow dispatch confirmation) can trip default socket idle timers with no traffic.
+**Orca prior art.** `runtime-rpc.ts` — `{"_keepalive":true}` frame every 10s past 10s idle; clients tolerate and discard.
+**Cockpit change.** In `src/control/protocol.ts`, a `_keepalive` frame every 10s when idle; all consumers MUST discard. Pairs with #87 (keepalive becomes a known frame, not invalid).
+**Acceptance.** A connection held open for 60s+ with no app traffic stays alive on both sides; consumers discard `_keepalive` silently.
+**Related.** #87. Prerequisite for the interactive-codex streaming subscribe channel. **Label.** `enhancement`
+
+### B2-7 · #95 · dispatch: pre-flight worktree git-drift check (skip-not-fail on stale base)
+
+**Why.** A crew dispatched into a worktree whose base has drifted may waste a full dispatch reasoning against stale ground.
+**Orca prior art.** `coordinator.ts:481-521` — drift check before dispatch; if >20 commits behind base, **skip, don't fail** (burning the breaker would convert recoverable→hard-fail).
+**Cockpit change.** In `src/commands/crew-control.ts` `dispatch` (and daemon-side dispatch entry), compute drift when `cwd` is a git worktree; over a configurable threshold (default 20), return a structured `stale-base` deferral (not a failure) the Captain or decision-gate (Bucket 1 item 4) can resolve.
+**Acceptance.** Dispatch into stale worktree doesn't burn a crew/turn; returns a non-failure deferral.
+**Label.** `enhancement`
+
+---
+
+## Bucket 3 — Multi-provider expansion patterns (architecture notes; no issues today)
+
+Not goals today, but the patterns are recorded so we use them when the moment arrives.
+
+- **`TUI_AGENT_CONFIG`-style single-source-of-truth row per provider.** Orca onboards a new agent with one row + (optional) hook-service. Cockpit's runtime-driver slot should grow a similar single per-provider record: detect/launch commands, prompt-injection mode (`argv` / `flag-prompt*` / `stdin-after-start`), preflight-trust artifact, foot-gun catalogue. Today scattered across drivers; consolidate when the 4th interactive provider lands.
+- **Per-provider foot-gun catalogue baked into the driver.** Examples worth pre-encoding: `codex --ephemeral`/copilot `--prompt` would kill a hosted TUI; argv prompt > Windows/SSH cmdline limits → use stdin; `node-pty` NAPI `ThreadSafeFunction`s must be disposed before kill (if cockpit ever pty-hosts); treat `resumeRef` as an opaque hashed token, never parsed (orca #1148 session-id-shape regression).
+- **codex 0.129+ silent hook-drop / trust-hash precondition** — already encoded in Bucket-1 item 2 (handshake-ready). Memo the general lesson: codex silently degrades when config preconditions unmet; never treat silence as success.
+
+---
+
+## Bucket 4 — Independent validations (no work, confirm direction)
+
+- **CLI as ignition.** Orca's CLI is a thin RPC client + app-launcher (`launchOrcaApp()`). Identical to cockpit's "CLI is an ignition key, not the brain." External validation; no change.
+- **`CLAUDE.md` = `@AGENTS.md` one-liner.** Orca ships this exact pattern. Validates cockpit's multi-agent direction (`AGENTS.md` canonical, `CLAUDE.md` thin wrapper).
+- **Portable `SKILL.md`.** Orca ships `skills/{orchestration,orca-cli,computer-use}/SKILL.md`. Same pattern cockpit already uses. Validation.
+
+---
+
+## Bucket 5 — Future-architecture notes (not goals today, reference for later)
+
+- **Lightweight remote-relay pattern** (SCP'd daemon over SSH + framed JSON-RPC + grace-period PTY survival on a unix socket across disconnects, hosting the same hook pipeline remotely): orca `src/relay/`. Pattern of record for when "cockpit goes remote" becomes a goal.
+- **WS + E2EE + pairing + device-registry** (orca's mobile companion): not cockpit's direction today — Obsidian hub-spoke covers reporting. Recorded for completeness.
+
+---
+
+## Where cockpit is genuinely ahead — do NOT regress
+
+These are **not action items** — they are guardrails. Orca lacks them, the orca study reinforces them, future cockpit work must not weaken them.
+
+1. **Pure `reduce(state, event)` + typed per-task JSON state + `TERMINAL_STATES`.** Orca's live-agent truth is an opaque xterm screen blob. Cockpit's auditable typed state is strictly better engineering for an orchestrator.
+2. **Anti-false-done invariant as a stated principle.** Orca has the bug class (#1437 stuck-spinner, tui-idle null→idle hangs) and patches reactively. Cockpit elevates "turn-end is liveness, never completion" to an invariant. Do not weaken to match orca's pragmatic title-scraping.
+3. **Non-invasive config footprint (`~/.config/cockpit`).** Orca writes into 8 third-party agent home dirs (`~/.claude .codex .copilot .cursor .factory .gemini .grok .hermes`). If cockpit ever adopts agent-hooks, copy orca's mitigations (filename-scoped matchers + hash-matched cleanup), not the blast radius.
+4. **Self-improving subsystems** (learnings, LLM-wiki, self-heal-on-invoke). Zero orca analog. Keep investing.
+5. **Orchestration as an LLM session, not hardcoded code.** Orca's coordinator literally cannot AI-decompose (`coordinator.ts:201-206` defers it). Cockpit's Command/Captain are already that phase. Real lead — don't regress.
+
+---
+
+## History
+
+- 2026-05-19 — Drafted from full-system orca study; Bucket-1 approved for inclusion in the interactive-codex spec.
+- 2026-05-19 — Bucket-2 filed as issues #89, #90, #91, #92, #93, #94, #95 (one issue per item, `enhancement` label, bodies verbatim with orca `file:line` evidence + named cockpit subsystem).
+
+---
+
+## Sources
+
+- `docs/research/2026-05-19-orca-full-system-study.md` — the deep memo with file:line evidence (agent: a1aa048435c21bec1)
+- `docs/research/2026-05-19-orca-full-system-study.html` — reviewable HTML
+- `docs/research/2026-05-19-orca-codex-wrapping-study.md` / `.html` — codex-specific deep dive
+- `docs/research/2026-05-19-cockpit-vs-orca-system-comparison.html` — system-level positioning
+- Orca repo: `github.com/stablyai/orca` @ `03b88951` (shallow clone at `/tmp/orca-study`, ephemeral)
+- Cockpit @ `develop 9e61220` (post PR #85, control-plane merged)

--- a/docs/research/2026-05-19-orca-full-system-study.html
+++ b/docs/research/2026-05-19-orca-full-system-study.html
@@ -1,0 +1,259 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Orca — Full-System Study &amp; Deep Comparison vs. Cockpit</title>
+<style>
+  :root{
+    --bg:#0f1115;--panel:#171a21;--panel2:#1d212a;--ink:#e6e8ee;--mut:#9aa3b2;
+    --line:#2a2f3a;--accent:#5db0ff;--ck:#7c9eff;--or:#ff9d6b;
+    --good:#4ade80;--warn:#fbbf24;--bad:#f87171;
+    --code:#0b0d12;--mono:"SF Mono",ui-monospace,Menlo,Consolas,monospace;
+  }
+  *{box-sizing:border-box} html{scroll-behavior:smooth}
+  body{margin:0;background:var(--bg);color:var(--ink);
+    font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;}
+  .wrap{display:grid;grid-template-columns:268px 1fr;max-width:1280px;margin:0 auto;}
+  nav{position:sticky;top:0;align-self:start;height:100vh;overflow:auto;
+    padding:26px 16px;border-right:1px solid var(--line);font-size:13px;}
+  nav h2{font-size:11.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--mut);margin:18px 0 8px}
+  nav h2:first-child{margin-top:0}
+  nav a{display:block;color:var(--mut);text-decoration:none;padding:4px 8px;border-radius:6px;margin:1px 0}
+  nav a:hover{color:var(--ink);background:var(--panel2)}
+  nav a.sub{padding-left:18px;font-size:12.5px;opacity:.82}
+  main{padding:46px 56px 120px;min-width:0}
+  header.hero{border-bottom:1px solid var(--line);padding-bottom:24px;margin-bottom:30px}
+  .kicker{color:var(--accent);font-size:12.5px;letter-spacing:.14em;text-transform:uppercase;font-weight:700}
+  h1{font-size:29px;line-height:1.25;margin:10px 0 8px;letter-spacing:-.01em}
+  .sub{color:var(--mut);font-size:14px}
+  .meta{display:flex;flex-wrap:wrap;gap:9px;margin-top:16px}
+  .pill{background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:5px 11px;font-size:12px;color:var(--mut)}
+  .pill b{color:var(--ink)}
+  h2.sec{font-size:21px;margin:50px 0 12px;padding-top:10px;border-top:1px solid var(--line);letter-spacing:-.01em}
+  h2.part{font-size:13px;letter-spacing:.18em;text-transform:uppercase;color:var(--accent);margin:54px 0 0;border-top:2px solid var(--accent);padding-top:14px}
+  h3{font-size:16.5px;margin:26px 0 9px;color:#cdd3df}
+  p{margin:11px 0}
+  code{font-family:var(--mono);font-size:12.5px;background:var(--panel2);padding:2px 6px;border-radius:5px;color:#cfe6ff}
+  .ev{color:var(--mut);font-size:12px;font-family:var(--mono)}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:16px 20px;margin:16px 0}
+  .callout{border-left:3px solid var(--accent);background:var(--panel);padding:14px 18px;border-radius:0 10px 10px 0;margin:16px 0}
+  .callout.good{border-color:var(--good)} .callout.warn{border-color:var(--warn)} .callout.bad{border-color:var(--bad)}
+  .callout .lbl{font-size:11px;letter-spacing:.12em;text-transform:uppercase;font-weight:700;color:var(--mut);display:block;margin-bottom:6px}
+  table{border-collapse:collapse;width:100%;margin:18px 0;font-size:13px}
+  th,td{border:1px solid var(--line);padding:9px 11px;text-align:left;vertical-align:top}
+  th{background:var(--panel2);color:#cdd3df;font-weight:600}
+  td.y{color:var(--good)} td.n{color:var(--bad)} td.m{color:var(--warn)}
+  .tag{display:inline-block;font-size:10.5px;font-weight:700;padding:2px 7px;border-radius:999px;border:1px solid var(--line)}
+  .tag.green{color:var(--good);border-color:#2f6b46} .tag.amber{color:var(--warn);border-color:#6b5520}
+  .tag.red{color:var(--bad);border-color:#6b2f2f} .tag.blue{color:var(--accent);border-color:#2f4f6b}
+  ul,ol{margin:10px 0;padding-left:22px} li{margin:6px 0}
+  pre{background:var(--code);border:1px solid var(--line);border-radius:10px;padding:14px 16px;overflow:auto;margin:14px 0}
+  pre code{background:none;padding:0;color:#d6dcea;font-size:12px}
+  .foot{margin-top:56px;border-top:1px solid var(--line);padding-top:18px;color:var(--mut);font-size:12px}
+  .big{font-size:15px}
+  @media(max-width:980px){.wrap{grid-template-columns:1fr}nav{display:none}main{padding:28px 20px 80px}}
+</style>
+</head>
+<body>
+<div class="wrap">
+<nav>
+  <h2>Part A — Orca system</h2>
+  <a href="#tldr">Executive summary</a>
+  <a href="#a0" class="sub">A0 · Architecture</a>
+  <a href="#a1" class="sub">A1 · Driving model (crux)</a>
+  <a href="#a1n" class="sub">A1 · 3-tier normalization</a>
+  <a href="#a2" class="sub">A2 · PTY layer</a>
+  <a href="#a3" class="sub">A3 · Hook ingestion</a>
+  <a href="#a4" class="sub">A4 · Orchestrator</a>
+  <a href="#a5" class="sub">A5–A7 · Worktree/SCM/integrations</a>
+  <a href="#a8" class="sub">A8 · The PTY daemon ★</a>
+  <a href="#a9" class="sub">A9–A11 · CLI/footprint/learning</a>
+  <a href="#a12" class="sub">A12 · Bugs &amp; gotchas</a>
+  <h2>Part B — vs Cockpit</h2>
+  <a href="#bi">B(i) · Subsystem matrix</a>
+  <a href="#bii">B(ii) · 5 deepest insights</a>
+  <a href="#biii">B(iii) · Where cockpit leads</a>
+  <a href="#biv">B(iv) · Recommendations</a>
+  <h2>Decision</h2>
+  <a href="#fork">Impact on the fork</a>
+</nav>
+<main>
+
+<header class="hero">
+  <div class="kicker">Cockpit · Full-System Prior-Art Study</div>
+  <h1>Orca — Whole System &amp; Deep Comparison vs. Cockpit</h1>
+  <div class="sub">Every major subsystem with file:line evidence, then a rigorous head-to-head against cockpit's post-PR-#85 architecture.</div>
+  <div class="meta">
+    <span class="pill">Date <b>2026-05-19</b></span>
+    <span class="pill">Orca <b>@ 03b88951 (~2000 PRs)</b></span>
+    <span class="pill">Cockpit <b>@ develop 9e61220</b></span>
+    <span class="pill">Companions <b>orca-codex-wrapping · cockpit-vs-orca</b></span>
+  </div>
+</header>
+
+<section id="tldr">
+<div class="callout">
+<span class="lbl">What orca actually is</span>
+An <b>Electron terminal-multiplexer-for-agents</b>. It hosts ~30 CLI agents as their <b>native interactive TUI inside node-pty</b>, one per worktree pane. The agent loop is PTY-centric end to end; protocols (<code>codex app-server</code>) are used only for side-channel telemetry.
+</div>
+<div class="card big">
+<b>How it drives everything — three tiers, degrading:</b>
+<ol>
+<li><b>Primary — native hooks.</b> It installs each agent's <i>own</i> hook system (9 bespoke <code>hook-service.ts</code> files writing into 8 third-party home dirs), and a server-side normalizer collapses ~10 incompatible event vocabularies into <b>4 canonical states</b> (<code>working/blocked/waiting/done</code>) via a <code>never</code>-guarded exhaustive switch.</li>
+<li><b>Fallback — OSC-title screen-scraping</b> for <code>tui-idle</code> waits — which orca itself documents as buggy (#1437 stuck-spinner; null→idle hangs).</li>
+<li><b>Last resort — terminal output reading</b>, explicitly demoted in its own skill docs.</li>
+</ol>
+</div>
+<div class="callout good">
+<span class="lbl">The single biggest strategic insight for cockpit</span>
+<b>Issue #86 is not a process-supervision problem — it's a missing resume-artifact problem, and orca proves the fix.</b> Orca survives daemon/app bounce because each session persists a <i>first-class resumable representation</i> written on every state transition (its "final checkpoint" snapshot), plus a versioned protocol and restart-coalescing. Cockpit's headless path doesn't need a screen snapshot — it needs the equivalent: persist an opaque <code>resumeRef</code> (codex-exec rollout id / <code>claude --resume</code> id / app-server <code>thread</code> id) into per-task JSON <b>on every transition</b>, and make state-machine recovery re-attach through it on bounce. Pair with a daemon protocol-version constant + concurrent-restart coalescing. <b>That single change closes #86 properly</b> and is the highest-leverage thing this study surfaces.
+</div>
+</section>
+
+<h2 class="part">Part A — Orca: The Whole System</h2>
+
+<h2 class="sec" id="a0">A0 · One-paragraph architecture</h2>
+<p>Orca is an Electron desktop IDE that hosts any CLI agent as its native TUI in a <code>node-pty</code>, xterm.js-rendered, one per git-worktree pane. Three layers bolt on: (1) an out-of-process <b>PTY daemon</b> (<code>src/main/daemon/</code>) that owns the pty children and survives Electron restarts via server-side headless-terminal snapshots; (2) a <b>unified agent-status pipeline</b> that installs each agent's own native hooks and normalizes ~10 vocabularies into 4 states over a loopback HTTP server; (3) an <b>RPC runtime</b> (<code>src/main/runtime/</code>) exposing an <code>orca</code> CLI over AF_UNIX (plus WebSocket+E2EE for mobile), on which a polling <b>orchestration coordinator</b> dispatches a SQLite task DAG by typing prompts into PTYs and collecting <code>worker_done</code> callbacks.</p>
+
+<h2 class="sec" id="a1">A1 · Generic agent-driving model — the crux</h2>
+<p>The per-agent launch table is <code>src/shared/tui-agent-config.ts</code> — <code>TUI_AGENT_CONFIG</code> for 30 agents (<span class="ev">:58–260</span>). Each entry: <code>detectCmd/launchCmd/expectedProcess</code>, <code>promptInjectionMode</code>, optional <code>preflightTrust</code>, <code>draftPasteReadySignal</code>.</p>
+<ul>
+<li><b><code>promptInjectionMode</code></b> (<span class="ev">:3–9</span>): <code>argv</code> (claude, codex, cursor — codex's positional auto-submits so a draft paste is still needed, <span class="ev">:75–79</span>); <code>flag-prompt*</code> (opencode <code>--prompt</code>, gemini, copilot <code>-i</code> because <code>--prompt</code> would run non-interactively and <i>kill the hosted TUI</i>, <span class="ev">:242–246</span>); <code>stdin-after-start</code> (aider, goose, amp, ~15 others — <b>screen-timing-dependent injection</b>).</li>
+<li><b><code>preflightTrust</code></b> (<span class="ev">:36–43</span>): pre-writes the agent's "trust this folder" artifact (<code>agent-trust-presets.ts</code>) so the menu never eats the bracketed paste.</li>
+<li><b><code>draftPasteReadySignal</code></b> (<span class="ev">:44–49</span>): generic agents use a quiet-render timer; codex gets the stronger <code>codex-composer-prompt</code> (watches the rendered <code>›</code> prompt) — the only place orca reads codex's TUI, and only for paste-timing.</li>
+</ul>
+<p>Onboarding a new agent = one <code>TUI_AGENT_CONFIG</code> row + (if it has hooks) a <code>src/main/&lt;agent&gt;/hook-service.ts</code>.</p>
+
+<h3 id="a1n">Turn/done normalization across heterogeneous agents — THE key decision</h3>
+<p>Every agent has a <i>different</i> native hook system. Orca writes a per-agent managed script and <b>normalizes server-side</b>. Nine <code>hook-service.ts</code> files, each on that agent's own vocabulary:</p>
+<table>
+<tr><th>Agent</th><th>Config target</th><th>Native turn-start / done (evidence)</th></tr>
+<tr><td>claude</td><td><code>~/.claude/settings.json</code></td><td><code>UserPromptSubmit</code>/<code>Stop</code> <span class="ev">claude/hook-service.ts:21–42</span></td></tr>
+<tr><td>codex</td><td><code>~/.codex/hooks.json</code> + <code>config.toml</code> trust</td><td><code>UserPromptSubmit</code>/<code>Stop</code>, <code>PermissionRequest</code> <span class="ev">:42–49</span></td></tr>
+<tr><td>gemini</td><td><code>~/.gemini/settings.json</code></td><td><code>BeforeAgent</code>/<code>AfterAgent</code>; <b>no permission hook → no waiting state</b> <span class="ev">:21–32</span></td></tr>
+<tr><td>cursor</td><td><code>~/.cursor/hooks.json</code></td><td><code>beforeSubmitPrompt</code>/<code>stop</code>; shell/MCP = approvals <span class="ev">:22–46</span></td></tr>
+<tr><td>grok</td><td><code>~/.grok/hooks/orca-status.json</code></td><td><code>user_prompt_submit</code>/<code>Stop</code> <span class="ev">:21–45</span></td></tr>
+<tr><td>copilot</td><td><code>~/.copilot/hooks/orca.json</code></td><td><code>UserPromptSubmit</code>/<code>Stop</code>, <code>subagentStart</code> <span class="ev">:27–44</span></td></tr>
+<tr><td>droid</td><td><code>~/.factory/settings.json</code></td><td><code>UserPromptSubmit</code>/<code>Stop</code> <span class="ev">:19–37</span></td></tr>
+<tr><td>hermes</td><td><code>~/.hermes</code> YAML plugin</td><td><code>pre_llm_call</code>/<code>post_llm_call</code>, <code>pre_approval_request</code> <span class="ev">:26–37</span></td></tr>
+<tr><td>opencode</td><td>injected JS plugin</td><td><code>SessionBusy</code>/<code>SessionIdle</code>/<code>PermissionRequest</code> <span class="ev">:53–60</span></td></tr>
+</table>
+<p>Normalization is server-side in <code>src/shared/agent-hook-listener.ts</code>: per-source <code>normalize&lt;Agent&gt;Event()</code> map every vocabulary onto <b>4 canonical states</b> <code>working|blocked|waiting|done</code> (<span class="ev">agent-status-types.ts:6</span>). An <b>exhaustive <code>switch</code> with a <code>never</code> guard</b> (<code>isNewTurnEvent</code> <span class="ev">:1274–1305</span>) forces a <i>compile error</i> if a new source lacks a turn-start mapping — "fail at typecheck, not silently false."</p>
+<div class="callout warn">
+<span class="lbl">The crux answer — "does every agent use hooks?" NO, three tiers</span>
+<b>(1)</b> native hooks → 4-state normalization. <b>(2)</b> OSC-title scraping for <code>tui-idle</code> (<span class="ev">orca-runtime.ts:1797–1872</span>) — resolves on <i>any</i> →idle because "Claude Code may skip 'working' on fast tasks, going null→idle, and the waiter would hang forever" (<span class="ev">:1861–1866</span>); the #1437 stuck-spinner bug is field evidence this is fragile. <b>(3)</b> terminal output read (120-line buffer) — skill doc: "for status monitoring, not result extraction. Prefer structured <code>worker_done</code>."
+</div>
+<p><b>Non-obvious tradeoff:</b> orca accepts heterogeneity over a protocol — 8 third-party home dirs, 9 installers, a giant switch — to get <i>real</i> turn signals without scraping. Cost: enormous surface area + version coupling (codex 0.129+ trust hashes).</p>
+
+<h2 class="sec" id="a2">A2 · PTY / process layer</h2>
+<p><code>local-pty-provider.ts</code>: <code>node-pty</code>, pane→process by pty id, env scrubbed so child identity ≠ parent (<span class="ev">:232–271</span>). <code>ssh-pty-provider.ts</code> mirrors over SSH. Native gotcha (<span class="ev">:39</span>): node-pty's NAPI ThreadSafeFunctions for <code>onData/onExit</code> <b>must be disposed before kill</b> or they "leave callbacks alive into Electron shutdown, which can abort the app."</p>
+
+<h2 class="sec" id="a3">A3 · Hook ingestion &amp; install lifecycle</h2>
+<p><code>agent-hooks/server.ts</code>: loopback <code>http.createServer</code>, <b>bearer-token auth</b>, IPC fanout, on-disk <code>last-status.json</code> surviving restart. Shared listener so an SSH relay can host the same pipeline remotely ("relay normalizes; Orca routes"). Managed-script lifecycle: <code>createManagedCommandMatcher</code> matches by <i>filename not exact command</i> so installs sweep stale entries without clobbering user hooks. Scripts re-source <code>$ORCA_AGENT_HOOK_ENDPOINT</code> each fire so a surviving pty keeps reporting to a new orca instance after restart.</p>
+<div class="callout warn">
+<span class="lbl">Most reusable production gotcha in the repo</span>
+<b>Codex 0.129+ silently drops untrusted hooks.</b> Orca computes the <code>trusted_hash</code> (mirroring codex-rs <code>fingerprint.rs</code> + <code>hooks/src/lib.rs</code>), writes per-hook trust into <code>~/.codex/config.toml</code>, and reports <code>partial</code> if trust is stale because "a green status without trust verification is misleading" (<span class="ev">config-toml-trust.ts; hook-service.ts:150–152,297–338</span>). General lesson: <b>codex silently degrades when config preconditions are unmet — never treat silence as success.</b>
+</div>
+
+<h2 class="sec" id="a4">A4 · Orchestration coordinator</h2>
+<p><code>runtime/orchestration/{coordinator,preamble,db}.ts</code>, SQLite-backed:</p>
+<ul>
+<li><b>Task DAG</b>: <code>task-create --deps</code>; task→<code>ready</code> when deps complete; completion auto-promotes dependents.</li>
+<li><b>Loop</b> (<span class="ev">coordinator.ts:148–225</span>): poll <code>tick()</code> every 2 s — messages → escalations → decision-gates → stale-warn → dispatch → convergence. <b>Decomposition is NOT AI</b> — tasks pre-created; AI-decompose explicitly deferred to "a future phase where the coordinator itself is an LLM agent" (<span class="ev">:201–206</span>).</li>
+<li><b>Dispatch</b> (<span class="ev">:480–574</span>): git-drift guard (skip-not-fail if worktree &gt;20 commits behind — burning the breaker would convert recoverable→hard-fail); then <code>runtime.sendTerminal(handle,{text:preamble,enter:true})</code> — <b>types the prompt into the pty</b>; <code>writeTerminalAction</code> writes text, <code>setTimeout 500ms</code>, then <code>\r</code> ("TUI apps treat a single large write as a paste"). <i>This is exactly cockpit's legacy cmux injection.</i></li>
+<li><b>Feedback</b>: agent voluntarily runs <code>orca orchestration send --type worker_done</code> (taught by <code>preamble.ts</code>); cooperative callback, no protocol.</li>
+<li><b>Watchdog</b>: 5-min heartbeat, 10-min hung threshold; <code>warnStaleDispatches</code> <b>only warns, deliberately does NOT auto-fail</b> ("false-positive cost of killing a slow-but-correct worker &gt; false-negative of a hung worker holding a slot"); heartbeats keyed by <code>dispatchId</code> not task, so a stale heartbeat from a dead retry can't mask a hung new dispatch (<span class="ev">:274–301</span>).</li>
+<li><b>Circuit breaker</b>: 3 consecutive failures → <code>circuit_broken</code>. Dispatch contexts are <i>separate rows</i> from tasks ("sling pattern") so retries don't dirty task state.</li>
+<li><b>Decision gates</b>: HITL — block task, human resolves, resolution injected into the next preamble.</li>
+</ul>
+
+<h2 class="sec" id="a5">A5–A7 · Worktrees · Source control · Integrations</h2>
+<p><b>Worktrees:</b> git-worktree-native, one pane per worktree; drift guard treats stale-base as a <i>dispatch</i> concern not a worktree concern. <b>SCM:</b> diffs in main, rendered in renderer; inline commit; commit-message is the only non-agent <code>codex exec</code> use (stdin delivery for diff-size safety). <b>Integrations:</b> GitHub/Linear/GitLab/Gitea/Azure/Bitbucket dirs; <b>SSH relay</b> daemon SCP'd over SSH, framed JSON-RPC, keeps PTYs alive in a grace period on a unix socket across disconnects, hosts the same hook pipeline; <b>mobile</b> React Native over WS + E2EE + pairing + device registry, renders the daemon's headless snapshots.</p>
+
+<h2 class="sec" id="a8">A8 · The PTY daemon ★ (the standout — direct <code>cockpitd</code> analog)</h2>
+<div class="card">
+<p><code>src/main/daemon/</code>, 59 files. Electron <code>fork()</code>s it (<span class="ev">daemon-init.ts:12</span>), AF_UNIX <code>chmod 0o600</code>, token auth, <b>protocol versioning</b> (<span class="ev">types.ts:6</span> <code>PROTOCOL_VERSION=7</code>, <code>PREVIOUS=[1..6]</code> — "daemons survive app updates; bump for wire-shape changes").</p>
+<ul>
+<li><b>Server-side headless terminal</b>: each session runs a <code>@xterm/headless</code> <code>Terminal</code> + <code>SerializeAddon</code> — the daemon keeps the <i>rendered screen</i>, not just bytes.</li>
+<li><b>Reattach via snapshot</b>: on reconnect, <code>getSnapshot()</code> returns <code>TerminalSnapshot{snapshotAnsi}</code>; a <b>"final checkpoint" snapshot persisted on exit</b>. Sessions whose subprocess hasn't exited are not reattached as new (guard <span class="ev">terminal-host.ts:66–76</span>).</li>
+<li><b>Restart orchestration</b>: documented 7-step atomic provider-swap; <code>restartInFlight</code> promise <b>coalescing</b> so two restart triggers can't both enter teardown (<span class="ev">daemon-init.ts:40–46</span>); stale-daemon detection + <code>killStaleDaemon</code>.</li>
+</ul>
+<p><b>Net:</b> Electron main/renderer can crash and restart; the pty children keep running in the daemon; the UI reattaches to a serialized screen. The agent <i>conversation</i> still isn't truly resumable (it's whatever the live pty holds) — but <b>the process and screen survive</b>. This is orca's answer to the daemon-bounce-orphans class — i.e. cockpit's open <b>#86</b>.</p>
+</div>
+
+<h2 class="sec" id="a9">A9–A11 · CLI · Footprint · Self-improvement</h2>
+<p><b>CLI as ignition:</b> <code>src/cli/index.ts</code> → <code>RuntimeClient</code> → AF_UNIX/WS RPC; <code>launchOrcaApp()</code> spawns Electron if down — <b>conceptually identical to cockpit's "CLI is an ignition key, not the brain."</b> <b>Footprint:</b> invasive by necessity — writes into <b>8 third-party agent home dirs</b>; mitigated by filename-scoped matchers + hash-matched cleanup; the opposite of cockpit's <code>~/.config/cockpit</code> hygiene. <b>Self-improvement:</b> <b>none</b> — <code>telemetry/</code> is anonymous opt-out analytics, not a feedback loop. No learnings, no wiki, no self-heal. (Cockpit's learnings + LLM-wiki + self-healing daemon have <b>zero orca analog</b>.)</p>
+
+<h2 class="sec" id="a12">A12 · Real bugs / workarounds / version-gotchas (the gold)</h2>
+<ul>
+<li><b>Codex 0.129+ silent hook-drop</b> w/o <code>config.toml</code> trust hash — relevant to any codex-hooks path.</li>
+<li><b>#1437 stuck-spinner</b>: OSC-title 'working' stays sticky after agent exits → <i>title-scraping for completion is fragile</i>.</li>
+<li><b>#1148 opencode regression</b>: sessionId shape changed numeric→<code>&lt;wtId&gt;@@&lt;uuid&gt;</code>; old path-traversal regex rejected every legit id → <i>session-id shape changes are a recurring break source</i>; fixed by SHA-256-hashing the id.</li>
+<li><b>node-pty NAPI leak</b>: dispose <code>onData/onExit</code> before kill or Electron aborts on shutdown.</li>
+<li><b>Non-interactive flag foot-guns</b>: <code>codex --ephemeral</code>, copilot <code>--prompt</code> kill the hosted TUI; large argv prompt exceeds Win/SSH limits → stdin.</li>
+<li><b>Coordinator can't AI-decompose</b> (deferred); <code>allow-stale-base</code> regex matches inside fenced code blocks (accepted v1 limit); tui-idle null→idle race.</li>
+</ul>
+
+<h2 class="part">Part B — Deep Comparison vs. Cockpit</h2>
+
+<h2 class="sec" id="bi">B(i) · Subsystem-by-subsystem</h2>
+<table>
+<tr><th>Subsystem</th><th>Orca</th><th>Cockpit (post #85)</th><th>Ahead &amp; why</th></tr>
+<tr><td>Agent driving (interactive)</td><td>Native TUI in pty; prompt typed in</td><td>Headless = daemon child PID; interactive = injected hooks (Claude); codex = open fork</td><td class="m">Split — cockpit headless cleaner for batch; orca has the only human-attachable live session today</td></tr>
+<tr><td>Turn/done detection</td><td>Native hooks → 4-state; OSC fallback; output last</td><td><code>reduce(state,event)</code>; hooks (Claude); anti-false-done invariant</td><td class="y">Cockpit on rigor; orca on breadth. Orca's #1437/tui-idle bugs <b>validate</b> cockpit's distrust of scrape-done</td></tr>
+<tr><td>Cross-agent normalization</td><td><code>never</code>-guarded per-source switch → 4 states</td><td>Provider tiering; per-provider drivers</td><td class="n">Orca ahead — cockpit has no unified normalization layer (orca's deepest asset)</td></tr>
+<tr><td>Daemon / supervision</td><td>Out-of-proc, protocol-versioned, <b>headless-screen snapshot + reattach</b></td><td><code>cockpitd</code>, per-task JSON, heartbeat watchdog, <code>reduce</code></td><td class="m">Orca on resilience (#86 is exactly what its snapshot/version/coalesce solves); cockpit on state purity</td></tr>
+<tr><td>Orchestration</td><td>SQLite DAG, polling, preamble typed in, <code>worker_done</code>, breaker, gates</td><td>Command→Captain→Crew + Reactor; orchestration inside an LLM session</td><td class="m">Different locus — orca deterministic but can't AI-decompose; cockpit's is the LLM phase orca's roadmap chases</td></tr>
+<tr><td>HITL / approvals</td><td>Punted to agent's own TUI; decision-gates as workflow checkpoints</td><td>Open codex-interactive question</td><td class="m">Orca pragmatic not better; its decision-gate primitive is worth stealing</td></tr>
+<tr><td>CLI as ignition</td><td>Thin RPC client + app-launcher</td><td>"Ignition key, not the brain"</td><td class="y">Identical philosophy, independently arrived at — validation</td></tr>
+<tr><td>Skills / portability</td><td><code>SKILL.md</code>s; <code>CLAUDE.md</code> = <code>@AGENTS.md</code> one-liner</td><td>Load-on-demand portable skills; AGENTS.md canonical</td><td class="y">Identical pattern — validation</td></tr>
+<tr><td>Multi-agent breadth</td><td>30 agents, 9 hooked, generic fallback</td><td>Claude ref, codex/opencode headless, driver abstraction</td><td class="n">Orca far ahead — its config+hook-service pattern is a proven template for cockpit's runtime slot</td></tr>
+<tr><td>Config footprint</td><td>Invasive — 8 agent home dirs</td><td>Non-invasive — <code>~/.config/cockpit</code></td><td class="y">Cockpit on hygiene (but only because it doesn't yet do hook-based interactive multi-agent)</td></tr>
+<tr><td>Self-improvement</td><td>None (analytics only)</td><td>Learnings + LLM-wiki + self-heal</td><td class="y">Cockpit clearly ahead — no orca analog; do not regress</td></tr>
+<tr><td>State model</td><td>Screen-snapshot blob + SQLite rows</td><td>Pure typed <code>reduce</code>, JSON per-task</td><td class="y">Cockpit ahead — orca's live truth is an opaque screen; cockpit's is auditable/testable</td></tr>
+</table>
+
+<h2 class="sec" id="bii">B(ii) · The 5 deepest insights for cockpit</h2>
+<ol class="big">
+<li><b>Daemon-bounce is solved with a server-side resumable snapshot + reattach + protocol version, not just process supervision.</b> For cockpit's <i>headless</i> path the resumable representation isn't a screen — it's the <b>JSON state + the child's resumable session id</b>. Design the resume artifact as a first-class persisted thing the daemon writes on <i>every</i> transition (orca's "final checkpoint"), not reconstructed at bounce.</li>
+<li><b>No protocol gives turn-done for free across agents.</b> Orca proves the only reliable signal is the agent's own runtime event; titles/output/timeouts are a degrading fallback it openly distrusts (#1437, tui-idle). This is field evidence <i>for</i> cockpit's anti-false-done invariant. The codex fork should bias toward a <b>real codex-emitted event</b> (app-server <code>TurnCompleted</code> as liveness, or codex's own hooks), and treat legacy cmux scrape as the same "last resort" tier orca demotes.</li>
+<li><b>Heterogeneous agents demand a normalization layer; orca's <code>never</code>-guarded per-source switch is the template.</b> If cockpit grows beyond Claude for interactive, it hits orca's exact problem. Grow an explicit <code>normalizeProviderEvent</code> seam with compile-time exhaustiveness feeding <code>reduce()</code>.</li>
+<li><b>Orca's watchdog beats cockpit's current heartbeat on three specifics:</b> (a) heartbeats keyed by <b>dispatch-id not task</b>; (b) <b>warn-don't-autofail</b> on stale; (c) <b>circuit breaker as a separate dispatch-context row</b> from the task ("sling pattern") so retries don't dirty task state.</li>
+<li><b>Decision-gates are a clean codeable HITL primitive cockpit lacks.</b> Block task → human answers a structured question → resolution auto-injected into the next dispatch. Exactly cockpit's "semi-automatic, prompted-at-key-moments" ethos, formalized as a first-class gating state.</li>
+</ol>
+
+<h2 class="sec" id="biii">B(iii) · Where cockpit is genuinely ahead — do NOT regress</h2>
+<ol>
+<li><b>Pure <code>reduce(state,event)</code> + typed per-task JSON + TERMINAL_STATES.</b> Orca's live-agent truth is an opaque xterm blob. Keep cockpit's auditable model.</li>
+<li><b>Anti-false-done as a stated invariant.</b> Orca has the bug class and patches reactively; cockpit elevates it to a principle. Don't weaken to match orca's title-scraping.</li>
+<li><b>Non-invasive footprint.</b> Adopt agent-hooks only eyes-open; if so, copy orca's mitigations (filename-scoped matchers, hash-matched cleanup), not the blast radius.</li>
+<li><b>Self-improving subsystems.</b> Zero orca analog. Genuinely differentiating. Keep investing.</li>
+<li><b>Orchestration as an LLM session, not hardcoded code.</b> Orca's coordinator literally can't decompose a spec yet; cockpit's Command/Captain already are that phase. A real lead.</li>
+</ol>
+
+<h2 class="sec" id="biv">B(iv) · Concrete recommendations (named subsystems/files)</h2>
+<ol class="big">
+<li><b>Close #86 with an orca-style resume artifact.</b> In <code>cockpitd</code>'s per-task JSON store, persist a <code>resumeRef</code> on every transition: headless codex = rollout id for <code>codex exec resume</code>; <code>claude -p</code> = <code>--resume</code> id; app-server = <code>thread</code> id. Recovery re-attaches via <code>resumeRef</code>. Add a daemon <b>protocol-version</b> constant and <b>coalesce concurrent restarts</b>.</li>
+<li><b>Add <code>normalizeProviderEvent(provider,raw)→CanonicalEvent</code> with compile-time exhaustiveness</b>, feeding <code>reduce()</code>; keep <code>TurnCompleted/Stop</code> as <i>liveness</i>, gated to completion only by an explicit terminal event.</li>
+<li><b>Refactor watchdog to dispatch-attempt granularity</b> — attempts as sub-records with own <code>lastHeartbeatAt</code> + <code>circuitBroken</code>; <b>warn-don't-autofail</b> default; surface to Captain.</li>
+<li><b>Codex-interactive fork: orca's evidence tilts toward app-server, not orca's hook path.</b> Orca only uses codex hooks because it's <i>already</i> hosting the TUI for a human; cockpit's interactive codex has no such forcing requirement, and <code>codex-fetcher.ts:88–261</code> proves a clean app-server client works. Take the hook-trust gotcha as a general warning: make daemon "ready" contingent on a successful app-server <code>initialize</code> round-trip, not just child-spawned.</li>
+<li><b>Adopt the decision-gate primitive in the Captain layer</b> — first-class <code>gate{pending|resolved|timeout}</code> blocking a DAG node, structured question to the human, resolution injected into the next Crew dispatch.</li>
+<li><b>Steal the foot-gun catalogue</b> into cockpit's runtime drivers: TUI-killing non-interactive flags, argv-vs-stdin for large prompts, node-pty dispose-before-kill (if cockpit ever pty-hosts), and treat <code>resumeRef</code> as an <b>opaque hashed token, never parsed</b> (orca #1148).</li>
+</ol>
+
+<h2 class="sec" id="fork">What this means for the open brainstorm fork</h2>
+<div class="callout good">
+<span class="lbl">The study sharpens — and confirms — Path X</span>
+Recommendation #4 is the decisive one: orca's reason for using codex's <i>hooks</i> instead of app-server is that <b>it already hosts the TUI for a human</b> — a constraint cockpit's interactive codex <b>does not have</b>. Strip that constraint and orca's own working <code>codex-fetcher.ts</code> app-server client is the evidence the protocol path is sound. So <b>Path X (app-server) holds</b>, now with three orca-derived hardening requirements baked in: (a) <code>resumeRef</code>-on-every-transition closes #86 and makes <code>thread/resume</code> real; (b) daemon "ready" = successful <code>initialize</code> handshake, not spawn (counters codex silent-degradation); (c) a <code>normalizeProviderEvent</code> seam so the same machinery generalizes when more interactive providers arrive.
+</div>
+<p>The fork is still formally yours to call (X / Y / Z) — but the full-system study removes the main argument for Y (orca's hook path) by showing <i>why</i> orca chose it doesn't apply to cockpit. Net for the spec: <b>X, with #86's resume-artifact promoted from "Phase-2 nice-to-have" to a Phase-2 cornerstone.</b></p>
+
+<div class="foot">
+Source memo: <code>docs/research/2026-05-19-orca-full-system-study.md</code> (~195 lines, file:line-backed) · Companions: <code>2026-05-19-orca-codex-wrapping-study.html</code>, <code>2026-05-19-cockpit-vs-orca-system-comparison.html</code> · Orca @ <code>03b88951</code> (shallow clone; historical "why" from in-code comments, not git log) · Cockpit @ <code>develop 9e61220</code>.
+</div>
+
+</main>
+</div>
+</body>
+</html>

--- a/docs/research/2026-05-19-orca-full-system-study.md
+++ b/docs/research/2026-05-19-orca-full-system-study.md
@@ -1,0 +1,194 @@
+# Orca — Full-System Study & Deep Comparison vs. Cockpit
+
+**Date:** 2026-05-19
+**Subject:** https://github.com/stablyai/orca @ `03b88951` (HEAD 2026-05-19, "feat: expand ai commit agent support (#1928)")
+**Clone:** `/tmp/orca-study` (TypeScript / Electron / pnpm; ~2000 merged PRs by bug-ref numbering)
+**Compared against:** cockpit @ develop `9e61220` (post PR #85, control-plane merged)
+**Companion memo:** `2026-05-19-orca-codex-wrapping-study.md` (codex-specific deep dive — read first for the codex mechanism)
+
+This memo is the whole-system study: every major subsystem with file:line evidence, then a rigorous head-to-head against cockpit's architecture.
+
+---
+
+# PART A — Orca: The Whole System
+
+## A0. One-paragraph architecture
+
+Orca is an **Electron desktop IDE** that hosts *any* CLI coding agent as its **native interactive TUI inside a `node-pty`**, rendered with xterm.js, one per git-worktree pane. It is fundamentally a **terminal multiplexer for agents** with three layers bolted on: (1) an out-of-process **PTY daemon** (`src/main/daemon/`) that owns the pty children and survives Electron restarts via server-side headless-terminal snapshots; (2) a **unified agent-status pipeline** that installs each agent's *own native hook system* and normalizes ~10 different event vocabularies into 4 canonical states over a loopback HTTP server; (3) an **RPC runtime** (`src/main/runtime/`) exposing an `orca ...` CLI over an AF_UNIX socket (plus WebSocket+E2EE for the mobile app), on top of which a polling **orchestration coordinator** dispatches a task DAG to agent terminals by *typing prompts into PTYs* and collecting `worker_done` callbacks. The agent loop is PTY-centric end to end; protocols (`codex app-server`) are used only for side-channel telemetry.
+
+## A1. Generic agent-driving model — the crux
+
+**The per-agent launch table** is `src/shared/tui-agent-config.ts`. `TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig>` (`:58-260`) holds 30 agents. Each entry: `detectCmd` / `launchCmd` / `expectedProcess` (PATH probe, spawn, process-recognition), `promptInjectionMode`, optional `preflightTrust`, `draftPromptFlag`, `draftPromptEnvVar`, `draftPasteReadySignal`.
+
+**`promptInjectionMode` variants** (`:3-9`) — how the *first* prompt reaches the agent:
+- `argv` — passed as a CLI argument (claude, codex, pi, droid, cursor). For codex the comment `:75-79` notes the positional prompt auto-submits, so orca still must paste a draft.
+- `flag-prompt` / `flag-prompt-interactive` / `flag-interactive` — agent-specific flag (opencode `--prompt`; gemini; copilot `-i` because `--prompt` would run non-interactively and *kill the hosted TUI*, `:242-246`).
+- `stdin-after-start` — type into the running TUI after it boots (aider, goose, amp, ~15 others). **This is screen-timing-dependent injection**: write text into the pty, wait, send Enter.
+
+**`preflightTrust`** (`:36-43`): cursor/copilot/codex gate first launch behind a "trust this folder?" menu that would *eat* the bracketed paste. Orca pre-writes the exact trust artifact the agent writes post-accept (`src/main/agent-trust-presets.ts`) so the menu never fires. Codex uses `'codex'` preset (its `config.toml` trust hash machinery, see A3).
+
+**`draftPasteReadySignal`** (`:44-49`): for a draft (non-submitted) prompt, orca must time the bracketed paste. Generic agents use a quiet-render timer; codex gets the stronger `'codex-composer-prompt'` signal — orca watches the rendered pty stream for codex's `›` composer prompt (it even cites codex's internal `chat_composer.rs`). Consumed in `src/renderer/src/lib/agent-paste-draft.ts`. **This is the only place orca reads codex's rendered TUI to make a decision, and it's purely paste-timing.**
+
+**Onboarding a new agent** = add one `TUI_AGENT_CONFIG` row + (if the agent has a hook system) a `src/main/<agent>/hook-service.ts`. Header comment `:52-57` is explicit: this table exists so "the picker, launcher, and preflight checks [don't] quietly drift apart as new agents are added."
+
+### Turn/done normalization across heterogeneous agents — THE key engineering decision
+
+**Every agent has a *different* native hook system; orca writes a per-agent managed script and normalizes server-side.** Nine `hook-service.ts` files (`claude, codex, copilot, cursor, droid, gemini, grok, hermes, opencode`), each subscribing to that agent's *own* event vocabulary:
+
+| Agent | Config target | Native turn-start / turn-done events (evidence) |
+|---|---|---|
+| claude | `~/.claude/settings.json` | `UserPromptSubmit` / `Stop` (`claude/hook-service.ts:21-42`) |
+| codex | `~/.codex/hooks.json` + `config.toml` trust | `UserPromptSubmit` / `Stop`, `PermissionRequest` (`codex/hook-service.ts:42-49`) |
+| gemini | `~/.gemini/settings.json` | `BeforeAgent` / `AfterAgent`; **no permission hook → no waiting state** (`gemini/hook-service.ts:21-32`) |
+| cursor | `~/.cursor/hooks.json` (camelCase) | `beforeSubmitPrompt` / `stop`; `beforeShellExecution`/`beforeMCPExecution` = approvals (`cursor/hook-service.ts:22-46`) |
+| grok | `~/.grok/hooks/orca-status.json` | `user_prompt_submit`/`Stop` (`grok/hook-service.ts:21-45`) |
+| copilot | `~/.copilot/hooks/orca.json` | PascalCase `UserPromptSubmit`/`Stop`, `subagentStart` (`copilot/hook-service.ts:27-44`) |
+| droid | `~/.factory/settings.json` | `UserPromptSubmit`/`Stop` (`droid/hook-service.ts:19-37`) |
+| hermes | `~/.hermes/...` YAML plugin | `pre_llm_call`/`post_llm_call`, `pre_approval_request` (`hermes/hook-service.ts:26-37`) |
+| opencode | injected JS plugin | `SessionBusy`/`SessionIdle`/`PermissionRequest` (plugin-side mapped, `opencode/hook-service.ts:53-60`) |
+
+The managed script POSTs the raw hook payload + pane metadata to a loopback HTTP server. **Normalization is server-side** in `src/shared/agent-hook-listener.ts`: per-source `normalize<Agent>Event()` functions (`:1344` claude, `:1434` codex, `:1392` gemini, `:1478` opencode, …) map every vocabulary onto **4 canonical states**: `'working' | 'blocked' | 'waiting' | 'done'` (`src/shared/agent-status-types.ts:6`). E.g. claude `:1351-1361`: `{UserPromptSubmit,PreToolUse,PostToolUse}→working`, `PermissionRequest→waiting`, `Stop→done`. An **exhaustive `switch` with a `never` guard** (`isNewTurnEvent` `:1274-1305`) forces a compile error if a new agent source is added without a turn-start mapping — a deliberate "fail at typecheck, not silently false" design.
+
+**Crucial truth (the answer to "does every agent use hooks"): NO — three tiers, degrading.**
+1. **Primary: native hooks** → 4-state normalization (above).
+2. **Fallback: OSC-title scraping.** `orca-runtime.ts:1797-1872`: `extractLastOscTitle(data)` → `detectAgentStatusFromTitle()` on raw pty bytes. This drives the `terminal wait --for tui-idle` primitive (`:4289,:4330`) used by the orchestration coordinator when no hooks/preamble exist. Comment `:1861-1866`: resolves tui-idle on *any* transition→idle because "Claude Code may skip 'working' entirely on fast tasks, going null→idle, and the coordinator's tui-idle waiter would hang forever." This is **screen-scraping for completion** — exactly the class of signal cockpit's anti-false-done invariant distrusts. Orca itself documents its fragility (the "#1437 stuck-spinner bug": stale 'working' after agent exits, `:1846-1850`).
+3. **Last resort: terminal output reading** (`terminal read`, 120-line buffer). The orchestration skill explicitly says "for status monitoring, not result extraction. Prefer structured `worker_done` payloads over parsing terminal output" (`skills/orchestration/SKILL.md`).
+
+**Non-obvious tradeoff:** orca accepts heterogeneity instead of forcing a protocol. It writes into 8 third-party agent home dirs (`~/.claude .codex .copilot .cursor .factory .gemini .grok .hermes`) and maintains 9 bespoke installers + a giant normalization switch. The payoff: real turn signals from each agent's own runtime without scraping. The cost: enormous surface area, per-agent drift risk, and a documented version-coupling (codex 0.129+ trust hashes, A3).
+
+## A2. PTY / process layer
+
+`src/main/providers/local-pty-provider.ts` — `import * as pty from 'node-pty'` (`:11`), `ptyProcesses = Map<string, pty.IPty>` (`:37`), `spawn()` (`:160-320`) builds env (`:232-271` — strips inherited NO_COLOR, sets LANG, removes pane-identity env so child identity ≠ parent), uses `spawnShellWithFallback` (`:310`). A pane→process map is by pty id. `ssh-pty-provider.ts` mirrors this over SSH (`ssh2`). Comment `:39` flags a real native gotcha: node-pty's `onData/onExit` register NAPI ThreadSafeFunctions that must be disposed before kill or they "leave callbacks alive into Electron shutdown, which can abort the app" (also seen in `codex-fetcher.ts:347-351`).
+
+## A3. Hook/event ingestion & install lifecycle
+
+`src/main/agent-hooks/server.ts` (39 KB, one class by design `:1`): loopback `http.createServer` with **bearer-token auth** (`X-Orca-Agent-Hook-Token`), **IPC fanout** (`setListener`/`lastStatusByPaneKey` replay), an `ingestRemote()` path that bypasses HTTP for SSH-relay-forwarded events, and an on-disk `last-status.json` (`:71`) that survives restart so dashboard rows reappear. The shared listener (`src/shared/agent-hook-listener.ts`) holds the parser/normalizer so the SSH relay can host the *same* pipeline remotely without Electron ("relay normalizes; Orca routes", `:12`).
+
+**Managed-script lifecycle** (`agent-hooks/installer-utils.ts`): `install()` writes a `<agent>-hook.sh`/`.cmd`/`.ps1` and registers it; `createManagedCommandMatcher(scriptFileName)` matches by *filename not exact command* so a fresh install sweeps stale entries from old builds / different Electron userData (dev vs prod) — without it "repeated installs accumulate duplicate hook entries" (`codex/hook-service.ts:268-272`). Scripts re-source `$ORCA_AGENT_HOOK_ENDPOINT` on every fire so a *surviving pty* keeps reporting to a *new* orca instance's port/token after restart (`codex/hook-service.ts:104-112`).
+
+**Codex 0.129+ trust-hash machinery** (`src/main/codex/config-toml-trust.ts`, `hook-service.ts:297-320`): codex 0.129+ "silently drops untrusted hooks" — orca computes the `trusted_hash` (mirroring codex-rs `fingerprint.rs::version_for_toml` and `hooks/src/lib.rs::hook_event_key_label`), writes per-hook trust entries into `~/.codex/config.toml` last (`:325-338`), and reports `partial` if trust is stale because "a green status without trust verification is misleading" (`:150-152`). **This is the single most reusable production gotcha in the repo.**
+
+## A4. Orchestration coordinator (autonomous multi-agent)
+
+`src/main/runtime/orchestration/{coordinator,preamble,db}.ts`. SQLite-backed (`db.ts` 33 KB). Model:
+- **Tasks form a DAG** (`task-create --deps`); a task→`ready` when all deps `completed`; completing a task auto-promotes dependents (skill doc "DAG resolution step").
+- **Coordinator loop** (`coordinator.ts:148-225`): `decompose()` then poll `tick()` every 2 s (`DEFAULT_POLL_MS=2000`): `processMessages → processEscalations → processDecisionGates → warnStaleDispatches → dispatchReadyTasks → checkConvergence`. Phases `decomposing→dispatching→monitoring→merging→done` (`:74`). **Decomposition is NOT AI** — tasks must be pre-created; `:201-206` explicitly defers AI decomposition to "a future phase where the coordinator itself is an LLM agent."
+- **Dispatch** (`:480-574`): pre-flight git-drift guard (skip, don't fail, if worktree >20 commits behind base — burning the circuit breaker would convert a recoverable state into hard-fail, `:481-521`); create dispatch context; build preamble; **`runtime.sendTerminal(handle,{text:preamble, enter:true})`** — i.e. *type the prompt into the pty*. `writeTerminalAction` (`orca-runtime.ts:4245-4273`): writes text, **`setTimeout 500ms`**, then writes `\r` — "TUI apps treat a single large write as a paste event." This is exactly cockpit's legacy cmux screen-scrape injection.
+- **Feedback** = the agent voluntarily runs `orca orchestration send --type worker_done --payload {...}` (taught by `preamble.ts:buildDispatchPreamble`, `:38-60`+). Coordinator reads the SQLite mailbox; `handleWorkerDone` (`:303-343`) marks task complete & frees the terminal. No protocol — cooperative callback.
+- **Watchdog**: heartbeat every 5 min (preamble), `HUNG_THRESHOLD_MS=10min` (`coordinator.ts:88`). `warnStaleDispatches` (`:227-241`) only **warns**, deliberately does NOT auto-fail: "the false-positive cost (a slow worker producing correct output) is higher than the false-negative cost (a hung worker keeps its terminal slot until a human notices)." Heartbeats keyed by `dispatchId` not task, so a stale heartbeat from a previously-failed retry can't mask a hung new dispatch (`:274-301`).
+- **Circuit breaker**: 3 consecutive dispatch failures → context `circuit_broken`, task `failed` (skill doc; `failDispatch` `:562-568`). Dispatch contexts are separate rows from tasks ("sling pattern") so retries don't dirty the task.
+- **Decision gates** = human-in-the-loop: `gate-create` blocks a task + completes its dispatch; `gate-resolve` returns it to `ready` with resolution injected into the next preamble.
+
+## A5. Worktree management
+
+Git-worktree-native (README: "Every feature gets its own worktree"). `orca-runtime-git.ts` (24 KB) + `worktree-teardown.ts` + `ipc/worktrees.ts`. Each pane bound to a worktree; the orchestration "inter-worktree pattern" (one agent per worktree for parallel work) vs "intra-worktree" (split panes, shared files) is documented in the skill. Drift guard (A4) is the notable engineering decision: stale base detection is a *dispatch* concern, not a worktree concern.
+
+## A6. Source control / review
+
+`src/main/source-control/` + `orca-runtime-git.ts`. Diffs computed in main, rendered in renderer; "Annotate AI Diffs" and inline commit without leaving the app (README feature wall). Commit-message generation is the *only* non-agent `codex exec` use (`commit-message-agent-spec.ts:248-269`, `exec --ephemeral --skip-git-repo-check -s read-only`, stdin delivery for diff-size safety).
+
+## A7. Integrations
+
+- **GitHub / Linear / GitLab / Gitea / Azure DevOps / Bitbucket** — dedicated `src/main/{github,linear,gitlab,...}` dirs; PRs/issues/Actions linked per worktree.
+- **SSH remotes** — `src/relay/` ships a **lightweight relay daemon** SCP'd to the remote and launched over an SSH exec channel, framed JSON-RPC over stdin/stdout. On client disconnect the relay keeps PTYs alive in a grace period on a unix socket; reconnect via `relay.js --connect` bridging the new SSH channel (`src/relay/relay.ts:13-20`). It hosts the *same* agent-hook pipeline (`src/relay/agent-hook-server.ts`).
+- **Mobile companion app** (`mobile/`, React Native): connects to the desktop runtime's **WebSocket transport + E2EE channel** (`runtime-rpc.ts:21-23,229-290`, `DEFAULT_WS_PORT=6768`). Pairing via an encoded offer (`shared/pairing.ts`, `PAIRING_OFFER_VERSION`); E2EE keypair (`runtime/e2ee-keypair.ts`); device registry with scopes (`runtime/device-registry.ts`). The daemon's headless terminal snapshots (A8) are what the phone renders.
+
+## A8. Electron architecture & the PTY daemon
+
+`src/{main,renderer,preload,shared,cli,relay}`. Main owns truth; renderer is a view; preload bridges; shared is Electron-free (so relay can reuse it). **Security boundary** for the CLI: `src/main/runtime/runtime-rpc.ts` ("the single security boundary for the bundled CLI", `:1-8`) — token auth, bootstrap-metadata file (exactly one on-disk discovery file), AF_UNIX + optional WS, keepalive framing (`{"_keepalive":true}` every 10 s past 10 s so long dispatches don't trip the 30 s socket idle timer, `:46+`), orphan-socket sweep.
+
+**The PTY daemon** (`src/main/daemon/`, 59 files) is the standout subsystem and the direct analog to `cockpitd`:
+- Out-of-process: Electron `fork()`s it (`daemon-init.ts:12`), AF_UNIX socket (`daemon-server.ts:55-134`), `chmod 0o600`, token auth, **protocol versioning** (`types.ts:6` `PROTOCOL_VERSION=7`, `PREVIOUS_DAEMON_PROTOCOL_VERSIONS=[1..6]` — "daemons can survive app updates; bump for wire-shape changes").
+- **Server-side headless terminal**: each session runs a `@xterm/headless` `Terminal` + `SerializeAddon` (`headless-emulator.ts:1-5`) so the daemon maintains the *rendered* screen state, not just bytes.
+- **Reattach via snapshot**: `terminal-host.ts:66-76,202-229` — on client reconnect, `getSnapshot()` returns `TerminalSnapshot{snapshotAnsi,...}` (`types.ts:14-16`); a "final checkpoint" snapshot is persisted on exit (`history-manager.ts`). Sessions whose subprocess hasn't exited are *not* reattached as new ("reattaching would..." guard `:66-71`).
+- **Restart orchestration**: a documented 7-step atomic provider-swap (`daemon-init.ts:1-8`), `restartInFlight` promise coalescing so two restart triggers can't both enter the sequence (`:40-46`). Stale-daemon detection + `killStaleDaemon` (`daemon-health.ts`).
+- This means: **Electron main/renderer can crash and restart; the pty children keep running in the daemon; the UI reattaches to a serialized screen.** The codex/agent *conversation* still isn't resumable (it's whatever state the live pty holds), but the *process and screen survive*. This is orca's answer to the daemon-bounce-orphans class of problem.
+
+## A9. CLI surface (the "ignition key")
+
+`src/cli/index.ts` → `RuntimeClient` → AF_UNIX/WS RPC to the running runtime. `src/cli/runtime/launch.ts::launchOrcaApp()` will *spawn the Electron app* if not running (`ORCA_OPEN_COMMAND`/`ORCA_APP_EXECUTABLE` overrides; `open <bundle>` on macOS). So the CLI is genuinely a thin RPC client + app-launcher — **conceptually identical to cockpit's "CLI is an ignition key, not the brain."** Command specs in `src/cli/specs/`, handlers in `src/cli/handlers/` (`orchestration.ts`, `terminal.ts`, `worktree.ts`, …). `codex-command-classification.ts` classifies user-typed codex commands into "needs visible terminal" vs "safe in background pty" (knows the full ≥0.13x subcommand surface incl. `app-server`, `mcp-server`, `remote-control`, `exec-server`, `stdio-to-uds` — but only to classify, never to drive).
+
+## A10. Config footprint (what orca writes outside its own dir)
+
+**Invasive by necessity of the hooks model.** Writes managed scripts + hook registrations into **8 third-party agent home dirs**: `~/.claude/settings.json`, `~/.codex/hooks.json` + `~/.codex/config.toml`, `~/.copilot/hooks/orca.json`, `~/.cursor/hooks.json`, `~/.factory/settings.json`, `~/.gemini/settings.json`, `~/.grok/hooks/orca-status.json`, `~/.hermes/...`, plus `~/.orca/agent-hooks/*.sh`. Mitigations: filename-scoped matchers to avoid clobbering user hooks; trust-entry cleanup that only removes entries hash-matching orca's own command (`codex/hook-service.ts:485-511`, "a sourcePath-only filter would wipe the user's manually-approved entries"). Still: this is the opposite of cockpit's "scoped to `~/.config/cockpit`, non-invasive" stance.
+
+## A11. Self-improvement / learning / telemetry
+
+**No self-improving/learning subsystem.** `src/main/telemetry/` is anonymous-usage analytics only (`consent.ts`, `install-id.ts`, `cohort-classifier.ts`, `burst-cap.ts`, `classify-error.ts`) — opt-out telemetry, not a feedback loop that changes behavior. There is no learnings-capture, no wiki-compilation, no self-heal-on-invocation. (Cockpit's learnings + LLM-wiki + self-healing daemon have no orca analog — see Part B.)
+
+## A12. Real bugs / workarounds / version-gotchas (the gold)
+
+- **Codex 0.129+ silent hook-drop** unless `config.toml` trust hash present (A3) — directly relevant to any codex-hooks path.
+- **#1437 stuck-spinner**: OSC-title 'working' stays sticky after agent exits & shell takes over title; fixed by clearing `lastAgentStatus` on unclassifiable titles (`orca-runtime.ts:1846-1860`). *Evidence that title-scraping for completion is fragile.*
+- **#1148 opencode daemon-parity regression**: sessionId shape changed from numeric to `<worktreeId>@@<uuid>`; an old path-traversal regex silently rejected every legit id, leaving the plugin never loading. Fixed by SHA-256-hashing the id to a 32-hex dir name (`opencode/hook-service.ts:22-50`). *Evidence: session-id shape changes are a recurring break source.*
+- **node-pty NAPI ThreadSafeFunction leak**: must dispose onData/onExit before kill or Electron aborts on shutdown (`local-pty-provider.ts:39`, `codex-fetcher.ts:347-351`).
+- **codex `--prompt`/`--ephemeral` & copilot `--prompt` foot-guns**: non-interactive flags would kill the hosted TUI (`tui-agent-config.ts:242-246`); argv prompt exceeds Windows/SSH cmdline limits → stdin (`commit-message-agent-spec.ts:251-253`).
+- **Coordinator can't AI-decompose yet** (`coordinator.ts:201-206`) — tasks must be pre-created.
+- **`allow-stale-base` regex matches inside fenced code blocks** — accepted v1 limitation, fails toward "dispatches through" (`coordinator.ts:44-49`).
+- **tui-idle null→idle race**: fast tasks skip 'working'; waiter would hang forever (`orca-runtime.ts:1861-1866`).
+
+---
+
+# PART B — Deep Comparison vs. Cockpit
+
+## B(i) Subsystem-by-subsystem
+
+| Subsystem | Orca approach | Cockpit approach (post #85) | Who's ahead & why |
+|---|---|---|---|
+| **Agent driving (interactive)** | Native TUI in node-pty; prompt typed in (`sendTerminal` + 500 ms + `\r`) | Headless = daemon-owned child PID (`claude -p`, `opencode run`, `codex exec --json`); interactive = injected hooks (Claude); codex-interactive is the open fork | **Split.** Cockpit's headless path is cleaner (no screen timing) for batch; orca's TUI model is the only thing that gives a *human-attachable* live session today. Cockpit lacks orca's reattachable live UI. |
+| **Turn/done detection** | Native hooks → 4-state normalization; OSC-title fallback; output read last | `reduce(state,event)` state machine; hook events (Claude); anti-false-done invariant | **Cockpit ahead on rigor** (pure reducer, TERMINAL_STATES, explicit "turn-end ≠ completion"). **Orca ahead on breadth** (9 agents normalized, real signals). Orca's #1437/tui-idle bugs *empirically validate* cockpit's distrust of scrape-based done. |
+| **Cross-agent normalization** | `agent-hook-listener.ts` per-source `normalize*` + `never`-guarded switch; 4 canonical states | Provider tiering (provider × mode); per-provider drivers | **Orca ahead.** Cockpit has no equivalent unified normalization layer across heterogeneous hook vocabularies — this is orca's deepest asset. |
+| **Daemon / process supervision** | Out-of-proc forked daemon, AF_UNIX, token, **protocol-versioned**, **server-side headless-terminal snapshot + reattach** | `cockpitd` launchd, AF_UNIX, per-task JSON state, heartbeat watchdog, `reduce` | **Orca ahead on resilience** (reattach via serialized screen survives main/renderer crash). Cockpit's open issue #86 (daemon-bounce orphans in-flight headless) is *exactly* the problem orca's snapshot/reattach + protocol-version + restart-coalescing solves. **Cockpit ahead on state purity** (typed JSON state machine vs orca's screen blob). |
+| **Orchestration model** | SQLite task DAG, polling coordinator (2 s), preamble injected by typing, `worker_done` callback, circuit breaker, decision gates, dispatch-context "sling" | Command→Captain→Crew + Reactor; orchestration *inside* an agent session | **Comparable, different locus.** Orca's coordinator is *code* (deterministic, but can't AI-decompose). Cockpit's is an *LLM session* (flexible, AI-decomposes natively). Orca's circuit-breaker + dispatchId-keyed heartbeat + "warn-don't-autofail" are battle-tested patterns cockpit's watchdog should adopt. |
+| **HITL / approvals** | Punted: agent shows its own TUI approval; orca observes (`PermissionRequest→waiting`) + decision-gates as workflow checkpoints | Anti-false-done; approvals are the open codex-interactive design question | **Orca pragmatic, not better.** Its approvals are answered by a human in the TUI, not over a protocol. Cockpit answering approvals over app-server is a capability orca lacks — but has zero prior art here (high risk). Orca's *decision-gate* concept (block task → human resolves → resolution injected into next preamble) is a clean pattern cockpit's Captain layer could adopt directly. |
+| **CLI as ignition** | `orca` CLI = thin RPC client; `launchOrcaApp()` spawns the app if down | "CLI is ignition key, not the brain" — bootstraps then orchestration in-session | **Identical philosophy, independently arrived at.** Strong validation of cockpit's stance. |
+| **Skills / portability** | Ships `skills/{orchestration,orca-cli,computer-use}/SKILL.md`; `CLAUDE.md` = `@AGENTS.md` one-liner | Load-on-demand portable skills; `AGENTS.md` canonical, `CLAUDE.md` thin wrapper | **Identical pattern, independently arrived at.** Orca's `CLAUDE.md → @AGENTS.md` is literally cockpit's stated direction. Validation. |
+| **Multi-agent breadth** | 30 agents, 9 with native hooks, generic fallback for the rest | Claude (ref), codex/opencode headless, others via driver abstraction | **Orca far ahead on breadth.** Its `TUI_AGENT_CONFIG` + per-agent hook-service pattern is a proven template for cockpit's runtime-driver slot. |
+| **Remote / SSH** | Relay daemon SCP'd over SSH, grace-period pty survival, same hook pipeline remote | Not a focus | **Orca ahead** (not a current cockpit goal; note for later). |
+| **Mobile / external UI** | WS + E2EE + pairing + device registry; renders daemon snapshots | Obsidian hub-spoke reporting (read-only-ish) | **Different goals.** Orca = live control; cockpit = reporting. Not directly comparable. |
+| **Config footprint** | Invasive: writes into 8 agent home dirs (hooks model) | Non-invasive: scoped to `~/.config/cockpit` | **Cockpit ahead on hygiene** — but note this is *because* cockpit doesn't yet do interactive multi-agent via native hooks. If cockpit adopts agent hooks it inherits orca's footprint problem; orca's filename-scoped matchers + hash-matched cleanup are the mitigation template. |
+| **Self-improvement / learning** | None (telemetry is analytics only) | Learnings system + LLM-wiki + self-healing daemon | **Cockpit clearly ahead** — unique, no orca analog. Do not regress. |
+| **State model** | Screen-snapshot blob + SQLite orchestration rows | Pure `reduce(state,event)`, typed JSON per-task, TERMINAL_STATES | **Cockpit ahead.** Orca's "truth" for a live agent is a serialized terminal — opaque, un-introspectable. Cockpit's typed state is auditable and testable. Keep it. |
+
+## B(ii) The 5 deepest architectural insights for cockpit
+
+1. **Daemon-bounce is solved with a server-side rendered-state snapshot + reattach + protocol version, not just process supervision.** Cockpit's issue #86 (daemon bounce orphans in-flight headless) is *the* problem `src/main/daemon/{terminal-host,headless-emulator,history-manager}.ts` + `types.ts:6` `PROTOCOL_VERSION` solve. The insight: a daemon owning agent children needs (a) a serialized resumable representation of each child's state, (b) a versioned protocol so a child outlives an app upgrade, (c) restart-coalescing so concurrent bounce triggers can't double-enter teardown (`daemon-init.ts:40-46`). For cockpit's *headless* path the resumable representation isn't a screen — it's the **JSON state + the child's resumable session id** (`codex exec` rollout, `claude --resume`). The orca lesson: design the resume artifact as a first-class persisted thing the daemon writes on every state transition (orca's "final checkpoint"), not something reconstructed at bounce time.
+
+2. **There is no protocol that gives you turn-done for free across agents — orca proves the only reliable signal is the agent's own runtime event (hooks), and everything else (titles, output, timeouts) is a degrading fallback it openly distrusts.** Orca's #1437 and tui-idle-null→idle bugs are field evidence *for* cockpit's anti-false-done invariant. Strategic implication: cockpit's codex-interactive fork should bias toward whatever yields a *real codex-emitted event* — `codex app-server` notifications (`TurnCompleted` as liveness) OR codex's own hooks (the orca path) — and treat the legacy cmux scrape as the same "last resort" tier orca explicitly demotes.
+
+3. **Heterogeneous agents demand a normalization layer; orca's `never`-guarded per-source switch is the template.** If cockpit grows beyond Claude for *interactive*, it will hit orca's exact problem: 9 different event vocabularies, no two agents agreeing on "turn started." `agent-hook-listener.ts`'s design — bespoke `normalize<Agent>Event()` per source, exhaustive switch that fails at *typecheck* when a source is unmapped, collapsing to 4 canonical states — is the proven shape. Cockpit's provider-tiering should grow an explicit `normalizeProviderEvent` seam with the same compile-time exhaustiveness, feeding the `reduce()`.
+
+4. **The orchestration coordinator's battle-tested watchdog patterns beat cockpit's current heartbeat design on three specifics:** (a) **heartbeats keyed by dispatch-id not task** (a retried task has multiple dispatches; a late heartbeat from the dead one must not refresh the live one — `coordinator.ts:274-301`); (b) **warn-don't-autofail on stale** (false-positive killing a slow-but-correct worker costs more than a hung worker holding a slot — `:227-231`); (c) **circuit breaker as a separate "dispatch-context" row from the task** so retries don't dirty task state ("sling pattern"). Cockpit's per-task JSON state + watchdog should explicitly model dispatch attempts as separate sub-records with their own heartbeat lineage.
+
+5. **Decision-gates are a clean, codeable HITL primitive cockpit lacks.** Orca's gate = "block task → human answers a structured question → resolution text auto-injected into the next dispatch preamble" (`skills/orchestration/SKILL.md`, `coordinator.ts` gate handling). This is exactly the "semi-automatic, prompted-at-key-moments" pattern in cockpit's own design memory, but formalized as a first-class state (`pending|resolved|timeout`) that gates the DAG. Cockpit's Captain close-out / approval moments could adopt this verbatim.
+
+## B(iii) Where cockpit is genuinely ahead — do NOT regress toward orca
+
+1. **Pure `reduce(state,event)` + typed per-task JSON state + TERMINAL_STATES.** Orca's live-agent "truth" is a serialized xterm screen blob — opaque, un-unit-testable, un-queryable. Cockpit's auditable typed state machine is strictly better engineering for an orchestrator. Orca's SQLite orchestration rows are fine but the *agent-state* truth is a screen. Keep cockpit's model.
+2. **Anti-false-done invariant as a stated principle.** Orca *has* the bug class (#1437, tui-idle hangs) and patches them reactively. Cockpit elevates "turn-end is liveness, never completion" to an invariant. That's the right level. Do not weaken it to match orca's pragmatic title-scraping.
+3. **Non-invasive config footprint (`~/.config/cockpit`).** Orca writes into 8 third-party home dirs and carries the maintenance burden (9 installers, trust-hash sync, filename-scoped sweep, codex-0.129 coupling). Cockpit should adopt agent-hooks *only with eyes open* about this cost — and if it does, copy orca's mitigations (filename-scoped matchers, hash-matched cleanup) rather than the blast radius.
+4. **Self-improving subsystems (learnings, LLM-wiki, self-heal-on-invoke).** Zero orca analog. Genuinely differentiating. Keep investing.
+5. **Orchestration as an LLM session, not hardcoded code.** Orca's coordinator literally cannot decompose a spec (`coordinator.ts:201-206` — deferred to "a future phase where the coordinator itself is an LLM agent"). Cockpit's Command/Captain *are* that future phase already. This is a real lead — orca's roadmap is chasing where cockpit already is.
+
+## B(iv) Concrete recommendations for cockpit (named subsystems/files)
+
+1. **Close issue #86 with an orca-style resume artifact, not just process supervision.** In `cockpitd`'s per-task JSON state store, persist a `resumeRef` on every state transition: for headless codex = the rollout/session id usable by `codex exec resume`; for `claude -p` = the `--resume` session id; for app-server = the `thread` id (`thread/resume`). On daemon bounce, the state machine's recovery path re-attaches via `resumeRef`, mirroring orca's "final checkpoint snapshot." Add a daemon **protocol version** constant (orca `types.ts:6`) so a child can outlive a cockpitd upgrade, and **coalesce concurrent restarts** (orca `daemon-init.ts:40-46`).
+
+2. **Add a `normalizeProviderEvent(provider, rawEvent) -> CanonicalEvent` seam with compile-time exhaustiveness**, feeding `reduce()`. Model it on `agent-hook-listener.ts:1274-1342` (per-source function + `never`-guarded switch). Canonical set should map cleanly to cockpit's existing states; keep `TurnCompleted`/`Stop` classified as *liveness*, gated to *completion* only by an explicit terminal event — the invariant survives the new seam.
+
+3. **Refactor the watchdog to dispatch-attempt granularity.** In the per-task state, model attempts as sub-records each with their own `lastHeartbeatAt` and a `circuitBroken` flag after N failures (orca `coordinator.ts:274-301`, "sling pattern"). Adopt **warn-don't-autofail** as the default stale policy (orca `:227-231`) — surface to Captain, don't kill.
+
+4. **For the codex-interactive fork: orca's evidence tilts toward app-server, not orca's own hook path.** Reason: orca only uses codex hooks because it's *already* hosting the TUI for a human; cockpit's interactive codex has no human-attached TUI requirement that forces the pty model, and orca's `codex-fetcher.ts:88-261` proves a clean app-server JSON-RPC client works (mandatory ordered handshake: `initialize`→await→`initialized` *notification*→methods; newline-framed; id-less = notification; envelope-wrapped results). Take orca's hook-trust gotcha as a *general* warning (codex silently degrades when config preconditions unmet → make daemon "ready" contingent on a successful app-server `initialize` round-trip, not just child-spawned).
+
+5. **Adopt the decision-gate primitive in the Captain layer.** A first-class `gate{pending|resolved|timeout}` state that blocks a task's DAG node, surfaces a structured question to the human (cockpit's semi-automatic ethos), and injects the resolution into the next Crew dispatch. Orca's `gate-create`/`gate-resolve` + "resolution context included in the next dispatch preamble" is the exact shape.
+
+6. **Steal the foot-gun catalogue verbatim into cockpit's runtime drivers:** non-interactive flags that kill a hosted session (`codex --ephemeral`, copilot `--prompt`), argv-vs-stdin for large prompts (`commit-message-agent-spec.ts:251-253`), node-pty NAPI dispose-before-kill (`local-pty-provider.ts:39`) if cockpit ever pty-hosts, and session-id-shape-change as a recurring break source (orca #1148) — cockpit's `resumeRef` from rec #1 must be treated as an opaque hashed token, not parsed.
+
+---
+
+## Appendix — Honest uncertainty
+
+- Shallow clone (`--depth=1`); historical "why" is from in-code comments + bug-ref numbers, not git log. Bug numbers (#1437, #1148, etc.) are referenced in comments; I did not fetch the PRs.
+- `db.ts` (33 KB) and `orca-runtime.ts` (369 KB) were sampled at the load-bearing call sites, not read in full — orchestration DAG-promotion and the full sendTerminal path are evidenced but the entire 369 KB runtime was not exhaustively read.
+- Mobile/relay E2EE flow studied at the runtime-rpc seam, not into the React Native client.
+- Orca's *internal* design docs (`docs/design/agent-status-over-ssh.md`, `DESIGN_DOC_PREAMBLE_FIX.md`, `daemon-staleness-ux.md`) are referenced by comments but several are not present in this shallow checkout; claims tied to them rest on the comment text quoting their section numbers.

--- a/docs/specs/2026-05-20-cockpit-interactive-codex-design.md
+++ b/docs/specs/2026-05-20-cockpit-interactive-codex-design.md
@@ -1,0 +1,279 @@
+# Cockpit Interactive Codex — Design
+
+**Date:** 2026-05-20
+**Status:** Approved design, pre-implementation. Brainstormed in-session 2026-05-19→20; supersedes the deferred interactive section of `docs/specs/2026-05-17-cockpit-control-plane-design.md` for `provider=codex`.
+**Predecessors (read first):**
+- `docs/research/2026-05-19-codex-interactive-handoff.md` — problem brief
+- `docs/research/2026-05-19-orca-codex-wrapping-study.md` (+ `.html`) — codex-wrapping prior art
+- `docs/research/2026-05-19-orca-full-system-study.md` (+ `.html`) — full-system orca study
+- `docs/research/2026-05-19-orca-derived-cockpit-improvements.md` (+ `.html`) — Bucket-2 issues #89–#95
+**Cross-refs:** closes the **interactive-codex slice** of #86; depends on / cooperates with #87, #91, #92, #94.
+
+---
+
+## 1 · Problem & non-goals
+
+**Problem.** Cockpit's only live human↔agent surface today is Claude (a chat in a cmux tab). Codex is one-shot only (`codex exec --json`). The user wants live human↔codex with the same feel as a Claude crew tab, but **without** the unreliability that "drive a codex TUI by send-keys/read-screen" reintroduces (the pattern the control-plane was built to retire).
+
+**Two paths exist, this spec commits to one.**
+
+- **Iterative codex (already works, no build).** Multi-step codex work — spec → implement → review → iterate — works today via control-plane chained one-shot dispatch. Proven in prod (oneplan / PR #52). If the user's underlying need was "codex iterates with review loops," it is already satisfied.
+- **Live human↔codex (this spec).** A person watching/poking a codex session like a Claude crew tab. Codex's only *native* live surface is its full-screen TUI; scraping that TUI is rejected (orca's #1437 / null→idle bugs are field evidence the pattern fails).
+
+**The mechanism this spec uses.** The `codex app-server` JSON-RPC protocol — codex's documented, production-grade protocol (the same one OpenAI's VSCode ChatGPT extension uses for live human↔codex chat; orca's `codex-fetcher.ts:88–261` is a working reference client we mine). Provides real `TurnStarted/Completed` notifications, `AgentMessageDelta` streaming, native `ToolRequestUserInput`/approval requests, and `thread/start|resume|read|inject_items` lifecycle — i.e. a true protocol, not a screen.
+
+**Non-goals (YAGNI — explicitly out):**
+- Other providers' interactive mode. `provider≠codex, mode=interactive` continues to fail loud (red-team #4 stands).
+- App-server transports beyond `stdio://`. `unix://` and `ws://` deferred.
+- `codex realtime/*` (audio), `thread/fork`, `marketplace/*`, `plugin/*` methods. Wrap ~10 methods, ignore the other ~90.
+- A captain-mediated codex variant (you talk to captain, captain talks to codex). Rejected during brainstorm — the user wants the direct cmux-tab surface.
+- TUI scraping. Permanently rejected; not a fallback.
+- A general cockpit-wide decision-gate primitive across all providers/roles. This spec implements the interactive-codex HITL slice only; broader rollout is a follow-up.
+- Closing the **headless slice** of #86. Headless orphan-on-restart remains open; addressed when headless adapters adopt the same `resumeRef` discipline (tracked in #91 follow-ups).
+
+---
+
+## 2 · Approach (Approach 3, two-phase)
+
+**Phase 1 — `feature/codex-app-server-client`.** A standalone, TDD'd, typed JSON-RPC client lib for the codex app-server protocol + a smoke command that proves it works. No daemon, no TaskRecord, no cmux client. **Phase 1 is the empirical go/no-go gate** ("make sure codex can work" before daemon surgery). Mergeable on its own; if Phase 2 stalls it remains a usable direct-client interim.
+
+**Phase 2 — `feature/codex-interactive-crew`.** Wires the proven lib into `cockpitd` as the interactive driver; adds a streaming subscribe channel to the daemon socket; ships the cmux-tab client.
+
+**Boundary.** The lib speaks app-server JSON-RPC. The daemon never hand-rolls protocol. The cmux client never speaks app-server — it speaks cockpit's daemon protocol. Three layers, one direction.
+
+---
+
+## 3 · Phase 1 — `codexAppServerClient`
+
+### 3.1 Transport
+
+Spawn `codex app-server` as a child (default `--listen stdio://`). Frame JSON-RPC over its stdin/stdout, **newline-delimited** (one JSON object per line). Defensive parser: ignore non-JSON lines (orca evidence: `codex-fetcher.ts:160–164, 219–221`), route by `id`/`method`:
+
+- Messages with `id` + `result|error` → match against a pending-request map → resolve.
+- Messages with no `id` → notifications → fan out to the typed event emitter.
+
+### 3.2 Mandatory handshake — enforced
+
+Per orca `codex-fetcher.ts:142–146` ("skipping the notification causes 'Not initialized' errors"):
+
+1. Send `initialize` (request, params: `{clientInfo:{name:"cockpit",version}}`).
+2. Await response.
+3. Send `initialized` notification (no `id`).
+4. Only then permit any other method.
+
+The client refuses (throws synchronously) if a non-handshake method is called before step 3 completes. Smoke test asserts the "Not initialized" path cannot occur.
+
+### 3.3 Types — vendored, not hand-written
+
+`codex app-server generate-ts --experimental --out src/control/codex/protocol/` writes the TS bindings. Vendored into the repo; regenerable via an npm script (`npm run codex:gen-types`) and a one-line comment at the top of the generated dir saying "regenerated from codex-cli ≥0.130.0; do not edit by hand." All method calls + notifications import from these types — never re-declare shapes.
+
+### 3.4 Public API
+
+The smallest surface that satisfies Phase 2's needs:
+
+- `initialize(clientInfo) → InitializeResponse` (handshake step 1+3, internal `initialized` notification sent automatically)
+- `startThread({cwd, model?, sandbox?, approvalPolicy?}) → {threadId}`
+- `resumeThread({threadId, cwd?}) → ThreadResumeResponse` (built in Phase 1, used in Phase 2 / #86)
+- `readThread({threadId, lastN?}) → items` (for cmux tab replay after reconnect)
+- `sendTurn(threadId, text) → Promise<TurnResult>` — resolves on `TurnCompletedNotification` for that turn; streams via events meanwhile
+- `steerTurn(threadId, text) / interruptTurn(threadId)` — mid-turn interject / stop
+- `injectItems(threadId, items)` — between-turn injection
+- `respondToServerRequest(requestId, payload)` — answer a `ToolRequestUserInput` / approval request
+- Events on the emitter: `agentMessageDelta`, `reasoningTextDelta`, `turnStarted`, `turnCompleted`, `itemStarted`, `itemCompleted`, `userInputRequested`, `approvalRequested(*)`, `error`, `closed`
+
+(*) covers `CommandExecutionRequestApproval`, `ApplyPatchApproval`, `FileChangeRequestApproval`, `ExecCommandApproval`, `PermissionsRequestApproval` — surfaced as one `approvalRequested` event with a discriminator on the inner type.
+
+### 3.5 Smoke command — the proof gate
+
+`cockpit codex-chat-smoke [--cwd .] [--model M]`:
+
+1. Spawn `codex app-server`; run handshake; assert success.
+2. `startThread({cwd})`.
+3. **`sendTurn("Reply with exactly: PING-OK")`** — assert streamed text contains `PING-OK`; assert `TurnCompleted` fires.
+4. **`sendTurn("Now reply with: PONG-OK")`** — assert `PONG-OK`; proves multi-turn context.
+5. **Approval round-trip** (the orca-zero-prior-art surface — must pass for Phase 1 to merge): a turn that triggers a tool needing approval (e.g. asks codex to write a file in a workspace-write sandbox under a path that requires approval); on `approvalRequested`, respond via `respondToServerRequest`; assert `TurnCompleted` after the resolution.
+
+Exit 0 on all asserts; non-zero with the full transcript on any failure.
+
+### 3.6 Phase 1 acceptance
+
+- All five smoke assertions pass against real `codex-cli ≥0.130.0` on the developer's machine.
+- The client refuses a pre-handshake method call (unit-tested).
+- The defensive parser ignores non-JSON lines (unit-tested).
+- No daemon code touched.
+
+If the approval round-trip fails, **stop**. The fork's residual risk has landed; revisit (`Path Y` becomes the considered fallback at this point — cheap to switch because Phase 2 hasn't started).
+
+---
+
+## 4 · Phase 2 — daemon interactive driver, streaming channel, cmux client
+
+### 4.1 App-server child lifecycle
+
+The daemon owns **one** long-lived `codex app-server` child (spawned on first interactive codex dispatch, kept warm, PID tracked like headless children). One server hosts many threads. If it dies, the daemon respawns and `resumeThread`s every live interactive codex attempt (see §5).
+
+### 4.2 New verb
+
+`cockpit crew chat --provider codex --project <name> [--cwd <dir>] [--model <m>]`:
+
+- Creates a TaskRecord with `mode: "interactive"` — finally implementing the deferred mode, flipping red-team #4's fail-loud for `provider=codex` only.
+- Daemon (driver): `initialize` (once per app-server) → `startThread({cwd, model, sandbox:"workspace-write"})` → store `threadId` as the attempt's `resumeRef` on the TaskRecord.
+- Then execs the cmux-tab client below, attached to that task.
+
+### 4.3 TaskRecord shape — schema for #91 lands here
+
+Add a `DispatchAttempt` sub-record to `TaskRecord` (in `src/control/types.ts`). Written by the reducer on every transition:
+
+```
+DispatchAttempt = {
+  attemptId: string
+  startedAt: number
+  pid?: number
+  resumeRef?: string        // opaque, hashed-treated, NEVER parsed (orca #1148 lesson)
+  lastHeartbeatAt: number
+  error?: string
+  exitCode?: number
+  circuitBroken?: boolean
+}
+TaskRecord.attempts: DispatchAttempt[]   // append-only; current attempt = last()
+```
+
+This is the schema #91 will roll out across all providers; this spec ships the *schema* and uses it for codex interactive only. The reducer remains pure; the existing per-task top-level fields become derived from `attempts.at(-1)`.
+
+### 4.4 Daemon "ready" — flipped definition
+
+A chat task is not `working` when the codex child has spawned. It is `working` only after:
+
+1. `codex app-server` child up.
+2. `initialize` request acked.
+3. `initialized` notification sent.
+4. `thread/start` returned a `threadId`.
+
+If any step fails or times out (default 10s), the task transitions to `failed` with a clear error. This counters codex 0.129+'s silent-degradation pattern (orca `config-toml-trust.ts:14,20`).
+
+### 4.5 Streaming subscribe channel — the one new protocol surface
+
+The cockpitd socket today is request/response. Live chat needs server→client push. Add **one** framed verb to `src/control/protocol.ts`:
+
+- Client → daemon: `{"op":"attach","taskId":"..."}` opens a long-lived subscription.
+- Daemon → client (newline-delimited JSON frames): `{"type":"delta",text}`, `{"type":"turn-started"}`, `{"type":"turn-completed"}`, `{"type":"input-requested",question,requestId}`, `{"type":"approval-requested",kind,detail,requestId}`, `{"type":"gate-promoted",gateId}`, `{"type":"reattached"}`, `{"type":"closed",reason}`.
+- Client → daemon (further frames on the same connection): `{"op":"say",text}` → `sendTurn`; `{"op":"steer",text}` → `steerTurn`; `{"op":"interrupt"}`; `{"op":"answer",requestId,payload}` → `respondToServerRequest`.
+
+Additive — existing request/response verbs untouched. Schema-validated (cooperates with #87). The channel uses #94's keepalive framing once that lands (until then, an inline `{"_keepalive":true}` every 10s past idle; clients discard).
+
+### 4.6 cmux-tab client
+
+A new subcommand: `cockpit crew attach <taskId>`. The cmux tab opened by `cockpit crew chat` runs this command in the tab. It connects to the cockpitd socket, sends `attach`, renders streamed deltas as they arrive, readline for input → `say`/`steer`. Renders `input-requested` / `approval-requested` as a clear prompt block. The client is **not** an app-server client; it is **not** codex's TUI. It is a renderer over the cockpit daemon.
+
+Flow: `cockpit crew chat ...` (1) creates the TaskRecord + drives the daemon to `startThread`, then (2) opens a cmux tab whose command is `cockpit crew attach <taskId>`. The two halves are decoupled — `attach` can be called by hand on any existing interactive task, which is also the reconnect path after a daemon bounce (§5).
+
+### 4.7 `normalizeProviderEvent` seam
+
+In `src/control/codex/driver.ts`, a typed function:
+
+```
+normalizeAppServerNotification(n: ServerNotification): CanonicalEvent
+```
+
+Implemented with an exhaustive `switch` on the notification union from the vendored types. **`never`-guarded**: if codex adds a new notification kind and we regenerate types, the build fails until the new kind is mapped. Canonical mapping (anti-#2576 invariant baked in):
+
+- `TurnStartedNotification` → `working` (state)
+- `TurnCompletedNotification` → **`awaiting-input` (liveness, NOT `done`)** — this is the exact #2576 trap; refused here, codified.
+- `AgentMessageDeltaNotification` / `ReasoningTextDeltaNotification` / `CommandExecOutputDeltaNotification` → heartbeat (no state change)
+- `ToolRequestUserInputParams` (server request) → `blocked` (with `question` set)
+- Any `*ApprovalParams` (server request) → `blocked` (with `kind`+`detail`)
+- `ErrorNotification` → no state change; surfaced as a tab frame; sticky errors raise a follow-up state via the existing watchdog
+- `ContextCompactedNotification`, `ThreadTokenUsageUpdatedNotification`, model/reasoning meta → status-line only
+
+`done` is reached only when the human/captain explicitly closes the chat (`thread/archive` + task close).
+
+Streaming-frame mapping (what §4.5's frames are emitted from): `agentMessageDelta`/`reasoningTextDelta`/`commandExecOutputDelta` → `{"type":"delta",text}`; canonical `working`→`turn-started`; canonical `awaiting-input`→`turn-completed`; canonical `blocked` (input) → `input-requested`; canonical `blocked` (approval) → `approval-requested`; gate promotion (§4.9) → `gate-promoted`; reattach (§5) → `reattached`; task close → `closed`.
+
+### 4.8 State machine — anti-#2576 explicit
+
+- `submitted` → handshake/`thread/start` → `working`
+- `working` --[`TurnCompleted`]--> `awaiting-input` --[next `say`/`turn/start`]--> `working`
+- `working|awaiting-input` --[`ToolRequestUserInput` / `*Approval`]--> `blocked` --[`answer` or gate-resolve]--> `working`
+- Any state --[explicit close]--> `done`
+- Stall (no notification ≥ `heartbeatBudgetMs`) → `stalled` (warn + surface to Captain per #90; never auto-`failed`)
+- Driver error (handshake fail, app-server crash with no resume possible) → `failed`
+
+`done` is terminal. `stalled` is recoverable. `failed` is terminal. (TERMINAL_STATES stays the same.)
+
+### 4.9 Decision-gate — the HITL slice
+
+When `blocked` lands and **no client has been attached to the task for ≥5 seconds** (the human stepped away, never attached, or the tab is mid-reconnect), the daemon promotes the pending request to a `gate`. The 5s buffer avoids racing with a momentary disconnect. Once a client (re)attaches, the daemon emits `gate-promoted` so the tab can offer to take over the answer if the gate is still `pending`.
+
+Gate schema:
+
+```
+Gate = {
+  gateId: string
+  taskId: string
+  kind: "input" | "approval"
+  question: string | { kind, detail }
+  state: "pending" | "resolved" | "timeout"
+  createdAt: number
+  resolvedBy?: string
+  resolution?: unknown
+}
+```
+
+The Captain sees gates via `cockpit crew status` (which gains a `gates` field) and resolves them via `cockpit crew reply --gate <gateId> ...`. The driver translates a `gate-resolve` into `respondToServerRequest` against the saved `requestId`. Gates have a configurable timeout (default 30 min) → `timeout` state surfaces to Captain.
+
+A gate is the cockpit-wide primitive's interactive-codex slice. The schema/states are usable as-is when expanded to other providers/roles; that broader rollout is a separate spec.
+
+### 4.10 Phase 2 acceptance
+
+- `cockpit crew chat --provider codex --project X --cwd <worktree>` opens a real codex chat in a cmux tab; the tab streams codex output token-by-token; the user can type a follow-up; codex responds; the user can `Ctrl-C` to `interrupt` mid-turn.
+- A codex `approvalRequested` surfaces in the tab; answering it in-tab continues the turn; ignoring it for 5+ seconds promotes to a gate visible in `cockpit crew status` and resolvable from the Captain.
+- Killing `cockpitd` mid-chat and restarting it: the cmux tab reconnects (auto-backoff), the daemon `resumeThread`s, the tab shows a `reattached` frame followed by a `thread/read` tail; the next `say` lands on the same thread. **The interactive-codex slice of #86 is closed.**
+- `provider≠codex, mode=interactive` continues to fail loud (no behavioral change for other providers).
+- A `normalizeAppServerNotification` exhaustiveness gap fails the build (TS verified).
+
+---
+
+## 5 · Resilience — `resumeRef` as the cornerstone
+
+Daemon-bounce survival is defined entirely by `resumeRef`, not by any codex-specific feature:
+
+**App-server child dies.** Daemon respawns it; iterates `attempts` with non-terminal state + non-empty `resumeRef`; calls driver's `reattach(resumeRef)`, which for codex interactive is `thread/resume{threadId, cwd}`. Then a `thread/read` tail replays to any attached cmux client. The app-server's own thread state is durable across this.
+
+**Daemon process bounces** (the launchd `kickstart` case). Cmux client's `attach` connection drops. Client auto-reconnects with backoff and re-`attach`es by `taskId`. Daemon (post-restart) re-`reattach`s the attempts; replays via `thread/read`. The TaskRecord on disk is the durable handle across the bounce. Once #93 (restart coalescing) lands, the bounce window narrows further.
+
+**Honest scope.** This design closes the **interactive-codex slice** of #86. The *headless* slice (a `codex exec` / `claude -p` / `opencode run` mid-flight when the daemon bounces) is NOT closed here. The `DispatchAttempt.resumeRef` field is reusable by those adapters — when they each grow a `reattach(resumeRef)` driver method (`codex exec resume <rolloutId>`, `claude --resume <id>`, etc.), they inherit the same resilience. That cross-provider rollout is part of #91's follow-up.
+
+---
+
+## 6 · Orca-derived hardening (Bucket-1, embedded above)
+
+For traceability, the four Bucket-1 items from `docs/research/2026-05-19-orca-derived-cockpit-improvements.md` and where each lives:
+
+| Bucket-1 item | Section | Notes |
+|---|---|---|
+| `resumeRef`-on-every-transition (closes #86 interactive slice) | §4.3, §5 | Schema added to `DispatchAttempt`; reducer writes it on every transition |
+| Daemon "ready" = successful `initialize` handshake | §4.4 | Explicit gate before `working` |
+| `normalizeProviderEvent` seam with `never`-guarded switch | §4.7 | Codex-only today; future-provider expansion = add a case, fail at typecheck if you don't |
+| Decision-gate HITL primitive | §4.9 | Interactive-codex slice; cockpit-wide rollout separate |
+
+The Bucket-2 issues (#89–#95) are *not* in this spec — they ship on their own cadence and apply across providers. This spec depends on / cooperates with them but does not require their completion to merge.
+
+---
+
+## 7 · Cross-references & follow-ups
+
+- **Closes** the interactive-codex slice of **#86** (orphan-on-restart). Headless slice remains open.
+- **Cooperates with** **#87** (protocol schema validation — the new streaming verb is schema-validated in the same change), **#92** (`PROTOCOL_VERSION` — bumped when this verb lands), **#94** (keepalive framing — used by the streaming channel).
+- **Sets up** **#91** (dispatch-attempt sub-records — schema introduced here, rolled across other providers later) and **#90** (warn-don't-autofail — already used in §4.8's `stalled`).
+- **Does not block** **#89**, **#93**, **#95** — but each compounds well with this spec.
+- **Follow-up spec:** cockpit-wide decision-gate primitive across all providers/roles (extracting §4.9 to a generic).
+- **Follow-up spec:** headless `resumeRef` rollout for `claude -p` / `codex exec` / `opencode run`, closing the headless slice of #86.
+
+---
+
+## 8 · Implementation phasing summary
+
+| Phase | Branch | What ships | Mergeable on its own? |
+|---|---|---|---|
+| 1 | `feature/codex-app-server-client` | `codexAppServerClient` lib + vendored types + `codex-chat-smoke` command incl. approval round-trip | Yes. Phase 1 PASS = empirical go-no-go for Phase 2. |
+| 2 | `feature/codex-interactive-crew` | Daemon driver, streaming subscribe channel, cmux client, `DispatchAttempt` schema, `normalizeProviderEvent`, decision-gates, resilience wiring | Yes. Requires Phase 1 merged. |


### PR DESCRIPTION
Research → spec → plan for live human↔codex via codex's `app-server` JSON-RPC protocol (Approach 3, two-phase).

**Research** (3 HTML reports + their markdown sources): deep prior-art study of stablyai/orca — codex-wrapping mechanism, full-system architecture, cockpit-vs-orca system comparison, and a roadmap doc cataloging every applicable orca lesson (Bucket 1 in spec; Bucket 2 filed as #89–#95).

**Spec** `docs/specs/2026-05-20-cockpit-interactive-codex-design.md` — closes the interactive-codex slice of #86. Bucket-1 orca-derived items folded in: `resumeRef`-on-every-transition; daemon "ready" = successful initialize handshake; `normalizeProviderEvent` seam with `never`-guarded exhaustive switch; decision-gate HITL primitive. Anti-#2576 invariant codified (`TurnCompleted → awaiting-input`, never `done`).

**Plan** `docs/plans/2026-05-20-cockpit-interactive-codex.md` — 28-task TDD plan across the two phases (`feature/codex-app-server-client` and `feature/codex-interactive-crew`).

This is a docs-only PR. Phase 1 implementation lands separately on `feature/codex-app-server-client` (Phase 1 empirical gate already passed against codex-cli 0.130.0; evidence captured locally).

Sources: brainstorming → orca full-system study → cockpit-vs-orca comparison → roadmap → spec → plan. Authored 2026-05-19 / 2026-05-20.