### PR TITLE
feat(crew): inject crew role for codex spawn (parity with claude)

### DIFF
--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -69,6 +69,14 @@ vi.mock("../crew-control.js", () => ({
   sendCodexFirstTurn,
 }));
 
+const existsSyncMock = vi.hoisted(() => vi.fn());
+const readFileSyncMock = vi.hoisted(() => vi.fn());
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  const merged = { ...actual, existsSync: existsSyncMock, readFileSync: readFileSyncMock };
+  return { ...merged, default: merged };
+});
+
 import { runCrewSpawn, runCrewSend, runCrewRead, runCrewClose, runCrewList } from "../crew.js";
 
 const baseConfig = {
@@ -96,6 +104,11 @@ describe("cockpit crew spawn", () => {
     buildDispatchRequest.mockReset();
     sendCodexFirstTurn.mockReset();
     sendCodexFirstTurn.mockResolvedValue(undefined);
+    existsSyncMock.mockReset();
+    readFileSyncMock.mockReset();
+    // Default: pretend the codex role template is absent so older tests that
+    // don't care about role injection still pass unchanged.
+    existsSyncMock.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -228,6 +241,31 @@ describe("cockpit crew spawn", () => {
     await runCrewSpawn({ project: "brove", task: "(interactive)", agent: "codex" });
 
     expect(sendCodexFirstTurn).not.toHaveBeenCalled();
+  });
+
+  it("--agent codex forwards crew.generic.md role content as roleInstructions on dispatch", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-role" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-role" });
+
+    existsSyncMock.mockReturnValue(true);
+    readFileSyncMock.mockReturnValue(
+      "# Crew Member — Generic Agent\n\nYou are a crew member working on a specific task in a git worktree.\n",
+    );
+
+    await runCrewSpawn({ project: "brove", task: "do the thing", agent: "codex" });
+
+    expect(buildDispatchRequest).toHaveBeenCalledWith(expect.objectContaining({
+      provider: "codex",
+      roleInstructions: expect.stringContaining("You are a crew member"),
+    }));
+    expect(readFileSyncMock).toHaveBeenCalledWith(
+      expect.stringContaining("crew.generic.md"),
+      "utf8",
+    );
   });
 
   it("--agent codex --approval propagates approvalPolicy='untrusted' into the dispatch", async () => {

--- a/src/commands/crew-control.ts
+++ b/src/commands/crew-control.ts
@@ -51,7 +51,7 @@ export async function sendCodexFirstTurn(taskId: string, text: string): Promise<
 
 export function buildDispatchRequest(o: {
   project: string; provider: Provider; mode: Mode; task: string; budgetMs?: number; cwd?: string;
-  approvalPolicy?: string;
+  approvalPolicy?: string; roleInstructions?: string;
 }): { kind: "dispatch"; record: TaskRecord } {
   const now = Date.now();
   const attemptId = randomUUID();
@@ -63,6 +63,7 @@ export function buildDispatchRequest(o: {
       lastEvent: "dispatch", heartbeatBudgetMs: o.budgetMs ?? 300000,
       attempts: [{ attemptId, startedAt: now, lastHeartbeatAt: now }],
       ...(o.approvalPolicy ? { approvalPolicy: o.approvalPolicy } : {}),
+      ...(o.roleInstructions ? { roleInstructions: o.roleInstructions } : {}),
     },
   };
 }

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import chalk from "chalk";
@@ -139,6 +140,13 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
   // crew-attach renderer running in the captain tab, so 'crew send' / 'crew
   // read' / 'crew close' work identically to the Claude crew UX.
   if (agentName === "codex") {
+    // Mirror claude's --append-system-prompt-file: read the crew role template
+    // and forward it to codex via thread/start.developerInstructions so the
+    // session knows it's a crew member, not a bare shell.
+    const codexRoleFile = path.join(TEMPLATES_DIR, `crew.${agent.templateSuffix}.md`);
+    const roleInstructions = fs.existsSync(codexRoleFile)
+      ? fs.readFileSync(codexRoleFile, "utf8")
+      : undefined;
     return runCodexInteractiveSpawn({
       project: input.project,
       task: input.task,
@@ -148,6 +156,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
       name,
       direction: input.direction ?? "tab",
       approvalPolicy: input.approvalPolicy,
+      roleInstructions,
     });
   }
 
@@ -200,6 +209,7 @@ async function runCodexInteractiveSpawn(o: {
   name: string;
   direction: PanePlacement;
   approvalPolicy?: string;
+  roleInstructions?: string;
 }): Promise<PaneRef> {
   const req = buildDispatchRequest({
     provider: "codex",
@@ -208,6 +218,7 @@ async function runCodexInteractiveSpawn(o: {
     cwd: o.cwd,
     task: o.task,
     ...(o.approvalPolicy ? { approvalPolicy: o.approvalPolicy } : {}),
+    ...(o.roleInstructions ? { roleInstructions: o.roleInstructions } : {}),
   });
   const rec = (await cockpitdCall(req)) as TaskRecord;
   const title = titleFor(o.project, o.name);

--- a/src/control/codex/app-server-client.ts
+++ b/src/control/codex/app-server-client.ts
@@ -68,7 +68,7 @@ export class AppServerClient extends EventEmitter {
     return res;
   }
 
-  async startThread(params: { cwd: string; model?: string; sandbox?: string; approvalPolicy?: string }): Promise<{ threadId: string }> {
+  async startThread(params: { cwd: string; model?: string; sandbox?: string; approvalPolicy?: string; developerInstructions?: string }): Promise<{ threadId: string }> {
     const res = await this._sendRequest("thread/start", params) as { thread?: { id?: string } };
     const id = res?.thread?.id;
     if (typeof id !== "string") throw new Error(`thread/start: unexpected response shape (no thread.id): ${JSON.stringify(res).slice(0, 200)}`);

--- a/src/control/codex/driver.ts
+++ b/src/control/codex/driver.ts
@@ -53,6 +53,7 @@ export class CodexInteractiveDriver {
         model: rec.model,
         sandbox: "workspace-write",
         ...(rec.approvalPolicy ? { approvalPolicy: rec.approvalPolicy } : {}),
+        ...(rec.roleInstructions ? { developerInstructions: rec.roleInstructions } : {}),
       });
       this.threadByTask.set(rec.id, threadId);
       this.taskByThread.set(threadId, rec.id);

--- a/src/control/types.ts
+++ b/src/control/types.ts
@@ -60,6 +60,10 @@ export interface TaskRecord {
    *  When set to "untrusted", codex requests approval for tool/shell calls,
    *  exercising the gate-promotion flow end-to-end. */
   approvalPolicy?: string;
+  /** Role-priming content forwarded to startThread's developerInstructions
+   *  (interactive only). Parity with claude's --append-system-prompt-file:
+   *  injects crew rules / Karpathy discipline before the first user turn. */
+  roleInstructions?: string;
 }
 
 export type ControlEvent =


### PR DESCRIPTION
## Summary

- `cockpit crew spawn --agent codex <task>` now injects the crew role doc (`~/.config/cockpit/templates/crew.generic.md`) into the codex session, matching the claude path that uses `--append-system-prompt-file`.
- Mechanism: codex's `thread/start` protocol exposes `developerInstructions`. Plumbs a new `roleInstructions` field through the same seam already used for `approvalPolicy` (`crew.ts` → `buildDispatchRequest` → `TaskRecord` → `driver.dispatch` → `app-server-client.startThread`).
- Reading from `crew.generic.md` (via `agent.templateSuffix`) means a single-file edit propagates to all generic agents (codex/gemini/aider/opencode) when they get interactive support.

## Why

Before this change, codex crews started bare: the model got a raw task arg with no \"you are a crew member, follow these rules, commit and report when done\" framing. Claude crews always get this. PR brings codex to parity.

## Test plan

- [x] `npm run build` passes
- [x] `npm test -- --run` — 514/514 green, includes new unit test `--agent codex forwards crew.generic.md role content as roleInstructions on dispatch` that mocks `node:fs` and asserts the dispatch payload carries role content
- [ ] Manual: `cockpit crew spawn brove --agent codex \"introduce yourself\"` — codex first turn should acknowledge crew role (worktree-only, commit-and-report) rather than just answering as a fresh assistant