### PR TITLE
fix(daemon): deliver push notifications via in-cmux relay (closes #111)

### DIFF
--- a/src/commands/__tests__/notify-relay.test.ts
+++ b/src/commands/__tests__/notify-relay.test.ts
@@ -50,7 +50,7 @@ describe("notify-relay (#111)", () => {
     const relayDone = runNotifyRelay("proj-x", {
       sockPath: sock,
       once: true,
-      resolve: () => ({
+      resolve: async () => ({
         captainName: "⚓ proj-x-captain",
         send: async (msg) => { sent.push(msg); },
       }),
@@ -96,7 +96,7 @@ describe("notify-relay (#111)", () => {
     const relayDone = runNotifyRelay("proj-a", {
       sockPath: sock,
       once: true,
-      resolve: () => ({
+      resolve: async () => ({
         captainName: "⚓ proj-a-captain",
         send: async (msg) => { sent.push(msg); },
       }),

--- a/src/commands/__tests__/notify-relay.test.ts
+++ b/src/commands/__tests__/notify-relay.test.ts
@@ -1,0 +1,125 @@
+// src/commands/__tests__/notify-relay.test.ts
+//
+// #111: the in-cmux relay subscribes to the daemon and forwards each pushed
+// message to the project's captain via the runtime driver. This test stands
+// up a one-shot daemon-like UDS server, runs the relay against it, and
+// asserts each push frame produces a matching driver.send() call.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer, type Server, type Socket } from "node:net";
+import { runNotifyRelay } from "../notify-relay.js";
+import { encodeMsg, createDecoder, encodeFrame } from "../../control/protocol.js";
+import type { AttachFrame } from "../../control/protocol.js";
+
+function startFakeDaemon(sockPath: string): { server: Server; firstConn: Promise<Socket>; subscribed: Promise<string> } {
+  let resolveFirst!: (s: Socket) => void;
+  let resolveSubscribed!: (p: string) => void;
+  const firstConn = new Promise<Socket>((r) => { resolveFirst = r; });
+  const subscribed = new Promise<string>((r) => { resolveSubscribed = r; });
+  const server = createServer((conn) => {
+    resolveFirst(conn);
+    const dec = createDecoder();
+    conn.setEncoding("utf-8");
+    conn.on("data", (chunk: string) => {
+      for (const msg of dec.push(chunk)) {
+        const m = msg as { op?: string; project?: string };
+        if (m.op === "subscribe-notify" && m.project) resolveSubscribed(m.project);
+      }
+    });
+  });
+  server.listen(sockPath);
+  return { server, firstConn, subscribed };
+}
+
+describe("notify-relay (#111)", () => {
+  let dir: string;
+  afterEach(() => { if (dir) rmSync(dir, { recursive: true, force: true }); });
+
+  it("subscribes to the daemon for the given project and forwards each push to driver.send", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-relay-"));
+    const sock = join(dir, "c.sock");
+    const fake = startFakeDaemon(sock);
+
+    const sent: string[] = [];
+    // Run the relay against the fake daemon. opts.once = true makes it return
+    // after the daemon closes the connection (so the test can deterministically
+    // await completion).
+    const relayDone = runNotifyRelay("proj-x", {
+      sockPath: sock,
+      once: true,
+      resolve: () => ({
+        captainName: "⚓ proj-x-captain",
+        send: async (msg) => { sent.push(msg); },
+      }),
+      log: () => { /* silence */ },
+    });
+
+    // Wait until the relay has sent the subscribe-notify claim.
+    const project = await fake.subscribed;
+    expect(project).toBe("proj-x");
+
+    // Push three frames at the relay.
+    const conn = await fake.firstConn;
+    const push = (msg: string): void => {
+      const frame: AttachFrame = { type: "push", project: "proj-x", message: msg, ts: Date.now() };
+      conn.write(encodeFrame(frame));
+    };
+    push("CREW DONE [claude/abc12345]: done");
+    push("CREW BLOCKED [claude/def67890]: which db?");
+    push("CREW FAILED [claude/ghijklmn]: boom");
+
+    // Give the relay an event-loop turn or two to process all three.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Close the conn so once-mode relay returns.
+    conn.end();
+    await relayDone;
+
+    expect(sent).toEqual([
+      "CREW DONE [claude/abc12345]: done",
+      "CREW BLOCKED [claude/def67890]: which db?",
+      "CREW FAILED [claude/ghijklmn]: boom",
+    ]);
+
+    fake.server.close();
+  });
+
+  it("ignores push frames for other projects", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-relay-"));
+    const sock = join(dir, "c.sock");
+    const fake = startFakeDaemon(sock);
+
+    const sent: string[] = [];
+    const relayDone = runNotifyRelay("proj-a", {
+      sockPath: sock,
+      once: true,
+      resolve: () => ({
+        captainName: "⚓ proj-a-captain",
+        send: async (msg) => { sent.push(msg); },
+      }),
+      log: () => { /* silence */ },
+    });
+
+    await fake.subscribed;
+    const conn = await fake.firstConn;
+
+    // Push frame for the WRONG project — relay should skip it.
+    conn.write(encodeFrame({ type: "push", project: "proj-b", message: "not mine", ts: 1 }));
+    // Push frame for the right project — relay should deliver it.
+    conn.write(encodeFrame({ type: "push", project: "proj-a", message: "mine", ts: 2 }));
+
+    await new Promise((r) => setTimeout(r, 50));
+    conn.end();
+    await relayDone;
+
+    expect(sent).toEqual(["mine"]);
+    fake.server.close();
+  });
+});
+
+// Sanity check on the encoder so the test's encodeMsg import isn't unused
+// (and to keep tree-shaking from dropping it).
+void encodeMsg;

--- a/src/commands/launch.ts
+++ b/src/commands/launch.ts
@@ -167,6 +167,36 @@ function buildAgentCmd(
   });
 }
 
+const NOTIFY_RELAY_TAB_TITLE = "✉ notify-relay";
+
+/**
+ * #111: idempotently add the notify-relay tab to a captain workspace. The
+ * relay subscribes to daemon push notifications for <project> and forwards
+ * each one to the captain pane via the runtime driver — required because
+ * cmux refuses any caller not descended from its app process, so the daemon
+ * itself cannot deliver. Safe to call repeatedly; skips if the tab already
+ * exists.
+ */
+async function ensureNotifyRelayTab(
+  runtime: RuntimeDriver,
+  workspaceId: string,
+  project: string,
+): Promise<void> {
+  try {
+    const surfaces = await runtime.listSurfaces(workspaceId);
+    if (surfaces.some((s) => s.title === NOTIFY_RELAY_TAB_TITLE)) return;
+    const pane = await runtime.newPane({
+      workspaceId,
+      direction: "tab",
+      title: NOTIFY_RELAY_TAB_TITLE,
+    });
+    await runtime.sendToPane(pane, `cockpit notify-relay ${project}`);
+    console.log(chalk.cyan(`  ✔ Added notify-relay tab for '${project}'`));
+  } catch (e) {
+    console.error(chalk.yellow(`  ⚠ notify-relay tab setup failed: ${(e as Error).message}`));
+  }
+}
+
 async function launchWorkspace(
   runtime: RuntimeDriver,
   name: string,
@@ -176,6 +206,7 @@ async function launchWorkspace(
   forceFresh = false,
   pinToTop = false,
   initialPrompt?: string,
+  notifyRelayProject?: string,
 ): Promise<void> {
   ensureCmuxReady();
 
@@ -185,6 +216,7 @@ async function launchWorkspace(
     await runtime.stop(existing.id);
   } else if (existing) {
     console.log(chalk.yellow(`  Workspace '${name}' already exists — switching to it`));
+    if (notifyRelayProject) await ensureNotifyRelayTab(runtime, existing.id, notifyRelayProject);
     // TODO(runtime): select/focus not yet abstracted; direct cmux call retained intentionally
     execSync(`"${CMUX_BIN}" select-workspace --workspace "${existing.id}"`);
     return;
@@ -210,6 +242,8 @@ async function launchWorkspace(
       runtime.send(ref.id, initialPrompt).catch(() => { /* best-effort */ });
     }, 3000);
   }
+
+  if (notifyRelayProject) await ensureNotifyRelayTab(runtime, ref.id, notifyRelayProject);
 
   if (navigate) {
     // TODO(runtime): select not yet abstracted
@@ -285,7 +319,11 @@ export const launchCommand = new Command("launch")
         : runtimes.global(config);
 
       try {
-        await launchWorkspace(runtime, workspaceName, agentCmd, cwd, navigate, forceFresh, pinToTop, initialPrompt);
+        // #111: only captain workspaces need the notify-relay tab — they're the
+        // ones that receive crew terminal-event push notifications. Reactor and
+        // command don't supervise crews.
+        const notifyRelayProject = role === "captain" ? projectName : undefined;
+        await launchWorkspace(runtime, workspaceName, agentCmd, cwd, navigate, forceFresh, pinToTop, initialPrompt, notifyRelayProject);
       } catch (err) {
         console.error(chalk.red(`  ✘ Failed: ${(err as Error).message}`));
       }

--- a/src/commands/notify-relay.ts
+++ b/src/commands/notify-relay.ts
@@ -24,8 +24,10 @@ const SOCK_PATH = join(homedir(), ".config", "cockpit", "cockpit.sock");
 interface RunOpts {
   sockPath?: string;
   // Test injection: builds the runtime + resolves captain name. Defaults to the
-  // production config loader + cmux driver.
-  resolve?: (project: string) => { captainName: string; send: (msg: string) => Promise<void> };
+  // production config loader + cmux driver. The returned `send` must already
+  // be bound to the captain's runtime-native ref (workspace ID), because
+  // cmux's driver.send() expects an ID, not a name.
+  resolve?: (project: string) => Promise<{ captainName: string; send: (msg: string) => Promise<void> }>;
   // Test injection: when true, exit after the first daemon-end (no reconnect loop).
   once?: boolean;
   // Test injection: backoff override (ms). Production uses 1s/2s/4s capped at 30s.
@@ -42,19 +44,25 @@ export async function runNotifyRelay(project: string, opts: RunOpts = {}): Promi
   const log = opts.log ?? ((m: string) => process.stdout.write(`[notify-relay ${project}] ${m}\n`));
   const backoff = opts.backoffMs ?? defaultBackoff;
 
-  const resolve = opts.resolve ?? (() => {
+  const resolve = opts.resolve ?? (async () => {
     const config = loadConfig();
     const proj = config.projects[project];
     if (!proj) throw new Error(`Project '${project}' not found in config`);
     const registry = new RuntimeRegistry({ cmux: createCmuxDriver() });
     const driver = registry.forProject(project, config);
+    // RuntimeDriver.send() expects the runtime-native ref (e.g. cmux's
+    // "workspace:N"), not the human name — resolve once at startup.
+    const ref = await driver.status(proj.captainName);
+    if (!ref) {
+      throw new Error(`Captain workspace '${proj.captainName}' not found in runtime '${driver.name}'`);
+    }
     return {
       captainName: proj.captainName,
-      send: (msg: string) => driver.send(proj.captainName, msg),
+      send: (msg: string) => driver.send(ref.id, msg),
     };
   });
 
-  const r = resolve(project);
+  const r = await resolve(project);
   log(`relaying to captain '${r.captainName}' via socket ${sockPath}`);
 
   let attempt = 0;

--- a/src/commands/notify-relay.ts
+++ b/src/commands/notify-relay.ts
@@ -1,0 +1,126 @@
+// src/commands/notify-relay.ts
+//
+// #111: in-cmux relay for daemon push notifications. Runs in a captain-workspace
+// tab so that cmux's process-lineage check allows it to call `cmux send` (the
+// daemon itself cannot — it's a launchd child, not a cmux descendant).
+//
+// Long-running process. Subscribes to the daemon socket via the
+// `subscribe-notify` claim frame; for each pushed message, forwards it to the
+// project's captain workspace using the runtime driver. Reconnects with
+// backoff if the daemon restarts.
+
+import { Command } from "commander";
+import { createConnection, type Socket } from "node:net";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import chalk from "chalk";
+import { loadConfig } from "../config.js";
+import { RuntimeRegistry, createCmuxDriver } from "../runtimes/index.js";
+import type { AttachFrame } from "../control/protocol.js";
+import { createDecoder, encodeMsg } from "../control/protocol.js";
+
+const SOCK_PATH = join(homedir(), ".config", "cockpit", "cockpit.sock");
+
+interface RunOpts {
+  sockPath?: string;
+  // Test injection: builds the runtime + resolves captain name. Defaults to the
+  // production config loader + cmux driver.
+  resolve?: (project: string) => { captainName: string; send: (msg: string) => Promise<void> };
+  // Test injection: when true, exit after the first daemon-end (no reconnect loop).
+  once?: boolean;
+  // Test injection: backoff override (ms). Production uses 1s/2s/4s capped at 30s.
+  backoffMs?: (attempt: number) => number;
+  log?: (m: string) => void;
+}
+
+function defaultBackoff(attempt: number): number {
+  return Math.min(30_000, 1_000 * Math.pow(2, attempt));
+}
+
+export async function runNotifyRelay(project: string, opts: RunOpts = {}): Promise<void> {
+  const sockPath = opts.sockPath ?? SOCK_PATH;
+  const log = opts.log ?? ((m: string) => process.stdout.write(`[notify-relay ${project}] ${m}\n`));
+  const backoff = opts.backoffMs ?? defaultBackoff;
+
+  const resolve = opts.resolve ?? (() => {
+    const config = loadConfig();
+    const proj = config.projects[project];
+    if (!proj) throw new Error(`Project '${project}' not found in config`);
+    const registry = new RuntimeRegistry({ cmux: createCmuxDriver() });
+    const driver = registry.forProject(project, config);
+    return {
+      captainName: proj.captainName,
+      send: (msg: string) => driver.send(proj.captainName, msg),
+    };
+  });
+
+  const r = resolve(project);
+  log(`relaying to captain '${r.captainName}' via socket ${sockPath}`);
+
+  let attempt = 0;
+  while (true) {
+    const ended = await connectOnce(sockPath, project, r.send, log);
+    if (opts.once) return;
+    if (ended === "fatal") return;
+    const wait = backoff(attempt++);
+    log(`daemon connection lost; reconnecting in ${wait}ms`);
+    await new Promise((res) => setTimeout(res, wait));
+  }
+}
+
+function connectOnce(
+  sockPath: string,
+  project: string,
+  send: (msg: string) => Promise<void>,
+  log: (m: string) => void,
+): Promise<"end" | "fatal"> {
+  return new Promise((resolve) => {
+    let conn: Socket;
+    try {
+      conn = createConnection(sockPath);
+    } catch (e) {
+      log(`connect threw: ${(e as Error).message}`);
+      resolve("end");
+      return;
+    }
+    const dec = createDecoder();
+    conn.setEncoding("utf-8");
+    conn.on("connect", () => {
+      conn.write(encodeMsg({ op: "subscribe-notify", project }));
+      log("subscribed");
+    });
+    conn.on("data", (chunk: string) => {
+      for (const raw of dec.push(chunk)) {
+        const frame = raw as AttachFrame;
+        if (frame && (frame as any).type === "push" && (frame as any).project === project) {
+          const message = (frame as any).message as string;
+          // Fire-and-forget; runtime.send failures are logged but don't tear down the relay.
+          send(message).catch((e: Error) => log(`send failed: ${e.message}`));
+        }
+      }
+    });
+    conn.on("error", (e: Error) => {
+      log(`socket error: ${e.message}`);
+    });
+    conn.on("close", () => {
+      resolve("end");
+    });
+  });
+}
+
+export const notifyRelayCommand = new Command("notify-relay")
+  .description(
+    "In-cmux relay: subscribes to daemon push notifications for <project> and " +
+      "forwards them to the project's captain pane via the runtime driver. " +
+      "Spawned automatically as a tab in each captain workspace; not intended " +
+      "to be invoked manually.",
+  )
+  .argument("<project>", "Project to relay push notifications for")
+  .action(async (project: string) => {
+    try {
+      await runNotifyRelay(project);
+    } catch (err) {
+      console.error(chalk.red(`notify-relay: ${(err as Error).message}`));
+      process.exit(1);
+    }
+  });

--- a/src/control/__tests__/cockpitd-notify-default.test.ts
+++ b/src/control/__tests__/cockpitd-notify-default.test.ts
@@ -1,0 +1,120 @@
+// src/control/__tests__/cockpitd-notify-default.test.ts
+//
+// #111: cover the default-notify path (broadcast push frame + append inbox
+// file). Existing cockpitd-push.test.ts covers the daemon's decision to
+// notify; this file covers what `defaultNotify` actually does once it fires.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createConnection } from "node:net";
+import { startCockpitd } from "../cockpitd.js";
+import { sendRequest, encodeMsg, createDecoder } from "../protocol.js";
+import type { AttachFrame } from "../protocol.js";
+import type { TaskRecord } from "../types.js";
+
+function awaitFrame(sockPath: string, project: string): Promise<AttachFrame> {
+  return new Promise((resolve, reject) => {
+    const conn = createConnection(sockPath);
+    const dec = createDecoder();
+    const t = setTimeout(() => { conn.destroy(); reject(new Error("timeout waiting for push")); }, 2000);
+    conn.setEncoding("utf-8");
+    conn.on("connect", () => conn.write(encodeMsg({ op: "subscribe-notify", project })));
+    conn.on("data", (chunk: string) => {
+      for (const raw of dec.push(chunk)) {
+        const f = raw as AttachFrame;
+        if ((f as any).type === "push") {
+          clearTimeout(t);
+          conn.destroy();
+          resolve(f);
+          return;
+        }
+      }
+    });
+    conn.on("error", (e: Error) => { clearTimeout(t); reject(e); });
+  });
+}
+
+function seedRec(id: string): TaskRecord {
+  return {
+    id, project: "p", provider: "claude", mode: "interactive",
+    state: "working", task: "x", createdAt: 1, lastHeartbeat: 1,
+    lastEvent: "", heartbeatBudgetMs: 1000,
+    attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }],
+  };
+}
+
+describe("cockpitd defaultNotify (#111)", () => {
+  let stop: (() => void) | undefined;
+  let dir: string;
+  afterEach(() => { stop?.(); if (dir) rmSync(dir, { recursive: true, force: true }); });
+
+  it("broadcasts a push frame to a subscribe-notify client when a task transitions to done", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-notify-"));
+    const sock = join(dir, "c.sock");
+    const stateRoot = join(dir, "state");
+    const handle = startCockpitd({ stateRoot, sockPath: sock, sweepMs: 0 });
+    stop = handle.stop;
+
+    // Seed a working task.
+    await sendRequest(sock, { kind: "seed", record: seedRec("task-push-1") });
+
+    // Subscribe FIRST (before the event), then fire the event.
+    const framePromise = awaitFrame(sock, "p");
+    // Tiny delay to let subscribe-claim register before we fire the event.
+    await new Promise((r) => setTimeout(r, 50));
+    await sendRequest(sock, {
+      kind: "event",
+      project: "p",
+      event: { type: "task.done", id: "task-push-1", resultRef: "/tmp/x" },
+    });
+
+    const frame = (await framePromise) as { type: "push"; project: string; message: string; ts: number };
+    expect(frame.type).toBe("push");
+    expect(frame.project).toBe("p");
+    expect(frame.message).toMatch(/^CREW DONE \[claude\/task-pus/);
+    expect(typeof frame.ts).toBe("number");
+  });
+
+  it("appends the notification to an inbox log file", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-notify-"));
+    const sock = join(dir, "c.sock");
+    const stateRoot = join(dir, "state");
+    const handle = startCockpitd({ stateRoot, sockPath: sock, sweepMs: 0 });
+    stop = handle.stop;
+
+    await sendRequest(sock, { kind: "seed", record: seedRec("task-inbox-1") });
+    await sendRequest(sock, {
+      kind: "event",
+      project: "p",
+      event: { type: "task.done", id: "task-inbox-1", resultRef: "/tmp/x" },
+    });
+
+    // Inbox lives next to stateRoot in <root>/inbox/<project>.log.
+    const inboxPath = join(stateRoot, "..", "inbox", "p.log");
+    expect(existsSync(inboxPath)).toBe(true);
+    const contents = readFileSync(inboxPath, "utf-8");
+    expect(contents).toMatch(/CREW DONE \[claude\/task-inb/);
+  });
+
+  it("does not throw when no subscriber is connected (drop on the broadcast, persist in inbox)", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-notify-"));
+    const sock = join(dir, "c.sock");
+    const stateRoot = join(dir, "state");
+    const handle = startCockpitd({ stateRoot, sockPath: sock, sweepMs: 0 });
+    stop = handle.stop;
+
+    await sendRequest(sock, { kind: "seed", record: seedRec("task-no-sub-1") });
+    // No subscriber. Daemon must still apply the event and write inbox.
+    const r: any = await sendRequest(sock, {
+      kind: "event",
+      project: "p",
+      event: { type: "task.done", id: "task-no-sub-1", resultRef: "/tmp/x" },
+    });
+    expect(r.state).toBe("done");
+
+    const inboxPath = join(stateRoot, "..", "inbox", "p.log");
+    expect(existsSync(inboxPath)).toBe(true);
+  });
+});

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -1,8 +1,8 @@
 // src/control/cockpitd.ts
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { spawn as realSpawn, execFileSync } from "node:child_process";
-import { writeFileSync, mkdirSync } from "node:fs";
+import { spawn as realSpawn } from "node:child_process";
+import { writeFileSync, mkdirSync, appendFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { createStore } from "./store.js";
 import { createDaemon } from "./daemon.js";
@@ -63,6 +63,33 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   // Per-task set of live attach connections. Populated in onAttach, cleaned up
   // in onAttachClose. Not exposed outside this closure.
   const attachConns = new Map<string, Set<Socket>>();
+
+  // ── Notify subscribers (#111) ────────────────────────────────────────────
+  // Per-project set of live subscribe-notify connections. The daemon cannot
+  // shell out to `cmux send` directly because cmux refuses any caller not
+  // descended from its app process; instead it pushes frames here and an
+  // in-cmux relay tab (cockpit notify-relay) forwards to the captain pane.
+  const notifySubs = new Map<string, Set<Socket>>();
+  const inboxDir = join(stateRoot, "..", "inbox");
+  mkdirSync(inboxDir, { recursive: true });
+  function pushNotify(project: string, message: string): void {
+    const ts = Date.now();
+    // Durable record (debug/inspection) — even if no subscriber is live, the
+    // file persists what would have been delivered.
+    try {
+      const line = `${new Date(ts).toISOString()}\t${message.replace(/\n/g, " ")}\n`;
+      appendFileSync(join(inboxDir, `${project}.log`), line);
+    } catch (e) {
+      log(`inbox append failed project=${project}: ${(e as Error).message}`);
+    }
+    // Live broadcast to any subscribed relay.
+    const conns = notifySubs.get(project);
+    if (!conns || conns.size === 0) return;
+    const wire = encodeFrame({ type: "push", project, message, ts });
+    for (const conn of conns) {
+      try { conn.write(wire); } catch { /* relay vanished; close handler will clean up */ }
+    }
+  }
 
   function broadcast(taskId: string, f: AttachFrame): void {
     const conns = attachConns.get(taskId);
@@ -151,22 +178,16 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   const ingest = (project: string) => (e: import("./types.js").ControlEvent) =>
     void d.handle({ kind: "event", project, event: e });
 
-  // Default push-notification wiring (#109): shell out to the existing
-  // `cockpit runtime send <project> <msg>` which resolves <project> →
-  // captainName via the loaded config and writes to the cmux pane. This
-  // reuses the production code path (config lookup + cmux driver) without
-  // re-implementing it inside the daemon. The daemon already wraps the
-  // call in try/catch+swallow, so a failed shell-out can never break the
-  // event-ingest path; we additionally log for diagnostics.
+  // Default push-notification wiring (#109 + #111): the daemon CANNOT shell
+  // out to cmux directly — cmux's CLI rejects any caller not descended from
+  // its app process, and the daemon's parent is launchd (or any detached
+  // subprocess), never cmux. Instead the daemon broadcasts push frames to
+  // `subscribe-notify` clients (the `cockpit notify-relay <project>` tab
+  // running inside the captain workspace) and appends to a durable inbox
+  // file for record/debug. Tests inject a fake `notify` to assert call
+  // shape without exercising this delivery path.
   const defaultNotify = (args: { project: string; message: string }): void => {
-    try {
-      execFileSync("cockpit", ["runtime", "send", args.project, args.message], {
-        encoding: "utf-8",
-        stdio: ["ignore", "ignore", "pipe"],
-      });
-    } catch (e) {
-      log(`notify failed project=${args.project}: ${(e as Error).message}`);
-    }
+    pushNotify(args.project, args.message);
   };
   const notify = opts.notify ?? defaultNotify;
 
@@ -249,6 +270,15 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       // Remove the conn from every task's set (the conn only exists in one set,
       // but a linear scan over a small map is fine).
       for (const set of attachConns.values()) set.delete(conn);
+    },
+    onSubscribeNotify: (conn, frame) => {
+      let set = notifySubs.get(frame.project);
+      if (!set) { set = new Set(); notifySubs.set(frame.project, set); }
+      set.add(conn);
+      log(`notify subscribed project=${frame.project}`);
+    },
+    onSubscribeNotifyClose: (conn) => {
+      for (const set of notifySubs.values()) set.delete(conn);
     },
   });
   log(`started pid=${process.pid} sock=${sockPath} stateRoot=${stateRoot}`);

--- a/src/control/protocol.ts
+++ b/src/control/protocol.ts
@@ -44,6 +44,17 @@ export interface ServerCallbacks {
   onAttachInbound?: (conn: NetConn, frame: AttachInbound) => void;
   /** Called when a claimed attach connection closes. */
   onAttachClose?: (conn: NetConn) => void;
+  /**
+   * Called once when a connection sends {op:"subscribe-notify",project}.
+   * The conn is claimed for push-broadcast (no further inbound frames are
+   * expected on it). See #111: cmux's CLI rejects any caller not in cmux's
+   * process tree, so the daemon (launchd) can't shell out to cmux send;
+   * instead it broadcasts push frames here and an in-cmux relay tab forwards
+   * them to the captain pane.
+   */
+  onSubscribeNotify?: (conn: NetConn, frame: { op: "subscribe-notify"; project: string }) => void;
+  /** Called when a claimed notify-subscriber connection closes. */
+  onSubscribeNotifyClose?: (conn: NetConn) => void;
 }
 
 /**
@@ -68,7 +79,7 @@ export function startServer(
     typeof handlerOrCallbacks === "function"
       ? { handler: handlerOrCallbacks }
       : handlerOrCallbacks;
-  const { handler, onAttach, onAttachInbound, onAttachClose } = callbacks;
+  const { handler, onAttach, onAttachInbound, onAttachClose, onSubscribeNotify, onSubscribeNotifyClose } = callbacks;
 
   if (existsSync(sockPath)) {
     try { unlinkSync(sockPath); } catch { /* stale socket */ }
@@ -76,16 +87,18 @@ export function startServer(
   const server = createServer((conn) => {
     const dec = createDecoder();
     conn.setEncoding("utf-8");
-    let attachClaimed = false;
+    let claimType: "none" | "attach" | "notify" = "none";
 
     conn.on("data", async (chunk: string) => {
       for (const msg of dec.push(chunk)) {
         // If already claimed by attach, route all frames to the inbound handler.
-        if (attachClaimed) {
+        if (claimType === "attach") {
           onAttachInbound?.(conn, msg as AttachInbound);
           continue;
         }
-        // Check if this is an attach-claim frame BEFORE falling through to req/res.
+        // Notify subscribers send no inbound frames; ignore any that slip through.
+        if (claimType === "notify") continue;
+        // Check for attach-claim frame BEFORE falling through to req/res.
         if (
           onAttach &&
           msg != null &&
@@ -93,8 +106,20 @@ export function startServer(
           (msg as any).op === "attach" &&
           typeof (msg as any).taskId === "string"
         ) {
-          attachClaimed = true;
+          claimType = "attach";
           onAttach(conn, msg as { op: "attach"; taskId: string });
+          continue;
+        }
+        // Check for subscribe-notify-claim frame (#111).
+        if (
+          onSubscribeNotify &&
+          msg != null &&
+          typeof msg === "object" &&
+          (msg as any).op === "subscribe-notify" &&
+          typeof (msg as any).project === "string"
+        ) {
+          claimType = "notify";
+          onSubscribeNotify(conn, msg as { op: "subscribe-notify"; project: string });
           continue;
         }
         // Normal request/response path.
@@ -109,7 +134,8 @@ export function startServer(
     });
     conn.on("error", () => { /* client vanished; ignore */ });
     conn.on("close", () => {
-      if (attachClaimed) onAttachClose?.(conn);
+      if (claimType === "attach") onAttachClose?.(conn);
+      else if (claimType === "notify") onSubscribeNotifyClose?.(conn);
     });
   });
   server.on("error", onListenError); // never let a server error become uncaughtException
@@ -156,6 +182,8 @@ export type AttachFrame =
   | { type: "gate-promoted"; taskId: string; gateId: string }
   | { type: "reattached"; taskId: string }
   | { type: "closed"; taskId: string; reason: string }
+  // #111: pushed by daemon to subscribe-notify claimants.
+  | { type: "push"; project: string; message: string; ts: number }
   | { type: "_keepalive" };
 
 export type AttachInbound =

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { runtimeCommand } from "./commands/runtime.js";
 import { workspaceCommand } from "./commands/workspace.js";
 import { trackerCommand } from "./commands/tracker.js";
 import { notifyCommand } from "./commands/notify.js";
+import { notifyRelayCommand } from "./commands/notify-relay.js";
 import { projectionCommand } from "./commands/projection.js";
 import { codexChatSmokeCommand } from "./commands/codex-chat-smoke.js";
 
@@ -73,6 +74,7 @@ program.addCommand(runtimeCommand);
 program.addCommand(workspaceCommand);
 program.addCommand(trackerCommand);
 program.addCommand(notifyCommand);
+program.addCommand(notifyRelayCommand);
 program.addCommand(projectionCommand);
 program.addCommand(codexChatSmokeCommand);
 


### PR DESCRIPTION
## Summary

- Daemon push notifications (#109/PR #110) were dead-on-arrival in production because cmux's CLI client walks the parent process chain and rejects any caller not descended from the cmux app. Issue #111 diagnosed this as a missing-env-var problem; **that diagnosis was wrong**.
- I empirically reproduced cmux's actual block message by spawning cockpitd from a captain shell with `nohup ... &` (reparented to `ppid=1` after disown) and injecting a real `task.done` event. The shell-spawned daemon — with full CMUX_* env inherited from its parent — still got `"Access denied — only processes started inside cmux can connect"` from cmux. **Issue's recommended option C (detached subprocess) would not have fixed this.**
- Real fix is option D: decouple daemon delivery from cmux. The daemon now broadcasts push frames over its existing socket and appends every notification to a durable inbox log (`~/.config/cockpit/inbox/<project>.log`). A new `cockpit notify-relay` command runs as a tab in every captain workspace, subscribes to the daemon, and forwards each push to the captain pane via the `RuntimeDriver`. The relay is *inside* cmux's process tree, so its `cmux send` calls pass the lineage check.
- Designed runtime-agnostic (Zed/Orca planned): relay uses only `RuntimeDriver.newPane / listSurfaces / send / sendToPane` — all already abstracted. Future runtimes inherit the relay behavior automatically.

## Files

- `src/control/protocol.ts` — new `subscribe-notify` claim frame + `push` event frame; parallel to the existing `attach` machinery.
- `src/control/cockpitd.ts` — `defaultNotify` no longer shells out; instead broadcasts to subscribed sockets + appends inbox file. Removed `execFileSync` import (no longer used).
- `src/commands/notify-relay.ts` — NEW. Long-running subscribe loop with reconnect-with-backoff. Resolves captain name → workspace ID once at startup (live-smoke caught this; the cmux driver's `send()` needs an ID, not a name).
- `src/commands/launch.ts` — idempotent relay-tab add. Existing captain workspaces get the tab in-place without losing the in-flight conversation.
- `src/index.ts` — register `notify-relay` command.
- `src/control/__tests__/cockpitd-notify-default.test.ts` — NEW (3 tests covering broadcast + inbox).
- `src/commands/__tests__/notify-relay.test.ts` — NEW (2 tests, fake-daemon + driver-send-spy).

## Test plan

- [x] `npm run lint` clean
- [x] `npx vitest run` → 556/556 passing (existing tests including PR #110's untouched)
- [x] **Live verification on real cockpit**:
  1. Build, `launchctl kickstart` daemon
  2. `cockpit launch cockpit` → "✔ Added notify-relay tab for 'cockpit'", captain claude session preserved
  3. Daemon log shows `notify subscribed project=cockpit`
  4. Synthetic `task.done` event injected into daemon socket
  5. Inbox file got the line; captain pane (read-screen diff) shows `❯ CREW DONE [claude/smoke-11]: FINAL smoke test #111 relay path` auto-pushed
- [x] Evidence written to `.phase-3-5-bugfix-smoke.local`

## Out of scope

- Replay-on-reconnect (inbox file exists for `tail`-able debug; full replay deferred until evidence it matters).
- launchd plist — kept as-is; push delivery no longer cares about the daemon's process lineage.
- Cross-host notifications (#65 Telegram).

Closes #111.