### PR TITLE
feat(daemon): push captain notifications on terminal task events (#109)

### DIFF
--- a/scripts/smoke-push-notify.mjs
+++ b/scripts/smoke-push-notify.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+// scripts/smoke-push-notify.mjs
+//
+// Live(ish) smoke for #109: spins up a real cockpitd from the worktree
+// dist on a temp socket, injects a capturing `notify`, seeds a task, then
+// drives the same control events that `cockpit crew signal done|blocked|
+// failed` would emit. Asserts that each terminal/attention transition
+// produced exactly one captain-bound notification with the spec'd
+// CREW … [<provider>/<taskId-8>]: … format. Also probes redundancy
+// (a second done is a no-op) and notifier-down resilience (a throwing
+// notify must not crash the daemon).
+//
+// We use `notify` capture rather than shelling out to the production
+// `cockpit runtime send` because (a) the unit suite already covers the
+// shell-out path, and (b) restarting the launchd-managed daemon to point
+// at the worktree build would interrupt unrelated in-flight sessions
+// (cockpit memory: "never auto-restart running captain/crew sessions").
+// This smoke validates startCockpitd → createDaemon → notify wiring
+// end-to-end through the real socket; the shell-out is one execFileSync
+// call away in the default `notify` and is covered by the cmux notifier
+// tests.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const distEntry = pathToFileURL(join(__dirname, "..", "dist", "control", "cockpitd.js")).href;
+const distProto = pathToFileURL(join(__dirname, "..", "dist", "control", "protocol.js")).href;
+const { startCockpitd } = await import(distEntry);
+const { sendRequest } = await import(distProto);
+
+const evidencePath = join(__dirname, "..", ".phase-3-5-smoke-evidence.local");
+const log = [];
+const record = (m) => { log.push(m); process.stdout.write(m + "\n"); };
+
+const dir = mkdtempSync(join(tmpdir(), "cp-phase35-"));
+const sock = join(dir, "c.sock");
+const captured = []; // {project, message}
+
+const handle = startCockpitd({
+  stateRoot: join(dir, "state"),
+  sockPath: sock,
+  sweepMs: 0,
+  notify: (args) => { captured.push({ project: args.project, message: args.message }); },
+});
+
+const baseRec = (id, overrides = {}) => ({
+  id, project: "p", provider: "claude", mode: "interactive",
+  state: "submitted", task: "ship the phase 3.5 push notifications",
+  createdAt: 1, lastHeartbeat: 1, lastEvent: "",
+  heartbeatBudgetMs: 1000,
+  attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }],
+  ...overrides,
+});
+
+let failures = 0;
+const assert = (cond, label) => {
+  if (cond) { record(`  ✓ ${label}`); }
+  else { record(`  ✗ ${label}`); failures++; }
+};
+
+try {
+  record(`# Phase 3.5 smoke (#109) — ${new Date().toISOString()}`);
+  record(`socket: ${sock}`);
+
+  // ── done ──────────────────────────────────────────────────────────────
+  record("\n[1] task.done → CREW DONE");
+  await sendRequest(sock, { kind: "seed", record: baseRec("done-abc12345", { state: "working" }) });
+  await sendRequest(sock, { kind: "event", project: "p",
+    event: { type: "task.done", id: "done-abc12345", resultRef: "/tmp/r1" } });
+  const done = captured.filter((c) => c.message.startsWith("CREW DONE"));
+  assert(done.length === 1, `exactly one CREW DONE captured (got ${done.length})`);
+  assert(done[0]?.project === "p", `project=p (got ${done[0]?.project})`);
+  assert(/^CREW DONE \[claude\/done-abc/.test(done[0]?.message ?? ""),
+    `message tag matches spec: ${done[0]?.message}`);
+
+  // Re-apply done → state machine absorbs, no second notify.
+  await sendRequest(sock, { kind: "event", project: "p",
+    event: { type: "task.done", id: "done-abc12345", resultRef: "/tmp/r1" } });
+  assert(captured.filter((c) => c.message.startsWith("CREW DONE")).length === 1,
+    "redundant task.done does NOT re-notify");
+
+  // ── blocked ───────────────────────────────────────────────────────────
+  record("\n[2] task.blocked → CREW BLOCKED");
+  await sendRequest(sock, { kind: "seed", record: baseRec("blocked-1xyz", { state: "working" }) });
+  await sendRequest(sock, { kind: "event", project: "p",
+    event: { type: "task.blocked", id: "blocked-1xyz", reason: "need-input",
+      question: "which database backend should I target?" } });
+  const blk = captured.filter((c) => c.message.startsWith("CREW BLOCKED"));
+  assert(blk.length === 1, `exactly one CREW BLOCKED captured (got ${blk.length})`);
+  assert((blk[0]?.message ?? "").includes("which database backend"),
+    `question surfaced: ${blk[0]?.message}`);
+
+  // ── failed ────────────────────────────────────────────────────────────
+  record("\n[3] task.failed → CREW FAILED");
+  await sendRequest(sock, { kind: "seed", record: baseRec("failed-9q", { state: "working" }) });
+  await sendRequest(sock, { kind: "event", project: "p",
+    event: { type: "task.failed", id: "failed-9q", error: "child exited with code 137 (OOM)" } });
+  const fld = captured.filter((c) => c.message.startsWith("CREW FAILED"));
+  assert(fld.length === 1, `exactly one CREW FAILED captured (got ${fld.length})`);
+  assert((fld[0]?.message ?? "").includes("OOM"), `error surfaced: ${fld[0]?.message}`);
+
+  // ── liveness → no notify ──────────────────────────────────────────────
+  record("\n[4] task.progress / heartbeat → no notify");
+  await sendRequest(sock, { kind: "seed", record: baseRec("live-7t", { state: "working" }) });
+  await sendRequest(sock, { kind: "event", project: "p",
+    event: { type: "task.progress", id: "live-7t" } });
+  await sendRequest(sock, { kind: "event", project: "p",
+    event: { type: "heartbeat", id: "live-7t" } });
+  const liveCount = captured.length;
+  assert(liveCount === 3, `liveness produced 0 new notifications (total still ${liveCount})`);
+
+  // ── notifier-down resilience ──────────────────────────────────────────
+  // Stop this daemon, restart with a notify that throws — daemon must
+  // still apply events to the store.
+  record("\n[5] notifier throwing → daemon survives, store still updated");
+  handle.stop();
+  const handle2 = startCockpitd({
+    stateRoot: join(dir, "state"),
+    sockPath: sock,
+    sweepMs: 0,
+    notify: () => { throw new Error("cmux pane crashed"); },
+  });
+  try {
+    await sendRequest(sock, { kind: "seed", record: baseRec("bang-pq", { state: "working" }) });
+    const r = await sendRequest(sock, { kind: "event", project: "p",
+      event: { type: "task.done", id: "bang-pq", resultRef: "/tmp/r-bang" } });
+    assert(r?.state === "done", `event still applied (state=${r?.state})`);
+    const after = await sendRequest(sock, { kind: "status", project: "p", id: "bang-pq" });
+    assert(after?.state === "done", `store reflects new state after throwing notify`);
+  } finally {
+    handle2.stop();
+  }
+
+  record(`\nresult: ${failures === 0 ? "PASS" : "FAIL"} (failures=${failures})`);
+} catch (err) {
+  record(`\nUNCAUGHT: ${err?.stack || err}`);
+  failures++;
+} finally {
+  try { handle.stop?.(); } catch { /* ignore */ }
+  writeFileSync(evidencePath, log.join("\n") + "\n");
+  record(`\nevidence written: ${evidencePath}`);
+  rmSync(dir, { recursive: true, force: true });
+  process.exit(failures === 0 ? 0 : 1);
+}

--- a/src/control/__tests__/cockpitd-push.test.ts
+++ b/src/control/__tests__/cockpitd-push.test.ts
@@ -1,0 +1,149 @@
+// src/control/__tests__/cockpitd-push.test.ts
+//
+// Phase 3.5 (#109): daemon-side push notifications to captain on terminal
+// task events. Tests the daemon.ts injection point with a fake `notify`
+// dep — no real cmux, no real config, just the trigger logic.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDaemon } from "../daemon.js";
+import { createStore } from "../store.js";
+import type { TaskRecord } from "../types.js";
+
+function rec(id: string, overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    id, project: "p", provider: "claude", mode: "interactive",
+    state: "working", task: "build the foo widget", createdAt: 1, lastHeartbeat: 1,
+    lastEvent: "", heartbeatBudgetMs: 1000,
+    attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }],
+    ...overrides,
+  };
+}
+
+interface NotifyCall {
+  project: string;
+  message: string;
+}
+
+function fakeNotify() {
+  const calls: NotifyCall[] = [];
+  return {
+    calls,
+    notify: (args: { project: string; message: string }) => {
+      calls.push({ project: args.project, message: args.message });
+    },
+  };
+}
+
+describe("cockpitd push notifications (#109)", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "cp-push-")); });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("done event triggers exactly one notify with CREW DONE prefix", async () => {
+    const store = createStore(dir);
+    store.put(rec("task-12345678", { task: "ship the widget" }));
+    const n = fakeNotify();
+    const d = createDaemon({ store, now: () => 2000, notify: n.notify });
+    await d.handle({
+      kind: "event",
+      project: "p",
+      event: { type: "task.done", id: "task-12345678", resultRef: "/tmp/missing-file-on-purpose" },
+    });
+    expect(n.calls).toHaveLength(1);
+    expect(n.calls[0]?.project).toBe("p");
+    expect(n.calls[0]?.message).toMatch(/^CREW DONE \[claude\/task-123/);
+  });
+
+  it("blocked event triggers CREW BLOCKED with the question", async () => {
+    const store = createStore(dir);
+    store.put(rec("task-blocked-1"));
+    const n = fakeNotify();
+    const d = createDaemon({ store, now: () => 2000, notify: n.notify });
+    await d.handle({
+      kind: "event",
+      project: "p",
+      event: { type: "task.blocked", id: "task-blocked-1", reason: "need-input", question: "which db?" },
+    });
+    expect(n.calls).toHaveLength(1);
+    expect(n.calls[0]?.message).toMatch(/^CREW BLOCKED \[claude\/task-blo/);
+    expect(n.calls[0]?.message).toContain("which db?");
+  });
+
+  it("failed event triggers CREW FAILED with the error", async () => {
+    const store = createStore(dir);
+    store.put(rec("task-failed-1"));
+    const n = fakeNotify();
+    const d = createDaemon({ store, now: () => 2000, notify: n.notify });
+    await d.handle({
+      kind: "event",
+      project: "p",
+      event: { type: "task.failed", id: "task-failed-1", error: "boom: subprocess crashed" },
+    });
+    expect(n.calls).toHaveLength(1);
+    expect(n.calls[0]?.message).toMatch(/^CREW FAILED \[claude\/task-fai/);
+    expect(n.calls[0]?.message).toContain("boom: subprocess crashed");
+  });
+
+  it("stalled (from sweep) triggers CREW STALLED with budget", async () => {
+    const store = createStore(dir);
+    store.put(rec("task-stall-1", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250 }));
+    const n = fakeNotify();
+    const d = createDaemon({ store, now: () => 5000, notify: n.notify });
+    d.sweep();
+    expect(store.get("p", "task-stall-1")?.state).toBe("stalled");
+    expect(n.calls).toHaveLength(1);
+    expect(n.calls[0]?.message).toMatch(/^CREW STALLED \[claude\/task-sta/);
+    expect(n.calls[0]?.message).toMatch(/no heartbeat/i);
+  });
+
+  it("redundant terminal event does NOT re-notify (state-change guard)", async () => {
+    const store = createStore(dir);
+    // Already done — state machine ignores further events idempotently.
+    store.put(rec("task-done-already", { state: "done" }));
+    const n = fakeNotify();
+    const d = createDaemon({ store, now: () => 2000, notify: n.notify });
+    await d.handle({
+      kind: "event",
+      project: "p",
+      event: { type: "task.done", id: "task-done-already", resultRef: "/tmp/x" },
+    });
+    expect(n.calls).toHaveLength(0);
+  });
+
+  it("liveness events (progress/heartbeat) do NOT notify", async () => {
+    const store = createStore(dir);
+    store.put(rec("task-live-1", { state: "working" }));
+    const n = fakeNotify();
+    const d = createDaemon({ store, now: () => 2000, notify: n.notify });
+    await d.handle({
+      kind: "event",
+      project: "p",
+      event: { type: "task.progress", id: "task-live-1" },
+    });
+    await d.handle({
+      kind: "event",
+      project: "p",
+      event: { type: "heartbeat", id: "task-live-1" },
+    });
+    expect(n.calls).toHaveLength(0);
+  });
+
+  it("notifier throwing does NOT crash the daemon; event still applies", async () => {
+    const store = createStore(dir);
+    store.put(rec("task-bang-1"));
+    const throwingNotify = () => { throw new Error("cmux is down"); };
+    const d = createDaemon({ store, now: () => 2000, notify: throwingNotify });
+    // The handle call must NOT reject.
+    const r = await d.handle({
+      kind: "event",
+      project: "p",
+      event: { type: "task.done", id: "task-bang-1", resultRef: "/tmp/x" },
+    });
+    expect((r as TaskRecord).state).toBe("done");
+    // And the store still reflects the new state.
+    expect(store.get("p", "task-bang-1")?.state).toBe("done");
+  });
+});

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -1,7 +1,7 @@
 // src/control/cockpitd.ts
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { spawn as realSpawn } from "node:child_process";
+import { spawn as realSpawn, execFileSync } from "node:child_process";
 import { writeFileSync, mkdirSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { createStore } from "./store.js";
@@ -19,6 +19,13 @@ export interface CockpitdOpts {
   sweepMs?: number; // 0 disables the interval (tests)
   isPidAlive?: (pid: number) => boolean; // injectable for the headless reconcile path (tests)
   spawn?: typeof realSpawn;
+  /**
+   * Push-notification hook (#109). Defaults to shelling out to
+   * `cockpit runtime send <project> <message>` (which already does the
+   * project→captain workspace lookup via NotifierRegistry + config).
+   * Tests inject a fake to assert call shape without spawning.
+   */
+  notify?: (args: { project: string; message: string }) => Promise<void> | void;
   /** Inject a fake driver for tests. Defaults to a real CodexInteractiveDriver. */
   codexDriver?: import("./codex/driver.js").CodexInteractiveDriver | {
     dispatch: (rec: any) => Promise<void>;
@@ -144,8 +151,27 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   const ingest = (project: string) => (e: import("./types.js").ControlEvent) =>
     void d.handle({ kind: "event", project, event: e });
 
+  // Default push-notification wiring (#109): shell out to the existing
+  // `cockpit runtime send <project> <msg>` which resolves <project> →
+  // captainName via the loaded config and writes to the cmux pane. This
+  // reuses the production code path (config lookup + cmux driver) without
+  // re-implementing it inside the daemon. The daemon already wraps the
+  // call in try/catch+swallow, so a failed shell-out can never break the
+  // event-ingest path; we additionally log for diagnostics.
+  const defaultNotify = (args: { project: string; message: string }): void => {
+    try {
+      execFileSync("cockpit", ["runtime", "send", args.project, args.message], {
+        encoding: "utf-8",
+        stdio: ["ignore", "ignore", "pipe"],
+      });
+    } catch (e) {
+      log(`notify failed project=${args.project}: ${(e as Error).message}`);
+    }
+  };
+  const notify = opts.notify ?? defaultNotify;
+
   const d = createDaemon({
-    store, now: () => Date.now(), isPidAlive,
+    store, now: () => Date.now(), isPidAlive, notify,
     launchHeadless: async (rec) => {
       await runHeadless({
         provider: rec.provider, task: rec.task, id: rec.id, sessionId: rec.sessionId,

--- a/src/control/daemon.ts
+++ b/src/control/daemon.ts
@@ -1,6 +1,6 @@
 // src/control/daemon.ts
 import type { Store } from "./store.js";
-import type { ControlEvent, TaskRecord } from "./types.js";
+import type { ControlEvent, TaskRecord, TaskState } from "./types.js";
 import { reduce } from "./state-machine.js";
 import { evaluateStall, recoverStall } from "./watchdog.js";
 
@@ -24,6 +24,60 @@ export interface DaemonDeps {
    * resolution payload back to the interactive session (spec §4.9).
    */
   resolveInteractiveGate?: (taskId: string, payload: unknown) => Promise<void> | void;
+  /**
+   * Push notification hook (#109). Called on every state transition into
+   * {done, blocked, failed, stalled}. The implementation in cockpitd shells
+   * out to the runtime so the captain's pane shows the message inline.
+   * Errors are caught + swallowed here so an unhealthy notifier never
+   * breaks the event-ingest path.
+   */
+  notify?: (args: { project: string; message: string }) => Promise<void> | void;
+}
+
+const ATTENTION_STATES: ReadonlySet<TaskState> = new Set(["done", "blocked", "failed", "stalled"]);
+
+function shortId(id: string): string {
+  return id.slice(0, 8);
+}
+
+function formatMessage(rec: TaskRecord): string | null {
+  const tag = `[${rec.provider}/${shortId(rec.id)}]`;
+  switch (rec.state) {
+    case "done": {
+      // Spec: "<resultRef-content-first-line-or-the-task-snippet>".
+      // resultRef content lives on disk; for daemon-purity we don't read it
+      // here. The task snippet is the documented fallback and gives the
+      // captain enough context to know which crew finished.
+      const snippet = (rec.task ?? "").split(/\r?\n/)[0]?.trim().slice(0, 120) ?? "";
+      return `CREW DONE ${tag}: ${snippet}`;
+    }
+    case "blocked":
+      return `CREW BLOCKED ${tag}: ${(rec.question ?? "(no question)").trim()}`;
+    case "failed":
+      return `CREW FAILED ${tag}: ${(rec.error ?? "(no error)").trim()}`;
+    case "stalled":
+      return `CREW STALLED ${tag}: no heartbeat in ${rec.heartbeatBudgetMs}ms`;
+    default:
+      return null;
+  }
+}
+
+function firePush(deps: DaemonDeps, project: string, prev: TaskState, next: TaskRecord): void {
+  if (!deps.notify) return;
+  if (prev === next.state) return;
+  if (!ATTENTION_STATES.has(next.state)) return;
+  const message = formatMessage(next);
+  if (!message) return;
+  // Fire-and-forget; swallow errors so the daemon never trips on a flaky
+  // notifier. Sync throws and async rejections both land here.
+  try {
+    const r = deps.notify({ project, message });
+    if (r && typeof (r as Promise<void>).catch === "function") {
+      (r as Promise<void>).catch(() => {});
+    }
+  } catch {
+    // intentionally swallowed
+  }
 }
 
 type Req =
@@ -74,7 +128,10 @@ export function createDaemon(deps: DaemonDeps) {
           const cur = store.get(req.project, req.event.id);
           if (!cur) throw new Error(`unknown task ${req.event.id}`);
           const next = reduce(cur, req.event, now());
-          if (next !== cur) store.put(next); // skip redundant write on terminal no-ops
+          if (next !== cur) {
+            store.put(next); // skip redundant write on terminal no-ops
+            firePush(deps, req.project, cur.state, next);
+          }
           return next;
         }
         case "status": {
@@ -114,7 +171,7 @@ export function createDaemon(deps: DaemonDeps) {
       const t = now();
       for (const r of store.listAll()) {
         const stalled = evaluateStall(r, t);
-        if (stalled) { store.put(stalled); continue; }
+        if (stalled) { store.put(stalled); firePush(deps, r.project, r.state, stalled); continue; }
         const recovered = recoverStall(r, t);
         // recoverStall does NOT check heartbeat freshness — guard per its contract
         if (recovered && t - r.lastHeartbeat <= r.heartbeatBudgetMs) store.put(recovered);
@@ -126,12 +183,16 @@ export function createDaemon(deps: DaemonDeps) {
         if (r.state !== "working" && r.state !== "submitted") continue;
         if (r.mode === "headless") {
           if (r.pid != null && alive(r.pid)) continue; // still running, keep watching
-          store.put({
+          const failed: TaskRecord = {
             ...r, state: "failed", lastEvent: "reconcile",
             error: "orphaned by daemon restart; exit unobserved (conservative fail)",
-          });
+          };
+          store.put(failed);
+          firePush(deps, r.project, r.state, failed);
         } else {
-          store.put({ ...r, state: "stalled", lastEvent: "reconcile" });
+          const stalled: TaskRecord = { ...r, state: "stalled", lastEvent: "reconcile" };
+          store.put(stalled);
+          firePush(deps, r.project, r.state, stalled);
         }
       }
     },


### PR DESCRIPTION
## Summary

Closes the captain-side gap from #109. PR #108 made the daemon ledger queryable, but an idle captain never noticed terminal transitions unless they polled. This wires `createDaemon` to fire a push notification at the exact moment a task flips into a terminal/attention state, routed through the existing `cockpit runtime send <project>` path so the captain's cmux pane shows it inline — same channel as user input.

- **Inject point:** every site that flips `state` into `{done, blocked, failed, stalled}` — the `case "event"` handler, `sweep()` (watchdog → stalled), and `reconcile()` (boot-time orphan → failed/stalled). One small `firePush` helper handles all three.
- **State-change guard:** notifications only fire when `prev.state !== next.state`. The state machine already absorbs redundant terminal events idempotently; the guard makes the notification side-effect equally idempotent.
- **Failure tolerance:** sync throws and async rejections from the notifier are caught + swallowed inside `firePush`. The daemon never blocks because a notifier is unhealthy.
- **Production wiring:** `startCockpitd` provides a default `notify` that shells out to `cockpit runtime send <project> <msg>` via `execFileSync`. That existing path already does the project → captainName lookup via the loaded config and writes to the captain's pane through the cmux runtime driver. Tests inject a fake `notify` via `CockpitdOpts.notify` to assert call shape without spawning.

## Message format (per spec)
```
CREW DONE    [<provider>/<taskId-8>]: <task snippet>
CREW BLOCKED [<provider>/<taskId-8>]: <question>
CREW FAILED  [<provider>/<taskId-8>]: <error>
CREW STALLED [<provider>/<taskId-8>]: no heartbeat in <budget>ms
```

For `done` the spec accepts `resultRef-content-first-line OR the task snippet`; this PR uses the task snippet to keep `daemon.ts` pure (no filesystem I/O). The full result body is still one `cockpit crew status` query away.

## Out of scope (matches issue)
Cross-host (#65), captain-side filtering/DND, push on dispatch/progress/heartbeat, anything reactor-shaped (#107).

## Files
- `src/control/daemon.ts` — `notify` dep + `firePush` helper + 3 call sites
- `src/control/cockpitd.ts` — default `notify` shelling out to `cockpit runtime send`
- `src/control/__tests__/cockpitd-push.test.ts` — 7 unit tests (RED → GREEN)
- `scripts/smoke-push-notify.mjs` — live-ish smoke through real socket

## Test plan
- [x] `npx vitest run src/control/__tests__/cockpitd-push.test.ts` — 7/7 ✓
- [x] `npx vitest run` — 558/558 ✓ (no regression on the 551 baseline)
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `node scripts/smoke-push-notify.mjs` — 11/11 assertions PASS through real `startCockpitd` + AF_UNIX socket
  - evidence: `.phase-3-5-smoke-evidence.local` (gitignored)
- [ ] Captain merge + real end-to-end through the launchd daemon (intentionally deferred: I'm running in a crew worktree and the cockpit "never auto-restart running sessions" rule blocked me from kickstarting the launchd-managed daemon onto the worktree build. The synthetic smoke exercises the same `startCockpitd → daemon.handle → notify` wiring; only the final `execFileSync("cockpit", ["runtime", "send", …])` is unproven end-to-end, and that path is already covered by the cmux notifier tests.)

## Acceptance criteria mapping
| Issue criterion | Where verified |
| --- | --- |
| `done` → captain pane within ~1s | smoke `[1]`, daemon unit test |
| Re-applied `done` does NOT re-notify | smoke `[1]`, `redundant terminal event` unit test |
| `blocked` shows question, `failed` shows error | smoke `[2]`/`[3]`, dedicated unit tests |
| `stalled` triggers when watchdog flips state | `sweep` call site + dedicated unit test |
| Notifier down → daemon keeps running | smoke `[5]`, `throwing notify` unit test |
| Unit test with fake notifier + assertions | `cockpitd-push.test.ts` |