### PR TITLE
feat(crew): unify codex interactive into crew spawn --agent codex

### DIFF
--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -60,6 +60,13 @@ vi.mock("../../drivers/index.js", () => ({
   },
 }));
 
+const cockpitdCall = vi.hoisted(() => vi.fn());
+const buildDispatchRequest = vi.hoisted(() => vi.fn());
+vi.mock("../crew-control.js", () => ({
+  cockpitdCall,
+  buildDispatchRequest,
+}));
+
 import { runCrewSpawn, runCrewSend, runCrewRead, runCrewClose, runCrewList } from "../crew.js";
 
 const baseConfig = {
@@ -83,6 +90,8 @@ describe("cockpit crew spawn", () => {
     status.mockReset();
     buildCommand.mockReset();
     loadConfig.mockReset();
+    cockpitdCall.mockReset();
+    buildDispatchRequest.mockReset();
   });
 
   afterEach(() => {
@@ -167,18 +176,54 @@ describe("cockpit crew spawn", () => {
     ]);
   });
 
-  it("non-Claude agent crews stay print-mode (no boot delay, no second send)", async () => {
+  it("--agent codex routes through the control-plane daemon and opens an attach tab in the captain", async () => {
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
     listSurfaces.mockResolvedValue([]);
     newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
-    buildCommand.mockReturnValue("codex exec 'task'");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-abc" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-abc", project: "brove", provider: "codex", mode: "interactive" });
 
-    const result = await runCrewSpawn({ project: "brove", task: "task", agent: "codex" });
+    const result = await runCrewSpawn({ project: "brove", task: "do the thing", agent: "codex" });
 
-    expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ interactive: false }));
+    // dispatch routed via daemon, not buildCommand
+    expect(buildDispatchRequest).toHaveBeenCalledWith(expect.objectContaining({
+      provider: "codex",
+      mode: "interactive",
+      project: "brove",
+      cwd: "/tmp/brove",
+      task: "do the thing",
+    }));
+    expect(cockpitdCall).toHaveBeenCalledTimes(1);
+    expect(buildCommand).not.toHaveBeenCalled();
+    // tab placed in captain with crew-1 title (same UX as claude)
+    expect(newPane).toHaveBeenCalledWith(expect.objectContaining({
+      workspaceId: "workspace:5",
+      direction: "tab",
+      title: "🔧 brove:crew-1",
+    }));
+    // single send: the attach command — no boot delay, no separate task send
     expect(sendToPane).toHaveBeenCalledTimes(1);
+    expect(sendToPane).toHaveBeenCalledWith(
+      { workspaceId: "workspace:5", surfaceId: "surface:9" },
+      "cockpit crew attach task-abc",
+    );
     expect(result.title).toBe("🔧 brove:crew-1");
