### PR TITLE
feat(crew-attach): polish codex renderer (color, framed turns, status)

### DIFF
--- a/src/commands/__tests__/crew-attach.test.ts
+++ b/src/commands/__tests__/crew-attach.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import {
+  stripAnsi,
+  formatTurnHeader,
+  formatTurnFooter,
+  formatStatus,
+  formatApproval,
+  formatDoneFollowup,
+  formatGatePromoted,
+} from "../crew-attach.js";
+
+describe("crew-attach formatters", () => {
+  it("stripAnsi removes color codes but preserves text", () => {
+    const colored = formatTurnHeader(1);
+    const plain = stripAnsi(colored);
+    expect(plain).toContain("codex");
+    expect(plain).toContain("turn 1");
+    expect(plain).not.toMatch(/\x1b\[/);
+  });
+
+  it("formatTurnHeader frames with rounded box-drawing chars", () => {
+    const plain = stripAnsi(formatTurnHeader(3, 40));
+    expect(plain.startsWith("╭─")).toBe(true);
+    expect(plain.endsWith("╮")).toBe(true);
+    expect(plain).toContain("turn 3");
+  });
+
+  it("formatTurnFooter shows elapsed seconds and closes box", () => {
+    const plain = stripAnsi(formatTurnFooter(3200, 40));
+    expect(plain.startsWith("╰─")).toBe(true);
+    expect(plain.endsWith("╯")).toBe(true);
+    expect(plain).toContain("3.2s");
+  });
+
+  it("formatStatus reports state, turn, and elapsed", () => {
+    const plain = stripAnsi(formatStatus("working", 2, 1500));
+    expect(plain).toContain("state=working");
+    expect(plain).toContain("turn=2");
+    expect(plain).toContain("elapsed=1.5s");
+  });
+
+  it("formatApproval includes kind and question", () => {
+    const plain = stripAnsi(formatApproval("exec", "Run rm -rf?"));
+    expect(plain).toContain("[approval] exec");
+    expect(plain).toContain("Run rm -rf?");
+  });
+
+  it("dim helpers contain expected text", () => {
+    expect(stripAnsi(formatDoneFollowup())).toContain("done — type a follow-up");
+    expect(stripAnsi(formatGatePromoted("g-123"))).toContain("g-123");
+  });
+});

--- a/src/commands/crew-attach.ts
+++ b/src/commands/crew-attach.ts
@@ -1,5 +1,6 @@
 // src/commands/crew-attach.ts
 import { Command } from "commander";
+import chalk from "chalk";
 import { createConnection } from "node:net";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -10,6 +11,84 @@ function socketPath(): string {
   return process.env.COCKPITD_SOCK ?? join(homedir(), ".config", "cockpit", "cockpit.sock");
 }
 
+// --- Pure formatters (exported for tests) ---
+
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+
+export function stripAnsi(s: string): string {
+  return s.replace(ANSI_RE, "");
+}
+
+function rule(width: number, ch = "─"): string {
+  return ch.repeat(Math.max(0, width));
+}
+
+export function formatTurnHeader(turn: number, width = 60): string {
+  const label = ` codex · turn ${turn} `;
+  const remaining = Math.max(2, width - label.length - 2);
+  const left = "╭─";
+  const right = rule(remaining) + "╮";
+  return chalk.cyan.bold(left) + chalk.cyan.bold(label) + chalk.cyan(right);
+}
+
+export function formatTurnFooter(elapsedMs: number, width = 60): string {
+  const secs = (elapsedMs / 1000).toFixed(1);
+  const label = ` done · ${secs}s `;
+  const remaining = Math.max(2, width - label.length - 2);
+  const left = "╰─";
+  const right = rule(remaining) + "╯";
+  return chalk.dim(left + label + right);
+}
+
+export type RendererState = "idle" | "working" | "awaiting-input" | "blocked";
+
+export function formatStatus(state: RendererState, turn: number, elapsedMs: number): string {
+  const secs = (elapsedMs / 1000).toFixed(1);
+  return chalk.dim(`  · state=${state}  turn=${turn}  elapsed=${secs}s`);
+}
+
+export function formatApproval(kind: string, question: string): string {
+  return chalk.yellow.bold(`[approval] ${kind}`) + chalk.yellow(`: ${question}`);
+}
+
+export function formatApprovalPrompt(): string {
+  return chalk.yellow("[approve/deny]> ");
+}
+
+export function formatInputQuestion(question: string): string {
+  return chalk.cyan.bold("[codex asks] ") + question;
+}
+
+export function formatInputPrompt(): string {
+  return chalk.cyan("[answer]> ");
+}
+
+export function formatDoneFollowup(): string {
+  return chalk.dim("[done — type a follow-up or Ctrl-C]");
+}
+
+export function formatAttached(): string {
+  return chalk.dim("(attached)");
+}
+
+export function formatReattached(): string {
+  return chalk.dim("(reattached)");
+}
+
+export function formatClosed(reason: string): string {
+  return chalk.dim(`(closed: ${reason})`);
+}
+
+export function formatConnectionClosed(): string {
+  return chalk.dim("(connection closed)");
+}
+
+export function formatGatePromoted(gateId: string): string {
+  return chalk.dim(`(no client was attached; question promoted to gate ${gateId})`);
+}
+
+// --- CLI command ---
+
 export const crewAttachCommand = new Command("attach")
   .description("Attach to a live interactive task (renders deltas; takes follow-ups). Spec §4.6.")
   .argument("<taskId>", "task id to attach to")
@@ -19,6 +98,17 @@ export const crewAttachCommand = new Command("attach")
     conn.on("connect", () => send({ op: "attach", taskId }));
     let pendingRequestId: number | undefined;
     let buf = "";
+
+    // Renderer state
+    let turnCount = 0;
+    let turnStartMs = 0;
+    let inTurn = false;
+    let state: RendererState = "idle";
+    let attachedOnce = false;
+
+    const elapsed = () => (turnStartMs ? Date.now() - turnStartMs : 0);
+    const writeStatus = () => process.stdout.write(formatStatus(state, turnCount, elapsed()) + "\n");
+
     conn.on("data", (chunk) => {
       buf += chunk.toString();
       const lastNl = buf.lastIndexOf("\n");
@@ -27,27 +117,48 @@ export const crewAttachCommand = new Command("attach")
       buf = buf.slice(lastNl + 1);
       for (const f of decodeFrames(consumable)) render(f);
     });
-    conn.on("close", () => { process.stderr.write("\n(connection closed)\n"); process.exit(0); });
-    conn.on("error", (e) => { process.stderr.write(`\n(socket error: ${e.message})\n`); process.exit(1); });
+    conn.on("close", () => { process.stderr.write("\n" + formatConnectionClosed() + "\n"); process.exit(0); });
+    conn.on("error", (e) => { process.stderr.write(`\n${chalk.red(`(socket error: ${e.message})`)}\n`); process.exit(1); });
 
     function render(f: AttachFrame): void {
       switch (f.type) {
-        case "delta": process.stdout.write(f.text); break;
-        case "turn-started": process.stdout.write("\n[codex]\n"); break;
+        case "delta":
+          process.stdout.write(f.text);
+          break;
+        case "turn-started":
+          turnCount += 1;
+          turnStartMs = Date.now();
+          inTurn = true;
+          state = "working";
+          process.stdout.write("\n" + formatTurnHeader(turnCount) + "\n");
+          writeStatus();
+          break;
         case "turn-completed":
-          process.stdout.write("\n[done — type a follow-up or Ctrl-C]\n> "); break;
+          process.stdout.write("\n" + formatTurnFooter(elapsed()) + "\n");
+          state = "idle";
+          inTurn = false;
+          process.stdout.write(formatDoneFollowup() + "\n> ");
+          break;
         case "input-requested":
           pendingRequestId = f.requestId;
-          process.stdout.write(`\n[codex asks] ${f.question}\n[answer]> `); break;
+          state = "awaiting-input";
+          process.stdout.write("\n" + formatInputQuestion(f.question) + "\n" + formatInputPrompt());
+          break;
         case "approval-requested":
           pendingRequestId = f.requestId;
-          process.stdout.write(`\n[approval] ${f.kind}: ${f.question}\n[approve/deny]> `); break;
+          state = "blocked";
+          process.stdout.write("\n" + formatApproval(f.kind, f.question) + "\n" + formatApprovalPrompt());
+          break;
         case "gate-promoted":
-          process.stdout.write(`\n(no client was attached; question promoted to gate ${f.gateId})\n> `); break;
+          process.stdout.write("\n" + formatGatePromoted(f.gateId) + "\n> ");
+          break;
         case "reattached":
-          process.stdout.write("\n(attached)\n> "); break;  // ack on first/re-attach
+          process.stdout.write("\n" + (attachedOnce ? formatReattached() : formatAttached()) + "\n> ");
+          attachedOnce = true;
+          break;
         case "closed":
-          process.stdout.write(`\n(closed: ${f.reason})\n`); break;
+          process.stdout.write("\n" + formatClosed(f.reason) + "\n");
+          break;
         case "_keepalive":
           break;
       }
@@ -60,6 +171,7 @@ export const crewAttachCommand = new Command("attach")
         const decision = lower.startsWith("approve") ? "approve" : lower.startsWith("deny") ? "deny" : undefined;
         send({ op: "answer", taskId, requestId: pendingRequestId, payload: { text, decision } });
         pendingRequestId = undefined;
+        if (state === "awaiting-input" || state === "blocked") state = "working";
       } else {
         send({ op: "say", taskId, text });
       }


### PR DESCRIPTION
## Summary
Quick UI polish pass on `src/commands/crew-attach.ts` — the renderer that runs in each cmux tab for `cockpit crew spawn --agent codex`. Goal was the cheap 1-2 hour win against the bare-marker look that compared poorly to native codex CLI. Full TUI parity is a separate milestone-sized follow-up.

## What changed
- **chalk-colored markers** — cyan/bold `[codex]` header, yellow/bold `[approval]`, dim transients (`(attached)`, `(connection closed)`, gate-promotion notice, done-follow-up hint).
- **Framed turns** — rounded box-drawing block opens at `turn-started` (`╭─ codex · turn N ─╮`) and closes at `turn-completed` with elapsed time (`╰─ done · 3.2s ─╯`).
- **Status line** — on state transitions only (not every delta), prints `state=working  turn=N  elapsed=Ts`. Inline, not sticky — scrollback stays readable.
- **Reattach** distinguishes first attach vs subsequent reattach.
- **ANSI passthrough preserved** — deltas write raw, so any inline color codex emits survives.
- Formatters factored as **pure functions** for testing.

## What did NOT change
- No new dependencies (chalk was already in `package.json`).
- Daemon, driver, protocol, control plane — all untouched.
- Attach client's stdin handling unchanged.
- No dirty pre-existing files touched (`AGENTS.md`, `CLAUDE.md`, `daemon.test.ts`).

## Test plan
- [x] `npm run build` — clean
- [x] `npm test -- --run` — 519/519 passing, including 6 new unit tests in `src/commands/__tests__/crew-attach.test.ts` covering color stripping, box framing, status content, approval format
- [ ] Manual smoke (reviewer): `cockpit crew spawn --agent codex` in a cmux workspace, send a turn, observe colored header / footer / status

## Context
Filed in parallel to a milestone-sized issue for the proper TUI renderer on top of app-server events; this PR is the surgical polish, not that work.