### PR TITLE
fix(templates): identity-first crew.generic.md + no-nested-subagents rule

### DIFF
--- a/orchestrator/crew.generic.md
+++ b/orchestrator/crew.generic.md
@@ -1,12 +1,15 @@
 # Crew Member — Generic Agent
 
-You are a crew member working on a specific task in a git worktree.
+**Your identity: you are a crew member.** This is who you are for this session — not background context to file away. You run on some underlying agent (Codex, Gemini, Aider, or another), but that is your engine, not your role. Your role is **crew member**, working on one task your captain assigned, inside a git worktree.
+
+If asked "who are you?", answer that you are a crew member working on an assigned task. Lead with the crew role, not the name of your underlying model.
 
 ## Rules
 
 1. You are in a worktree, NOT the main branch. Do not modify files outside your worktree.
-2. When your task is complete, commit your work and report back.
-3. Commit your work frequently with descriptive messages.
+2. You are a single agent session working alone on your task. Do NOT spawn nested sub-agents, sub-teams, or child agent sessions — there is no nesting. Complete the work yourself in this session.
+3. When your task is complete, commit your work and report back.
+4. Commit your work frequently with descriptive messages.
 
 ## Your Worktree
 


### PR DESCRIPTION
Closes #105.

## Problem

During live testing of PR #104, codex crews asked "who are you?" cold answered **"I am Codex, your coding agent"** — not "I am a crew member." The crew role *is* delivered to codex (via `developer_instructions`/`roleInstructions`), but codex treats developer instructions as **background context**, so the model's built-in identity ("I am Codex") wins.

Claude crews don't have this problem: their role arrives via `--append-system-prompt-file`, which carries far more **identity weight** than codex's developer-instruction channel. Same content, different framing strength.

We can't change codex's plumbing here, but we *can* strengthen the template content so the identity assertion is forceful and identity-framed rather than incidental — closing the gap at the source the generic agents actually read.

Separately, `crew.generic.md` was missing the explicit **no-nested-subagents** rule that `crew.claude.md` already has (its rules 2 & 4). Added a generic-phrased equivalent for parity.

## Changes (`orchestrator/crew.generic.md`)

1. **Identity-first opening** — replaced the single passive line ("You are a crew member working on a specific task…") with an explicit identity block: states the crew role *is* who you are (not background), names the underlying agent as "engine, not role," and instructs the agent to lead with the crew role — not its model name — when asked "who are you?"
2. **No-nested-subagents rule** — new Rules item: single agent session, do not spawn nested sub-agents / sub-teams / child agent sessions. Phrased generically (no Claude-only tooling) to stay portable across codex/gemini/aider.

## Constraints respected

- Edited the **source** template in `orchestrator/` only. The runtime copy at `~/.config/cockpit/templates/crew.generic.md` is re-synced automatically by `ensureRuntimeSynced` on the next cockpit invocation — no manual runtime edit needed.
- `role-templates.test.ts` forbids Claude-specific tool tokens (`TaskCreate`/`TaskUpdate`/`TeamCreate`, backtick-wrapped `Agent`/`Skill`) in the generic templates. The new rule deliberately uses plain-text "sub-agents"/"sub-teams" to comply.
- Surgical: one file, 6 insertions / 3 deletions.

## Verification

```
npx vitest run src/lib/__tests__/role-templates.test.ts        # 6 passed
npx vitest run src/commands/__tests__/crew.test.ts             # 18 passed
npx vitest run src/lib/__tests__/canonical-source.test.ts      # 14 passed
```