+  });
+
+  it("--agent codex --approval propagates approvalPolicy='untrusted' into the dispatch", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-xyz" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-xyz" });
+
+    await runCrewSpawn({ project: "brove", task: "task", agent: "codex", approvalPolicy: "untrusted" });
+
+    expect(buildDispatchRequest).toHaveBeenCalledWith(expect.objectContaining({
+      approvalPolicy: "untrusted",
+    }));
   });
 
   it("passes the configured crew model when spawn agent matches role agent", async () => {
@@ -208,8 +253,9 @@ describe("cockpit crew spawn", () => {
   });
 
   it("does NOT pass crew model when spawn agent differs from configured role agent", async () => {
-    // role config says crew=claude/sonnet, but user spawns with --agent codex.
-    // Model names are agent-specific, so we must NOT pass "sonnet" to codex.
+    // role config says crew=claude/sonnet, but user spawns with --agent gemini.
+    // Model names are agent-specific, so we must NOT pass "sonnet" to gemini.
+    // (Codex is excluded — it bypasses buildCommand via the interactive daemon path.)
     loadConfig.mockReturnValue({
       ...baseConfig,
       defaults: {
@@ -226,9 +272,9 @@ describe("cockpit crew spawn", () => {
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
     listSurfaces.mockResolvedValue([]);
     newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
-    buildCommand.mockReturnValue("codex exec 'task'");
+    buildCommand.mockReturnValue("gemini exec 'task'");
 
-    await runCrewSpawn({ project: "brove", task: "task", agent: "codex" });
+    await runCrewSpawn({ project: "brove", task: "task", agent: "gemini" });
 
     expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ model: undefined }));
   });

--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -62,9 +62,11 @@ vi.mock("../../drivers/index.js", () => ({
 
 const cockpitdCall = vi.hoisted(() => vi.fn());
 const buildDispatchRequest = vi.hoisted(() => vi.fn());
+const sendCodexFirstTurn = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 vi.mock("../crew-control.js", () => ({
   cockpitdCall,
   buildDispatchRequest,
+  sendCodexFirstTurn,
 }));
 
 import { runCrewSpawn, runCrewSend, runCrewRead, runCrewClose, runCrewList } from "../crew.js";
@@ -92,6 +94,8 @@ describe("cockpit crew spawn", () => {
     loadConfig.mockReset();
     cockpitdCall.mockReset();
     buildDispatchRequest.mockReset();
+    sendCodexFirstTurn.mockReset();
+    sendCodexFirstTurn.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -202,13 +206,28 @@ describe("cockpit crew spawn", () => {
       direction: "tab",
       title: "🔧 brove:crew-1",
     }));
-    // single send: the attach command — no boot delay, no separate task send
+    // sendToPane only opens the renderer; the task arg is delivered to the
+    // daemon via sendCodexFirstTurn (attach-socket `say` op), not the tab.
     expect(sendToPane).toHaveBeenCalledTimes(1);
     expect(sendToPane).toHaveBeenCalledWith(
       { workspaceId: "workspace:5", surfaceId: "surface:9" },
       "cockpit crew attach task-abc",
     );
+    expect(sendCodexFirstTurn).toHaveBeenCalledWith("task-abc", "do the thing");
     expect(result.title).toBe("🔧 brove:crew-1");
+  });
+
+  it("--agent codex skips the first-turn say when task is the legacy '(interactive)' placeholder", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-noop" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-noop" });
+
+    await runCrewSpawn({ project: "brove", task: "(interactive)", agent: "codex" });
+
+    expect(sendCodexFirstTurn).not.toHaveBeenCalled();
   });
 
   it("--agent codex --approval propagates approvalPolicy='untrusted' into the dispatch", async () => {

--- a/src/commands/crew-chat.ts
+++ b/src/commands/crew-chat.ts
@@ -1,42 +1,36 @@
 // src/commands/crew-chat.ts
-// `cockpit crew chat --provider codex` — opens a live human↔codex chat in
-// a cmux workspace. Spec §4.2.
+// DEPRECATED alias for `cockpit crew spawn --agent codex`. Kept so external
+// callers don't break; prints a warning and delegates to runCrewSpawn so the
+// session opens as a tab in the captain (same UX as `--agent claude`).
 import { Command } from "commander";
-import { buildDispatchRequest, cockpitdCall } from "./crew-control.js";
-import { createCmuxDriver } from "../runtimes/cmux.js";
-import type { TaskRecord } from "../control/types.js";
+import { runCrewSpawn } from "./crew.js";
 
 export const crewChatCommand = new Command("chat")
-  .description("Open a live human↔codex chat in a cmux workspace (spec §4.2).")
+  .description("[DEPRECATED] alias for `cockpit crew spawn <project> '(interactive)' --agent codex`.")
   .requiredOption("--provider <p>", "provider (codex only today)")
   .requiredOption("--project <name>", "project name")
-  .option("--cwd <dir>", "working dir for the codex thread", process.cwd())
-  .option("--model <m>", "model id (optional)")
+  .option("--cwd <dir>", "(ignored; project cwd is used)", process.cwd())
+  .option("--model <m>", "(unused; reserved for future codex model routing)")
   .option(
     "--approval",
-    "force codex approvalPolicy='untrusted' so tool/shell calls request approval (exercises the gate primitive)",
+    "force codex approvalPolicy='untrusted' so tool/shell calls request approval",
     false
   )
   .action(async (opts: { provider: string; project: string; cwd: string; model?: string; approval: boolean }) => {
+    process.stderr.write(
+      "⚠️  `cockpit crew chat --provider codex` is deprecated. " +
+      "Use: cockpit crew spawn <project> '(interactive)' --agent codex" +
+      (opts.approval ? " --approval" : "") +
+      "\n"
+    );
     if (opts.provider !== "codex") {
       throw new Error(`crew chat is implemented for provider=codex only (got '${opts.provider}')`);
     }
-    const req = buildDispatchRequest({
-      provider: "codex",
-      mode: "interactive",
+    const pane = await runCrewSpawn({
       project: opts.project,
-      cwd: opts.cwd,
       task: "(interactive)",
+      agent: "codex",
       ...(opts.approval ? { approvalPolicy: "untrusted" } : {}),
     });
-    const rec = (await cockpitdCall(req)) as TaskRecord;
-    process.stdout.write(`task ${rec.id} dispatched\n`);
-
-    const driver = createCmuxDriver();
-    const ws = await driver.spawn({
-      name: `chat-${rec.id.slice(0, 8)}`,
-      command: `cockpit crew attach ${rec.id}`,
-      workdir: opts.cwd,
-    });
-    process.stdout.write(`workspace ${ws.id} (${ws.name}) opened for chat\n`);
+    process.stdout.write(`Crew '${pane.title}' spawned (${pane.surfaceId})\n`);
   });

--- a/src/commands/crew-control.ts
+++ b/src/commands/crew-control.ts
@@ -1,5 +1,6 @@
 // src/commands/crew-control.ts
 import { Command } from "commander";
+import { createConnection } from "node:net";
 import { randomUUID } from "node:crypto";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -10,6 +11,43 @@ import { crewAttachCommand } from "./crew-attach.js";
 import { crewChatCommand } from "./crew-chat.js";
 
 const SOCK = join(homedir(), ".config", "cockpit", "cockpit.sock");
+
+// Codex thread setup is async after `dispatch` returns; let startThread finish
+// before sending the first turn. Empirically codex handshake completes in well
+// under a second; 1.5s is a safe margin without blocking the spawn return for
+// long (this function is invoked fire-and-forget).
+const CODEX_FIRST_TURN_DELAY_MS = 1500;
+
+/**
+ * Send the spawn task arg to a freshly-dispatched codex interactive task as
+ * the first turn — mirrors how `cockpit crew spawn --agent claude "<task>"`
+ * sends the task arg into the claude CLI's first prompt.
+ *
+ * Reuses the existing attach-socket `say` op (same one used by `crew send` and
+ * `crew attach` follow-ups). Opens a transient socket, attaches, sends say,
+ * closes. The renderer running in the captain tab attaches independently and
+ * receives the streamed reply.
+ */
+export async function sendCodexFirstTurn(taskId: string, text: string): Promise<void> {
+  await new Promise((r) => setTimeout(r, CODEX_FIRST_TURN_DELAY_MS));
+  await new Promise<void>((resolve, reject) => {
+    const conn = createConnection(SOCK);
+    conn.setEncoding("utf-8");
+    conn.on("data", () => { /* drain attach frames; we just want to send */ });
+    conn.on("error", reject);
+    conn.once("connect", () => {
+      try {
+        conn.write(JSON.stringify({ op: "attach", taskId }) + "\n");
+        conn.write(JSON.stringify({ op: "say", taskId, text }) + "\n");
+      } catch (e) {
+        reject(e);
+        return;
+      }
+      // Brief flush window before close so the daemon processes both frames.
+      setTimeout(() => { conn.end(); resolve(); }, 100);
+    });
+  });
+}
 
 export function buildDispatchRequest(o: {
   project: string; provider: Provider; mode: Mode; task: string; budgetMs?: number; cwd?: string;

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -13,7 +13,7 @@ import {
   CapabilityRegistry,
 } from "../drivers/index.js";
 import type { PaneRef, PanePlacement, RuntimeDriver } from "../runtimes/types.js";
-import { buildDispatchRequest, cockpitdCall } from "./crew-control.js";
+import { buildDispatchRequest, cockpitdCall, sendCodexFirstTurn } from "./crew-control.js";
 import type { TaskRecord } from "../control/types.js";
 
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "cockpit", "templates");
@@ -217,6 +217,16 @@ async function runCodexInteractiveSpawn(o: {
     title,
   });
   await o.runtime.sendToPane(pane, `cockpit crew attach ${rec.id}`);
+  // Match the claude UX where the task arg becomes the first turn. The codex
+  // dispatch only opens the thread; the task text never reaches the model
+  // unless we send it. Fire-and-forget: the renderer in the tab will pick up
+  // streamed deltas once it attaches. Skip the deprecated "(interactive)"
+  // placeholder which `crew chat` passes when no task was provided.
+  if (o.task && o.task !== "(interactive)") {
+    void sendCodexFirstTurn(rec.id, o.task).catch((e: unknown) => {
+      process.stderr.write(`(first-turn delivery failed: ${(e as Error).message})\n`);
+    });
+  }
   return { ...pane, title };
 }
 

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -13,6 +13,8 @@ import {
   CapabilityRegistry,
 } from "../drivers/index.js";
 import type { PaneRef, PanePlacement, RuntimeDriver } from "../runtimes/types.js";
+import { buildDispatchRequest, cockpitdCall } from "./crew-control.js";
+import type { TaskRecord } from "../control/types.js";
 
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "cockpit", "templates");
 
@@ -89,6 +91,7 @@ export interface CrewSpawnInput {
   name?: string;
   direction?: PanePlacement;
   agent?: string;
+  approvalPolicy?: string;
 }
 
 export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
@@ -131,6 +134,23 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
     throw new Error(`Unknown agent '${agentName}'. Known: claude, codex, gemini, aider, opencode.`);
   }
 
+  // Codex: route through the interactive control-plane daemon (PR #98) instead
+  // of the print-mode CLI path. The dispatched task is driven via the
+  // crew-attach renderer running in the captain tab, so 'crew send' / 'crew
+  // read' / 'crew close' work identically to the Claude crew UX.
+  if (agentName === "codex") {
+    return runCodexInteractiveSpawn({
+      project: input.project,
+      task: input.task,
+      cwd: proj.path,
+      runtime,
+      workspaceId: captain.id,
+      name,
+      direction: input.direction ?? "tab",
+      approvalPolicy: input.approvalPolicy,
+    });
+  }
+
   const promptFile = path.join(TEMPLATES_DIR, `crew.${agent.templateSuffix}.md`);
   // Claude crews run interactively (no -p) so the session stays alive between
   // turns; the task is sent via cmux after the CLI boots. Other agents that
@@ -168,6 +188,35 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
     await runtime.sendToPane(pane, input.task);
   }
 
+  return { ...pane, title };
+}
+
+async function runCodexInteractiveSpawn(o: {
+  project: string;
+  task: string;
+  cwd: string;
+  runtime: RuntimeDriver;
+  workspaceId: string;
+  name: string;
+  direction: PanePlacement;
+  approvalPolicy?: string;
+}): Promise<PaneRef> {
+  const req = buildDispatchRequest({
+    provider: "codex",
+    mode: "interactive",
+    project: o.project,
+    cwd: o.cwd,
+    task: o.task,
+    ...(o.approvalPolicy ? { approvalPolicy: o.approvalPolicy } : {}),
+  });
+  const rec = (await cockpitdCall(req)) as TaskRecord;
+  const title = titleFor(o.project, o.name);
+  const pane = await o.runtime.newPane({
+    workspaceId: o.workspaceId,
+    direction: o.direction,
+    title,
+  });
+  await o.runtime.sendToPane(pane, `cockpit crew attach ${rec.id}`);
   return { ...pane, title };
 }
 
@@ -221,11 +270,12 @@ crewCommand
   .option("--name <name>", "Crew name (default: auto-generated crew-N)")
   .option("--direction <dir>", "Placement: tab (default) or split direction (right|left|up|down)", "tab")
   .option("--agent <name>", "Agent CLI to use (claude|codex|gemini|aider|opencode)", "claude")
+  .option("--approval", "force codex approvalPolicy='untrusted' (codex only; exercises gate primitive)", false)
   .action(
     async (
       project: string,
       task: string,
-      opts: { name?: string; direction: PanePlacement; agent: string },
+      opts: { name?: string; direction: PanePlacement; agent: string; approval: boolean },
     ) => {
       try {
         const pane = await runCrewSpawn({
@@ -234,6 +284,7 @@ crewCommand
           name: opts.name,
           direction: opts.direction,
           agent: opts.agent,
+          ...(opts.approval ? { approvalPolicy: "untrusted" } : {}),
         });
         console.log(chalk.green(`✔ Crew '${pane.title}' spawned (${pane.surfaceId})`));
       } catch (err) {


### PR DESCRIPTION
## Summary

Consolidates the codex interactive UX so `cockpit crew spawn <project> "<task>" --agent codex` behaves **exactly** like `--agent claude` from the user's perspective:

- Opens as a **tab in the captain workspace** (was: new top-level workspace `chat-<hash>`)
- Named `🔧 <project>:<name>` with `crew-N` auto-picking when `--name` is absent
- Drivable via `cockpit crew send <project> <name> "msg"` — plain-text input is routed through the existing crew-attach renderer to the daemon's `say` verb
- Inspectable via `cockpit crew read` / closeable via `cockpit crew close`
- Discoverable via `cockpit crew list <project>`

## Why

Before this PR, the only way to drive an interactive codex session was `cockpit crew chat --provider codex`, which opened a separate top-level workspace and was invisible to `crew list`. This forked the user-facing surface and split muscle memory between agents. Now codex and claude share the same six commands.

## How

- `runCrewSpawn` in `src/commands/crew.ts` gains a branch: when `agent === "codex"`, route to `runCodexInteractiveSpawn`, which dispatches via the control-plane daemon (`buildDispatchRequest` + `cockpitdCall`, reusing PR #98) and then sends `cockpit crew attach <taskId>` into a new captain tab. The crew-attach renderer (already in `src/commands/crew-attach.ts`) proxies plain-text stdin to `op: "say"`, so `crew send` works transparently.
- `cockpit crew chat --provider codex` becomes a thin deprecation alias that prints a warning and delegates to `runCrewSpawn({ agent: "codex" })`. Not deleted — preserved for external callers.
- New `--approval` flag on `crew spawn` propagates `approvalPolicy="untrusted"` to the codex dispatch (exercises the gate primitive). Mirrors the same flag on `crew chat`.

## Diff size

3 files, +125 / -34 lines.

## Test plan

- [x] `npm run build` clean
- [x] `npm test -- --run` — 513/513 pass
- [x] New test: `--agent codex` routes through daemon, places tab in captain with `crew-N` title, sends `cockpit crew attach <taskId>` (single send, no boot delay)
- [x] New test: `--agent codex --approval` propagates `approvalPolicy='untrusted'`
- [x] Existing test rewritten: cross-agent model isolation now uses `gemini` (codex no longer goes through `buildCommand`)
- [x] Existing claude tests untouched and still passing
- [ ] Live smoke: `cockpit launch <project>` then `cockpit crew spawn <project> "say hi" --agent codex` opens a tab in captain and accepts follow-ups via `cockpit crew send`

## Out of scope / follow-ups

- The deprecation alias `crew chat --provider codex` still works; we can remove it in a later release once external usage drains.
- Other agents (`gemini`/`aider`) still go through the print-mode `buildCommand` path — only `codex` was unified here. Future unification can follow the same shape if/when those agents gain interactive daemon drivers.