### PR TITLE
feat(mailbox): mailbox + injector foundational refactor (closes #113, foundation for #114/#115)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .DS_Store
 .worktrees/
 *.local
+.mailbox-injector-smoke.local

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ dist/
 .DS_Store
 .worktrees/
 *.local
-.mailbox-injector-smoke.local

--- a/docs/plans/2026-05-27-mailbox-injector.md
+++ b/docs/plans/2026-05-27-mailbox-injector.md
@@ -1,0 +1,2181 @@
+# Mailbox + Injector Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace PR #112's subscribe/broadcast machinery with a file-as-source-of-truth mailbox the daemon appends to, plus a pull-from-cursor injector that runs inside the captain workspace's process tree and delivers each event to the captain pane via a runtime-agnostic `RuntimeDriver` surface.
+
+**Architecture:** Single PR, four logical commits in atomic micro-steps. Daemon side gains a `mailbox.ts` module (append-only JSON-lines + rotation + cursor primitives), loses the subscribe-notify socket protocol. Injector side becomes a `tail -F`-from-cursor loop with fsync'd ack writes. `RuntimeDriver` gains `spawnInjector` (in-tree process) and `sendToSurface` (per-surface text delivery). cmux implementation uses split-pane (hidden if possible, visible tab as fallback). Approach 3 boundary preserved — daemon owns the event stream, never the captain or crew processes.
+
+**Tech Stack:** TypeScript strict ESM, vitest, commander, node:net AF_UNIX, node:fs (writeFile/appendFile with `O_APPEND` + flock-equivalent via `proper-lockfile` or built-in `fs.flock`), chokidar (fallback to `fs.watch` + 1s polling), cmux CLI as the runtime under test.
+
+**Spec:** `docs/specs/2026-05-27-mailbox-injector-design.md`
+
+**Conventions seen in cockpit (follow these):**
+- Tests are vitest siblings in `src/<area>/__tests__/<source>.test.ts`. Pure-function modules get `src/lib/__tests__/...` or `src/control/__tests__/...`.
+- All TS imports use `.js` suffix (ESM).
+- Pure functions stay pure; side effects in adapters/launchers/runners.
+- Anti-#2576 invariant: bare `Stop`/`SubagentStop`/`SessionEnd` hooks map only to `task.progress` — never `task.done` (enforced in `firePush` gate, unchanged by this plan).
+- Atomic commits: one task = one commit. Commit subject prefix `feat(mailbox)` / `test(mailbox)` / `refactor(daemon)` / `chore(mailbox)`.
+
+---
+
+## File Structure
+
+**Create:**
+- `src/control/mailbox.ts` — pure mailbox ops: `appendToMailbox`, `rotateIfNeeded`, `readFromCursor`, `readCursor`, `writeCursor`, types.
+- `src/control/__tests__/mailbox.test.ts` — unit tests for all of the above. Uses `node:fs` + tmpdir.
+- `src/runtimes/__tests__/cmux-spawn-injector.live.test.ts` — opt-in live test for the cmux `spawnInjector` implementation. Skipped unless `CMUX_LIVE=1` env var set.
+- `scripts/mailbox-injector-smoke.mjs` — E2E smoke that drives a daemon + simulated injector against a temp socket; mirrors `scripts/smoke-push-notify.mjs` and `scripts/claude-iv-smoke.mjs` patterns.
+
+**Modify:**
+- `src/control/cockpitd.ts` (`startCockpitd` and `defaultNotify`, ~line 151 onward) — replace shell-out with `appendToMailbox` call; delete subscribe-notify socket frame handler; add rotation timer at startup/cleanup at shutdown.
+- `src/control/daemon.ts` (`firePush` function, ~lines 36-79) — update `notify` callback signature so it receives `{project, message, record, event}` instead of `{project, message}`. Keep gate logic unchanged.
+- `src/control/protocol.ts` — remove `SubscribeNotifyClaim` and `PushFrame` definitions (added in PR #112).
+- `src/control/__tests__/cockpitd-notify-default.test.ts` — replace broadcast tests with mailbox-append tests.
+- `src/control/__tests__/daemon.test.ts` — adjust firePush signature assertions if present.
+- `src/commands/notify-relay.ts` — rewrite as file-tailer (cursor read → tail loop → format → sendToSurface → cursor write). Delete socket-subscribe code.
+- `src/commands/__tests__/notify-relay.test.ts` — rewrite tests for the new file-tailer behavior.
+- `src/commands/launch.ts` (the function that adds the relay tab, look for `NOTIFY_RELAY_TAB_TITLE`) — switch from `runtime.newPane` to `runtime.spawnInjector({placement: "hidden"})`; kill any existing notify-relay surface (visible OR hidden) before spawning the new one.
+- `src/runtimes/types.ts` — add `spawnInjector` and `sendToSurface` method signatures to `RuntimeDriver`.
+- `src/runtimes/cmux.ts` — implement `spawnInjector` (new-split → resize → rename → return SurfaceRef) and `sendToSurface` (cmux send --workspace --surface). Implement memory driver too if tests need it (`src/runtimes/__tests__/helpers/memory-runtime.ts` or similar).
+
+**No changes to:** `src/control/state-machine.ts`, `src/control/store.ts`, `src/control/types.ts` (except possibly adding `Provider` re-export to ease use in mailbox), `src/control/headless-launcher.ts`, `src/control/codex/*`, `src/control/interactive/*`, `src/drivers/*`. **If a task tempts you to touch these, STOP — it has scope-crept.**
+
+---
+
+## Pre-Flight (do once before Task 1)
+
+- [ ] **Step P1: Confirm branch + clean tree**
+
+```bash
+git status -sb
+git branch --show-current
+```
+
+Expected: on `feature/mailbox-injector`, only the pre-existing dirty files from the start of this work (`M AGENTS.md`, untracked `docs/diagrams/`, `docs/research/2026-05-16-idle-detection-*`, `.codex-smoke-evidence.local`, `.claude/`). The new spec + research files added on this branch should NOT show as dirty (they were committed in the brainstorm commit).
+
+If on wrong branch, run:
+
+```bash
+git checkout feature/mailbox-injector
+```
+
+- [ ] **Step P2: Confirm daemon is reachable + tests pass on current code**
+
+```bash
+test -S ~/.config/cockpit/cockpit.sock && echo "sock present" || echo "sock missing (will respawn via ensureDaemon)"
+npm test 2>&1 | tail -5
+```
+
+Expected: all existing tests (PR #112's notify-relay + cockpitd-notify-default + interactive-claude-hook etc.) pass. If they don't, stop and investigate — don't build on a broken baseline.
+
+- [ ] **Step P3: Note baseline file sizes for reference**
+
+```bash
+wc -l src/control/cockpitd.ts src/commands/notify-relay.ts src/control/protocol.ts src/commands/launch.ts
+```
+
+Record. After all tasks, `notify-relay.ts` should be roughly 1/3 smaller and `cockpitd.ts` should be slightly smaller (subscribe code removed) or unchanged (rotation timer added cancels).
+
+---
+
+# COMMIT GROUP 1: mailbox.ts (pure functions)
+
+Pure-function module — no daemon wiring yet. After this group lands, end-to-end behavior is unchanged (the existing PR #112 broadcast still works); we've just added a new unused module that's fully unit-tested.
+
+---
+
+## Task 1: Mailbox types + appendToMailbox
+
+**Files:**
+- Create: `src/control/mailbox.ts`
+- Create: `src/control/__tests__/mailbox.test.ts`
+
+- [ ] **Step 1.1: Write the failing test for appendToMailbox**
+
+Create `src/control/__tests__/mailbox.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { appendToMailbox } from "../mailbox.js";
+import type { TaskRecord, ControlEvent } from "../types.js";
+
+function freshState(): string {
+  return mkdtempSync(join(tmpdir(), "mbox-"));
+}
+
+const sampleRecord: TaskRecord = {
+  id: "11111111-2222-3333-4444-555555555555",
+  project: "demo",
+  provider: "claude",
+  mode: "interactive",
+  state: "working",
+  task: "smoke test task description",
+  cwd: "/tmp",
+  createdAt: 1000,
+  lastHeartbeat: 1000,
+  lastEvent: "task.progress",
+  heartbeatBudgetMs: 60000,
+  attempts: [],
+};
+
+const doneEvent: ControlEvent = {
+  type: "task.done",
+  id: sampleRecord.id,
+  resultRef: "/tmp/result.txt",
+};
+
+describe("appendToMailbox", () => {
+  it("creates inbox/<project>.log on first append and assigns seq=1", async () => {
+    const stateRoot = freshState();
+    const seq = await appendToMailbox({
+      stateRoot,
+      project: "demo",
+      taskRecord: sampleRecord,
+      event: doneEvent,
+    });
+    expect(seq).toBe(1);
+    const logPath = join(stateRoot, "inbox", "demo.log");
+    expect(existsSync(logPath)).toBe(true);
+    const lines = readFileSync(logPath, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+    const entry = JSON.parse(lines[0]);
+    expect(entry.seq).toBe(1);
+    expect(entry.taskId).toBe(sampleRecord.id);
+    expect(entry.kind).toBe("task.done");
+    expect(entry.provider).toBe("claude");
+    expect(entry.payload.resultRef).toBe("/tmp/result.txt");
+    expect(typeof entry.ts).toBe("string");
+  });
+
+  it("assigns monotonically increasing seq on subsequent appends", async () => {
+    const stateRoot = freshState();
+    const s1 = await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    const s2 = await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    const s3 = await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    expect([s1, s2, s3]).toEqual([1, 2, 3]);
+  });
+
+  it("isolates seq per project", async () => {
+    const stateRoot = freshState();
+    const a = await appendToMailbox({ stateRoot, project: "a", taskRecord: sampleRecord, event: doneEvent });
+    const b = await appendToMailbox({ stateRoot, project: "b", taskRecord: sampleRecord, event: doneEvent });
+    const a2 = await appendToMailbox({ stateRoot, project: "a", taskRecord: sampleRecord, event: doneEvent });
+    expect(a).toBe(1);
+    expect(b).toBe(1);
+    expect(a2).toBe(2);
+  });
+
+  it("resumes seq from max in file after daemon restart simulation", async () => {
+    const stateRoot = freshState();
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    // simulate restart by calling appendToMailbox in a way that re-reads max seq
+    const s3 = await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    expect(s3).toBe(3);
+  });
+});
+```
+
+- [ ] **Step 1.2: Run the test, verify it fails**
+
+```bash
+npx vitest run src/control/__tests__/mailbox.test.ts
+```
+
+Expected: FAIL with "Cannot find module '../mailbox.js'" or similar.
+
+- [ ] **Step 1.3: Create the minimum mailbox.ts to make tests pass**
+
+Create `src/control/mailbox.ts`:
+
+```typescript
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import type { TaskRecord, ControlEvent } from "./types.js";
+
+export interface MailboxEntry {
+  seq: number;
+  ts: string;
+  taskId: string;
+  kind: ControlEvent["type"];
+  provider: TaskRecord["provider"];
+  payload: Record<string, unknown>;
+}
+
+interface AppendOpts {
+  stateRoot: string;
+  project: string;
+  taskRecord: TaskRecord;
+  event: ControlEvent;
+}
+
+function inboxDir(stateRoot: string): string {
+  return join(stateRoot, "inbox");
+}
+
+function logPath(stateRoot: string, project: string): string {
+  return join(inboxDir(stateRoot), `${project}.log`);
+}
+
+function extractPayload(event: ControlEvent): Record<string, unknown> {
+  // ControlEvent is a discriminated union — strip type/id, keep the rest.
+  const { type: _type, id: _id, ...payload } = event as Record<string, unknown> & { type: string; id: string };
+  return payload;
+}
+
+async function readMaxSeq(file: string): Promise<number> {
+  try {
+    const buf = await fs.readFile(file, "utf-8");
+    if (!buf.trim()) return 0;
+    const lines = buf.trim().split("\n");
+    // walk backwards finding last parseable line (last line may be partial)
+    for (let i = lines.length - 1; i >= 0; i--) {
+      try {
+        const obj = JSON.parse(lines[i]) as MailboxEntry;
+        return obj.seq;
+      } catch { continue; }
+    }
+    return 0;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return 0;
+    throw e;
+  }
+}
+
+export async function appendToMailbox(opts: AppendOpts): Promise<number> {
+  const dir = inboxDir(opts.stateRoot);
+  await fs.mkdir(dir, { recursive: true });
+  const file = logPath(opts.stateRoot, opts.project);
+  const lastSeq = await readMaxSeq(file);
+  const seq = lastSeq + 1;
+  const entry: MailboxEntry = {
+    seq,
+    ts: new Date().toISOString(),
+    taskId: opts.taskRecord.id,
+    kind: opts.event.type,
+    provider: opts.taskRecord.provider,
+    payload: extractPayload(opts.event),
+  };
+  await fs.appendFile(file, JSON.stringify(entry) + "\n", { encoding: "utf-8" });
+  return seq;
+}
+```
+
+- [ ] **Step 1.4: Run the test, verify it passes**
+
+```bash
+npx vitest run src/control/__tests__/mailbox.test.ts
+```
+
+Expected: all 4 tests pass.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add src/control/mailbox.ts src/control/__tests__/mailbox.test.ts
+git commit -m "feat(mailbox): appendToMailbox primitive with monotonic seq per project"
+```
+
+---
+
+## Task 2: Cursor read/write primitives
+
+**Files:**
+- Modify: `src/control/mailbox.ts` (add `readCursor`, `writeCursor`)
+- Modify: `src/control/__tests__/mailbox.test.ts` (add tests)
+
+- [ ] **Step 2.1: Write failing tests for cursor functions**
+
+Append to `src/control/__tests__/mailbox.test.ts`:
+
+```typescript
+import { readCursor, writeCursor } from "../mailbox.js";
+
+describe("cursor read/write", () => {
+  it("readCursor returns null when file does not exist", async () => {
+    const stateRoot = freshState();
+    const c = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    expect(c).toBeNull();
+  });
+
+  it("writeCursor then readCursor round-trips lastAckedSeq", async () => {
+    const stateRoot = freshState();
+    await writeCursor({ stateRoot, project: "demo", subscriber: "captain", lastAckedSeq: 42 });
+    const c = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    expect(c?.lastAckedSeq).toBe(42);
+  });
+
+  it("writeCursor uses atomic rename (no partial-file race)", async () => {
+    const stateRoot = freshState();
+    await writeCursor({ stateRoot, project: "demo", subscriber: "captain", lastAckedSeq: 1 });
+    await writeCursor({ stateRoot, project: "demo", subscriber: "captain", lastAckedSeq: 2 });
+    const c = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    expect(c?.lastAckedSeq).toBe(2);
+    // .tmp file should not be left over
+    const tmpExists = existsSync(join(stateRoot, "inbox", "demo.captain.cursor.tmp"));
+    expect(tmpExists).toBe(false);
+  });
+
+  it("isolates cursors per subscriber", async () => {
+    const stateRoot = freshState();
+    await writeCursor({ stateRoot, project: "demo", subscriber: "captain", lastAckedSeq: 10 });
+    await writeCursor({ stateRoot, project: "demo", subscriber: "telegram", lastAckedSeq: 5 });
+    const cap = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    const tg = await readCursor({ stateRoot, project: "demo", subscriber: "telegram" });
+    expect(cap?.lastAckedSeq).toBe(10);
+    expect(tg?.lastAckedSeq).toBe(5);
+  });
+});
+```
+
+- [ ] **Step 2.2: Run tests, verify they fail**
+
+```bash
+npx vitest run src/control/__tests__/mailbox.test.ts
+```
+
+Expected: 4 failures with "readCursor is not a function" etc.
+
+- [ ] **Step 2.3: Implement readCursor + writeCursor**
+
+Append to `src/control/mailbox.ts`:
+
+```typescript
+function cursorPath(stateRoot: string, project: string, subscriber: string): string {
+  return join(inboxDir(stateRoot), `${project}.${subscriber}.cursor`);
+}
+
+interface CursorOpts {
+  stateRoot: string;
+  project: string;
+  subscriber: string;
+}
+
+export interface CursorState {
+  lastAckedSeq: number;
+  subscriber: string;
+  updatedAt: string;
+}
+
+export async function readCursor(opts: CursorOpts): Promise<CursorState | null> {
+  try {
+    const buf = await fs.readFile(cursorPath(opts.stateRoot, opts.project, opts.subscriber), "utf-8");
+    return JSON.parse(buf) as CursorState;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw e;
+  }
+}
+
+export async function writeCursor(opts: CursorOpts & { lastAckedSeq: number }): Promise<void> {
+  await fs.mkdir(inboxDir(opts.stateRoot), { recursive: true });
+  const dest = cursorPath(opts.stateRoot, opts.project, opts.subscriber);
+  const tmp = dest + ".tmp";
+  const data: CursorState = {
+    lastAckedSeq: opts.lastAckedSeq,
+    subscriber: opts.subscriber,
+    updatedAt: new Date().toISOString(),
+  };
+  const handle = await fs.open(tmp, "w");
+  try {
+    await handle.writeFile(JSON.stringify(data), { encoding: "utf-8" });
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  await fs.rename(tmp, dest);
+}
+```
+
+- [ ] **Step 2.4: Run tests, verify all pass**
+
+```bash
+npx vitest run src/control/__tests__/mailbox.test.ts
+```
+
+Expected: 8 tests pass (4 from Task 1 + 4 from Task 2).
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add src/control/mailbox.ts src/control/__tests__/mailbox.test.ts
+git commit -m "feat(mailbox): readCursor + writeCursor with fsync + atomic rename"
+```
+
+---
+
+## Task 3: readFromCursor (async iterable)
+
+**Files:**
+- Modify: `src/control/mailbox.ts`
+- Modify: `src/control/__tests__/mailbox.test.ts`
+
+- [ ] **Step 3.1: Write failing tests for readFromCursor**
+
+Append to test file:
+
+```typescript
+import { readFromCursor } from "../mailbox.js";
+
+async function collect<T>(iter: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const item of iter) out.push(item);
+  return out;
+}
+
+describe("readFromCursor", () => {
+  it("returns empty iterable when file does not exist", async () => {
+    const stateRoot = freshState();
+    const items = await collect(readFromCursor({ stateRoot, project: "demo", fromSeq: 1 }));
+    expect(items).toEqual([]);
+  });
+
+  it("returns all entries with seq >= fromSeq", async () => {
+    const stateRoot = freshState();
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    const items = await collect(readFromCursor({ stateRoot, project: "demo", fromSeq: 2 }));
+    expect(items.map((i) => i.seq)).toEqual([2, 3]);
+  });
+
+  it("skips entries with seq < fromSeq", async () => {
+    const stateRoot = freshState();
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    const items = await collect(readFromCursor({ stateRoot, project: "demo", fromSeq: 100 }));
+    expect(items).toEqual([]);
+  });
+
+  it("tolerates a partial last line (mid-write crash)", async () => {
+    const stateRoot = freshState();
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    // simulate partial write by appending non-JSON suffix
+    const file = join(stateRoot, "inbox", "demo.log");
+    await (await import("node:fs/promises")).appendFile(file, '{"seq":2,"ts":"2026', "utf-8");
+    const items = await collect(readFromCursor({ stateRoot, project: "demo", fromSeq: 1 }));
+    expect(items.map((i) => i.seq)).toEqual([1]);
+  });
+});
+```
+
+- [ ] **Step 3.2: Run, verify failure**
+
+```bash
+npx vitest run src/control/__tests__/mailbox.test.ts
+```
+
+Expected: 4 failures.
+
+- [ ] **Step 3.3: Implement readFromCursor**
+
+Append to `src/control/mailbox.ts`:
+
+```typescript
+interface ReadFromCursorOpts {
+  stateRoot: string;
+  project: string;
+  fromSeq: number;
+}
+
+export async function* readFromCursor(opts: ReadFromCursorOpts): AsyncIterable<MailboxEntry> {
+  const file = logPath(opts.stateRoot, opts.project);
+  let buf: string;
+  try {
+    buf = await fs.readFile(file, "utf-8");
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw e;
+  }
+  for (const line of buf.split("\n")) {
+    if (!line.trim()) continue;
+    let entry: MailboxEntry;
+    try {
+      entry = JSON.parse(line) as MailboxEntry;
+    } catch {
+      // partial / corrupted line; skip
+      continue;
+    }
+    if (entry.seq >= opts.fromSeq) yield entry;
+  }
+}
+```
+
+- [ ] **Step 3.4: Run, verify all pass**
+
+```bash
+npx vitest run src/control/__tests__/mailbox.test.ts
+```
+
+Expected: 12 tests pass.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add src/control/mailbox.ts src/control/__tests__/mailbox.test.ts
+git commit -m "feat(mailbox): readFromCursor async iterable with partial-line tolerance"
+```
+
+---
+
+## Task 4: Rotation + reading across rotated files
+
+**Files:**
+- Modify: `src/control/mailbox.ts`
+- Modify: `src/control/__tests__/mailbox.test.ts`
+
+- [ ] **Step 4.1: Write failing tests for rotation**
+
+Append to test file:
+
+```typescript
+import { rotateIfNeeded } from "../mailbox.js";
+import { statSync } from "node:fs";
+
+describe("rotateIfNeeded", () => {
+  it("returns rotated=false when file under thresholds", async () => {
+    const stateRoot = freshState();
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    const r = await rotateIfNeeded({ stateRoot, project: "demo", maxBytes: 1024 * 1024, maxAgeMs: 24 * 60 * 60 * 1000, keepCount: 3 });
+    expect(r.rotated).toBe(false);
+  });
+
+  it("rotates when size exceeds maxBytes", async () => {
+    const stateRoot = freshState();
+    // append until file > 200 bytes
+    for (let i = 0; i < 10; i++) {
+      await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    }
+    const sizeBefore = statSync(join(stateRoot, "inbox", "demo.log")).size;
+    expect(sizeBefore).toBeGreaterThan(200);
+    const r = await rotateIfNeeded({ stateRoot, project: "demo", maxBytes: 200, maxAgeMs: 999999999, keepCount: 3 });
+    expect(r.rotated).toBe(true);
+    expect(existsSync(join(stateRoot, "inbox", "demo.log.1"))).toBe(true);
+    expect(statSync(join(stateRoot, "inbox", "demo.log")).size).toBe(0);
+  });
+
+  it("seq is monotonic across rotation boundary", async () => {
+    const stateRoot = freshState();
+    for (let i = 0; i < 10; i++) {
+      await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    }
+    await rotateIfNeeded({ stateRoot, project: "demo", maxBytes: 200, maxAgeMs: 999999999, keepCount: 3 });
+    const s = await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    expect(s).toBe(11);
+  });
+
+  it("keeps only keepCount rotated files", async () => {
+    const stateRoot = freshState();
+    for (let cycle = 0; cycle < 5; cycle++) {
+      for (let i = 0; i < 5; i++) {
+        await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+      }
+      await rotateIfNeeded({ stateRoot, project: "demo", maxBytes: 100, maxAgeMs: 999999999, keepCount: 2 });
+    }
+    expect(existsSync(join(stateRoot, "inbox", "demo.log.1"))).toBe(true);
+    expect(existsSync(join(stateRoot, "inbox", "demo.log.2"))).toBe(true);
+    expect(existsSync(join(stateRoot, "inbox", "demo.log.3"))).toBe(false);
+  });
+
+  it("readFromCursor reads across rotated files", async () => {
+    const stateRoot = freshState();
+    for (let i = 0; i < 5; i++) {
+      await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    }
+    await rotateIfNeeded({ stateRoot, project: "demo", maxBytes: 50, maxAgeMs: 999999999, keepCount: 3 });
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    const items = await collect(readFromCursor({ stateRoot, project: "demo", fromSeq: 1 }));
+    expect(items.map((i) => i.seq)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+});
+```
+
+- [ ] **Step 4.2: Run, verify failures**
+
+```bash
+npx vitest run src/control/__tests__/mailbox.test.ts
+```
+
+Expected: 5 failures.
+
+- [ ] **Step 4.3: Implement rotateIfNeeded + update readFromCursor**
+
+Append to `src/control/mailbox.ts`:
+
+```typescript
+interface RotateOpts {
+  stateRoot: string;
+  project: string;
+  maxBytes: number;
+  maxAgeMs: number;
+  keepCount: number;
+}
+
+export interface RotateResult {
+  rotated: boolean;
+  from?: string;
+  to?: string;
+}
+
+async function oldestEntryAgeMs(file: string): Promise<number> {
+  try {
+    const buf = await fs.readFile(file, "utf-8");
+    const firstLine = buf.split("\n").find((l) => l.trim());
+    if (!firstLine) return 0;
+    const entry = JSON.parse(firstLine) as MailboxEntry;
+    return Date.now() - new Date(entry.ts).getTime();
+  } catch {
+    return 0;
+  }
+}
+
+export async function rotateIfNeeded(opts: RotateOpts): Promise<RotateResult> {
+  const file = logPath(opts.stateRoot, opts.project);
+  let size = 0;
+  try { size = (await fs.stat(file)).size; }
+  catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return { rotated: false };
+    throw e;
+  }
+  const age = await oldestEntryAgeMs(file);
+  if (size < opts.maxBytes && age < opts.maxAgeMs) return { rotated: false };
+
+  // shift existing .N files down (.1 → .2, .2 → .3, etc.), deleting beyond keepCount
+  for (let n = opts.keepCount; n >= 1; n--) {
+    const src = `${file}.${n}`;
+    const dst = `${file}.${n + 1}`;
+    try {
+      await fs.access(src);
+      if (n >= opts.keepCount) {
+        await fs.unlink(src);
+      } else {
+        await fs.rename(src, dst);
+      }
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+    }
+  }
+  // current → .1
+  await fs.rename(file, `${file}.1`);
+  // create fresh empty current
+  await fs.writeFile(file, "", { encoding: "utf-8" });
+  return { rotated: true, from: file, to: `${file}.1` };
+}
+```
+
+Now update `readFromCursor` to also read across rotated files. Replace the existing function with:
+
+```typescript
+async function listRotatedNewestFirst(stateRoot: string, project: string): Promise<string[]> {
+  const dir = inboxDir(stateRoot);
+  let entries: string[];
+  try { entries = await fs.readdir(dir); }
+  catch { return []; }
+  const prefix = `${project}.log.`;
+  const rotated = entries
+    .filter((e) => e.startsWith(prefix) && /^\d+$/.test(e.slice(prefix.length)))
+    .map((e) => ({ name: e, n: Number(e.slice(prefix.length)) }))
+    .sort((a, b) => b.n - a.n) // .3 first (oldest), .1 last (newest rotated)
+    .map((e) => join(dir, e.name));
+  return rotated;
+}
+
+export async function* readFromCursor(opts: ReadFromCursorOpts): AsyncIterable<MailboxEntry> {
+  // Order: oldest rotated first, then current. .3 → .2 → .1 → current.
+  const rotated = await listRotatedNewestFirst(opts.stateRoot, opts.project);
+  const files = [...rotated, logPath(opts.stateRoot, opts.project)];
+  for (const file of files) {
+    let buf: string;
+    try { buf = await fs.readFile(file, "utf-8"); }
+    catch (e) {
+      if ((e as NodeJS.ErrnoException).code === "ENOENT") continue;
+      throw e;
+    }
+    for (const line of buf.split("\n")) {
+      if (!line.trim()) continue;
+      let entry: MailboxEntry;
+      try { entry = JSON.parse(line) as MailboxEntry; }
+      catch { continue; }
+      if (entry.seq >= opts.fromSeq) yield entry;
+    }
+  }
+}
+```
+
+Also update `appendToMailbox`'s `readMaxSeq` to scan rotated files too (so seq stays monotonic after rotation). Replace `readMaxSeq` with:
+
+```typescript
+async function readMaxSeq(stateRoot: string, project: string): Promise<number> {
+  let max = 0;
+  const files = [
+    logPath(stateRoot, project),
+    ...(await listRotatedNewestFirst(stateRoot, project)),
+  ];
+  for (const file of files) {
+    try {
+      const buf = await fs.readFile(file, "utf-8");
+      if (!buf.trim()) continue;
+      const lines = buf.trim().split("\n");
+      for (let i = lines.length - 1; i >= 0; i--) {
+        try {
+          const obj = JSON.parse(lines[i]) as MailboxEntry;
+          if (obj.seq > max) max = obj.seq;
+          break;
+        } catch { continue; }
+      }
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+    }
+  }
+  return max;
+}
+```
+
+And update the call site in `appendToMailbox`:
+
+```typescript
+  // ...inside appendToMailbox, replace the readMaxSeq call:
+  const lastSeq = await readMaxSeq(opts.stateRoot, opts.project);
+```
+
+- [ ] **Step 4.4: Run all mailbox tests**
+
+```bash
+npx vitest run src/control/__tests__/mailbox.test.ts
+```
+
+Expected: 17 tests pass.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add src/control/mailbox.ts src/control/__tests__/mailbox.test.ts
+git commit -m "feat(mailbox): size/age-based rotation + cross-rotation read"
+```
+
+---
+
+# COMMIT GROUP 2: Daemon-side switchover
+
+After this group: events land in the mailbox file. PR #112's relay tab still spawns but receives no socket events (idle — no errors). Bridge state. Commit Group 3 closes the loop.
+
+---
+
+## Task 5: Update firePush signature to pass record + event
+
+**Files:**
+- Modify: `src/control/daemon.ts` (around lines 26-79 for `firePush` and `DaemonDeps`)
+- Modify: `src/control/__tests__/daemon.test.ts` (if it asserts notify shape)
+
+- [ ] **Step 5.1: Read current firePush + DaemonDeps**
+
+```bash
+sed -n '20,90p' src/control/daemon.ts
+```
+
+Identify: the `notify` callback in `DaemonDeps` currently has signature `(args: {project: string; message: string}) => Promise<void> | void`. We need to add `record: TaskRecord` and `event: ControlEvent`.
+
+- [ ] **Step 5.2: Update DaemonDeps signature in daemon.ts**
+
+Edit `src/control/daemon.ts`. Find the `notify?:` line in `DaemonDeps` and replace its signature:
+
+```typescript
+  /**
+   * Push notification hook (#109, refactored under mailbox-injector spec).
+   * Called on every state transition into {done, blocked, failed, stalled}.
+   * Implementations append to the mailbox; never shell out.
+   */
+  notify?: (args: {
+    project: string;
+    message: string;
+    record: TaskRecord;
+    event: ControlEvent;
+  }) => Promise<void> | void;
+```
+
+- [ ] **Step 5.3: Update firePush invocation to pass record + event**
+
+Find the `firePush` function in `daemon.ts`. Update the `deps.notify(...)` call to pass `record: next, event: req.event`:
+
+Replace the existing call site (currently `deps.notify({ project, message })`) with:
+
+```typescript
+    const r = deps.notify({ project, message, record: next, event });
+```
+
+You may need to pass `event` into `firePush` from the call site in the `case "event":` handler. Look at:
+
+```typescript
+        case "event": {
+          const cur = store.get(req.project, req.event.id);
+          if (!cur) throw new Error(`unknown task ${req.event.id}`);
+          const next = reduce(cur, req.event, now());
+          if (next !== cur) {
+            store.put(next);
+            firePush(deps, req.project, cur.state, next);
+          }
+          return next;
+        }
+```
+
+Change `firePush` signature to accept event:
+
+```typescript
+function firePush(deps: DaemonDeps, project: string, prev: TaskState, next: TaskRecord, event: ControlEvent): void {
+  if (!deps.notify) return;
+  if (prev === next.state) return;
+  if (!ATTENTION_STATES.has(next.state)) return;
+  const message = formatMessage(next);
+  if (!message) return;
+  try {
+    const r = deps.notify({ project, message, record: next, event });
+    if (r && typeof (r as Promise<void>).catch === "function") {
+      (r as Promise<void>).catch(() => {});
+    }
+  } catch { /* swallowed */ }
+}
+```
+
+And the call site:
+
+```typescript
+            firePush(deps, req.project, cur.state, next, req.event);
+```
+
+Also: the watchdog stall path (later in the file) needs to construct a synthetic event. Find the section that emits stall events and add an event arg:
+
+```typescript
+      for (const r of store.listAll()) {
+        const stalled = evaluateStall(r, t);
+        if (stalled) {
+          store.put(stalled);
+          // synthesize a stalled "event" for the notify path
+          const synthEvent: ControlEvent = { type: "task.stalled", id: r.id } as ControlEvent;
+          firePush(deps, r.project, r.state, stalled, synthEvent);
+          continue;
+        }
+        // ... existing recover logic
+      }
+```
+
+(If `task.stalled` isn't in your ControlEvent union, this may need a small type widening — check `src/control/types.ts` for the event types. The exact shape can be a small extension; the daemon already uses `task.stalled` as a state, just needs an event-type counterpart for the notify payload.)
+
+- [ ] **Step 5.4: Update existing daemon tests if any reference notify shape**
+
+```bash
+grep -rn "notify.*project.*message" src/control/__tests__/ src/notifiers/__tests__/
+```
+
+Update any test asserting the old `{project, message}` shape to the new `{project, message, record, event}` shape. Don't add new tests yet; that's Task 6.
+
+- [ ] **Step 5.5: Run all existing tests**
+
+```bash
+npm test 2>&1 | tail -10
+```
+
+Expected: all previously passing tests still pass. If something breaks, fix the test to use the new signature.
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add src/control/daemon.ts src/control/__tests__/
+git commit -m "refactor(daemon): firePush passes full record+event to notify (prep for mailbox)"
+```
+
+---
+
+## Task 6: defaultNotify writes to mailbox instead of shelling out
+
+**Files:**
+- Modify: `src/control/cockpitd.ts` (the `defaultNotify` block, around line 155-175)
+- Modify: `src/control/__tests__/cockpitd-notify-default.test.ts` (rewrite tests)
+
+- [ ] **Step 6.1: Read the current defaultNotify**
+
+```bash
+sed -n '150,200p' src/control/cockpitd.ts
+```
+
+Identify the `defaultNotify` function (uses `execFileSync` to shell out to `cockpit runtime send`).
+
+- [ ] **Step 6.2: Write the failing test for the new mailbox-writing defaultNotify**
+
+Rewrite `src/control/__tests__/cockpitd-notify-default.test.ts` (delete old test bodies, keep file path). Use this content:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startCockpitd } from "../cockpitd.js";
+import type { TaskRecord, ControlEvent } from "../types.js";
+
+function freshState(): string {
+  return mkdtempSync(join(tmpdir(), "cpd-"));
+}
+
+async function rpc(sock: string, req: unknown): Promise<unknown> {
+  const net = await import("node:net");
+  return new Promise((resolve, reject) => {
+    const s = net.createConnection(sock, () => {
+      s.write(JSON.stringify(req) + "\n");
+    });
+    s.on("data", (d) => { resolve(JSON.parse(d.toString().trim())); s.end(); });
+    s.on("error", reject);
+  });
+}
+
+describe("defaultNotify writes to mailbox", () => {
+  it("appends a task.done event to the mailbox file", async () => {
+    const stateRoot = freshState();
+    const sock = join(stateRoot, "c.sock");
+    const cpd = startCockpitd({ socketPath: sock, stateRoot, sweepMs: 0 });
+    try {
+      // dispatch + apply a task.started then task.done
+      const rec = (await rpc(sock, {
+        kind: "dispatch",
+        record: {
+          id: "t1", project: "demo", provider: "claude", mode: "headless",
+          state: "submitted", task: "tt", cwd: "/", createdAt: 1, lastHeartbeat: 1,
+          lastEvent: "dispatch", heartbeatBudgetMs: 60000, attempts: [],
+        },
+      })) as TaskRecord;
+      await rpc(sock, { kind: "event", project: "demo", event: { type: "task.started", id: rec.id } });
+      await rpc(sock, { kind: "event", project: "demo", event: { type: "task.done", id: rec.id, resultRef: "/r" } });
+      // wait briefly for async append
+      await new Promise((r) => setTimeout(r, 100));
+      const log = readFileSync(join(stateRoot, "inbox", "demo.log"), "utf-8");
+      const lines = log.trim().split("\n").map((l) => JSON.parse(l));
+      // only the terminal event triggers a notify (firePush gate)
+      expect(lines).toHaveLength(1);
+      expect(lines[0].kind).toBe("task.done");
+      expect(lines[0].provider).toBe("claude");
+      expect(lines[0].payload.resultRef).toBe("/r");
+      expect(lines[0].seq).toBe(1);
+    } finally {
+      cpd.stop();
+    }
+  });
+
+  it("does NOT shell out (no execFileSync invoked)", async () => {
+    // This test asserts behavior implicitly — if defaultNotify shelled out we'd
+    // see errors when 'cockpit' binary is on PATH but cmux is not reachable.
+    // The mailbox-write path has zero subprocess overhead.
+    const stateRoot = freshState();
+    const sock = join(stateRoot, "c.sock");
+    const cpd = startCockpitd({ socketPath: sock, stateRoot, sweepMs: 0 });
+    try {
+      const start = Date.now();
+      const rec = (await rpc(sock, {
+        kind: "dispatch",
+        record: {
+          id: "t2", project: "demo", provider: "claude", mode: "headless",
+          state: "submitted", task: "tt", cwd: "/", createdAt: 1, lastHeartbeat: 1,
+          lastEvent: "dispatch", heartbeatBudgetMs: 60000, attempts: [],
+        },
+      })) as TaskRecord;
+      await rpc(sock, { kind: "event", project: "demo", event: { type: "task.started", id: rec.id } });
+      await rpc(sock, { kind: "event", project: "demo", event: { type: "task.done", id: rec.id, resultRef: "/r" } });
+      const elapsed = Date.now() - start;
+      // execFileSync to cockpit runtime send took ~50-200ms; mailbox append is < 20ms
+      expect(elapsed).toBeLessThan(500);
+    } finally {
+      cpd.stop();
+    }
+  });
+});
+```
+
+- [ ] **Step 6.3: Run the test, verify it fails**
+
+```bash
+npx vitest run src/control/__tests__/cockpitd-notify-default.test.ts
+```
+
+Expected: failure (defaultNotify still shells out + doesn't write to mailbox file).
+
+- [ ] **Step 6.4: Rewrite defaultNotify in cockpitd.ts**
+
+Edit `src/control/cockpitd.ts`. Find the `defaultNotify` function (around lines 155-175) and the `execFileSync` import. Replace:
+
+```typescript
+// old:
+import { spawn as realSpawn, execFileSync } from "node:child_process";
+
+// new:
+import { spawn as realSpawn } from "node:child_process";
+import { appendToMailbox, rotateIfNeeded } from "./mailbox.js";
+```
+
+Replace the `defaultNotify` function body. Old:
+
+```typescript
+  const defaultNotify = (args: { project: string; message: string }): void => {
+    try {
+      execFileSync("cockpit", ["runtime", "send", args.project, args.message], {
+        encoding: "utf-8",
+        stdio: ["ignore", "ignore", "pipe"],
+      });
+    } catch (e) {
+      log(`notify failed project=${args.project}: ${(e as Error).message}`);
+    }
+  };
+```
+
+New:
+
+```typescript
+  const defaultNotify = async (args: {
+    project: string;
+    message: string;
+    record: import("./types.js").TaskRecord;
+    event: import("./types.js").ControlEvent;
+  }): Promise<void> => {
+    try {
+      await appendToMailbox({
+        stateRoot,
+        project: args.project,
+        taskRecord: args.record,
+        event: args.event,
+      });
+    } catch (e) {
+      log(`mailbox append failed project=${args.project}: ${(e as Error).message}`);
+    }
+  };
+```
+
+- [ ] **Step 6.5: Run the test, verify it passes**
+
+```bash
+npx vitest run src/control/__tests__/cockpitd-notify-default.test.ts
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 6.6: Run full test suite to check for regressions**
+
+```bash
+npm test 2>&1 | tail -10
+```
+
+Expected: 556+ pass (same as before, plus the new mailbox + rewritten cockpitd-notify-default tests).
+
+- [ ] **Step 6.7: Commit**
+
+```bash
+git add src/control/cockpitd.ts src/control/__tests__/cockpitd-notify-default.test.ts
+git commit -m "refactor(cockpitd): defaultNotify writes to mailbox instead of shelling out"
+```
+
+---
+
+## Task 7: Rotation timer
+
+**Files:**
+- Modify: `src/control/cockpitd.ts` (in `startCockpitd`)
+- Modify: `src/control/__tests__/cockpitd-notify-default.test.ts` (add timer test)
+
+- [ ] **Step 7.1: Add failing test for rotation timer**
+
+Append to `src/control/__tests__/cockpitd-notify-default.test.ts`:
+
+```typescript
+describe("rotation timer", () => {
+  it("rotates oversize mailbox files automatically", async () => {
+    const stateRoot = freshState();
+    const sock = join(stateRoot, "c.sock");
+    // mailbox config: tiny maxBytes so even one entry triggers rotation
+    const cpd = startCockpitd({
+      socketPath: sock,
+      stateRoot,
+      sweepMs: 50, // fast rotation timer for test
+      mailboxConfig: { maxBytes: 50, maxAgeMs: 999_999_999, keepCount: 3 },
+    } as any);
+    try {
+      const rec = (await rpc(sock, {
+        kind: "dispatch",
+        record: {
+          id: "tr1", project: "demo", provider: "claude", mode: "headless",
+          state: "submitted", task: "tt", cwd: "/", createdAt: 1, lastHeartbeat: 1,
+          lastEvent: "dispatch", heartbeatBudgetMs: 60000, attempts: [],
+        },
+      })) as TaskRecord;
+      await rpc(sock, { kind: "event", project: "demo", event: { type: "task.started", id: rec.id } });
+      // fire a bunch of done events to grow the file
+      for (let i = 0; i < 5; i++) {
+        await rpc(sock, { kind: "event", project: "demo", event: { type: "task.done", id: rec.id, resultRef: `/r${i}` } });
+      }
+      await new Promise((r) => setTimeout(r, 200)); // wait for rotation timer
+      // Expect at least one rotated file
+      expect(existsSync(join(stateRoot, "inbox", "demo.log.1"))).toBe(true);
+    } finally {
+      cpd.stop();
+    }
+  });
+});
+```
+
+(Note: this test re-emits `task.done` to a record that's already `done` — the firePush gate suppresses, so we need to bypass. Adjust: dispatch separate records OR write directly to the mailbox. Easier: dispatch separate records.)
+
+Replace the timer test with one that dispatches distinct records:
+
+```typescript
+describe("rotation timer", () => {
+  it("rotates oversize mailbox files automatically", async () => {
+    const stateRoot = freshState();
+    const sock = join(stateRoot, "c.sock");
+    const cpd = startCockpitd({
+      socketPath: sock,
+      stateRoot,
+      sweepMs: 0,
+      rotationIntervalMs: 50,
+      mailboxConfig: { maxBytes: 100, maxAgeMs: 999_999_999, keepCount: 3 },
+    } as any);
+    try {
+      for (let i = 0; i < 5; i++) {
+        const id = `tr${i}`;
+        await rpc(sock, {
+          kind: "dispatch",
+          record: {
+            id, project: "demo", provider: "claude", mode: "headless",
+            state: "submitted", task: `t${i}`, cwd: "/", createdAt: 1, lastHeartbeat: 1,
+            lastEvent: "dispatch", heartbeatBudgetMs: 60000, attempts: [],
+          },
+        });
+        await rpc(sock, { kind: "event", project: "demo", event: { type: "task.started", id } });
+        await rpc(sock, { kind: "event", project: "demo", event: { type: "task.done", id, resultRef: `/r${i}` } });
+      }
+      await new Promise((r) => setTimeout(r, 200));
+      expect(existsSync(join(stateRoot, "inbox", "demo.log.1"))).toBe(true);
+    } finally {
+      cpd.stop();
+    }
+  });
+});
+```
+
+- [ ] **Step 7.2: Run, verify failure**
+
+Expected: fail because `rotationIntervalMs` and `mailboxConfig` options aren't handled.
+
+- [ ] **Step 7.3: Add rotation timer + config to startCockpitd**
+
+In `src/control/cockpitd.ts`, find `CockpitdOpts`. Add:
+
+```typescript
+  /** Background rotation timer interval (ms). 0 disables. */
+  rotationIntervalMs?: number; // default 60_000
+  /** Mailbox rotation config. */
+  mailboxConfig?: {
+    maxBytes?: number;
+    maxAgeMs?: number;
+    keepCount?: number;
+  };
+```
+
+In `startCockpitd`, after the daemon is constructed and before the return, add the rotation timer:
+
+```typescript
+  const rotationInterval = opts.rotationIntervalMs ?? 60_000;
+  const mboxCfg = {
+    maxBytes: opts.mailboxConfig?.maxBytes ?? 5 * 1024 * 1024,
+    maxAgeMs: opts.mailboxConfig?.maxAgeMs ?? 7 * 24 * 60 * 60 * 1000,
+    keepCount: opts.mailboxConfig?.keepCount ?? 3,
+  };
+  let rotationTimer: NodeJS.Timeout | null = null;
+  if (rotationInterval > 0) {
+    rotationTimer = setInterval(async () => {
+      try {
+        const inboxRoot = join(stateRoot, "inbox");
+        let entries: string[];
+        try { entries = await (await import("node:fs/promises")).readdir(inboxRoot); }
+        catch { return; }
+        const projects = new Set(
+          entries
+            .filter((e) => e.endsWith(".log"))
+            .map((e) => e.slice(0, -".log".length))
+        );
+        for (const project of projects) {
+          await rotateIfNeeded({ stateRoot, project, ...mboxCfg });
+        }
+      } catch (e) {
+        log(`rotation timer error: ${(e as Error).message}`);
+      }
+    }, rotationInterval);
+  }
+```
+
+Add to the cleanup/stop path:
+
+```typescript
+  // in the existing stop() function:
+  if (rotationTimer) clearInterval(rotationTimer);
+```
+
+- [ ] **Step 7.4: Run rotation timer test, verify pass**
+
+```bash
+npx vitest run src/control/__tests__/cockpitd-notify-default.test.ts
+```
+
+Expected: rotation timer test passes.
+
+- [ ] **Step 7.5: Run full suite to check no regressions**
+
+```bash
+npm test 2>&1 | tail -5
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7.6: Commit**
+
+```bash
+git add src/control/cockpitd.ts src/control/__tests__/cockpitd-notify-default.test.ts
+git commit -m "feat(cockpitd): background rotation timer for mailbox files"
+```
+
+---
+
+## Task 8: Remove subscribe-notify + push frames from protocol.ts
+
+**Files:**
+- Modify: `src/control/protocol.ts`
+- Modify: `src/control/cockpitd.ts` (delete subscriber registry + broadcast loop)
+- Modify: any tests referencing subscribe-notify or push frames
+
+- [ ] **Step 8.1: Find all references to remove**
+
+```bash
+grep -rn "subscribe-notify\|SubscribeNotifyClaim\|PushFrame\|subscribers\b" src/
+```
+
+List the files. Likely: `src/control/protocol.ts` (type defs), `src/control/cockpitd.ts` (handler + registry), possibly test files.
+
+- [ ] **Step 8.2: Delete subscribe-notify + push from protocol.ts**
+
+In `src/control/protocol.ts`, find and delete the `SubscribeNotifyClaim` type, the `PushFrame` type, and any union members or builders that reference them. Keep the rest of the protocol intact.
+
+If there's a discriminated union `SocketRequest` that includes `"subscribe-notify"`, remove just that variant.
+
+- [ ] **Step 8.3: Delete the subscriber registry + broadcast loop in cockpitd.ts**
+
+In `src/control/cockpitd.ts`, find:
+- The subscriber-tracking data structure (probably `subscribers: Set<...>` or a map).
+- The `case "subscribe-notify"` handler.
+- The broadcast loop that iterates `subscribers` and writes push frames.
+
+Delete all three. Verify nothing else references them.
+
+- [ ] **Step 8.4: Delete subscribe-related tests**
+
+```bash
+grep -rln "subscribe-notify\|broadcasts to subscribed" src/control/__tests__/
+```
+
+Delete the tests that exclusively test broadcast behavior. Update tests that test other things but mention subscribers.
+
+- [ ] **Step 8.5: Run full suite**
+
+```bash
+npm test 2>&1 | tail -10
+```
+
+Expected: all tests pass. The notify-relay tests from PR #112 may now fail because they expect a subscribe protocol that no longer exists — that's expected; Commit Group 3 rewrites them.
+
+If a notify-relay test fails with "Cannot find type 'SubscribeNotifyClaim'" or similar — leave it failing; it gets rewritten in Task 10.
+
+- [ ] **Step 8.6: Confirm only notify-relay tests are failing**
+
+```bash
+npm test 2>&1 | grep -A1 "FAIL" | head -20
+```
+
+Expected: only `src/commands/__tests__/notify-relay.test.ts` failing. Anything else failing = stop, investigate.
+
+- [ ] **Step 8.7: Commit**
+
+```bash
+git add src/control/protocol.ts src/control/cockpitd.ts src/control/__tests__/
+git commit -m "refactor(daemon): remove subscribe-notify + push broadcast (replaced by mailbox)"
+```
+
+---
+
+# COMMIT GROUP 3: notify-relay rewrite
+
+After this group: end-to-end delivery is back. Captain pane receives `CREW DONE` lines auto-pushed via mailbox→tail→sendToSurface chain.
+
+---
+
+## Task 9: notify-relay skeleton + cursor boot
+
+**Files:**
+- Modify: `src/commands/notify-relay.ts` (rewrite)
+- Modify: `src/commands/__tests__/notify-relay.test.ts` (rewrite)
+
+- [ ] **Step 9.1: Write failing test for boot behavior**
+
+Replace `src/commands/__tests__/notify-relay.test.ts` content with:
+
+```typescript
+import { describe, it, expect, vi } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { appendToMailbox, writeCursor, readCursor } from "../../control/mailbox.js";
+import { runNotifyRelay } from "../notify-relay.js";
+import type { TaskRecord, ControlEvent } from "../../control/types.js";
+
+function freshState(): string {
+  return mkdtempSync(join(tmpdir(), "nr-"));
+}
+
+const rec: TaskRecord = {
+  id: "deadbeefcafebabe1234567890abcdef",
+  project: "demo", provider: "claude", mode: "interactive",
+  state: "done", task: "task body", cwd: "/", createdAt: 1, lastHeartbeat: 1,
+  lastEvent: "task.done", heartbeatBudgetMs: 60000, attempts: [],
+};
+const doneEvent: ControlEvent = { type: "task.done", id: rec.id, resultRef: "/r" };
+
+describe("notify-relay boot", () => {
+  it("starts from seq 1 when cursor missing", async () => {
+    const stateRoot = freshState();
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneEvent });
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    const stop = await runNotifyRelay({
+      project: "demo", subscriber: "captain", stateRoot,
+      runtime: { sendToSurface: sendSpy, status: vi.fn().mockResolvedValue({ id: "ws1" }), listSurfaces: vi.fn().mockResolvedValue([{ id: "s1", title: "captain" }]) } as any,
+      captainName: "captain",
+      pollMs: 50,
+    });
+    await new Promise((r) => setTimeout(r, 200));
+    stop();
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(sendSpy.mock.calls[0][1]).toContain("CREW DONE");
+    const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    expect(cursor?.lastAckedSeq).toBe(1);
+  });
+
+  it("starts from seq+1 when cursor exists", async () => {
+    const stateRoot = freshState();
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneEvent });
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneEvent });
+    await writeCursor({ stateRoot, project: "demo", subscriber: "captain", lastAckedSeq: 1 });
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    const stop = await runNotifyRelay({
+      project: "demo", subscriber: "captain", stateRoot,
+      runtime: { sendToSurface: sendSpy, status: vi.fn().mockResolvedValue({ id: "ws1" }), listSurfaces: vi.fn().mockResolvedValue([{ id: "s1", title: "captain" }]) } as any,
+      captainName: "captain",
+      pollMs: 50,
+    });
+    await new Promise((r) => setTimeout(r, 200));
+    stop();
+    // only seq 2 should be delivered
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 9.2: Run, verify failure**
+
+```bash
+npx vitest run src/commands/__tests__/notify-relay.test.ts
+```
+
+Expected: fail with "runNotifyRelay is not a function" or similar.
+
+- [ ] **Step 9.3: Rewrite notify-relay.ts**
+
+Replace `src/commands/notify-relay.ts` entirely:
+
+```typescript
+import { Command } from "commander";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { promises as fs } from "node:fs";
+import { loadConfig } from "../lib/config.js";
+import { RuntimeRegistry } from "../runtimes/registry.js";
+import { createCmuxDriver } from "../runtimes/cmux.js";
+import type { RuntimeDriver, WorkspaceRef, SurfaceRef } from "../runtimes/types.js";
+import { readCursor, writeCursor, readFromCursor, type MailboxEntry } from "../control/mailbox.js";
+
+function shortId(id: string): string { return id.slice(0, 8); }
+
+export function formatEntry(entry: MailboxEntry): string | null {
+  const tag = `[${entry.provider}/${shortId(entry.taskId)}]`;
+  switch (entry.kind) {
+    case "task.started":
+    case "task.progress":
+      return null; // suppress liveness/start
+    case "task.done": {
+      const msg = (entry.payload.message as string) ?? (entry.payload.resultRef as string) ?? "(no message)";
+      return `CREW DONE ${tag}: ${msg.toString().split(/\r?\n/)[0].slice(0, 200)}`;
+    }
+    case "task.blocked":
+      return `CREW BLOCKED ${tag}: ${(entry.payload.question as string) ?? "(no question)"}`;
+    case "task.failed":
+      return `CREW FAILED ${tag}: ${(entry.payload.error as string) ?? "(no error)"}`;
+    case "task.stalled":
+      return `CREW STALLED ${tag}: no heartbeat`;
+    default:
+      return null;
+  }
+}
+
+interface RunOpts {
+  project: string;
+  subscriber: string;
+  stateRoot: string;
+  runtime: RuntimeDriver;
+  captainName: string;
+  pollMs?: number;
+}
+
+export async function runNotifyRelay(opts: RunOpts): Promise<() => void> {
+  // resolve captain workspace + primary surface once
+  const ws = await opts.runtime.status(opts.captainName);
+  if (!ws) throw new Error(`captain workspace '${opts.captainName}' not running`);
+  const surfaces = await opts.runtime.listSurfaces?.(ws.id) ?? [];
+  const captainSurface: SurfaceRef = (surfaces.find((s: any) => s.title === opts.captainName) ?? surfaces[0]) as SurfaceRef;
+  if (!captainSurface) throw new Error("no surfaces in captain workspace");
+
+  let cursor = await readCursor({ stateRoot: opts.stateRoot, project: opts.project, subscriber: opts.subscriber });
+  let lastAcked = cursor?.lastAckedSeq ?? 0;
+  let stopped = false;
+
+  async function drain(): Promise<void> {
+    for await (const entry of readFromCursor({ stateRoot: opts.stateRoot, project: opts.project, fromSeq: lastAcked + 1 })) {
+      if (stopped) return;
+      const msg = formatEntry(entry);
+      if (msg) {
+        try {
+          await opts.runtime.sendToSurface(captainSurface, msg);
+        } catch (e) {
+          console.error(`[notify-relay ${opts.project}] sendToSurface failed seq=${entry.seq}: ${(e as Error).message}`);
+          await new Promise((r) => setTimeout(r, 1000));
+          continue; // do not advance cursor; retry on next loop
+        }
+      }
+      await writeCursor({ stateRoot: opts.stateRoot, project: opts.project, subscriber: opts.subscriber, lastAckedSeq: entry.seq });
+      lastAcked = entry.seq;
+    }
+  }
+
+  const interval = setInterval(() => { if (!stopped) drain().catch((e) => console.error(e)); }, opts.pollMs ?? 1000);
+  // initial drain
+  await drain();
+  return () => { stopped = true; clearInterval(interval); };
+}
+
+export const notifyRelayCommand = new Command("notify-relay")
+  .description("Subscribe to a project's mailbox and deliver events to the captain pane")
+  .argument("<project>", "project name")
+  .option("--as <subscriber>", "subscriber name", "captain")
+  .option("--state-root <path>", "override state root", join(homedir(), ".config", "cockpit"))
+  .action(async (project: string, opts: { as: string; stateRoot: string }) => {
+    const config = await loadConfig();
+    const projCfg = config.projects[project];
+    if (!projCfg) {
+      console.error(`unknown project '${project}'`);
+      process.exit(1);
+    }
+    const runtime = new RuntimeRegistry({ cmux: createCmuxDriver() }).forProject(project, config);
+    console.log(`[notify-relay ${project}] subscriber=${opts.as} stateRoot=${opts.stateRoot}`);
+    await runNotifyRelay({
+      project, subscriber: opts.as, stateRoot: opts.stateRoot,
+      runtime, captainName: projCfg.captainName,
+      pollMs: 1000,
+    });
+    // long-running; process exits on SIGTERM
+    process.on("SIGTERM", () => process.exit(0));
+  });
+```
+
+- [ ] **Step 9.4: Run, verify boot tests pass**
+
+```bash
+npx vitest run src/commands/__tests__/notify-relay.test.ts
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 9.5: Commit**
+
+```bash
+git add src/commands/notify-relay.ts src/commands/__tests__/notify-relay.test.ts
+git commit -m "feat(notify-relay): file-tailer skeleton with cursor boot + format dispatch"
+```
+
+---
+
+## Task 10: Bounded retry on sendToSurface failure
+
+**Files:**
+- Modify: `src/commands/notify-relay.ts`
+- Modify: `src/commands/__tests__/notify-relay.test.ts`
+
+- [ ] **Step 10.1: Write failing test for retry behavior**
+
+Append to test file:
+
+```typescript
+it("does not advance cursor when sendToSurface throws", async () => {
+  const stateRoot = freshState();
+  await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneEvent });
+  const sendSpy = vi.fn().mockRejectedValue(new Error("send failed"));
+  const stop = await runNotifyRelay({
+    project: "demo", subscriber: "captain", stateRoot,
+    runtime: { sendToSurface: sendSpy, status: vi.fn().mockResolvedValue({ id: "ws1" }), listSurfaces: vi.fn().mockResolvedValue([{ id: "s1", title: "captain" }]) } as any,
+    captainName: "captain",
+    pollMs: 50,
+  });
+  await new Promise((r) => setTimeout(r, 200));
+  stop();
+  const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+  expect(cursor).toBeNull(); // cursor never written
+  expect(sendSpy.mock.calls.length).toBeGreaterThan(0); // attempted
+});
+
+it("delivers seq 2 even if seq 1 was already acked", async () => {
+  const stateRoot = freshState();
+  await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneEvent });
+  await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneEvent });
+  await writeCursor({ stateRoot, project: "demo", subscriber: "captain", lastAckedSeq: 1 });
+  const sendSpy = vi.fn().mockResolvedValue(undefined);
+  const stop = await runNotifyRelay({
+    project: "demo", subscriber: "captain", stateRoot,
+    runtime: { sendToSurface: sendSpy, status: vi.fn().mockResolvedValue({ id: "ws1" }), listSurfaces: vi.fn().mockResolvedValue([{ id: "s1", title: "captain" }]) } as any,
+    captainName: "captain",
+    pollMs: 50,
+  });
+  await new Promise((r) => setTimeout(r, 200));
+  stop();
+  expect(sendSpy).toHaveBeenCalledTimes(1);
+  const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+  expect(cursor?.lastAckedSeq).toBe(2);
+});
+```
+
+- [ ] **Step 10.2: Run, verify pass**
+
+```bash
+npx vitest run src/commands/__tests__/notify-relay.test.ts
+```
+
+Expected: both tests pass (the existing implementation from Task 9 already handles this — the `continue` in the catch block skips the cursor write).
+
+If a test fails, debug the existing implementation; do NOT add a separate retry layer (the loop's natural cycle is the retry).
+
+- [ ] **Step 10.3: Commit (no code change needed if tests pass — add the tests only)**
+
+```bash
+git add src/commands/__tests__/notify-relay.test.ts
+git commit -m "test(notify-relay): assert no-cursor-advance on send failure + replay correctness"
+```
+
+---
+
+## Task 11: Register notify-relay command in CLI
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 11.1: Confirm notify-relay is registered (it likely is from PR #112)**
+
+```bash
+grep -n "notifyRelayCommand\|notify-relay" src/index.ts
+```
+
+If already registered: nothing to do; move to Task 12.
+
+If not registered, add:
+
+```typescript
+import { notifyRelayCommand } from "./commands/notify-relay.js";
+// ...
+program.addCommand(notifyRelayCommand);
+```
+
+- [ ] **Step 11.2: Smoke the CLI**
+
+```bash
+npm run build
+node dist/index.js notify-relay --help
+```
+
+Expected: help text printed (not "unknown command").
+
+- [ ] **Step 11.3: If a change was needed, commit**
+
+```bash
+git add src/index.ts
+git commit -m "chore(cli): register notify-relay command"
+```
+
+(Skip the commit if registration was already in place from PR #112.)
+
+---
+
+# COMMIT GROUP 4: RuntimeDriver + cmux + launch
+
+After this group: the relay tab from PR #112 becomes a hidden split-pane (or falls back to visible tab if cmux can't hide).
+
+---
+
+## Task 12: Add spawnInjector + sendToSurface to RuntimeDriver type
+
+**Files:**
+- Modify: `src/runtimes/types.ts`
+- Modify: any memory/test driver helpers
+
+- [ ] **Step 12.1: Read current RuntimeDriver interface**
+
+```bash
+sed -n '1,80p' src/runtimes/types.ts
+```
+
+Locate the `RuntimeDriver` interface definition.
+
+- [ ] **Step 12.2: Add method signatures**
+
+Add to the `RuntimeDriver` interface in `src/runtimes/types.ts`:
+
+```typescript
+  /**
+   * Spawn a long-running process INSIDE the captain workspace's process tree,
+   * such that any IPC/socket constraints of the runtime (e.g. cmux's parent-
+   * lineage check) are satisfied. Returns a SurfaceRef so the caller can
+   * inspect / cleanup later.
+   *
+   * placement: "hidden" produces a non-distracting surface (zero/minimal-size
+   * split, minimized pane, off-screen tab — runtime decides). "visible"
+   * produces a normal pane (debug).
+   */
+  spawnInjector(opts: {
+    captainWorkspace: WorkspaceRef;
+    command: string;
+    title?: string;
+    placement: "hidden" | "visible";
+  }): Promise<SurfaceRef>;
+
+  /**
+   * Send text to a specific surface. Unlike `send` (workspace-level) this
+   * targets one surface directly. Used by the injector to deliver messages
+   * to the captain's main surface.
+   *
+   * Returns when the runtime has accepted the write. Throws if the surface
+   * no longer exists.
+   */
+  sendToSurface(surface: SurfaceRef, text: string): Promise<void>;
+```
+
+- [ ] **Step 12.3: Build, expect type errors in cmux.ts (intentional — Task 13 fixes them)**
+
+```bash
+npm run build 2>&1 | tail -15
+```
+
+Expected: error like `Property 'spawnInjector' is missing in type ...` in `cmux.ts` and any memory driver. This is the failing precondition for the next task.
+
+- [ ] **Step 12.4: Commit (type-only change; broken build is intentional — next task fixes)**
+
+```bash
+git add src/runtimes/types.ts
+git commit -m "feat(runtime): add spawnInjector + sendToSurface to RuntimeDriver type"
+```
+
+---
+
+## Task 13: cmux implementation — sendToSurface (easier; do first)
+
+**Files:**
+- Modify: `src/runtimes/cmux.ts`
+- Modify: `src/runtimes/__tests__/cmux.test.ts` (or create if doesn't exist)
+
+- [ ] **Step 13.1: Read existing cmux `send` to find the surface-targeting pattern**
+
+```bash
+sed -n '85,110p' src/runtimes/cmux.ts
+```
+
+The existing `send()` already routes to a surface internally. Extract that logic.
+
+- [ ] **Step 13.2: Add sendToSurface method to cmux driver**
+
+Edit `src/runtimes/cmux.ts`. In the returned object, add:
+
+```typescript
+    async sendToSurface(surface: SurfaceRef, text: string): Promise<void> {
+      cmux(`send --workspace "${surface.workspaceId}" --surface "${surface.id}" "${escape(text)}"`);
+      cmux(`send-key --workspace "${surface.workspaceId}" --surface "${surface.id}" Enter`);
+    },
+```
+
+Make sure `SurfaceRef` is imported and includes both `id` and `workspaceId`. If `SurfaceRef` lacks `workspaceId`, add it to the type in `src/runtimes/types.ts` and to wherever surfaces are constructed in cmux.ts.
+
+- [ ] **Step 13.3: Run build**
+
+```bash
+npm run build 2>&1 | tail -5
+```
+
+Expected: still an error about `spawnInjector` missing; sendToSurface now satisfied.
+
+- [ ] **Step 13.4: No standalone test for sendToSurface — covered by notify-relay test which uses a fake driver. Commit.**
+
+```bash
+git add src/runtimes/cmux.ts src/runtimes/types.ts
+git commit -m "feat(cmux): sendToSurface routes to a specific surface within a workspace"
+```
+
+---
+
+## Task 14: cmux implementation — spawnInjector
+
+**Files:**
+- Modify: `src/runtimes/cmux.ts`
+
+- [ ] **Step 14.1: Implement spawnInjector with placement support**
+
+Add to the cmux driver:
+
+```typescript
+    async spawnInjector(opts: {
+      captainWorkspace: WorkspaceRef;
+      command: string;
+      title?: string;
+      placement: "hidden" | "visible";
+    }): Promise<SurfaceRef> {
+      const ws = opts.captainWorkspace.id;
+      // 1. Create a new split-pane down (or right — pick whichever cmux accepts reliably)
+      const splitOutput = cmux(`new-split down --workspace "${ws}"`);
+      // splitOutput typically contains 'surface:NN' — parse it
+      const m = splitOutput.match(/surface:\d+/);
+      if (!m) throw new Error(`cmux new-split did not return a surface id: ${splitOutput}`);
+      const surfaceId = m[0];
+      const title = opts.title ?? "✉ notify-relay";
+      try {
+        cmux(`rename-tab --workspace "${ws}" --surface "${surfaceId}" "${escape(title)}"`);
+      } catch { /* best-effort rename */ }
+      // 2. Send the command into the new surface
+      cmux(`send --workspace "${ws}" --surface "${surfaceId}" "${escape(opts.command)}"`);
+      cmux(`send-key --workspace "${ws}" --surface "${surfaceId}" Enter`);
+      // 3. If hidden, try to minimize the split. cmux's resize-split may not exist;
+      //    swallow failure (fallback to default size — degraded but functional).
+      if (opts.placement === "hidden") {
+        try {
+          cmux(`resize-pane --workspace "${ws}" --surface "${surfaceId}" --rows 1`);
+        } catch {
+          // resize unsupported; accept default size as graceful fallback
+        }
+      }
+      return { id: surfaceId, workspaceId: ws, title, status: "running" } as SurfaceRef;
+    },
+```
+
+(Adjust cmux subcommand names — `new-split`, `rename-tab`, `resize-pane` — to whatever the cmux CLI actually accepts. Verify with `cmux --help` and `cmux new-split --help` first.)
+
+- [ ] **Step 14.2: Build cleanly**
+
+```bash
+npm run build 2>&1 | tail -5
+```
+
+Expected: zero errors.
+
+- [ ] **Step 14.3: Create live opt-in test for cmux integration**
+
+Create `src/runtimes/__tests__/cmux-spawn-injector.live.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { createCmuxDriver } from "../cmux.js";
+
+const LIVE = process.env.CMUX_LIVE === "1";
+
+describe.skipIf(!LIVE)("cmux spawnInjector live", () => {
+  it("spawns a hidden split-pane that accepts a no-op command", async () => {
+    const driver = createCmuxDriver();
+    const wss = await driver.list();
+    expect(wss.length).toBeGreaterThan(0);
+    const captainWs = wss[0]; // assumes a captain is running
+    const surface = await driver.spawnInjector({
+      captainWorkspace: captainWs,
+      command: "echo notify-relay-probe; sleep 30",
+      title: "✉ probe",
+      placement: "hidden",
+    });
+    expect(surface.id).toMatch(/^surface:\d+$/);
+    // best-effort: try sendToSurface
+    await driver.sendToSurface(surface, "echo HELLO_FROM_TEST");
+    // manual cleanup: user closes the pane afterward
+  });
+});
+```
+
+(Mark this test opt-in via `CMUX_LIVE=1` — it requires a real cmux session.)
+
+- [ ] **Step 14.4: Run the live test manually (one-time validation)**
+
+```bash
+CMUX_LIVE=1 npx vitest run src/runtimes/__tests__/cmux-spawn-injector.live.test.ts
+```
+
+Expected: pass. Visually verify a tiny split-pane appeared in the captain workspace. If cmux fails to hide it (resize-pane unsupported), confirm fallback to default split size still works.
+
+If cmux's CLI verbs differ from what's written (e.g. cmux uses `split-pane down` instead of `new-split down`), adjust the strings in `spawnInjector`. Document any discrepancy in a code comment.
+
+- [ ] **Step 14.5: Commit**
+
+```bash
+git add src/runtimes/cmux.ts src/runtimes/__tests__/cmux-spawn-injector.live.test.ts
+git commit -m "feat(cmux): spawnInjector creates split-pane with hidden/visible placement"
+```
+
+---
+
+## Task 15: launch.ts uses spawnInjector instead of newPane
+
+**Files:**
+- Modify: `src/commands/launch.ts`
+
+- [ ] **Step 15.1: Read current launch.ts relay-tab spawn code**
+
+```bash
+grep -nA20 "NOTIFY_RELAY_TAB_TITLE\|notify-relay tab" src/commands/launch.ts
+```
+
+Identify the function that adds the notify-relay tab (probably uses `runtime.newPane({direction: "tab"})` from PR #112).
+
+- [ ] **Step 15.2: Replace with spawnInjector + dedup**
+
+Find the helper that adds the tab (likely named something like `addNotifyRelayTab` or `ensureNotifyRelayTab`). Modify it:
+
+```typescript
+const NOTIFY_RELAY_TAB_TITLE = "✉ notify-relay";
+
+async function ensureNotifyRelay(runtime: RuntimeDriver, captainWs: WorkspaceRef, project: string): Promise<void> {
+  // Kill any pre-existing relay surface (visible tab OR hidden split — dedup before respawn)
+  const surfaces = await runtime.listSurfaces?.(captainWs.id) ?? [];
+  for (const s of surfaces) {
+    if (s.title === NOTIFY_RELAY_TAB_TITLE) {
+      try { await runtime.closeSurface?.(s); } catch { /* best effort */ }
+    }
+  }
+  try {
+    await runtime.spawnInjector({
+      captainWorkspace: captainWs,
+      command: `cockpit notify-relay ${project} --as captain`,
+      title: NOTIFY_RELAY_TAB_TITLE,
+      placement: "hidden",
+    });
+    console.log(chalk.cyan(`  ✔ Added hidden notify-relay for '${project}'`));
+  } catch (e) {
+    console.error(chalk.yellow(`  ⚠ notify-relay setup failed: ${(e as Error).message}`));
+  }
+}
+```
+
+(`closeSurface` may not exist on `RuntimeDriver` today. If not, add a basic implementation in cmux.ts: `async closeSurface(s: SurfaceRef) { cmux(`close-surface --workspace "${s.workspaceId}" --surface "${s.id}"`); }` and the type signature in `src/runtimes/types.ts`.)
+
+- [ ] **Step 15.3: Build**
+
+```bash
+npm run build 2>&1 | tail -5
+```
+
+Expected: clean.
+
+- [ ] **Step 15.4: Manual smoke — relaunch a captain workspace**
+
+```bash
+# kill old captain if running
+cockpit shutdown cockpit 2>&1 || true
+# relaunch
+cockpit launch cockpit
+```
+
+Expected: captain workspace re-spawns with a hidden split-pane labeled `✉ notify-relay`. Old visible tab from PR #112 (if any) is gone.
+
+If the hidden split is still very visible (1-3 rows is OK; full half-workspace is too much), check that the resize-pane invocation in cmux.ts is actually accepting the row count.
+
+- [ ] **Step 15.5: Commit**
+
+```bash
+git add src/commands/launch.ts src/runtimes/cmux.ts src/runtimes/types.ts
+git commit -m "feat(launch): notify-relay spawns as hidden split-pane (dedup pre-existing)"
+```
+
+---
+
+# FINAL TASKS: smoke, lint, build, PR
+
+## Task 16: E2E smoke script
+
+**Files:**
+- Create: `scripts/mailbox-injector-smoke.mjs`
+
+- [ ] **Step 16.1: Write the smoke script**
+
+Create `scripts/mailbox-injector-smoke.mjs`:
+
+```javascript
+#!/usr/bin/env node
+// E2E smoke for mailbox + injector
+// Drives a daemon + simulates an injector against a temp socket
+// Mirrors scripts/smoke-push-notify.mjs
+
+import { mkdtempSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+import { createConnection } from "node:net";
+
+const stateRoot = mkdtempSync(join(tmpdir(), "mailbox-smoke-"));
+const sock = join(stateRoot, "c.sock");
+const evidenceFile = ".mailbox-injector-smoke.local";
+
+let evidence = [`# Mailbox + Injector smoke — ${new Date().toISOString()}`, `state: ${stateRoot}`, ""];
+const log = (line) => { console.log(line); evidence.push(line); };
+
+async function rpc(req) {
+  return new Promise((resolve, reject) => {
+    const s = createConnection(sock);
+    s.on("connect", () => s.write(JSON.stringify(req) + "\n"));
+    s.on("data", (d) => { resolve(JSON.parse(d.toString().trim())); s.end(); });
+    s.on("error", reject);
+  });
+}
+
+async function main() {
+  // 1. Boot daemon
+  const cpd = spawn("node", [join(process.cwd(), "dist/control/cockpitd.js")], {
+    env: { ...process.env, COCKPIT_SOCKET_PATH: sock, COCKPIT_STATE_ROOT: stateRoot },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  cpd.stdout.on("data", (b) => process.stderr.write(`[cpd] ${b}`));
+  cpd.stderr.on("data", (b) => process.stderr.write(`[cpd] ${b}`));
+  await new Promise((r) => setTimeout(r, 1500));
+
+  let failures = 0;
+  const assert = (cond, msg) => { log(cond ? `  ✓ ${msg}` : `  ✗ ${msg}`); if (!cond) failures++; };
+
+  try {
+    log("--- 1. dispatch + signal done — mailbox file gets the entry ---");
+    const rec = await rpc({
+      kind: "dispatch",
+      record: {
+        id: "smoke-1", project: "demo", provider: "claude", mode: "headless",
+        state: "submitted", task: "smoke test #1", cwd: "/", createdAt: 1, lastHeartbeat: 1,
+        lastEvent: "dispatch", heartbeatBudgetMs: 60000, attempts: [],
+      },
+    });
+    await rpc({ kind: "event", project: "demo", event: { type: "task.started", id: "smoke-1" } });
+    await rpc({ kind: "event", project: "demo", event: { type: "task.done", id: "smoke-1", resultRef: "/r1" } });
+    await new Promise((r) => setTimeout(r, 200));
+    const logPath = join(stateRoot, "inbox", "demo.log");
+    assert(existsSync(logPath), "mailbox file created");
+    const lines = readFileSync(logPath, "utf-8").trim().split("\n");
+    assert(lines.length === 1, `exactly one entry (got ${lines.length})`);
+    const entry = JSON.parse(lines[0]);
+    assert(entry.seq === 1, `seq=1 (got ${entry.seq})`);
+    assert(entry.kind === "task.done", `kind=task.done (got ${entry.kind})`);
+
+    log("--- 2. simulate injector reading from cursor ---");
+    // dynamic import of compiled mailbox module
+    const mailbox = await import(join(process.cwd(), "dist/control/mailbox.js"));
+    const items = [];
+    for await (const it of mailbox.readFromCursor({ stateRoot, project: "demo", fromSeq: 1 })) items.push(it);
+    assert(items.length === 1, `injector reads 1 entry from cursor (got ${items.length})`);
+    await mailbox.writeCursor({ stateRoot, project: "demo", subscriber: "captain", lastAckedSeq: 1 });
+    const cursor = await mailbox.readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    assert(cursor?.lastAckedSeq === 1, `cursor advanced to 1`);
+
+    log("--- 3. daemon bounce simulation: dispatch more events while injector 'offline' ---");
+    await rpc({ kind: "dispatch", record: { id: "smoke-2", project: "demo", provider: "claude", mode: "headless", state: "submitted", task: "t2", cwd: "/", createdAt: 1, lastHeartbeat: 1, lastEvent: "dispatch", heartbeatBudgetMs: 60000, attempts: [] } });
+    await rpc({ kind: "event", project: "demo", event: { type: "task.started", id: "smoke-2" } });
+    await rpc({ kind: "event", project: "demo", event: { type: "task.done", id: "smoke-2", resultRef: "/r2" } });
+    await new Promise((r) => setTimeout(r, 200));
+
+    log("--- 4. injector resumes from cursor — reads only the new event ---");
+    const items2 = [];
+    for await (const it of mailbox.readFromCursor({ stateRoot, project: "demo", fromSeq: 2 })) items2.push(it);
+    assert(items2.length === 1 && items2[0].seq === 2, `replay yields exactly seq 2`);
+
+    log(`\n${failures === 0 ? "✔ ALL SMOKE ASSERTIONS PASSED" : `✗ ${failures} FAILURES`}`);
+  } finally {
+    cpd.kill();
+    writeFileSync(evidenceFile, evidence.join("\n") + "\n");
+    log(`evidence: ${evidenceFile}`);
+    process.exit(failures > 0 ? 1 : 0);
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });
+```
+
+- [ ] **Step 16.2: Build + run smoke**
+
+```bash
+npm run build
+node scripts/mailbox-injector-smoke.mjs
+```
+
+Expected: all assertions pass; `.mailbox-injector-smoke.local` written.
+
+If startCockpitd's CLI form needs different env vars to honor a custom socket/stateRoot, inspect `dist/control/cockpitd.js` to find what it reads. Adjust the env-var names in the smoke script.
+
+- [ ] **Step 16.3: Add the .local evidence file to .gitignore if not already**
+
+```bash
+grep -q "\.mailbox-injector-smoke\.local" .gitignore || echo ".mailbox-injector-smoke.local" >> .gitignore
+```
+
+- [ ] **Step 16.4: Commit**
+
+```bash
+git add scripts/mailbox-injector-smoke.mjs .gitignore
+git commit -m "chore(smoke): mailbox+injector E2E smoke script with daemon-bounce check"
+```
+
+---
+
+## Task 17: Full validation + PR
+
+- [ ] **Step 17.1: Lint, build, full test suite**
+
+```bash
+npm run lint
+npm run build
+npm test
+```
+
+All three must exit 0.
+
+- [ ] **Step 17.2: Live verification with real captain (manual)**
+
+This is the acceptance criterion. Carefully:
+
+```bash
+# 1. Confirm a captain is running (or launch one fresh)
+cockpit launch cockpit
+
+# 2. Spawn a small Claude crew via the daemon-supervised path
+cockpit crew spawn cockpit "Run cockpit crew signal done --message 'mailbox-injector live test successful'" --agent claude --name mbox-livetest
+
+# 3. Watch the captain pane (your own session). Within ~1s of the crew signaling
+#    done, you should see a line appear:
+#    CREW DONE [claude/<id8>]: mailbox-injector live test successful
+
+# 4. Bounce daemon mid-second-test
+cockpit crew spawn cockpit "Sleep 2 then run cockpit crew signal done --message 'after-bounce'" --agent claude --name mbox-bouncetest
+# in another shell, while crew is sleeping:
+kill $(pgrep cockpitd)
+# wait for cockpit cli to auto-respawn daemon (will happen on next cli call)
+cockpit runtime status --command || true
+# expect CREW DONE [claude/...]: after-bounce to STILL appear in captain pane
+```
+
+Document outcomes in `.mailbox-injector-live-evidence.local` (gitignored). Both pass = PR-ready.
+
+If outcomes fail, do NOT open the PR. Diagnose: check the inbox file content, the cursor file, the relay tab content (`cmux read-screen --surface <relay-surface>`), and the daemon log.
+
+- [ ] **Step 17.3: gitnexus refresh + change scope check**
+
+```bash
+npx gitnexus analyze --embeddings
+# Then per project CLAUDE.md hard rule, run via the MCP tool:
+# gitnexus_detect_changes({scope:"compare", base_ref:"develop"})
+```
+
+Confirm the diff touches only files in the "File Structure" section at the top of this plan.
+
+- [ ] **Step 17.4: Open the PR against develop**
+
+```bash
+git push -u origin feature/mailbox-injector
+gh pr create --base develop --title "feat(mailbox): mailbox + injector foundational refactor (closes #113, foundation for #114/#115)" --body "$(cat <<'EOF'
+## Summary
+
+Replaces PR #112's subscribe/broadcast machinery with a file-as-source-of-truth mailbox + pull-from-cursor injector. The cockpit daemon now appends `ControlEvent`s to a per-project mailbox file; a `notify-relay` process runs as a hidden split-pane inside each captain workspace and delivers events to the captain pane via the new `RuntimeDriver.sendToSurface`. Daemon-bounce-tolerant by design; at-least-once delivery; runtime-agnostic.
+
+## Architecture (one paragraph)
+
+Daemon appends to `~/.config/cockpit/inbox/<project>.log` (JSON-lines, monotonic per-project `seq`, flock on write, size+age rotation). Injector inside captain workspace (`cockpit notify-relay <project> --as captain`) tails the file from a `lastAckedSeq` cursor (`<project>.captain.cursor`, fsync+atomic-rename), formats each entry, and delivers via `RuntimeDriver.sendToSurface(captainSurface, msg)`. The injector is spawned via the new `RuntimeDriver.spawnInjector({placement:"hidden"})` so it lives inside cmux's process tree (satisfies cmux's CLI lineage check). Subscribe-notify socket protocol + push frames added in PR #112 are deleted. Anti-#2576 invariant preserved: terminal state only via explicit `cockpit crew signal`.
+
+## Lessons applied
+
+- **PR #110 lesson:** daemon-from-launchd can't shell out to cmux. Daemon now never invokes cmux-aware commands; only appends to a file.
+- **PR #112 lesson:** push-with-no-replay loses events during bounce backoff. Pull-from-cursor model: file is durable, injector resumes from cursor on restart.
+- **Research 2026-05-27 lesson:** the relay-tab pattern is the right shape; what was missing was a durable queue and cleaner RuntimeDriver abstraction. This PR dignifies the relay into a first-class injector.
+
+## Closes / depends
+
+- **Closes #113** (replay-on-reconnect — by construction; the bug cannot occur in this design).
+- **Foundation for #114** (hybrid codex: native TUI + hook bridge — codex hooks emit events that flow through the same mailbox).
+- **Foundation for #115** (opencode interactive wiring — opencode plugin events flow through the same mailbox).
+- **Preserves PR #98** (codex app-server for headless) — untouched.
+- **Preserves PR #108** (claude through daemon) — its hook bridge now feeds the mailbox instead of pushing.
+
+## Test plan
+
+- [x] `npm run lint` clean
+- [x] `npm run build` clean
+- [x] `npx vitest run` — all 556+ tests pass (mailbox: 17 new, notify-relay: 4 new, cockpitd-notify-default: 3 rewritten, subscribe-notify tests deleted)
+- [x] E2E smoke: `node scripts/mailbox-injector-smoke.mjs` — evidence in `.mailbox-injector-smoke.local`
+- [x] Live captain verification: spawn Claude crew, signal done, captain pane receives line within ~1s; daemon-bounce mid-second-test, second line STILL arrives after respawn — evidence in `.mailbox-injector-live-evidence.local`
+- [x] cmux integration (opt-in `CMUX_LIVE=1`): hidden split-pane spawned; sendToSurface lands text
+
+## Spec / plan
+
+- Spec: `docs/specs/2026-05-27-mailbox-injector-design.md`
+- Plan: `docs/plans/2026-05-27-mailbox-injector.md`
+- Motivating research: `docs/research/2026-05-27-multi-session-orchestrator-notification-patterns.md`
+EOF
+)"
+```
+
+- [ ] **Step 17.5: Notify the user via the now-working push (eat-our-own-dogfood)**
+
+```bash
+# After the PR opens, signal completion via the new mailbox path so the captain
+# sees the auto-pushed line via the live relay.
+cockpit crew signal done --message "Phase 4 (mailbox+injector) implementation merged-ready. PR opened — review evidence files for live + smoke proof."
+```
+
+(This works only if you're inside a crew with `COCKPIT_CREW_TASK_ID` set. If you're the captain manually executing, just print the line and move on.)
+
+---
+
+## Rollback plan
+
+Each task = one commit. If a task breaks captain workflows in field test, `git revert <sha>` restores prior behavior:
+
+- Revert task 15 (launch.ts spawnInjector switch) → tabs come back, mailbox still works
+- Revert task 8 (subscribe-protocol removal) → PR #112 broadcast restored, mailbox additional
+- Revert task 6 (defaultNotify rewrite) → execFileSync path restored, mailbox additional
+- Revert all 4 commit groups → back to develop tip
+
+Most-likely partial-revert scenario: task 14 (cmux spawnInjector) producing visually broken split-panes. Easy revert: keep mailbox+injector logic, change launch.ts to call `runtime.newPane({direction:"tab"})` for the relay (PR #112 visual behavior) until cmux command tuning is sorted.
+
+## Out of scope for this plan — to be filed as follow-ups
+
+- Telegram subscriber implementation (#65). Schema supports per-subscriber cursor; just needs a new subscriber binary.
+- Captain-ops skill migration from `cockpit crew read` polling to `cockpit crew status` (separate spec).
+- Generalizing the cursor file naming for multi-captain-per-project (no demand today).
+
+---
+
+## Self-review (run after writing this plan, before handoff)
+
+- ✅ **Spec coverage:** Every spec section maps to tasks. §4 architecture → Tasks 6,9,15. §5 mailbox model → Tasks 1-4. §6 daemon → Tasks 5-8. §7 injector → Tasks 9-11. §8 RuntimeDriver → Tasks 12-14. §9 migration → ordered commit groups + Task 17 PR.
+- ✅ **No TBD/placeholders:** every step has actual code or actual commands.
+- ✅ **Type consistency:** `appendToMailbox`, `readCursor`, `writeCursor`, `readFromCursor`, `rotateIfNeeded` names match across all tasks. `spawnInjector` + `sendToSurface` signatures match between type def (Task 12) and impl (Tasks 13-14). `SurfaceRef.workspaceId` added consistently. `MailboxEntry` schema matches between mailbox.ts and notify-relay.ts format function.
+- ⚠️  **Known risks documented**: cmux subcommand names (`new-split`, `rename-tab`, `resize-pane`, `close-surface`) may differ in production cmux — Task 14.4 includes a probe step + comment to adjust. Documented in rollback plan.
+- ✅ **Scope check:** All tasks contribute to the mailbox+injector refactor. No drive-by refactors. No "while we're here" tasks.

--- a/docs/research/2026-05-27-multi-session-orchestrator-notification-patterns.html
+++ b/docs/research/2026-05-27-multi-session-orchestrator-notification-patterns.html
@@ -1,0 +1,995 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <title>Multi-Session Orchestrator Notification Patterns — Prior-Art Survey</title>
+  <style>
+
+span.smallcaps{font-variant: small-caps;}
+div.columns{display: flex; gap: min(4vw, 1.5em);}
+div.column{flex: auto; overflow-x: auto;}
+div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+
+ul.task-list[class]{list-style: none;}
+ul.task-list li input[type="checkbox"] {
+font-size: inherit;
+width: 0.8em;
+margin: 0 0.8em 0.2em -1.6em;
+vertical-align: middle;
+}
+.display.math{display: block; text-align: center; margin: 0.5rem auto;}
+</style>
+  <style type="text/css">:root{--bg:#0f1115;--panel:#171a21;--panel2:#1d212a;--ink:#e6e8ee;--mut:#9aa3b2;--line:#2a2f3a;--accent:#5db0ff;--ck:#7c9eff;--or:#ff9d6b;--good:#4ade80;--warn:#fbbf24;--bad:#f87171;--code:#0b0d12;--mono:"SF Mono",ui-monospace,Menlo,Consolas,monospace}
+*{box-sizing:border-box}html{scroll-behavior:smooth}
+body{margin:0;background:var(--bg);color:var(--ink);font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;max-width:980px;padding:46px 56px 120px;margin:0 auto}
+h1{font-size:29px;line-height:1.25;margin:10px 0 16px;letter-spacing:-.01em;border-bottom:1px solid var(--line);padding-bottom:14px}
+h2{font-size:22px;margin-top:42px;padding-top:14px;border-top:1px solid var(--line);color:var(--accent)}
+h3{font-size:17px;margin-top:28px;color:var(--ck)}
+h4{font-size:15px;margin-top:20px;color:var(--mut);text-transform:uppercase;letter-spacing:.05em}
+p,li{color:var(--ink)}
+a{color:var(--accent);text-decoration:none}a:hover{text-decoration:underline}
+code{font-family:var(--mono);background:var(--code);padding:2px 6px;border-radius:4px;font-size:13.5px;color:var(--or)}
+pre{background:var(--code);padding:14px 18px;border-radius:8px;border:1px solid var(--line);overflow-x:auto;font-size:13px;line-height:1.5}
+pre code{background:none;padding:0;color:var(--ink)}
+blockquote{border-left:3px solid var(--accent);margin:16px 0;padding:8px 18px;color:var(--mut);background:var(--panel)}
+table{width:100%;border-collapse:collapse;margin:18px 0;font-size:14px}
+th,td{border:1px solid var(--line);padding:9px 12px;text-align:left;vertical-align:top}
+th{background:var(--panel2);color:var(--accent);font-weight:600}
+tr:nth-child(2n) td{background:var(--panel)}
+hr{border:none;border-top:1px solid var(--line);margin:36px 0}
+ul,ol{padding-left:24px}li{margin:4px 0}
+strong{color:#fff}em{color:var(--ck)}
+</style>
+</head>
+<body>
+<header id="title-block-header">
+<h1 class="title">Multi-Session Orchestrator Notification Patterns —
+Prior-Art Survey</h1>
+</header>
+<h1 id="multi-session-orchestrator-notification-patterns--prior-art-survey">Multi-Session
+Orchestrator Notification Patterns — Prior-Art Survey</h1>
+<p><strong>Date:</strong> 2026-05-27 <strong>Author:</strong> Cockpit
+research (parent: develop) <strong>Purpose:</strong> Survey how
+comparable multi-agent / multi-session systems solve the
+<em>crew-completion → captain-attention</em> problem before redesigning
+cockpit&#39;s daemon-relay-tab mechanism.</p>
+<hr />
+<h2 id="0-the-cockpit-problem-stated-precisely">0. The Cockpit Problem,
+Stated Precisely</h2>
+<p>Cockpit runs a <strong>captain</strong> session (a Claude/Codex/etc.
+process inside a cmux pane) that coordinates <strong>crew</strong>
+sessions (more Claude/Codex/etc. processes in their own cmux panes).
+When a crew finishes, the captain needs to know — ideally as a
+<em>message that lands in the captain&#39;s input stream</em>, so the
+captain&#39;s next turn naturally picks it up.</p>
+<p>Two failed approaches and one current workaround:</p>
+<ul>
+<li><strong>Naive shell-out</strong> — daemon (or a hook) calls
+<code>cockpit runtime send &lt;captain&gt; &quot;&lt;msg&gt;&quot;</code>. cmux
+rejects this because the caller&#39;s PID is not in cmux&#39;s process-tree
+(cmux enforces a process-lineage check, not an env-var/socket-token
+check).</li>
+<li><strong>Daemon push events</strong> — same problem: whatever process
+the daemon delegates to is not parented by cmux.</li>
+<li><strong><code>notify-relay</code> tab inside the captain
+workspace</strong> — daemon broadcasts events over its Unix socket; a
+long-lived &quot;relay&quot; terminal tab <em>inside</em> the captain&#39;s cmux
+workspace subscribes to that socket and forwards via the cmux send
+pathway, which works because the relay is itself a cmux-spawned child.
+This is correct but feels heavy: an extra tab per captain, a daemon-side
+fanout, and a per-runtime relay impl.</li>
+</ul>
+<p>The interesting question is what <em>category</em> of mechanism prior
+art uses, and whether the relay-tab is an instance of a known good
+pattern or a workaround we should retire.</p>
+<hr />
+<h2 id="1-the-surveyed-systems-6--background">1. The Surveyed Systems
+(≥6 + background)</h2>
+<p>Each entry answers: captain↔︎crew analog · completion signal · signal
+landing · supervisor delivery · broker · process model · failure mode ·
+abstraction surface.</p>
+<h3 id="11-openhands-formerly-opendevin--githubcomall-hands-aiopenhands">1.1
+OpenHands (formerly OpenDevin) — github.com/All-Hands-AI/OpenHands</h3>
+<ul>
+<li><strong>Analog:</strong> <code>AgentController</code> ⇄
+<code>Runtime</code> (sandboxed exec env) and child agent
+delegates.</li>
+<li><strong>Signal:</strong> Typed
+<code>Action</code>/<code>Observation</code> events. Crew posts an
+<code>Observation</code>; &quot;done&quot; is a specific terminal observation
+(e.g. <code>AgentFinishAction</code>).</li>
+<li><strong>Lands first:</strong> In-process <code>EventStream</code> —
+a central pub/sub hub. Quoting OpenHands docs: <em>&quot;The EventStream is a
+central hub for Events, where any component can publish Events, or
+listen for Events published by other components.&quot;</em> (<a href="https://www.emergentmind.com/topics/openhands-agent-framework">emergentmind</a>,
+<a href="https://deepwiki.com/OpenHands/OpenHands">DeepWiki</a>)</li>
+<li><strong>Supervisor delivery:</strong> <code>AgentController</code>
+is a registered subscriber — <em>&quot;The AgentController performs Event
+Stream Subscription, subscribing to
+<code>EventStreamSubscriber.AGENT_CONTROLLER</code> unless it&#39;s a
+delegate.&quot;</em></li>
+<li><strong>Broker:</strong> Yes — <code>EventStream</code> is the
+broker, persists events to disk for replay/history (PR #2709,
+<em>Refactoring: event stream based agent history</em>).</li>
+<li><strong>Process model:</strong> Single Python process owns the
+controller + event stream; runtime executes in a sandboxed
+subprocess/container; events cross that boundary as serialized
+messages.</li>
+<li><strong>Failure mode:</strong> Replayable — event log on disk means
+a restarted controller reconstructs state.</li>
+<li><strong>Abstraction:</strong> Excellent. Subscribers see typed
+events; no IPC primitives leak.</li>
+</ul>
+<h3 id="12-autogen-microsoft--githubcommicrosoftautogen">1.2 AutoGen
+(Microsoft) — github.com/microsoft/autogen</h3>
+<ul>
+<li><strong>Analog:</strong> <code>GroupChatManager</code> ⇄ participant
+agents.</li>
+<li><strong>Signal:</strong> Agents publish chat messages to topics;
+&quot;turn done&quot; = manager observes the latest message and decides next
+speaker (or a <code>GroupChatTermination</code> event for
+done-with-everything).</li>
+<li><strong>Lands first:</strong> AutoGen Core&#39;s <strong>agent
+runtime</strong> — a pub/sub message bus with <strong>topic-based
+routing</strong>. Per the source: a <em>group topic</em> (broadcast),
+per-participant topics (direct), and an <em>output topic</em> (results
+channel).</li>
+<li><strong>Supervisor delivery:</strong> Manager is a
+<code>SequentialRoutedAgent</code> subscribed to the group topic. Output
+collection: <code>_output_message_queue</code> until a
+<code>GroupChatTermination</code> event arrives.</li>
+<li><strong>Broker:</strong> Yes — the <code>AgentRuntime</code>
+(in-process local, or distributed gRPC variant).</li>
+<li><strong>Process model:</strong> Configurable. Default: all agents in
+one Python process. Distributed: agents on separate hosts behind a gRPC
+runtime.</li>
+<li><strong>Failure mode:</strong> In-memory loss by default;
+distributed variant adds delivery guarantees.</li>
+<li><strong>Abstraction:</strong> Strong. Agents only know
+<code>publish_message(topic, msg)</code> and subscriptions — never
+sockets.</li>
+</ul>
+<h3 id="13-crewai--githubcomcrewaiinccrewai">1.3 crewAI —
+github.com/crewAIInc/crewAI</h3>
+<ul>
+<li><strong>Analog:</strong> <code>Crew</code> ⇄ <code>Task</code> ⇄
+<code>Agent</code>.</li>
+<li><strong>Signal:</strong> Plain Python function return.
+<code>task.execute_sync()</code> returns; <code>Crew.kickoff()</code>
+loops sequentially over tasks. Optional
+<strong><code>task_callback</code></strong> fires after each task;
+<strong><code>step_callback</code></strong> fires after each agent step.
+For the HTTP-API surface, equivalents are
+<code>taskWebhookUrl</code>/<code>stepWebhookUrl</code>/<code>crewWebhookUrl</code>
+(<a href="https://docs.crewai.com/en/learn/sequential-process">CrewAI
+docs</a>, <a href="https://community.crewai.com/t/how-does-the-task-callback-parameter-work/389">community
+thread</a>).</li>
+<li><strong>Lands first:</strong> Same Python stack frame (sync) or
+webhook receiver (API mode).</li>
+<li><strong>Supervisor delivery:</strong> Loop continuation; callback
+invocation.</li>
+<li><strong>Broker:</strong> None (in-process). Webhooks are the only
+out-of-process surface.</li>
+<li><strong>Process model:</strong> Single Python process for the local
+SDK. Tasks are not subprocesses.</li>
+<li><strong>Failure mode:</strong> Exceptions bubble; no built-in
+replay.</li>
+<li><strong>Abstraction:</strong> Sync function semantics — simplest
+possible.</li>
+</ul>
+<h3 id="14-langgraph-langchain-ai--multi-agent-supervisor-pattern">1.4
+LangGraph (langchain-ai) — multi-agent supervisor pattern</h3>
+<ul>
+<li><strong>Analog:</strong> Supervisor node ⇄ worker nodes in a state
+graph.</li>
+<li><strong>Signal:</strong> Workers return a
+<strong><code>Command</code></strong> object. Specifically
+<code>Command(goto=target, graph=Command.PARENT, update={...})</code> to
+hand control somewhere; <code>create_handoff_back_messages()</code> to
+return to supervisor with <code>__is_handoff_back</code> marker (<a href="https://deepwiki.com/langchain-ai/langgraph-supervisor-py/3.2-handoff-tools">DeepWiki:
+Handoff Tools</a>).</li>
+<li><strong>Lands first:</strong> The LangGraph runtime — interprets the
+<code>Command</code> and transitions the state graph.</li>
+<li><strong>Supervisor delivery:</strong> Next graph step; supervisor&#39;s
+prompt rebuilt with appended messages.</li>
+<li><strong>Broker:</strong> The graph runtime itself.</li>
+<li><strong>Process model:</strong> Single Python process; node
+executions are awaited coroutines.</li>
+<li><strong>Failure mode:</strong> Checkpointer persists graph state;
+resumable.</li>
+<li><strong>Abstraction:</strong> Very clean — declarative graph, no IPC
+visible.</li>
+</ul>
+<h3 id="15-openai-swarm--githubcomopenaiswarm">1.5 OpenAI Swarm —
+github.com/openai/swarm</h3>
+<ul>
+<li><strong>Analog:</strong> &quot;Current agent&quot; ⇄ &quot;next agent&quot; via
+handoff.</li>
+<li><strong>Signal:</strong> A tool function returns an
+<code>Agent</code> (or <code>Result(agent=...)</code>). The run loop
+swaps to it. <em>&quot;Swarm&#39;s <code>run()</code> function is analogous to
+<code>chat.completions.create()</code> — it takes <code>messages</code>
+and returns <code>messages</code> and saves no state between
+calls.&quot;</em></li>
+<li><strong>Lands first:</strong> Same Python stack; the loop sees the
+returned <code>Agent</code> and continues with it.</li>
+<li><strong>Supervisor delivery:</strong> Function return —
+synchronous.</li>
+<li><strong>Broker:</strong> None. Stateless.</li>
+<li><strong>Process model:</strong> Single Python process, single linear
+loop.</li>
+<li><strong>Failure mode:</strong> Caller&#39;s problem; no
+persistence.</li>
+<li><strong>Abstraction:</strong> Minimal: a function returns the next
+worker.</li>
+</ul>
+<h3 id="16-tmux-orchestrator--githubcomjedward23tmux-orchestrator">1.6
+Tmux-Orchestrator — github.com/Jedward23/Tmux-Orchestrator</h3>
+<p>This is the closest cousin to cockpit and the most instructive
+comparison.</p>
+<ul>
+<li><strong>Analog:</strong> Orchestrator → Project Managers →
+Engineers, each as a separate tmux window running its own Claude
+instance.</li>
+<li><strong>Signal:</strong> <strong>Polled + self-scheduled.</strong>
+No async push exists. A Claude instance schedules its own check-in via
+<code>schedule_with_note.sh 30 &quot;Continue dashboard implementation&quot;</code>.
+The orchestrator periodically reads pane content via
+<code>tmux capture-pane</code>.</li>
+<li><strong>Lands first:</strong> Tmux&#39;s own pane scrollback (text). The
+&quot;broker&quot; is <em>the screen</em>.</li>
+<li><strong>Supervisor delivery:</strong> Orchestrator polls + reads +
+interprets. To talk back:
+<code>send-claude-message.sh session:window &quot;msg&quot;</code>, which
+<code>tmux send-keys</code>&#39;s the text into the target pane. This is the
+exact equivalent of cockpit&#39;s <code>cockpit runtime send</code> — and it
+works in tmux because tmux does <strong>not</strong> enforce a
+process-lineage check on the writer (anyone with socket perms can
+<code>send-keys</code>).</li>
+<li><strong>Broker:</strong> None — tmux is both transport and
+storage.</li>
+<li><strong>Process model:</strong> Multi-process; each Claude is a
+child of its tmux pane.</li>
+<li><strong>Failure mode:</strong> Lost work is unbounded if the
+orchestrator never checks back. The self-scheduling pattern is the only
+safety net.</li>
+<li><strong>Abstraction:</strong> Leaky — scripts that scrape and inject
+text. The prompt-engineering rules are the contract.</li>
+</ul>
+<p><strong>Cockpit-relevant lesson:</strong> Tmux-Orchestrator works
+because tmux&#39;s authorization model is &quot;owner of the socket&quot; — no lineage
+check. cmux&#39;s stricter check is what forces cockpit to host the sender
+inside cmux&#39;s tree. Tmux-Orchestrator also reveals the
+<strong>cooperative-callback pattern</strong> that Orca later
+formalized.</p>
+<h3 id="17-claude-squad--githubcomsmtg-aiclaude-squad">1.7 Claude Squad
+— github.com/smtg-ai/claude-squad</h3>
+<ul>
+<li><strong>Analog:</strong> N independent Claude instances, each in its
+own git worktree + tmux session.</li>
+<li><strong>Signal:</strong> <strong>None automatic.</strong> Completion
+is human-detected via the TUI (preview/diff tabs, manual <code>c</code>
+checkout / <code>r</code> resume).</li>
+<li><strong>Lands first:</strong> User&#39;s eyes.</li>
+<li><strong>Supervisor delivery:</strong> User.</li>
+<li><strong>Broker:</strong> None.</li>
+<li><strong>Process model:</strong> Multi-process, isolated
+worktrees.</li>
+<li><strong>Failure mode:</strong> Human in the loop.</li>
+<li><strong>Abstraction:</strong> Deliberately <em>not</em> an
+orchestrator — explicitly says it leaves coordination to the human.</li>
+</ul>
+<p><strong>Lesson:</strong> A respected multi-Claude tool ducked the
+captain↔︎crew problem entirely. Cockpit&#39;s ambition (autonomous captain
+reacting to crew) is meaningfully harder than what Claude Squad
+attempts.</p>
+<h3 id="18-orca-stablyai--githubcomstablyaiorca-already-studied">1.8
+Orca (stablyai) — github.com/stablyai/orca (already studied)</h3>
+<ul>
+<li><strong>Analog:</strong> Coordinator + per-agent terminal panes
+(PTY-hosted).</li>
+<li><strong>Signal:</strong> Two simultaneous channels, depending on
+agent:
+<ol type="1">
+<li><strong>Native hooks → loopback HTTP</strong> (Claude Code &amp;
+Codex 0.129+). Hooks <code>curl</code> a JSON payload to
+<code>http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/&lt;agent&gt;</code>
+with a bearer token. <code>Stop</code> event = turn done. See
+<code>src/main/codex/hook-service.ts:42-49</code> and
+<code>src/main/agent-hooks/server.ts</code>.</li>
+<li><strong>Cooperative CLI callback</strong> for the autonomous
+coordinator: prompt preamble teaches the agent to call
+<code>orca task complete --body &lt;summary&gt;</code>, plus a 10-min
+stale-heartbeat watchdog
+(<code>src/main/runtime/orchestration/coordinator.ts:172,230,332-335</code>).</li>
+</ol></li>
+<li><strong>Lands first:</strong> Orca&#39;s main Electron process (HTTP
+server + IPC). Persisted in <code>last-status.json</code> for restart
+survival.</li>
+<li><strong>Supervisor delivery:</strong> IPC fanout to the renderer
+process / orchestration coordinator.</li>
+<li><strong>Broker:</strong> The loopback HTTP server + on-disk status
+cache.</li>
+<li><strong>Process model:</strong> Multi-process; each agent is its own
+<code>node-pty</code> child. Orca itself owns the broker.</li>
+<li><strong>Failure mode:</strong> Replay from
+<code>last-status.json</code>; hook script re-reads
+<code>$ORCA_AGENT_HOOK_ENDPOINT</code> so it survives Orca restart on
+the <em>same</em> PTY.</li>
+<li><strong>Abstraction:</strong> Excellent inside Orca; leaks through
+the hook config files in <code>~/.codex/hooks.json</code> and
+<code>~/.codex/config.toml</code>.</li>
+</ul>
+<h3 id="19-codename-goose-block--githubcomblockgoose">1.9 Codename Goose
+(Block) — github.com/block/goose</h3>
+<ul>
+<li><strong>Analog:</strong> Single agent + MCP
+<strong>extensions</strong> (tool servers).</li>
+<li><strong>Signal:</strong> Standard MCP — JSON-RPC over
+stdio/SSE/streamable HTTP. <em>Not a multi-agent coordinator.</em>
+There&#39;s no inter-extension event bus; extensions are tool providers, not
+peer agents.</li>
+<li><strong>Lands first:</strong> MCP client transport.</li>
+<li><strong>Process model:</strong> Goose host + one subprocess per
+stdio extension.</li>
+<li><strong>Lesson for cockpit:</strong> MCP is a <em>tool-call</em>
+protocol, not a peer-to-peer notification protocol. Modeling
+crew→captain as an MCP tool call would invert the right direction
+(captain pulls, never pushed).</li>
+</ul>
+<h3 id="110-codex-cli-app-server-openai--see-docsresearch2026-05-19-orca-codex-wrapping-studymd">1.10
+Codex CLI app-server (OpenAI) — see
+<code>docs/research/2026-05-19-orca-codex-wrapping-study.md</code></h3>
+<ul>
+<li><strong>Analog:</strong> Driver process ⇄ codex child via JSON-RPC
+over stdio.</li>
+<li><strong>Signal:</strong> Notifications in the JSON-RPC stream
+(<code>turn.completed</code>, etc.), framed as newline-delimited
+JSON.</li>
+<li><strong>Lands first:</strong> Driver&#39;s stdio reader.</li>
+<li><strong>Broker:</strong> None — direct stdio.</li>
+<li><strong>Process model:</strong> Parent owns the child via pipe.</li>
+<li><strong>Lesson:</strong> Strong typed-event channel <strong>but only
+between a parent and its own child</strong>. Useless if the captain
+isn&#39;t the codex parent — which is exactly the cockpit constraint (cmux
+owns the codex/claude child, not cockpit&#39;s daemon).</li>
+</ul>
+<h3 id="111-background--process-coordination-prior-art">1.11 Background
+— process-coordination prior art</h3>
+<table>
+<thead>
+<tr>
+<th>System</th>
+<th>One-line lesson</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>systemd <code>sd_notify</code></strong></td>
+<td>Single UDP-style datagram to <code>$NOTIFY_SOCKET</code> (Unix
+DGRAM). <code>READY=1</code>, <code>STATUS=…</code>,
+<code>WATCHDOG=1</code>. Auth via <code>SCM_CREDENTIALS</code>. No
+broker, no queue — fire-and-forget but reliable on localhost. (<a href="https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html">sd_notify
+man</a>)</td>
+</tr>
+<tr>
+<td><strong>D-Bus</strong></td>
+<td>Mature pub/sub: signals broadcast; clients register interest; bus
+daemon fans out. Strong typing via introspection. Transport: Unix domain
+sockets. (<a href="https://dbus.freedesktop.org/doc/dbus-specification.html">spec</a>)</td>
+</tr>
+<tr>
+<td><strong>macOS XPC</strong></td>
+<td>Modern client/server IPC with privilege separation; the recommended
+replacement for <code>NSDistributedNotificationCenter</code> (which
+can&#39;t carry user info).</td>
+</tr>
+<tr>
+<td><strong>Erlang/OTP</strong></td>
+<td>Supervisor <code>monitor</code>s worker process; worker death →
+<code>{&#39;DOWN&#39;, Ref, ...}</code> lands in supervisor&#39;s <em>mailbox</em>
+(a queue per process). Mailbox is the broker; pattern-match dequeue.
+Gold-standard fault-tolerance semantics.</td>
+</tr>
+<tr>
+<td><strong>OpenTelemetry collector</strong></td>
+<td><code>receiver → processor → exporter</code> pipeline; receivers are
+pluggable transports; same data can fan out to N exporters. Mirrors
+cockpit&#39;s &quot;event from any runtime → many sinks (TUI, Telegram, push)&quot;
+need.</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="2-comparison-table">2. Comparison Table</h2>
+<table>
+<thead>
+<tr>
+<th>System</th>
+<th>Process model</th>
+<th>Signal mechanism</th>
+<th>Delivery</th>
+<th>Reliability</th>
+<th>Abstraction</th>
+<th>Cockpit-applicable insight</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>OpenHands</td>
+<td>1 host + sandbox subproc</td>
+<td>Typed event in <code>EventStream</code></td>
+<td>Subscriber callback (push)</td>
+<td>Disk-replayable</td>
+<td>Strong (events)</td>
+<td>Central in-process bus + on-disk log = best decoupling story</td>
+</tr>
+<tr>
+<td>AutoGen</td>
+<td>1 proc (or gRPC)</td>
+<td>Topic-pub/sub message</td>
+<td>Topic subscriber</td>
+<td>In-mem (local) / guaranteed (gRPC)</td>
+<td>Strong</td>
+<td>Topic routing scales to many-to-many</td>
+</tr>
+<tr>
+<td>crewAI</td>
+<td>1 proc</td>
+<td>Function return + callback</td>
+<td>Loop continuation</td>
+<td>None</td>
+<td>Trivial</td>
+<td>Don&#39;t over-engineer if you control the loop</td>
+</tr>
+<tr>
+<td>LangGraph</td>
+<td>1 proc</td>
+<td><code>Command(goto=…)</code> value</td>
+<td>Graph step</td>
+<td>Checkpointed</td>
+<td>Declarative</td>
+<td>Express handoff as data, not IPC</td>
+</tr>
+<tr>
+<td>OpenAI Swarm</td>
+<td>1 proc</td>
+<td>Function returns <code>Agent</code></td>
+<td>Loop continuation</td>
+<td>None</td>
+<td>Trivial</td>
+<td>Stateless transfer is enough when in-process</td>
+</tr>
+<tr>
+<td>Tmux-Orchestrator</td>
+<td>Multi-proc (tmux)</td>
+<td>Scrape pane + <code>send-keys</code></td>
+<td>Poll + injected text</td>
+<td>Lost if unread</td>
+<td>Leaky</td>
+<td>tmux allows external sender → no relay needed there</td>
+</tr>
+<tr>
+<td>Claude Squad</td>
+<td>Multi-proc (tmux)</td>
+<td>None — human checks</td>
+<td>Manual</td>
+<td>N/A</td>
+<td>N/A</td>
+<td>Punted entirely</td>
+</tr>
+<tr>
+<td>Orca</td>
+<td>Multi-proc (PTY)</td>
+<td>Native hooks → loopback HTTP</td>
+<td>HTTP POST + IPC fanout</td>
+<td>Disk-cached</td>
+<td>Strong</td>
+<td><strong>Hooks-as-source-of-truth + broker is the winning
+pattern</strong></td>
+</tr>
+<tr>
+<td>Goose (MCP)</td>
+<td>Multi-proc (MCP)</td>
+<td>JSON-RPC tool call</td>
+<td>Caller awaits</td>
+<td>Per-call</td>
+<td>Strong</td>
+<td>Wrong direction for completion notify</td>
+</tr>
+<tr>
+<td>Codex app-server</td>
+<td>Parent + child</td>
+<td>JSON-RPC notification</td>
+<td>stdio read</td>
+<td>Stream lifetime</td>
+<td>Strong</td>
+<td>Requires parent-of-child relationship</td>
+</tr>
+<tr>
+<td>systemd sd_notify</td>
+<td>Multi-proc</td>
+<td>Unix DGRAM</td>
+<td>Daemon recv</td>
+<td>Localhost-reliable</td>
+<td>Strong</td>
+<td>Smallest viable IPC</td>
+</tr>
+<tr>
+<td>D-Bus</td>
+<td>Multi-proc</td>
+<td>Signal broadcast</td>
+<td>Bus fanout</td>
+<td>Bus-mediated</td>
+<td>Strong</td>
+<td>Real-world pub/sub at OS level</td>
+</tr>
+<tr>
+<td>Erlang/OTP</td>
+<td>Multi-proc (BEAM)</td>
+<td><code>monitor</code> + mailbox</td>
+<td>Mailbox dequeue</td>
+<td>Queued</td>
+<td>Gold</td>
+<td>Per-supervisor mailbox = ideal mental model</td>
+</tr>
+<tr>
+<td>OTel collector</td>
+<td>Pluggable</td>
+<td>Receiver → exporter pipeline</td>
+<td>Push</td>
+<td>Configurable</td>
+<td>Strong</td>
+<td>One event, many sinks (TUI/push/file)</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="3-recommendations-for-cockpit-ranked">3. Recommendations for
+cockpit (ranked)</h2>
+<p>I&#39;m ranking <strong>3 patterns</strong> by fit, given cockpit&#39;s hard
+constraints:</p>
+<ol type="1">
+<li>Multi-runtime (Claude Code, Codex, Gemini, Aider, opencode).</li>
+<li>Multi-host runtime (cmux today; Orca, Zed, IntelliJ-MCP
+tomorrow).</li>
+<li>The captain runs in a <em>real shell inside the runtime&#39;s pane</em>
+and consumes input from that runtime&#39;s input mechanism.</li>
+<li>cmux enforces a process-lineage check: the writer to the captain&#39;s
+pane <strong>must</strong> be in cmux&#39;s process tree.</li>
+</ol>
+<h3 id="rank-1--mailbox--injector-pattern-erlang--orca-hybrid-strongly-recommended">Rank
+1 — <strong>Mailbox + injector pattern</strong> (Erlang + Orca hybrid).
+Strongly recommended.</h3>
+<p><strong>Mechanism.</strong> The cockpit daemon is the
+<strong>broker</strong> (Erlang&#39;s <code>gen_server</code> analog). Every
+captain has a <strong>mailbox</strong>: a queue on the daemon&#39;s side
+keyed by captain-id. Each runtime registers exactly <strong>one
+injector</strong> — a tiny long-lived process <em>inside that runtime&#39;s
+process tree</em> — whose only job is to dequeue from the captain&#39;s
+mailbox and call the runtime-specific &quot;type into pane&quot; API. The injector
+is the cockpit-side analog of the <strong><code>notify-relay</code> tab
+you already have</strong>, but generalized and dignified as a
+first-class architectural element rather than an &quot;extra terminal
+tab.&quot;</p>
+<p><strong>Why this is the right rebranding of what you&#39;ve
+built.</strong></p>
+<ul>
+<li>The relay-tab is not a workaround — it is the same pattern Erlang
+uses (the per-process mailbox needs a per-process dequeuer that runs
+<em>inside</em> that process&#39;s scheduler). cmux&#39;s lineage check is the
+equivalent of the BEAM scheduler boundary: only the right context can
+deliver. You were right to put a process inside cmux; you were wrong to
+feel bad about it.</li>
+<li>The mailbox semantics fix the failure mode the current design
+<em>doesn&#39;t</em> address well: if the captain is mid-turn, mid-shutdown,
+or briefly absent, events queue rather than vanish. (Today the relay tab
+forwards immediately; if the captain pane is busy, cmux send may swallow
+the input.)</li>
+<li>One injector per runtime, not per captain: a single
+<code>cockpit-injector</code> daemon process per cmux instance can serve
+every captain hosted there.</li>
+</ul>
+<p><strong>Concrete sketch replacing the relay-tab.</strong></p>
+<ul>
+<li>Daemon exposes <code>MailboxAppend(captainId, event)</code> and
+<code>MailboxClaim(captainId, sinceCursor) → events</code>.</li>
+<li>Runtime driver implements <code>Injector(runtime, captainId)</code>
+— a small Go/Node/Python binary started by <code>cmux spawn</code> as a
+hidden helper process inside the captain&#39;s workspace. Long-poll
+<code>MailboxClaim</code>, then call the runtime&#39;s send mechanism. On
+startup the injector also drains any backlog accumulated while the
+captain was idle.</li>
+<li>Captain shutdown removes the mailbox; restart restores it from disk
+(Orca-style <code>last-status.json</code> analog).</li>
+<li>Tracker integration: the daemon&#39;s existing socket pub/sub becomes a
+<em>receiver</em> in OTel-collector parlance; the mailbox is a
+<em>processor</em>; the injector is the only <em>exporter</em> that has
+to satisfy cmux&#39;s lineage rule. Telegram, TUI, and push notifications
+continue to subscribe to the receiver directly — they don&#39;t go through
+the lineage-bound exporter.</li>
+</ul>
+<p><strong>Handles cmux&#39;s lineage check:</strong> Yes — the injector is
+spawned by cmux and lives inside its tree by definition. For
+Orca/Zed/IntelliJ-MCP, the same injector concept reincarnates as: an
+Orca pane hosting <code>cockpit-injector orca</code>; a Zed task; an
+IntelliJ background process. Each runtime driver owns its injector
+binary; the mailbox protocol is shared.</p>
+<p><strong>Complexity tradeoff:</strong> Mid. You already have most of
+this (daemon socket pub/sub + relay tab). The work is (a) adding a queue
++ cursor on the daemon side, (b) generalizing the relay into a
+<code>cockpit-injector</code> binary that any runtime can spawn, (c)
+shipping a per-runtime &quot;start injector at workspace open&quot; lifecycle
+hook.</p>
+<h3 id="rank-2--hooks-into-loopback-broker-orca-pattern-generalized">Rank 2
+— <strong>Hooks-into-loopback-broker</strong> (Orca pattern,
+generalized).</h3>
+<p><strong>Mechanism.</strong> Every supported agent CLI has
+<em>some</em> native completion hook (Claude Code: <code>Stop</code>
+hook; Codex 0.129+: <code>Stop</code> hook; Gemini: still TBD; Aider:
+<code>--message</code> mode returns; opencode: events). The hook
+<code>curl</code>s a loopback HTTP endpoint on the daemon. The daemon
+now has the authoritative &quot;crew X is done&quot; signal <em>from the agent
+itself</em>, not from process-watching or PTY-scraping.</p>
+<p><strong>This solves a different problem</strong> — it&#39;s about
+<strong>detection</strong>, not <strong>delivery</strong>. You still
+need pattern #1 (or #3) to <em>get the news into the captain&#39;s
+input</em>. But pairing #2 with #1 gives cockpit a complete loop:</p>
+<ul>
+<li>Detection: native hook → daemon (Orca-validated).</li>
+<li>Delivery: daemon mailbox → in-cmux injector (Rank 1).</li>
+</ul>
+<p><strong>Handles cmux&#39;s lineage check:</strong> Irrelevant for
+detection. Delivery still needs Rank 1.</p>
+<p><strong>Why not rank it #1:</strong> You implicitly already have
+detection (cmux&#39;s <code>read-screen</code> + your own heuristics). The
+acute pain is delivery, not detection. Adopt #2 incrementally as each
+runtime gains native hooks, but it doesn&#39;t supplant #1.</p>
+<h3 id="rank-3--captain-side-polling-against-the-daemon-socket-the-do-nothing-in-cmux-option">Rank
+3 — <strong>Captain-side polling against the daemon socket</strong> (the
+&quot;do nothing in-cmux&quot; option).</h3>
+<p><strong>Mechanism.</strong> Drop the relay tab entirely. Teach the
+captain — via its system prompt / a skill — to <strong>periodically run
+a CLI command</strong> (<code>cockpit inbox</code>) inside its own loop,
+which reads from the daemon socket and returns new events as plain text.
+The captain has shell access; calling a CLI is well within its
+toolset.</p>
+<p><strong>Why this is tempting.</strong> Zero extra processes. Zero
+relay. The captain is the one with cmux-blessed input access (it
+<em>is</em> the cmux child), so by definition any text it generates
+lands in the right place. The &quot;delivery&quot; step becomes &quot;captain prints
+what it reads.&quot; Polling cadence is captain-decided.</p>
+<p><strong>Why it&#39;s #3, not #1.</strong> It changes captain semantics
+from <em>reactive</em> to <em>proactive</em>. A captain that&#39;s mid-turn
+won&#39;t poll. A captain that&#39;s stuck in a tool call doesn&#39;t notice the
+crew finished. The whole point of push-notification was to make the
+captain wake up when crew lands; rank 3 quietly returns to polling,
+which we already rejected in the 2026-05-16 idle-detection research. Use
+only as a fallback for runtimes where injector-spawn isn&#39;t possible.</p>
+<p><strong>Handles cmux&#39;s lineage check:</strong> Trivially — there is
+no external sender.</p>
+<p><strong>For Orca/Zed/IntelliJ-MCP:</strong> Works in all of them.
+This is the universal-fallback path.</p>
+<hr />
+<h2 id="4-synthesis-the-proposed-design">4. Synthesis: the proposed
+design</h2>
+<pre><code>                 ┌──────────────────┐
+   crew event ──▶│  daemon receiver │ (existing)
+                 └────────┬─────────┘
+                          │ fanout
+            ┌─────────────┼─────────────────┐
+            ▼             ▼                 ▼
+        Telegram       TUI/push     ┌─────────────────┐
+                                    │ per-captain     │
+                                    │ mailbox (queue) │ (NEW)
+                                    └────────┬────────┘
+                                             │ long-poll
+                                             ▼
+                                  ┌─────────────────────┐
+                                  │ cockpit-injector    │  ◀── spawned by cmux,
+                                  │ (1 per runtime host)│      lives in cmux tree
+                                  └────────┬────────────┘
+                                           │ runtime.send()
+                                           ▼
+                                    captain&#39;s input</code></pre>
+<p>This is <strong>the relay-tab pattern, renamed and
+dignified</strong>: the relay becomes a first-class &quot;injector&quot; with a
+queue behind it. Add native-hook detection (Orca pattern, Rank 2) as
+runtimes support it. Keep CLI-poll (Rank 3) as the never-fails fallback
+the captain can always run.</p>
+<h3 id="what-this-buys-you-vs-the-current-relay-tab">What this buys you
+vs. the current relay-tab</h3>
+<ul>
+<li><strong>Buffering</strong> — events don&#39;t vanish if the captain pane
+is briefly busy.</li>
+<li><strong>Restart survival</strong> — mailbox is durable; injector
+restart drains backlog.</li>
+<li><strong>One concept, all runtimes</strong> — Orca/Zed/IntelliJ get
+the same protocol; only the injector binary changes per runtime.</li>
+<li><strong>No new IPC primitives</strong> — uses your existing daemon
+socket; the mailbox is just a map&lt;captainId, []event&gt; on the
+daemon plus a cursor.</li>
+<li><strong>Tracker stays decoupled</strong> — receivers, processors
+(mailbox), exporters (injector) is the OTel-collector shape, which makes
+&quot;send the same event to Telegram and the captain&quot; a config concern
+rather than a code concern.</li>
+</ul>
+<hr />
+<h2 id="provider-coverage-audit--claude--codex--opencode">Provider
+Coverage Audit — Claude / Codex / Opencode</h2>
+<p>The relay/notify pattern in section 3 assumes each runtime provider
+can hand cockpit a &quot;crew finished&quot; signal. Today claude-code emits this
+via <code>Stop</code> / <code>SessionEnd</code> hooks (PR #108) and
+codex emits it via app-server JSON-RPC notifications (PR #97/#98).
+Opencode interactive crews currently route through the legacy cmux-only
+spawn path (<code>src/commands/crew.ts:163</code>) — the daemon is
+unaware of them. This audit answers whether opencode can be wired into
+the same notify loop, and what shape that wiring should take.</p>
+<h3 id="findings--opencode-sstopencode">Findings — opencode
+(sst/opencode)</h3>
+<ol type="1">
+<li><p><strong>Hook / lifecycle event system — YES, via the plugin
+system.</strong> Opencode ships a first-class plugin framework. A plugin
+is a TypeScript module placed under <code>.opencode/plugin/*.ts</code>
+or wired through <code>opencode.json → plugins</code>. Plugins receive
+an async <code>event</code> callback and can also wrap tool execution
+with <code>tool.execute.before</code> / <code>tool.execute.after</code>.
+Documented event names include <code>session.idle</code> and
+tool-execution events; the DEV.to overview and the SDK page both
+reference these as the canonical extension surface (<a href="https://dev.to/einarcesar/does-opencode-support-hooks-a-complete-guide-to-extensibility-k3p">dev.to
+&quot;Does OpenCode Support Hooks?&quot;</a>, <a href="https://opencode.ai/docs/sdk/">OpenCode SDK docs</a>). DeepWiki&#39;s
+session-lifecycle page confirms a <code>session_start</code> /
+<code>session_idle</code> / <code>session_end</code> taxonomy on the
+event bus but does not enumerate the exact wire names (<a href="https://deepwiki.com/sst/opencode/2.1-session-lifecycle-and-state">DeepWiki
+§2.1 session lifecycle</a>). <strong>Unable to confirm via public
+docs</strong> whether <code>session.end</code> is a stable
+plugin-callable event or only an internal-bus event; the safe assumption
+is <code>session.idle</code> (the documented one) is the closest &quot;turn
+done&quot; analog for cockpit&#39;s purposes.</p></li>
+<li><p><strong>App-server / streaming protocol — YES, but it&#39;s HTTP REST
++ SSE, not JSON-RPC.</strong> <code>opencode serve</code> starts a
+headless HTTP server exposing an OpenAPI 3.1 spec; flags include
+<code>--port</code>, <code>--hostname</code>, <code>--mdns</code>,
+<code>--cors</code>, and <code>OPENCODE_SERVER_PASSWORD</code> for basic
+auth (<a href="https://opencode.ai/docs/server/">Server docs</a>). Two
+SSE endpoints stream the event bus: <code>GET /event</code>
+(per-session/global bus; first message is <code>server.connected</code>,
+then bus events) and <code>GET /global/event</code>. This is a
+long-lived subscribe pattern; a daemon can keep one HTTP connection open
+and receive every bus event for the life of the server.</p></li>
+<li><p><strong>MCP — opencode is an MCP <em>client</em>, not an MCP
+server exposing lifecycle events.</strong> Opencode&#39;s MCP integration is
+for <em>adding tools to opencode</em>, not for letting outside processes
+subscribe to opencode events (<a href="https://opencode.ai/docs/mcp-servers/">MCP docs</a>). The Goose
+lesson from §1.9 applies: MCP is the wrong direction for
+completion-notify.</p></li>
+<li><p><strong><code>opencode run --format json</code> — YES.</strong>
+The <code>run</code> subcommand supports <code>--format json</code>,
+documented as &quot;raw JSON events&quot;. Combined with
+<code>--session &lt;id&gt;</code> / <code>--continue</code> /
+<code>--fork</code>, this gives a headless invocation that streams
+structured events to stdout — usable from a non-cmux wrapper, though for
+the cockpit-interactive case the SSE bus is the better channel because
+it persists across multiple turns.</p></li>
+<li><p><strong>Programmatic SDKs — YES.</strong> Official
+<code>@opencode-ai/sdk</code> (TypeScript) wraps the HTTP + SSE surface
+in typed methods including <code>event.subscribe()</code> (<a href="https://deepwiki.com/sst/opencode/7.1-javascripttypescript-sdk">JS
+SDK DeepWiki</a>). Community-maintained Go
+(<code>opencode-sdk-go</code>) and Python
+(<code>opencode-sdk-python</code>) SDKs are generated from the same
+OpenAPI spec. Also worth flagging: opencode implements the <strong>Agent
+Client Protocol (ACP) over JSON-RPC</strong> for editor integrations
+(Zed et al.), exposing events like <code>permission.asked</code> and
+<code>usage_update</code> (<a href="https://deepwiki.com/sst/opencode/7.4-agent-client-protocol-(acp)">DeepWiki
+ACP</a>); ACP is a <em>second</em> event surface alongside the HTTP/SSE
+bus, used when something on the IDE side needs to be the agent&#39;s loop
+driver.</p></li>
+<li><p><strong>Resume semantics — YES.</strong> Both
+<code>opencode run</code> and the TUI accept <code>--continue</code>
+(<code>-c</code>), <code>--session &lt;id&gt;</code> (<code>-s</code>),
+and <code>--fork</code>. Sessions are persisted (SQLite via Drizzle ORM
+per the lifecycle page); reattaching after a daemon bounce is supported,
+with the daemon recovering the session-id from its own state rather than
+from opencode itself.</p></li>
+</ol>
+<h3 id="comparison-table">Comparison table</h3>
+<table>
+<thead>
+<tr>
+<th>Capability</th>
+<th>Claude</th>
+<th>Codex</th>
+<th>Opencode</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Hook system (file-configurable lifecycle events)</td>
+<td>YES — <code>settings.json</code> Stop / SubagentStop /
+SessionEnd</td>
+<td>NO native; Orca proves Codex 0.129+ adds <code>Stop</code> hooks but
+cockpit doesn&#39;t use them yet</td>
+<td>YES — TS plugin in <code>.opencode/plugin/*.ts</code>;
+<code>event</code> callback + tool before/after;
+<code>session.idle</code> documented</td>
+<td>Opencode plugin is code, not pure JSON, so harder to template than
+Claude&#39;s <code>settings.json</code> but more expressive</td>
+</tr>
+<tr>
+<td>App-server / streaming protocol</td>
+<td>NO (stdio CLI only)</td>
+<td>YES — app-server, JSON-RPC over stdio</td>
+<td>YES — <code>opencode serve</code> HTTP + SSE; ACP JSON-RPC also
+available</td>
+<td>Opencode is the only one with a <em>socket-listening</em> server out
+of the box</td>
+</tr>
+<tr>
+<td>MCP server interface (exposes events)</td>
+<td>Claude is MCP client only</td>
+<td>Codex is MCP client only</td>
+<td>Opencode is MCP client only</td>
+<td>None of the three lets cockpit subscribe via MCP</td>
+</tr>
+<tr>
+<td>JSON output mode (headless)</td>
+<td>YES — <code>claude -p --output-format=json</code></td>
+<td>YES — <code>codex exec --json</code></td>
+<td>YES — <code>opencode run --format json</code></td>
+<td>All three usable for one-shot non-interactive crews</td>
+</tr>
+<tr>
+<td>Session resume</td>
+<td>YES — <code>claude -c</code> / <code>--resume</code></td>
+<td>YES — <code>codex exec resume</code></td>
+<td>YES — <code>opencode run --session &lt;id&gt;</code> /
+<code>--continue</code> / <code>--fork</code></td>
+<td>All three persist sessions</td>
+</tr>
+<tr>
+<td>Programmatic SDK</td>
+<td>YES — <code>@anthropic-ai/claude-code</code> TS SDK</td>
+<td>CLI only (no first-party SDK as of 0.130)</td>
+<td>YES — <code>@opencode-ai/sdk</code> TS (official); Go &amp; Python
+(community, generated)</td>
+<td>Opencode has the richest SDK story</td>
+</tr>
+</tbody>
+</table>
+<h3 id="verdict--does-the-relaynotify-pattern-work-for-opencode">Verdict
+— does the relay/notify pattern work for opencode?</h3>
+<p><strong>Best path: SSE subscribe + a lightweight plugin
+emitter.</strong> Opencode is the <em>easiest</em> of the three
+providers to wire into the daemon. The daemon can connect once to
+<code>http://127.0.0.1:&lt;port&gt;/event</code> per running
+<code>opencode serve</code> and receive <code>session.idle</code> and
+other bus events with zero per-crew configuration. This is structurally
+identical to the codex app-server path (long-lived stream, daemon
+subscribes), differing only in transport (HTTP+SSE vs.
+JSON-RPC-over-stdio). To make the &quot;turn-done&quot; semantic explicit (rather
+than inferring from <code>session.idle</code>), cockpit can ship a tiny
+<code>.opencode/plugin/cockpit-emit.ts</code> that calls back into the
+daemon&#39;s <code>task.progress</code> endpoint on whatever lifecycle hook
+is most stable — this is the <em>exact same</em> shape as the PR #108
+claude-code hook, just expressed as a plugin instead of a
+<code>settings.json</code> entry. Net: opencode supports
+<strong>both</strong> of the prior patterns simultaneously, with the SSE
+path requiring zero crew-side config.</p>
+<p><strong>Fallback: app-server-style SSE alone.</strong> If the plugin
+emitter proves brittle (e.g. opencode plugin API changes between 0.x
+releases, which is plausible given the project&#39;s velocity), the daemon
+can rely purely on the documented SSE bus. <code>session.idle</code> is
+the canonical &quot;agent finished its turn&quot; signal per the public docs and
+is sufficient for the captain-attention use case. This is strictly the
+codex pattern, ported.</p>
+<p><strong>Universal fallback: explicit
+<code>cockpit crew signal done</code>.</strong> The crew template can
+always include an instruction to call
+<code>cockpit crew signal done</code> as the last action of any task —
+this is provider-agnostic and works today for opencode without any new
+wiring, at the cost of relying on the agent to remember to call it. This
+should remain in the opencode crew template as the belt-and-suspenders
+fallback even after auto-detection ships, mirroring the explicit-signal
+path that already exists for the claude path.</p>
+<p><strong>Ranked by honest-fit-for-opencode:</strong> (1) SSE subscribe
+with <code>session.idle</code> as the trigger — minimal moving parts,
+uses only documented public APIs, mirrors codex pattern. (2) Plugin
+emitter calling <code>task.progress</code> — most precise semantics, but
+ties cockpit to opencode&#39;s plugin API surface area. (3) Explicit
+<code>cockpit crew signal done</code> — always-works fallback, keep in
+template. <strong>Recommendation: ship (1) first, add (2) only if
+<code>session.idle</code> proves too noisy or imprecise, keep (3) in the
+template always.</strong></p>
+<p><strong>Does the section-3 architectural recommendation still hold
+across all three providers?</strong> <strong>Yes,
+unambiguously.</strong> The &quot;dignify the relay into a first-class
+injector with daemon-side mailbox&quot; verdict is <em>strengthened</em> by
+opencode entering the mix. Today the daemon receives three radically
+different completion signal shapes: file-configured hooks (claude),
+parent-of-child JSON-RPC (codex), and long-lived HTTP+SSE (opencode).
+The mailbox-plus-injector design is the only one of the three section-3
+ranks that absorbs all three transports cleanly: each runtime&#39;s driver
+translates its native event surface into
+<code>MailboxAppend(captainId, event)</code>, and the in-cmux injector
+remains the single lineage-blessed exporter. Without the mailbox
+abstraction, cockpit would need three parallel paths from
+detection-source straight to cmux send, each replicating its own
+buffering, retry, and lineage handling. The audit confirms detection is
+the easy part for all three providers; delivery into a
+process-lineage-restricted captain pane remains the hard part, and a
+per-captain mailbox is the right factoring of that responsibility.</p>
+<hr />
+<h2 id="5-inaccessible--partially-accessible-sources">5. Inaccessible /
+partially-accessible sources</h2>
+<ul>
+<li><code>github.com/All-Hands-AI/OpenHands/blob/main/openhands/events/stream.py</code>
+— repeatedly 404&#39;d via WebFetch (likely renamed or moved in current
+main). Compensated with DeepWiki + the <em>Refactoring: event stream
+based agent history</em> PR #2709 + the OpenHands README structure.</li>
+<li><code>github.com/crewAIInc/crewAI/blob/main/src/crewai/task.py</code>
+and <code>crew.py</code> — 404&#39;d via WebFetch (path layout has changed;
+likely under <code>src/crewai/lib/</code>). Compensated with crewAI
+official docs + community threads documenting
+<code>task_callback</code>/<code>step_callback</code> semantics.</li>
+<li><code>langchain-ai.github.io/langgraph/concepts/multi_agent/</code>
+— redirected to an empty page; used DeepWiki and the focused.io article
+instead.</li>
+<li><code>freedesktop.org/sd_notify</code> — 403 on the canonical URL;
+used Baeldung + the gist + general systemd docs.</li>
+<li>Goose source — README is high-level; did not deep-read
+<code>crates/</code>. Confirmed only that Goose has no peer-agent event
+bus (MCP is tool-call, not pub/sub).</li>
+<li>Aider — confirmed no built-in multi-session model. Skipped detailed
+source dive.</li>
+</ul>
+<p>No other systems on the request list were inaccessible.</p>
+<hr />
+<h2 id="6-references">6. References</h2>
+<ul>
+<li>OpenHands — <a href="https://github.com/All-Hands-AI/OpenHands">README</a>, <a href="https://deepwiki.com/OpenHands/OpenHands/6-configuration-system">DeepWiki
+Agent System</a>, <a href="https://www.emergentmind.com/topics/openhands-agent-framework">EmergentMind
+summary</a>, PR #2709</li>
+<li>AutoGen — <a href="https://github.com/microsoft/autogen">microsoft/autogen</a>,
+<code>python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py</code></li>
+<li>crewAI — <a href="https://docs.crewai.com/en/learn/sequential-process">docs.crewai.com
+sequential process</a>, <a href="https://community.crewai.com/t/how-does-the-task-callback-parameter-work/389">task_callback
+thread</a></li>
+<li>LangGraph — <a href="https://deepwiki.com/langchain-ai/langgraph-supervisor-py/3.2-handoff-tools">DeepWiki
+handoff tools</a>, <a href="https://focused.io/lab/multi-agent-orchestration-in-langgraph-supervisor-vs-swarm-tradeoffs-and-architecture">focused.io
+article</a></li>
+<li>OpenAI Swarm — <a href="https://github.com/openai/swarm">openai/swarm</a></li>
+<li>Tmux-Orchestrator — <a href="https://github.com/Jedward23/Tmux-Orchestrator">Jedward23/Tmux-Orchestrator</a>
+(<code>send-claude-message.sh</code>,
+<code>schedule_with_note.sh</code>)</li>
+<li>Claude Squad — <a href="https://github.com/smtg-ai/claude-squad">smtg-ai/claude-squad</a></li>
+<li>Orca — <a href="https://github.com/stablyai/orca">stablyai/orca</a>;
+see <code>docs/research/2026-05-19-orca-codex-wrapping-study.md</code>
+(<code>src/main/codex/hook-service.ts</code>,
+<code>src/main/agent-hooks/server.ts</code>,
+<code>src/main/runtime/orchestration/coordinator.ts</code>)</li>
+<li>Goose — <a href="https://github.com/block/goose">block/goose</a>, <a href="https://deepwiki.com/block/goose/5.3-extension-types-and-configuration">DeepWiki
+extension types</a></li>
+<li>Codex CLI — internal study
+<code>docs/research/2026-05-19-orca-codex-wrapping-study.md</code></li>
+<li>systemd <code>sd_notify</code> — <a href="https://www.baeldung.com/linux/systemd-notify">Baeldung</a>, <a href="https://gist.github.com/grawity/6e5980981dccf66f554bbebb8cd169fc">systemd
+Type=notify gist</a></li>
+<li>D-Bus — <a href="https://en.wikipedia.org/wiki/D-Bus">Wikipedia</a>,
+<a href="https://dbus.freedesktop.org/doc/dbus-specification.html">spec</a></li>
+<li>macOS XPC — <a href="https://nshipster.com/inter-process-communication/">NSHipster
+IPC</a>, <a href="https://karol-mazurek.medium.com/xpc-programming-on-macos-7e1918573f6d">Karol
+Mazurek XPC</a></li>
+<li>Erlang/OTP — <a href="https://www.erlang.org/doc/system/design_principles.html">Erlang
+System Documentation</a>, <a href="https://www.emqx.com/en/blog/hamler-0-2-otp-behaviours-with-type-classes">Hamler
+OTP behaviours</a></li>
+<li>OpenTelemetry collector — <a href="https://opentelemetry.io/docs/collector/architecture/">Architecture
+docs</a></li>
+<li>Prior cockpit research —
+<code>docs/research/2026-05-16-idle-detection-and-inter-agent-orchestration.md</code>,
+<code>docs/research/2026-05-19-orca-codex-wrapping-study.md</code>,
+<code>docs/research/2026-05-19-cockpit-vs-orca-system-comparison.html</code></li>
+</ul>
+</body>
+</html>

--- a/docs/research/2026-05-27-multi-session-orchestrator-notification-patterns.md
+++ b/docs/research/2026-05-27-multi-session-orchestrator-notification-patterns.md
@@ -1,0 +1,334 @@
+# Multi-Session Orchestrator Notification Patterns — Prior-Art Survey
+
+**Date:** 2026-05-27
+**Author:** Cockpit research (parent: develop)
+**Purpose:** Survey how comparable multi-agent / multi-session systems solve the *crew-completion → captain-attention* problem before redesigning cockpit's daemon-relay-tab mechanism.
+
+---
+
+## 0. The Cockpit Problem, Stated Precisely
+
+Cockpit runs a **captain** session (a Claude/Codex/etc. process inside a cmux pane) that coordinates **crew** sessions (more Claude/Codex/etc. processes in their own cmux panes). When a crew finishes, the captain needs to know — ideally as a *message that lands in the captain's input stream*, so the captain's next turn naturally picks it up.
+
+Two failed approaches and one current workaround:
+- **Naive shell-out** — daemon (or a hook) calls `cockpit runtime send <captain> "<msg>"`. cmux rejects this because the caller's PID is not in cmux's process-tree (cmux enforces a process-lineage check, not an env-var/socket-token check).
+- **Daemon push events** — same problem: whatever process the daemon delegates to is not parented by cmux.
+- **`notify-relay` tab inside the captain workspace** — daemon broadcasts events over its Unix socket; a long-lived "relay" terminal tab *inside* the captain's cmux workspace subscribes to that socket and forwards via the cmux send pathway, which works because the relay is itself a cmux-spawned child. This is correct but feels heavy: an extra tab per captain, a daemon-side fanout, and a per-runtime relay impl.
+
+The interesting question is what *category* of mechanism prior art uses, and whether the relay-tab is an instance of a known good pattern or a workaround we should retire.
+
+---
+
+## 1. The Surveyed Systems (≥6 + background)
+
+Each entry answers: captain↔crew analog · completion signal · signal landing · supervisor delivery · broker · process model · failure mode · abstraction surface.
+
+### 1.1 OpenHands (formerly OpenDevin) — github.com/All-Hands-AI/OpenHands
+
+- **Analog:** `AgentController` ⇄ `Runtime` (sandboxed exec env) and child agent delegates.
+- **Signal:** Typed `Action`/`Observation` events. Crew posts an `Observation`; "done" is a specific terminal observation (e.g. `AgentFinishAction`).
+- **Lands first:** In-process `EventStream` — a central pub/sub hub. Quoting OpenHands docs: *"The EventStream is a central hub for Events, where any component can publish Events, or listen for Events published by other components."* ([emergentmind](https://www.emergentmind.com/topics/openhands-agent-framework), [DeepWiki](https://deepwiki.com/OpenHands/OpenHands))
+- **Supervisor delivery:** `AgentController` is a registered subscriber — *"The AgentController performs Event Stream Subscription, subscribing to `EventStreamSubscriber.AGENT_CONTROLLER` unless it's a delegate."*
+- **Broker:** Yes — `EventStream` is the broker, persists events to disk for replay/history (PR #2709, *Refactoring: event stream based agent history*).
+- **Process model:** Single Python process owns the controller + event stream; runtime executes in a sandboxed subprocess/container; events cross that boundary as serialized messages.
+- **Failure mode:** Replayable — event log on disk means a restarted controller reconstructs state.
+- **Abstraction:** Excellent. Subscribers see typed events; no IPC primitives leak.
+
+### 1.2 AutoGen (Microsoft) — github.com/microsoft/autogen
+
+- **Analog:** `GroupChatManager` ⇄ participant agents.
+- **Signal:** Agents publish chat messages to topics; "turn done" = manager observes the latest message and decides next speaker (or a `GroupChatTermination` event for done-with-everything).
+- **Lands first:** AutoGen Core's **agent runtime** — a pub/sub message bus with **topic-based routing**. Per the source: a *group topic* (broadcast), per-participant topics (direct), and an *output topic* (results channel).
+- **Supervisor delivery:** Manager is a `SequentialRoutedAgent` subscribed to the group topic. Output collection: `_output_message_queue` until a `GroupChatTermination` event arrives.
+- **Broker:** Yes — the `AgentRuntime` (in-process local, or distributed gRPC variant).
+- **Process model:** Configurable. Default: all agents in one Python process. Distributed: agents on separate hosts behind a gRPC runtime.
+- **Failure mode:** In-memory loss by default; distributed variant adds delivery guarantees.
+- **Abstraction:** Strong. Agents only know `publish_message(topic, msg)` and subscriptions — never sockets.
+
+### 1.3 crewAI — github.com/crewAIInc/crewAI
+
+- **Analog:** `Crew` ⇄ `Task` ⇄ `Agent`.
+- **Signal:** Plain Python function return. `task.execute_sync()` returns; `Crew.kickoff()` loops sequentially over tasks. Optional **`task_callback`** fires after each task; **`step_callback`** fires after each agent step. For the HTTP-API surface, equivalents are `taskWebhookUrl`/`stepWebhookUrl`/`crewWebhookUrl` ([CrewAI docs](https://docs.crewai.com/en/learn/sequential-process), [community thread](https://community.crewai.com/t/how-does-the-task-callback-parameter-work/389)).
+- **Lands first:** Same Python stack frame (sync) or webhook receiver (API mode).
+- **Supervisor delivery:** Loop continuation; callback invocation.
+- **Broker:** None (in-process). Webhooks are the only out-of-process surface.
+- **Process model:** Single Python process for the local SDK. Tasks are not subprocesses.
+- **Failure mode:** Exceptions bubble; no built-in replay.
+- **Abstraction:** Sync function semantics — simplest possible.
+
+### 1.4 LangGraph (langchain-ai) — multi-agent supervisor pattern
+
+- **Analog:** Supervisor node ⇄ worker nodes in a state graph.
+- **Signal:** Workers return a **`Command`** object. Specifically `Command(goto=target, graph=Command.PARENT, update={...})` to hand control somewhere; `create_handoff_back_messages()` to return to supervisor with `__is_handoff_back` marker ([DeepWiki: Handoff Tools](https://deepwiki.com/langchain-ai/langgraph-supervisor-py/3.2-handoff-tools)).
+- **Lands first:** The LangGraph runtime — interprets the `Command` and transitions the state graph.
+- **Supervisor delivery:** Next graph step; supervisor's prompt rebuilt with appended messages.
+- **Broker:** The graph runtime itself.
+- **Process model:** Single Python process; node executions are awaited coroutines.
+- **Failure mode:** Checkpointer persists graph state; resumable.
+- **Abstraction:** Very clean — declarative graph, no IPC visible.
+
+### 1.5 OpenAI Swarm — github.com/openai/swarm
+
+- **Analog:** "Current agent" ⇄ "next agent" via handoff.
+- **Signal:** A tool function returns an `Agent` (or `Result(agent=...)`). The run loop swaps to it. *"Swarm's `run()` function is analogous to `chat.completions.create()` — it takes `messages` and returns `messages` and saves no state between calls."*
+- **Lands first:** Same Python stack; the loop sees the returned `Agent` and continues with it.
+- **Supervisor delivery:** Function return — synchronous.
+- **Broker:** None. Stateless.
+- **Process model:** Single Python process, single linear loop.
+- **Failure mode:** Caller's problem; no persistence.
+- **Abstraction:** Minimal: a function returns the next worker.
+
+### 1.6 Tmux-Orchestrator — github.com/Jedward23/Tmux-Orchestrator
+
+This is the closest cousin to cockpit and the most instructive comparison.
+
+- **Analog:** Orchestrator → Project Managers → Engineers, each as a separate tmux window running its own Claude instance.
+- **Signal:** **Polled + self-scheduled.** No async push exists. A Claude instance schedules its own check-in via `schedule_with_note.sh 30 "Continue dashboard implementation"`. The orchestrator periodically reads pane content via `tmux capture-pane`.
+- **Lands first:** Tmux's own pane scrollback (text). The "broker" is *the screen*.
+- **Supervisor delivery:** Orchestrator polls + reads + interprets. To talk back: `send-claude-message.sh session:window "msg"`, which `tmux send-keys`'s the text into the target pane. This is the exact equivalent of cockpit's `cockpit runtime send` — and it works in tmux because tmux does **not** enforce a process-lineage check on the writer (anyone with socket perms can `send-keys`).
+- **Broker:** None — tmux is both transport and storage.
+- **Process model:** Multi-process; each Claude is a child of its tmux pane.
+- **Failure mode:** Lost work is unbounded if the orchestrator never checks back. The self-scheduling pattern is the only safety net.
+- **Abstraction:** Leaky — scripts that scrape and inject text. The prompt-engineering rules are the contract.
+
+**Cockpit-relevant lesson:** Tmux-Orchestrator works because tmux's authorization model is "owner of the socket" — no lineage check. cmux's stricter check is what forces cockpit to host the sender inside cmux's tree. Tmux-Orchestrator also reveals the **cooperative-callback pattern** that Orca later formalized.
+
+### 1.7 Claude Squad — github.com/smtg-ai/claude-squad
+
+- **Analog:** N independent Claude instances, each in its own git worktree + tmux session.
+- **Signal:** **None automatic.** Completion is human-detected via the TUI (preview/diff tabs, manual `c` checkout / `r` resume).
+- **Lands first:** User's eyes.
+- **Supervisor delivery:** User.
+- **Broker:** None.
+- **Process model:** Multi-process, isolated worktrees.
+- **Failure mode:** Human in the loop.
+- **Abstraction:** Deliberately *not* an orchestrator — explicitly says it leaves coordination to the human.
+
+**Lesson:** A respected multi-Claude tool ducked the captain↔crew problem entirely. Cockpit's ambition (autonomous captain reacting to crew) is meaningfully harder than what Claude Squad attempts.
+
+### 1.8 Orca (stablyai) — github.com/stablyai/orca (already studied)
+
+- **Analog:** Coordinator + per-agent terminal panes (PTY-hosted).
+- **Signal:** Two simultaneous channels, depending on agent:
+  1. **Native hooks → loopback HTTP** (Claude Code & Codex 0.129+). Hooks `curl` a JSON payload to `http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/<agent>` with a bearer token. `Stop` event = turn done. See `src/main/codex/hook-service.ts:42-49` and `src/main/agent-hooks/server.ts`.
+  2. **Cooperative CLI callback** for the autonomous coordinator: prompt preamble teaches the agent to call `orca task complete --body <summary>`, plus a 10-min stale-heartbeat watchdog (`src/main/runtime/orchestration/coordinator.ts:172,230,332-335`).
+- **Lands first:** Orca's main Electron process (HTTP server + IPC). Persisted in `last-status.json` for restart survival.
+- **Supervisor delivery:** IPC fanout to the renderer process / orchestration coordinator.
+- **Broker:** The loopback HTTP server + on-disk status cache.
+- **Process model:** Multi-process; each agent is its own `node-pty` child. Orca itself owns the broker.
+- **Failure mode:** Replay from `last-status.json`; hook script re-reads `$ORCA_AGENT_HOOK_ENDPOINT` so it survives Orca restart on the *same* PTY.
+- **Abstraction:** Excellent inside Orca; leaks through the hook config files in `~/.codex/hooks.json` and `~/.codex/config.toml`.
+
+### 1.9 Codename Goose (Block) — github.com/block/goose
+
+- **Analog:** Single agent + MCP **extensions** (tool servers).
+- **Signal:** Standard MCP — JSON-RPC over stdio/SSE/streamable HTTP. *Not a multi-agent coordinator.* There's no inter-extension event bus; extensions are tool providers, not peer agents.
+- **Lands first:** MCP client transport.
+- **Process model:** Goose host + one subprocess per stdio extension.
+- **Lesson for cockpit:** MCP is a *tool-call* protocol, not a peer-to-peer notification protocol. Modeling crew→captain as an MCP tool call would invert the right direction (captain pulls, never pushed).
+
+### 1.10 Codex CLI app-server (OpenAI) — see `docs/research/2026-05-19-orca-codex-wrapping-study.md`
+
+- **Analog:** Driver process ⇄ codex child via JSON-RPC over stdio.
+- **Signal:** Notifications in the JSON-RPC stream (`turn.completed`, etc.), framed as newline-delimited JSON.
+- **Lands first:** Driver's stdio reader.
+- **Broker:** None — direct stdio.
+- **Process model:** Parent owns the child via pipe.
+- **Lesson:** Strong typed-event channel **but only between a parent and its own child**. Useless if the captain isn't the codex parent — which is exactly the cockpit constraint (cmux owns the codex/claude child, not cockpit's daemon).
+
+### 1.11 Background — process-coordination prior art
+
+| System | One-line lesson |
+|---|---|
+| **systemd `sd_notify`** | Single UDP-style datagram to `$NOTIFY_SOCKET` (Unix DGRAM). `READY=1`, `STATUS=…`, `WATCHDOG=1`. Auth via `SCM_CREDENTIALS`. No broker, no queue — fire-and-forget but reliable on localhost. ([sd_notify man](https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html)) |
+| **D-Bus** | Mature pub/sub: signals broadcast; clients register interest; bus daemon fans out. Strong typing via introspection. Transport: Unix domain sockets. ([spec](https://dbus.freedesktop.org/doc/dbus-specification.html)) |
+| **macOS XPC** | Modern client/server IPC with privilege separation; the recommended replacement for `NSDistributedNotificationCenter` (which can't carry user info). |
+| **Erlang/OTP** | Supervisor `monitor`s worker process; worker death → `{'DOWN', Ref, ...}` lands in supervisor's *mailbox* (a queue per process). Mailbox is the broker; pattern-match dequeue. Gold-standard fault-tolerance semantics. |
+| **OpenTelemetry collector** | `receiver → processor → exporter` pipeline; receivers are pluggable transports; same data can fan out to N exporters. Mirrors cockpit's "event from any runtime → many sinks (TUI, Telegram, push)" need. |
+
+---
+
+## 2. Comparison Table
+
+| System | Process model | Signal mechanism | Delivery | Reliability | Abstraction | Cockpit-applicable insight |
+|---|---|---|---|---|---|---|
+| OpenHands | 1 host + sandbox subproc | Typed event in `EventStream` | Subscriber callback (push) | Disk-replayable | Strong (events) | Central in-process bus + on-disk log = best decoupling story |
+| AutoGen | 1 proc (or gRPC) | Topic-pub/sub message | Topic subscriber | In-mem (local) / guaranteed (gRPC) | Strong | Topic routing scales to many-to-many |
+| crewAI | 1 proc | Function return + callback | Loop continuation | None | Trivial | Don't over-engineer if you control the loop |
+| LangGraph | 1 proc | `Command(goto=…)` value | Graph step | Checkpointed | Declarative | Express handoff as data, not IPC |
+| OpenAI Swarm | 1 proc | Function returns `Agent` | Loop continuation | None | Trivial | Stateless transfer is enough when in-process |
+| Tmux-Orchestrator | Multi-proc (tmux) | Scrape pane + `send-keys` | Poll + injected text | Lost if unread | Leaky | tmux allows external sender → no relay needed there |
+| Claude Squad | Multi-proc (tmux) | None — human checks | Manual | N/A | N/A | Punted entirely |
+| Orca | Multi-proc (PTY) | Native hooks → loopback HTTP | HTTP POST + IPC fanout | Disk-cached | Strong | **Hooks-as-source-of-truth + broker is the winning pattern** |
+| Goose (MCP) | Multi-proc (MCP) | JSON-RPC tool call | Caller awaits | Per-call | Strong | Wrong direction for completion notify |
+| Codex app-server | Parent + child | JSON-RPC notification | stdio read | Stream lifetime | Strong | Requires parent-of-child relationship |
+| systemd sd_notify | Multi-proc | Unix DGRAM | Daemon recv | Localhost-reliable | Strong | Smallest viable IPC |
+| D-Bus | Multi-proc | Signal broadcast | Bus fanout | Bus-mediated | Strong | Real-world pub/sub at OS level |
+| Erlang/OTP | Multi-proc (BEAM) | `monitor` + mailbox | Mailbox dequeue | Queued | Gold | Per-supervisor mailbox = ideal mental model |
+| OTel collector | Pluggable | Receiver → exporter pipeline | Push | Configurable | Strong | One event, many sinks (TUI/push/file) |
+
+---
+
+## 3. Recommendations for cockpit (ranked)
+
+I'm ranking **3 patterns** by fit, given cockpit's hard constraints:
+1. Multi-runtime (Claude Code, Codex, Gemini, Aider, opencode).
+2. Multi-host runtime (cmux today; Orca, Zed, IntelliJ-MCP tomorrow).
+3. The captain runs in a *real shell inside the runtime's pane* and consumes input from that runtime's input mechanism.
+4. cmux enforces a process-lineage check: the writer to the captain's pane **must** be in cmux's process tree.
+
+### Rank 1 — **Mailbox + injector pattern** (Erlang + Orca hybrid). Strongly recommended.
+
+**Mechanism.** The cockpit daemon is the **broker** (Erlang's `gen_server` analog). Every captain has a **mailbox**: a queue on the daemon's side keyed by captain-id. Each runtime registers exactly **one injector** — a tiny long-lived process *inside that runtime's process tree* — whose only job is to dequeue from the captain's mailbox and call the runtime-specific "type into pane" API. The injector is the cockpit-side analog of the **`notify-relay` tab you already have**, but generalized and dignified as a first-class architectural element rather than an "extra terminal tab."
+
+**Why this is the right rebranding of what you've built.**
+- The relay-tab is not a workaround — it is the same pattern Erlang uses (the per-process mailbox needs a per-process dequeuer that runs *inside* that process's scheduler). cmux's lineage check is the equivalent of the BEAM scheduler boundary: only the right context can deliver. You were right to put a process inside cmux; you were wrong to feel bad about it.
+- The mailbox semantics fix the failure mode the current design *doesn't* address well: if the captain is mid-turn, mid-shutdown, or briefly absent, events queue rather than vanish. (Today the relay tab forwards immediately; if the captain pane is busy, cmux send may swallow the input.)
+- One injector per runtime, not per captain: a single `cockpit-injector` daemon process per cmux instance can serve every captain hosted there.
+
+**Concrete sketch replacing the relay-tab.**
+- Daemon exposes `MailboxAppend(captainId, event)` and `MailboxClaim(captainId, sinceCursor) → events`.
+- Runtime driver implements `Injector(runtime, captainId)` — a small Go/Node/Python binary started by `cmux spawn` as a hidden helper process inside the captain's workspace. Long-poll `MailboxClaim`, then call the runtime's send mechanism. On startup the injector also drains any backlog accumulated while the captain was idle.
+- Captain shutdown removes the mailbox; restart restores it from disk (Orca-style `last-status.json` analog).
+- Tracker integration: the daemon's existing socket pub/sub becomes a *receiver* in OTel-collector parlance; the mailbox is a *processor*; the injector is the only *exporter* that has to satisfy cmux's lineage rule. Telegram, TUI, and push notifications continue to subscribe to the receiver directly — they don't go through the lineage-bound exporter.
+
+**Handles cmux's lineage check:** Yes — the injector is spawned by cmux and lives inside its tree by definition. For Orca/Zed/IntelliJ-MCP, the same injector concept reincarnates as: an Orca pane hosting `cockpit-injector orca`; a Zed task; an IntelliJ background process. Each runtime driver owns its injector binary; the mailbox protocol is shared.
+
+**Complexity tradeoff:** Mid. You already have most of this (daemon socket pub/sub + relay tab). The work is (a) adding a queue + cursor on the daemon side, (b) generalizing the relay into a `cockpit-injector` binary that any runtime can spawn, (c) shipping a per-runtime "start injector at workspace open" lifecycle hook.
+
+### Rank 2 — **Hooks-into-loopback-broker** (Orca pattern, generalized).
+
+**Mechanism.** Every supported agent CLI has *some* native completion hook (Claude Code: `Stop` hook; Codex 0.129+: `Stop` hook; Gemini: still TBD; Aider: `--message` mode returns; opencode: events). The hook `curl`s a loopback HTTP endpoint on the daemon. The daemon now has the authoritative "crew X is done" signal *from the agent itself*, not from process-watching or PTY-scraping.
+
+**This solves a different problem** — it's about **detection**, not **delivery**. You still need pattern #1 (or #3) to *get the news into the captain's input*. But pairing #2 with #1 gives cockpit a complete loop:
+- Detection: native hook → daemon (Orca-validated).
+- Delivery: daemon mailbox → in-cmux injector (Rank 1).
+
+**Handles cmux's lineage check:** Irrelevant for detection. Delivery still needs Rank 1.
+
+**Why not rank it #1:** You implicitly already have detection (cmux's `read-screen` + your own heuristics). The acute pain is delivery, not detection. Adopt #2 incrementally as each runtime gains native hooks, but it doesn't supplant #1.
+
+### Rank 3 — **Captain-side polling against the daemon socket** (the "do nothing in-cmux" option).
+
+**Mechanism.** Drop the relay tab entirely. Teach the captain — via its system prompt / a skill — to **periodically run a CLI command** (`cockpit inbox`) inside its own loop, which reads from the daemon socket and returns new events as plain text. The captain has shell access; calling a CLI is well within its toolset.
+
+**Why this is tempting.** Zero extra processes. Zero relay. The captain is the one with cmux-blessed input access (it *is* the cmux child), so by definition any text it generates lands in the right place. The "delivery" step becomes "captain prints what it reads." Polling cadence is captain-decided.
+
+**Why it's #3, not #1.** It changes captain semantics from *reactive* to *proactive*. A captain that's mid-turn won't poll. A captain that's stuck in a tool call doesn't notice the crew finished. The whole point of push-notification was to make the captain wake up when crew lands; rank 3 quietly returns to polling, which we already rejected in the 2026-05-16 idle-detection research. Use only as a fallback for runtimes where injector-spawn isn't possible.
+
+**Handles cmux's lineage check:** Trivially — there is no external sender.
+
+**For Orca/Zed/IntelliJ-MCP:** Works in all of them. This is the universal-fallback path.
+
+---
+
+## 4. Synthesis: the proposed design
+
+```
+                 ┌──────────────────┐
+   crew event ──▶│  daemon receiver │ (existing)
+                 └────────┬─────────┘
+                          │ fanout
+            ┌─────────────┼─────────────────┐
+            ▼             ▼                 ▼
+        Telegram       TUI/push     ┌─────────────────┐
+                                    │ per-captain     │
+                                    │ mailbox (queue) │ (NEW)
+                                    └────────┬────────┘
+                                             │ long-poll
+                                             ▼
+                                  ┌─────────────────────┐
+                                  │ cockpit-injector    │  ◀── spawned by cmux,
+                                  │ (1 per runtime host)│      lives in cmux tree
+                                  └────────┬────────────┘
+                                           │ runtime.send()
+                                           ▼
+                                    captain's input
+```
+
+This is **the relay-tab pattern, renamed and dignified**: the relay becomes a first-class "injector" with a queue behind it. Add native-hook detection (Orca pattern, Rank 2) as runtimes support it. Keep CLI-poll (Rank 3) as the never-fails fallback the captain can always run.
+
+### What this buys you vs. the current relay-tab
+
+- **Buffering** — events don't vanish if the captain pane is briefly busy.
+- **Restart survival** — mailbox is durable; injector restart drains backlog.
+- **One concept, all runtimes** — Orca/Zed/IntelliJ get the same protocol; only the injector binary changes per runtime.
+- **No new IPC primitives** — uses your existing daemon socket; the mailbox is just a map<captainId, []event> on the daemon plus a cursor.
+- **Tracker stays decoupled** — receivers, processors (mailbox), exporters (injector) is the OTel-collector shape, which makes "send the same event to Telegram and the captain" a config concern rather than a code concern.
+
+---
+
+## Provider Coverage Audit — Claude / Codex / Opencode
+
+The relay/notify pattern in section 3 assumes each runtime provider can hand cockpit a "crew finished" signal. Today claude-code emits this via `Stop` / `SessionEnd` hooks (PR #108) and codex emits it via app-server JSON-RPC notifications (PR #97/#98). Opencode interactive crews currently route through the legacy cmux-only spawn path (`src/commands/crew.ts:163`) — the daemon is unaware of them. This audit answers whether opencode can be wired into the same notify loop, and what shape that wiring should take.
+
+### Findings — opencode (sst/opencode)
+
+1. **Hook / lifecycle event system — YES, via the plugin system.** Opencode ships a first-class plugin framework. A plugin is a TypeScript module placed under `.opencode/plugin/*.ts` or wired through `opencode.json → plugins`. Plugins receive an async `event` callback and can also wrap tool execution with `tool.execute.before` / `tool.execute.after`. Documented event names include `session.idle` and tool-execution events; the DEV.to overview and the SDK page both reference these as the canonical extension surface ([dev.to "Does OpenCode Support Hooks?"](https://dev.to/einarcesar/does-opencode-support-hooks-a-complete-guide-to-extensibility-k3p), [OpenCode SDK docs](https://opencode.ai/docs/sdk/)). DeepWiki's session-lifecycle page confirms a `session_start` / `session_idle` / `session_end` taxonomy on the event bus but does not enumerate the exact wire names ([DeepWiki §2.1 session lifecycle](https://deepwiki.com/sst/opencode/2.1-session-lifecycle-and-state)). **Unable to confirm via public docs** whether `session.end` is a stable plugin-callable event or only an internal-bus event; the safe assumption is `session.idle` (the documented one) is the closest "turn done" analog for cockpit's purposes.
+
+2. **App-server / streaming protocol — YES, but it's HTTP REST + SSE, not JSON-RPC.** `opencode serve` starts a headless HTTP server exposing an OpenAPI 3.1 spec; flags include `--port`, `--hostname`, `--mdns`, `--cors`, and `OPENCODE_SERVER_PASSWORD` for basic auth ([Server docs](https://opencode.ai/docs/server/)). Two SSE endpoints stream the event bus: `GET /event` (per-session/global bus; first message is `server.connected`, then bus events) and `GET /global/event`. This is a long-lived subscribe pattern; a daemon can keep one HTTP connection open and receive every bus event for the life of the server.
+
+3. **MCP — opencode is an MCP *client*, not an MCP server exposing lifecycle events.** Opencode's MCP integration is for *adding tools to opencode*, not for letting outside processes subscribe to opencode events ([MCP docs](https://opencode.ai/docs/mcp-servers/)). The Goose lesson from §1.9 applies: MCP is the wrong direction for completion-notify.
+
+4. **`opencode run --format json` — YES.** The `run` subcommand supports `--format json`, documented as "raw JSON events". Combined with `--session <id>` / `--continue` / `--fork`, this gives a headless invocation that streams structured events to stdout — usable from a non-cmux wrapper, though for the cockpit-interactive case the SSE bus is the better channel because it persists across multiple turns.
+
+5. **Programmatic SDKs — YES.** Official `@opencode-ai/sdk` (TypeScript) wraps the HTTP + SSE surface in typed methods including `event.subscribe()` ([JS SDK DeepWiki](https://deepwiki.com/sst/opencode/7.1-javascripttypescript-sdk)). Community-maintained Go (`opencode-sdk-go`) and Python (`opencode-sdk-python`) SDKs are generated from the same OpenAPI spec. Also worth flagging: opencode implements the **Agent Client Protocol (ACP) over JSON-RPC** for editor integrations (Zed et al.), exposing events like `permission.asked` and `usage_update` ([DeepWiki ACP](https://deepwiki.com/sst/opencode/7.4-agent-client-protocol-(acp))); ACP is a *second* event surface alongside the HTTP/SSE bus, used when something on the IDE side needs to be the agent's loop driver.
+
+6. **Resume semantics — YES.** Both `opencode run` and the TUI accept `--continue` (`-c`), `--session <id>` (`-s`), and `--fork`. Sessions are persisted (SQLite via Drizzle ORM per the lifecycle page); reattaching after a daemon bounce is supported, with the daemon recovering the session-id from its own state rather than from opencode itself.
+
+### Comparison table
+
+| Capability | Claude | Codex | Opencode | Notes |
+|---|---|---|---|---|
+| Hook system (file-configurable lifecycle events) | YES — `settings.json` Stop / SubagentStop / SessionEnd | NO native; Orca proves Codex 0.129+ adds `Stop` hooks but cockpit doesn't use them yet | YES — TS plugin in `.opencode/plugin/*.ts`; `event` callback + tool before/after; `session.idle` documented | Opencode plugin is code, not pure JSON, so harder to template than Claude's `settings.json` but more expressive |
+| App-server / streaming protocol | NO (stdio CLI only) | YES — app-server, JSON-RPC over stdio | YES — `opencode serve` HTTP + SSE; ACP JSON-RPC also available | Opencode is the only one with a *socket-listening* server out of the box |
+| MCP server interface (exposes events) | Claude is MCP client only | Codex is MCP client only | Opencode is MCP client only | None of the three lets cockpit subscribe via MCP |
+| JSON output mode (headless) | YES — `claude -p --output-format=json` | YES — `codex exec --json` | YES — `opencode run --format json` | All three usable for one-shot non-interactive crews |
+| Session resume | YES — `claude -c` / `--resume` | YES — `codex exec resume` | YES — `opencode run --session <id>` / `--continue` / `--fork` | All three persist sessions |
+| Programmatic SDK | YES — `@anthropic-ai/claude-code` TS SDK | CLI only (no first-party SDK as of 0.130) | YES — `@opencode-ai/sdk` TS (official); Go & Python (community, generated) | Opencode has the richest SDK story |
+
+### Verdict — does the relay/notify pattern work for opencode?
+
+**Best path: SSE subscribe + a lightweight plugin emitter.** Opencode is the *easiest* of the three providers to wire into the daemon. The daemon can connect once to `http://127.0.0.1:<port>/event` per running `opencode serve` and receive `session.idle` and other bus events with zero per-crew configuration. This is structurally identical to the codex app-server path (long-lived stream, daemon subscribes), differing only in transport (HTTP+SSE vs. JSON-RPC-over-stdio). To make the "turn-done" semantic explicit (rather than inferring from `session.idle`), cockpit can ship a tiny `.opencode/plugin/cockpit-emit.ts` that calls back into the daemon's `task.progress` endpoint on whatever lifecycle hook is most stable — this is the *exact same* shape as the PR #108 claude-code hook, just expressed as a plugin instead of a `settings.json` entry. Net: opencode supports **both** of the prior patterns simultaneously, with the SSE path requiring zero crew-side config.
+
+**Fallback: app-server-style SSE alone.** If the plugin emitter proves brittle (e.g. opencode plugin API changes between 0.x releases, which is plausible given the project's velocity), the daemon can rely purely on the documented SSE bus. `session.idle` is the canonical "agent finished its turn" signal per the public docs and is sufficient for the captain-attention use case. This is strictly the codex pattern, ported.
+
+**Universal fallback: explicit `cockpit crew signal done`.** The crew template can always include an instruction to call `cockpit crew signal done` as the last action of any task — this is provider-agnostic and works today for opencode without any new wiring, at the cost of relying on the agent to remember to call it. This should remain in the opencode crew template as the belt-and-suspenders fallback even after auto-detection ships, mirroring the explicit-signal path that already exists for the claude path.
+
+**Ranked by honest-fit-for-opencode:** (1) SSE subscribe with `session.idle` as the trigger — minimal moving parts, uses only documented public APIs, mirrors codex pattern. (2) Plugin emitter calling `task.progress` — most precise semantics, but ties cockpit to opencode's plugin API surface area. (3) Explicit `cockpit crew signal done` — always-works fallback, keep in template. **Recommendation: ship (1) first, add (2) only if `session.idle` proves too noisy or imprecise, keep (3) in the template always.**
+
+**Does the section-3 architectural recommendation still hold across all three providers?** **Yes, unambiguously.** The "dignify the relay into a first-class injector with daemon-side mailbox" verdict is *strengthened* by opencode entering the mix. Today the daemon receives three radically different completion signal shapes: file-configured hooks (claude), parent-of-child JSON-RPC (codex), and long-lived HTTP+SSE (opencode). The mailbox-plus-injector design is the only one of the three section-3 ranks that absorbs all three transports cleanly: each runtime's driver translates its native event surface into `MailboxAppend(captainId, event)`, and the in-cmux injector remains the single lineage-blessed exporter. Without the mailbox abstraction, cockpit would need three parallel paths from detection-source straight to cmux send, each replicating its own buffering, retry, and lineage handling. The audit confirms detection is the easy part for all three providers; delivery into a process-lineage-restricted captain pane remains the hard part, and a per-captain mailbox is the right factoring of that responsibility.
+
+---
+
+## 5. Inaccessible / partially-accessible sources
+
+- `github.com/All-Hands-AI/OpenHands/blob/main/openhands/events/stream.py` — repeatedly 404'd via WebFetch (likely renamed or moved in current main). Compensated with DeepWiki + the *Refactoring: event stream based agent history* PR #2709 + the OpenHands README structure.
+- `github.com/crewAIInc/crewAI/blob/main/src/crewai/task.py` and `crew.py` — 404'd via WebFetch (path layout has changed; likely under `src/crewai/lib/`). Compensated with crewAI official docs + community threads documenting `task_callback`/`step_callback` semantics.
+- `langchain-ai.github.io/langgraph/concepts/multi_agent/` — redirected to an empty page; used DeepWiki and the focused.io article instead.
+- `freedesktop.org/sd_notify` — 403 on the canonical URL; used Baeldung + the gist + general systemd docs.
+- Goose source — README is high-level; did not deep-read `crates/`. Confirmed only that Goose has no peer-agent event bus (MCP is tool-call, not pub/sub).
+- Aider — confirmed no built-in multi-session model. Skipped detailed source dive.
+
+No other systems on the request list were inaccessible.
+
+---
+
+## 6. References
+
+- OpenHands — [README](https://github.com/All-Hands-AI/OpenHands), [DeepWiki Agent System](https://deepwiki.com/OpenHands/OpenHands/6-configuration-system), [EmergentMind summary](https://www.emergentmind.com/topics/openhands-agent-framework), PR #2709
+- AutoGen — [microsoft/autogen](https://github.com/microsoft/autogen), `python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py`
+- crewAI — [docs.crewai.com sequential process](https://docs.crewai.com/en/learn/sequential-process), [task_callback thread](https://community.crewai.com/t/how-does-the-task-callback-parameter-work/389)
+- LangGraph — [DeepWiki handoff tools](https://deepwiki.com/langchain-ai/langgraph-supervisor-py/3.2-handoff-tools), [focused.io article](https://focused.io/lab/multi-agent-orchestration-in-langgraph-supervisor-vs-swarm-tradeoffs-and-architecture)
+- OpenAI Swarm — [openai/swarm](https://github.com/openai/swarm)
+- Tmux-Orchestrator — [Jedward23/Tmux-Orchestrator](https://github.com/Jedward23/Tmux-Orchestrator) (`send-claude-message.sh`, `schedule_with_note.sh`)
+- Claude Squad — [smtg-ai/claude-squad](https://github.com/smtg-ai/claude-squad)
+- Orca — [stablyai/orca](https://github.com/stablyai/orca); see `docs/research/2026-05-19-orca-codex-wrapping-study.md` (`src/main/codex/hook-service.ts`, `src/main/agent-hooks/server.ts`, `src/main/runtime/orchestration/coordinator.ts`)
+- Goose — [block/goose](https://github.com/block/goose), [DeepWiki extension types](https://deepwiki.com/block/goose/5.3-extension-types-and-configuration)
+- Codex CLI — internal study `docs/research/2026-05-19-orca-codex-wrapping-study.md`
+- systemd `sd_notify` — [Baeldung](https://www.baeldung.com/linux/systemd-notify), [systemd Type=notify gist](https://gist.github.com/grawity/6e5980981dccf66f554bbebb8cd169fc)
+- D-Bus — [Wikipedia](https://en.wikipedia.org/wiki/D-Bus), [spec](https://dbus.freedesktop.org/doc/dbus-specification.html)
+- macOS XPC — [NSHipster IPC](https://nshipster.com/inter-process-communication/), [Karol Mazurek XPC](https://karol-mazurek.medium.com/xpc-programming-on-macos-7e1918573f6d)
+- Erlang/OTP — [Erlang System Documentation](https://www.erlang.org/doc/system/design_principles.html), [Hamler OTP behaviours](https://www.emqx.com/en/blog/hamler-0-2-otp-behaviours-with-type-classes)
+- OpenTelemetry collector — [Architecture docs](https://opentelemetry.io/docs/collector/architecture/)
+- Prior cockpit research — `docs/research/2026-05-16-idle-detection-and-inter-agent-orchestration.md`, `docs/research/2026-05-19-orca-codex-wrapping-study.md`, `docs/research/2026-05-19-cockpit-vs-orca-system-comparison.html`

--- a/docs/research/2026-05-27-multi-session-orchestrator-notification-patterns.vi.html
+++ b/docs/research/2026-05-27-multi-session-orchestrator-notification-patterns.vi.html
@@ -1,0 +1,988 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <title>Multi-Session Orchestrator Notification Patterns — Nghiên cứu so sánh thiết kế</title>
+  <style>
+
+span.smallcaps{font-variant: small-caps;}
+div.columns{display: flex; gap: min(4vw, 1.5em);}
+div.column{flex: auto; overflow-x: auto;}
+div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+
+ul.task-list[class]{list-style: none;}
+ul.task-list li input[type="checkbox"] {
+font-size: inherit;
+width: 0.8em;
+margin: 0 0.8em 0.2em -1.6em;
+vertical-align: middle;
+}
+.display.math{display: block; text-align: center; margin: 0.5rem auto;}
+</style>
+  <style type="text/css">:root{--bg:#0f1115;--panel:#171a21;--panel2:#1d212a;--ink:#e6e8ee;--mut:#9aa3b2;--line:#2a2f3a;--accent:#5db0ff;--ck:#7c9eff;--or:#ff9d6b;--good:#4ade80;--warn:#fbbf24;--bad:#f87171;--code:#0b0d12;--mono:"SF Mono",ui-monospace,Menlo,Consolas,monospace}
+*{box-sizing:border-box}html{scroll-behavior:smooth}
+body{margin:0;background:var(--bg);color:var(--ink);font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;max-width:980px;padding:46px 56px 120px;margin:0 auto}
+h1{font-size:29px;line-height:1.25;margin:10px 0 16px;letter-spacing:-.01em;border-bottom:1px solid var(--line);padding-bottom:14px}
+h2{font-size:22px;margin-top:42px;padding-top:14px;border-top:1px solid var(--line);color:var(--accent)}
+h3{font-size:17px;margin-top:28px;color:var(--ck)}
+h4{font-size:15px;margin-top:20px;color:var(--mut);text-transform:uppercase;letter-spacing:.05em}
+p,li{color:var(--ink)}
+a{color:var(--accent);text-decoration:none}a:hover{text-decoration:underline}
+code{font-family:var(--mono);background:var(--code);padding:2px 6px;border-radius:4px;font-size:13.5px;color:var(--or)}
+pre{background:var(--code);padding:14px 18px;border-radius:8px;border:1px solid var(--line);overflow-x:auto;font-size:13px;line-height:1.5}
+pre code{background:none;padding:0;color:var(--ink)}
+blockquote{border-left:3px solid var(--accent);margin:16px 0;padding:8px 18px;color:var(--mut);background:var(--panel)}
+table{width:100%;border-collapse:collapse;margin:18px 0;font-size:14px}
+th,td{border:1px solid var(--line);padding:9px 12px;text-align:left;vertical-align:top}
+th{background:var(--panel2);color:var(--accent);font-weight:600}
+tr:nth-child(2n) td{background:var(--panel)}
+hr{border:none;border-top:1px solid var(--line);margin:36px 0}
+ul,ol{padding-left:24px}li{margin:4px 0}
+strong{color:#fff}em{color:var(--ck)}
+</style>
+</head>
+<body>
+<header id="title-block-header">
+<h1 class="title">Multi-Session Orchestrator Notification Patterns —
+Nghiên cứu so sánh thiết kế</h1>
+</header>
+<h1 id="multi-session-orchestrator-notification-patterns--nghiên-cứu-so-sánh-thiết-kế">Multi-Session
+Orchestrator Notification Patterns — Nghiên cứu so sánh thiết kế</h1>
+<p><strong>Date:</strong> 2026-05-27 <strong>Tác giả:</strong> Cockpit
+research (parent: develop) <strong>Mục đích:</strong> Khảo sát cách các
+hệ multi-agent / multi-session tương đương giải quyết bài toán <em>crew
+hoàn thành → đánh thức captain</em>, trước khi thiết kế lại cơ chế
+daemon-relay-tab của cockpit.</p>
+<hr />
+<h2 id="0-vấn-đề-của-cockpit-phát-biểu-chính-xác">0. Vấn đề của Cockpit,
+phát biểu chính xác</h2>
+<p>Cockpit chạy một session <strong>captain</strong> (một process
+Claude/Codex/v.v. nằm trong một cmux pane) làm nhiệm vụ điều phối các
+session <strong>crew</strong> (cũng là các process Claude/Codex/v.v.,
+mỗi cái nằm trong cmux pane riêng). Khi một crew xong việc, captain cần
+biết — lý tưởng là dưới dạng một <em>message được đẩy thẳng vào input
+stream của captain</em>, để turn kế tiếp của captain nhận được nó một
+cách tự nhiên.</p>
+<p>Hai cách tiếp cận thất bại và một workaround hiện tại:</p>
+<ul>
+<li><strong>Naive shell-out</strong> — daemon (hoặc một hook) gọi
+<code>cockpit runtime send &lt;captain&gt; &quot;&lt;msg&gt;&quot;</code>. cmux từ
+chối vì PID của caller không nằm trong process-tree của cmux (cmux kiểm
+tra process-lineage chứ không phải env-var/socket-token).</li>
+<li><strong>Daemon push events</strong> — cùng vấn đề: process nào mà
+daemon delegate sang đều không có parent là cmux.</li>
+<li><strong><code>notify-relay</code> tab nằm trong captain
+workspace</strong> — daemon broadcast events qua Unix socket của nó; một
+terminal tab &quot;relay&quot; sống dai <em>bên trong</em> cmux workspace của
+captain subscribe socket đó và forward qua đường cmux send, hoạt động
+được vì relay tự nó là một child do cmux spawn ra. Cách này đúng nhưng
+có vẻ nặng nề: thêm một tab cho mỗi captain, thêm fanout phía daemon, và
+một relay impl cho mỗi runtime.</li>
+</ul>
+<p>Câu hỏi đáng hỏi là prior art dùng <em>category</em> mechanism nào,
+và liệu cái relay-tab kia là một instance của một pattern tốt đã biết
+hay là một workaround đáng vứt đi.</p>
+<hr />
+<h2 id="1-các-hệ-thống-được-khảo-sát-6--background">1. Các hệ thống được
+khảo sát (≥6 + background)</h2>
+<p>Mỗi mục trả lời: analog cho captain↔︎crew · completion signal · signal
+landing · supervisor delivery · broker · process model · failure mode ·
+abstraction surface.</p>
+<h3 id="11-openhands-trước-đây-là-opendevin--githubcomall-hands-aiopenhands">1.1
+OpenHands (trước đây là OpenDevin) —
+github.com/All-Hands-AI/OpenHands</h3>
+<ul>
+<li><strong>Analog:</strong> <code>AgentController</code> ⇄
+<code>Runtime</code> (sandboxed exec env) và các child agent
+delegate.</li>
+<li><strong>Signal:</strong> Typed
+<code>Action</code>/<code>Observation</code> events. Crew post một
+<code>Observation</code>; &quot;done&quot; là một terminal observation cụ thể (ví
+dụ <code>AgentFinishAction</code>).</li>
+<li><strong>Lands first:</strong> In-process <code>EventStream</code> —
+một central pub/sub hub. Trích docs OpenHands: <em>&quot;The EventStream is a
+central hub for Events, where any component can publish Events, or
+listen for Events published by other components.&quot;</em> (<a href="https://www.emergentmind.com/topics/openhands-agent-framework">emergentmind</a>,
+<a href="https://deepwiki.com/OpenHands/OpenHands">DeepWiki</a>)</li>
+<li><strong>Supervisor delivery:</strong> <code>AgentController</code>
+là một subscriber đã đăng ký — <em>&quot;The AgentController performs Event
+Stream Subscription, subscribing to
+<code>EventStreamSubscriber.AGENT_CONTROLLER</code> unless it&#39;s a
+delegate.&quot;</em></li>
+<li><strong>Broker:</strong> Có — <code>EventStream</code> chính là
+broker, persist events xuống đĩa để replay/history (PR #2709,
+<em>Refactoring: event stream based agent history</em>).</li>
+<li><strong>Process model:</strong> Một Python process duy nhất sở hữu
+controller + event stream; runtime chạy trong một sandboxed
+subprocess/container; events vượt qua boundary đó dưới dạng serialized
+messages.</li>
+<li><strong>Failure mode:</strong> Replayable — event log trên đĩa nghĩa
+là controller restart sẽ reconstruct được state.</li>
+<li><strong>Abstraction:</strong> Excellent. Subscribers chỉ thấy typed
+events; không có IPC primitive nào lộ ra.</li>
+</ul>
+<h3 id="12-autogen-microsoft--githubcommicrosoftautogen">1.2 AutoGen
+(Microsoft) — github.com/microsoft/autogen</h3>
+<ul>
+<li><strong>Analog:</strong> <code>GroupChatManager</code> ⇄ participant
+agents.</li>
+<li><strong>Signal:</strong> Agents publish chat messages lên topics;
+&quot;turn done&quot; = manager quan sát message mới nhất rồi quyết next speaker
+(hoặc một <code>GroupChatTermination</code> event nghĩa là
+done-with-everything).</li>
+<li><strong>Lands first:</strong> <strong>Agent runtime</strong> của
+AutoGen Core — một pub/sub message bus với <strong>topic-based
+routing</strong>. Theo source: một <em>group topic</em> (broadcast),
+per-participant topics (direct), và một <em>output topic</em> (results
+channel).</li>
+<li><strong>Supervisor delivery:</strong> Manager là một
+<code>SequentialRoutedAgent</code> đã subscribe group topic. Output
+collection: <code>_output_message_queue</code> cho đến khi nhận được
+<code>GroupChatTermination</code> event.</li>
+<li><strong>Broker:</strong> Có — <code>AgentRuntime</code> (in-process
+local, hoặc distributed gRPC variant).</li>
+<li><strong>Process model:</strong> Configurable. Default: tất cả agents
+trong một Python process. Distributed: agents trên các host khác nhau
+sau một gRPC runtime.</li>
+<li><strong>Failure mode:</strong> Mất in-memory theo default;
+distributed variant thêm delivery guarantees.</li>
+<li><strong>Abstraction:</strong> Mạnh. Agents chỉ biết
+<code>publish_message(topic, msg)</code> và subscriptions — không bao
+giờ thấy sockets.</li>
+</ul>
+<h3 id="13-crewai--githubcomcrewaiinccrewai">1.3 crewAI —
+github.com/crewAIInc/crewAI</h3>
+<ul>
+<li><strong>Analog:</strong> <code>Crew</code> ⇄ <code>Task</code> ⇄
+<code>Agent</code>.</li>
+<li><strong>Signal:</strong> Plain Python function return.
+<code>task.execute_sync()</code> return; <code>Crew.kickoff()</code>
+loop tuần tự qua các tasks. Có optional
+<strong><code>task_callback</code></strong> fire sau mỗi task;
+<strong><code>step_callback</code></strong> fire sau mỗi agent step. Ở
+mặt HTTP-API, tương đương là
+<code>taskWebhookUrl</code>/<code>stepWebhookUrl</code>/<code>crewWebhookUrl</code>
+(<a href="https://docs.crewai.com/en/learn/sequential-process">CrewAI
+docs</a>, <a href="https://community.crewai.com/t/how-does-the-task-callback-parameter-work/389">community
+thread</a>).</li>
+<li><strong>Lands first:</strong> Cùng Python stack frame (sync) hoặc
+webhook receiver (API mode).</li>
+<li><strong>Supervisor delivery:</strong> Loop tiếp tục; callback được
+gọi.</li>
+<li><strong>Broker:</strong> Không (in-process). Webhooks là surface duy
+nhất ra ngoài process.</li>
+<li><strong>Process model:</strong> Một Python process cho local SDK.
+Tasks không phải subprocesses.</li>
+<li><strong>Failure mode:</strong> Exceptions bubble lên; không có
+built-in replay.</li>
+<li><strong>Abstraction:</strong> Sync function semantics — đơn giản
+nhất có thể.</li>
+</ul>
+<h3 id="14-langgraph-langchain-ai--multi-agent-supervisor-pattern">1.4
+LangGraph (langchain-ai) — multi-agent supervisor pattern</h3>
+<ul>
+<li><strong>Analog:</strong> Supervisor node ⇄ worker nodes trong một
+state graph.</li>
+<li><strong>Signal:</strong> Workers return một object
+<strong><code>Command</code></strong>. Cụ thể
+<code>Command(goto=target, graph=Command.PARENT, update={...})</code> để
+chuyển control sang đâu đó; <code>create_handoff_back_messages()</code>
+để quay về supervisor với marker <code>__is_handoff_back</code> (<a href="https://deepwiki.com/langchain-ai/langgraph-supervisor-py/3.2-handoff-tools">DeepWiki:
+Handoff Tools</a>).</li>
+<li><strong>Lands first:</strong> LangGraph runtime — diễn giải
+<code>Command</code> rồi transition state graph.</li>
+<li><strong>Supervisor delivery:</strong> Graph step kế tiếp; prompt của
+supervisor được rebuild kèm messages bổ sung.</li>
+<li><strong>Broker:</strong> Chính bản thân graph runtime.</li>
+<li><strong>Process model:</strong> Một Python process; node executions
+là các awaited coroutines.</li>
+<li><strong>Failure mode:</strong> Checkpointer persist graph state;
+resumable.</li>
+<li><strong>Abstraction:</strong> Rất sạch — declarative graph, không
+thấy IPC.</li>
+</ul>
+<h3 id="15-openai-swarm--githubcomopenaiswarm">1.5 OpenAI Swarm —
+github.com/openai/swarm</h3>
+<ul>
+<li><strong>Analog:</strong> &quot;Current agent&quot; ⇄ &quot;next agent&quot; thông qua
+handoff.</li>
+<li><strong>Signal:</strong> Một tool function return về một
+<code>Agent</code> (hoặc <code>Result(agent=...)</code>). Run loop swap
+sang nó. <em>&quot;Swarm&#39;s <code>run()</code> function is analogous to
+<code>chat.completions.create()</code> — it takes <code>messages</code>
+and returns <code>messages</code> and saves no state between
+calls.&quot;</em></li>
+<li><strong>Lands first:</strong> Cùng Python stack; loop thấy
+<code>Agent</code> được return rồi tiếp tục với nó.</li>
+<li><strong>Supervisor delivery:</strong> Function return —
+synchronous.</li>
+<li><strong>Broker:</strong> Không. Stateless.</li>
+<li><strong>Process model:</strong> Một Python process, một linear
+loop.</li>
+<li><strong>Failure mode:</strong> Caller tự lo; không có
+persistence.</li>
+<li><strong>Abstraction:</strong> Tối giản: một function return ra
+worker kế tiếp.</li>
+</ul>
+<h3 id="16-tmux-orchestrator--githubcomjedward23tmux-orchestrator">1.6
+Tmux-Orchestrator — github.com/Jedward23/Tmux-Orchestrator</h3>
+<p>Đây là họ hàng gần cockpit nhất và là cuộc so sánh dạy được nhiều
+nhất.</p>
+<ul>
+<li><strong>Analog:</strong> Orchestrator → Project Managers →
+Engineers, mỗi cái là một tmux window riêng chạy Claude instance của
+nó.</li>
+<li><strong>Signal:</strong> <strong>Polled + self-scheduled.</strong>
+Không có async push nào cả. Một Claude instance tự schedule check-in cho
+mình bằng
+<code>schedule_with_note.sh 30 &quot;Continue dashboard implementation&quot;</code>.
+Orchestrator định kỳ đọc nội dung pane qua
+<code>tmux capture-pane</code>.</li>
+<li><strong>Lands first:</strong> Chính scrollback của pane tmux (text).
+&quot;Broker&quot; là <em>cái màn hình</em>.</li>
+<li><strong>Supervisor delivery:</strong> Orchestrator poll + đọc +
+interpret. Để nói ngược lại:
+<code>send-claude-message.sh session:window &quot;msg&quot;</code>, mà cái này
+<code>tmux send-keys</code> text vào pane đích. Đây đúng là tương đương
+của <code>cockpit runtime send</code> — và nó chạy được trên tmux vì
+tmux <strong>không</strong> enforce process-lineage check cho writer (ai
+có socket perms cũng có thể <code>send-keys</code>).</li>
+<li><strong>Broker:</strong> Không — tmux vừa là transport vừa là
+storage.</li>
+<li><strong>Process model:</strong> Multi-process; mỗi Claude là child
+của tmux pane của nó.</li>
+<li><strong>Failure mode:</strong> Mất việc không giới hạn nếu
+orchestrator không check lại. Pattern self-scheduling là cái phao duy
+nhất.</li>
+<li><strong>Abstraction:</strong> Leaky — scripts scrape rồi inject
+text. Prompt-engineering rules đóng vai trò contract.</li>
+</ul>
+<p><strong>Bài học cho cockpit:</strong> Tmux-Orchestrator chạy được vì
+authorization model của tmux là &quot;owner of the socket&quot; — không có lineage
+check. Check nghiêm của cmux mới là cái buộc cockpit phải host sender
+bên trong cmux&#39;s tree. Tmux-Orchestrator còn cho thấy
+<strong>cooperative-callback pattern</strong> mà Orca sau này
+formalize.</p>
+<h3 id="17-claude-squad--githubcomsmtg-aiclaude-squad">1.7 Claude Squad
+— github.com/smtg-ai/claude-squad</h3>
+<ul>
+<li><strong>Analog:</strong> N Claude instances độc lập, mỗi cái trong
+git worktree + tmux session riêng.</li>
+<li><strong>Signal:</strong> <strong>Không có gì tự động.</strong>
+Completion được human phát hiện qua TUI (preview/diff tabs, manual
+<code>c</code> checkout / <code>r</code> resume).</li>
+<li><strong>Lands first:</strong> Mắt người dùng.</li>
+<li><strong>Supervisor delivery:</strong> User.</li>
+<li><strong>Broker:</strong> Không.</li>
+<li><strong>Process model:</strong> Multi-process, isolated
+worktrees.</li>
+<li><strong>Failure mode:</strong> Human-in-the-loop.</li>
+<li><strong>Abstraction:</strong> Cố ý <em>không</em> phải một
+orchestrator — nói rõ là để coordination cho con người.</li>
+</ul>
+<p><strong>Bài học:</strong> Một tool multi-Claude được nể trọng đã né
+hoàn toàn bài toán captain↔︎crew. Tham vọng của cockpit (captain
+autonomous react theo crew) khó hơn đáng kể so với cái Claude Squad cố
+làm.</p>
+<h3 id="18-orca-stablyai--githubcomstablyaiorca-đã-nghiên-cứu-rồi">1.8
+Orca (stablyai) — github.com/stablyai/orca (đã nghiên cứu rồi)</h3>
+<ul>
+<li><strong>Analog:</strong> Coordinator + per-agent terminal panes
+(PTY-hosted).</li>
+<li><strong>Signal:</strong> Hai channel song song, tùy theo agent:
+<ol type="1">
+<li><strong>Native hooks → loopback HTTP</strong> (Claude Code &amp;
+Codex 0.129+). Hooks <code>curl</code> một JSON payload tới
+<code>http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/&lt;agent&gt;</code>
+kèm bearer token. <code>Stop</code> event = turn done. Xem
+<code>src/main/codex/hook-service.ts:42-49</code> và
+<code>src/main/agent-hooks/server.ts</code>.</li>
+<li><strong>Cooperative CLI callback</strong> cho autonomous
+coordinator: prompt preamble dạy agent gọi
+<code>orca task complete --body &lt;summary&gt;</code>, cộng với 10-min
+stale-heartbeat watchdog
+(<code>src/main/runtime/orchestration/coordinator.ts:172,230,332-335</code>).</li>
+</ol></li>
+<li><strong>Lands first:</strong> Main Electron process của Orca (HTTP
+server + IPC). Persist trong <code>last-status.json</code> để sống sót
+qua restart.</li>
+<li><strong>Supervisor delivery:</strong> IPC fanout sang renderer
+process / orchestration coordinator.</li>
+<li><strong>Broker:</strong> Loopback HTTP server + on-disk status
+cache.</li>
+<li><strong>Process model:</strong> Multi-process; mỗi agent là một
+<code>node-pty</code> child riêng. Orca tự sở hữu broker.</li>
+<li><strong>Failure mode:</strong> Replay từ
+<code>last-status.json</code>; hook script re-read
+<code>$ORCA_AGENT_HOOK_ENDPOINT</code> nên sống sót qua Orca restart
+trên <em>cùng</em> PTY.</li>
+<li><strong>Abstraction:</strong> Excellent bên trong Orca; leak ra qua
+hook config files trong <code>~/.codex/hooks.json</code> và
+<code>~/.codex/config.toml</code>.</li>
+</ul>
+<h3 id="19-codename-goose-block--githubcomblockgoose">1.9 Codename Goose
+(Block) — github.com/block/goose</h3>
+<ul>
+<li><strong>Analog:</strong> Một agent + MCP <strong>extensions</strong>
+(tool servers).</li>
+<li><strong>Signal:</strong> Standard MCP — JSON-RPC over
+stdio/SSE/streamable HTTP. <em>Không phải multi-agent coordinator.</em>
+Không có inter-extension event bus; extensions là tool providers, không
+phải peer agents.</li>
+<li><strong>Lands first:</strong> MCP client transport.</li>
+<li><strong>Process model:</strong> Goose host + một subprocess cho mỗi
+stdio extension.</li>
+<li><strong>Bài học cho cockpit:</strong> MCP là protocol
+<em>tool-call</em>, không phải protocol peer-to-peer notification. Mô
+hình hoá crew→captain thành một MCP tool call sẽ đảo chiều đúng (captain
+pull, không bao giờ được push).</li>
+</ul>
+<h3 id="110-codex-cli-app-server-openai--xem-docsresearch2026-05-19-orca-codex-wrapping-studymd">1.10
+Codex CLI app-server (OpenAI) — xem
+<code>docs/research/2026-05-19-orca-codex-wrapping-study.md</code></h3>
+<ul>
+<li><strong>Analog:</strong> Driver process ⇄ codex child qua JSON-RPC
+over stdio.</li>
+<li><strong>Signal:</strong> Notifications trong JSON-RPC stream
+(<code>turn.completed</code>, v.v.), framed dưới dạng newline-delimited
+JSON.</li>
+<li><strong>Lands first:</strong> Driver&#39;s stdio reader.</li>
+<li><strong>Broker:</strong> Không — stdio trực tiếp.</li>
+<li><strong>Process model:</strong> Parent sở hữu child qua pipe.</li>
+<li><strong>Bài học:</strong> Channel typed-event mạnh <strong>nhưng chỉ
+giữa parent và child của chính nó</strong>. Vô dụng nếu captain không
+phải parent của codex — mà đây đúng là constraint của cockpit (cmux sở
+hữu codex/claude child, không phải daemon của cockpit).</li>
+</ul>
+<h3 id="111-background--prior-art-về-process-coordination">1.11
+Background — prior art về process-coordination</h3>
+<table>
+<thead>
+<tr>
+<th>System</th>
+<th>One-line lesson</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>systemd <code>sd_notify</code></strong></td>
+<td>Một datagram dạng UDP gửi tới <code>$NOTIFY_SOCKET</code> (Unix
+DGRAM). <code>READY=1</code>, <code>STATUS=…</code>,
+<code>WATCHDOG=1</code>. Auth qua <code>SCM_CREDENTIALS</code>. Không
+broker, không queue — fire-and-forget nhưng reliable trên localhost. (<a href="https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html">sd_notify
+man</a>)</td>
+</tr>
+<tr>
+<td><strong>D-Bus</strong></td>
+<td>Pub/sub trưởng thành: signals broadcast; clients đăng ký interest;
+bus daemon fan out. Typing mạnh qua introspection. Transport: Unix
+domain sockets. (<a href="https://dbus.freedesktop.org/doc/dbus-specification.html">spec</a>)</td>
+</tr>
+<tr>
+<td><strong>macOS XPC</strong></td>
+<td>Client/server IPC hiện đại với privilege separation; được khuyến
+nghị thay cho <code>NSDistributedNotificationCenter</code> (cái này
+không mang được user info).</td>
+</tr>
+<tr>
+<td><strong>Erlang/OTP</strong></td>
+<td>Supervisor <code>monitor</code> worker process; worker chết →
+<code>{&#39;DOWN&#39;, Ref, ...}</code> rơi vào <em>mailbox</em> của supervisor
+(một queue cho mỗi process). Mailbox chính là broker; pattern-match
+dequeue. Fault-tolerance gold-standard.</td>
+</tr>
+<tr>
+<td><strong>OpenTelemetry collector</strong></td>
+<td>Pipeline <code>receiver → processor → exporter</code>; receivers là
+pluggable transports; cùng một data có thể fan out tới N exporters. Đúng
+nhu cầu &quot;event từ bất kỳ runtime → nhiều sinks (TUI, Telegram, push)&quot;
+của cockpit.</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="2-bảng-so-sánh">2. Bảng so sánh</h2>
+<table>
+<thead>
+<tr>
+<th>System</th>
+<th>Process model</th>
+<th>Signal mechanism</th>
+<th>Delivery</th>
+<th>Reliability</th>
+<th>Abstraction</th>
+<th>Cockpit-applicable insight</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>OpenHands</td>
+<td>1 host + sandbox subproc</td>
+<td>Typed event trong <code>EventStream</code></td>
+<td>Subscriber callback (push)</td>
+<td>Disk-replayable</td>
+<td>Strong (events)</td>
+<td>In-process bus + on-disk log = câu chuyện decoupling tốt nhất</td>
+</tr>
+<tr>
+<td>AutoGen</td>
+<td>1 proc (hoặc gRPC)</td>
+<td>Topic-pub/sub message</td>
+<td>Topic subscriber</td>
+<td>In-mem (local) / guaranteed (gRPC)</td>
+<td>Strong</td>
+<td>Topic routing scale tốt cho many-to-many</td>
+</tr>
+<tr>
+<td>crewAI</td>
+<td>1 proc</td>
+<td>Function return + callback</td>
+<td>Loop tiếp tục</td>
+<td>None</td>
+<td>Trivial</td>
+<td>Đừng over-engineer nếu bạn nắm cả loop</td>
+</tr>
+<tr>
+<td>LangGraph</td>
+<td>1 proc</td>
+<td>Value <code>Command(goto=…)</code></td>
+<td>Graph step</td>
+<td>Checkpointed</td>
+<td>Declarative</td>
+<td>Diễn đạt handoff là data, không phải IPC</td>
+</tr>
+<tr>
+<td>OpenAI Swarm</td>
+<td>1 proc</td>
+<td>Function return <code>Agent</code></td>
+<td>Loop tiếp tục</td>
+<td>None</td>
+<td>Trivial</td>
+<td>Stateless transfer là đủ khi in-process</td>
+</tr>
+<tr>
+<td>Tmux-Orchestrator</td>
+<td>Multi-proc (tmux)</td>
+<td>Scrape pane + <code>send-keys</code></td>
+<td>Poll + injected text</td>
+<td>Mất nếu không đọc</td>
+<td>Leaky</td>
+<td>tmux cho external sender → không cần relay ở đó</td>
+</tr>
+<tr>
+<td>Claude Squad</td>
+<td>Multi-proc (tmux)</td>
+<td>Không — human check</td>
+<td>Manual</td>
+<td>N/A</td>
+<td>N/A</td>
+<td>Né hoàn toàn</td>
+</tr>
+<tr>
+<td>Orca</td>
+<td>Multi-proc (PTY)</td>
+<td>Native hooks → loopback HTTP</td>
+<td>HTTP POST + IPC fanout</td>
+<td>Disk-cached</td>
+<td>Strong</td>
+<td><strong>Hooks-as-source-of-truth + broker chính là pattern
+thắng</strong></td>
+</tr>
+<tr>
+<td>Goose (MCP)</td>
+<td>Multi-proc (MCP)</td>
+<td>JSON-RPC tool call</td>
+<td>Caller await</td>
+<td>Per-call</td>
+<td>Strong</td>
+<td>Sai chiều cho completion notify</td>
+</tr>
+<tr>
+<td>Codex app-server</td>
+<td>Parent + child</td>
+<td>JSON-RPC notification</td>
+<td>stdio read</td>
+<td>Stream lifetime</td>
+<td>Strong</td>
+<td>Yêu cầu parent-of-child relationship</td>
+</tr>
+<tr>
+<td>systemd sd_notify</td>
+<td>Multi-proc</td>
+<td>Unix DGRAM</td>
+<td>Daemon recv</td>
+<td>Localhost-reliable</td>
+<td>Strong</td>
+<td>IPC nhỏ gọn nhất khả thi</td>
+</tr>
+<tr>
+<td>D-Bus</td>
+<td>Multi-proc</td>
+<td>Signal broadcast</td>
+<td>Bus fanout</td>
+<td>Bus-mediated</td>
+<td>Strong</td>
+<td>Pub/sub thực tế ở mức OS</td>
+</tr>
+<tr>
+<td>Erlang/OTP</td>
+<td>Multi-proc (BEAM)</td>
+<td><code>monitor</code> + mailbox</td>
+<td>Mailbox dequeue</td>
+<td>Queued</td>
+<td>Gold</td>
+<td>Mailbox per supervisor = mental model lý tưởng</td>
+</tr>
+<tr>
+<td>OTel collector</td>
+<td>Pluggable</td>
+<td>Pipeline receiver → exporter</td>
+<td>Push</td>
+<td>Configurable</td>
+<td>Strong</td>
+<td>Một event, nhiều sinks (TUI/push/file)</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="3-khuyến-nghị-cho-cockpit-xếp-hạng">3. Khuyến nghị cho cockpit
+(xếp hạng)</h2>
+<p>Tôi xếp hạng <strong>3 pattern</strong> theo độ phù hợp, xét tới các
+ràng buộc cứng của cockpit:</p>
+<ol type="1">
+<li>Multi-runtime (Claude Code, Codex, Gemini, Aider, opencode).</li>
+<li>Multi-host runtime (cmux hiện tại; Orca, Zed, IntelliJ-MCP trong
+tương lai).</li>
+<li>Captain chạy trong một <em>real shell bên trong pane của
+runtime</em> và tiêu thụ input từ chính cơ chế input của runtime
+đó.</li>
+<li>cmux enforce process-lineage check: writer ghi vào pane của captain
+<strong>bắt buộc</strong> phải nằm trong process tree của cmux.</li>
+</ol>
+<h3 id="hạng-1--mailbox--injector-pattern-lai-erlang--orca-khuyến-nghị-mạnh">Hạng
+1 — <strong>Mailbox + injector pattern</strong> (lai Erlang + Orca).
+Khuyến nghị mạnh.</h3>
+<p><strong>Mechanism.</strong> Daemon của cockpit là
+<strong>broker</strong> (tương đương <code>gen_server</code> của
+Erlang). Mỗi captain có một <strong>mailbox</strong>: một queue ở phía
+daemon, key là captain-id. Mỗi runtime đăng ký đúng <strong>một
+injector</strong> — một process tí hon sống dai <em>bên trong process
+tree của runtime đó</em> — nhiệm vụ duy nhất là dequeue từ mailbox của
+captain và gọi API &quot;type into pane&quot; riêng của runtime. Injector chính là
+analog cockpit-side của <strong><code>notify-relay</code> tab bạn đã
+có</strong>, nhưng được tổng quát hoá và được &quot;phong tước&quot; thành một
+first-class architectural element thay vì &quot;một terminal tab thừa&quot;.</p>
+<p><strong>Tại sao đây là cách rebrand đúng cho cái bạn đã
+xây.</strong></p>
+<ul>
+<li>Relay-tab không phải workaround — nó chính là pattern Erlang dùng
+(per-process mailbox cần một per-process dequeuer chạy <em>bên
+trong</em> scheduler của process đó). Lineage check của cmux tương đương
+với BEAM scheduler boundary: chỉ context đúng mới deliver được. Bạn đúng
+khi đặt một process bên trong cmux; bạn sai khi cảm thấy ngại về điều
+đó.</li>
+<li>Mailbox semantics fix luôn cái failure mode mà thiết kế hiện tại
+<em>không</em> xử lý tốt: nếu captain đang giữa turn, đang shutdown,
+hoặc tạm vắng một lúc, events sẽ queue lại thay vì bay mất. (Hiện tại
+relay tab forward ngay; nếu captain pane đang bận, cmux send có thể nuốt
+input.)</li>
+<li>Một injector cho mỗi runtime, không phải mỗi captain: một daemon
+process <code>cockpit-injector</code> duy nhất cho mỗi cmux instance có
+thể phục vụ mọi captain host ở đó.</li>
+</ul>
+<p><strong>Sketch cụ thể thay cho relay-tab.</strong></p>
+<ul>
+<li>Daemon expose <code>MailboxAppend(captainId, event)</code> và
+<code>MailboxClaim(captainId, sinceCursor) → events</code>.</li>
+<li>Runtime driver implement <code>Injector(runtime, captainId)</code> —
+một binary Go/Node/Python nhỏ được <code>cmux spawn</code> khởi động làm
+hidden helper process bên trong workspace của captain. Long-poll
+<code>MailboxClaim</code>, rồi gọi cơ chế send của runtime. Khi khởi
+động, injector cũng drain backlog đã tích lũy lúc captain idle.</li>
+<li>Captain shutdown thì remove mailbox; restart thì restore từ đĩa
+(analog của <code>last-status.json</code> kiểu Orca).</li>
+<li>Tracker integration: socket pub/sub hiện có của daemon trở thành
+<em>receiver</em> theo từ vựng OTel-collector; mailbox là
+<em>processor</em>; injector là <em>exporter</em> duy nhất phải thoả
+lineage rule của cmux. Telegram, TUI, và push notifications vẫn
+subscribe trực tiếp vào receiver — chúng không đi qua exporter bị ràng
+buộc lineage.</li>
+</ul>
+<p><strong>Xử lý lineage check của cmux:</strong> Có — injector được
+cmux spawn nên theo định nghĩa là sống trong tree của nó. Với
+Orca/Zed/IntelliJ-MCP, cùng concept injector tái sinh thành: một Orca
+pane host <code>cockpit-injector orca</code>; một Zed task; một IntelliJ
+background process. Mỗi runtime driver sở hữu injector binary của mình;
+mailbox protocol thì dùng chung.</p>
+<p><strong>Tradeoff về complexity:</strong> Vừa phải. Bạn đã có hầu hết
+rồi (daemon socket pub/sub + relay tab). Việc cần làm là (a) thêm queue
++ cursor phía daemon, (b) tổng quát hoá relay thành một binary
+<code>cockpit-injector</code> mà bất kỳ runtime nào cũng spawn được, (c)
+ship lifecycle hook &quot;start injector khi mở workspace&quot; cho từng
+runtime.</p>
+<h3 id="hạng-2--hooks-into-loopback-broker-orca-pattern-tổng-quát-hoá">Hạng
+2 — <strong>Hooks-into-loopback-broker</strong> (Orca pattern, tổng quát
+hoá).</h3>
+<p><strong>Mechanism.</strong> Mỗi agent CLI được support đều có
+<em>kiểu nào đó</em> completion hook native (Claude Code:
+<code>Stop</code> hook; Codex 0.129+: <code>Stop</code> hook; Gemini:
+vẫn TBD; Aider: chế độ <code>--message</code> return; opencode: events).
+Hook <code>curl</code> một loopback HTTP endpoint trên daemon. Daemon
+giờ có signal &quot;crew X xong&quot; có thẩm quyền <em>từ chính agent</em>, không
+phải từ process-watching hay PTY-scraping.</p>
+<p><strong>Cái này giải bài toán khác</strong> — nó là về
+<strong>detection</strong>, không phải <strong>delivery</strong>. Bạn
+vẫn cần pattern #1 (hoặc #3) để <em>đưa tin vào input của captain</em>.
+Nhưng ghép #2 với #1 thì cockpit có vòng lặp hoàn chỉnh:</p>
+<ul>
+<li>Detection: native hook → daemon (đã được Orca validate).</li>
+<li>Delivery: daemon mailbox → in-cmux injector (Hạng 1).</li>
+</ul>
+<p><strong>Xử lý lineage check của cmux:</strong> Không liên quan đối
+với detection. Delivery vẫn cần Hạng 1.</p>
+<p><strong>Tại sao không xếp #1:</strong> Bạn đã ngầm có detection rồi
+(cmux <code>read-screen</code> + heuristics của bạn). Nỗi đau cấp tính
+là delivery, không phải detection. Adopt #2 dần khi mỗi runtime có
+native hook, nhưng nó không thay được #1.</p>
+<h3 id="hạng-3--captain-side-polling-vào-daemon-socket-option-không-làm-gì-in-cmux">Hạng
+3 — <strong>Captain-side polling vào daemon socket</strong> (option
+&quot;không làm gì in-cmux&quot;).</h3>
+<p><strong>Mechanism.</strong> Bỏ luôn relay tab. Dạy captain — qua
+system prompt / một skill — <strong>định kỳ chạy một CLI
+command</strong> (<code>cockpit inbox</code>) trong loop của chính nó,
+đọc từ daemon socket và return new events dưới dạng plain text. Captain
+có shell access; gọi một CLI là hoàn toàn nằm trong toolset của nó.</p>
+<p><strong>Tại sao hấp dẫn.</strong> Zero extra processes. Zero relay.
+Captain là kẻ duy nhất có quyền input được cmux chúc phúc (nó <em>chính
+là</em> cmux child), nên theo định nghĩa, bất kỳ text nào nó sinh ra
+cũng rơi đúng chỗ. Bước &quot;delivery&quot; trở thành &quot;captain in ra cái nó đọc
+được.&quot; Cadence polling do captain tự quyết.</p>
+<p><strong>Tại sao là #3, không phải #1.</strong> Nó đổi captain
+semantics từ <em>reactive</em> thành <em>proactive</em>. Captain đang
+giữa turn sẽ không poll. Captain đang kẹt trong một tool call sẽ không
+thấy crew xong. Mục tiêu của push-notification ban đầu là làm captain
+thức dậy khi crew hoàn thành; hạng 3 lặng lẽ quay về polling, mà cái này
+nghiên cứu idle-detection 2026-05-16 đã loại rồi. Chỉ dùng làm fallback
+cho runtime nào không spawn được injector.</p>
+<p><strong>Xử lý lineage check của cmux:</strong> Trivially — không có
+external sender.</p>
+<p><strong>Cho Orca/Zed/IntelliJ-MCP:</strong> Chạy được trong cả ba.
+Đây là universal-fallback path.</p>
+<hr />
+<h2 id="4-tổng-hợp-thiết-kế-đề-xuất">4. Tổng hợp: thiết kế đề xuất</h2>
+<pre><code>                 ┌──────────────────┐
+   crew event ──▶│  daemon receiver │ (existing)
+                 └────────┬─────────┘
+                          │ fanout
+            ┌─────────────┼─────────────────┐
+            ▼             ▼                 ▼
+        Telegram       TUI/push     ┌─────────────────┐
+                                    │ per-captain     │
+                                    │ mailbox (queue) │ (NEW)
+                                    └────────┬────────┘
+                                             │ long-poll
+                                             ▼
+                                  ┌─────────────────────┐
+                                  │ cockpit-injector    │  ◀── spawned by cmux,
+                                  │ (1 per runtime host)│      lives in cmux tree
+                                  └────────┬────────────┘
+                                           │ runtime.send()
+                                           ▼
+                                    captain&#39;s input</code></pre>
+<p>Đây là <strong>relay-tab pattern, đổi tên và phong tước</strong>:
+relay trở thành &quot;injector&quot; first-class với một queue đằng sau. Thêm
+native-hook detection (Orca pattern, Hạng 2) khi runtime support. Giữ
+CLI-poll (Hạng 3) làm fallback không-bao-giờ-fail mà captain luôn có thể
+chạy.</p>
+<h3 id="cái-này-mua-được-gì-so-với-relay-tab-hiện-tại">Cái này mua được
+gì so với relay-tab hiện tại</h3>
+<ul>
+<li><strong>Buffering</strong> — events không bay mất nếu captain pane
+bận tạm thời.</li>
+<li><strong>Restart survival</strong> — mailbox là durable; injector
+restart sẽ drain backlog.</li>
+<li><strong>Một concept, mọi runtime</strong> — Orca/Zed/IntelliJ dùng
+cùng protocol; chỉ injector binary đổi theo runtime.</li>
+<li><strong>Không thêm IPC primitive mới</strong> — dùng lại daemon
+socket có sẵn; mailbox chỉ là một map&lt;captainId, []event&gt; trên
+daemon cộng với một cursor.</li>
+<li><strong>Tracker vẫn decoupled</strong> — receivers, processors
+(mailbox), exporters (injector) là shape OTel-collector, biến &quot;gửi cùng
+event tới Telegram và captain&quot; thành chuyện cấu hình chứ không phải
+chuyện code.</li>
+</ul>
+<hr />
+<h2 id="provider-coverage-audit--claude--codex--opencode">Provider
+Coverage Audit — Claude / Codex / Opencode</h2>
+<p>Pattern relay/notify ở section 3 giả định mỗi runtime provider có thể
+đẩy cho cockpit một signal &quot;crew finished&quot;. Hôm nay claude-code emit
+signal này qua <code>Stop</code> / <code>SessionEnd</code> hooks (PR
+#108) và codex emit qua app-server JSON-RPC notifications (PR #97/#98).
+Opencode interactive crews hiện vẫn đi theo đường legacy cmux-only spawn
+(<code>src/commands/crew.ts:163</code>) — daemon hoàn toàn không biết
+chúng tồn tại. Phần audit này trả lời câu hỏi liệu opencode có thể được
+wire vào cùng notify loop không, và shape của wiring đó nên thế nào.</p>
+<h3 id="findings--opencode-sstopencode">Findings — opencode
+(sst/opencode)</h3>
+<ol type="1">
+<li><p><strong>Hook / lifecycle event system — CÓ, qua plugin
+system.</strong> Opencode ship một plugin framework first-class. Một
+plugin là một TypeScript module đặt dưới
+<code>.opencode/plugin/*.ts</code> hoặc khai báo qua
+<code>opencode.json → plugins</code>. Plugin nhận một async
+<code>event</code> callback và còn có thể wrap tool execution với
+<code>tool.execute.before</code> / <code>tool.execute.after</code>.
+Event names được tài liệu hoá bao gồm <code>session.idle</code> và
+tool-execution events; bài DEV.to overview và trang SDK đều nhắc đến
+chúng như extension surface chính (<a href="https://dev.to/einarcesar/does-opencode-support-hooks-a-complete-guide-to-extensibility-k3p">dev.to
+&quot;Does OpenCode Support Hooks?&quot;</a>, <a href="https://opencode.ai/docs/sdk/">OpenCode SDK docs</a>). DeepWiki
+page về session-lifecycle confirm có taxonomy <code>session_start</code>
+/ <code>session_idle</code> / <code>session_end</code> trên event bus
+nhưng không liệt kê wire names chính xác (<a href="https://deepwiki.com/sst/opencode/2.1-session-lifecycle-and-state">DeepWiki
+§2.1 session lifecycle</a>). <strong>Unable to confirm via public
+docs</strong> liệu <code>session.end</code> có phải là một stable
+plugin-callable event hay chỉ là internal-bus event; assumption an toàn
+là <code>session.idle</code> (cái được tài liệu hoá) là analog &quot;turn
+done&quot; gần nhất cho mục đích của cockpit.</p></li>
+<li><p><strong>App-server / streaming protocol — CÓ, nhưng là HTTP REST
++ SSE, không phải JSON-RPC.</strong> <code>opencode serve</code> khởi
+một headless HTTP server expose một OpenAPI 3.1 spec; flags gồm
+<code>--port</code>, <code>--hostname</code>, <code>--mdns</code>,
+<code>--cors</code>, và <code>OPENCODE_SERVER_PASSWORD</code> cho basic
+auth (<a href="https://opencode.ai/docs/server/">Server docs</a>). Hai
+SSE endpoints stream event bus: <code>GET /event</code> (per-session /
+global bus; message đầu là <code>server.connected</code>, rồi đến bus
+events) và <code>GET /global/event</code>. Đây là pattern subscribe sống
+dai; daemon có thể giữ một HTTP connection mở và nhận mọi bus event suốt
+vòng đời server.</p></li>
+<li><p><strong>MCP — opencode là MCP <em>client</em>, không phải MCP
+server expose lifecycle events.</strong> MCP integration của opencode là
+để <em>thêm tool vào opencode</em>, không phải để cho process bên ngoài
+subscribe vào opencode events (<a href="https://opencode.ai/docs/mcp-servers/">MCP docs</a>). Bài học từ
+Goose ở §1.9 áp dụng tại đây: MCP là sai hướng cho
+completion-notify.</p></li>
+<li><p><strong><code>opencode run --format json</code> — CÓ.</strong>
+Subcommand <code>run</code> hỗ trợ <code>--format json</code>, được tài
+liệu hoá là &quot;raw JSON events&quot;. Kết hợp với
+<code>--session &lt;id&gt;</code> / <code>--continue</code> /
+<code>--fork</code>, nó cho ra một headless invocation stream structured
+events ra stdout — dùng được từ non-cmux wrapper, dù với case
+cockpit-interactive thì SSE bus là channel tốt hơn vì nó persist qua
+nhiều turn.</p></li>
+<li><p><strong>Programmatic SDKs — CÓ.</strong> SDK chính thức
+<code>@opencode-ai/sdk</code> (TypeScript) wrap HTTP + SSE surface vào
+typed methods bao gồm <code>event.subscribe()</code> (<a href="https://deepwiki.com/sst/opencode/7.1-javascripttypescript-sdk">JS
+SDK DeepWiki</a>). Community-maintained Go
+(<code>opencode-sdk-go</code>) và Python
+(<code>opencode-sdk-python</code>) SDKs được generate từ cùng OpenAPI
+spec. Một điểm đáng note: opencode còn implement <strong>Agent Client
+Protocol (ACP) qua JSON-RPC</strong> cho editor integrations (Zed và bạn
+bè), expose events như <code>permission.asked</code> và
+<code>usage_update</code> (<a href="https://deepwiki.com/sst/opencode/7.4-agent-client-protocol-(acp)">DeepWiki
+ACP</a>); ACP là event surface <em>thứ hai</em> song song với HTTP/SSE
+bus, dùng khi phía IDE cần là loop driver của agent.</p></li>
+<li><p><strong>Resume semantics — CÓ.</strong> Cả
+<code>opencode run</code> lẫn TUI đều nhận <code>--continue</code>
+(<code>-c</code>), <code>--session &lt;id&gt;</code> (<code>-s</code>),
+và <code>--fork</code>. Sessions được persist (SQLite qua Drizzle ORM
+theo lifecycle page); reattach sau khi daemon bounce là support được,
+với daemon recover session-id từ state của chính nó chứ không phải từ
+opencode.</p></li>
+</ol>
+<h3 id="bảng-so-sánh">Bảng so sánh</h3>
+<table>
+<thead>
+<tr>
+<th>Capability</th>
+<th>Claude</th>
+<th>Codex</th>
+<th>Opencode</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Hook system (lifecycle events file-configurable)</td>
+<td>CÓ — <code>settings.json</code> Stop / SubagentStop /
+SessionEnd</td>
+<td>KHÔNG có native; Orca chứng minh Codex 0.129+ có <code>Stop</code>
+hooks nhưng cockpit chưa dùng</td>
+<td>CÓ — TS plugin trong <code>.opencode/plugin/*.ts</code>;
+<code>event</code> callback + tool before/after;
+<code>session.idle</code> documented</td>
+<td>Opencode plugin là code chứ không phải pure JSON, nên khó template
+hơn <code>settings.json</code> của Claude nhưng expressive hơn</td>
+</tr>
+<tr>
+<td>App-server / streaming protocol</td>
+<td>KHÔNG (stdio CLI only)</td>
+<td>CÓ — app-server, JSON-RPC qua stdio</td>
+<td>CÓ — <code>opencode serve</code> HTTP + SSE; ACP JSON-RPC cũng có
+sẵn</td>
+<td>Opencode là cái duy nhất có <em>socket-listening</em> server ngay từ
+đầu</td>
+</tr>
+<tr>
+<td>MCP server interface (expose events)</td>
+<td>Claude chỉ là MCP client</td>
+<td>Codex chỉ là MCP client</td>
+<td>Opencode chỉ là MCP client</td>
+<td>Không cái nào cho cockpit subscribe qua MCP</td>
+</tr>
+<tr>
+<td>JSON output mode (headless)</td>
+<td>CÓ — <code>claude -p --output-format=json</code></td>
+<td>CÓ — <code>codex exec --json</code></td>
+<td>CÓ — <code>opencode run --format json</code></td>
+<td>Cả ba dùng được cho one-shot non-interactive crews</td>
+</tr>
+<tr>
+<td>Session resume</td>
+<td>CÓ — <code>claude -c</code> / <code>--resume</code></td>
+<td>CÓ — <code>codex exec resume</code></td>
+<td>CÓ — <code>opencode run --session &lt;id&gt;</code> /
+<code>--continue</code> / <code>--fork</code></td>
+<td>Cả ba đều persist session</td>
+</tr>
+<tr>
+<td>Programmatic SDK</td>
+<td>CÓ — <code>@anthropic-ai/claude-code</code> TS SDK</td>
+<td>CLI only (chưa có first-party SDK tính đến 0.130)</td>
+<td>CÓ — <code>@opencode-ai/sdk</code> TS (chính thức); Go &amp; Python
+(community, generated)</td>
+<td>Opencode có story SDK phong phú nhất</td>
+</tr>
+</tbody>
+</table>
+<h3 id="verdict--pattern-relaynotify-có-chạy-được-cho-opencode-không">Verdict
+— pattern relay/notify có chạy được cho opencode không?</h3>
+<p><strong>Best path: SSE subscribe + một plugin emitter nhẹ.</strong>
+Opencode là cái <em>dễ wire</em> nhất trong ba provider để gắn vào
+daemon. Daemon có thể connect một lần tới
+<code>http://127.0.0.1:&lt;port&gt;/event</code> cho mỗi
+<code>opencode serve</code> đang chạy và nhận <code>session.idle</code>
+cùng các bus events khác với zero per-crew configuration. Cấu trúc này
+identical với codex app-server path (long-lived stream, daemon
+subscribe), khác duy nhất ở transport (HTTP+SSE vs.
+JSON-RPC-over-stdio). Để làm semantic &quot;turn-done&quot; thành explicit (thay
+vì infer từ <code>session.idle</code>), cockpit có thể ship một plugin
+nhỏ <code>.opencode/plugin/cockpit-emit.ts</code> gọi ngược về daemon&#39;s
+<code>task.progress</code> endpoint trên hook lifecycle nào ổn định nhất
+— đây là <em>đúng cùng</em> shape với claude-code hook trong PR #108,
+chỉ là express dưới dạng plugin thay vì entry trong
+<code>settings.json</code>. Net: opencode support <strong>cả
+hai</strong> pattern trước đó cùng lúc, với SSE path đòi hỏi zero
+crew-side config.</p>
+<p><strong>Fallback: app-server-style SSE riêng.</strong> Nếu plugin
+emitter chứng tỏ brittle (ví dụ opencode plugin API đổi giữa các bản 0.x
+— khá khả thi vì velocity của project), daemon có thể dựa thuần vào
+documented SSE bus. <code>session.idle</code> là canonical signal &quot;agent
+finished its turn&quot; theo public docs và đủ cho use case
+captain-attention. Đây strictly là codex pattern, port qua.</p>
+<p><strong>Universal fallback: explicit
+<code>cockpit crew signal done</code>.</strong> Crew template luôn có
+thể bao gồm chỉ thị gọi <code>cockpit crew signal done</code> như action
+cuối của mọi task — provider-agnostic, hôm nay đã chạy được cho opencode
+mà không cần wiring mới nào, đổi lại phải dựa vào việc agent nhớ gọi.
+Cái này nên giữ lại trong opencode crew template như belt-and-suspenders
+fallback ngay cả sau khi auto-detection ship, mirror đường
+explicit-signal đã tồn tại cho claude.</p>
+<p><strong>Ranked by honest-fit-for-opencode:</strong> (1) SSE subscribe
+với <code>session.idle</code> làm trigger — ít moving parts nhất, chỉ
+dùng documented public APIs, mirror codex pattern. (2) Plugin emitter
+gọi <code>task.progress</code> — semantic chính xác nhất, nhưng buộc
+cockpit vào plugin API surface của opencode. (3) Explicit
+<code>cockpit crew signal done</code> — fallback luôn-chạy, giữ trong
+template. <strong>Recommendation: ship (1) trước, thêm (2) nếu
+<code>session.idle</code> quá noisy hoặc không đủ chính xác, giữ (3)
+trong template luôn.</strong></p>
+<p><strong>Recommendation kiến trúc ở section 3 có còn đứng vững khi xét
+cả ba provider?</strong> <strong>Có, không có gì để bàn cãi.</strong>
+Verdict &quot;dignify cái relay thành first-class injector với daemon-side
+mailbox&quot; <em>được củng cố</em> khi opencode bước vào bức tranh. Hôm nay
+daemon nhận ba shape completion signal khác nhau hoàn toàn:
+file-configured hooks (claude), parent-of-child JSON-RPC (codex), và
+long-lived HTTP+SSE (opencode). Design mailbox-plus-injector là cái duy
+nhất trong ba rank ở section 3 hấp thụ được cả ba transport một cách
+sạch sẽ: driver của mỗi runtime dịch event surface native của nó thành
+<code>MailboxAppend(captainId, event)</code>, còn in-cmux injector vẫn
+là exporter duy nhất được lineage-blessed. Không có abstraction mailbox,
+cockpit sẽ phải có ba đường song song từ detection-source thẳng tới cmux
+send, mỗi đường replicate riêng buffering, retry, và lineage handling.
+Audit này confirm detection là phần dễ với cả ba provider; delivery vào
+captain pane bị restrict bởi process-lineage vẫn là phần khó, và mailbox
+per-captain là cách factor đúng cho responsibility đó.</p>
+<hr />
+<h2 id="5-nguồn-không-truy-cập-được--chỉ-truy-cập-được-một-phần">5.
+Nguồn không truy cập được / chỉ truy cập được một phần</h2>
+<ul>
+<li><code>github.com/All-Hands-AI/OpenHands/blob/main/openhands/events/stream.py</code>
+— 404 liên tục qua WebFetch (có khả năng đã đổi tên hoặc dời chỗ trong
+main hiện tại). Bù lại bằng DeepWiki + PR #2709 <em>Refactoring: event
+stream based agent history</em> + cấu trúc README của OpenHands.</li>
+<li><code>github.com/crewAIInc/crewAI/blob/main/src/crewai/task.py</code>
+và <code>crew.py</code> — 404 qua WebFetch (path layout đã đổi; có khả
+năng nằm dưới <code>src/crewai/lib/</code>). Bù bằng docs chính thức của
+crewAI + community threads tài liệu hoá semantics
+<code>task_callback</code>/<code>step_callback</code>.</li>
+<li><code>langchain-ai.github.io/langgraph/concepts/multi_agent/</code>
+— redirect về trang trống; dùng DeepWiki và bài focused.io thay
+thế.</li>
+<li><code>freedesktop.org/sd_notify</code> — 403 ở URL canonical; dùng
+Baeldung + gist + systemd docs chung.</li>
+<li>Goose source — README ở mức cao; chưa đọc sâu <code>crates/</code>.
+Chỉ confirm rằng Goose không có peer-agent event bus (MCP là tool-call,
+không phải pub/sub).</li>
+<li>Aider — confirm không có multi-session model built-in. Bỏ qua bước
+đào sâu source.</li>
+</ul>
+<p>Không còn hệ thống nào khác trong request list bị inaccessible.</p>
+<hr />
+<h2 id="6-tài-liệu-tham-khảo">6. Tài liệu tham khảo</h2>
+<ul>
+<li>OpenHands — <a href="https://github.com/All-Hands-AI/OpenHands">README</a>, <a href="https://deepwiki.com/OpenHands/OpenHands/6-configuration-system">DeepWiki
+Agent System</a>, <a href="https://www.emergentmind.com/topics/openhands-agent-framework">EmergentMind
+summary</a>, PR #2709</li>
+<li>AutoGen — <a href="https://github.com/microsoft/autogen">microsoft/autogen</a>,
+<code>python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py</code></li>
+<li>crewAI — <a href="https://docs.crewai.com/en/learn/sequential-process">docs.crewai.com
+sequential process</a>, <a href="https://community.crewai.com/t/how-does-the-task-callback-parameter-work/389">task_callback
+thread</a></li>
+<li>LangGraph — <a href="https://deepwiki.com/langchain-ai/langgraph-supervisor-py/3.2-handoff-tools">DeepWiki
+handoff tools</a>, <a href="https://focused.io/lab/multi-agent-orchestration-in-langgraph-supervisor-vs-swarm-tradeoffs-and-architecture">focused.io
+article</a></li>
+<li>OpenAI Swarm — <a href="https://github.com/openai/swarm">openai/swarm</a></li>
+<li>Tmux-Orchestrator — <a href="https://github.com/Jedward23/Tmux-Orchestrator">Jedward23/Tmux-Orchestrator</a>
+(<code>send-claude-message.sh</code>,
+<code>schedule_with_note.sh</code>)</li>
+<li>Claude Squad — <a href="https://github.com/smtg-ai/claude-squad">smtg-ai/claude-squad</a></li>
+<li>Orca — <a href="https://github.com/stablyai/orca">stablyai/orca</a>;
+xem <code>docs/research/2026-05-19-orca-codex-wrapping-study.md</code>
+(<code>src/main/codex/hook-service.ts</code>,
+<code>src/main/agent-hooks/server.ts</code>,
+<code>src/main/runtime/orchestration/coordinator.ts</code>)</li>
+<li>Goose — <a href="https://github.com/block/goose">block/goose</a>, <a href="https://deepwiki.com/block/goose/5.3-extension-types-and-configuration">DeepWiki
+extension types</a></li>
+<li>Codex CLI — internal study
+<code>docs/research/2026-05-19-orca-codex-wrapping-study.md</code></li>
+<li>systemd <code>sd_notify</code> — <a href="https://www.baeldung.com/linux/systemd-notify">Baeldung</a>, <a href="https://gist.github.com/grawity/6e5980981dccf66f554bbebb8cd169fc">systemd
+Type=notify gist</a></li>
+<li>D-Bus — <a href="https://en.wikipedia.org/wiki/D-Bus">Wikipedia</a>,
+<a href="https://dbus.freedesktop.org/doc/dbus-specification.html">spec</a></li>
+<li>macOS XPC — <a href="https://nshipster.com/inter-process-communication/">NSHipster
+IPC</a>, <a href="https://karol-mazurek.medium.com/xpc-programming-on-macos-7e1918573f6d">Karol
+Mazurek XPC</a></li>
+<li>Erlang/OTP — <a href="https://www.erlang.org/doc/system/design_principles.html">Erlang
+System Documentation</a>, <a href="https://www.emqx.com/en/blog/hamler-0-2-otp-behaviours-with-type-classes">Hamler
+OTP behaviours</a></li>
+<li>OpenTelemetry collector — <a href="https://opentelemetry.io/docs/collector/architecture/">Architecture
+docs</a></li>
+<li>Nghiên cứu cockpit trước —
+<code>docs/research/2026-05-16-idle-detection-and-inter-agent-orchestration.md</code>,
+<code>docs/research/2026-05-19-orca-codex-wrapping-study.md</code>,
+<code>docs/research/2026-05-19-cockpit-vs-orca-system-comparison.html</code></li>
+</ul>
+</body>
+</html>

--- a/docs/research/2026-05-27-multi-session-orchestrator-notification-patterns.vi.md
+++ b/docs/research/2026-05-27-multi-session-orchestrator-notification-patterns.vi.md
@@ -1,0 +1,334 @@
+# Multi-Session Orchestrator Notification Patterns — Nghiên cứu so sánh thiết kế
+
+**Date:** 2026-05-27
+**Tác giả:** Cockpit research (parent: develop)
+**Mục đích:** Khảo sát cách các hệ multi-agent / multi-session tương đương giải quyết bài toán *crew hoàn thành → đánh thức captain*, trước khi thiết kế lại cơ chế daemon-relay-tab của cockpit.
+
+---
+
+## 0. Vấn đề của Cockpit, phát biểu chính xác
+
+Cockpit chạy một session **captain** (một process Claude/Codex/v.v. nằm trong một cmux pane) làm nhiệm vụ điều phối các session **crew** (cũng là các process Claude/Codex/v.v., mỗi cái nằm trong cmux pane riêng). Khi một crew xong việc, captain cần biết — lý tưởng là dưới dạng một *message được đẩy thẳng vào input stream của captain*, để turn kế tiếp của captain nhận được nó một cách tự nhiên.
+
+Hai cách tiếp cận thất bại và một workaround hiện tại:
+- **Naive shell-out** — daemon (hoặc một hook) gọi `cockpit runtime send <captain> "<msg>"`. cmux từ chối vì PID của caller không nằm trong process-tree của cmux (cmux kiểm tra process-lineage chứ không phải env-var/socket-token).
+- **Daemon push events** — cùng vấn đề: process nào mà daemon delegate sang đều không có parent là cmux.
+- **`notify-relay` tab nằm trong captain workspace** — daemon broadcast events qua Unix socket của nó; một terminal tab "relay" sống dai *bên trong* cmux workspace của captain subscribe socket đó và forward qua đường cmux send, hoạt động được vì relay tự nó là một child do cmux spawn ra. Cách này đúng nhưng có vẻ nặng nề: thêm một tab cho mỗi captain, thêm fanout phía daemon, và một relay impl cho mỗi runtime.
+
+Câu hỏi đáng hỏi là prior art dùng *category* mechanism nào, và liệu cái relay-tab kia là một instance của một pattern tốt đã biết hay là một workaround đáng vứt đi.
+
+---
+
+## 1. Các hệ thống được khảo sát (≥6 + background)
+
+Mỗi mục trả lời: analog cho captain↔crew · completion signal · signal landing · supervisor delivery · broker · process model · failure mode · abstraction surface.
+
+### 1.1 OpenHands (trước đây là OpenDevin) — github.com/All-Hands-AI/OpenHands
+
+- **Analog:** `AgentController` ⇄ `Runtime` (sandboxed exec env) và các child agent delegate.
+- **Signal:** Typed `Action`/`Observation` events. Crew post một `Observation`; "done" là một terminal observation cụ thể (ví dụ `AgentFinishAction`).
+- **Lands first:** In-process `EventStream` — một central pub/sub hub. Trích docs OpenHands: *"The EventStream is a central hub for Events, where any component can publish Events, or listen for Events published by other components."* ([emergentmind](https://www.emergentmind.com/topics/openhands-agent-framework), [DeepWiki](https://deepwiki.com/OpenHands/OpenHands))
+- **Supervisor delivery:** `AgentController` là một subscriber đã đăng ký — *"The AgentController performs Event Stream Subscription, subscribing to `EventStreamSubscriber.AGENT_CONTROLLER` unless it's a delegate."*
+- **Broker:** Có — `EventStream` chính là broker, persist events xuống đĩa để replay/history (PR #2709, *Refactoring: event stream based agent history*).
+- **Process model:** Một Python process duy nhất sở hữu controller + event stream; runtime chạy trong một sandboxed subprocess/container; events vượt qua boundary đó dưới dạng serialized messages.
+- **Failure mode:** Replayable — event log trên đĩa nghĩa là controller restart sẽ reconstruct được state.
+- **Abstraction:** Excellent. Subscribers chỉ thấy typed events; không có IPC primitive nào lộ ra.
+
+### 1.2 AutoGen (Microsoft) — github.com/microsoft/autogen
+
+- **Analog:** `GroupChatManager` ⇄ participant agents.
+- **Signal:** Agents publish chat messages lên topics; "turn done" = manager quan sát message mới nhất rồi quyết next speaker (hoặc một `GroupChatTermination` event nghĩa là done-with-everything).
+- **Lands first:** **Agent runtime** của AutoGen Core — một pub/sub message bus với **topic-based routing**. Theo source: một *group topic* (broadcast), per-participant topics (direct), và một *output topic* (results channel).
+- **Supervisor delivery:** Manager là một `SequentialRoutedAgent` đã subscribe group topic. Output collection: `_output_message_queue` cho đến khi nhận được `GroupChatTermination` event.
+- **Broker:** Có — `AgentRuntime` (in-process local, hoặc distributed gRPC variant).
+- **Process model:** Configurable. Default: tất cả agents trong một Python process. Distributed: agents trên các host khác nhau sau một gRPC runtime.
+- **Failure mode:** Mất in-memory theo default; distributed variant thêm delivery guarantees.
+- **Abstraction:** Mạnh. Agents chỉ biết `publish_message(topic, msg)` và subscriptions — không bao giờ thấy sockets.
+
+### 1.3 crewAI — github.com/crewAIInc/crewAI
+
+- **Analog:** `Crew` ⇄ `Task` ⇄ `Agent`.
+- **Signal:** Plain Python function return. `task.execute_sync()` return; `Crew.kickoff()` loop tuần tự qua các tasks. Có optional **`task_callback`** fire sau mỗi task; **`step_callback`** fire sau mỗi agent step. Ở mặt HTTP-API, tương đương là `taskWebhookUrl`/`stepWebhookUrl`/`crewWebhookUrl` ([CrewAI docs](https://docs.crewai.com/en/learn/sequential-process), [community thread](https://community.crewai.com/t/how-does-the-task-callback-parameter-work/389)).
+- **Lands first:** Cùng Python stack frame (sync) hoặc webhook receiver (API mode).
+- **Supervisor delivery:** Loop tiếp tục; callback được gọi.
+- **Broker:** Không (in-process). Webhooks là surface duy nhất ra ngoài process.
+- **Process model:** Một Python process cho local SDK. Tasks không phải subprocesses.
+- **Failure mode:** Exceptions bubble lên; không có built-in replay.
+- **Abstraction:** Sync function semantics — đơn giản nhất có thể.
+
+### 1.4 LangGraph (langchain-ai) — multi-agent supervisor pattern
+
+- **Analog:** Supervisor node ⇄ worker nodes trong một state graph.
+- **Signal:** Workers return một object **`Command`**. Cụ thể `Command(goto=target, graph=Command.PARENT, update={...})` để chuyển control sang đâu đó; `create_handoff_back_messages()` để quay về supervisor với marker `__is_handoff_back` ([DeepWiki: Handoff Tools](https://deepwiki.com/langchain-ai/langgraph-supervisor-py/3.2-handoff-tools)).
+- **Lands first:** LangGraph runtime — diễn giải `Command` rồi transition state graph.
+- **Supervisor delivery:** Graph step kế tiếp; prompt của supervisor được rebuild kèm messages bổ sung.
+- **Broker:** Chính bản thân graph runtime.
+- **Process model:** Một Python process; node executions là các awaited coroutines.
+- **Failure mode:** Checkpointer persist graph state; resumable.
+- **Abstraction:** Rất sạch — declarative graph, không thấy IPC.
+
+### 1.5 OpenAI Swarm — github.com/openai/swarm
+
+- **Analog:** "Current agent" ⇄ "next agent" thông qua handoff.
+- **Signal:** Một tool function return về một `Agent` (hoặc `Result(agent=...)`). Run loop swap sang nó. *"Swarm's `run()` function is analogous to `chat.completions.create()` — it takes `messages` and returns `messages` and saves no state between calls."*
+- **Lands first:** Cùng Python stack; loop thấy `Agent` được return rồi tiếp tục với nó.
+- **Supervisor delivery:** Function return — synchronous.
+- **Broker:** Không. Stateless.
+- **Process model:** Một Python process, một linear loop.
+- **Failure mode:** Caller tự lo; không có persistence.
+- **Abstraction:** Tối giản: một function return ra worker kế tiếp.
+
+### 1.6 Tmux-Orchestrator — github.com/Jedward23/Tmux-Orchestrator
+
+Đây là họ hàng gần cockpit nhất và là cuộc so sánh dạy được nhiều nhất.
+
+- **Analog:** Orchestrator → Project Managers → Engineers, mỗi cái là một tmux window riêng chạy Claude instance của nó.
+- **Signal:** **Polled + self-scheduled.** Không có async push nào cả. Một Claude instance tự schedule check-in cho mình bằng `schedule_with_note.sh 30 "Continue dashboard implementation"`. Orchestrator định kỳ đọc nội dung pane qua `tmux capture-pane`.
+- **Lands first:** Chính scrollback của pane tmux (text). "Broker" là *cái màn hình*.
+- **Supervisor delivery:** Orchestrator poll + đọc + interpret. Để nói ngược lại: `send-claude-message.sh session:window "msg"`, mà cái này `tmux send-keys` text vào pane đích. Đây đúng là tương đương của `cockpit runtime send` — và nó chạy được trên tmux vì tmux **không** enforce process-lineage check cho writer (ai có socket perms cũng có thể `send-keys`).
+- **Broker:** Không — tmux vừa là transport vừa là storage.
+- **Process model:** Multi-process; mỗi Claude là child của tmux pane của nó.
+- **Failure mode:** Mất việc không giới hạn nếu orchestrator không check lại. Pattern self-scheduling là cái phao duy nhất.
+- **Abstraction:** Leaky — scripts scrape rồi inject text. Prompt-engineering rules đóng vai trò contract.
+
+**Bài học cho cockpit:** Tmux-Orchestrator chạy được vì authorization model của tmux là "owner of the socket" — không có lineage check. Check nghiêm của cmux mới là cái buộc cockpit phải host sender bên trong cmux's tree. Tmux-Orchestrator còn cho thấy **cooperative-callback pattern** mà Orca sau này formalize.
+
+### 1.7 Claude Squad — github.com/smtg-ai/claude-squad
+
+- **Analog:** N Claude instances độc lập, mỗi cái trong git worktree + tmux session riêng.
+- **Signal:** **Không có gì tự động.** Completion được human phát hiện qua TUI (preview/diff tabs, manual `c` checkout / `r` resume).
+- **Lands first:** Mắt người dùng.
+- **Supervisor delivery:** User.
+- **Broker:** Không.
+- **Process model:** Multi-process, isolated worktrees.
+- **Failure mode:** Human-in-the-loop.
+- **Abstraction:** Cố ý *không* phải một orchestrator — nói rõ là để coordination cho con người.
+
+**Bài học:** Một tool multi-Claude được nể trọng đã né hoàn toàn bài toán captain↔crew. Tham vọng của cockpit (captain autonomous react theo crew) khó hơn đáng kể so với cái Claude Squad cố làm.
+
+### 1.8 Orca (stablyai) — github.com/stablyai/orca (đã nghiên cứu rồi)
+
+- **Analog:** Coordinator + per-agent terminal panes (PTY-hosted).
+- **Signal:** Hai channel song song, tùy theo agent:
+  1. **Native hooks → loopback HTTP** (Claude Code & Codex 0.129+). Hooks `curl` một JSON payload tới `http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/<agent>` kèm bearer token. `Stop` event = turn done. Xem `src/main/codex/hook-service.ts:42-49` và `src/main/agent-hooks/server.ts`.
+  2. **Cooperative CLI callback** cho autonomous coordinator: prompt preamble dạy agent gọi `orca task complete --body <summary>`, cộng với 10-min stale-heartbeat watchdog (`src/main/runtime/orchestration/coordinator.ts:172,230,332-335`).
+- **Lands first:** Main Electron process của Orca (HTTP server + IPC). Persist trong `last-status.json` để sống sót qua restart.
+- **Supervisor delivery:** IPC fanout sang renderer process / orchestration coordinator.
+- **Broker:** Loopback HTTP server + on-disk status cache.
+- **Process model:** Multi-process; mỗi agent là một `node-pty` child riêng. Orca tự sở hữu broker.
+- **Failure mode:** Replay từ `last-status.json`; hook script re-read `$ORCA_AGENT_HOOK_ENDPOINT` nên sống sót qua Orca restart trên *cùng* PTY.
+- **Abstraction:** Excellent bên trong Orca; leak ra qua hook config files trong `~/.codex/hooks.json` và `~/.codex/config.toml`.
+
+### 1.9 Codename Goose (Block) — github.com/block/goose
+
+- **Analog:** Một agent + MCP **extensions** (tool servers).
+- **Signal:** Standard MCP — JSON-RPC over stdio/SSE/streamable HTTP. *Không phải multi-agent coordinator.* Không có inter-extension event bus; extensions là tool providers, không phải peer agents.
+- **Lands first:** MCP client transport.
+- **Process model:** Goose host + một subprocess cho mỗi stdio extension.
+- **Bài học cho cockpit:** MCP là protocol *tool-call*, không phải protocol peer-to-peer notification. Mô hình hoá crew→captain thành một MCP tool call sẽ đảo chiều đúng (captain pull, không bao giờ được push).
+
+### 1.10 Codex CLI app-server (OpenAI) — xem `docs/research/2026-05-19-orca-codex-wrapping-study.md`
+
+- **Analog:** Driver process ⇄ codex child qua JSON-RPC over stdio.
+- **Signal:** Notifications trong JSON-RPC stream (`turn.completed`, v.v.), framed dưới dạng newline-delimited JSON.
+- **Lands first:** Driver's stdio reader.
+- **Broker:** Không — stdio trực tiếp.
+- **Process model:** Parent sở hữu child qua pipe.
+- **Bài học:** Channel typed-event mạnh **nhưng chỉ giữa parent và child của chính nó**. Vô dụng nếu captain không phải parent của codex — mà đây đúng là constraint của cockpit (cmux sở hữu codex/claude child, không phải daemon của cockpit).
+
+### 1.11 Background — prior art về process-coordination
+
+| System | One-line lesson |
+|---|---|
+| **systemd `sd_notify`** | Một datagram dạng UDP gửi tới `$NOTIFY_SOCKET` (Unix DGRAM). `READY=1`, `STATUS=…`, `WATCHDOG=1`. Auth qua `SCM_CREDENTIALS`. Không broker, không queue — fire-and-forget nhưng reliable trên localhost. ([sd_notify man](https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html)) |
+| **D-Bus** | Pub/sub trưởng thành: signals broadcast; clients đăng ký interest; bus daemon fan out. Typing mạnh qua introspection. Transport: Unix domain sockets. ([spec](https://dbus.freedesktop.org/doc/dbus-specification.html)) |
+| **macOS XPC** | Client/server IPC hiện đại với privilege separation; được khuyến nghị thay cho `NSDistributedNotificationCenter` (cái này không mang được user info). |
+| **Erlang/OTP** | Supervisor `monitor` worker process; worker chết → `{'DOWN', Ref, ...}` rơi vào *mailbox* của supervisor (một queue cho mỗi process). Mailbox chính là broker; pattern-match dequeue. Fault-tolerance gold-standard. |
+| **OpenTelemetry collector** | Pipeline `receiver → processor → exporter`; receivers là pluggable transports; cùng một data có thể fan out tới N exporters. Đúng nhu cầu "event từ bất kỳ runtime → nhiều sinks (TUI, Telegram, push)" của cockpit. |
+
+---
+
+## 2. Bảng so sánh
+
+| System | Process model | Signal mechanism | Delivery | Reliability | Abstraction | Cockpit-applicable insight |
+|---|---|---|---|---|---|---|
+| OpenHands | 1 host + sandbox subproc | Typed event trong `EventStream` | Subscriber callback (push) | Disk-replayable | Strong (events) | In-process bus + on-disk log = câu chuyện decoupling tốt nhất |
+| AutoGen | 1 proc (hoặc gRPC) | Topic-pub/sub message | Topic subscriber | In-mem (local) / guaranteed (gRPC) | Strong | Topic routing scale tốt cho many-to-many |
+| crewAI | 1 proc | Function return + callback | Loop tiếp tục | None | Trivial | Đừng over-engineer nếu bạn nắm cả loop |
+| LangGraph | 1 proc | Value `Command(goto=…)` | Graph step | Checkpointed | Declarative | Diễn đạt handoff là data, không phải IPC |
+| OpenAI Swarm | 1 proc | Function return `Agent` | Loop tiếp tục | None | Trivial | Stateless transfer là đủ khi in-process |
+| Tmux-Orchestrator | Multi-proc (tmux) | Scrape pane + `send-keys` | Poll + injected text | Mất nếu không đọc | Leaky | tmux cho external sender → không cần relay ở đó |
+| Claude Squad | Multi-proc (tmux) | Không — human check | Manual | N/A | N/A | Né hoàn toàn |
+| Orca | Multi-proc (PTY) | Native hooks → loopback HTTP | HTTP POST + IPC fanout | Disk-cached | Strong | **Hooks-as-source-of-truth + broker chính là pattern thắng** |
+| Goose (MCP) | Multi-proc (MCP) | JSON-RPC tool call | Caller await | Per-call | Strong | Sai chiều cho completion notify |
+| Codex app-server | Parent + child | JSON-RPC notification | stdio read | Stream lifetime | Strong | Yêu cầu parent-of-child relationship |
+| systemd sd_notify | Multi-proc | Unix DGRAM | Daemon recv | Localhost-reliable | Strong | IPC nhỏ gọn nhất khả thi |
+| D-Bus | Multi-proc | Signal broadcast | Bus fanout | Bus-mediated | Strong | Pub/sub thực tế ở mức OS |
+| Erlang/OTP | Multi-proc (BEAM) | `monitor` + mailbox | Mailbox dequeue | Queued | Gold | Mailbox per supervisor = mental model lý tưởng |
+| OTel collector | Pluggable | Pipeline receiver → exporter | Push | Configurable | Strong | Một event, nhiều sinks (TUI/push/file) |
+
+---
+
+## 3. Khuyến nghị cho cockpit (xếp hạng)
+
+Tôi xếp hạng **3 pattern** theo độ phù hợp, xét tới các ràng buộc cứng của cockpit:
+1. Multi-runtime (Claude Code, Codex, Gemini, Aider, opencode).
+2. Multi-host runtime (cmux hiện tại; Orca, Zed, IntelliJ-MCP trong tương lai).
+3. Captain chạy trong một *real shell bên trong pane của runtime* và tiêu thụ input từ chính cơ chế input của runtime đó.
+4. cmux enforce process-lineage check: writer ghi vào pane của captain **bắt buộc** phải nằm trong process tree của cmux.
+
+### Hạng 1 — **Mailbox + injector pattern** (lai Erlang + Orca). Khuyến nghị mạnh.
+
+**Mechanism.** Daemon của cockpit là **broker** (tương đương `gen_server` của Erlang). Mỗi captain có một **mailbox**: một queue ở phía daemon, key là captain-id. Mỗi runtime đăng ký đúng **một injector** — một process tí hon sống dai *bên trong process tree của runtime đó* — nhiệm vụ duy nhất là dequeue từ mailbox của captain và gọi API "type into pane" riêng của runtime. Injector chính là analog cockpit-side của **`notify-relay` tab bạn đã có**, nhưng được tổng quát hoá và được "phong tước" thành một first-class architectural element thay vì "một terminal tab thừa".
+
+**Tại sao đây là cách rebrand đúng cho cái bạn đã xây.**
+- Relay-tab không phải workaround — nó chính là pattern Erlang dùng (per-process mailbox cần một per-process dequeuer chạy *bên trong* scheduler của process đó). Lineage check của cmux tương đương với BEAM scheduler boundary: chỉ context đúng mới deliver được. Bạn đúng khi đặt một process bên trong cmux; bạn sai khi cảm thấy ngại về điều đó.
+- Mailbox semantics fix luôn cái failure mode mà thiết kế hiện tại *không* xử lý tốt: nếu captain đang giữa turn, đang shutdown, hoặc tạm vắng một lúc, events sẽ queue lại thay vì bay mất. (Hiện tại relay tab forward ngay; nếu captain pane đang bận, cmux send có thể nuốt input.)
+- Một injector cho mỗi runtime, không phải mỗi captain: một daemon process `cockpit-injector` duy nhất cho mỗi cmux instance có thể phục vụ mọi captain host ở đó.
+
+**Sketch cụ thể thay cho relay-tab.**
+- Daemon expose `MailboxAppend(captainId, event)` và `MailboxClaim(captainId, sinceCursor) → events`.
+- Runtime driver implement `Injector(runtime, captainId)` — một binary Go/Node/Python nhỏ được `cmux spawn` khởi động làm hidden helper process bên trong workspace của captain. Long-poll `MailboxClaim`, rồi gọi cơ chế send của runtime. Khi khởi động, injector cũng drain backlog đã tích lũy lúc captain idle.
+- Captain shutdown thì remove mailbox; restart thì restore từ đĩa (analog của `last-status.json` kiểu Orca).
+- Tracker integration: socket pub/sub hiện có của daemon trở thành *receiver* theo từ vựng OTel-collector; mailbox là *processor*; injector là *exporter* duy nhất phải thoả lineage rule của cmux. Telegram, TUI, và push notifications vẫn subscribe trực tiếp vào receiver — chúng không đi qua exporter bị ràng buộc lineage.
+
+**Xử lý lineage check của cmux:** Có — injector được cmux spawn nên theo định nghĩa là sống trong tree của nó. Với Orca/Zed/IntelliJ-MCP, cùng concept injector tái sinh thành: một Orca pane host `cockpit-injector orca`; một Zed task; một IntelliJ background process. Mỗi runtime driver sở hữu injector binary của mình; mailbox protocol thì dùng chung.
+
+**Tradeoff về complexity:** Vừa phải. Bạn đã có hầu hết rồi (daemon socket pub/sub + relay tab). Việc cần làm là (a) thêm queue + cursor phía daemon, (b) tổng quát hoá relay thành một binary `cockpit-injector` mà bất kỳ runtime nào cũng spawn được, (c) ship lifecycle hook "start injector khi mở workspace" cho từng runtime.
+
+### Hạng 2 — **Hooks-into-loopback-broker** (Orca pattern, tổng quát hoá).
+
+**Mechanism.** Mỗi agent CLI được support đều có *kiểu nào đó* completion hook native (Claude Code: `Stop` hook; Codex 0.129+: `Stop` hook; Gemini: vẫn TBD; Aider: chế độ `--message` return; opencode: events). Hook `curl` một loopback HTTP endpoint trên daemon. Daemon giờ có signal "crew X xong" có thẩm quyền *từ chính agent*, không phải từ process-watching hay PTY-scraping.
+
+**Cái này giải bài toán khác** — nó là về **detection**, không phải **delivery**. Bạn vẫn cần pattern #1 (hoặc #3) để *đưa tin vào input của captain*. Nhưng ghép #2 với #1 thì cockpit có vòng lặp hoàn chỉnh:
+- Detection: native hook → daemon (đã được Orca validate).
+- Delivery: daemon mailbox → in-cmux injector (Hạng 1).
+
+**Xử lý lineage check của cmux:** Không liên quan đối với detection. Delivery vẫn cần Hạng 1.
+
+**Tại sao không xếp #1:** Bạn đã ngầm có detection rồi (cmux `read-screen` + heuristics của bạn). Nỗi đau cấp tính là delivery, không phải detection. Adopt #2 dần khi mỗi runtime có native hook, nhưng nó không thay được #1.
+
+### Hạng 3 — **Captain-side polling vào daemon socket** (option "không làm gì in-cmux").
+
+**Mechanism.** Bỏ luôn relay tab. Dạy captain — qua system prompt / một skill — **định kỳ chạy một CLI command** (`cockpit inbox`) trong loop của chính nó, đọc từ daemon socket và return new events dưới dạng plain text. Captain có shell access; gọi một CLI là hoàn toàn nằm trong toolset của nó.
+
+**Tại sao hấp dẫn.** Zero extra processes. Zero relay. Captain là kẻ duy nhất có quyền input được cmux chúc phúc (nó *chính là* cmux child), nên theo định nghĩa, bất kỳ text nào nó sinh ra cũng rơi đúng chỗ. Bước "delivery" trở thành "captain in ra cái nó đọc được." Cadence polling do captain tự quyết.
+
+**Tại sao là #3, không phải #1.** Nó đổi captain semantics từ *reactive* thành *proactive*. Captain đang giữa turn sẽ không poll. Captain đang kẹt trong một tool call sẽ không thấy crew xong. Mục tiêu của push-notification ban đầu là làm captain thức dậy khi crew hoàn thành; hạng 3 lặng lẽ quay về polling, mà cái này nghiên cứu idle-detection 2026-05-16 đã loại rồi. Chỉ dùng làm fallback cho runtime nào không spawn được injector.
+
+**Xử lý lineage check của cmux:** Trivially — không có external sender.
+
+**Cho Orca/Zed/IntelliJ-MCP:** Chạy được trong cả ba. Đây là universal-fallback path.
+
+---
+
+## 4. Tổng hợp: thiết kế đề xuất
+
+```
+                 ┌──────────────────┐
+   crew event ──▶│  daemon receiver │ (existing)
+                 └────────┬─────────┘
+                          │ fanout
+            ┌─────────────┼─────────────────┐
+            ▼             ▼                 ▼
+        Telegram       TUI/push     ┌─────────────────┐
+                                    │ per-captain     │
+                                    │ mailbox (queue) │ (NEW)
+                                    └────────┬────────┘
+                                             │ long-poll
+                                             ▼
+                                  ┌─────────────────────┐
+                                  │ cockpit-injector    │  ◀── spawned by cmux,
+                                  │ (1 per runtime host)│      lives in cmux tree
+                                  └────────┬────────────┘
+                                           │ runtime.send()
+                                           ▼
+                                    captain's input
+```
+
+Đây là **relay-tab pattern, đổi tên và phong tước**: relay trở thành "injector" first-class với một queue đằng sau. Thêm native-hook detection (Orca pattern, Hạng 2) khi runtime support. Giữ CLI-poll (Hạng 3) làm fallback không-bao-giờ-fail mà captain luôn có thể chạy.
+
+### Cái này mua được gì so với relay-tab hiện tại
+
+- **Buffering** — events không bay mất nếu captain pane bận tạm thời.
+- **Restart survival** — mailbox là durable; injector restart sẽ drain backlog.
+- **Một concept, mọi runtime** — Orca/Zed/IntelliJ dùng cùng protocol; chỉ injector binary đổi theo runtime.
+- **Không thêm IPC primitive mới** — dùng lại daemon socket có sẵn; mailbox chỉ là một map<captainId, []event> trên daemon cộng với một cursor.
+- **Tracker vẫn decoupled** — receivers, processors (mailbox), exporters (injector) là shape OTel-collector, biến "gửi cùng event tới Telegram và captain" thành chuyện cấu hình chứ không phải chuyện code.
+
+---
+
+## Provider Coverage Audit — Claude / Codex / Opencode
+
+Pattern relay/notify ở section 3 giả định mỗi runtime provider có thể đẩy cho cockpit một signal "crew finished". Hôm nay claude-code emit signal này qua `Stop` / `SessionEnd` hooks (PR #108) và codex emit qua app-server JSON-RPC notifications (PR #97/#98). Opencode interactive crews hiện vẫn đi theo đường legacy cmux-only spawn (`src/commands/crew.ts:163`) — daemon hoàn toàn không biết chúng tồn tại. Phần audit này trả lời câu hỏi liệu opencode có thể được wire vào cùng notify loop không, và shape của wiring đó nên thế nào.
+
+### Findings — opencode (sst/opencode)
+
+1. **Hook / lifecycle event system — CÓ, qua plugin system.** Opencode ship một plugin framework first-class. Một plugin là một TypeScript module đặt dưới `.opencode/plugin/*.ts` hoặc khai báo qua `opencode.json → plugins`. Plugin nhận một async `event` callback và còn có thể wrap tool execution với `tool.execute.before` / `tool.execute.after`. Event names được tài liệu hoá bao gồm `session.idle` và tool-execution events; bài DEV.to overview và trang SDK đều nhắc đến chúng như extension surface chính ([dev.to "Does OpenCode Support Hooks?"](https://dev.to/einarcesar/does-opencode-support-hooks-a-complete-guide-to-extensibility-k3p), [OpenCode SDK docs](https://opencode.ai/docs/sdk/)). DeepWiki page về session-lifecycle confirm có taxonomy `session_start` / `session_idle` / `session_end` trên event bus nhưng không liệt kê wire names chính xác ([DeepWiki §2.1 session lifecycle](https://deepwiki.com/sst/opencode/2.1-session-lifecycle-and-state)). **Unable to confirm via public docs** liệu `session.end` có phải là một stable plugin-callable event hay chỉ là internal-bus event; assumption an toàn là `session.idle` (cái được tài liệu hoá) là analog "turn done" gần nhất cho mục đích của cockpit.
+
+2. **App-server / streaming protocol — CÓ, nhưng là HTTP REST + SSE, không phải JSON-RPC.** `opencode serve` khởi một headless HTTP server expose một OpenAPI 3.1 spec; flags gồm `--port`, `--hostname`, `--mdns`, `--cors`, và `OPENCODE_SERVER_PASSWORD` cho basic auth ([Server docs](https://opencode.ai/docs/server/)). Hai SSE endpoints stream event bus: `GET /event` (per-session / global bus; message đầu là `server.connected`, rồi đến bus events) và `GET /global/event`. Đây là pattern subscribe sống dai; daemon có thể giữ một HTTP connection mở và nhận mọi bus event suốt vòng đời server.
+
+3. **MCP — opencode là MCP *client*, không phải MCP server expose lifecycle events.** MCP integration của opencode là để *thêm tool vào opencode*, không phải để cho process bên ngoài subscribe vào opencode events ([MCP docs](https://opencode.ai/docs/mcp-servers/)). Bài học từ Goose ở §1.9 áp dụng tại đây: MCP là sai hướng cho completion-notify.
+
+4. **`opencode run --format json` — CÓ.** Subcommand `run` hỗ trợ `--format json`, được tài liệu hoá là "raw JSON events". Kết hợp với `--session <id>` / `--continue` / `--fork`, nó cho ra một headless invocation stream structured events ra stdout — dùng được từ non-cmux wrapper, dù với case cockpit-interactive thì SSE bus là channel tốt hơn vì nó persist qua nhiều turn.
+
+5. **Programmatic SDKs — CÓ.** SDK chính thức `@opencode-ai/sdk` (TypeScript) wrap HTTP + SSE surface vào typed methods bao gồm `event.subscribe()` ([JS SDK DeepWiki](https://deepwiki.com/sst/opencode/7.1-javascripttypescript-sdk)). Community-maintained Go (`opencode-sdk-go`) và Python (`opencode-sdk-python`) SDKs được generate từ cùng OpenAPI spec. Một điểm đáng note: opencode còn implement **Agent Client Protocol (ACP) qua JSON-RPC** cho editor integrations (Zed và bạn bè), expose events như `permission.asked` và `usage_update` ([DeepWiki ACP](https://deepwiki.com/sst/opencode/7.4-agent-client-protocol-(acp))); ACP là event surface *thứ hai* song song với HTTP/SSE bus, dùng khi phía IDE cần là loop driver của agent.
+
+6. **Resume semantics — CÓ.** Cả `opencode run` lẫn TUI đều nhận `--continue` (`-c`), `--session <id>` (`-s`), và `--fork`. Sessions được persist (SQLite qua Drizzle ORM theo lifecycle page); reattach sau khi daemon bounce là support được, với daemon recover session-id từ state của chính nó chứ không phải từ opencode.
+
+### Bảng so sánh
+
+| Capability | Claude | Codex | Opencode | Notes |
+|---|---|---|---|---|
+| Hook system (lifecycle events file-configurable) | CÓ — `settings.json` Stop / SubagentStop / SessionEnd | KHÔNG có native; Orca chứng minh Codex 0.129+ có `Stop` hooks nhưng cockpit chưa dùng | CÓ — TS plugin trong `.opencode/plugin/*.ts`; `event` callback + tool before/after; `session.idle` documented | Opencode plugin là code chứ không phải pure JSON, nên khó template hơn `settings.json` của Claude nhưng expressive hơn |
+| App-server / streaming protocol | KHÔNG (stdio CLI only) | CÓ — app-server, JSON-RPC qua stdio | CÓ — `opencode serve` HTTP + SSE; ACP JSON-RPC cũng có sẵn | Opencode là cái duy nhất có *socket-listening* server ngay từ đầu |
+| MCP server interface (expose events) | Claude chỉ là MCP client | Codex chỉ là MCP client | Opencode chỉ là MCP client | Không cái nào cho cockpit subscribe qua MCP |
+| JSON output mode (headless) | CÓ — `claude -p --output-format=json` | CÓ — `codex exec --json` | CÓ — `opencode run --format json` | Cả ba dùng được cho one-shot non-interactive crews |
+| Session resume | CÓ — `claude -c` / `--resume` | CÓ — `codex exec resume` | CÓ — `opencode run --session <id>` / `--continue` / `--fork` | Cả ba đều persist session |
+| Programmatic SDK | CÓ — `@anthropic-ai/claude-code` TS SDK | CLI only (chưa có first-party SDK tính đến 0.130) | CÓ — `@opencode-ai/sdk` TS (chính thức); Go & Python (community, generated) | Opencode có story SDK phong phú nhất |
+
+### Verdict — pattern relay/notify có chạy được cho opencode không?
+
+**Best path: SSE subscribe + một plugin emitter nhẹ.** Opencode là cái *dễ wire* nhất trong ba provider để gắn vào daemon. Daemon có thể connect một lần tới `http://127.0.0.1:<port>/event` cho mỗi `opencode serve` đang chạy và nhận `session.idle` cùng các bus events khác với zero per-crew configuration. Cấu trúc này identical với codex app-server path (long-lived stream, daemon subscribe), khác duy nhất ở transport (HTTP+SSE vs. JSON-RPC-over-stdio). Để làm semantic "turn-done" thành explicit (thay vì infer từ `session.idle`), cockpit có thể ship một plugin nhỏ `.opencode/plugin/cockpit-emit.ts` gọi ngược về daemon's `task.progress` endpoint trên hook lifecycle nào ổn định nhất — đây là *đúng cùng* shape với claude-code hook trong PR #108, chỉ là express dưới dạng plugin thay vì entry trong `settings.json`. Net: opencode support **cả hai** pattern trước đó cùng lúc, với SSE path đòi hỏi zero crew-side config.
+
+**Fallback: app-server-style SSE riêng.** Nếu plugin emitter chứng tỏ brittle (ví dụ opencode plugin API đổi giữa các bản 0.x — khá khả thi vì velocity của project), daemon có thể dựa thuần vào documented SSE bus. `session.idle` là canonical signal "agent finished its turn" theo public docs và đủ cho use case captain-attention. Đây strictly là codex pattern, port qua.
+
+**Universal fallback: explicit `cockpit crew signal done`.** Crew template luôn có thể bao gồm chỉ thị gọi `cockpit crew signal done` như action cuối của mọi task — provider-agnostic, hôm nay đã chạy được cho opencode mà không cần wiring mới nào, đổi lại phải dựa vào việc agent nhớ gọi. Cái này nên giữ lại trong opencode crew template như belt-and-suspenders fallback ngay cả sau khi auto-detection ship, mirror đường explicit-signal đã tồn tại cho claude.
+
+**Ranked by honest-fit-for-opencode:** (1) SSE subscribe với `session.idle` làm trigger — ít moving parts nhất, chỉ dùng documented public APIs, mirror codex pattern. (2) Plugin emitter gọi `task.progress` — semantic chính xác nhất, nhưng buộc cockpit vào plugin API surface của opencode. (3) Explicit `cockpit crew signal done` — fallback luôn-chạy, giữ trong template. **Recommendation: ship (1) trước, thêm (2) nếu `session.idle` quá noisy hoặc không đủ chính xác, giữ (3) trong template luôn.**
+
+**Recommendation kiến trúc ở section 3 có còn đứng vững khi xét cả ba provider?** **Có, không có gì để bàn cãi.** Verdict "dignify cái relay thành first-class injector với daemon-side mailbox" *được củng cố* khi opencode bước vào bức tranh. Hôm nay daemon nhận ba shape completion signal khác nhau hoàn toàn: file-configured hooks (claude), parent-of-child JSON-RPC (codex), và long-lived HTTP+SSE (opencode). Design mailbox-plus-injector là cái duy nhất trong ba rank ở section 3 hấp thụ được cả ba transport một cách sạch sẽ: driver của mỗi runtime dịch event surface native của nó thành `MailboxAppend(captainId, event)`, còn in-cmux injector vẫn là exporter duy nhất được lineage-blessed. Không có abstraction mailbox, cockpit sẽ phải có ba đường song song từ detection-source thẳng tới cmux send, mỗi đường replicate riêng buffering, retry, và lineage handling. Audit này confirm detection là phần dễ với cả ba provider; delivery vào captain pane bị restrict bởi process-lineage vẫn là phần khó, và mailbox per-captain là cách factor đúng cho responsibility đó.
+
+---
+
+## 5. Nguồn không truy cập được / chỉ truy cập được một phần
+
+- `github.com/All-Hands-AI/OpenHands/blob/main/openhands/events/stream.py` — 404 liên tục qua WebFetch (có khả năng đã đổi tên hoặc dời chỗ trong main hiện tại). Bù lại bằng DeepWiki + PR #2709 *Refactoring: event stream based agent history* + cấu trúc README của OpenHands.
+- `github.com/crewAIInc/crewAI/blob/main/src/crewai/task.py` và `crew.py` — 404 qua WebFetch (path layout đã đổi; có khả năng nằm dưới `src/crewai/lib/`). Bù bằng docs chính thức của crewAI + community threads tài liệu hoá semantics `task_callback`/`step_callback`.
+- `langchain-ai.github.io/langgraph/concepts/multi_agent/` — redirect về trang trống; dùng DeepWiki và bài focused.io thay thế.
+- `freedesktop.org/sd_notify` — 403 ở URL canonical; dùng Baeldung + gist + systemd docs chung.
+- Goose source — README ở mức cao; chưa đọc sâu `crates/`. Chỉ confirm rằng Goose không có peer-agent event bus (MCP là tool-call, không phải pub/sub).
+- Aider — confirm không có multi-session model built-in. Bỏ qua bước đào sâu source.
+
+Không còn hệ thống nào khác trong request list bị inaccessible.
+
+---
+
+## 6. Tài liệu tham khảo
+
+- OpenHands — [README](https://github.com/All-Hands-AI/OpenHands), [DeepWiki Agent System](https://deepwiki.com/OpenHands/OpenHands/6-configuration-system), [EmergentMind summary](https://www.emergentmind.com/topics/openhands-agent-framework), PR #2709
+- AutoGen — [microsoft/autogen](https://github.com/microsoft/autogen), `python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py`
+- crewAI — [docs.crewai.com sequential process](https://docs.crewai.com/en/learn/sequential-process), [task_callback thread](https://community.crewai.com/t/how-does-the-task-callback-parameter-work/389)
+- LangGraph — [DeepWiki handoff tools](https://deepwiki.com/langchain-ai/langgraph-supervisor-py/3.2-handoff-tools), [focused.io article](https://focused.io/lab/multi-agent-orchestration-in-langgraph-supervisor-vs-swarm-tradeoffs-and-architecture)
+- OpenAI Swarm — [openai/swarm](https://github.com/openai/swarm)
+- Tmux-Orchestrator — [Jedward23/Tmux-Orchestrator](https://github.com/Jedward23/Tmux-Orchestrator) (`send-claude-message.sh`, `schedule_with_note.sh`)
+- Claude Squad — [smtg-ai/claude-squad](https://github.com/smtg-ai/claude-squad)
+- Orca — [stablyai/orca](https://github.com/stablyai/orca); xem `docs/research/2026-05-19-orca-codex-wrapping-study.md` (`src/main/codex/hook-service.ts`, `src/main/agent-hooks/server.ts`, `src/main/runtime/orchestration/coordinator.ts`)
+- Goose — [block/goose](https://github.com/block/goose), [DeepWiki extension types](https://deepwiki.com/block/goose/5.3-extension-types-and-configuration)
+- Codex CLI — internal study `docs/research/2026-05-19-orca-codex-wrapping-study.md`
+- systemd `sd_notify` — [Baeldung](https://www.baeldung.com/linux/systemd-notify), [systemd Type=notify gist](https://gist.github.com/grawity/6e5980981dccf66f554bbebb8cd169fc)
+- D-Bus — [Wikipedia](https://en.wikipedia.org/wiki/D-Bus), [spec](https://dbus.freedesktop.org/doc/dbus-specification.html)
+- macOS XPC — [NSHipster IPC](https://nshipster.com/inter-process-communication/), [Karol Mazurek XPC](https://karol-mazurek.medium.com/xpc-programming-on-macos-7e1918573f6d)
+- Erlang/OTP — [Erlang System Documentation](https://www.erlang.org/doc/system/design_principles.html), [Hamler OTP behaviours](https://www.emqx.com/en/blog/hamler-0-2-otp-behaviours-with-type-classes)
+- OpenTelemetry collector — [Architecture docs](https://opentelemetry.io/docs/collector/architecture/)
+- Nghiên cứu cockpit trước — `docs/research/2026-05-16-idle-detection-and-inter-agent-orchestration.md`, `docs/research/2026-05-19-orca-codex-wrapping-study.md`, `docs/research/2026-05-19-cockpit-vs-orca-system-comparison.html`

--- a/docs/research/2026-05-27-tracking-codex-while-keeping-native-tui.html
+++ b/docs/research/2026-05-27-tracking-codex-while-keeping-native-tui.html
@@ -1,0 +1,760 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <title>Tracking Codex While Keeping the Native TUI</title>
+  <style>
+
+span.smallcaps{font-variant: small-caps;}
+div.columns{display: flex; gap: min(4vw, 1.5em);}
+div.column{flex: auto; overflow-x: auto;}
+div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+
+ul.task-list[class]{list-style: none;}
+ul.task-list li input[type="checkbox"] {
+font-size: inherit;
+width: 0.8em;
+margin: 0 0.8em 0.2em -1.6em;
+vertical-align: middle;
+}
+.display.math{display: block; text-align: center; margin: 0.5rem auto;}
+
+html { -webkit-text-size-adjust: 100%; }
+pre > code.sourceCode { white-space: pre; position: relative; }
+pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
+pre > code.sourceCode > span:empty { height: 1.2em; }
+.sourceCode { overflow: visible; }
+code.sourceCode > span { color: inherit; text-decoration: inherit; }
+div.sourceCode { margin: 1em 0; }
+pre.sourceCode { margin: 0; }
+@media screen {
+div.sourceCode { overflow: auto; }
+}
+@media print {
+pre > code.sourceCode { white-space: pre-wrap; }
+pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
+}
+pre.numberSource code
+{ counter-reset: source-line 0; }
+pre.numberSource code > span
+{ position: relative; left: -4em; counter-increment: source-line; }
+pre.numberSource code > span > a:first-child::before
+{ content: counter(source-line);
+position: relative; left: -1em; text-align: right; vertical-align: baseline;
+border: none; display: inline-block;
+-webkit-touch-callout: none; -webkit-user-select: none;
+-khtml-user-select: none; -moz-user-select: none;
+-ms-user-select: none; user-select: none;
+padding: 0 4px; width: 4em;
+color: #aaaaaa;
+}
+pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa; padding-left: 4px; }
+div.sourceCode
+{ }
+@media screen {
+pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
+}
+code span.al { color: #ff0000; font-weight: bold; } 
+code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } 
+code span.at { color: #7d9029; } 
+code span.bn { color: #40a070; } 
+code span.bu { color: #008000; } 
+code span.cf { color: #007020; font-weight: bold; } 
+code span.ch { color: #4070a0; } 
+code span.cn { color: #880000; } 
+code span.co { color: #60a0b0; font-style: italic; } 
+code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } 
+code span.do { color: #ba2121; font-style: italic; } 
+code span.dt { color: #902000; } 
+code span.dv { color: #40a070; } 
+code span.er { color: #ff0000; font-weight: bold; } 
+code span.ex { } 
+code span.fl { color: #40a070; } 
+code span.fu { color: #06287e; } 
+code span.im { color: #008000; font-weight: bold; } 
+code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } 
+code span.kw { color: #007020; font-weight: bold; } 
+code span.op { color: #666666; } 
+code span.ot { color: #007020; } 
+code span.pp { color: #bc7a00; } 
+code span.sc { color: #4070a0; } 
+code span.ss { color: #bb6688; } 
+code span.st { color: #4070a0; } 
+code span.va { color: #19177c; } 
+code span.vs { color: #4070a0; } 
+code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } 
+</style>
+  <style type="text/css">:root{--bg:#0f1115;--panel:#171a21;--panel2:#1d212a;--ink:#e6e8ee;--mut:#9aa3b2;--line:#2a2f3a;--accent:#5db0ff;--ck:#7c9eff;--or:#ff9d6b;--good:#4ade80;--warn:#fbbf24;--bad:#f87171;--code:#0b0d12;--mono:"SF Mono",ui-monospace,Menlo,Consolas,monospace}
+*{box-sizing:border-box}html{scroll-behavior:smooth}
+body{margin:0;background:var(--bg);color:var(--ink);font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;max-width:980px;padding:46px 56px 120px;margin:0 auto}
+h1{font-size:29px;line-height:1.25;margin:10px 0 16px;letter-spacing:-.01em;border-bottom:1px solid var(--line);padding-bottom:14px}
+h2{font-size:22px;margin-top:42px;padding-top:14px;border-top:1px solid var(--line);color:var(--accent)}
+h3{font-size:17px;margin-top:28px;color:var(--ck)}
+h4{font-size:15px;margin-top:20px;color:var(--mut);text-transform:uppercase;letter-spacing:.05em}
+p,li{color:var(--ink)}
+a{color:var(--accent);text-decoration:none}a:hover{text-decoration:underline}
+code{font-family:var(--mono);background:var(--code);padding:2px 6px;border-radius:4px;font-size:13.5px;color:var(--or)}
+pre{background:var(--code);padding:14px 18px;border-radius:8px;border:1px solid var(--line);overflow-x:auto;font-size:13px;line-height:1.5}
+pre code{background:none;padding:0;color:var(--ink)}
+blockquote{border-left:3px solid var(--accent);margin:16px 0;padding:8px 18px;color:var(--mut);background:var(--panel)}
+table{width:100%;border-collapse:collapse;margin:18px 0;font-size:14px}
+th,td{border:1px solid var(--line);padding:9px 12px;text-align:left;vertical-align:top}
+th{background:var(--panel2);color:var(--accent);font-weight:600}
+tr:nth-child(2n) td{background:var(--panel)}
+hr{border:none;border-top:1px solid var(--line);margin:36px 0}
+ul,ol{padding-left:24px}li{margin:4px 0}
+strong{color:#fff}em{color:var(--ck)}
+</style>
+</head>
+<body>
+<header id="title-block-header">
+<h1 class="title">Tracking Codex While Keeping the Native TUI</h1>
+</header>
+<h1 id="tracking-codex-while-keeping-the-native-tui--can-cockpit-have-both">Tracking
+Codex While Keeping the Native TUI — Can Cockpit Have Both?</h1>
+<p><strong>Date:</strong> 2026-05-27 <strong>Author:</strong> Cockpit
+research (parent: develop) <strong>Question this answers:</strong> PR
+#98 of cockpit chose <code>codex app-server</code> (structured JSON-RPC,
+we render UI ourselves) over wrapping the native <code>codex</code> TUI
+in a tmux pane (great UI, fragile state extraction). The user pushes
+back: <em>&quot;Orca, Zed IDE, and notchi all manage to track what codex is
+doing while keeping the native TUI — why can&#39;t cockpit?&quot;</em>. Is there
+a third option?</p>
+<hr />
+<h2 id="0-the-trilemma-restated">0. The trilemma, restated</h2>
+<p>Three properties we want from a codex integration:</p>
+<ol type="1">
+<li><strong>Full native <code>codex</code> TUI</strong> rendered for the
+user (no second-class UI to compete with it).</li>
+<li><strong>Structured activity tracking</strong> the daemon can
+subscribe to (turn-started, turn-completed, awaiting-input, etc).</li>
+<li><strong>Reliable across process churn</strong> — daemon bounces,
+reattach, anti-#2576 (false &quot;done&quot;), gate primitive.</li>
+</ol>
+<p>PR #98 picked (2) + (3) by giving up (1). Issue #102 doubles down on
+(1) by building our own TUI on top of (2)+(3)&#39;s events. The user&#39;s
+push-back is: <em>notchi gets all three, why not cockpit?</em></p>
+<p>The answer turns out to be: <strong>all three reference systems do
+it, but they each pay a different price — and the price varies by an
+order of magnitude.</strong> Cockpit can almost certainly have all
+three, but choosing <em>which side-channel</em> is the load-bearing
+decision, and it&#39;s not the same one notchi picked.</p>
+<hr />
+<h2 id="1-notchi--whats-the-actual-mechanism">1. notchi — what&#39;s the
+actual mechanism?</h2>
+<p><strong>Repo:</strong> <a href="https://github.com/sk-ruban/notchi"><code>github.com/sk-ruban/notchi</code></a>
+· 894 stars · Swift macOS app · default branch <code>main</code> at
+audit time (2026-05-27).</p>
+<h3 id="11-readmes-own-summary">1.1 README&#39;s own summary</h3>
+<p>The README states the architecture in one line:</p>
+<blockquote>
+<p><code>Claude Code / Codex --&gt; Hooks (shell scripts) --&gt; Unix Socket --&gt; Event Parser --&gt; State Machine --&gt; Animated Sprites</code></p>
+</blockquote>
+<p>And:</p>
+<blockquote>
+<p><em>&quot;Notchi registers shell script hooks with Claude Code and Codex
+on launch. When either agent emits events (tool use, thinking, prompts,
+permission requests, compaction, session start/end), the hook script
+sends JSON payloads to a Unix socket.&quot;</em></p>
+</blockquote>
+<p>So <strong>notchi does not parse the rendered TUI</strong>. It does
+not snapshot the terminal, does not OSC-sniff, does not parse stdout. It
+taps codex&#39;s <strong>first-class native hooks system</strong> — the same
+one Orca uses — and pipes the JSON events to a local Unix socket.</p>
+<h3 id="12-the-actual-install-path-codexhookinstallerswift">1.2 The
+actual install path (<code>CodexHookInstaller.swift</code>)</h3>
+<p><code>notchi/notchi/Services/CodexHookInstaller.swift</code> writes
+three things into <code>~/.codex/</code>:</p>
+<ol type="1">
+<li><p><strong>Hook script</strong> at
+<code>~/.codex/hooks/notchi-codex-hook.sh</code> (mode
+<code>0o755</code>):</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode swift"><code class="sourceCode swift"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="co">// CodexHookInstaller.swift:43-62</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="va">bundled</span> <span class="op">=</span> Bundle<span class="op">.</span>main<span class="op">.</span>url<span class="op">(</span>forResource<span class="op">:</span> <span class="st">&quot;notchi-codex-hook&quot;</span><span class="op">,</span> withExtension<span class="op">:</span> <span class="st">&quot;sh&quot;</span><span class="op">)</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="va">bundledData</span> <span class="op">=</span> <span class="cf">try</span> Data<span class="op">(</span>contentsOf<span class="op">:</span> bundled<span class="op">)</span></span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a><span class="cf">try</span> bundledData<span class="op">.</span>write<span class="op">(</span>to<span class="op">:</span> hookScriptURL<span class="op">,</span> options<span class="op">:</span> <span class="op">.</span>atomic<span class="op">)</span></span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a><span class="cf">try</span> fileManager<span class="op">.</span>setAttributes<span class="op">([.</span>posixPermissions<span class="op">:</span> <span class="er">0</span>o755<span class="op">],</span> ofItemAtPath<span class="op">:</span> hookScriptURL<span class="op">.</span>path<span class="op">)</span></span></code></pre></div></li>
+<li><p><strong><code>~/.codex/hooks.json</code></strong> with three
+event registrations (<code>upsertHooksJSON</code>, lines 69–95):</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode swift"><code class="sourceCode swift"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="va">desiredHookEvents</span><span class="op">:</span> <span class="op">[</span>String<span class="op">:</span> <span class="op">[[</span>String<span class="op">:</span> Any<span class="op">]]]</span> <span class="op">=</span> <span class="op">[</span></span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>  <span class="st">&quot;SessionStart&quot;</span><span class="op">:</span>     <span class="op">[</span>makeHookGroup<span class="op">(</span>matcher<span class="op">:</span> <span class="st">&quot;startup|resume&quot;</span><span class="op">,</span> command<span class="op">:</span> command<span class="op">)],</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>  <span class="st">&quot;UserPromptSubmit&quot;</span><span class="op">:</span> <span class="op">[</span>makeHookGroup<span class="op">(</span>matcher<span class="op">:</span> <span class="kw">nil</span><span class="op">,</span>              command<span class="op">:</span> command<span class="op">)],</span></span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a>  <span class="st">&quot;Stop&quot;</span><span class="op">:</span>             <span class="op">[</span>makeHookGroup<span class="op">(</span>matcher<span class="op">:</span> <span class="kw">nil</span><span class="op">,</span>              command<span class="op">:</span> command<span class="op">,</span> timeout<span class="op">:</span> <span class="dv">30</span><span class="op">)],</span></span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a><span class="op">]</span></span></code></pre></div></li>
+<li><p><strong><code>~/.codex/config.toml</code></strong> with
+<code>codex_hooks = true</code> under <code>[features]</code>
+(<code>upsertFeatureFlag</code>, lines 118–145).</p></li>
+</ol>
+<p>Notchi registers <strong>only three</strong> of codex&#39;s ten hook
+events (<code>SessionStart</code>, <code>UserPromptSubmit</code>,
+<code>Stop</code>). It doesn&#39;t bother with
+<code>PreToolUse</code>/<code>PostToolUse</code>/<code>PermissionRequest</code>/<code>PreCompact</code>/etc
+— the UI just needs idle/working/waiting transitions, so three is
+enough.</p>
+<h3 id="13-the-hook-payload-path-notchi-codex-hooksh">1.3 The hook
+payload path (<code>notchi-codex-hook.sh</code>)</h3>
+<p>The installed script is a bash + inline Python program. The relevant
+lines:</p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="co"># notchi/notchi/Resources/notchi-codex-hook.sh</span></span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a><span class="va">SOCKET_PATH</span><span class="op">=</span><span class="st">&quot;/tmp/notchi.sock&quot;</span></span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a><span class="bu">[</span> <span class="ot">-S</span> <span class="st">&quot;</span><span class="va">$SOCKET_PATH</span><span class="st">&quot;</span> <span class="bu">]</span> <span class="kw">||</span> <span class="bu">exit</span> 0       <span class="co"># silent no-op if app not running</span></span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a><span class="ex">/usr/bin/python3</span> <span class="at">-c</span> <span class="st">&quot;</span></span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a><span class="st">  input_data = json.load(sys.stdin)   # codex pipes hook JSON to stdin</span></span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a><span class="st">  ...</span></span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a><span class="st">  output = {</span></span>
+<span id="cb3-8"><a href="#cb3-8" aria-hidden="true" tabindex="-1"></a><span class="st">    &#39;provider&#39;: &#39;codex&#39;,</span></span>
+<span id="cb3-9"><a href="#cb3-9" aria-hidden="true" tabindex="-1"></a><span class="st">    &#39;session_id&#39;: input_data.get(&#39;session_id&#39;, &#39;&#39;),</span></span>
+<span id="cb3-10"><a href="#cb3-10" aria-hidden="true" tabindex="-1"></a><span class="st">    &#39;transcript_path&#39;: input_data.get(&#39;transcript_path&#39;),</span></span>
+<span id="cb3-11"><a href="#cb3-11" aria-hidden="true" tabindex="-1"></a><span class="st">    &#39;event&#39;: hook_event,</span></span>
+<span id="cb3-12"><a href="#cb3-12" aria-hidden="true" tabindex="-1"></a><span class="st">    &#39;status&#39;: status_map.get(hook_event, ...),   # SessionStart→waiting_for_input, UserPromptSubmit→processing, Stop→waiting_for_input</span></span>
+<span id="cb3-13"><a href="#cb3-13" aria-hidden="true" tabindex="-1"></a><span class="st">    ...</span></span>
+<span id="cb3-14"><a href="#cb3-14" aria-hidden="true" tabindex="-1"></a><span class="st">  }</span></span>
+<span id="cb3-15"><a href="#cb3-15" aria-hidden="true" tabindex="-1"></a><span class="st">  sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)</span></span>
+<span id="cb3-16"><a href="#cb3-16" aria-hidden="true" tabindex="-1"></a><span class="st">  sock.connect(&#39;</span><span class="va">$SOCKET_PATH</span><span class="st">&#39;)</span></span>
+<span id="cb3-17"><a href="#cb3-17" aria-hidden="true" tabindex="-1"></a><span class="st">  sock.sendall(json.dumps(output).encode())</span></span>
+<span id="cb3-18"><a href="#cb3-18" aria-hidden="true" tabindex="-1"></a><span class="st">&quot;</span></span></code></pre></div>
+<p>It also walks the process tree (<code>codex_process_context</code>)
+to attribute the event to a specific <code>codex</code> PID and to mark
+whether the origin is <code>cli</code> (has a tty) or
+<code>desktop</code> (no tty).</p>
+<h3 id="14-the-receiver-socketserverswift">1.4 The receiver
+(<code>SocketServer.swift</code>)</h3>
+<p>A Swift <code>AF_UNIX/SOCK_STREAM</code> listener at
+<code>/tmp/notchi.sock</code> with <code>chmod 0600</code>, accepts each
+hook fire, decodes the <code>AgentHookEnvelope</code>, normalizes via
+<code>CodexProviderAdapter.normalize</code>, and feeds the state
+machine. The envelope schema (<code>HookEvent.swift:876-933</code>) is
+the full superset (<code>tool</code>, <code>tool_input</code>,
+<code>permission_mode</code>, <code>transcript_path</code>,
+<code>codex_origin</code>, …) — notchi&#39;s parser is ready for the events
+it doesn&#39;t currently register, hint that the architecture is designed to
+be expanded.</p>
+<h3 id="15-reliability--latency-story">1.5 Reliability / latency
+story</h3>
+<ul>
+<li><strong>Latency:</strong> sub-millisecond local Unix socket; the
+bash wrapper adds ~30ms of Python startup per fire. For idle/working
+transitions this is invisible.</li>
+<li><strong>Reliability:</strong> the hook script <code>exit 0</code>s
+silently if the socket isn&#39;t there
+(<code>[ -S &quot;$SOCKET_PATH&quot; ] || exit 0</code>) — codex never sees a
+failing hook, so the user&#39;s session is never affected by notchi being
+closed. The <code>timeout: 30</code> on <code>Stop</code> (line 81 of
+<code>CodexHookInstaller.swift</code>) is codex&#39;s own per-hook timeout,
+used so a hung notchi cannot stall codex.</li>
+<li><strong>Restart survival:</strong> the hook is filesystem state, not
+process state. Hooks fire correctly whether notchi was running
+yesterday, restarted just now, or never started — same as Orca&#39;s
+loopback HTTP design (<code>hook-service.ts:104-112</code> in
+Orca).</li>
+<li><strong>TUI compatibility:</strong> <em>codex runs as its plain
+interactive TUI</em>. The hook is purely out-of-band. Nothing about
+codex&#39;s rendering, prompt composer, or terminal is touched.</li>
+</ul>
+<h3 id="16-net-characterization">1.6 Net characterization</h3>
+<p><strong>notchi tracks codex by installing entries into
+<code>~/.codex/hooks.json</code> that fire shell scripts which forward
+the JSON payload to a Unix socket. It does not parse the TUI at
+all.</strong> It is a strictly-better Orca: same mechanism (codex native
+hooks), simpler transport (Unix socket vs loopback HTTP + bearer token),
+narrower event set (3 vs 6 events).</p>
+<p>This is the <em>exact same channel</em> PR #98 had available and
+chose not to use. Notchi is not solving a different problem with a
+clever trick — it is using a channel cockpit currently does not.</p>
+<hr />
+<h2 id="2-orca-revisited">2. Orca, revisited</h2>
+<p>Cockpit&#39;s prior research at <a href="2026-05-19-orca-codex-wrapping-study.md"><code>docs/research/2026-05-19-orca-codex-wrapping-study.md</code></a>
+concluded that Orca&#39;s approach was rejected because state extraction was
+<em>&quot;fragile&quot;</em>. <strong>That conclusion needs revising in light of
+notchi&#39;s evidence.</strong></p>
+<p>Re-reading the Orca study against the source code:</p>
+<ul>
+<li><strong>Orca does not screen-scrape state.</strong> §2.2 of the
+prior research: <em>&quot;Orca does not infer turn state from PTY output. It
+installs managed entries into codex&#39;s own hooks system and listens for
+the events.&quot;</em> The mechanism is
+<code>src/main/codex/hook-service.ts:42-49</code> registering the six
+hook events, then <code>curl</code>ing them to a loopback HTTP server on
+<code>127.0.0.1:${ORCA_AGENT_HOOK_PORT}</code> with a bearer token.</li>
+<li><strong>Orca only screen-scrapes for two trivial things:</strong>
+(a) paste-timing (waiting for the <code>›</code> composer prompt before
+bracketed-paste of a draft, <code>agent-paste-draft.ts</code>), and (b)
+a fallback rate-limit <code>/status</code> read it openly distrusts
+(&quot;app-server can fail independently of the interactive CLI&quot;,
+<code>codex-fetcher.ts:440</code>).</li>
+</ul>
+<p><strong>The &quot;fragile&quot; verdict in the 2026-05-19 study was about
+<em>driving codex through the TUI</em> (typing into it, reading from
+it). The <em>tracking</em> path Orca actually uses is the hook system,
+which is structured JSON, identical in robustness to app-server&#39;s
+events.</strong></p>
+<p>This was a category error in the cockpit research: the prior write-up
+conflated &quot;wrapping the TUI&quot; (fragile because of bidirectional terminal
+IO) with &quot;tracking codex while showing its TUI&quot; (not fragile, because
+the channel is JSON hooks, not the TUI). Both Orca and notchi do the
+latter. Neither does the former.</p>
+<hr />
+<h2 id="3-zed--a-third-mechanism-entirely">3. Zed — a third mechanism
+entirely</h2>
+<p>Zed integrates codex via <a href="https://github.com/zed-industries/codex-acp"><code>github.com/zed-industries/codex-acp</code></a>
+(<a href="https://zed.dev/blog/codex-is-live-in-zed">blog post</a>, <a href="https://zed.dev/docs/ai/external-agents">external-agents doc</a>).
+The README states: <em>&quot;This tool implements an ACP adapter around the
+Codex CLI&quot;</em>. But &quot;wraps the Codex CLI&quot; turns out to be a misnomer —
+<code>codex-acp/Cargo.toml</code> reveals:</p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode toml"><code class="sourceCode toml"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="dt">codex-core</span>         <span class="op">=</span> <span class="op">{ </span><span class="dt">git</span><span class="op"> =</span> <span class="st">&quot;https://github.com/openai/codex&quot;</span><span class="op">, </span><span class="dt">tag</span><span class="op"> =</span> <span class="st">&quot;rust-v0.133.0&quot;</span><span class="op"> }</span></span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a><span class="dt">codex-mcp-server</span>   <span class="op">=</span> <span class="op">{ </span><span class="dt">git</span><span class="op"> =</span> <span class="st">&quot;https://github.com/openai/codex&quot;</span><span class="op">, </span><span class="dt">tag</span><span class="op"> =</span> <span class="st">&quot;rust-v0.133.0&quot;</span><span class="op"> }</span></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a><span class="dt">codex-exec-server</span>  <span class="op">=</span> <span class="op">{ </span><span class="dt">git</span><span class="op"> =</span> <span class="st">&quot;https://github.com/openai/codex&quot;</span><span class="op">, </span><span class="dt">tag</span><span class="op"> =</span> <span class="st">&quot;rust-v0.133.0&quot;</span><span class="op"> }</span></span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a><span class="dt">codex-protocol</span>     <span class="op">=</span> <span class="op">{ </span><span class="dt">git</span><span class="op"> =</span> <span class="st">&quot;https://github.com/openai/codex&quot;</span><span class="op">, </span><span class="dt">tag</span><span class="op"> =</span> <span class="st">&quot;rust-v0.133.0&quot;</span><span class="op"> }</span></span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a><span class="dt">codex-login</span>        <span class="op">=</span> <span class="op">{ </span><span class="dt">git</span><span class="op"> =</span> <span class="st">&quot;https://github.com/openai/codex&quot;</span><span class="op">, </span><span class="dt">tag</span><span class="op"> =</span> <span class="st">&quot;rust-v0.133.0&quot;</span><span class="op"> }</span></span></code></pre></div>
+<p>And from <code>src/codex_agent.rs</code>:</p>
+<div class="sourceCode" id="cb5"><pre class="sourceCode rust"><code class="sourceCode rust"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="kw">use</span> <span class="pp">codex_core::</span><span class="op">{</span></span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a>    NewThread<span class="op">,</span> RolloutRecorder<span class="op">,</span> SortDirection<span class="op">,</span> StateDbHandle<span class="op">,</span> ThreadManager<span class="op">,</span> <span class="op">...,</span></span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a>    <span class="pp">config::</span>Config<span class="op">,</span> find_thread_path_by_id_str<span class="op">,</span> init_state_db<span class="op">,</span></span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a>    resolve_installation_id<span class="op">,</span> thread_store_from_config<span class="op">,</span></span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a><span class="op">};</span></span>
+<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> thread_manager <span class="op">=</span> <span class="pp">ThreadManager::</span>new(<span class="op">&amp;</span>config<span class="op">,</span> auth_manager<span class="op">.</span>clone()<span class="op">,</span> <span class="pp">SessionSource::</span>Unknown<span class="op">,</span> <span class="op">...</span>)<span class="op">;</span></span>
+<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> history <span class="op">=</span> <span class="pp">RolloutRecorder::</span>get_rollout_history(<span class="op">&amp;</span>rollout_path)<span class="op">.</span><span class="kw">await</span><span class="op">...;</span></span></code></pre></div>
+<p><strong>Zed does not spawn <code>codex</code> as a subprocess at
+all.</strong> It statically links <code>codex-core</code> as a Rust
+library inside its <code>codex-acp</code> binary and runs the agent loop
+in-process. The Zed blog post confirms a related architectural detail:
+<em>&quot;the Codex agent runs terminal commands in its own process, and then
+streams output bytes from that terminal process to the client&quot;</em> —
+i.e. Zed treats codex&#39;s <em>tool calls</em> as the unit it brokers, not
+the codex process itself.</p>
+<p>Zed renders <strong>its own UI</strong>, not codex&#39;s TUI. The native
+codex TUI is <em>replaced</em>, not augmented. Zed users who want the
+native TUI don&#39;t use Zed — they run <code>codex</code> in a terminal. So
+Zed is <strong>not actually an example of &quot;native TUI +
+tracking&quot;</strong>; it&#39;s an example of &quot;no codex process at all,
+codex-core embedded as a library, no TUI involved.&quot;</p>
+<p>This is a fourth architectural option that&#39;s only available to
+projects willing to take a hard build dependency on
+<code>codex-core</code> (Rust, pinned version, broken on every upstream
+refactor). For cockpit — a Node/TypeScript daemon supporting Codex
+<em>and</em> Claude <em>and</em> Opencode <em>and</em> Aider — this is a
+non-starter. It&#39;s mentioned here only to clear it from the field.</p>
+<hr />
+<h2 id="4-what-does-codex-itself-expose">4. What does codex itself
+expose?</h2>
+<p>This is the load-bearing answer. There are exactly four side-channels
+of codex state that don&#39;t require parsing the TUI:</p>
+<h3 id="41-hooks-the-channel-notchi--orca-use">4.1 Hooks (the channel
+notchi + Orca use)</h3>
+<p><strong>Source:</strong> <code>codex-rs/hooks/src/lib.rs</code>. The
+full list:</p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode rust"><code class="sourceCode rust"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="kw">pub</span> <span class="kw">const</span> HOOK_EVENT_NAMES<span class="op">:</span> [<span class="op">&amp;</span><span class="dt">str</span><span class="op">;</span> <span class="dv">10</span>] <span class="op">=</span> [</span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;PreToolUse&quot;</span><span class="op">,</span> <span class="st">&quot;PermissionRequest&quot;</span><span class="op">,</span> <span class="st">&quot;PostToolUse&quot;</span><span class="op">,</span></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;PreCompact&quot;</span><span class="op">,</span>  <span class="st">&quot;PostCompact&quot;</span><span class="op">,</span></span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;SessionStart&quot;</span><span class="op">,</span> <span class="st">&quot;UserPromptSubmit&quot;</span><span class="op">,</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;SubagentStart&quot;</span><span class="op">,</span> <span class="st">&quot;SubagentStop&quot;</span><span class="op">,</span></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;Stop&quot;</span><span class="op">,</span></span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a>]<span class="op">;</span></span></code></pre></div>
+<p><strong>Registration:</strong> <code>~/.codex/hooks.json</code> with
+per-event entries pointing to a command. Codex pipes a JSON payload to
+that command&#39;s stdin; stderr/exit are observed.</p>
+<p><strong>TUI vs exec:</strong> The hooks crate is <em>invoked from the
+session layer</em> (<code>codex-rs/core/src/session/mod.rs</code>
+exposes <code>hooks()</code> on the session, which is created
+identically for TUI and exec runs). Concrete evidence the TUI path goes
+through it: <code>codex-rs/tui/src/hooks_rpc.rs</code>
+(<code>fetch_hooks_list</code>, <code>HookTrustUpdate</code>) and
+<code>codex-rs/tui/src/chatwidget/hooks.rs</code> (the TUI&#39;s own hooks
+browser view). Notchi and Orca both run codex as the regular interactive
+TUI and rely on the hooks firing — this is empirically proven in
+production.</p>
+<p><strong>Codex 0.129+ caveat (also documented in cockpit&#39;s prior Orca
+research):</strong> Codex silently drops hooks that don&#39;t have a
+matching <code>trusted_hash</code> entry in <code>config.toml</code>.
+Both notchi (<code>upsertFeatureFlag</code> for
+<code>codex_hooks = true</code>) and Orca
+(<code>config-toml-trust.ts</code>) handle this. Any cockpit integration
+must too.</p>
+<p><strong>Conclusion:</strong> <strong>This is the channel.</strong> It
+is structured JSON, fires in TUI mode, is decoupled from rendering, has
+explicit timeouts, fails open, and is what every other tracker in the
+wild uses.</p>
+<h3 id="42-rollout-jsonl-the-channel-zed-reads-after-the-fact">4.2
+Rollout JSONL (the channel Zed reads after-the-fact)</h3>
+<p><strong>Source:</strong> <a href="https://github.com/openai/codex"><code>codex-rs/core/src/rollout/</code></a>
+<code>RolloutRecorder</code>. Documented at <a href="https://deepwiki.com/openai/codex/3.5.2-rollout-persistence-and-replay">DeepWiki
+§3.5.2</a>.</p>
+<p><strong>Path:</strong>
+<code>~/.codex/sessions/YYYY/MM/DD/rollout-{ISO_TIMESTAMP}-{UUID}.jsonl</code>.
+Verified live on this machine:</p>
+<pre><code>~/.codex/sessions/2026/05/25/rollout-2026-05-25T10-35-03-019e5d33-...jsonl</code></pre>
+<p><strong>Format:</strong> <code>RolloutLine</code> envelopes
+containing <code>ResponseItem</code> / <code>EventMsg</code> /
+<code>SessionMeta</code> / <code>TurnContext</code> /
+<code>Compacted</code> items. First line of a real session on this
+machine:</p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span><span class="dt">&quot;timestamp&quot;</span><span class="fu">:</span><span class="st">&quot;2026-05-25T03:39:05.138Z&quot;</span><span class="fu">,</span><span class="dt">&quot;type&quot;</span><span class="fu">:</span><span class="st">&quot;session_meta&quot;</span><span class="fu">,</span><span class="dt">&quot;payload&quot;</span><span class="fu">:{</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;id&quot;</span><span class="fu">:</span><span class="st">&quot;019e5d33-4ca6-7b31-9005-6e15664ae943&quot;</span><span class="fu">,</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;cwd&quot;</span><span class="fu">:</span><span class="st">&quot;/Users/q3labsadmin/me/LumiLabs/OnePlanApp&quot;</span><span class="fu">,</span></span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;originator&quot;</span><span class="fu">:</span><span class="st">&quot;codex-tui&quot;</span><span class="fu">,</span>           <span class="er">//</span> <span class="er">←</span> <span class="er">proves</span> <span class="er">TUI</span> <span class="er">writes</span> <span class="er">this</span></span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;cli_version&quot;</span><span class="fu">:</span><span class="st">&quot;0.133.0&quot;</span><span class="fu">,</span></span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>  <span class="er">...</span></span>
+<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}}</span></span></code></pre></div>
+<p><code>originator: &quot;codex-tui&quot;</code> is direct evidence that the
+rollout file is written <em>by the TUI</em> — same as exec, same as
+app-server.</p>
+<p><strong>Streaming?</strong> DeepWiki: <em>&quot;asynchronous persistence
+via a background RolloutWriterTask … near-real-time asynchronous
+recording.&quot;</em> So a tail-style follower (e.g. <code>chokidar</code> or
+<code>fs.watch</code> on the per-day directory + <code>tail -F</code>
+semantics on the latest file) would see events within tens of ms of them
+happening.</p>
+<p><strong>Limitations:</strong> This is replay data, not orchestration.
+There&#39;s no <code>PermissionRequest</code> distinct event; the rollout
+sees the final approved/denied decision and the resulting tool call. It
+is <strong>strictly less rich than hooks</strong> for &quot;what is codex
+<em>currently</em> waiting on.&quot; Suitable as a <em>secondary</em> signal
+(e.g. &quot;the last user-visible turn ended N seconds ago, daemon must have
+missed the Stop hook&quot;) but not as a primary tracker.</p>
+<h3 id="43-codex-app-server-json-rpc-cockpits-current-channel">4.3
+<code>codex app-server</code> JSON-RPC (cockpit&#39;s current channel)</h3>
+<p>This is what PR #97/#98 ship. Full structured event surface, but
+<strong>requires running codex via <code>codex app-server</code> rather
+than as the interactive TUI</strong>. The TUI binary and the app-server
+binary are <em>different runtime modes of the same executable</em>; you
+cannot have both simultaneously for the same session.</p>
+<p>This is the irreducible cost of PR #98: choosing app-server means
+there <em>is</em> no native TUI to display, because the codex process
+running is not in TUI mode.</p>
+<h3 id="44-osc-titles--stdout--pty-scraping">4.4 OSC titles / stdout /
+pty scraping</h3>
+<p>The thing PR #98 rejected. Both Orca and notchi <em>also</em> reject
+it (modulo Orca&#39;s paste-timing exception). No prior art uses it for
+state tracking. Confirming the original PR #98 reasoning: this is the
+fragile path and we should keep avoiding it.</p>
+<hr />
+<h2 id="5-synthesis--can-cockpit-have-native-codex-tui--structured-tracking">5.
+Synthesis — can cockpit have native codex TUI + structured
+tracking?</h2>
+<h3 id="51-the-yes-path--passthrough-tui--hook-tap">5.1 The Yes Path —
+&quot;passthrough TUI + hook tap&quot;</h3>
+<p><strong>Yes.</strong> The mechanism is <em>the same one notchi
+uses</em>, ported into cockpit&#39;s daemon. Concretely:</p>
+<ol type="1">
+<li><strong>Spawn codex as its plain interactive TUI inside a cmux
+pane</strong>, exactly as Orca does (<code>codex</code> with no
+subcommand, in a pty), exactly as a user running <code>codex</code>
+interactively does today. The user sees the real codex TUI and types
+into it directly. The bridge crew-attach renderer goes away — there&#39;s
+nothing to render, the user is looking at codex itself.</li>
+<li><strong>At daemon startup, install (or upgrade)
+<code>~/.codex/hooks.json</code> entries</strong> that point to a small
+<code>cockpit-codex-hook</code> shim. The shim is bundled with cockpit,
+written once at daemon boot, mode 0755, and reads JSON from stdin like
+notchi&#39;s does.</li>
+<li><strong>The shim forwards each event to the cockpit daemon&#39;s Unix
+socket</strong> (<code>~/.config/cockpit/cockpit.sock</code>) — same
+socket the daemon already uses. Add a new frame type
+<code>hook-event</code> to the protocol.</li>
+<li><strong>The daemon&#39;s existing state machine</strong> consumes these
+events the same way it currently consumes <code>app-server</code>
+notifications. The <code>normalizeAppServerNotification</code> in
+<code>src/control/codex/</code> becomes one of two normalizers; a new
+<code>normalizeHookEvent</code> covers the TUI path. Both produce the
+same <code>ControlEvent</code> shape — anti-#2576 invariant
+unchanged.</li>
+<li><strong>Handle codex 0.129+ trust:</strong> write the matching
+<code>trusted_hash</code> + <code>codex_hooks = true</code> into
+<code>~/.codex/config.toml</code> like notchi and Orca do.</li>
+<li><strong>Reattach across daemon bounce:</strong> trivially better
+than the app-server path. The codex <em>process</em> is the cmux pane,
+owned by cmux, not by the daemon. A daemon restart doesn&#39;t kill codex;
+the hook shim re-resolves the socket on each fire (it&#39;s a filename, not
+a fd) and starts hitting the new daemon immediately. There&#39;s nothing to
+&quot;reattach&quot; — the tap is stateless.</li>
+<li><strong>Gate primitive:</strong> <code>PermissionRequest</code> hook
+fires. The shim forwards it. The daemon promotes it to a Gate just like
+today. Resolution: the human answers in the TUI directly (same as Orca —
+<code>hook-service.ts:39-41</code> comment) and the
+<code>PostToolUse</code>/<code>Stop</code> hook closes the gate. Or, if
+cockpit wants programmatic answers, we still have the gate-resolve verb,
+but with a small protocol gap (we can&#39;t <em>force</em> an approval
+choice into the TUI without typing into it, which is the fragile
+thing).</li>
+</ol>
+<p><strong>Migration delta from PR #98:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Component</th>
+<th>Today (app-server)</th>
+<th>Yes path (TUI + hooks)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>codex spawn</td>
+<td><code>codex app-server</code> long-lived child owned by daemon</td>
+<td>bare <code>codex</code> in cmux pane, owned by cmux, daemon does not
+own it</td>
+</tr>
+<tr>
+<td>Tracking channel</td>
+<td>JSON-RPC over stdio</td>
+<td>hook shim → Unix socket</td>
+</tr>
+<tr>
+<td><code>crew-attach</code> UI</td>
+<td>bordered renderer with chalk/Ink (per #102)</td>
+<td>nothing — user sees native TUI</td>
+</tr>
+<tr>
+<td>Reattach</td>
+<td>daemon → <code>thread/resume</code> after bounce</td>
+<td>nothing — codex process survives daemon bounce</td>
+</tr>
+<tr>
+<td>Initiator</td>
+<td>daemon issues <code>turn/start</code></td>
+<td>user types in TUI directly</td>
+</tr>
+<tr>
+<td><code>cockpit say</code></td>
+<td>daemon RPC into the same child</td>
+<td><code>cmux send</code> to type into the pane (cmux process-tree
+rules apply — see existing notify-relay design)</td>
+</tr>
+<tr>
+<td>Gate primitive</td>
+<td>first-class via <code>ToolRequestUserInput</code></td>
+<td>observes via <code>PermissionRequest</code> hook; cannot inject
+answer except via cmux send</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Trade-off:</strong> cockpit loses <em>programmatic</em>
+control of the conversation (you can&#39;t <code>turn/start</code> over RPC;
+you must type into the TUI via cmux send). This is the same trade-off
+Orca explicitly took and called acceptable in their orchestration
+coordinator (<code>coordinator.ts</code> — agent calls back via
+<code>orca task complete</code>, not protocol).</p>
+<h3 id="52-the-no-path--what-would-kill-this-idea">5.2 The No Path —
+what would kill this idea</h3>
+<p>Things that would force cockpit to stay with app-server:</p>
+<ul>
+<li><strong>Programmatic dispatch.</strong> If cockpit&#39;s
+captain-spawns-crew flow requires <em>the daemon</em> to send the
+initial prompt to codex without a human typing, that&#39;s app-server
+territory. (Counter: cmux send works, see notify-relay; cockpit already
+accepts process-tree dance for the captain.)</li>
+<li><strong>Cross-restart conversation resume that survives the codex
+process dying.</strong> With the hook approach, if codex itself crashes,
+the conversation is gone (no <code>thread/resume</code> equivalent
+without app-server — Orca documents this as a real gap). With
+app-server, daemon-owned codex can be relaunched and
+<code>thread/resume</code>&#39;d.</li>
+<li><strong>Programmatic approval answering.</strong> If cockpit wants
+the captain to auto-approve some classes of tool calls, the app-server
+<code>ToolRequestUserInput</code> round-trip is the only way; hooks
+observe but don&#39;t decide (notchi and Orca punt this to the human).</li>
+</ul>
+<p>None of these are <em>fatal</em>. They are real capability deltas. PR
+#98 is genuinely more ambitious than notchi/Orca on dimensions (5.1.5)
+and (5.1.7); the question is whether those ambitions are worth the UI
+cost.</p>
+<h3 id="53-the-hybrid-path--tui-for-display-hooks-and-app-server-for-tracking">5.3
+The Hybrid Path — TUI for display, hooks AND app-server for
+tracking</h3>
+<p>Codex 0.133 supports <code>codex app-server</code> and the TUI as
+<em>separate processes</em>. Nothing forbids running both:</p>
+<ul>
+<li>One <strong>interactive TUI codex</strong> in a cmux pane, for
+display + human input, with hooks tapped.</li>
+<li>A <strong>separate app-server codex</strong> for
+<em>programmatic</em> tasks (the captain spawning a headless crew,
+programmatic approvals, anti-#2576 strict event semantics).</li>
+</ul>
+<p>This is, in effect, the cockpit-today design split by use case:</p>
+<ul>
+<li><em>Interactive crew</em> (human typing): TUI + hooks. No bridge
+renderer. Issue #102 is closed by deletion.</li>
+<li><em>Headless crew</em> (captain spawns codex with a prompt, gets a
+result): app-server, same as PR #98 today.</li>
+</ul>
+<p>The split is along the line PR #98&#39;s own scope already drew: PR #98
+closed the &quot;interactive-codex slice&quot; of #86; the &quot;headless slice&quot;
+remains for a follow-up. The hybrid path is to <strong>stop trying to
+interactively-render through app-server</strong> (issue #102&#39;s whole
+framing) and accept that interactive == TUI + hooks, headless ==
+app-server.</p>
+<p>The cost: two normalizers, two integration tests, two version-skew
+matrices to track. The benefit: each use case uses the channel it&#39;s
+actually best at.</p>
+<hr />
+<h2 id="6-ranking-and-recommendation">6. Ranking and recommendation</h2>
+<table>
+<thead>
+<tr>
+<th>Path</th>
+<th>Native TUI?</th>
+<th>Structured tracking?</th>
+<th>Daemon-bounce survival?</th>
+<th>Programmatic dispatch?</th>
+<th>Prior art?</th>
+<th>Eng cost from today</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Stay on PR #98 + ship #102</strong></td>
+<td>No (we render)</td>
+<td>Yes</td>
+<td>Yes</td>
+<td>Yes</td>
+<td>Cockpit (alone)</td>
+<td>~4-6h for #102 renderer</td>
+</tr>
+<tr>
+<td><strong>Yes path (TUI + hooks only)</strong></td>
+<td>Yes</td>
+<td>Yes (less rich than app-server)</td>
+<td>Yes (codex process unowned by daemon)</td>
+<td>No (must type via cmux)</td>
+<td>notchi, Orca</td>
+<td>~1-2 days, deletes #102 entirely</td>
+</tr>
+<tr>
+<td><strong>Hybrid (TUI+hooks for interactive, app-server for
+headless)</strong></td>
+<td>Yes (interactive)</td>
+<td>Yes (both surfaces)</td>
+<td>Yes</td>
+<td>Yes (headless only)</td>
+<td>None — novel</td>
+<td>~2-3 days, deletes #102, adds 2nd normalizer</td>
+</tr>
+<tr>
+<td>Zed-style codex-core embed</td>
+<td>No</td>
+<td>Yes</td>
+<td>n/a</td>
+<td>Yes</td>
+<td>Zed</td>
+<td>Weeks; wrong language; rejected.</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Recommendation: the Hybrid Path.</strong></p>
+<p>Reasoning, opinionated:</p>
+<ol type="1">
+<li><p><strong>Issue #102 should be closed wontfix.</strong> Building a
+fake codex TUI on top of app-server events is exactly the work the rest
+of the ecosystem (notchi, Orca, Zed) decided not to do. We will spend
+renderer effort for years and still look worse than the real codex TUI a
+<code>brew install codex</code> away. The energy is wasted.</p></li>
+<li><p><strong>The &quot;fragility&quot; argument from the 2026-05-19 Orca
+research was misdiagnosed.</strong> It was true about TUI-as-driver. It
+was false about TUI-with-hook-side-channel. Notchi proves the hook
+channel is production-stable at scale (894-star app shipping to
+thousands of macOS notch users). The conclusion that justified PR #98&#39;s
+UI cost was over-broad.</p></li>
+<li><p><strong>PR #98&#39;s app-server foundation is still right for
+headless.</strong> Anti-#2576, daemon-bounce reattach via
+<code>thread/resume</code>, programmatic gates — these are real
+capabilities the hook channel cannot offer, and they matter for
+captain→crew dispatch. Don&#39;t tear PR #98 out; demote it to the headless
+half of a split.</p></li>
+<li><p><strong>Interactive becomes a thin shim.</strong>
+<code>cockpit crew chat --provider codex</code> spawns a codex TUI pane,
+installs hooks on first run, daemon listens. No bridge renderer. No
+#102. No fight with codex&#39;s own UI. The pane <em>is</em> the
+UI.</p></li>
+<li><p><strong>One real-world test before committing:</strong> prove the
+hook latency + reliability story on the cockpit daemon&#39;s existing Unix
+socket with a 30-minute interactive codex session under load (file
+edits, approvals, compaction). If hook fires drop or arrive out-of-order
+under stress, the Yes/Hybrid paths fail and we keep PR #98. Both notchi
+and Orca run this configuration in production, so the prior is strongly
+in favor.</p></li>
+</ol>
+<h3 id="61-does-this-flip-the-102-plan">6.1 Does this flip the #102
+plan?</h3>
+<p><strong>Yes — provided the hook-channel reliability test
+passes.</strong> Issue #102 exists because PR #98&#39;s architecture forced
+cockpit to render codex itself. The Hybrid Path eliminates that need for
+the interactive case, which is the only case #102 cares about. #102
+should be re-scoped to <em>&quot;investigate TUI-passthrough + hook tap; if
+feasible, close #102 wontfix and file the hybrid integration spec
+instead.&quot;</em></p>
+<h3 id="62-does-this-flip-the-pr-98-decision">6.2 Does this flip the PR
+#98 decision?</h3>
+<p><strong>No — PR #98 stays merged and shipping.</strong> The Hybrid
+Path keeps app-server for headless, where it&#39;s irreplaceable. The flip
+is on issue #102 (the renderer parity goal), not on PR #98 (the
+app-server foundation). The 2026-05-19 Orca research was directionally
+correct about app-server being the right answer for <em>one of two</em>
+use cases; it just framed it as the answer for <em>both</em>.</p>
+<hr />
+<h2 id="7-open-questions--next-actions">7. Open questions / next
+actions</h2>
+<ol type="1">
+<li><strong>Spike: hook latency under load.</strong> Write a 100-line
+cockpit-codex-hook shim, install into <code>~/.codex/hooks.json</code>
+against a local codex 0.133, run a real session, measure
+SessionStart→Stop event lag on the daemon socket. Target: p99 &lt;
+100ms.</li>
+<li><strong>Verify hooks fire in TUI with cmux <code>claude -c</code>
+resume semantics.</strong> Codex 0.130 introduced thread-resume in the
+TUI; confirm hooks still fire across
+<code>codex --continue</code>/<code>codex resume</code>. Notchi&#39;s
+<code>SessionStart</code> matcher is literally
+<code>&quot;startup|resume&quot;</code> so this is presumably handled, but we
+should test.</li>
+<li><strong><code>config.toml</code> trust-hash automation.</strong>
+Lift notchi&#39;s <code>upsertFeatureFlag</code> + Orca&#39;s
+<code>config-toml-trust.ts</code> into cockpit&#39;s first-run installer;
+otherwise hooks silently drop on 0.129+.</li>
+<li><strong>Decide the captain→crew dispatch story for the interactive
+case.</strong> Two options: (a) captain types prompts into the codex TUI
+pane via cmux send (notify-relay pattern, already-built); (b) crew is
+always spawned by a human typing in the captain pane. (a) is
+operationally identical to today&#39;s captain→Claude flow; (b) is a UX
+downgrade. Recommend (a).</li>
+<li><strong>File the hybrid spec</strong> as a follow-up to
+<code>docs/specs/2026-05-20-cockpit-interactive-codex-design.md</code>,
+scoped to the interactive slice only, before doing any renderer work on
+#102.</li>
+</ol>
+<hr />
+<h2 id="8-sources">8. Sources</h2>
+<ul>
+<li><a href="https://github.com/sk-ruban/notchi">notchi
+(sk-ruban/notchi)</a> — README, <code>CodexHookInstaller.swift</code>,
+<code>notchi-codex-hook.sh</code>, <code>SocketServer.swift</code>,
+<code>HookEvent.swift</code>,
+<code>CodexProviderAdapter.swift</code></li>
+<li>Orca prior research: <a href="2026-05-19-orca-codex-wrapping-study.md"><code>docs/research/2026-05-19-orca-codex-wrapping-study.md</code></a></li>
+<li><a href="https://zed.dev/docs/ai/external-agents">Zed external
+agents docs</a> — Codex via ACP</li>
+<li><a href="https://github.com/zed-industries/codex-acp">Zed codex-acp
+adapter</a> — <code>Cargo.toml</code>,
+<code>src/codex_agent.rs</code></li>
+<li><a href="https://zed.dev/blog/codex-is-live-in-zed">Zed blog: Codex
+is Live in Zed</a></li>
+<li><a href="https://github.com/openai/codex/blob/main/codex-rs/hooks/src/lib.rs">openai/codex
+<code>codex-rs/hooks/src/lib.rs</code></a> —
+<code>HOOK_EVENT_NAMES</code></li>
+<li><a href="https://github.com/openai/codex">openai/codex
+<code>codex-rs/tui/src/chatwidget/hooks.rs</code></a> — proof TUI
+invokes hooks</li>
+<li><a href="https://deepwiki.com/openai/codex/3.5.2-rollout-persistence-and-replay">DeepWiki:
+codex rollout persistence and replay (§3.5.2)</a></li>
+<li><a href="https://github.com/openai/codex/blob/main/docs/config.md">openai/codex
+docs/config.md <code>Lifecycle hooks</code></a></li>
+<li>Local evidence:
+<code>~/.codex/sessions/2026/05/25/rollout-*.jsonl</code> with
+<code>&quot;originator&quot;:&quot;codex-tui&quot;</code>,
+<code>&quot;cli_version&quot;:&quot;0.133.0&quot;</code></li>
+<li>Cockpit context: PR #98, Issue #102,
+<code>src/commands/crew-attach.ts</code></li>
+</ul>
+</body>
+</html>

--- a/docs/research/2026-05-27-tracking-codex-while-keeping-native-tui.md
+++ b/docs/research/2026-05-27-tracking-codex-while-keeping-native-tui.md
@@ -1,0 +1,335 @@
+# Tracking Codex While Keeping the Native TUI — Can Cockpit Have Both?
+
+**Date:** 2026-05-27
+**Author:** Cockpit research (parent: develop)
+**Question this answers:** PR #98 of cockpit chose `codex app-server` (structured JSON-RPC, we render UI ourselves) over wrapping the native `codex` TUI in a tmux pane (great UI, fragile state extraction). The user pushes back: *"Orca, Zed IDE, and notchi all manage to track what codex is doing while keeping the native TUI — why can't cockpit?"*. Is there a third option?
+
+---
+
+## 0. The trilemma, restated
+
+Three properties we want from a codex integration:
+
+1. **Full native `codex` TUI** rendered for the user (no second-class UI to compete with it).
+2. **Structured activity tracking** the daemon can subscribe to (turn-started, turn-completed, awaiting-input, etc).
+3. **Reliable across process churn** — daemon bounces, reattach, anti-#2576 (false "done"), gate primitive.
+
+PR #98 picked (2) + (3) by giving up (1). Issue #102 doubles down on (1) by building our own TUI on top of (2)+(3)'s events. The user's push-back is: *notchi gets all three, why not cockpit?*
+
+The answer turns out to be: **all three reference systems do it, but they each pay a different price — and the price varies by an order of magnitude.** Cockpit can almost certainly have all three, but choosing *which side-channel* is the load-bearing decision, and it's not the same one notchi picked.
+
+---
+
+## 1. notchi — what's the actual mechanism?
+
+**Repo:** [`github.com/sk-ruban/notchi`](https://github.com/sk-ruban/notchi) · 894 stars · Swift macOS app · default branch `main` at audit time (2026-05-27).
+
+### 1.1 README's own summary
+
+The README states the architecture in one line:
+
+> `Claude Code / Codex --> Hooks (shell scripts) --> Unix Socket --> Event Parser --> State Machine --> Animated Sprites`
+
+And:
+
+> *"Notchi registers shell script hooks with Claude Code and Codex on launch. When either agent emits events (tool use, thinking, prompts, permission requests, compaction, session start/end), the hook script sends JSON payloads to a Unix socket."*
+
+So **notchi does not parse the rendered TUI**. It does not snapshot the terminal, does not OSC-sniff, does not parse stdout. It taps codex's **first-class native hooks system** — the same one Orca uses — and pipes the JSON events to a local Unix socket.
+
+### 1.2 The actual install path (`CodexHookInstaller.swift`)
+
+`notchi/notchi/Services/CodexHookInstaller.swift` writes three things into `~/.codex/`:
+
+1. **Hook script** at `~/.codex/hooks/notchi-codex-hook.sh` (mode `0o755`):
+   ```swift
+   // CodexHookInstaller.swift:43-62
+   let bundled = Bundle.main.url(forResource: "notchi-codex-hook", withExtension: "sh")
+   let bundledData = try Data(contentsOf: bundled)
+   try bundledData.write(to: hookScriptURL, options: .atomic)
+   try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: hookScriptURL.path)
+   ```
+
+2. **`~/.codex/hooks.json`** with three event registrations (`upsertHooksJSON`, lines 69–95):
+   ```swift
+   let desiredHookEvents: [String: [[String: Any]]] = [
+     "SessionStart":     [makeHookGroup(matcher: "startup|resume", command: command)],
+     "UserPromptSubmit": [makeHookGroup(matcher: nil,              command: command)],
+     "Stop":             [makeHookGroup(matcher: nil,              command: command, timeout: 30)],
+   ]
+   ```
+
+3. **`~/.codex/config.toml`** with `codex_hooks = true` under `[features]` (`upsertFeatureFlag`, lines 118–145).
+
+Notchi registers **only three** of codex's ten hook events (`SessionStart`, `UserPromptSubmit`, `Stop`). It doesn't bother with `PreToolUse`/`PostToolUse`/`PermissionRequest`/`PreCompact`/etc — the UI just needs idle/working/waiting transitions, so three is enough.
+
+### 1.3 The hook payload path (`notchi-codex-hook.sh`)
+
+The installed script is a bash + inline Python program. The relevant lines:
+
+```bash
+# notchi/notchi/Resources/notchi-codex-hook.sh
+SOCKET_PATH="/tmp/notchi.sock"
+[ -S "$SOCKET_PATH" ] || exit 0       # silent no-op if app not running
+/usr/bin/python3 -c "
+  input_data = json.load(sys.stdin)   # codex pipes hook JSON to stdin
+  ...
+  output = {
+    'provider': 'codex',
+    'session_id': input_data.get('session_id', ''),
+    'transcript_path': input_data.get('transcript_path'),
+    'event': hook_event,
+    'status': status_map.get(hook_event, ...),   # SessionStart→waiting_for_input, UserPromptSubmit→processing, Stop→waiting_for_input
+    ...
+  }
+  sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+  sock.connect('$SOCKET_PATH')
+  sock.sendall(json.dumps(output).encode())
+"
+```
+
+It also walks the process tree (`codex_process_context`) to attribute the event to a specific `codex` PID and to mark whether the origin is `cli` (has a tty) or `desktop` (no tty).
+
+### 1.4 The receiver (`SocketServer.swift`)
+
+A Swift `AF_UNIX/SOCK_STREAM` listener at `/tmp/notchi.sock` with `chmod 0600`, accepts each hook fire, decodes the `AgentHookEnvelope`, normalizes via `CodexProviderAdapter.normalize`, and feeds the state machine. The envelope schema (`HookEvent.swift:876-933`) is the full superset (`tool`, `tool_input`, `permission_mode`, `transcript_path`, `codex_origin`, …) — notchi's parser is ready for the events it doesn't currently register, hint that the architecture is designed to be expanded.
+
+### 1.5 Reliability / latency story
+
+- **Latency:** sub-millisecond local Unix socket; the bash wrapper adds ~30ms of Python startup per fire. For idle/working transitions this is invisible.
+- **Reliability:** the hook script `exit 0`s silently if the socket isn't there (`[ -S "$SOCKET_PATH" ] || exit 0`) — codex never sees a failing hook, so the user's session is never affected by notchi being closed. The `timeout: 30` on `Stop` (line 81 of `CodexHookInstaller.swift`) is codex's own per-hook timeout, used so a hung notchi cannot stall codex.
+- **Restart survival:** the hook is filesystem state, not process state. Hooks fire correctly whether notchi was running yesterday, restarted just now, or never started — same as Orca's loopback HTTP design (`hook-service.ts:104-112` in Orca).
+- **TUI compatibility:** *codex runs as its plain interactive TUI*. The hook is purely out-of-band. Nothing about codex's rendering, prompt composer, or terminal is touched.
+
+### 1.6 Net characterization
+
+**notchi tracks codex by installing entries into `~/.codex/hooks.json` that fire shell scripts which forward the JSON payload to a Unix socket. It does not parse the TUI at all.** It is a strictly-better Orca: same mechanism (codex native hooks), simpler transport (Unix socket vs loopback HTTP + bearer token), narrower event set (3 vs 6 events).
+
+This is the *exact same channel* PR #98 had available and chose not to use. Notchi is not solving a different problem with a clever trick — it is using a channel cockpit currently does not.
+
+---
+
+## 2. Orca, revisited
+
+Cockpit's prior research at [`docs/research/2026-05-19-orca-codex-wrapping-study.md`](2026-05-19-orca-codex-wrapping-study.md) concluded that Orca's approach was rejected because state extraction was *"fragile"*. **That conclusion needs revising in light of notchi's evidence.**
+
+Re-reading the Orca study against the source code:
+
+- **Orca does not screen-scrape state.** §2.2 of the prior research: *"Orca does not infer turn state from PTY output. It installs managed entries into codex's own hooks system and listens for the events."* The mechanism is `src/main/codex/hook-service.ts:42-49` registering the six hook events, then `curl`ing them to a loopback HTTP server on `127.0.0.1:${ORCA_AGENT_HOOK_PORT}` with a bearer token.
+- **Orca only screen-scrapes for two trivial things:** (a) paste-timing (waiting for the `›` composer prompt before bracketed-paste of a draft, `agent-paste-draft.ts`), and (b) a fallback rate-limit `/status` read it openly distrusts ("app-server can fail independently of the interactive CLI", `codex-fetcher.ts:440`).
+
+**The "fragile" verdict in the 2026-05-19 study was about *driving codex through the TUI* (typing into it, reading from it). The *tracking* path Orca actually uses is the hook system, which is structured JSON, identical in robustness to app-server's events.**
+
+This was a category error in the cockpit research: the prior write-up conflated "wrapping the TUI" (fragile because of bidirectional terminal IO) with "tracking codex while showing its TUI" (not fragile, because the channel is JSON hooks, not the TUI). Both Orca and notchi do the latter. Neither does the former.
+
+---
+
+## 3. Zed — a third mechanism entirely
+
+Zed integrates codex via [`github.com/zed-industries/codex-acp`](https://github.com/zed-industries/codex-acp) ([blog post](https://zed.dev/blog/codex-is-live-in-zed), [external-agents doc](https://zed.dev/docs/ai/external-agents)). The README states: *"This tool implements an ACP adapter around the Codex CLI"*. But "wraps the Codex CLI" turns out to be a misnomer — `codex-acp/Cargo.toml` reveals:
+
+```toml
+codex-core         = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-mcp-server   = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-exec-server  = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-protocol     = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-login        = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+```
+
+And from `src/codex_agent.rs`:
+
+```rust
+use codex_core::{
+    NewThread, RolloutRecorder, SortDirection, StateDbHandle, ThreadManager, ...,
+    config::Config, find_thread_path_by_id_str, init_state_db,
+    resolve_installation_id, thread_store_from_config,
+};
+
+let thread_manager = ThreadManager::new(&config, auth_manager.clone(), SessionSource::Unknown, ...);
+let history = RolloutRecorder::get_rollout_history(&rollout_path).await...;
+```
+
+**Zed does not spawn `codex` as a subprocess at all.** It statically links `codex-core` as a Rust library inside its `codex-acp` binary and runs the agent loop in-process. The Zed blog post confirms a related architectural detail: *"the Codex agent runs terminal commands in its own process, and then streams output bytes from that terminal process to the client"* — i.e. Zed treats codex's *tool calls* as the unit it brokers, not the codex process itself.
+
+Zed renders **its own UI**, not codex's TUI. The native codex TUI is *replaced*, not augmented. Zed users who want the native TUI don't use Zed — they run `codex` in a terminal. So Zed is **not actually an example of "native TUI + tracking"**; it's an example of "no codex process at all, codex-core embedded as a library, no TUI involved."
+
+This is a fourth architectural option that's only available to projects willing to take a hard build dependency on `codex-core` (Rust, pinned version, broken on every upstream refactor). For cockpit — a Node/TypeScript daemon supporting Codex *and* Claude *and* Opencode *and* Aider — this is a non-starter. It's mentioned here only to clear it from the field.
+
+---
+
+## 4. What does codex itself expose?
+
+This is the load-bearing answer. There are exactly four side-channels of codex state that don't require parsing the TUI:
+
+### 4.1 Hooks (the channel notchi + Orca use)
+
+**Source:** `codex-rs/hooks/src/lib.rs`. The full list:
+
+```rust
+pub const HOOK_EVENT_NAMES: [&str; 10] = [
+    "PreToolUse", "PermissionRequest", "PostToolUse",
+    "PreCompact",  "PostCompact",
+    "SessionStart", "UserPromptSubmit",
+    "SubagentStart", "SubagentStop",
+    "Stop",
+];
+```
+
+**Registration:** `~/.codex/hooks.json` with per-event entries pointing to a command. Codex pipes a JSON payload to that command's stdin; stderr/exit are observed.
+
+**TUI vs exec:** The hooks crate is *invoked from the session layer* (`codex-rs/core/src/session/mod.rs` exposes `hooks()` on the session, which is created identically for TUI and exec runs). Concrete evidence the TUI path goes through it: `codex-rs/tui/src/hooks_rpc.rs` (`fetch_hooks_list`, `HookTrustUpdate`) and `codex-rs/tui/src/chatwidget/hooks.rs` (the TUI's own hooks browser view). Notchi and Orca both run codex as the regular interactive TUI and rely on the hooks firing — this is empirically proven in production.
+
+**Codex 0.129+ caveat (also documented in cockpit's prior Orca research):** Codex silently drops hooks that don't have a matching `trusted_hash` entry in `config.toml`. Both notchi (`upsertFeatureFlag` for `codex_hooks = true`) and Orca (`config-toml-trust.ts`) handle this. Any cockpit integration must too.
+
+**Conclusion:** **This is the channel.** It is structured JSON, fires in TUI mode, is decoupled from rendering, has explicit timeouts, fails open, and is what every other tracker in the wild uses.
+
+### 4.2 Rollout JSONL (the channel Zed reads after-the-fact)
+
+**Source:** [`codex-rs/core/src/rollout/`](https://github.com/openai/codex) `RolloutRecorder`. Documented at [DeepWiki §3.5.2](https://deepwiki.com/openai/codex/3.5.2-rollout-persistence-and-replay).
+
+**Path:** `~/.codex/sessions/YYYY/MM/DD/rollout-{ISO_TIMESTAMP}-{UUID}.jsonl`. Verified live on this machine:
+
+```
+~/.codex/sessions/2026/05/25/rollout-2026-05-25T10-35-03-019e5d33-...jsonl
+```
+
+**Format:** `RolloutLine` envelopes containing `ResponseItem` / `EventMsg` / `SessionMeta` / `TurnContext` / `Compacted` items. First line of a real session on this machine:
+
+```json
+{"timestamp":"2026-05-25T03:39:05.138Z","type":"session_meta","payload":{
+  "id":"019e5d33-4ca6-7b31-9005-6e15664ae943",
+  "cwd":"/Users/q3labsadmin/me/LumiLabs/OnePlanApp",
+  "originator":"codex-tui",           // ← proves TUI writes this
+  "cli_version":"0.133.0",
+  ...
+}}
+```
+
+`originator: "codex-tui"` is direct evidence that the rollout file is written *by the TUI* — same as exec, same as app-server.
+
+**Streaming?** DeepWiki: *"asynchronous persistence via a background RolloutWriterTask … near-real-time asynchronous recording."* So a tail-style follower (e.g. `chokidar` or `fs.watch` on the per-day directory + `tail -F` semantics on the latest file) would see events within tens of ms of them happening.
+
+**Limitations:** This is replay data, not orchestration. There's no `PermissionRequest` distinct event; the rollout sees the final approved/denied decision and the resulting tool call. It is **strictly less rich than hooks** for "what is codex *currently* waiting on." Suitable as a *secondary* signal (e.g. "the last user-visible turn ended N seconds ago, daemon must have missed the Stop hook") but not as a primary tracker.
+
+### 4.3 `codex app-server` JSON-RPC (cockpit's current channel)
+
+This is what PR #97/#98 ship. Full structured event surface, but **requires running codex via `codex app-server` rather than as the interactive TUI**. The TUI binary and the app-server binary are *different runtime modes of the same executable*; you cannot have both simultaneously for the same session.
+
+This is the irreducible cost of PR #98: choosing app-server means there *is* no native TUI to display, because the codex process running is not in TUI mode.
+
+### 4.4 OSC titles / stdout / pty scraping
+
+The thing PR #98 rejected. Both Orca and notchi *also* reject it (modulo Orca's paste-timing exception). No prior art uses it for state tracking. Confirming the original PR #98 reasoning: this is the fragile path and we should keep avoiding it.
+
+---
+
+## 5. Synthesis — can cockpit have native codex TUI + structured tracking?
+
+### 5.1 The Yes Path — "passthrough TUI + hook tap"
+
+**Yes.** The mechanism is *the same one notchi uses*, ported into cockpit's daemon. Concretely:
+
+1. **Spawn codex as its plain interactive TUI inside a cmux pane**, exactly as Orca does (`codex` with no subcommand, in a pty), exactly as a user running `codex` interactively does today. The user sees the real codex TUI and types into it directly. The bridge crew-attach renderer goes away — there's nothing to render, the user is looking at codex itself.
+2. **At daemon startup, install (or upgrade) `~/.codex/hooks.json` entries** that point to a small `cockpit-codex-hook` shim. The shim is bundled with cockpit, written once at daemon boot, mode 0755, and reads JSON from stdin like notchi's does.
+3. **The shim forwards each event to the cockpit daemon's Unix socket** (`~/.config/cockpit/cockpit.sock`) — same socket the daemon already uses. Add a new frame type `hook-event` to the protocol.
+4. **The daemon's existing state machine** consumes these events the same way it currently consumes `app-server` notifications. The `normalizeAppServerNotification` in `src/control/codex/` becomes one of two normalizers; a new `normalizeHookEvent` covers the TUI path. Both produce the same `ControlEvent` shape — anti-#2576 invariant unchanged.
+5. **Handle codex 0.129+ trust:** write the matching `trusted_hash` + `codex_hooks = true` into `~/.codex/config.toml` like notchi and Orca do.
+6. **Reattach across daemon bounce:** trivially better than the app-server path. The codex *process* is the cmux pane, owned by cmux, not by the daemon. A daemon restart doesn't kill codex; the hook shim re-resolves the socket on each fire (it's a filename, not a fd) and starts hitting the new daemon immediately. There's nothing to "reattach" — the tap is stateless.
+7. **Gate primitive:** `PermissionRequest` hook fires. The shim forwards it. The daemon promotes it to a Gate just like today. Resolution: the human answers in the TUI directly (same as Orca — `hook-service.ts:39-41` comment) and the `PostToolUse`/`Stop` hook closes the gate. Or, if cockpit wants programmatic answers, we still have the gate-resolve verb, but with a small protocol gap (we can't *force* an approval choice into the TUI without typing into it, which is the fragile thing).
+
+**Migration delta from PR #98:**
+
+| Component | Today (app-server) | Yes path (TUI + hooks) |
+|---|---|---|
+| codex spawn | `codex app-server` long-lived child owned by daemon | bare `codex` in cmux pane, owned by cmux, daemon does not own it |
+| Tracking channel | JSON-RPC over stdio | hook shim → Unix socket |
+| `crew-attach` UI | bordered renderer with chalk/Ink (per #102) | nothing — user sees native TUI |
+| Reattach | daemon → `thread/resume` after bounce | nothing — codex process survives daemon bounce |
+| Initiator | daemon issues `turn/start` | user types in TUI directly |
+| `cockpit say` | daemon RPC into the same child | `cmux send` to type into the pane (cmux process-tree rules apply — see existing notify-relay design) |
+| Gate primitive | first-class via `ToolRequestUserInput` | observes via `PermissionRequest` hook; cannot inject answer except via cmux send |
+
+**Trade-off:** cockpit loses *programmatic* control of the conversation (you can't `turn/start` over RPC; you must type into the TUI via cmux send). This is the same trade-off Orca explicitly took and called acceptable in their orchestration coordinator (`coordinator.ts` — agent calls back via `orca task complete`, not protocol).
+
+### 5.2 The No Path — what would kill this idea
+
+Things that would force cockpit to stay with app-server:
+
+- **Programmatic dispatch.** If cockpit's captain-spawns-crew flow requires *the daemon* to send the initial prompt to codex without a human typing, that's app-server territory. (Counter: cmux send works, see notify-relay; cockpit already accepts process-tree dance for the captain.)
+- **Cross-restart conversation resume that survives the codex process dying.** With the hook approach, if codex itself crashes, the conversation is gone (no `thread/resume` equivalent without app-server — Orca documents this as a real gap). With app-server, daemon-owned codex can be relaunched and `thread/resume`'d.
+- **Programmatic approval answering.** If cockpit wants the captain to auto-approve some classes of tool calls, the app-server `ToolRequestUserInput` round-trip is the only way; hooks observe but don't decide (notchi and Orca punt this to the human).
+
+None of these are *fatal*. They are real capability deltas. PR #98 is genuinely more ambitious than notchi/Orca on dimensions (5.1.5) and (5.1.7); the question is whether those ambitions are worth the UI cost.
+
+### 5.3 The Hybrid Path — TUI for display, hooks AND app-server for tracking
+
+Codex 0.133 supports `codex app-server` and the TUI as *separate processes*. Nothing forbids running both:
+
+- One **interactive TUI codex** in a cmux pane, for display + human input, with hooks tapped.
+- A **separate app-server codex** for *programmatic* tasks (the captain spawning a headless crew, programmatic approvals, anti-#2576 strict event semantics).
+
+This is, in effect, the cockpit-today design split by use case:
+- *Interactive crew* (human typing): TUI + hooks. No bridge renderer. Issue #102 is closed by deletion.
+- *Headless crew* (captain spawns codex with a prompt, gets a result): app-server, same as PR #98 today.
+
+The split is along the line PR #98's own scope already drew: PR #98 closed the "interactive-codex slice" of #86; the "headless slice" remains for a follow-up. The hybrid path is to **stop trying to interactively-render through app-server** (issue #102's whole framing) and accept that interactive == TUI + hooks, headless == app-server.
+
+The cost: two normalizers, two integration tests, two version-skew matrices to track. The benefit: each use case uses the channel it's actually best at.
+
+---
+
+## 6. Ranking and recommendation
+
+| Path | Native TUI? | Structured tracking? | Daemon-bounce survival? | Programmatic dispatch? | Prior art? | Eng cost from today |
+|---|---|---|---|---|---|---|
+| **Stay on PR #98 + ship #102** | No (we render) | Yes | Yes | Yes | Cockpit (alone) | ~4-6h for #102 renderer |
+| **Yes path (TUI + hooks only)** | Yes | Yes (less rich than app-server) | Yes (codex process unowned by daemon) | No (must type via cmux) | notchi, Orca | ~1-2 days, deletes #102 entirely |
+| **Hybrid (TUI+hooks for interactive, app-server for headless)** | Yes (interactive) | Yes (both surfaces) | Yes | Yes (headless only) | None — novel | ~2-3 days, deletes #102, adds 2nd normalizer |
+| Zed-style codex-core embed | No | Yes | n/a | Yes | Zed | Weeks; wrong language; rejected. |
+
+**Recommendation: the Hybrid Path.**
+
+Reasoning, opinionated:
+
+1. **Issue #102 should be closed wontfix.** Building a fake codex TUI on top of app-server events is exactly the work the rest of the ecosystem (notchi, Orca, Zed) decided not to do. We will spend renderer effort for years and still look worse than the real codex TUI a `brew install codex` away. The energy is wasted.
+
+2. **The "fragility" argument from the 2026-05-19 Orca research was misdiagnosed.** It was true about TUI-as-driver. It was false about TUI-with-hook-side-channel. Notchi proves the hook channel is production-stable at scale (894-star app shipping to thousands of macOS notch users). The conclusion that justified PR #98's UI cost was over-broad.
+
+3. **PR #98's app-server foundation is still right for headless.** Anti-#2576, daemon-bounce reattach via `thread/resume`, programmatic gates — these are real capabilities the hook channel cannot offer, and they matter for captain→crew dispatch. Don't tear PR #98 out; demote it to the headless half of a split.
+
+4. **Interactive becomes a thin shim.** `cockpit crew chat --provider codex` spawns a codex TUI pane, installs hooks on first run, daemon listens. No bridge renderer. No #102. No fight with codex's own UI. The pane *is* the UI.
+
+5. **One real-world test before committing:** prove the hook latency + reliability story on the cockpit daemon's existing Unix socket with a 30-minute interactive codex session under load (file edits, approvals, compaction). If hook fires drop or arrive out-of-order under stress, the Yes/Hybrid paths fail and we keep PR #98. Both notchi and Orca run this configuration in production, so the prior is strongly in favor.
+
+### 6.1 Does this flip the #102 plan?
+
+**Yes — provided the hook-channel reliability test passes.** Issue #102 exists because PR #98's architecture forced cockpit to render codex itself. The Hybrid Path eliminates that need for the interactive case, which is the only case #102 cares about. #102 should be re-scoped to *"investigate TUI-passthrough + hook tap; if feasible, close #102 wontfix and file the hybrid integration spec instead."*
+
+### 6.2 Does this flip the PR #98 decision?
+
+**No — PR #98 stays merged and shipping.** The Hybrid Path keeps app-server for headless, where it's irreplaceable. The flip is on issue #102 (the renderer parity goal), not on PR #98 (the app-server foundation). The 2026-05-19 Orca research was directionally correct about app-server being the right answer for *one of two* use cases; it just framed it as the answer for *both*.
+
+---
+
+## 7. Open questions / next actions
+
+1. **Spike: hook latency under load.** Write a 100-line cockpit-codex-hook shim, install into `~/.codex/hooks.json` against a local codex 0.133, run a real session, measure SessionStart→Stop event lag on the daemon socket. Target: p99 < 100ms.
+2. **Verify hooks fire in TUI with cmux `claude -c` resume semantics.** Codex 0.130 introduced thread-resume in the TUI; confirm hooks still fire across `codex --continue`/`codex resume`. Notchi's `SessionStart` matcher is literally `"startup|resume"` so this is presumably handled, but we should test.
+3. **`config.toml` trust-hash automation.** Lift notchi's `upsertFeatureFlag` + Orca's `config-toml-trust.ts` into cockpit's first-run installer; otherwise hooks silently drop on 0.129+.
+4. **Decide the captain→crew dispatch story for the interactive case.** Two options: (a) captain types prompts into the codex TUI pane via cmux send (notify-relay pattern, already-built); (b) crew is always spawned by a human typing in the captain pane. (a) is operationally identical to today's captain→Claude flow; (b) is a UX downgrade. Recommend (a).
+5. **File the hybrid spec** as a follow-up to `docs/specs/2026-05-20-cockpit-interactive-codex-design.md`, scoped to the interactive slice only, before doing any renderer work on #102.
+
+---
+
+## 8. Sources
+
+- [notchi (sk-ruban/notchi)](https://github.com/sk-ruban/notchi) — README, `CodexHookInstaller.swift`, `notchi-codex-hook.sh`, `SocketServer.swift`, `HookEvent.swift`, `CodexProviderAdapter.swift`
+- Orca prior research: [`docs/research/2026-05-19-orca-codex-wrapping-study.md`](2026-05-19-orca-codex-wrapping-study.md)
+- [Zed external agents docs](https://zed.dev/docs/ai/external-agents) — Codex via ACP
+- [Zed codex-acp adapter](https://github.com/zed-industries/codex-acp) — `Cargo.toml`, `src/codex_agent.rs`
+- [Zed blog: Codex is Live in Zed](https://zed.dev/blog/codex-is-live-in-zed)
+- [openai/codex `codex-rs/hooks/src/lib.rs`](https://github.com/openai/codex/blob/main/codex-rs/hooks/src/lib.rs) — `HOOK_EVENT_NAMES`
+- [openai/codex `codex-rs/tui/src/chatwidget/hooks.rs`](https://github.com/openai/codex) — proof TUI invokes hooks
+- [DeepWiki: codex rollout persistence and replay (§3.5.2)](https://deepwiki.com/openai/codex/3.5.2-rollout-persistence-and-replay)
+- [openai/codex docs/config.md `Lifecycle hooks`](https://github.com/openai/codex/blob/main/docs/config.md)
+- Local evidence: `~/.codex/sessions/2026/05/25/rollout-*.jsonl` with `"originator":"codex-tui"`, `"cli_version":"0.133.0"`
+- Cockpit context: PR #98, Issue #102, `src/commands/crew-attach.ts`

--- a/docs/research/2026-05-27-tracking-codex-while-keeping-native-tui.vi.html
+++ b/docs/research/2026-05-27-tracking-codex-while-keeping-native-tui.vi.html
@@ -1,0 +1,683 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <title>Tracking Codex Mà Vẫn Giữ Native TUI</title>
+  <style>
+
+span.smallcaps{font-variant: small-caps;}
+div.columns{display: flex; gap: min(4vw, 1.5em);}
+div.column{flex: auto; overflow-x: auto;}
+div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+
+ul.task-list[class]{list-style: none;}
+ul.task-list li input[type="checkbox"] {
+font-size: inherit;
+width: 0.8em;
+margin: 0 0.8em 0.2em -1.6em;
+vertical-align: middle;
+}
+.display.math{display: block; text-align: center; margin: 0.5rem auto;}
+
+html { -webkit-text-size-adjust: 100%; }
+pre > code.sourceCode { white-space: pre; position: relative; }
+pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
+pre > code.sourceCode > span:empty { height: 1.2em; }
+.sourceCode { overflow: visible; }
+code.sourceCode > span { color: inherit; text-decoration: inherit; }
+div.sourceCode { margin: 1em 0; }
+pre.sourceCode { margin: 0; }
+@media screen {
+div.sourceCode { overflow: auto; }
+}
+@media print {
+pre > code.sourceCode { white-space: pre-wrap; }
+pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
+}
+pre.numberSource code
+{ counter-reset: source-line 0; }
+pre.numberSource code > span
+{ position: relative; left: -4em; counter-increment: source-line; }
+pre.numberSource code > span > a:first-child::before
+{ content: counter(source-line);
+position: relative; left: -1em; text-align: right; vertical-align: baseline;
+border: none; display: inline-block;
+-webkit-touch-callout: none; -webkit-user-select: none;
+-khtml-user-select: none; -moz-user-select: none;
+-ms-user-select: none; user-select: none;
+padding: 0 4px; width: 4em;
+color: #aaaaaa;
+}
+pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa; padding-left: 4px; }
+div.sourceCode
+{ }
+@media screen {
+pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
+}
+code span.al { color: #ff0000; font-weight: bold; } 
+code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } 
+code span.at { color: #7d9029; } 
+code span.bn { color: #40a070; } 
+code span.bu { color: #008000; } 
+code span.cf { color: #007020; font-weight: bold; } 
+code span.ch { color: #4070a0; } 
+code span.cn { color: #880000; } 
+code span.co { color: #60a0b0; font-style: italic; } 
+code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } 
+code span.do { color: #ba2121; font-style: italic; } 
+code span.dt { color: #902000; } 
+code span.dv { color: #40a070; } 
+code span.er { color: #ff0000; font-weight: bold; } 
+code span.ex { } 
+code span.fl { color: #40a070; } 
+code span.fu { color: #06287e; } 
+code span.im { color: #008000; font-weight: bold; } 
+code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } 
+code span.kw { color: #007020; font-weight: bold; } 
+code span.op { color: #666666; } 
+code span.ot { color: #007020; } 
+code span.pp { color: #bc7a00; } 
+code span.sc { color: #4070a0; } 
+code span.ss { color: #bb6688; } 
+code span.st { color: #4070a0; } 
+code span.va { color: #19177c; } 
+code span.vs { color: #4070a0; } 
+code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } 
+</style>
+  <style type="text/css">:root{--bg:#0f1115;--panel:#171a21;--panel2:#1d212a;--ink:#e6e8ee;--mut:#9aa3b2;--line:#2a2f3a;--accent:#5db0ff;--ck:#7c9eff;--or:#ff9d6b;--good:#4ade80;--warn:#fbbf24;--bad:#f87171;--code:#0b0d12;--mono:"SF Mono",ui-monospace,Menlo,Consolas,monospace}
+*{box-sizing:border-box}html{scroll-behavior:smooth}
+body{margin:0;background:var(--bg);color:var(--ink);font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;max-width:980px;padding:46px 56px 120px;margin:0 auto}
+h1{font-size:29px;line-height:1.25;margin:10px 0 16px;letter-spacing:-.01em;border-bottom:1px solid var(--line);padding-bottom:14px}
+h2{font-size:22px;margin-top:42px;padding-top:14px;border-top:1px solid var(--line);color:var(--accent)}
+h3{font-size:17px;margin-top:28px;color:var(--ck)}
+h4{font-size:15px;margin-top:20px;color:var(--mut);text-transform:uppercase;letter-spacing:.05em}
+p,li{color:var(--ink)}
+a{color:var(--accent);text-decoration:none}a:hover{text-decoration:underline}
+code{font-family:var(--mono);background:var(--code);padding:2px 6px;border-radius:4px;font-size:13.5px;color:var(--or)}
+pre{background:var(--code);padding:14px 18px;border-radius:8px;border:1px solid var(--line);overflow-x:auto;font-size:13px;line-height:1.5}
+pre code{background:none;padding:0;color:var(--ink)}
+blockquote{border-left:3px solid var(--accent);margin:16px 0;padding:8px 18px;color:var(--mut);background:var(--panel)}
+table{width:100%;border-collapse:collapse;margin:18px 0;font-size:14px}
+th,td{border:1px solid var(--line);padding:9px 12px;text-align:left;vertical-align:top}
+th{background:var(--panel2);color:var(--accent);font-weight:600}
+tr:nth-child(2n) td{background:var(--panel)}
+hr{border:none;border-top:1px solid var(--line);margin:36px 0}
+ul,ol{padding-left:24px}li{margin:4px 0}
+strong{color:#fff}em{color:var(--ck)}
+</style>
+</head>
+<body>
+<header id="title-block-header">
+<h1 class="title">Tracking Codex Mà Vẫn Giữ Native TUI</h1>
+</header>
+<h1 id="tracking-codex-mà-vẫn-giữ-native-tui--cockpit-có-thể-có-cả-hai-không">Tracking
+Codex Mà Vẫn Giữ Native TUI — Cockpit Có Thể Có Cả Hai Không?</h1>
+<p><strong>Date:</strong> 2026-05-27 <strong>Tác giả:</strong> Cockpit
+research (parent: develop) <strong>Câu hỏi:</strong> PR #98 của cockpit
+chọn <code>codex app-server</code> (JSON-RPC có cấu trúc, cockpit tự
+render UI) thay vì wrap native <code>codex</code> TUI trong tmux pane
+(UI đẹp nhưng state extraction mong manh). User push back: <em>&quot;Orca,
+Zed IDE, và notchi đều track được codex mà vẫn giữ native TUI — sao
+cockpit lại không?&quot;</em>. Có một option thứ ba không?</p>
+<hr />
+<h2 id="0-trilemma-phát-biểu-lại">0. Trilemma, phát biểu lại</h2>
+<p>Ba thuộc tính muốn có ở một codex integration:</p>
+<ol type="1">
+<li><strong>Full native <code>codex</code> TUI</strong> hiển thị cho
+user (không cần một UI hạng hai phải cạnh tranh với nó).</li>
+<li><strong>Structured activity tracking</strong> mà daemon subscribe
+được (turn-started, turn-completed, awaiting-input, v.v.).</li>
+<li><strong>Reliable across process churn</strong> — daemon bounces,
+reattach, anti-#2576 (false &quot;done&quot;), gate primitive.</li>
+</ol>
+<p>PR #98 chọn (2) + (3), bỏ (1). Issue #102 nhân đôi nỗ lực cho (1)
+bằng cách tự build TUI trên events của (2)+(3). User push-back:
+<em>notchi có cả ba, sao cockpit không?</em></p>
+<p>Câu trả lời: <strong>cả ba reference systems đều làm được, nhưng mỗi
+cái trả một giá khác nhau — và mức giá lệch nhau cả một bậc.</strong>
+Cockpit gần như chắc chắn có thể có cả ba, nhưng việc chọn
+<em>side-channel nào</em> mới là quyết định load-bearing, và đó không
+phải kênh notchi chọn.</p>
+<hr />
+<h2 id="1-notchi--mechanism-thực-sự-là-gì">1. notchi — mechanism thực sự
+là gì?</h2>
+<p><strong>Repo:</strong> <a href="https://github.com/sk-ruban/notchi"><code>github.com/sk-ruban/notchi</code></a>
+· 894 stars · Swift macOS app · default branch <code>main</code> tại
+thời điểm audit (2026-05-27).</p>
+<h3 id="11-readme-tự-tóm-tắt">1.1 README tự tóm tắt</h3>
+<p>README phát biểu architecture trong một dòng:</p>
+<blockquote>
+<p><code>Claude Code / Codex --&gt; Hooks (shell scripts) --&gt; Unix Socket --&gt; Event Parser --&gt; State Machine --&gt; Animated Sprites</code></p>
+</blockquote>
+<p>Và:</p>
+<blockquote>
+<p><em>&quot;Notchi registers shell script hooks with Claude Code and Codex
+on launch. When either agent emits events (tool use, thinking, prompts,
+permission requests, compaction, session start/end), the hook script
+sends JSON payloads to a Unix socket.&quot;</em></p>
+</blockquote>
+<p>Tức là <strong>notchi không parse rendered TUI</strong>. Không
+snapshot terminal, không OSC-sniff, không parse stdout. Nó tap vào
+<strong>first-class native hooks system của codex</strong> — đúng kênh
+Orca dùng — rồi pipe các JSON event sang một Unix socket cục bộ.</p>
+<h3 id="12-install-path-thực-tế-codexhookinstallerswift">1.2 Install
+path thực tế (<code>CodexHookInstaller.swift</code>)</h3>
+<p><code>notchi/notchi/Services/CodexHookInstaller.swift</code> ghi ba
+thứ vào <code>~/.codex/</code>:</p>
+<ol type="1">
+<li><p><strong>Hook script</strong> tại
+<code>~/.codex/hooks/notchi-codex-hook.sh</code> (mode
+<code>0o755</code>):</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode swift"><code class="sourceCode swift"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="co">// CodexHookInstaller.swift:43-62</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="va">bundled</span> <span class="op">=</span> Bundle<span class="op">.</span>main<span class="op">.</span>url<span class="op">(</span>forResource<span class="op">:</span> <span class="st">&quot;notchi-codex-hook&quot;</span><span class="op">,</span> withExtension<span class="op">:</span> <span class="st">&quot;sh&quot;</span><span class="op">)</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a><span class="cf">try</span> bundledData<span class="op">.</span>write<span class="op">(</span>to<span class="op">:</span> hookScriptURL<span class="op">,</span> options<span class="op">:</span> <span class="op">.</span>atomic<span class="op">)</span></span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a><span class="cf">try</span> fileManager<span class="op">.</span>setAttributes<span class="op">([.</span>posixPermissions<span class="op">:</span> <span class="er">0</span>o755<span class="op">],</span> ofItemAtPath<span class="op">:</span> hookScriptURL<span class="op">.</span>path<span class="op">)</span></span></code></pre></div></li>
+<li><p><strong><code>~/.codex/hooks.json</code></strong> với ba event
+registrations (<code>upsertHooksJSON</code>, dòng 69–95):</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode swift"><code class="sourceCode swift"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="va">desiredHookEvents</span><span class="op">:</span> <span class="op">[</span>String<span class="op">:</span> <span class="op">[[</span>String<span class="op">:</span> Any<span class="op">]]]</span> <span class="op">=</span> <span class="op">[</span></span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>  <span class="st">&quot;SessionStart&quot;</span><span class="op">:</span>     <span class="op">[</span>makeHookGroup<span class="op">(</span>matcher<span class="op">:</span> <span class="st">&quot;startup|resume&quot;</span><span class="op">,</span> command<span class="op">:</span> command<span class="op">)],</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>  <span class="st">&quot;UserPromptSubmit&quot;</span><span class="op">:</span> <span class="op">[</span>makeHookGroup<span class="op">(</span>matcher<span class="op">:</span> <span class="kw">nil</span><span class="op">,</span>              command<span class="op">:</span> command<span class="op">)],</span></span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a>  <span class="st">&quot;Stop&quot;</span><span class="op">:</span>             <span class="op">[</span>makeHookGroup<span class="op">(</span>matcher<span class="op">:</span> <span class="kw">nil</span><span class="op">,</span>              command<span class="op">:</span> command<span class="op">,</span> timeout<span class="op">:</span> <span class="dv">30</span><span class="op">)],</span></span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a><span class="op">]</span></span></code></pre></div></li>
+<li><p><strong><code>~/.codex/config.toml</code></strong> với
+<code>codex_hooks = true</code> dưới <code>[features]</code>
+(<code>upsertFeatureFlag</code>, 118–145).</p></li>
+</ol>
+<p>Notchi chỉ register <strong>ba</strong> trong số mười hook event của
+codex (<code>SessionStart</code>, <code>UserPromptSubmit</code>,
+<code>Stop</code>). Không cần
+<code>PreToolUse</code>/<code>PostToolUse</code>/<code>PermissionRequest</code>/…
+— UI chỉ cần idle/working/waiting transitions, ba là đủ.</p>
+<h3 id="13-hook-payload-path-notchi-codex-hooksh">1.3 Hook payload path
+(<code>notchi-codex-hook.sh</code>)</h3>
+<p>Script đã cài là một chương trình bash + inline Python. Các dòng quan
+trọng:</p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="va">SOCKET_PATH</span><span class="op">=</span><span class="st">&quot;/tmp/notchi.sock&quot;</span></span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a><span class="bu">[</span> <span class="ot">-S</span> <span class="st">&quot;</span><span class="va">$SOCKET_PATH</span><span class="st">&quot;</span> <span class="bu">]</span> <span class="kw">||</span> <span class="bu">exit</span> 0       <span class="co"># silent no-op nếu app không chạy</span></span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a><span class="ex">/usr/bin/python3</span> <span class="at">-c</span> <span class="st">&quot;</span></span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a><span class="st">  input_data = json.load(sys.stdin)   # codex pipe hook JSON vào stdin</span></span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a><span class="st">  ...</span></span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a><span class="st">  output = { &#39;provider&#39;:&#39;codex&#39;, &#39;session_id&#39;:..., &#39;event&#39;:hook_event,</span></span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a><span class="st">             &#39;status&#39;:status_map.get(hook_event,...), ... }</span></span>
+<span id="cb3-8"><a href="#cb3-8" aria-hidden="true" tabindex="-1"></a><span class="st">  sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)</span></span>
+<span id="cb3-9"><a href="#cb3-9" aria-hidden="true" tabindex="-1"></a><span class="st">  sock.connect(&#39;</span><span class="va">$SOCKET_PATH</span><span class="st">&#39;); sock.sendall(json.dumps(output).encode())</span></span>
+<span id="cb3-10"><a href="#cb3-10" aria-hidden="true" tabindex="-1"></a><span class="st">&quot;</span></span></code></pre></div>
+<p>Nó cũng walk process-tree (<code>codex_process_context</code>) để gán
+event cho một PID <code>codex</code> cụ thể, và đánh dấu origin là
+<code>cli</code> (có tty) hay <code>desktop</code> (không tty).</p>
+<h3 id="14-receiver-socketserverswift">1.4 Receiver
+(<code>SocketServer.swift</code>)</h3>
+<p>Listener Swift <code>AF_UNIX/SOCK_STREAM</code> tại
+<code>/tmp/notchi.sock</code>, <code>chmod 0600</code>, accept mỗi hook
+fire, decode <code>AgentHookEnvelope</code>, normalize qua
+<code>CodexProviderAdapter.normalize</code>, feed state machine.
+Envelope schema (<code>HookEvent.swift:876-933</code>) là superset đầy
+đủ (<code>tool</code>, <code>tool_input</code>,
+<code>permission_mode</code>, <code>transcript_path</code>,
+<code>codex_origin</code>, …) — parser của notchi sẵn sàng cho cả những
+event chưa register.</p>
+<h3 id="15-reliability--latency-story">1.5 Reliability / latency
+story</h3>
+<ul>
+<li><strong>Latency:</strong> sub-millisecond local Unix socket; bash
+wrapper thêm ~30ms Python startup mỗi fire. Với idle/working transitions
+thì invisible.</li>
+<li><strong>Reliability:</strong> hook script <code>exit 0</code> âm
+thầm nếu không có socket (<code>[ -S &quot;$SOCKET_PATH&quot; ] || exit 0</code>)
+— codex không bao giờ thấy hook failing, session của user không bao giờ
+bị ảnh hưởng bởi việc notchi đóng. <code>timeout: 30</code> trên
+<code>Stop</code> là per-hook timeout của codex để notchi treo cũng
+không stall codex.</li>
+<li><strong>Restart survival:</strong> hook là filesystem state, không
+phải process state. Hook fire đúng dù notchi vừa restart hay chưa start
+bao giờ — như loopback HTTP của Orca.</li>
+<li><strong>TUI compatibility:</strong> <em>codex chạy như plain
+interactive TUI</em>. Hook hoàn toàn out-of-band. Không đụng gì tới
+rendering, prompt composer, terminal của codex.</li>
+</ul>
+<h3 id="16-net-characterization">1.6 Net characterization</h3>
+<p><strong>notchi track codex bằng cách install entries vào
+<code>~/.codex/hooks.json</code> fire shell scripts forward JSON payload
+sang Unix socket. Không parse TUI gì cả.</strong> Nó là một Orca
+strictly-better: cùng mechanism (codex native hooks), transport đơn giản
+hơn (Unix socket vs loopback HTTP + bearer), event set hẹp hơn (3 vs
+6).</p>
+<p>Đây là <strong>đúng kênh</strong> mà PR #98 có sẵn và đã không dùng.
+notchi không giải bài toán khác bằng mánh khác — nó dùng một kênh
+cockpit hiện chưa dùng.</p>
+<hr />
+<h2 id="2-orca-xem-lại">2. Orca, xem lại</h2>
+<p>Prior research của cockpit ở <a href="2026-05-19-orca-codex-wrapping-study.md"><code>docs/research/2026-05-19-orca-codex-wrapping-study.md</code></a>
+kết luận rằng Orca approach bị reject vì state extraction
+<em>&quot;fragile&quot;</em>. <strong>Kết luận đó cần xem lại trước evidence của
+notchi.</strong></p>
+<p>Đọc lại Orca study so với source code:</p>
+<ul>
+<li><strong>Orca không screen-scrape state.</strong> §2.2 của prior
+research: <em>&quot;Orca does not infer turn state from PTY output. It
+installs managed entries into codex&#39;s own hooks system and listens for
+the events.&quot;</em> Mechanism là
+<code>src/main/codex/hook-service.ts:42-49</code> register 6 hook
+events, rồi <code>curl</code> sang loopback HTTP server.</li>
+<li><strong>Orca chỉ screen-scrape cho hai chuyện trivial:</strong> (a)
+paste-timing và (b) một <code>/status</code> fallback mà chính nó cũng
+không tin (<em>&quot;app-server can fail independently of the interactive
+CLI&quot;</em>, <code>codex-fetcher.ts:440</code>).</li>
+</ul>
+<p><strong>Verdict &quot;fragile&quot; trong study 2026-05-19 là về <em>driving
+codex qua TUI</em> (gõ vào, đọc ra). Path <em>tracking</em> mà Orca thực
+sự dùng là hook system — JSON có cấu trúc, robust ngang app-server&#39;s
+events.</strong></p>
+<p>Đây là một category error trong cockpit research trước: write-up cũ
+trộn lẫn &quot;wrap TUI&quot; (fragile vì bidirectional terminal IO) với &quot;track
+codex trong khi hiển thị TUI của nó&quot; (không fragile, kênh là JSON hooks,
+không phải TUI). Cả Orca và notchi đều làm cái sau. Không cái nào làm
+cái trước.</p>
+<hr />
+<h2 id="3-zed--một-mechanism-thứ-ba-hoàn-toàn">3. Zed — một mechanism
+thứ ba hoàn toàn</h2>
+<p>Zed integrate codex qua <a href="https://github.com/zed-industries/codex-acp"><code>github.com/zed-industries/codex-acp</code></a>.
+README nói: <em>&quot;This tool implements an ACP adapter around the Codex
+CLI&quot;</em>. Nhưng &quot;wraps the Codex CLI&quot; hóa ra là dùng từ sai —
+<code>codex-acp/Cargo.toml</code>:</p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode toml"><code class="sourceCode toml"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="dt">codex-core</span>        <span class="op">=</span> <span class="op">{ </span><span class="dt">git</span><span class="op"> =</span> <span class="st">&quot;https://github.com/openai/codex&quot;</span><span class="op">, </span><span class="dt">tag</span><span class="op"> =</span> <span class="st">&quot;rust-v0.133.0&quot;</span><span class="op"> }</span></span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a><span class="dt">codex-mcp-server</span>  <span class="op">=</span> <span class="op">{ </span><span class="dt">git</span><span class="op"> =</span> <span class="st">&quot;https://github.com/openai/codex&quot;</span><span class="op">, </span><span class="dt">tag</span><span class="op"> =</span> <span class="st">&quot;rust-v0.133.0&quot;</span><span class="op"> }</span></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a><span class="dt">codex-exec-server</span> <span class="op">=</span> <span class="op">{ </span><span class="dt">git</span><span class="op"> =</span> <span class="st">&quot;https://github.com/openai/codex&quot;</span><span class="op">, </span><span class="dt">tag</span><span class="op"> =</span> <span class="st">&quot;rust-v0.133.0&quot;</span><span class="op"> }</span></span></code></pre></div>
+<p>Và từ <code>src/codex_agent.rs</code>:</p>
+<div class="sourceCode" id="cb5"><pre class="sourceCode rust"><code class="sourceCode rust"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="kw">use</span> <span class="pp">codex_core::</span><span class="op">{</span> ThreadManager<span class="op">,</span> RolloutRecorder<span class="op">,</span> <span class="pp">config::</span>Config<span class="op">,</span> <span class="op">...</span> <span class="op">};</span></span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> thread_manager <span class="op">=</span> <span class="pp">ThreadManager::</span>new(<span class="op">&amp;</span>config<span class="op">,</span> auth_manager<span class="op">.</span>clone()<span class="op">,</span> <span class="op">...</span>)<span class="op">;</span></span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> history <span class="op">=</span> <span class="pp">RolloutRecorder::</span>get_rollout_history(<span class="op">&amp;</span>rollout_path)<span class="op">.</span><span class="kw">await</span><span class="op">...;</span></span></code></pre></div>
+<p><strong>Zed không spawn <code>codex</code> như subprocess.</strong>
+Nó static-link <code>codex-core</code> như một Rust library inside
+<code>codex-acp</code> binary và chạy agent loop in-process. Zed render
+<strong>UI của chính nó</strong>, không phải codex TUI. Native codex TUI
+bị <em>thay thế</em>, không phải augmented.</p>
+<p>Vậy Zed <strong>không phải example của &quot;native TUI +
+tracking&quot;</strong>; nó là example của &quot;không có codex process,
+codex-core embedded as library, không TUI&quot;. Đây là một option thứ tư chỉ
+dành cho project chấp nhận hard build dependency vào
+<code>codex-core</code> (Rust, pinned version, vỡ mỗi lần upstream
+refactor). Với cockpit — Node/TypeScript daemon support Codex + Claude +
+Opencode + Aider — đây là non-starter. Nêu ra chỉ để loại nó khỏi sân
+chơi.</p>
+<hr />
+<h2 id="4-bản-thân-codex-expose-những-gì">4. Bản thân codex expose những
+gì?</h2>
+<p>Đây là câu trả lời load-bearing. Có đúng bốn side-channel của codex
+state không yêu cầu parse TUI:</p>
+<h3 id="41-hooks-kênh-notchi--orca-dùng">4.1 Hooks (kênh notchi + Orca
+dùng)</h3>
+<p><strong>Source:</strong> <code>codex-rs/hooks/src/lib.rs</code>:</p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode rust"><code class="sourceCode rust"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="kw">pub</span> <span class="kw">const</span> HOOK_EVENT_NAMES<span class="op">:</span> [<span class="op">&amp;</span><span class="dt">str</span><span class="op">;</span> <span class="dv">10</span>] <span class="op">=</span> [</span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;PreToolUse&quot;</span><span class="op">,</span> <span class="st">&quot;PermissionRequest&quot;</span><span class="op">,</span> <span class="st">&quot;PostToolUse&quot;</span><span class="op">,</span></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;PreCompact&quot;</span><span class="op">,</span>  <span class="st">&quot;PostCompact&quot;</span><span class="op">,</span></span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;SessionStart&quot;</span><span class="op">,</span> <span class="st">&quot;UserPromptSubmit&quot;</span><span class="op">,</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;SubagentStart&quot;</span><span class="op">,</span> <span class="st">&quot;SubagentStop&quot;</span><span class="op">,</span> <span class="st">&quot;Stop&quot;</span><span class="op">,</span></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>]<span class="op">;</span></span></code></pre></div>
+<p><strong>Registration:</strong> <code>~/.codex/hooks.json</code>.
+Codex pipe JSON payload vào stdin của command; stderr/exit được
+observe.</p>
+<p><strong>TUI vs exec:</strong> Hooks crate được invoke từ session
+layer (<code>codex-rs/core/src/session/mod.rs</code> expose
+<code>hooks()</code> trên session, tạo giống hệt nhau cho TUI và exec).
+Bằng chứng cụ thể TUI đi qua nó:
+<code>codex-rs/tui/src/hooks_rpc.rs</code> và
+<code>codex-rs/tui/src/chatwidget/hooks.rs</code>. notchi và Orca cả hai
+chạy codex như interactive TUI thường và dựa vào hooks fire —
+empirically proven in production.</p>
+<p><strong>Codex 0.129+ caveat:</strong> codex âm thầm drop hooks không
+có matching <code>trusted_hash</code> trong <code>config.toml</code>. Cả
+notchi (<code>upsertFeatureFlag</code>) và Orca
+(<code>config-toml-trust.ts</code>) đều handle. Bất kỳ cockpit
+integration nào cũng phải.</p>
+<p><strong>Kết luận:</strong> <strong>Đây là kênh.</strong> Structured
+JSON, fire trong TUI mode, decoupled khỏi rendering, có timeout
+explicit, fail open, và là cái mọi tracker khác trong wild đều dùng.</p>
+<h3 id="42-rollout-jsonl-kênh-zed-đọc-after-the-fact">4.2 Rollout JSONL
+(kênh Zed đọc after-the-fact)</h3>
+<p><strong>Source:</strong> <code>RolloutRecorder</code> trong
+<code>codex-rs/core/src/rollout/</code>.</p>
+<p><strong>Path:</strong>
+<code>~/.codex/sessions/YYYY/MM/DD/rollout-{ISO_TIMESTAMP}-{UUID}.jsonl</code>.
+Verified live trên máy này:</p>
+<pre><code>~/.codex/sessions/2026/05/25/rollout-2026-05-25T10-35-03-019e5d33-...jsonl</code></pre>
+<p><strong>Format:</strong> <code>RolloutLine</code> envelopes chứa
+<code>ResponseItem</code> / <code>EventMsg</code> /
+<code>SessionMeta</code> / <code>TurnContext</code> /
+<code>Compacted</code>. Dòng đầu của một session thật trên máy này:</p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span><span class="dt">&quot;timestamp&quot;</span><span class="fu">:</span><span class="st">&quot;2026-05-25T03:39:05.138Z&quot;</span><span class="fu">,</span><span class="dt">&quot;type&quot;</span><span class="fu">:</span><span class="st">&quot;session_meta&quot;</span><span class="fu">,</span><span class="dt">&quot;payload&quot;</span><span class="fu">:{</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;originator&quot;</span><span class="fu">:</span><span class="st">&quot;codex-tui&quot;</span><span class="fu">,</span>        <span class="er">//</span> <span class="er">←</span> <span class="er">bằng</span> <span class="er">chứng</span> <span class="er">TUI</span> <span class="er">ghi</span> <span class="er">file</span> <span class="er">này</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;cli_version&quot;</span><span class="fu">:</span><span class="st">&quot;0.133.0&quot;</span><span class="fu">,</span> <span class="er">...</span> <span class="fu">}}</span></span></code></pre></div>
+<p><code>originator: &quot;codex-tui&quot;</code> là evidence trực tiếp rằng
+rollout file được ghi <em>bởi TUI</em> — y hệt như exec, y hệt như
+app-server.</p>
+<p><strong>Streaming?</strong> DeepWiki: <em>&quot;asynchronous persistence
+via a background RolloutWriterTask … near-real-time asynchronous
+recording.&quot;</em> Tail-style follower (e.g. <code>chokidar</code> +
+<code>tail -F</code> trên file mới nhất) sẽ thấy events trong tens of
+ms.</p>
+<p><strong>Limitations:</strong> Đây là replay data, không phải
+orchestration. Không có distinct <code>PermissionRequest</code> event;
+rollout thấy final approved/denied decision và tool call kết quả.
+<strong>Strictly less rich hơn hooks</strong> cho câu &quot;codex đang chờ
+gì&quot;. Phù hợp làm secondary signal nhưng không phải primary tracker.</p>
+<h3 id="43-codex-app-server-json-rpc-kênh-hiện-tại-của-cockpit">4.3
+<code>codex app-server</code> JSON-RPC (kênh hiện tại của cockpit)</h3>
+<p>Cái PR #97/#98 ship. Full structured event surface, nhưng <strong>yêu
+cầu chạy codex qua <code>codex app-server</code> chứ không phải
+interactive TUI</strong>. TUI binary và app-server binary là <em>hai
+runtime mode khác nhau của cùng executable</em>; không thể có cả hai cho
+cùng session.</p>
+<p>Đây là cost không tránh được của PR #98: chọn app-server nghĩa là
+<em>không có</em> native TUI để hiển thị, vì codex process đang chạy
+không ở TUI mode.</p>
+<h3 id="44-osc-titles--stdout--pty-scraping">4.4 OSC titles / stdout /
+pty scraping</h3>
+<p>Cái PR #98 reject. Cả Orca và notchi <em>cũng</em> reject (trừ
+exception paste-timing của Orca). Không prior art nào dùng cho state
+tracking. Confirm lại reasoning của PR #98: đây là path fragile, nên
+tiếp tục tránh.</p>
+<hr />
+<h2 id="5-synthesis--cockpit-có-thể-có-native-codex-tui--structured-tracking-không">5.
+Synthesis — cockpit có thể có native codex TUI + structured tracking
+không?</h2>
+<h3 id="51-yes-path--passthrough-tui--hook-tap">5.1 Yes Path —
+&quot;passthrough TUI + hook tap&quot;</h3>
+<p><strong>Có.</strong> Mechanism là <em>cái notchi dùng</em>, port sang
+daemon của cockpit. Cụ thể:</p>
+<ol type="1">
+<li><strong>Spawn codex như plain interactive TUI trong cmux
+pane</strong>, đúng như Orca làm. User nhìn thấy real codex TUI và gõ
+trực tiếp. Bridge crew-attach renderer biến mất — không có gì để render,
+user đang nhìn chính codex.</li>
+<li><strong>Lúc daemon startup, install (hoặc upgrade) entries trong
+<code>~/.codex/hooks.json</code></strong> trỏ tới một shim
+<code>cockpit-codex-hook</code> nhỏ. Shim bundle với cockpit, ghi một
+lần lúc boot, mode 0755, đọc JSON từ stdin như shim của notchi.</li>
+<li><strong>Shim forward mỗi event sang Unix socket của cockpit
+daemon</strong> (<code>~/.config/cockpit/cockpit.sock</code>) — cùng
+socket daemon đã dùng. Thêm frame type mới <code>hook-event</code> vào
+protocol.</li>
+<li><strong>State machine sẵn có của daemon</strong> consume các event
+này y hệt cách đang consume <code>app-server</code> notifications.
+<code>normalizeAppServerNotification</code> trong
+<code>src/control/codex/</code> trở thành một trong hai normalizer;
+<code>normalizeHookEvent</code> mới cover TUI path. Cả hai produce cùng
+shape <code>ControlEvent</code> — anti-#2576 invariant không đổi.</li>
+<li><strong>Handle codex 0.129+ trust:</strong> ghi matching
+<code>trusted_hash</code> + <code>codex_hooks = true</code> vào
+<code>~/.codex/config.toml</code> như notchi và Orca.</li>
+<li><strong>Reattach across daemon bounce:</strong> trivially better hơn
+app-server path. Codex <em>process</em> là cmux pane, owned bởi cmux,
+không phải daemon. Daemon restart không kill codex; hook shim re-resolve
+socket mỗi fire (là filename, không phải fd) và bắt đầu hit daemon mới
+ngay lập tức. Không có gì để &quot;reattach&quot; — tap là stateless.</li>
+<li><strong>Gate primitive:</strong> <code>PermissionRequest</code> hook
+fire. Shim forward. Daemon promote thành Gate như hiện tại. Resolution:
+human trả lời trong TUI trực tiếp (như Orca) và
+<code>PostToolUse</code>/<code>Stop</code> hook đóng gate. Hoặc nếu
+cockpit muốn programmatic answers, vẫn có gate-resolve verb, nhưng với
+một protocol gap nhỏ (không <em>force</em> được approval choice vào TUI
+mà không gõ vào nó — chính là cái fragile).</li>
+</ol>
+<p><strong>Migration delta từ PR #98:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Component</th>
+<th>Hôm nay (app-server)</th>
+<th>Yes path (TUI + hooks)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>codex spawn</td>
+<td><code>codex app-server</code> long-lived child do daemon own</td>
+<td><code>codex</code> trần trong cmux pane, do cmux own, daemon không
+own</td>
+</tr>
+<tr>
+<td>Tracking channel</td>
+<td>JSON-RPC qua stdio</td>
+<td>hook shim → Unix socket</td>
+</tr>
+<tr>
+<td><code>crew-attach</code> UI</td>
+<td>bordered renderer với chalk/Ink (theo #102)</td>
+<td>không có gì — user thấy native TUI</td>
+</tr>
+<tr>
+<td>Reattach</td>
+<td>daemon → <code>thread/resume</code> sau bounce</td>
+<td>không có gì — codex process sống qua daemon bounce</td>
+</tr>
+<tr>
+<td>Initiator</td>
+<td>daemon issue <code>turn/start</code></td>
+<td>user gõ vào TUI trực tiếp</td>
+</tr>
+<tr>
+<td><code>cockpit say</code></td>
+<td>daemon RPC vào cùng child</td>
+<td><code>cmux send</code> gõ vào pane (process-tree của cmux apply —
+xem notify-relay)</td>
+</tr>
+<tr>
+<td>Gate primitive</td>
+<td>first-class qua <code>ToolRequestUserInput</code></td>
+<td>observe qua <code>PermissionRequest</code> hook; không inject được
+answer trừ qua cmux send</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Trade-off:</strong> cockpit mất <em>programmatic</em> control
+của conversation (không <code>turn/start</code> qua RPC; phải gõ vào TUI
+qua cmux send). Đây chính là trade-off Orca lấy explicitly và gọi là
+acceptable.</p>
+<h3 id="52-no-path--điều-gì-sẽ-giết-idea-này">5.2 No Path — điều gì sẽ
+giết idea này</h3>
+<p>Những thứ sẽ buộc cockpit ở lại với app-server:</p>
+<ul>
+<li><strong>Programmatic dispatch.</strong> Nếu flow captain-spawns-crew
+yêu cầu <em>daemon</em> gửi initial prompt cho codex không cần human gõ,
+đó là territory của app-server. (Counter: cmux send works.)</li>
+<li><strong>Cross-restart conversation resume sống sót việc codex
+process chết.</strong> Với hook approach, nếu codex tự crash,
+conversation mất (không <code>thread/resume</code> equivalent). Với
+app-server, daemon-owned codex relaunch được và
+<code>thread/resume</code>.</li>
+<li><strong>Programmatic approval answering.</strong> Nếu cockpit muốn
+captain auto-approve một số class tool calls, app-server
+<code>ToolRequestUserInput</code> round-trip là cách duy nhất; hooks
+observe nhưng không decide.</li>
+</ul>
+<p>Không cái nào <em>fatal</em>. Đều là capability deltas thật. PR #98
+thật sự ambitious hơn notchi/Orca ở (5.1.5) và (5.1.7); câu hỏi là có
+đáng với UI cost không.</p>
+<h3 id="53-hybrid-path--tui-để-display-hooks-và-app-server-để-tracking">5.3
+Hybrid Path — TUI để display, hooks VÀ app-server để tracking</h3>
+<p>Codex 0.133 support <code>codex app-server</code> và TUI như hai
+process <em>riêng biệt</em>. Không cấm chạy cả hai:</p>
+<ul>
+<li>Một <strong>interactive TUI codex</strong> trong cmux pane, để
+display + human input, có hooks tap.</li>
+<li>Một <strong>app-server codex riêng</strong> cho task
+<em>programmatic</em> (captain spawn headless crew, programmatic
+approvals, anti-#2576 strict event semantics).</li>
+</ul>
+<p>Đây thực chất là design cockpit-today chia theo use case:</p>
+<ul>
+<li><em>Interactive crew</em> (human gõ): TUI + hooks. Không bridge
+renderer. Issue #102 đóng bằng cách xóa.</li>
+<li><em>Headless crew</em> (captain spawn codex với prompt, lấy result):
+app-server, như PR #98 hôm nay.</li>
+</ul>
+<p>Split đi theo line scope PR #98 đã vẽ: PR #98 close
+&quot;interactive-codex slice&quot; của #86; &quot;headless slice&quot; để follow-up. Hybrid
+path là <strong>dừng cố interactively-render qua app-server</strong>
+(cái issue #102 framing) và chấp nhận rằng interactive == TUI + hooks,
+headless == app-server.</p>
+<p>Cost: hai normalizer, hai integration test, hai version-skew matrix.
+Benefit: mỗi use case dùng đúng kênh phù hợp nhất.</p>
+<hr />
+<h2 id="6-ranking-và-recommendation">6. Ranking và recommendation</h2>
+<table>
+<thead>
+<tr>
+<th>Path</th>
+<th>Native TUI?</th>
+<th>Structured tracking?</th>
+<th>Daemon-bounce survival?</th>
+<th>Programmatic dispatch?</th>
+<th>Prior art?</th>
+<th>Eng cost từ hôm nay</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Ở lại PR #98 + ship #102</strong></td>
+<td>Không (cockpit render)</td>
+<td>Có</td>
+<td>Có</td>
+<td>Có</td>
+<td>Cockpit (một mình)</td>
+<td>~4-6h cho renderer #102</td>
+</tr>
+<tr>
+<td><strong>Yes path (TUI + hooks only)</strong></td>
+<td>Có</td>
+<td>Có (less rich hơn app-server)</td>
+<td>Có (codex process không do daemon own)</td>
+<td>Không (phải gõ qua cmux)</td>
+<td>notchi, Orca</td>
+<td>~1-2 ngày, xóa hẳn #102</td>
+</tr>
+<tr>
+<td><strong>Hybrid (TUI+hooks cho interactive, app-server cho
+headless)</strong></td>
+<td>Có (interactive)</td>
+<td>Có (cả hai surface)</td>
+<td>Có</td>
+<td>Có (headless only)</td>
+<td>Không — novel</td>
+<td>~2-3 ngày, xóa #102, thêm normalizer thứ 2</td>
+</tr>
+<tr>
+<td>Zed-style codex-core embed</td>
+<td>Không</td>
+<td>Có</td>
+<td>n/a</td>
+<td>Có</td>
+<td>Zed</td>
+<td>Tuần; sai ngôn ngữ; reject.</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Recommendation: Hybrid Path.</strong></p>
+<p>Reasoning, opinionated:</p>
+<ol type="1">
+<li><p><strong>Issue #102 nên đóng wontfix.</strong> Build một codex TUI
+giả trên app-server events đúng là việc phần còn lại của ecosystem
+(notchi, Orca, Zed) đã quyết định không làm. Cockpit sẽ tốn renderer
+effort hàng năm và vẫn xấu hơn real codex TUI cách một
+<code>brew install codex</code>. Năng lượng phí.</p></li>
+<li><p><strong>&quot;Fragility&quot; argument từ Orca research 2026-05-19 là
+misdiagnosed.</strong> Đúng về TUI-as-driver. Sai về
+TUI-with-hook-side-channel. notchi chứng minh hook channel là
+production-stable ở scale (app 894-star ship cho hàng ngàn macOS notch
+users). Kết luận justify UI cost của PR #98 là over-broad.</p></li>
+<li><p><strong>App-server foundation của PR #98 vẫn đúng cho
+headless.</strong> Anti-#2576, daemon-bounce reattach qua
+<code>thread/resume</code>, programmatic gates — đây là capabilities
+thật mà hook channel không có, và quan trọng cho captain→crew dispatch.
+Đừng tear PR #98 ra; demote nó thành nửa-headless của split.</p></li>
+<li><p><strong>Interactive trở thành thin shim.</strong>
+<code>cockpit crew chat --provider codex</code> spawn codex TUI pane,
+install hooks lần đầu chạy, daemon listen. Không bridge renderer. Không
+#102. Không tranh với UI của codex. Pane <em>là</em> UI.</p></li>
+<li><p><strong>Một real-world test trước khi commit:</strong> prove hook
+latency + reliability story trên Unix socket của cockpit daemon với
+30-phút interactive codex session under load (file edits, approvals,
+compaction). Nếu hook fire drop hoặc đến out-of-order under stress,
+Yes/Hybrid path thất bại và giữ PR #98. Cả notchi và Orca chạy config
+này in production, prior strongly in favor.</p></li>
+</ol>
+<h3 id="61-có-flip-plan-102-không">6.1 Có flip plan #102 không?</h3>
+<p><strong>Có — provided hook-channel reliability test pass.</strong>
+Issue #102 tồn tại vì architecture của PR #98 buộc cockpit phải tự
+render codex. Hybrid Path xóa nhu cầu đó cho interactive case, là case
+duy nhất #102 quan tâm. #102 nên re-scope thành <em>&quot;investigate
+TUI-passthrough + hook tap; nếu feasible, close #102 wontfix và file
+hybrid integration spec instead.&quot;</em></p>
+<h3 id="62-có-flip-decision-pr-98-không">6.2 Có flip decision PR #98
+không?</h3>
+<p><strong>Không — PR #98 vẫn merged và shipping.</strong> Hybrid Path
+giữ app-server cho headless, là chỗ nó irreplaceable. Flip là ở issue
+#102 (renderer parity goal), không phải PR #98 (app-server foundation).
+Orca research 2026-05-19 directionally đúng về app-server là answer cho
+<em>một trong hai</em> use case; chỉ framing nó như answer cho <em>cả
+hai</em>.</p>
+<hr />
+<h2 id="7-open-questions--next-actions">7. Open questions / next
+actions</h2>
+<ol type="1">
+<li><strong>Spike: hook latency under load.</strong> Viết shim
+cockpit-codex-hook 100-line, install vào
+<code>~/.codex/hooks.json</code> chống lại codex 0.133 cục bộ, chạy
+session thật, đo SessionStart→Stop event lag trên daemon socket. Target:
+p99 &lt; 100ms.</li>
+<li><strong>Verify hooks fire trong TUI với cmux <code>claude -c</code>
+resume semantics.</strong> Codex 0.130 thêm thread-resume trong TUI;
+confirm hooks vẫn fire qua
+<code>codex --continue</code>/<code>codex resume</code>. notchi
+<code>SessionStart</code> matcher là <code>&quot;startup|resume&quot;</code> nên
+presumably handled, nhưng nên test.</li>
+<li><strong><code>config.toml</code> trust-hash automation.</strong>
+Lift <code>upsertFeatureFlag</code> của notchi +
+<code>config-toml-trust.ts</code> của Orca vào first-run installer của
+cockpit; ngược lại hooks âm thầm drop trên 0.129+.</li>
+<li><strong>Quyết định captain→crew dispatch story cho interactive
+case.</strong> Hai option: (a) captain gõ prompt vào codex TUI pane qua
+cmux send (notify-relay pattern, đã built); (b) crew luôn được spawn bởi
+human gõ trong captain pane. (a) operationally giống captain→Claude flow
+hôm nay; (b) là UX downgrade. Recommend (a).</li>
+<li><strong>File hybrid spec</strong> như follow-up cho
+<code>docs/specs/2026-05-20-cockpit-interactive-codex-design.md</code>,
+scope đến interactive slice only, trước khi làm renderer work cho
+#102.</li>
+</ol>
+<hr />
+<h2 id="8-sources">8. Sources</h2>
+<ul>
+<li><a href="https://github.com/sk-ruban/notchi">notchi
+(sk-ruban/notchi)</a> — README, <code>CodexHookInstaller.swift</code>,
+<code>notchi-codex-hook.sh</code>, <code>SocketServer.swift</code>,
+<code>HookEvent.swift</code>,
+<code>CodexProviderAdapter.swift</code></li>
+<li>Orca prior research: <a href="2026-05-19-orca-codex-wrapping-study.md"><code>docs/research/2026-05-19-orca-codex-wrapping-study.md</code></a></li>
+<li><a href="https://zed.dev/docs/ai/external-agents">Zed external
+agents docs</a></li>
+<li><a href="https://github.com/zed-industries/codex-acp">Zed codex-acp
+adapter</a> — <code>Cargo.toml</code>,
+<code>src/codex_agent.rs</code></li>
+<li><a href="https://zed.dev/blog/codex-is-live-in-zed">Zed blog: Codex
+is Live in Zed</a></li>
+<li><a href="https://github.com/openai/codex/blob/main/codex-rs/hooks/src/lib.rs">openai/codex
+<code>codex-rs/hooks/src/lib.rs</code></a> —
+<code>HOOK_EVENT_NAMES</code></li>
+<li><a href="https://github.com/openai/codex">openai/codex
+<code>codex-rs/tui/src/chatwidget/hooks.rs</code></a> — chứng minh TUI
+invoke hooks</li>
+<li><a href="https://deepwiki.com/openai/codex/3.5.2-rollout-persistence-and-replay">DeepWiki:
+codex rollout persistence and replay (§3.5.2)</a></li>
+<li>Local evidence:
+<code>~/.codex/sessions/2026/05/25/rollout-*.jsonl</code> với
+<code>&quot;originator&quot;:&quot;codex-tui&quot;</code>,
+<code>&quot;cli_version&quot;:&quot;0.133.0&quot;</code></li>
+<li>Cockpit context: PR #98, Issue #102,
+<code>src/commands/crew-attach.ts</code></li>
+</ul>
+</body>
+</html>

--- a/docs/research/2026-05-27-tracking-codex-while-keeping-native-tui.vi.md
+++ b/docs/research/2026-05-27-tracking-codex-while-keeping-native-tui.vi.md
@@ -1,0 +1,311 @@
+# Tracking Codex Mà Vẫn Giữ Native TUI — Cockpit Có Thể Có Cả Hai Không?
+
+**Date:** 2026-05-27
+**Tác giả:** Cockpit research (parent: develop)
+**Câu hỏi:** PR #98 của cockpit chọn `codex app-server` (JSON-RPC có cấu trúc, cockpit tự render UI) thay vì wrap native `codex` TUI trong tmux pane (UI đẹp nhưng state extraction mong manh). User push back: *"Orca, Zed IDE, và notchi đều track được codex mà vẫn giữ native TUI — sao cockpit lại không?"*. Có một option thứ ba không?
+
+---
+
+## 0. Trilemma, phát biểu lại
+
+Ba thuộc tính muốn có ở một codex integration:
+
+1. **Full native `codex` TUI** hiển thị cho user (không cần một UI hạng hai phải cạnh tranh với nó).
+2. **Structured activity tracking** mà daemon subscribe được (turn-started, turn-completed, awaiting-input, v.v.).
+3. **Reliable across process churn** — daemon bounces, reattach, anti-#2576 (false "done"), gate primitive.
+
+PR #98 chọn (2) + (3), bỏ (1). Issue #102 nhân đôi nỗ lực cho (1) bằng cách tự build TUI trên events của (2)+(3). User push-back: *notchi có cả ba, sao cockpit không?*
+
+Câu trả lời: **cả ba reference systems đều làm được, nhưng mỗi cái trả một giá khác nhau — và mức giá lệch nhau cả một bậc.** Cockpit gần như chắc chắn có thể có cả ba, nhưng việc chọn *side-channel nào* mới là quyết định load-bearing, và đó không phải kênh notchi chọn.
+
+---
+
+## 1. notchi — mechanism thực sự là gì?
+
+**Repo:** [`github.com/sk-ruban/notchi`](https://github.com/sk-ruban/notchi) · 894 stars · Swift macOS app · default branch `main` tại thời điểm audit (2026-05-27).
+
+### 1.1 README tự tóm tắt
+
+README phát biểu architecture trong một dòng:
+
+> `Claude Code / Codex --> Hooks (shell scripts) --> Unix Socket --> Event Parser --> State Machine --> Animated Sprites`
+
+Và:
+
+> *"Notchi registers shell script hooks with Claude Code and Codex on launch. When either agent emits events (tool use, thinking, prompts, permission requests, compaction, session start/end), the hook script sends JSON payloads to a Unix socket."*
+
+Tức là **notchi không parse rendered TUI**. Không snapshot terminal, không OSC-sniff, không parse stdout. Nó tap vào **first-class native hooks system của codex** — đúng kênh Orca dùng — rồi pipe các JSON event sang một Unix socket cục bộ.
+
+### 1.2 Install path thực tế (`CodexHookInstaller.swift`)
+
+`notchi/notchi/Services/CodexHookInstaller.swift` ghi ba thứ vào `~/.codex/`:
+
+1. **Hook script** tại `~/.codex/hooks/notchi-codex-hook.sh` (mode `0o755`):
+   ```swift
+   // CodexHookInstaller.swift:43-62
+   let bundled = Bundle.main.url(forResource: "notchi-codex-hook", withExtension: "sh")
+   try bundledData.write(to: hookScriptURL, options: .atomic)
+   try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: hookScriptURL.path)
+   ```
+
+2. **`~/.codex/hooks.json`** với ba event registrations (`upsertHooksJSON`, dòng 69–95):
+   ```swift
+   let desiredHookEvents: [String: [[String: Any]]] = [
+     "SessionStart":     [makeHookGroup(matcher: "startup|resume", command: command)],
+     "UserPromptSubmit": [makeHookGroup(matcher: nil,              command: command)],
+     "Stop":             [makeHookGroup(matcher: nil,              command: command, timeout: 30)],
+   ]
+   ```
+
+3. **`~/.codex/config.toml`** với `codex_hooks = true` dưới `[features]` (`upsertFeatureFlag`, 118–145).
+
+Notchi chỉ register **ba** trong số mười hook event của codex (`SessionStart`, `UserPromptSubmit`, `Stop`). Không cần `PreToolUse`/`PostToolUse`/`PermissionRequest`/… — UI chỉ cần idle/working/waiting transitions, ba là đủ.
+
+### 1.3 Hook payload path (`notchi-codex-hook.sh`)
+
+Script đã cài là một chương trình bash + inline Python. Các dòng quan trọng:
+
+```bash
+SOCKET_PATH="/tmp/notchi.sock"
+[ -S "$SOCKET_PATH" ] || exit 0       # silent no-op nếu app không chạy
+/usr/bin/python3 -c "
+  input_data = json.load(sys.stdin)   # codex pipe hook JSON vào stdin
+  ...
+  output = { 'provider':'codex', 'session_id':..., 'event':hook_event,
+             'status':status_map.get(hook_event,...), ... }
+  sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+  sock.connect('$SOCKET_PATH'); sock.sendall(json.dumps(output).encode())
+"
+```
+
+Nó cũng walk process-tree (`codex_process_context`) để gán event cho một PID `codex` cụ thể, và đánh dấu origin là `cli` (có tty) hay `desktop` (không tty).
+
+### 1.4 Receiver (`SocketServer.swift`)
+
+Listener Swift `AF_UNIX/SOCK_STREAM` tại `/tmp/notchi.sock`, `chmod 0600`, accept mỗi hook fire, decode `AgentHookEnvelope`, normalize qua `CodexProviderAdapter.normalize`, feed state machine. Envelope schema (`HookEvent.swift:876-933`) là superset đầy đủ (`tool`, `tool_input`, `permission_mode`, `transcript_path`, `codex_origin`, …) — parser của notchi sẵn sàng cho cả những event chưa register.
+
+### 1.5 Reliability / latency story
+
+- **Latency:** sub-millisecond local Unix socket; bash wrapper thêm ~30ms Python startup mỗi fire. Với idle/working transitions thì invisible.
+- **Reliability:** hook script `exit 0` âm thầm nếu không có socket (`[ -S "$SOCKET_PATH" ] || exit 0`) — codex không bao giờ thấy hook failing, session của user không bao giờ bị ảnh hưởng bởi việc notchi đóng. `timeout: 30` trên `Stop` là per-hook timeout của codex để notchi treo cũng không stall codex.
+- **Restart survival:** hook là filesystem state, không phải process state. Hook fire đúng dù notchi vừa restart hay chưa start bao giờ — như loopback HTTP của Orca.
+- **TUI compatibility:** *codex chạy như plain interactive TUI*. Hook hoàn toàn out-of-band. Không đụng gì tới rendering, prompt composer, terminal của codex.
+
+### 1.6 Net characterization
+
+**notchi track codex bằng cách install entries vào `~/.codex/hooks.json` fire shell scripts forward JSON payload sang Unix socket. Không parse TUI gì cả.** Nó là một Orca strictly-better: cùng mechanism (codex native hooks), transport đơn giản hơn (Unix socket vs loopback HTTP + bearer), event set hẹp hơn (3 vs 6).
+
+Đây là **đúng kênh** mà PR #98 có sẵn và đã không dùng. notchi không giải bài toán khác bằng mánh khác — nó dùng một kênh cockpit hiện chưa dùng.
+
+---
+
+## 2. Orca, xem lại
+
+Prior research của cockpit ở [`docs/research/2026-05-19-orca-codex-wrapping-study.md`](2026-05-19-orca-codex-wrapping-study.md) kết luận rằng Orca approach bị reject vì state extraction *"fragile"*. **Kết luận đó cần xem lại trước evidence của notchi.**
+
+Đọc lại Orca study so với source code:
+
+- **Orca không screen-scrape state.** §2.2 của prior research: *"Orca does not infer turn state from PTY output. It installs managed entries into codex's own hooks system and listens for the events."* Mechanism là `src/main/codex/hook-service.ts:42-49` register 6 hook events, rồi `curl` sang loopback HTTP server.
+- **Orca chỉ screen-scrape cho hai chuyện trivial:** (a) paste-timing và (b) một `/status` fallback mà chính nó cũng không tin (*"app-server can fail independently of the interactive CLI"*, `codex-fetcher.ts:440`).
+
+**Verdict "fragile" trong study 2026-05-19 là về *driving codex qua TUI* (gõ vào, đọc ra). Path *tracking* mà Orca thực sự dùng là hook system — JSON có cấu trúc, robust ngang app-server's events.**
+
+Đây là một category error trong cockpit research trước: write-up cũ trộn lẫn "wrap TUI" (fragile vì bidirectional terminal IO) với "track codex trong khi hiển thị TUI của nó" (không fragile, kênh là JSON hooks, không phải TUI). Cả Orca và notchi đều làm cái sau. Không cái nào làm cái trước.
+
+---
+
+## 3. Zed — một mechanism thứ ba hoàn toàn
+
+Zed integrate codex qua [`github.com/zed-industries/codex-acp`](https://github.com/zed-industries/codex-acp). README nói: *"This tool implements an ACP adapter around the Codex CLI"*. Nhưng "wraps the Codex CLI" hóa ra là dùng từ sai — `codex-acp/Cargo.toml`:
+
+```toml
+codex-core        = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-mcp-server  = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+```
+
+Và từ `src/codex_agent.rs`:
+
+```rust
+use codex_core::{ ThreadManager, RolloutRecorder, config::Config, ... };
+let thread_manager = ThreadManager::new(&config, auth_manager.clone(), ...);
+let history = RolloutRecorder::get_rollout_history(&rollout_path).await...;
+```
+
+**Zed không spawn `codex` như subprocess.** Nó static-link `codex-core` như một Rust library inside `codex-acp` binary và chạy agent loop in-process. Zed render **UI của chính nó**, không phải codex TUI. Native codex TUI bị *thay thế*, không phải augmented.
+
+Vậy Zed **không phải example của "native TUI + tracking"**; nó là example của "không có codex process, codex-core embedded as library, không TUI". Đây là một option thứ tư chỉ dành cho project chấp nhận hard build dependency vào `codex-core` (Rust, pinned version, vỡ mỗi lần upstream refactor). Với cockpit — Node/TypeScript daemon support Codex + Claude + Opencode + Aider — đây là non-starter. Nêu ra chỉ để loại nó khỏi sân chơi.
+
+---
+
+## 4. Bản thân codex expose những gì?
+
+Đây là câu trả lời load-bearing. Có đúng bốn side-channel của codex state không yêu cầu parse TUI:
+
+### 4.1 Hooks (kênh notchi + Orca dùng)
+
+**Source:** `codex-rs/hooks/src/lib.rs`:
+
+```rust
+pub const HOOK_EVENT_NAMES: [&str; 10] = [
+    "PreToolUse", "PermissionRequest", "PostToolUse",
+    "PreCompact",  "PostCompact",
+    "SessionStart", "UserPromptSubmit",
+    "SubagentStart", "SubagentStop", "Stop",
+];
+```
+
+**Registration:** `~/.codex/hooks.json`. Codex pipe JSON payload vào stdin của command; stderr/exit được observe.
+
+**TUI vs exec:** Hooks crate được invoke từ session layer (`codex-rs/core/src/session/mod.rs` expose `hooks()` trên session, tạo giống hệt nhau cho TUI và exec). Bằng chứng cụ thể TUI đi qua nó: `codex-rs/tui/src/hooks_rpc.rs` và `codex-rs/tui/src/chatwidget/hooks.rs`. notchi và Orca cả hai chạy codex như interactive TUI thường và dựa vào hooks fire — empirically proven in production.
+
+**Codex 0.129+ caveat:** codex âm thầm drop hooks không có matching `trusted_hash` trong `config.toml`. Cả notchi (`upsertFeatureFlag`) và Orca (`config-toml-trust.ts`) đều handle. Bất kỳ cockpit integration nào cũng phải.
+
+**Kết luận:** **Đây là kênh.** Structured JSON, fire trong TUI mode, decoupled khỏi rendering, có timeout explicit, fail open, và là cái mọi tracker khác trong wild đều dùng.
+
+### 4.2 Rollout JSONL (kênh Zed đọc after-the-fact)
+
+**Source:** `RolloutRecorder` trong `codex-rs/core/src/rollout/`.
+
+**Path:** `~/.codex/sessions/YYYY/MM/DD/rollout-{ISO_TIMESTAMP}-{UUID}.jsonl`. Verified live trên máy này:
+
+```
+~/.codex/sessions/2026/05/25/rollout-2026-05-25T10-35-03-019e5d33-...jsonl
+```
+
+**Format:** `RolloutLine` envelopes chứa `ResponseItem` / `EventMsg` / `SessionMeta` / `TurnContext` / `Compacted`. Dòng đầu của một session thật trên máy này:
+
+```json
+{"timestamp":"2026-05-25T03:39:05.138Z","type":"session_meta","payload":{
+  "originator":"codex-tui",        // ← bằng chứng TUI ghi file này
+  "cli_version":"0.133.0", ... }}
+```
+
+`originator: "codex-tui"` là evidence trực tiếp rằng rollout file được ghi *bởi TUI* — y hệt như exec, y hệt như app-server.
+
+**Streaming?** DeepWiki: *"asynchronous persistence via a background RolloutWriterTask … near-real-time asynchronous recording."* Tail-style follower (e.g. `chokidar` + `tail -F` trên file mới nhất) sẽ thấy events trong tens of ms.
+
+**Limitations:** Đây là replay data, không phải orchestration. Không có distinct `PermissionRequest` event; rollout thấy final approved/denied decision và tool call kết quả. **Strictly less rich hơn hooks** cho câu "codex đang chờ gì". Phù hợp làm secondary signal nhưng không phải primary tracker.
+
+### 4.3 `codex app-server` JSON-RPC (kênh hiện tại của cockpit)
+
+Cái PR #97/#98 ship. Full structured event surface, nhưng **yêu cầu chạy codex qua `codex app-server` chứ không phải interactive TUI**. TUI binary và app-server binary là *hai runtime mode khác nhau của cùng executable*; không thể có cả hai cho cùng session.
+
+Đây là cost không tránh được của PR #98: chọn app-server nghĩa là *không có* native TUI để hiển thị, vì codex process đang chạy không ở TUI mode.
+
+### 4.4 OSC titles / stdout / pty scraping
+
+Cái PR #98 reject. Cả Orca và notchi *cũng* reject (trừ exception paste-timing của Orca). Không prior art nào dùng cho state tracking. Confirm lại reasoning của PR #98: đây là path fragile, nên tiếp tục tránh.
+
+---
+
+## 5. Synthesis — cockpit có thể có native codex TUI + structured tracking không?
+
+### 5.1 Yes Path — "passthrough TUI + hook tap"
+
+**Có.** Mechanism là *cái notchi dùng*, port sang daemon của cockpit. Cụ thể:
+
+1. **Spawn codex như plain interactive TUI trong cmux pane**, đúng như Orca làm. User nhìn thấy real codex TUI và gõ trực tiếp. Bridge crew-attach renderer biến mất — không có gì để render, user đang nhìn chính codex.
+2. **Lúc daemon startup, install (hoặc upgrade) entries trong `~/.codex/hooks.json`** trỏ tới một shim `cockpit-codex-hook` nhỏ. Shim bundle với cockpit, ghi một lần lúc boot, mode 0755, đọc JSON từ stdin như shim của notchi.
+3. **Shim forward mỗi event sang Unix socket của cockpit daemon** (`~/.config/cockpit/cockpit.sock`) — cùng socket daemon đã dùng. Thêm frame type mới `hook-event` vào protocol.
+4. **State machine sẵn có của daemon** consume các event này y hệt cách đang consume `app-server` notifications. `normalizeAppServerNotification` trong `src/control/codex/` trở thành một trong hai normalizer; `normalizeHookEvent` mới cover TUI path. Cả hai produce cùng shape `ControlEvent` — anti-#2576 invariant không đổi.
+5. **Handle codex 0.129+ trust:** ghi matching `trusted_hash` + `codex_hooks = true` vào `~/.codex/config.toml` như notchi và Orca.
+6. **Reattach across daemon bounce:** trivially better hơn app-server path. Codex *process* là cmux pane, owned bởi cmux, không phải daemon. Daemon restart không kill codex; hook shim re-resolve socket mỗi fire (là filename, không phải fd) và bắt đầu hit daemon mới ngay lập tức. Không có gì để "reattach" — tap là stateless.
+7. **Gate primitive:** `PermissionRequest` hook fire. Shim forward. Daemon promote thành Gate như hiện tại. Resolution: human trả lời trong TUI trực tiếp (như Orca) và `PostToolUse`/`Stop` hook đóng gate. Hoặc nếu cockpit muốn programmatic answers, vẫn có gate-resolve verb, nhưng với một protocol gap nhỏ (không *force* được approval choice vào TUI mà không gõ vào nó — chính là cái fragile).
+
+**Migration delta từ PR #98:**
+
+| Component | Hôm nay (app-server) | Yes path (TUI + hooks) |
+|---|---|---|
+| codex spawn | `codex app-server` long-lived child do daemon own | `codex` trần trong cmux pane, do cmux own, daemon không own |
+| Tracking channel | JSON-RPC qua stdio | hook shim → Unix socket |
+| `crew-attach` UI | bordered renderer với chalk/Ink (theo #102) | không có gì — user thấy native TUI |
+| Reattach | daemon → `thread/resume` sau bounce | không có gì — codex process sống qua daemon bounce |
+| Initiator | daemon issue `turn/start` | user gõ vào TUI trực tiếp |
+| `cockpit say` | daemon RPC vào cùng child | `cmux send` gõ vào pane (process-tree của cmux apply — xem notify-relay) |
+| Gate primitive | first-class qua `ToolRequestUserInput` | observe qua `PermissionRequest` hook; không inject được answer trừ qua cmux send |
+
+**Trade-off:** cockpit mất *programmatic* control của conversation (không `turn/start` qua RPC; phải gõ vào TUI qua cmux send). Đây chính là trade-off Orca lấy explicitly và gọi là acceptable.
+
+### 5.2 No Path — điều gì sẽ giết idea này
+
+Những thứ sẽ buộc cockpit ở lại với app-server:
+
+- **Programmatic dispatch.** Nếu flow captain-spawns-crew yêu cầu *daemon* gửi initial prompt cho codex không cần human gõ, đó là territory của app-server. (Counter: cmux send works.)
+- **Cross-restart conversation resume sống sót việc codex process chết.** Với hook approach, nếu codex tự crash, conversation mất (không `thread/resume` equivalent). Với app-server, daemon-owned codex relaunch được và `thread/resume`.
+- **Programmatic approval answering.** Nếu cockpit muốn captain auto-approve một số class tool calls, app-server `ToolRequestUserInput` round-trip là cách duy nhất; hooks observe nhưng không decide.
+
+Không cái nào *fatal*. Đều là capability deltas thật. PR #98 thật sự ambitious hơn notchi/Orca ở (5.1.5) và (5.1.7); câu hỏi là có đáng với UI cost không.
+
+### 5.3 Hybrid Path — TUI để display, hooks VÀ app-server để tracking
+
+Codex 0.133 support `codex app-server` và TUI như hai process *riêng biệt*. Không cấm chạy cả hai:
+
+- Một **interactive TUI codex** trong cmux pane, để display + human input, có hooks tap.
+- Một **app-server codex riêng** cho task *programmatic* (captain spawn headless crew, programmatic approvals, anti-#2576 strict event semantics).
+
+Đây thực chất là design cockpit-today chia theo use case:
+- *Interactive crew* (human gõ): TUI + hooks. Không bridge renderer. Issue #102 đóng bằng cách xóa.
+- *Headless crew* (captain spawn codex với prompt, lấy result): app-server, như PR #98 hôm nay.
+
+Split đi theo line scope PR #98 đã vẽ: PR #98 close "interactive-codex slice" của #86; "headless slice" để follow-up. Hybrid path là **dừng cố interactively-render qua app-server** (cái issue #102 framing) và chấp nhận rằng interactive == TUI + hooks, headless == app-server.
+
+Cost: hai normalizer, hai integration test, hai version-skew matrix. Benefit: mỗi use case dùng đúng kênh phù hợp nhất.
+
+---
+
+## 6. Ranking và recommendation
+
+| Path | Native TUI? | Structured tracking? | Daemon-bounce survival? | Programmatic dispatch? | Prior art? | Eng cost từ hôm nay |
+|---|---|---|---|---|---|---|
+| **Ở lại PR #98 + ship #102** | Không (cockpit render) | Có | Có | Có | Cockpit (một mình) | ~4-6h cho renderer #102 |
+| **Yes path (TUI + hooks only)** | Có | Có (less rich hơn app-server) | Có (codex process không do daemon own) | Không (phải gõ qua cmux) | notchi, Orca | ~1-2 ngày, xóa hẳn #102 |
+| **Hybrid (TUI+hooks cho interactive, app-server cho headless)** | Có (interactive) | Có (cả hai surface) | Có | Có (headless only) | Không — novel | ~2-3 ngày, xóa #102, thêm normalizer thứ 2 |
+| Zed-style codex-core embed | Không | Có | n/a | Có | Zed | Tuần; sai ngôn ngữ; reject. |
+
+**Recommendation: Hybrid Path.**
+
+Reasoning, opinionated:
+
+1. **Issue #102 nên đóng wontfix.** Build một codex TUI giả trên app-server events đúng là việc phần còn lại của ecosystem (notchi, Orca, Zed) đã quyết định không làm. Cockpit sẽ tốn renderer effort hàng năm và vẫn xấu hơn real codex TUI cách một `brew install codex`. Năng lượng phí.
+
+2. **"Fragility" argument từ Orca research 2026-05-19 là misdiagnosed.** Đúng về TUI-as-driver. Sai về TUI-with-hook-side-channel. notchi chứng minh hook channel là production-stable ở scale (app 894-star ship cho hàng ngàn macOS notch users). Kết luận justify UI cost của PR #98 là over-broad.
+
+3. **App-server foundation của PR #98 vẫn đúng cho headless.** Anti-#2576, daemon-bounce reattach qua `thread/resume`, programmatic gates — đây là capabilities thật mà hook channel không có, và quan trọng cho captain→crew dispatch. Đừng tear PR #98 ra; demote nó thành nửa-headless của split.
+
+4. **Interactive trở thành thin shim.** `cockpit crew chat --provider codex` spawn codex TUI pane, install hooks lần đầu chạy, daemon listen. Không bridge renderer. Không #102. Không tranh với UI của codex. Pane *là* UI.
+
+5. **Một real-world test trước khi commit:** prove hook latency + reliability story trên Unix socket của cockpit daemon với 30-phút interactive codex session under load (file edits, approvals, compaction). Nếu hook fire drop hoặc đến out-of-order under stress, Yes/Hybrid path thất bại và giữ PR #98. Cả notchi và Orca chạy config này in production, prior strongly in favor.
+
+### 6.1 Có flip plan #102 không?
+
+**Có — provided hook-channel reliability test pass.** Issue #102 tồn tại vì architecture của PR #98 buộc cockpit phải tự render codex. Hybrid Path xóa nhu cầu đó cho interactive case, là case duy nhất #102 quan tâm. #102 nên re-scope thành *"investigate TUI-passthrough + hook tap; nếu feasible, close #102 wontfix và file hybrid integration spec instead."*
+
+### 6.2 Có flip decision PR #98 không?
+
+**Không — PR #98 vẫn merged và shipping.** Hybrid Path giữ app-server cho headless, là chỗ nó irreplaceable. Flip là ở issue #102 (renderer parity goal), không phải PR #98 (app-server foundation). Orca research 2026-05-19 directionally đúng về app-server là answer cho *một trong hai* use case; chỉ framing nó như answer cho *cả hai*.
+
+---
+
+## 7. Open questions / next actions
+
+1. **Spike: hook latency under load.** Viết shim cockpit-codex-hook 100-line, install vào `~/.codex/hooks.json` chống lại codex 0.133 cục bộ, chạy session thật, đo SessionStart→Stop event lag trên daemon socket. Target: p99 < 100ms.
+2. **Verify hooks fire trong TUI với cmux `claude -c` resume semantics.** Codex 0.130 thêm thread-resume trong TUI; confirm hooks vẫn fire qua `codex --continue`/`codex resume`. notchi `SessionStart` matcher là `"startup|resume"` nên presumably handled, nhưng nên test.
+3. **`config.toml` trust-hash automation.** Lift `upsertFeatureFlag` của notchi + `config-toml-trust.ts` của Orca vào first-run installer của cockpit; ngược lại hooks âm thầm drop trên 0.129+.
+4. **Quyết định captain→crew dispatch story cho interactive case.** Hai option: (a) captain gõ prompt vào codex TUI pane qua cmux send (notify-relay pattern, đã built); (b) crew luôn được spawn bởi human gõ trong captain pane. (a) operationally giống captain→Claude flow hôm nay; (b) là UX downgrade. Recommend (a).
+5. **File hybrid spec** như follow-up cho `docs/specs/2026-05-20-cockpit-interactive-codex-design.md`, scope đến interactive slice only, trước khi làm renderer work cho #102.
+
+---
+
+## 8. Sources
+
+- [notchi (sk-ruban/notchi)](https://github.com/sk-ruban/notchi) — README, `CodexHookInstaller.swift`, `notchi-codex-hook.sh`, `SocketServer.swift`, `HookEvent.swift`, `CodexProviderAdapter.swift`
+- Orca prior research: [`docs/research/2026-05-19-orca-codex-wrapping-study.md`](2026-05-19-orca-codex-wrapping-study.md)
+- [Zed external agents docs](https://zed.dev/docs/ai/external-agents)
+- [Zed codex-acp adapter](https://github.com/zed-industries/codex-acp) — `Cargo.toml`, `src/codex_agent.rs`
+- [Zed blog: Codex is Live in Zed](https://zed.dev/blog/codex-is-live-in-zed)
+- [openai/codex `codex-rs/hooks/src/lib.rs`](https://github.com/openai/codex/blob/main/codex-rs/hooks/src/lib.rs) — `HOOK_EVENT_NAMES`
+- [openai/codex `codex-rs/tui/src/chatwidget/hooks.rs`](https://github.com/openai/codex) — chứng minh TUI invoke hooks
+- [DeepWiki: codex rollout persistence and replay (§3.5.2)](https://deepwiki.com/openai/codex/3.5.2-rollout-persistence-and-replay)
+- Local evidence: `~/.codex/sessions/2026/05/25/rollout-*.jsonl` với `"originator":"codex-tui"`, `"cli_version":"0.133.0"`
+- Cockpit context: PR #98, Issue #102, `src/commands/crew-attach.ts`

--- a/docs/specs/2026-05-27-mailbox-injector-design.md
+++ b/docs/specs/2026-05-27-mailbox-injector-design.md
@@ -1,0 +1,675 @@
+# Mailbox + Injector — Foundational Design for Captain Notifications
+
+**Date:** 2026-05-27
+**Status:** Approved design, pre-implementation. Brainstormed in-session 2026-05-27.
+**Predecessors (read first):**
+- `docs/specs/2026-05-26-claude-interactive-through-daemon-design.md` — Phase 3 (PR #108) — daemon-supervised Claude crews.
+- `docs/research/2026-05-27-multi-session-orchestrator-notification-patterns.md` — pattern survey across OpenHands/AutoGen/crewAI/LangGraph/Swarm/tmux-orchestrator/Claude Squad/Aider/Goose/Continue/Codex/Erlang/D-Bus/XPC/sd_notify/OTel. **Rank-1 recommendation: mailbox + injector (Erlang + Orca hybrid).** This spec implements that recommendation.
+- `docs/research/2026-05-27-tracking-codex-while-keeping-native-tui.md` — finds that codex hooks fire in TUI mode (notchi/Orca pattern). Motivates #114.
+
+**Cross-refs:**
+- **Closes** the un-shipped half of **#113** (replay-on-reconnect) by construction — pull-from-cursor is replay-by-default.
+- **Foundation for** **#114** (hybrid codex: native TUI + hook bridge) and **#115** (opencode interactive wiring).
+- **Replaces** the subscribe/broadcast machinery added in **PR #112** with a pull-from-file model. PR #112's relay-tab idea survives (correct shape per the research); the protocol underneath it gets simpler.
+
+---
+
+## 1 · Problem & non-goals
+
+**Problem.** Cockpit's captain → crew → captain feedback loop went through three architectural attempts in May 2026:
+
+1. **PR #110 (#109):** daemon shells out to `cockpit runtime send <project> "CREW DONE ..."` after a terminal `ControlEvent`. Fails in production because cmux's CLI rejects callers not in its process tree (proc-lineage check, verified empirically).
+2. **PR #112 (#111 fix):** daemon broadcasts events over its socket; a `notify-relay` tab inside each captain workspace subscribes and forwards to the captain pane via `RuntimeDriver.send`. Works in steady state because the relay tab IS inside cmux's tree. **Breaks during daemon-bounce backoff windows** (#113): pushes broadcast while the relay is reconnecting are silently lost. The inbox file written alongside the broadcast was scoped as "debug backup," never replayed.
+3. **Field complaint (this session):** the relay-tab + subscribe-protocol + reconnect-backoff machinery is more complex than the value it delivers, and the visible tab clutters captain workspaces.
+
+The 2026-05-27 research survey identified the right architectural shape — already present in PR #112 — but called out that the relay was "treated as a workaround rather than dignified as a first-class element," and that the missing pieces were (a) durable per-captain mailbox, (b) pull-from-cursor delivery instead of push-with-no-replay, (c) RuntimeDriver abstraction of the injector spawn.
+
+**Goal.** Replace PR #112's subscribe/broadcast machinery with a **file-as-source-of-truth mailbox** the daemon appends to and an **injector inside the captain workspace** that tails the mailbox from a persisted cursor and delivers each event to the captain pane via a runtime-agnostic `RuntimeDriver` surface. The result:
+- At-least-once delivery (closes #113 by construction)
+- Daemon-bounce-tolerant by design (file is durable; no socket coordination)
+- Uniform pattern across claude / codex / opencode (each provider emits `ControlEvent`s into the mailbox via its native hook surface; the injector is provider-agnostic)
+- Runtime-agnostic (cmux today, orca / zed / IntelliJ-MCP later — each runtime implements two driver methods)
+
+**Non-goals (YAGNI — explicitly out):**
+- Replacing PR #98's app-server foundation for codex headless. App-server remains the headless path and reference impl for the gate primitive. This spec is about notifications, not codex driver replacement.
+- Multi-captain-per-project workflows. Today one captain per project. Schema allows extending the cursor file naming (`<project>.<captain-name>.cursor`) if multi-captain comes later.
+- Cross-host notifications (Telegram / SMS / etc — #65 deferred). The mailbox schema supports multi-subscriber via per-subscriber cursor files; the Telegram subscriber, when implemented, gets its own cursor.
+- Replacing legacy `cockpit crew read` / `crew send` / `crew close` (cmux-pane verbs). Those keep working unchanged.
+- A general decision-gate primitive (PR #98's gates stay codex-only for now).
+- Killing the daemon socket protocol entirely. The socket still serves `dispatch` / `status` / `tasks` / `reply` / `_hook` / `gate-resolve`. Only the `subscribe-notify` + `push` frames added in PR #112 get removed.
+
+---
+
+## 2 · Lessons applied from PRs #110 and #112
+
+This is the **third** iteration on captain notifications in May 2026. Each prior attempt taught something this design must honor.
+
+| Lesson | Source | How this design honors it |
+|---|---|---|
+| Shelling out via `cockpit runtime send` from launchctl-spawned daemon fails — cmux's CLI rejects non-cmux-tree callers | PR #110 → #111 diagnosis | Daemon never invokes any cmux-aware command. It only appends to a file. The injector — which IS inside cmux's tree — owns all `RuntimeDriver` interaction. |
+| Push-with-no-replay loses events during daemon-bounce backoff windows | PR #112 → #113 | Pull-from-cursor model: injector reads from `lastAckedSeq + 1` on every restart. Daemon bouncing doesn't break delivery; the file is durable. |
+| Subscribe protocol + reconnect-backoff is more complex than needed for a single in-process subscriber | PR #112 field experience | No subscribe protocol. No socket connection from injector to daemon. Injector tails a file. Loop is ~50 lines vs PR #112's ~150. |
+| The "relay tab" idea is correct (process must be in cmux's tree); the protocol behind it is what's wrong | Research 2026-05-27 § *"The relay tab is not a workaround"* | Keep the in-cmux-tree process. Change only how it gets events. |
+| Visible relay tab in workspace is cosmetic clutter | User complaint this session | RuntimeDriver `spawnInjector("hidden")`; cmux impl uses a height-minimized split-pane (or falls back to visible if cmux can't hide). |
+| `RuntimeDriver` is the right place for runtime-specific concerns; daemon stays runtime-agnostic | Architectural invariant since PR #74 | Driver gains two methods: `spawnInjector` + `sendToSurface`. Daemon never references cmux. |
+| Anti-#2576 invariant: terminal state comes from explicit `cockpit crew signal`, never from liveness hooks | Spec line 109 of control-plane design (PR #85) | Mailbox content is whatever the daemon's state machine + `firePush` gate already produces. This spec doesn't change WHICH events fire; only how they reach the captain. |
+
+The research's central observation also applies: the relay-tab pattern is the same shape as Erlang per-process mailboxes (BEAM-allocated queue per actor, owner pulls from it on schedule) and Orca's hook receiver (in-process listener for codex events). Dignifying it with a durable queue and a clean driver surface is what was missing.
+
+---
+
+## 3 · Approach (single PR, surgical, atomic commits)
+
+One branch: `feature/mailbox-injector`. Four atomic commits in one PR:
+
+1. **`src/control/mailbox.ts` (NEW)** — pure mailbox operations + tests. No daemon wiring yet.
+2. **Daemon side switchover** — `cockpitd.ts`'s `defaultNotify` rewired to `appendToMailbox`; subscribe-broadcast machinery and `protocol.ts` subscribe/push frames deleted.
+3. **`notify-relay` rewrite** — `src/commands/notify-relay.ts` rewritten as file-tailer (replaces socket subscriber).
+4. **`RuntimeDriver.spawnInjector("hidden")` + cmux split-pane impl** — `launch.ts` switches from `newPane` (tab) to `spawnInjector` (hidden split).
+
+Each commit keeps end-to-end working (with the brief exception of commit 2, where events land in the mailbox but the relay isn't reading them yet — commit 3 lands the reader in the same PR, so the bridge state never reaches `develop`).
+
+**Approach 3 boundary preserved** (control-plane spec, line 47-52): daemon owns headless children by PID; for interactive, daemon owns the *event stream*, not the agent process. This spec keeps that invariant: daemon owns the mailbox; the injector owns delivery; neither owns the captain process.
+
+---
+
+## 4 · Architecture
+
+```
+   ┌──────────────────────────────┐    1. POST ControlEvent
+   │ crew (any provider)          │ ─────────────┐
+   │ - claude Stop hook → _hook   │              │
+   │ - codex hooks (#114) → _hook │              ▼
+   │ - opencode plugin (#115) →   │      ┌────────────────────────────────┐
+   │      _hook                   │      │ cockpitd                       │
+   │ - explicit `crew signal done`│      │ - apply event via state machine│
+   └──────────────────────────────┘      │ - firePush gate (existing):    │
+                                          │   only on done/blocked/failed/ │
+                                          │   stalled AND state changed    │
+                                          │ - appendToMailbox()            │
+                                          │ - rotateIfNeeded() (timer)     │
+                                          │ NO subscribe protocol          │
+                                          │ NO socket broadcast            │
+                                          └────────────────────────────────┘
+                                                          │
+                                                          │ append-only
+                                                          ▼
+                                          ┌────────────────────────────────┐
+                                          │ ~/.config/cockpit/inbox/        │
+                                          │   <project>.log                 │
+                                          │   <project>.log.1 (rotated)     │
+                                          │   <project>.<sub>.cursor        │
+                                          │ JSON-lines, append-only,        │
+                                          │ flock-protected on write        │
+                                          └────────────────────────────────┘
+                                                          │
+                                                          │ tail -F from cursor
+                                                          ▼
+   ┌─────────────────────────────────────────────────────────────┐
+   │ Injector — hidden split-pane in captain's tab (cmux)        │
+   │  `cockpit notify-relay <project> --as captain`              │
+   │  - read cursor (lastAckedSeq)                                │
+   │  - tail mailbox file from seq+1                              │
+   │  - for each entry:                                           │
+   │      msg = format(entry)                                     │
+   │      runtime.sendToSurface(captainSurface, msg)              │
+   │      writeCursor(entry.seq) [fsync + atomic rename]          │
+   │  - in cmux's process tree → cmux send works (lineage OK)    │
+   └─────────────────────────────────────────────────────────────┘
+```
+
+**Key invariants:**
+
+- **Mailbox file is single source of truth for the notification stream.** Daemon writes; injector reads. No other path delivers events to the captain.
+- **Pull, not push.** Injector is responsible for catching up; daemon doesn't track subscribers. Daemon-bounce is irrelevant to delivery correctness.
+- **At-least-once.** Cursor advances only after `sendToSurface` returns. Crash before fsync = replay on restart. Captain may see one event twice; never zero.
+- **Runtime-agnostic.** Daemon and notify-relay reference `RuntimeDriver`, never cmux directly. The two new driver methods (`spawnInjector`, `sendToSurface`) are the entire surface area runtimes must implement.
+
+---
+
+## 5 · Mailbox data model
+
+### 5.1 Directory layout
+
+```
+~/.config/cockpit/inbox/
+  <project>.log                 # current append-target (JSON-lines)
+  <project>.log.1               # rotated (older)
+  <project>.log.2               # ...
+  <project>.<subscriber>.cursor # per-subscriber checkpoint
+```
+
+Subscriber name today: `captain` (the only subscriber). Schema designed so future subscribers (Telegram, dashboard) get their own cursor file without changing the log format or contending on the same cursor.
+
+### 5.2 Log line schema
+
+Each line is one JSON object terminated by `\n`. Example:
+
+```json
+{"seq":42,"ts":"2026-05-27T14:23:45.123Z","taskId":"a1b2c3d4-e5f6-7890-abcd-ef1234567890","kind":"task.done","provider":"claude","payload":{"message":"PING-OK live test successful","resultRef":"/Users/.../state/_results/a1b2c3d4-...txt"}}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `seq` | number | Monotonic per project. Daemon increments atomically inside flock during `appendToMailbox`. Starts at 1 on fresh project; on daemon restart, daemon re-scans tail of current log file to find max-seq, resumes at max+1. |
+| `ts` | string (ISO-8601 UTC) | Wall-clock time of append. |
+| `taskId` | string (UUID) | TaskRecord this event belongs to. |
+| `kind` | `"task.started"` \| `"task.progress"` \| `"task.done"` \| `"task.blocked"` \| `"task.failed"` \| `"task.stalled"` | The normalized `ControlEvent` kind. |
+| `provider` | `"claude"` \| `"codex"` \| `"opencode"` | For future per-provider rendering / filtering. |
+| `payload` | object | Kind-specific: `{message, resultRef}` for done, `{question}` for blocked, `{error}` for failed, etc. |
+
+### 5.3 Cursor file schema
+
+```json
+{"lastAckedSeq":42,"subscriber":"captain","updatedAt":"2026-05-27T14:23:45.456Z"}
+```
+
+| Field | Notes |
+|---|---|
+| `lastAckedSeq` | The greatest `seq` the subscriber has *durably acked* (i.e. `sendToSurface` returned successfully AND cursor write completed). On next startup, subscriber resumes from `lastAckedSeq + 1`. |
+| `subscriber` | Cosmetic; matches the file's subscriber name slot. Used for diagnostics only. |
+| `updatedAt` | Wall-clock; for debug. |
+
+Cursor write is atomic: write to `<file>.tmp` → `fsync` → `rename(<file>.tmp, <file>)`. Survives mid-write crash; injector's restart-read either sees the old cursor (replays one event = at-least-once) or the new cursor (already advanced).
+
+### 5.4 Atomicity of seq increment
+
+Daemon is single-process node; the event loop guarantees serial execution of the `appendToMailbox` body. flock on `<project>.log` is held for the duration of read-max-seq + write-line + close, to guard against:
+- Briefly overlapping daemons during launchctl restart (rare, but possible)
+- Manual `cockpit` subprocess invocations that might write directly (none today, but defensive)
+
+flock is advisory on macOS; daemon and any future writer must voluntarily honor it. Documented in `mailbox.ts`.
+
+**First-append bootstrap.** On the first append for a project (no `<project>.log` yet), `appendToMailbox` opens the file with `O_CREAT | O_APPEND` and initializes seq=1. No special-case branch in callers.
+
+### 5.5 GC / rotation
+
+Daemon runs `rotateIfNeeded(project)` every 60 seconds (background timer) and immediately after every append. Rotation triggers when **either**:
+- `<project>.log` size > **5 MB** (tunable: `config.mailbox.maxBytes`), or
+- Oldest line in `<project>.log` timestamp > **7 days** old (tunable: `config.mailbox.maxAgeMs`)
+
+Rotation procedure:
+1. Hold flock on `<project>.log`.
+2. `rename(<project>.log, <project>.log.tmp-N)` (N = monotonic suffix to avoid races).
+3. Open new empty `<project>.log` for append.
+4. Release flock.
+5. Background: re-sort rotated files by name, rename to canonical `<project>.log.1`, `.2`, etc. Delete any beyond `keepCount = 3` (tunable: `config.mailbox.keepRotations`).
+
+Total retention window: up to ~20 MB (current 5 MB + 3 × 5 MB rotated) OR up to ~28 days (current 7 days + 3 × 7 days rotated), whichever fills first. Plenty for any realistic scrollback.
+
+### 5.6 Gap handling (cursor older than oldest retained)
+
+When injector starts and finds `lastAckedSeq` is older than the earliest entry in any retained log file:
+1. Inject a synthetic line into the captain pane:
+   `[notify-relay] cursor 42 stale; skipping to seq 158 (116 events lost during outage)`
+2. Update cursor to the current tail's max seq.
+3. Resume tailing normally.
+
+Honest degradation. User sees explicitly that events were lost (rather than silent stale state).
+
+### 5.7 Multi-subscriber design (forward-compatible, no work today)
+
+Each subscriber has its own cursor file. A future Telegram subscriber would:
+- Run `cockpit notify-relay <project> --as telegram --target telegram://...`
+- Read/write `<project>.telegram.cursor`
+- No contention with captain subscriber; independent cursor advancement
+
+Today only `--as captain` exists. The flag is parsed and used in file naming from day 1.
+
+---
+
+## 6 · Daemon-side changes
+
+### 6.1 New module: `src/control/mailbox.ts`
+
+Pure-ish module. Side effects limited to fs operations. All public functions take a `stateRoot` param for testability.
+
+```typescript
+export interface MailboxEntry {
+  seq: number;
+  ts: string;
+  taskId: string;
+  kind: ControlEvent["type"];
+  provider: Provider;
+  payload: Record<string, unknown>;
+}
+
+export async function appendToMailbox(opts: {
+  stateRoot: string;
+  project: string;
+  taskRecord: TaskRecord;
+  event: ControlEvent;
+}): Promise<number>; // returns seq
+
+export async function rotateIfNeeded(opts: {
+  stateRoot: string;
+  project: string;
+  maxBytes?: number;
+  maxAgeMs?: number;
+  keepCount?: number;
+}): Promise<{ rotated: boolean; from?: string; to?: string }>;
+
+export async function* readFromCursor(opts: {
+  stateRoot: string;
+  project: string;
+  fromSeq: number;
+}): AsyncIterable<MailboxEntry>;
+
+export async function readCursor(opts: {
+  stateRoot: string;
+  project: string;
+  subscriber: string;
+}): Promise<{ lastAckedSeq: number } | null>;
+
+export async function writeCursor(opts: {
+  stateRoot: string;
+  project: string;
+  subscriber: string;
+  lastAckedSeq: number;
+}): Promise<void>;
+```
+
+### 6.2 `defaultNotify` rewrite in `cockpitd.ts`
+
+Today (post-PR #110): `defaultNotify` shells out to `cockpit runtime send`. Tomorrow:
+
+```typescript
+const defaultNotify = async (args: { project: string; message: string; record: TaskRecord; event: ControlEvent }): Promise<void> => {
+  try {
+    await appendToMailbox({
+      stateRoot,
+      project: args.project,
+      taskRecord: args.record,
+      event: args.event,
+    });
+  } catch (e) {
+    log(`mailbox append failed project=${args.project}: ${(e as Error).message}`);
+  }
+};
+```
+
+**Signature change:** `defaultNotify` previously took `{project, message}`. Now takes `{project, message, record, event}` so it can serialize the rich payload. `firePush` is updated to pass these through. Tests assert new signature.
+
+### 6.3 Subscribe-broadcast removal
+
+- `src/control/protocol.ts`: delete `subscribe-notify` claim frame and `push` event frame (added in PR #112). Other frames untouched.
+- `cockpitd.ts`: delete the subscriber registry, the broadcast loop, and the `case "subscribe-notify"` handler.
+- Existing tests for these get deleted in the same commit.
+
+### 6.4 Background rotation timer
+
+```typescript
+const rotateTimer = setInterval(async () => {
+  for (const project of knownProjects(stateRoot)) {
+    try { await rotateIfNeeded({ stateRoot, project, ...rotationConfig }); }
+    catch (e) { log(`rotate failed project=${project}: ${(e as Error).message}`); }
+  }
+}, 60_000);
+
+// On shutdown: clearInterval(rotateTimer);
+```
+
+`knownProjects` is `readdirSync(stateRoot/inbox).filter(...)`. Cheap.
+
+### 6.5 firePush gate — unchanged
+
+The existing gate logic (PR #110, refined in PR #112) stays exactly as is:
+- Only fire on transitions where `prev.state !== next.state`
+- Only fire when `next.state ∈ {done, blocked, failed, stalled}`
+- Suppress liveness ticks (`task.progress` events that don't change state)
+
+The gate decides WHICH events reach `defaultNotify`. The mailbox decides WHERE the gated events go. Separation of concerns preserved.
+
+### 6.6 Daemon API surface — net delta
+
+| Surface | Before this spec | After |
+|---|---|---|
+| Socket frames | dispatch / status / list / reply / event / _hook / gate-resolve / **subscribe-notify** / **push** | dispatch / status / list / reply / event / _hook / gate-resolve |
+| Inbox file | Append-only debug log (PR #112); no replay support | **Primary delivery channel** with seq + cursor + rotation |
+| Subscriber tracking | In-memory list of socket connections | None |
+
+Net: daemon protocol gets simpler.
+
+### 6.7 Behavior on daemon bounce
+
+- Mid-append daemon kill → flock released by OS; line at EOF may be partial; injector's parser skips partial last line, picks up on next append.
+- Daemon restart → reads tail of `<project>.log` to find max seq; resumes at max+1.
+- Cursor file unaffected by daemon bounce (only injector writes it).
+
+---
+
+## 7 · Injector side
+
+### 7.1 Command surface
+
+```
+cockpit notify-relay <project> [--as <subscriber>] [--state-root <path>]
+  <project>         project name from cockpit config
+  --as              subscriber name (default: "captain"); determines cursor file name
+  --state-root      override default ~/.config/cockpit (tests / dev)
+```
+
+Long-running process. Designed to be spawned by `cockpit launch` via `RuntimeDriver.spawnInjector`. Survives until `SIGTERM` (clean shutdown — flushes cursor) or `SIGKILL` (next launch detects dead injector + respawns).
+
+### 7.2 Lifecycle
+
+```
+1. BOOT
+   - Parse args; resolve config; resolve project entry
+   - Resolve captain WorkspaceRef + primary SurfaceRef via RuntimeDriver
+     (one-shot; cached for process lifetime)
+   - Read cursor (~/.config/cockpit/inbox/<project>.<sub>.cursor)
+     - exists → lastAckedSeq = <value>
+     - missing → lastAckedSeq = 0 (start from seq 1)
+   - GAP CHECK: open <project>.log, peek first line's seq
+     - If first seq > lastAckedSeq + 1 → emit synthetic [GAP] line first,
+       then update cursor to (peeked-tail-max-seq), continue from there
+     - Else proceed normally
+
+2. LOOP
+   for await (const entry of readFromCursor({stateRoot, project, fromSeq: lastAckedSeq + 1})) {
+     msg = format(entry)
+     try {
+       await runtime.sendToSurface(captainSurface, msg)
+     } catch (e) {
+       log(`sendToSurface failed seq=${entry.seq}: ${e.message}`)
+       // do NOT advance cursor on send failure; bounded retry handled at outer loop
+       await sleep(1000)
+       continue
+     }
+     await writeCursor({stateRoot, project, subscriber, lastAckedSeq: entry.seq})
+     lastAckedSeq = entry.seq
+   }
+
+3. WAITING ON NEW EVENTS
+   - When readFromCursor reaches current EOF, switch to file-watcher
+     (chokidar or fs.watch). On 'change' event → re-enter the loop.
+   - Poll fallback: if watcher fails to register, poll every 1000ms.
+
+4. ROTATION HANDLING
+   - When readFromCursor reaches EOF AND <project>.log gets a new inode
+     (detected via stat.ino comparison or watcher 'rename' event),
+     close current FD, re-open path, continue.
+   - rotated files (<project>.log.1, etc.) are read transparently when
+     cursor + tail span the rotation boundary.
+
+5. SHUTDOWN
+   - SIGTERM: flush cursor write (already synchronous after each deliver)
+   - Exit 0
+```
+
+### 7.3 Format dispatch
+
+Per-event message format (matches existing PR #110 format for compat):
+
+| `entry.kind` | Rendered to captain pane |
+|---|---|
+| `task.started` | (suppressed — not actionable) |
+| `task.progress` | (suppressed — liveness; the gate shouldn't even send these, but defensive) |
+| `task.done` | `CREW DONE [<provider>/<id8>]: <payload.message OR taskRecord.task first line, 120 chars>` |
+| `task.blocked` | `CREW BLOCKED [<provider>/<id8>]: <payload.question>` |
+| `task.failed` | `CREW FAILED [<provider>/<id8>]: <payload.error>` |
+| `task.stalled` | `CREW STALLED [<provider>/<id8>]: no heartbeat in <budgetMs>ms` |
+
+`id8` = first 8 chars of taskId for compact identification. Identical to PR #110/#112 format for muscle memory.
+
+### 7.4 At-least-once invariant
+
+- Cursor only advances AFTER `sendToSurface` returns successfully (no exception thrown).
+- Cursor write uses fsync + atomic rename. Mid-write crash → restart reads old cursor → replays last event.
+- Captain may see one event twice (e.g. `sendToSurface` succeeded but the daemon SIGKILLed the injector before cursor write completed) — acceptable. The duplicate `CREW DONE` line is mildly confusing but never silently lost.
+
+### 7.5 Crash + respawn
+
+- Injector dies → captain workspace still has the (now-defunct) hidden split-pane
+- Next `cockpit launch <project>` (idempotent — captain-ops runs at session start) checks the injector pane: if process is dead, kill the pane and call `spawnInjector` again
+- Respawned injector reads cursor → continues from `lastAckedSeq + 1`
+- No coordination with daemon; daemon doesn't know or care if an injector is alive
+
+### 7.6 What was removed from PR #112
+
+The new `notify-relay.ts` is approximately 1/3 the size of PR #112's version:
+- ❌ Socket connect logic
+- ❌ Subscribe frame send/receive
+- ❌ Reconnect-with-backoff (2s → 4s → … → 30s)
+- ❌ Subscriber-side dedup
+- ✅ File tail + cursor advance (new)
+
+---
+
+## 8 · RuntimeDriver interface
+
+### 8.1 New methods
+
+```typescript
+interface RuntimeDriver {
+  // ... existing: status, list, send, sendToPane, newPane, listSurfaces, spawn, listSurfaces ...
+
+  /**
+   * Spawn a long-running process inside the captain workspace's process tree,
+   * such that any IPC/socket constraints of the runtime (e.g. cmux's parent-
+   * lineage check) are satisfied.
+   *
+   * placement: "hidden" should produce a non-distracting surface — runtime
+   * decides exactly how. "visible" is a normal pane (debug mode).
+   *
+   * Returns a SurfaceRef the caller can use later for read/inspect (e.g. to
+   * detect the injector has died).
+   */
+  spawnInjector(opts: {
+    captainWorkspace: WorkspaceRef;
+    command: string;       // the shell command to run, e.g. "cockpit notify-relay <proj>"
+    title?: string;
+    placement: "hidden" | "visible";
+  }): Promise<SurfaceRef>;
+
+  /**
+   * Send text to a specific surface (vs. send() which targets a workspace
+   * by name and routes to its primary tab). Used by the injector to deliver
+   * messages to the captain's main surface.
+   *
+   * Returns when the runtime has accepted the write. Throws if the surface
+   * no longer exists.
+   */
+  sendToSurface(surface: SurfaceRef, text: string): Promise<void>;
+}
+```
+
+### 8.2 cmux implementation (`src/runtimes/cmux.ts`)
+
+**`spawnInjector` with `placement: "hidden"`:**
+```
+1. cmux new-split --workspace <ws.id> down
+   → returns new surface id (parse from output)
+2. cmux send --workspace <ws.id> --surface <new> "<command>" + send-key Enter
+3. cmux resize-split (if supported) → height = minimum
+   If not supported: leave default; document the cosmetic cost
+4. cmux rename-tab --workspace <ws.id> --surface <new> "<title or '✉ notify-relay'>"
+5. Return SurfaceRef{id: <new>, workspaceId: <ws.id>, ...}
+```
+
+**`spawnInjector` with `placement: "visible"`:** identical, skip step 3.
+
+**`sendToSurface`:**
+```
+cmux send --workspace <surface.workspaceId> --surface <surface.id> "<text>"
+cmux send-key --workspace <surface.workspaceId> --surface <surface.id> Enter
+```
+
+This is essentially extracting the surface-targeting half of the existing `send()` method (already present in `cmux.ts:87-106` from PR #84) into its own callable method.
+
+### 8.3 Probing cmux capability before commit 4
+
+Commit 4 of the implementation PR must include a probe step:
+- Verify `cmux new-split --workspace <id> down` returns a parseable surface id
+- Verify `cmux resize-split` (or equivalent) can reduce a split to height ≤ 3 rows
+- If resize unsupported → fall back to spawn as a regular tab via `newPane` (PR #112 behavior). Update the spec's open question table to record this outcome.
+
+This is a hardware-of-the-runtime question that's faster to probe than to research; the design is robust to either answer.
+
+### 8.4 Future runtimes (orca / zed) — no daemon code changes
+
+- **orca**: `spawnInjector` could create a hidden status widget or background pane via orca's API. `sendToSurface` uses orca's IPC.
+- **zed**: zed has its own pane / buffer model. The injector could be a Zed extension or a sidebar process zed manages. Implementation is the runtime author's problem.
+- **none of the daemon code or notify-relay command source changes** when adding a new runtime. The `RuntimeDriver` registry already handles this dispatch.
+
+---
+
+## 9 · Migration & integration with related issues
+
+### 9.1 Single PR, four atomic commits — no flag day
+
+| Commit | What ships | Verifiable in isolation? |
+|---|---|---|
+| 1: `mailbox.ts` (NEW) + unit tests | Pure functions for append/rotate/read/cursor | Yes. Unit tests cover all schema invariants. No daemon wiring. |
+| 2: `cockpitd.ts` rewires `defaultNotify` to `appendToMailbox`; subscribe/broadcast removed from `protocol.ts` and `cockpitd.ts` | Events land in mailbox; relay-tab (PR #112 code) still runs but receives no socket events — harmless idle | Yes. Integration test: dispatch task.done, assert mailbox file has the entry. Captain pane does NOT receive the line yet — that's commit 3's job. |
+| 3: `notify-relay.ts` rewritten as file-tailer; PR #112's socket-subscribe code deleted | Captain pane receives lines again, this time via tail-from-cursor | Yes. E2E smoke: spawn crew, signal done, captain pane sees line. Also: bounce daemon mid-spawn, see line still arrive on next run. |
+| 4: `RuntimeDriver.spawnInjector("hidden")` + cmux split impl; `launch.ts` switches from tab to hidden split | No new functional capability; cosmetic upgrade. `launch.ts` detects any pre-existing `✉ notify-relay` surface (tab OR split) and closes it before spawning the hidden one — avoids duplicate injectors. | Yes. Visual check + smoke test. Fallback to visible tab if cmux can't hide. |
+
+End of PR: PR #112's old code is fully removed; mailbox-injector is the only path. No dead code period in `develop`.
+
+### 9.2 Closes #113 by construction
+
+The bounce-race that #113 documents — daemon broadcasts during injector's reconnect-backoff window → push lost — cannot happen in this design:
+- Daemon doesn't push. It appends to a file.
+- Injector doesn't reconnect to a socket. It tails a file.
+- Daemon bounce: file is there. Injector continues from cursor.
+- Injector bounce: file is there. Cursor is there. Resume on respawn.
+
+No replay protocol needed. No socket-level coordination. The "bug" goes away because the system that caused it is gone.
+
+### 9.3 Foundation for #114 (hybrid codex: native TUI + hook bridge)
+
+#114 adds:
+- `src/control/interactive/codex-hooks.ts` (new) — mirrors `interactive/claude.ts`. Writes per-task entry to `~/.codex/hooks.json` pointing the hook command to `cockpit crew _hook codex.<event>`.
+- `crew.ts` codex branch: spawn native `codex` CLI + write per-task hook config + clean up on crew close.
+- Daemon's `_hook` handler already understands the bridge from claude (PR #108); extend its event-name mapping table to include codex hook event names.
+
+**Zero injector or mailbox changes for #114.** Codex events flow into daemon → `firePush` gate → mailbox → injector → captain pane. The notification pipe is provider-agnostic.
+
+### 9.4 Foundation for #115 (opencode interactive wiring)
+
+#115 adds:
+- `src/control/interactive/opencode-plugin.ts` (new) — generates per-task `.opencode/plugin/cockpit-<taskId>.ts` that hooks `session.idle` (and related) and posts via `cockpit crew _hook opencode.<event>`.
+- `crew.ts` opencode branch: spawn native `opencode` TUI + write per-task plugin + clean up on close.
+- Universal fallback (explicit `cockpit crew signal done`) — already shipped in PR #110 / orchestrator templates.
+
+**Zero injector or mailbox changes for #115.** Same pipe.
+
+### 9.5 The unified provider-shape in `crew.ts`
+
+After #114 and #115 land on top of this spec:
+
+```typescript
+if (agentName === "claude" || agentName === "codex" || agentName === "opencode") {
+  // 1. Dispatch to daemon (TaskRecord created, daemon supervises)
+  const req = buildDispatchRequest({ provider: agentName, mode: "interactive", project, cwd: proj.path, task });
+  const rec = await cockpitdCall(req) as TaskRecord;
+
+  // 2. Provider-specific hook/plugin/settings injection (small adapter per provider)
+  const hookSetup = providerHookAdapter(agentName).setup({
+    taskId: rec.id, project, cwd: proj.path
+  });
+
+  // 3. Spawn native CLI with env carrying COCKPIT_CREW_TASK_ID + project
+  const cliCommand = agent.buildCommand({
+    ...
+    settingsPath: hookSetup.settingsPath,   // claude only
+    hookConfigPath: hookSetup.hookConfigPath, // codex only
+    pluginPath: hookSetup.pluginPath,       // opencode only
+  });
+  await runtime.sendToPane(pane, `${envPrefix} ${cliCommand}`);
+
+  // 4. Captain pane gets CREW DONE auto-pushed via mailbox → injector
+  //    (no extra code path; the pipe is already running)
+  return { ...pane, title };
+}
+```
+
+The codex / opencode branches each shrink to ~20 lines that essentially differ only in the `providerHookAdapter` call.
+
+### 9.6 Out of scope (filed separately or already filed)
+
+- **Telegram subscriber (#65)** — gets its own `<project>.telegram.cursor`; orthogonal. Becomes a new subscriber implementation reusing `readFromCursor`.
+- **Dashboard derived from mailbox** — orthogonal. A future PR can subscribe a dashboard service to the mailbox.
+- **`cockpit crew tasks` showing events from mailbox** — daemon already serves task state via store; this spec doesn't change that. Mailbox is for notifications, store is for state queries.
+
+### 9.7 Migration risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| `fs.watch`/chokidar misbehaving on macOS APFS | Med | Poll-fallback every 1s; test both code paths. |
+| flock not honored on unusual filesystems | Low | cockpit is single-host today; document the assumption. |
+| cmux `new-split` API differs from docs | Med | Probe in commit 4; fall back to visible tab if `spawnInjector("hidden")` cannot deliver hidden. |
+| Rotation race: daemon rotates while injector mid-read | Low | Injector reads by FD until EOF, then re-opens path. Standard tail -F pattern. |
+| Disk fills under abnormal event rate | Low | Daemon's `appendToMailbox` fails loud; `crew signal done` returns error; honest backpressure. |
+| Cursor file written but rename interrupted (powerloss) | Very low | fsync + atomic rename. Worst case: one duplicate event. At-least-once invariant holds. |
+| Hidden split-pane looks broken visually (zero rows, artifacts) | Med | Visual validation gates commit 4. Acceptable fallback: 1-3 row visible footer (still way less intrusive than a tab). |
+| Old PR #112 cursor format → not compatible | None | PR #112 had no cursor file (no replay). Fresh schema. |
+| Live captains during deploy mid-PR | Low | Each commit keeps end-to-end working; deploy after commit 4 is a no-op for in-flight events (mailbox is durable). |
+
+---
+
+## 10 · Testing strategy
+
+### 10.1 Layers
+
+| Layer | What's tested | Pattern |
+|---|---|---|
+| **Unit — mailbox.ts** | `appendToMailbox` seq monotonicity, atomic write under flock, line schema, rotation triggers; `readFromCursor` skip-rotated-files, partial-line tolerance, gap detection; `readCursor`/`writeCursor` atomicity (mocked rename fail) | vitest with temp tmpdir; no daemon, no socket, no runtime |
+| **Unit — notify-relay** | Cursor read/write atomicity, formatter dispatch per event kind, fake-runtime `sendToSurface` assertions, crash-mid-deliver replay (assert event re-delivered), bounded retry on send failure | vitest with `MemoryRuntimeDriver` (existing pattern in `notifiers/__tests__/helpers/`); spec the at-least-once contract |
+| **Integration — daemon** | `defaultNotify` writes to mailbox under flock; concurrent appends produce monotonic seq (simulate with `await Promise.all`); rotation under load doesn't lose events; subscribe protocol genuinely removed (assert socket frame rejected) | vitest temp-socket harness (existing `cockpitd-*.test.ts` pattern) |
+| **Integration — cmux RuntimeDriver** | `spawnInjector("hidden")` produces a surface; `sendToSurface` lands text in the right surface; resize-to-min succeeds OR fallback path works | vitest with `describe.skipIf(!cmuxAvailable)`; opt-in live |
+| **E2E smoke** | Spawn real Claude crew on cockpit project, signal done, captain pane receives line via mailbox→injector chain, cursor advances, daemon bounce mid-task → still delivers on respawn | `scripts/mailbox-injector-smoke.mjs`; evidence to `.mailbox-injector-smoke.local` (gitignored) |
+
+### 10.2 New test count estimate
+
+~25-35 new tests across the unit/integration layers. Existing PR #112 tests for `cockpitd-notify-default.test.ts` get modified (subscriber path tests deleted; mailbox path tests added). Existing `notify-relay.test.ts` rewritten in-place.
+
+### 10.3 Acceptance criteria for the final PR
+
+- [ ] All existing test files (except deleted subscribe-broadcast tests) pass
+- [ ] New mailbox + notify-relay tests cover all 7 risk-mitigation rows
+- [ ] E2E smoke evidence: bounce daemon mid-task, event arrives in captain pane after reconnect
+- [ ] cmux integration test shows hidden split-pane created (OR fallback documented)
+- [ ] Issues #113, #114, #115 explicitly reference this PR in their body as foundation
+- [ ] `cockpit doctor` still passes (no new failures introduced)
+- [ ] Live verification: spawn claude crew on cockpit, `signal done`, captain pane shows `CREW DONE [claude/<id8>]: ...` within ~1s, no daemon bounce required
+
+---
+
+## 11 · Open questions (resolve during plan or first task)
+
+1. **Subscriber name as flag vs hardcoded `captain`** — Spec recommends `--as captain` from day 1 (forward-compatible for telegram/dashboard). Trivial to implement; just makes a future Telegram PR cleaner. **Decided: implement as flag.**
+2. **Rotation thresholds in config vs constants** — Spec recommends config with the documented defaults. Adds ~10 lines of config schema. **Decided: config with defaults.**
+3. **`spawnInjector` placement on non-cmux runtimes** — Orca/Zed don't exist yet. **Decided: defer to first runtime author.** Spec says "runtime's choice for hidden."
+4. **Append-before vs after `store.put`** — Recommend AFTER (state must be durable before notifying). The current `firePush` gate already runs after `store.put`; **maintain that ordering**.
+5. **`fs.watch` vs chokidar vs polling-only** — Recommend `fs.watch` with chokidar as fallback IF macOS fs.watch proves unreliable. Add a 1-second poll fallback regardless. **Decided: try fs.watch first; poll fallback always present.**
+
+---
+
+## 12 · Cross-references & follow-ups
+
+- **Closes**: #113 (replay-on-reconnect — by construction).
+- **Foundation for**: #114 (hybrid codex), #115 (opencode wiring). Each issue's body should reference this spec.
+- **Replaces machinery from**: PR #110 (notify firing path stays; delivery mechanism replaced), PR #112 (subscribe-broadcast + visible tab — both replaced).
+- **Preserves**: PR #98 (codex app-server for headless), PR #108 (claude through daemon — its hook bridge feeds the mailbox now).
+- **Cooperates with**: #107 (reactor deletion — separate cleanup, no interaction needed).
+- **Follow-up spec**: dashboard derived from mailbox (when there's demand).
+- **Follow-up spec**: Telegram subscriber (#65 — when re-prioritized) — implements as a second cursor in the existing schema.
+
+---
+
+## 13 · Implementation phasing summary
+
+| Phase | Branch | What ships | Mergeable on its own? |
+|---|---|---|---|
+| Single PR | `feature/mailbox-injector` | 4 commits: mailbox.ts (NEW) → daemon switchover → notify-relay rewrite → RuntimeDriver hidden split | Yes. Each commit keeps end-to-end working (except commit 2's brief bridge state, healed by commit 3 in same PR). |
+
+No multi-phase rollout. Atomic shipment with a single PR validation cycle.
+
+---
+
+## 14 · Success criterion
+
+A captain spawns a Claude crew. The crew completes its work and runs `cockpit crew signal done --message "<summary>"`. **Within ~1 second the captain's pane shows a line `CREW DONE [claude/<id8>]: <summary>` — auto-pushed by the daemon-mailbox-injector pipe, without the captain polling, without a visible `notify-relay` tab cluttering the workspace.** The same captain bounces the daemon, spawns another crew, signals done — and the second line still arrives, this time delivered after the injector resumes from its persisted cursor across the daemon bounce. Issues #113 closes by construction; #114 and #115 each ship as small PRs that mount onto this foundation.

--- a/scripts/mailbox-injector-smoke.mjs
+++ b/scripts/mailbox-injector-smoke.mjs
@@ -99,6 +99,22 @@ try {
   assert(items2[0]?.kind === "task.done", `seq=2 is task.done`);
   assert(items2[1]?.kind === "task.blocked", `seq=3 is task.blocked`);
 
+  record("\n[5] liveness events (task.started, task.progress) do NOT write to mailbox");
+  // firePush gates on ATTENTION_STATES = {done, blocked, failed, stalled}.
+  // task.started / task.progress drive working state → must be suppressed.
+  await sendRequest(sock, { kind: "seed", record: baseRec("smoke-4cafebabe", { state: "submitted" }) });
+  await sendRequest(sock, { kind: "event", project: "demo",
+    event: { type: "task.started", id: "smoke-4cafebabe" } });
+  await sendRequest(sock, { kind: "event", project: "demo",
+    event: { type: "task.progress", id: "smoke-4cafebabe" } });
+  await sendRequest(sock, { kind: "event", project: "demo",
+    event: { type: "task.progress", id: "smoke-4cafebabe" } });
+  await new Promise((r) => setTimeout(r, 200));
+
+  const linesAfter = readFileSync(logPath, "utf-8").trim().split("\n").filter(Boolean);
+  assert(linesAfter.length === 3,
+    `mailbox still has 3 entries after liveness traffic (got ${linesAfter.length}) — liveness suppressed`);
+
   record(`\n${failures === 0 ? "✔ ALL SMOKE ASSERTIONS PASSED" : `✗ ${failures} FAILURES`}`);
 } finally {
   handle.stop();

--- a/scripts/mailbox-injector-smoke.mjs
+++ b/scripts/mailbox-injector-smoke.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// scripts/mailbox-injector-smoke.mjs
+//
+// E2E smoke for mailbox-injector refactor (replaces #109/#111 socket push).
+// Spins up a real cockpitd on a temp socket + stateRoot, drives a few
+// task.done events through the daemon, then verifies:
+//   1. defaultNotify writes structured entries to <stateRoot>/inbox/<project>.log
+//   2. readFromCursor yields each entry exactly once, in order
+//   3. writeCursor persists, readCursor returns the saved seq
+//   4. After a simulated "injector offline" window, resuming from the cursor
+//      reads only the entries added during the outage (no duplicates, no gaps)
+//
+// Uses startCockpitd + sendRequest directly (same pattern as
+// scripts/smoke-push-notify.mjs) rather than env vars — the daemon's CLI
+// surface takes stateRoot/sockPath as arguments, not env vars.
+
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const distEntry = pathToFileURL(join(__dirname, "..", "dist", "control", "cockpitd.js")).href;
+const distProto = pathToFileURL(join(__dirname, "..", "dist", "control", "protocol.js")).href;
+const distMailbox = pathToFileURL(join(__dirname, "..", "dist", "control", "mailbox.js")).href;
+
+const { startCockpitd } = await import(distEntry);
+const { sendRequest } = await import(distProto);
+const mailbox = await import(distMailbox);
+
+const evidencePath = join(__dirname, "..", ".mailbox-injector-smoke.local");
+const evidence = [];
+const record = (m) => { evidence.push(m); process.stdout.write(m + "\n"); };
+
+const dir = mkdtempSync(join(tmpdir(), "mailbox-smoke-"));
+const stateRoot = join(dir, "state");
+const sock = join(dir, "c.sock");
+
+const handle = startCockpitd({ stateRoot, sockPath: sock, sweepMs: 0 });
+
+const baseRec = (id, overrides = {}) => ({
+  id, project: "demo", provider: "claude", mode: "headless",
+  state: "submitted", task: "mailbox smoke", cwd: "/",
+  createdAt: 1, lastHeartbeat: 1, lastEvent: "",
+  heartbeatBudgetMs: 60000,
+  attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }],
+  ...overrides,
+});
+
+let failures = 0;
+const assert = (cond, label) => {
+  if (cond) { record(`  ✓ ${label}`); }
+  else { record(`  ✗ ${label}`); failures++; }
+};
+
+try {
+  record(`# Mailbox + injector smoke — ${new Date().toISOString()}`);
+  record(`state: ${stateRoot}`);
+  record(`socket: ${sock}`);
+
+  record("\n[1] dispatch + task.done → mailbox file gets one entry");
+  await sendRequest(sock, { kind: "seed", record: baseRec("smoke-1abcdef0", { state: "working" }) });
+  await sendRequest(sock, { kind: "event", project: "demo",
+    event: { type: "task.done", id: "smoke-1abcdef0", resultRef: "/r1" } });
+  await new Promise((r) => setTimeout(r, 150));
+
+  const logPath = join(stateRoot, "inbox", "demo.log");
+  assert(existsSync(logPath), `mailbox file created at ${logPath}`);
+  const lines1 = readFileSync(logPath, "utf-8").trim().split("\n").filter(Boolean);
+  assert(lines1.length === 1, `exactly one entry (got ${lines1.length})`);
+  const entry1 = JSON.parse(lines1[0]);
+  assert(entry1.seq === 1, `seq=1 (got ${entry1.seq})`);
+  assert(entry1.kind === "task.done", `kind=task.done (got ${entry1.kind})`);
+  assert(entry1.taskId === "smoke-1abcdef0", `taskId matches`);
+
+  record("\n[2] simulate injector reading from cursor");
+  const items = [];
+  for await (const it of mailbox.readFromCursor({ stateRoot, project: "demo", fromSeq: 1 })) items.push(it);
+  assert(items.length === 1, `injector reads 1 entry from cursor (got ${items.length})`);
+  await mailbox.writeCursor({ stateRoot, project: "demo", subscriber: "captain", lastAckedSeq: 1 });
+  const cursor = await mailbox.readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+  assert(cursor?.lastAckedSeq === 1, `cursor advanced to 1 (got ${cursor?.lastAckedSeq})`);
+
+  record("\n[3] simulate injector 'offline' — dispatch more events");
+  await sendRequest(sock, { kind: "seed", record: baseRec("smoke-2feedface", { state: "working" }) });
+  await sendRequest(sock, { kind: "event", project: "demo",
+    event: { type: "task.done", id: "smoke-2feedface", resultRef: "/r2" } });
+  await sendRequest(sock, { kind: "seed", record: baseRec("smoke-3deadbeef", { state: "working" }) });
+  await sendRequest(sock, { kind: "event", project: "demo",
+    event: { type: "task.blocked", id: "smoke-3deadbeef", question: "what now?" } });
+  await new Promise((r) => setTimeout(r, 200));
+
+  record("\n[4] injector resumes — reads only new events, in order, no duplicates");
+  const items2 = [];
+  for await (const it of mailbox.readFromCursor({ stateRoot, project: "demo", fromSeq: 2 })) items2.push(it);
+  assert(items2.length === 2, `replay yields exactly 2 new entries (got ${items2.length})`);
+  assert(items2[0]?.seq === 2 && items2[1]?.seq === 3,
+    `seqs are 2,3 (got ${items2.map((x) => x.seq).join(",")})`);
+  assert(items2[0]?.kind === "task.done", `seq=2 is task.done`);
+  assert(items2[1]?.kind === "task.blocked", `seq=3 is task.blocked`);
+
+  record(`\n${failures === 0 ? "✔ ALL SMOKE ASSERTIONS PASSED" : `✗ ${failures} FAILURES`}`);
+} finally {
+  handle.stop();
+  writeFileSync(evidencePath, evidence.join("\n") + "\n");
+  record(`evidence: ${evidencePath}`);
+  process.exit(failures > 0 ? 1 : 0);
+}

--- a/src/commands/__tests__/crew-signal.test.ts
+++ b/src/commands/__tests__/crew-signal.test.ts
@@ -13,7 +13,7 @@ describe("buildSignalRequest", () => {
     process.env = { ...SAVED };
   });
 
-  it("done + message → task.done event with resultRef from writer", () => {
+  it("done + message → task.done event with resultRef from writer AND message field for relay display", () => {
     const writes: Array<{ id: string; payload: string }> = [];
     const writeResult = (id: string, payload: string) => {
       writes.push({ id, payload });
@@ -26,6 +26,7 @@ describe("buildSignalRequest", () => {
       type: "task.done",
       id: "task-xyz",
       resultRef: "/tmp/results/task-xyz.txt",
+      message: "all green",
     });
     expect(writes).toEqual([{ id: "task-xyz", payload: "all green" }]);
   });
@@ -38,7 +39,7 @@ describe("buildSignalRequest", () => {
 
   it("done without writeResult → resultRef is empty string", () => {
     const req = buildSignalRequest("done", { message: "x" });
-    expect(req.event).toEqual({ type: "task.done", id: "task-xyz", resultRef: "" });
+    expect(req.event).toEqual({ type: "task.done", id: "task-xyz", resultRef: "", message: "x" });
   });
 
   it("blocked + question → task.blocked event", () => {

--- a/src/commands/__tests__/notify-relay.test.ts
+++ b/src/commands/__tests__/notify-relay.test.ts
@@ -6,10 +6,10 @@
 
 import { describe, it, expect, vi } from "vitest";
 import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { appendToMailbox, writeCursor, readCursor } from "../../control/mailbox.js";
-import { runNotifyRelay } from "../notify-relay.js";
+import { runNotifyRelay, DEFAULT_STATE_ROOT } from "../notify-relay.js";
 import type { TaskRecord, ControlEvent } from "../../control/types.js";
 
 function freshState(): string {
@@ -41,6 +41,16 @@ function fakeRuntime(sendSpy: ReturnType<typeof vi.fn>): unknown {
     ]),
   };
 }
+
+describe("notify-relay default stateRoot", () => {
+  it("matches the daemon's default stateRoot so writer/reader agree", () => {
+    // Daemon writes mailbox to <homedir>/.config/cockpit/state/inbox/<project>.log
+    // (see src/control/cockpitd.ts startCockpitd). The relay's default MUST
+    // resolve to the same root, otherwise no events are ever delivered.
+    const daemonDefault = join(homedir(), ".config", "cockpit", "state");
+    expect(DEFAULT_STATE_ROOT).toBe(daemonDefault);
+  });
+});
 
 describe("notify-relay file-tailer", () => {
   it("starts from seq 1 when cursor missing — delivers first event", async () => {

--- a/src/commands/__tests__/notify-relay.test.ts
+++ b/src/commands/__tests__/notify-relay.test.ts
@@ -146,4 +146,30 @@ describe("notify-relay file-tailer", () => {
     expect(msgs[1]).toMatch(/^CREW BLOCKED \[claude\/deadbeef\]: what now\?/);
     expect(msgs[2]).toMatch(/^CREW FAILED \[claude\/deadbeef\]: boom/);
   });
+
+  it("task.done with payload.message prefers message over resultRef in display", async () => {
+    const stateRoot = freshState();
+    const doneWithMessage: ControlEvent = {
+      type: "task.done",
+      id: rec.id,
+      resultRef: "/some/result/file.txt",
+      message: "hello world",
+    };
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneWithMessage });
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    const stop = await runNotifyRelay({
+      project: "demo",
+      subscriber: "captain",
+      stateRoot,
+      runtime: fakeRuntime(sendSpy) as never,
+      captainName: "captain",
+      pollMs: 50,
+    });
+    await new Promise((r) => setTimeout(r, 200));
+    stop();
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    const out = sendSpy.mock.calls[0][1] as string;
+    expect(out).toBe("CREW DONE [claude/deadbeef]: hello world");
+    expect(out).not.toContain("/some/result/file.txt");
+  });
 });

--- a/src/commands/__tests__/notify-relay.test.ts
+++ b/src/commands/__tests__/notify-relay.test.ts
@@ -1,125 +1,139 @@
 // src/commands/__tests__/notify-relay.test.ts
 //
-// #111: the in-cmux relay subscribes to the daemon and forwards each pushed
-// message to the project's captain via the runtime driver. This test stands
-// up a one-shot daemon-like UDS server, runs the relay against it, and
-// asserts each push frame produces a matching driver.send() call.
+// Mailbox-injector refactor: notify-relay is now a file tailer that reads
+// from the per-project mailbox using a per-subscriber cursor, then forwards
+// each delivered event to the captain's surface via the runtime driver.
 
-import { describe, it, expect, afterEach } from "vitest";
-import { mkdtempSync, rmSync } from "node:fs";
+import { describe, it, expect, vi } from "vitest";
+import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createServer, type Server, type Socket } from "node:net";
+import { appendToMailbox, writeCursor, readCursor } from "../../control/mailbox.js";
 import { runNotifyRelay } from "../notify-relay.js";
-import { encodeMsg, createDecoder, encodeFrame } from "../../control/protocol.js";
-import type { AttachFrame } from "../../control/protocol.js";
+import type { TaskRecord, ControlEvent } from "../../control/types.js";
 
-function startFakeDaemon(sockPath: string): { server: Server; firstConn: Promise<Socket>; subscribed: Promise<string> } {
-  let resolveFirst!: (s: Socket) => void;
-  let resolveSubscribed!: (p: string) => void;
-  const firstConn = new Promise<Socket>((r) => { resolveFirst = r; });
-  const subscribed = new Promise<string>((r) => { resolveSubscribed = r; });
-  const server = createServer((conn) => {
-    resolveFirst(conn);
-    const dec = createDecoder();
-    conn.setEncoding("utf-8");
-    conn.on("data", (chunk: string) => {
-      for (const msg of dec.push(chunk)) {
-        const m = msg as { op?: string; project?: string };
-        if (m.op === "subscribe-notify" && m.project) resolveSubscribed(m.project);
-      }
-    });
-  });
-  server.listen(sockPath);
-  return { server, firstConn, subscribed };
+function freshState(): string {
+  return mkdtempSync(join(tmpdir(), "nr-"));
 }
 
-describe("notify-relay (#111)", () => {
-  let dir: string;
-  afterEach(() => { if (dir) rmSync(dir, { recursive: true, force: true }); });
+const rec: TaskRecord = {
+  id: "deadbeefcafebabe1234567890abcdef",
+  project: "demo",
+  provider: "claude",
+  mode: "interactive",
+  state: "done",
+  task: "task body",
+  cwd: "/",
+  createdAt: 1,
+  lastHeartbeat: 1,
+  lastEvent: "task.done",
+  heartbeatBudgetMs: 60000,
+  attempts: [],
+};
+const doneEvent: ControlEvent = { type: "task.done", id: rec.id, resultRef: "/r" };
 
-  it("subscribes to the daemon for the given project and forwards each push to driver.send", async () => {
-    dir = mkdtempSync(join(tmpdir(), "cp-relay-"));
-    const sock = join(dir, "c.sock");
-    const fake = startFakeDaemon(sock);
+function fakeRuntime(sendSpy: ReturnType<typeof vi.fn>): unknown {
+  return {
+    sendToSurface: sendSpy,
+    status: vi.fn().mockResolvedValue({ id: "ws1", name: "captain", status: "running" }),
+    listSurfaces: vi.fn().mockResolvedValue([
+      { workspaceId: "ws1", surfaceId: "s1", title: "captain" },
+    ]),
+  };
+}
 
-    const sent: string[] = [];
-    // Run the relay against the fake daemon. opts.once = true makes it return
-    // after the daemon closes the connection (so the test can deterministically
-    // await completion).
-    const relayDone = runNotifyRelay("proj-x", {
-      sockPath: sock,
-      once: true,
-      resolve: async () => ({
-        captainName: "⚓ proj-x-captain",
-        send: async (msg) => { sent.push(msg); },
-      }),
-      log: () => { /* silence */ },
+describe("notify-relay file-tailer", () => {
+  it("starts from seq 1 when cursor missing — delivers first event", async () => {
+    const stateRoot = freshState();
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneEvent });
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    const stop = await runNotifyRelay({
+      project: "demo",
+      subscriber: "captain",
+      stateRoot,
+      runtime: fakeRuntime(sendSpy) as never,
+      captainName: "captain",
+      pollMs: 50,
     });
-
-    // Wait until the relay has sent the subscribe-notify claim.
-    const project = await fake.subscribed;
-    expect(project).toBe("proj-x");
-
-    // Push three frames at the relay.
-    const conn = await fake.firstConn;
-    const push = (msg: string): void => {
-      const frame: AttachFrame = { type: "push", project: "proj-x", message: msg, ts: Date.now() };
-      conn.write(encodeFrame(frame));
-    };
-    push("CREW DONE [claude/abc12345]: done");
-    push("CREW BLOCKED [claude/def67890]: which db?");
-    push("CREW FAILED [claude/ghijklmn]: boom");
-
-    // Give the relay an event-loop turn or two to process all three.
-    await new Promise((r) => setTimeout(r, 50));
-
-    // Close the conn so once-mode relay returns.
-    conn.end();
-    await relayDone;
-
-    expect(sent).toEqual([
-      "CREW DONE [claude/abc12345]: done",
-      "CREW BLOCKED [claude/def67890]: which db?",
-      "CREW FAILED [claude/ghijklmn]: boom",
-    ]);
-
-    fake.server.close();
+    await new Promise((r) => setTimeout(r, 200));
+    stop();
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(sendSpy.mock.calls[0][1] as string).toContain("CREW DONE");
+    const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    expect(cursor?.lastAckedSeq).toBe(1);
   });
 
-  it("ignores push frames for other projects", async () => {
-    dir = mkdtempSync(join(tmpdir(), "cp-relay-"));
-    const sock = join(dir, "c.sock");
-    const fake = startFakeDaemon(sock);
-
-    const sent: string[] = [];
-    const relayDone = runNotifyRelay("proj-a", {
-      sockPath: sock,
-      once: true,
-      resolve: async () => ({
-        captainName: "⚓ proj-a-captain",
-        send: async (msg) => { sent.push(msg); },
-      }),
-      log: () => { /* silence */ },
+  it("starts from seq+1 when cursor exists — delivers only newer events", async () => {
+    const stateRoot = freshState();
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneEvent });
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneEvent });
+    await writeCursor({ stateRoot, project: "demo", subscriber: "captain", lastAckedSeq: 1 });
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    const stop = await runNotifyRelay({
+      project: "demo",
+      subscriber: "captain",
+      stateRoot,
+      runtime: fakeRuntime(sendSpy) as never,
+      captainName: "captain",
+      pollMs: 50,
     });
+    await new Promise((r) => setTimeout(r, 200));
+    stop();
+    // Only seq 2 should be delivered.
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    expect(cursor?.lastAckedSeq).toBe(2);
+  });
 
-    await fake.subscribed;
-    const conn = await fake.firstConn;
+  it("does NOT advance cursor when sendToSurface throws", async () => {
+    const stateRoot = freshState();
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneEvent });
+    const sendSpy = vi.fn().mockRejectedValue(new Error("send failed"));
+    const stop = await runNotifyRelay({
+      project: "demo",
+      subscriber: "captain",
+      stateRoot,
+      runtime: fakeRuntime(sendSpy) as never,
+      captainName: "captain",
+      pollMs: 50,
+    });
+    await new Promise((r) => setTimeout(r, 200));
+    stop();
+    const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    expect(cursor).toBeNull(); // never written
+    expect(sendSpy.mock.calls.length).toBeGreaterThan(0); // attempted
+  });
 
-    // Push frame for the WRONG project — relay should skip it.
-    conn.write(encodeFrame({ type: "push", project: "proj-b", message: "not mine", ts: 1 }));
-    // Push frame for the right project — relay should deliver it.
-    conn.write(encodeFrame({ type: "push", project: "proj-a", message: "mine", ts: 2 }));
-
-    await new Promise((r) => setTimeout(r, 50));
-    conn.end();
-    await relayDone;
-
-    expect(sent).toEqual(["mine"]);
-    fake.server.close();
+  it("formats task.done/blocked/failed with provider + short id + payload", async () => {
+    const stateRoot = freshState();
+    const blockedEvent: ControlEvent = {
+      type: "task.blocked",
+      id: rec.id,
+      question: "what now?",
+    } as ControlEvent;
+    const failedEvent: ControlEvent = {
+      type: "task.failed",
+      id: rec.id,
+      error: "boom",
+    } as ControlEvent;
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneEvent });
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: blockedEvent });
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: failedEvent });
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    const stop = await runNotifyRelay({
+      project: "demo",
+      subscriber: "captain",
+      stateRoot,
+      runtime: fakeRuntime(sendSpy) as never,
+      captainName: "captain",
+      pollMs: 50,
+    });
+    await new Promise((r) => setTimeout(r, 200));
+    stop();
+    expect(sendSpy).toHaveBeenCalledTimes(3);
+    const msgs = sendSpy.mock.calls.map((c) => c[1] as string);
+    expect(msgs[0]).toMatch(/^CREW DONE \[claude\/deadbeef\]:/);
+    expect(msgs[1]).toMatch(/^CREW BLOCKED \[claude\/deadbeef\]: what now\?/);
+    expect(msgs[2]).toMatch(/^CREW FAILED \[claude\/deadbeef\]: boom/);
   });
 });
-
-// Sanity check on the encoder so the test's encodeMsg import isn't unused
-// (and to keep tree-shaking from dropping it).
-void encodeMsg;

--- a/src/commands/crew-control.ts
+++ b/src/commands/crew-control.ts
@@ -53,7 +53,7 @@ export async function sendCodexFirstTurn(taskId: string, text: string): Promise<
 
 export function buildDispatchRequest(o: {
   project: string; provider: Provider; mode: Mode; task: string; budgetMs?: number; cwd?: string;
-  approvalPolicy?: string; roleInstructions?: string;
+  approvalPolicy?: string; roleInstructions?: string; name?: string;
 }): { kind: "dispatch"; record: TaskRecord } {
   const now = Date.now();
   const attemptId = randomUUID();
@@ -66,6 +66,7 @@ export function buildDispatchRequest(o: {
       attempts: [{ attemptId, startedAt: now, lastHeartbeatAt: now }],
       ...(o.approvalPolicy ? { approvalPolicy: o.approvalPolicy } : {}),
       ...(o.roleInstructions ? { roleInstructions: o.roleInstructions } : {}),
+      ...(o.name ? { name: o.name } : {}),
     },
   };
 }

--- a/src/commands/crew-control.ts
+++ b/src/commands/crew-control.ts
@@ -135,7 +135,12 @@ export function buildSignalRequest(
   let event: ControlEvent;
   if (signal === "done") {
     const resultRef = o.writeResult ? o.writeResult(taskId, o.message ?? "") : "";
-    event = { type: "task.done", id: taskId, resultRef };
+    event = {
+      type: "task.done",
+      id: taskId,
+      resultRef,
+      ...(o.message !== undefined ? { message: o.message } : {}),
+    };
   } else if (signal === "blocked") {
     event = { type: "task.blocked", id: taskId, reason: "crew signaled blocked", question: o.question ?? "" };
   } else {

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -189,6 +189,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
       project: input.project,
       cwd: proj.path,
       task: input.task,
+      name,
     });
     // Fail loud if daemon unreachable — refusal-to-degrade.
     const rec = (await cockpitdCall(req)) as TaskRecord;
@@ -263,6 +264,7 @@ async function runCodexInteractiveSpawn(o: {
     project: o.project,
     cwd: o.cwd,
     task: o.task,
+    name: o.name,
     ...(o.approvalPolicy ? { approvalPolicy: o.approvalPolicy } : {}),
     ...(o.roleInstructions ? { roleInstructions: o.roleInstructions } : {}),
   });

--- a/src/commands/launch.ts
+++ b/src/commands/launch.ts
@@ -9,7 +9,7 @@ import { loadConfig, resolveHome, type ModelRoutingConfig } from "../config.js";
 import { createClaudeDriver, createCodexDriver, createGeminiDriver, createAiderDriver, createOpencodeDriver, CapabilityRegistry } from "../drivers/index.js";
 import type { AgentDriver, Role } from "../drivers/types.js";
 import { RuntimeRegistry, createCmuxDriver } from "../runtimes/index.js";
-import type { RuntimeDriver } from "../runtimes/index.js";
+import type { RuntimeDriver, WorkspaceRef } from "../runtimes/index.js";
 import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
 import { ensureSpokeLayout } from "../lib/vault-layout.js";
 
@@ -170,30 +170,35 @@ function buildAgentCmd(
 const NOTIFY_RELAY_TAB_TITLE = "✉ notify-relay";
 
 /**
- * #111: idempotently add the notify-relay tab to a captain workspace. The
- * relay subscribes to daemon push notifications for <project> and forwards
- * each one to the captain pane via the runtime driver — required because
- * cmux refuses any caller not descended from its app process, so the daemon
- * itself cannot deliver. Safe to call repeatedly; skips if the tab already
- * exists.
+ * Add the notify-relay to a captain workspace as a hidden split-pane. The
+ * relay tails the daemon's per-project mailbox and forwards each new event to
+ * the captain pane via runtime.sendToSurface — required because cmux refuses
+ * any caller not descended from its app process, so the daemon itself cannot
+ * deliver. Dedups by closing any pre-existing relay surface (visible tab or
+ * hidden split) before respawning, so the relay always boots fresh with the
+ * current cockpit binary.
  */
 async function ensureNotifyRelayTab(
   runtime: RuntimeDriver,
-  workspaceId: string,
+  workspace: WorkspaceRef,
   project: string,
 ): Promise<void> {
   try {
-    const surfaces = await runtime.listSurfaces(workspaceId);
-    if (surfaces.some((s) => s.title === NOTIFY_RELAY_TAB_TITLE)) return;
-    const pane = await runtime.newPane({
-      workspaceId,
-      direction: "tab",
+    const surfaces = await runtime.listSurfaces(workspace.id);
+    for (const s of surfaces) {
+      if (s.title === NOTIFY_RELAY_TAB_TITLE) {
+        try { await runtime.closePane(s); } catch { /* best effort */ }
+      }
+    }
+    await runtime.spawnInjector({
+      captainWorkspace: workspace,
+      command: `cockpit notify-relay ${project} --as captain`,
       title: NOTIFY_RELAY_TAB_TITLE,
+      placement: "hidden",
     });
-    await runtime.sendToPane(pane, `cockpit notify-relay ${project}`);
-    console.log(chalk.cyan(`  ✔ Added notify-relay tab for '${project}'`));
+    console.log(chalk.cyan(`  ✔ Added hidden notify-relay for '${project}'`));
   } catch (e) {
-    console.error(chalk.yellow(`  ⚠ notify-relay tab setup failed: ${(e as Error).message}`));
+    console.error(chalk.yellow(`  ⚠ notify-relay setup failed: ${(e as Error).message}`));
   }
 }
 
@@ -216,7 +221,7 @@ async function launchWorkspace(
     await runtime.stop(existing.id);
   } else if (existing) {
     console.log(chalk.yellow(`  Workspace '${name}' already exists — switching to it`));
-    if (notifyRelayProject) await ensureNotifyRelayTab(runtime, existing.id, notifyRelayProject);
+    if (notifyRelayProject) await ensureNotifyRelayTab(runtime, existing, notifyRelayProject);
     // TODO(runtime): select/focus not yet abstracted; direct cmux call retained intentionally
     execSync(`"${CMUX_BIN}" select-workspace --workspace "${existing.id}"`);
     return;
@@ -243,7 +248,7 @@ async function launchWorkspace(
     }, 3000);
   }
 
-  if (notifyRelayProject) await ensureNotifyRelayTab(runtime, ref.id, notifyRelayProject);
+  if (notifyRelayProject) await ensureNotifyRelayTab(runtime, ref, notifyRelayProject);
 
   if (navigate) {
     // TODO(runtime): select not yet abstracted

--- a/src/commands/notify-relay.ts
+++ b/src/commands/notify-relay.ts
@@ -28,7 +28,7 @@ function shortId(id: string): string {
 }
 
 export function formatEntry(entry: MailboxEntry): string | null {
-  const tag = `[${entry.provider}/${shortId(entry.taskId)}]`;
+  const tag = `[${entry.provider}/${entry.name != null ? entry.name : shortId(entry.taskId)}]`;
   switch (entry.kind) {
     case "task.started":
     case "task.progress":

--- a/src/commands/notify-relay.ts
+++ b/src/commands/notify-relay.ts
@@ -1,132 +1,172 @@
 // src/commands/notify-relay.ts
 //
-// #111: in-cmux relay for daemon push notifications. Runs in a captain-workspace
-// tab so that cmux's process-lineage check allows it to call `cmux send` (the
-// daemon itself cannot — it's a launchd child, not a cmux descendant).
-//
-// Long-running process. Subscribes to the daemon socket via the
-// `subscribe-notify` claim frame; for each pushed message, forwards it to the
-// project's captain workspace using the runtime driver. Reconnects with
-// backoff if the daemon restarts.
+// Mailbox-injector refactor: notify-relay is now a file-tailing process that
+// reads from a project's mailbox (.config/cockpit/inbox/<project>.log) using a
+// durable per-subscriber cursor. Each delivered event is forwarded to the
+// captain's primary surface via the runtime driver's sendToSurface. The
+// cursor only advances after a successful send, so failed deliveries are
+// naturally retried on the next poll.
 
 import { Command } from "commander";
-import { createConnection, type Socket } from "node:net";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import chalk from "chalk";
 import { loadConfig } from "../config.js";
 import { RuntimeRegistry, createCmuxDriver } from "../runtimes/index.js";
-import type { AttachFrame } from "../control/protocol.js";
-import { createDecoder, encodeMsg } from "../control/protocol.js";
+import type { RuntimeDriver } from "../runtimes/types.js";
+import {
+  readCursor,
+  writeCursor,
+  readFromCursor,
+  type MailboxEntry,
+} from "../control/mailbox.js";
 
-const SOCK_PATH = join(homedir(), ".config", "cockpit", "cockpit.sock");
+const DEFAULT_STATE_ROOT = join(homedir(), ".config", "cockpit");
 
-interface RunOpts {
-  sockPath?: string;
-  // Test injection: builds the runtime + resolves captain name. Defaults to the
-  // production config loader + cmux driver. The returned `send` must already
-  // be bound to the captain's runtime-native ref (workspace ID), because
-  // cmux's driver.send() expects an ID, not a name.
-  resolve?: (project: string) => Promise<{ captainName: string; send: (msg: string) => Promise<void> }>;
-  // Test injection: when true, exit after the first daemon-end (no reconnect loop).
-  once?: boolean;
-  // Test injection: backoff override (ms). Production uses 1s/2s/4s capped at 30s.
-  backoffMs?: (attempt: number) => number;
-  log?: (m: string) => void;
+function shortId(id: string): string {
+  return id.slice(0, 8);
 }
 
-function defaultBackoff(attempt: number): number {
-  return Math.min(30_000, 1_000 * Math.pow(2, attempt));
-}
-
-export async function runNotifyRelay(project: string, opts: RunOpts = {}): Promise<void> {
-  const sockPath = opts.sockPath ?? SOCK_PATH;
-  const log = opts.log ?? ((m: string) => process.stdout.write(`[notify-relay ${project}] ${m}\n`));
-  const backoff = opts.backoffMs ?? defaultBackoff;
-
-  const resolve = opts.resolve ?? (async () => {
-    const config = loadConfig();
-    const proj = config.projects[project];
-    if (!proj) throw new Error(`Project '${project}' not found in config`);
-    const registry = new RuntimeRegistry({ cmux: createCmuxDriver() });
-    const driver = registry.forProject(project, config);
-    // RuntimeDriver.send() expects the runtime-native ref (e.g. cmux's
-    // "workspace:N"), not the human name — resolve once at startup.
-    const ref = await driver.status(proj.captainName);
-    if (!ref) {
-      throw new Error(`Captain workspace '${proj.captainName}' not found in runtime '${driver.name}'`);
+export function formatEntry(entry: MailboxEntry): string | null {
+  const tag = `[${entry.provider}/${shortId(entry.taskId)}]`;
+  switch (entry.kind) {
+    case "task.started":
+    case "task.progress":
+      return null; // suppress liveness/start
+    case "task.done": {
+      const msg =
+        (entry.payload.message as string | undefined) ??
+        (entry.payload.resultRef as string | undefined) ??
+        "(no message)";
+      return `CREW DONE ${tag}: ${msg.toString().split(/\r?\n/)[0].slice(0, 200)}`;
     }
-    return {
-      captainName: proj.captainName,
-      send: (msg: string) => driver.send(ref.id, msg),
-    };
-  });
-
-  const r = await resolve(project);
-  log(`relaying to captain '${r.captainName}' via socket ${sockPath}`);
-
-  let attempt = 0;
-  while (true) {
-    const ended = await connectOnce(sockPath, project, r.send, log);
-    if (opts.once) return;
-    if (ended === "fatal") return;
-    const wait = backoff(attempt++);
-    log(`daemon connection lost; reconnecting in ${wait}ms`);
-    await new Promise((res) => setTimeout(res, wait));
+    case "task.blocked":
+      return `CREW BLOCKED ${tag}: ${(entry.payload.question as string | undefined) ?? "(no question)"}`;
+    case "task.failed":
+      return `CREW FAILED ${tag}: ${(entry.payload.error as string | undefined) ?? "(no error)"}`;
+    case "task.stalled":
+      return `CREW STALLED ${tag}: no heartbeat`;
+    default:
+      return null;
   }
 }
 
-function connectOnce(
-  sockPath: string,
-  project: string,
-  send: (msg: string) => Promise<void>,
-  log: (m: string) => void,
-): Promise<"end" | "fatal"> {
-  return new Promise((resolve) => {
-    let conn: Socket;
-    try {
-      conn = createConnection(sockPath);
-    } catch (e) {
-      log(`connect threw: ${(e as Error).message}`);
-      resolve("end");
-      return;
-    }
-    const dec = createDecoder();
-    conn.setEncoding("utf-8");
-    conn.on("connect", () => {
-      conn.write(encodeMsg({ op: "subscribe-notify", project }));
-      log("subscribed");
-    });
-    conn.on("data", (chunk: string) => {
-      for (const raw of dec.push(chunk)) {
-        const frame = raw as AttachFrame;
-        if (frame && (frame as any).type === "push" && (frame as any).project === project) {
-          const message = (frame as any).message as string;
-          // Fire-and-forget; runtime.send failures are logged but don't tear down the relay.
-          send(message).catch((e: Error) => log(`send failed: ${e.message}`));
-        }
-      }
-    });
-    conn.on("error", (e: Error) => {
-      log(`socket error: ${e.message}`);
-    });
-    conn.on("close", () => {
-      resolve("end");
-    });
+interface RunOpts {
+  project: string;
+  subscriber: string;
+  stateRoot: string;
+  runtime: RuntimeDriver;
+  captainName: string;
+  pollMs?: number;
+  log?: (m: string) => void;
+}
+
+export async function runNotifyRelay(opts: RunOpts): Promise<() => void> {
+  const log =
+    opts.log ?? ((m: string) => process.stdout.write(`[notify-relay ${opts.project}] ${m}\n`));
+
+  // Resolve captain workspace + primary surface once at boot.
+  const ws = await opts.runtime.status(opts.captainName);
+  if (!ws) throw new Error(`captain workspace '${opts.captainName}' not running`);
+  const surfaces =
+    (await (opts.runtime as RuntimeDriver & {
+      listSurfaces?: (id: string) => Promise<Array<{ title?: string }>>;
+    }).listSurfaces?.(ws.id)) ?? [];
+  const captainSurface =
+    (surfaces.find((s) => s.title === opts.captainName) ?? surfaces[0]) as {
+      workspaceId?: string;
+      surfaceId?: string;
+      title?: string;
+    } | undefined;
+  if (!captainSurface) throw new Error("no surfaces in captain workspace");
+
+  const cursor = await readCursor({
+    stateRoot: opts.stateRoot,
+    project: opts.project,
+    subscriber: opts.subscriber,
   });
+  let lastAcked = cursor?.lastAckedSeq ?? 0;
+  let stopped = false;
+  let draining = false;
+
+  async function drain(): Promise<void> {
+    if (draining) return;
+    draining = true;
+    try {
+      for await (const entry of readFromCursor({
+        stateRoot: opts.stateRoot,
+        project: opts.project,
+        fromSeq: lastAcked + 1,
+      })) {
+        if (stopped) return;
+        const msg = formatEntry(entry);
+        if (msg) {
+          try {
+            await (opts.runtime as RuntimeDriver & {
+              sendToSurface: (s: unknown, m: string) => Promise<void>;
+            }).sendToSurface(captainSurface, msg);
+          } catch (e) {
+            log(`sendToSurface failed seq=${entry.seq}: ${(e as Error).message}`);
+            // Don't advance cursor; the next poll will retry from the same seq.
+            return;
+          }
+        }
+        await writeCursor({
+          stateRoot: opts.stateRoot,
+          project: opts.project,
+          subscriber: opts.subscriber,
+          lastAckedSeq: entry.seq,
+        });
+        lastAcked = entry.seq;
+      }
+    } finally {
+      draining = false;
+    }
+  }
+
+  const interval = setInterval(() => {
+    if (!stopped) drain().catch((e) => log(`drain error: ${(e as Error).message}`));
+  }, opts.pollMs ?? 1000);
+
+  await drain(); // initial drain
+
+  return () => {
+    stopped = true;
+    clearInterval(interval);
+  };
 }
 
 export const notifyRelayCommand = new Command("notify-relay")
   .description(
-    "In-cmux relay: subscribes to daemon push notifications for <project> and " +
-      "forwards them to the project's captain pane via the runtime driver. " +
-      "Spawned automatically as a tab in each captain workspace; not intended " +
-      "to be invoked manually.",
+    "Subscribe to a project's mailbox and deliver events to the captain pane. " +
+      "Long-running tailer; reads from .config/cockpit/inbox/<project>.log " +
+      "using a per-subscriber cursor.",
   )
-  .argument("<project>", "Project to relay push notifications for")
-  .action(async (project: string) => {
+  .argument("<project>", "Project to relay mailbox events for")
+  .option("--as <subscriber>", "subscriber name", "captain")
+  .option("--state-root <path>", "override state root", DEFAULT_STATE_ROOT)
+  .action(async (project: string, opts: { as: string; stateRoot: string }) => {
     try {
-      await runNotifyRelay(project);
+      const config = loadConfig();
+      const projCfg = config.projects[project];
+      if (!projCfg) {
+        console.error(chalk.red(`notify-relay: unknown project '${project}'`));
+        process.exit(1);
+      }
+      const registry = new RuntimeRegistry({ cmux: createCmuxDriver() });
+      const runtime = registry.forProject(project, config);
+      process.stdout.write(
+        `[notify-relay ${project}] subscriber=${opts.as} stateRoot=${opts.stateRoot}\n`,
+      );
+      await runNotifyRelay({
+        project,
+        subscriber: opts.as,
+        stateRoot: opts.stateRoot,
+        runtime,
+        captainName: projCfg.captainName,
+        pollMs: 1000,
+      });
+      process.on("SIGTERM", () => process.exit(0));
     } catch (err) {
       console.error(chalk.red(`notify-relay: ${(err as Error).message}`));
       process.exit(1);

--- a/src/commands/notify-relay.ts
+++ b/src/commands/notify-relay.ts
@@ -21,7 +21,7 @@ import {
   type MailboxEntry,
 } from "../control/mailbox.js";
 
-const DEFAULT_STATE_ROOT = join(homedir(), ".config", "cockpit");
+export const DEFAULT_STATE_ROOT = join(homedir(), ".config", "cockpit", "state");
 
 function shortId(id: string): string {
   return id.slice(0, 8);

--- a/src/control/__tests__/cockpitd-notify-default.test.ts
+++ b/src/control/__tests__/cockpitd-notify-default.test.ts
@@ -1,40 +1,18 @@
 // src/control/__tests__/cockpitd-notify-default.test.ts
 //
-// #111: cover the default-notify path (broadcast push frame + append inbox
-// file). Existing cockpitd-push.test.ts covers the daemon's decision to
-// notify; this file covers what `defaultNotify` actually does once it fires.
+// Mailbox-injector: cover the default-notify path which now appends a JSON
+// entry to the mailbox file. Replaces the prior subscribe-notify broadcast
+// path (PR #112). The daemon's decision to notify is covered separately by
+// cockpitd-push.test.ts; this file covers what defaultNotify writes once it
+// fires.
 
 import { describe, it, expect, afterEach } from "vitest";
 import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createConnection } from "node:net";
 import { startCockpitd } from "../cockpitd.js";
-import { sendRequest, encodeMsg, createDecoder } from "../protocol.js";
-import type { AttachFrame } from "../protocol.js";
+import { sendRequest } from "../protocol.js";
 import type { TaskRecord } from "../types.js";
-
-function awaitFrame(sockPath: string, project: string): Promise<AttachFrame> {
-  return new Promise((resolve, reject) => {
-    const conn = createConnection(sockPath);
-    const dec = createDecoder();
-    const t = setTimeout(() => { conn.destroy(); reject(new Error("timeout waiting for push")); }, 2000);
-    conn.setEncoding("utf-8");
-    conn.on("connect", () => conn.write(encodeMsg({ op: "subscribe-notify", project })));
-    conn.on("data", (chunk: string) => {
-      for (const raw of dec.push(chunk)) {
-        const f = raw as AttachFrame;
-        if ((f as any).type === "push") {
-          clearTimeout(t);
-          conn.destroy();
-          resolve(f);
-          return;
-        }
-      }
-    });
-    conn.on("error", (e: Error) => { clearTimeout(t); reject(e); });
-  });
-}
 
 function seedRec(id: string): TaskRecord {
   return {
@@ -45,76 +23,78 @@ function seedRec(id: string): TaskRecord {
   };
 }
 
-describe("cockpitd defaultNotify (#111)", () => {
+describe("cockpitd defaultNotify writes to mailbox", () => {
   let stop: (() => void) | undefined;
   let dir: string;
   afterEach(() => { stop?.(); if (dir) rmSync(dir, { recursive: true, force: true }); });
 
-  it("broadcasts a push frame to a subscribe-notify client when a task transitions to done", async () => {
+  it("appends a task.done event to <stateRoot>/inbox/<project>.log as JSON", async () => {
     dir = mkdtempSync(join(tmpdir(), "cp-notify-"));
     const sock = join(dir, "c.sock");
     const stateRoot = join(dir, "state");
     const handle = startCockpitd({ stateRoot, sockPath: sock, sweepMs: 0 });
     stop = handle.stop;
 
-    // Seed a working task.
-    await sendRequest(sock, { kind: "seed", record: seedRec("task-push-1") });
-
-    // Subscribe FIRST (before the event), then fire the event.
-    const framePromise = awaitFrame(sock, "p");
-    // Tiny delay to let subscribe-claim register before we fire the event.
-    await new Promise((r) => setTimeout(r, 50));
+    await sendRequest(sock, { kind: "seed", record: seedRec("task-mbx-1") });
     await sendRequest(sock, {
       kind: "event",
       project: "p",
-      event: { type: "task.done", id: "task-push-1", resultRef: "/tmp/x" },
+      event: { type: "task.done", id: "task-mbx-1", resultRef: "/tmp/result" },
     });
+    // Allow the async append to flush.
+    await new Promise((r) => setTimeout(r, 100));
 
-    const frame = (await framePromise) as { type: "push"; project: string; message: string; ts: number };
-    expect(frame.type).toBe("push");
-    expect(frame.project).toBe("p");
-    expect(frame.message).toMatch(/^CREW DONE \[claude\/task-pus/);
-    expect(typeof frame.ts).toBe("number");
-  });
-
-  it("appends the notification to an inbox log file", async () => {
-    dir = mkdtempSync(join(tmpdir(), "cp-notify-"));
-    const sock = join(dir, "c.sock");
-    const stateRoot = join(dir, "state");
-    const handle = startCockpitd({ stateRoot, sockPath: sock, sweepMs: 0 });
-    stop = handle.stop;
-
-    await sendRequest(sock, { kind: "seed", record: seedRec("task-inbox-1") });
-    await sendRequest(sock, {
-      kind: "event",
-      project: "p",
-      event: { type: "task.done", id: "task-inbox-1", resultRef: "/tmp/x" },
-    });
-
-    // Inbox lives next to stateRoot in <root>/inbox/<project>.log.
-    const inboxPath = join(stateRoot, "..", "inbox", "p.log");
+    const inboxPath = join(stateRoot, "inbox", "p.log");
     expect(existsSync(inboxPath)).toBe(true);
-    const contents = readFileSync(inboxPath, "utf-8");
-    expect(contents).toMatch(/CREW DONE \[claude\/task-inb/);
+    const lines = readFileSync(inboxPath, "utf-8").trim().split("\n").map((l) => JSON.parse(l));
+    // Only the terminal event triggers a notify (firePush gate).
+    expect(lines).toHaveLength(1);
+    expect(lines[0].kind).toBe("task.done");
+    expect(lines[0].provider).toBe("claude");
+    expect(lines[0].taskId).toBe("task-mbx-1");
+    expect(lines[0].payload.resultRef).toBe("/tmp/result");
+    expect(lines[0].seq).toBe(1);
+    expect(typeof lines[0].ts).toBe("string");
   });
 
-  it("does not throw when no subscriber is connected (drop on the broadcast, persist in inbox)", async () => {
+  it("assigns monotonic seq across multiple notifies in the same project", async () => {
     dir = mkdtempSync(join(tmpdir(), "cp-notify-"));
     const sock = join(dir, "c.sock");
     const stateRoot = join(dir, "state");
     const handle = startCockpitd({ stateRoot, sockPath: sock, sweepMs: 0 });
     stop = handle.stop;
 
-    await sendRequest(sock, { kind: "seed", record: seedRec("task-no-sub-1") });
-    // No subscriber. Daemon must still apply the event and write inbox.
+    for (let i = 0; i < 3; i++) {
+      const id = `task-mbx-multi-${i}`;
+      await sendRequest(sock, { kind: "seed", record: seedRec(id) });
+      await sendRequest(sock, {
+        kind: "event",
+        project: "p",
+        event: { type: "task.done", id, resultRef: `/tmp/r${i}` },
+      });
+    }
+    await new Promise((r) => setTimeout(r, 100));
+
+    const inboxPath = join(stateRoot, "inbox", "p.log");
+    const lines = readFileSync(inboxPath, "utf-8").trim().split("\n").map((l) => JSON.parse(l));
+    expect(lines.map((l) => l.seq)).toEqual([1, 2, 3]);
+  });
+
+  it("does not crash when no captain is reachable (no subprocess invoked)", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-notify-"));
+    const sock = join(dir, "c.sock");
+    const stateRoot = join(dir, "state");
+    const handle = startCockpitd({ stateRoot, sockPath: sock, sweepMs: 0 });
+    stop = handle.stop;
+
+    await sendRequest(sock, { kind: "seed", record: seedRec("task-mbx-quiet") });
     const r: any = await sendRequest(sock, {
       kind: "event",
       project: "p",
-      event: { type: "task.done", id: "task-no-sub-1", resultRef: "/tmp/x" },
+      event: { type: "task.done", id: "task-mbx-quiet", resultRef: "/tmp/x" },
     });
     expect(r.state).toBe("done");
-
-    const inboxPath = join(stateRoot, "..", "inbox", "p.log");
-    expect(existsSync(inboxPath)).toBe(true);
+    await new Promise((r) => setTimeout(r, 100));
+    expect(existsSync(join(stateRoot, "inbox", "p.log"))).toBe(true);
   });
 });

--- a/src/control/__tests__/cockpitd-notify-default.test.ts
+++ b/src/control/__tests__/cockpitd-notify-default.test.ts
@@ -80,6 +80,32 @@ describe("cockpitd defaultNotify writes to mailbox", () => {
     expect(lines.map((l) => l.seq)).toEqual([1, 2, 3]);
   });
 
+  it("rotates oversize mailbox files automatically via background timer", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-notify-"));
+    const sock = join(dir, "c.sock");
+    const stateRoot = join(dir, "state");
+    const handle = startCockpitd({
+      stateRoot,
+      sockPath: sock,
+      sweepMs: 0,
+      rotationIntervalMs: 50,
+      mailboxConfig: { maxBytes: 100, maxAgeMs: 999_999_999, keepCount: 3 },
+    });
+    stop = handle.stop;
+
+    for (let i = 0; i < 5; i++) {
+      const id = `task-rot-${i}`;
+      await sendRequest(sock, { kind: "seed", record: seedRec(id) });
+      await sendRequest(sock, {
+        kind: "event",
+        project: "p",
+        event: { type: "task.done", id, resultRef: `/tmp/r${i}` },
+      });
+    }
+    await new Promise((r) => setTimeout(r, 250));
+    expect(existsSync(join(stateRoot, "inbox", "p.log.1"))).toBe(true);
+  });
+
   it("does not crash when no captain is reachable (no subprocess invoked)", async () => {
     dir = mkdtempSync(join(tmpdir(), "cp-notify-"));
     const sock = join(dir, "c.sock");

--- a/src/control/__tests__/cockpitd-push.test.ts
+++ b/src/control/__tests__/cockpitd-push.test.ts
@@ -10,7 +10,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createDaemon } from "../daemon.js";
 import { createStore } from "../store.js";
-import type { TaskRecord } from "../types.js";
+import type { TaskRecord, ControlEvent } from "../types.js";
 
 function rec(id: string, overrides: Partial<TaskRecord> = {}): TaskRecord {
   return {
@@ -31,7 +31,7 @@ function fakeNotify() {
   const calls: NotifyCall[] = [];
   return {
     calls,
-    notify: (args: { project: string; message: string }) => {
+    notify: (args: { project: string; message: string; record: TaskRecord; event: ControlEvent }) => {
       calls.push({ project: args.project, message: args.message });
     },
   };

--- a/src/control/__tests__/mailbox.test.ts
+++ b/src/control/__tests__/mailbox.test.ts
@@ -5,6 +5,8 @@ import { join } from "node:path";
 import { appendToMailbox } from "../mailbox.js";
 import { readCursor, writeCursor } from "../mailbox.js";
 import { readFromCursor } from "../mailbox.js";
+import { rotateIfNeeded } from "../mailbox.js";
+import { statSync } from "node:fs";
 import type { TaskRecord, ControlEvent } from "../types.js";
 
 function freshState(): string {
@@ -172,5 +174,61 @@ describe("readFromCursor", () => {
     await (await import("node:fs/promises")).appendFile(file, '{"seq":2,"ts":"2026', "utf-8");
     const items = await collect(readFromCursor({ stateRoot, project: "demo", fromSeq: 1 }));
     expect(items.map((i) => i.seq)).toEqual([1]);
+  });
+});
+
+describe("rotateIfNeeded", () => {
+  it("returns rotated=false when file under thresholds", async () => {
+    const stateRoot = freshState();
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    const r = await rotateIfNeeded({ stateRoot, project: "demo", maxBytes: 1024 * 1024, maxAgeMs: 24 * 60 * 60 * 1000, keepCount: 3 });
+    expect(r.rotated).toBe(false);
+  });
+
+  it("rotates when size exceeds maxBytes", async () => {
+    const stateRoot = freshState();
+    for (let i = 0; i < 10; i++) {
+      await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    }
+    const sizeBefore = statSync(join(stateRoot, "inbox", "demo.log")).size;
+    expect(sizeBefore).toBeGreaterThan(200);
+    const r = await rotateIfNeeded({ stateRoot, project: "demo", maxBytes: 200, maxAgeMs: 999999999, keepCount: 3 });
+    expect(r.rotated).toBe(true);
+    expect(existsSync(join(stateRoot, "inbox", "demo.log.1"))).toBe(true);
+    expect(statSync(join(stateRoot, "inbox", "demo.log")).size).toBe(0);
+  });
+
+  it("seq is monotonic across rotation boundary", async () => {
+    const stateRoot = freshState();
+    for (let i = 0; i < 10; i++) {
+      await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    }
+    await rotateIfNeeded({ stateRoot, project: "demo", maxBytes: 200, maxAgeMs: 999999999, keepCount: 3 });
+    const s = await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    expect(s).toBe(11);
+  });
+
+  it("keeps only keepCount rotated files", async () => {
+    const stateRoot = freshState();
+    for (let cycle = 0; cycle < 5; cycle++) {
+      for (let i = 0; i < 5; i++) {
+        await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+      }
+      await rotateIfNeeded({ stateRoot, project: "demo", maxBytes: 100, maxAgeMs: 999999999, keepCount: 2 });
+    }
+    expect(existsSync(join(stateRoot, "inbox", "demo.log.1"))).toBe(true);
+    expect(existsSync(join(stateRoot, "inbox", "demo.log.2"))).toBe(true);
+    expect(existsSync(join(stateRoot, "inbox", "demo.log.3"))).toBe(false);
+  });
+
+  it("readFromCursor reads across rotated files", async () => {
+    const stateRoot = freshState();
+    for (let i = 0; i < 5; i++) {
+      await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    }
+    await rotateIfNeeded({ stateRoot, project: "demo", maxBytes: 50, maxAgeMs: 999999999, keepCount: 3 });
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    const items = await collect(readFromCursor({ stateRoot, project: "demo", fromSeq: 1 }));
+    expect(items.map((i) => i.seq)).toEqual([1, 2, 3, 4, 5, 6]);
   });
 });

--- a/src/control/__tests__/mailbox.test.ts
+++ b/src/control/__tests__/mailbox.test.ts
@@ -78,4 +78,23 @@ describe("appendToMailbox", () => {
     const s3 = await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
     expect(s3).toBe(3);
   });
+
+  it("assigns unique monotonic seq under concurrent appends (no TOCTOU race)", async () => {
+    const stateRoot = freshState();
+    // Fire 20 concurrent appends; with a TOCTOU race some would get duplicate seqs
+    const results = await Promise.all(
+      Array.from({ length: 20 }, () =>
+        appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent })
+      )
+    );
+    // All seqs unique, exactly 1..20
+    const sorted = [...results].sort((a, b) => a - b);
+    expect(sorted).toEqual(Array.from({ length: 20 }, (_, i) => i + 1));
+    // File has exactly 20 lines, all parseable, with seqs 1..20
+    const logPath = join(stateRoot, "inbox", "demo.log");
+    const lines = readFileSync(logPath, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(20);
+    const seqs = lines.map((l) => JSON.parse(l).seq as number).sort((a, b) => a - b);
+    expect(seqs).toEqual(Array.from({ length: 20 }, (_, i) => i + 1));
+  });
 });

--- a/src/control/__tests__/mailbox.test.ts
+++ b/src/control/__tests__/mailbox.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { appendToMailbox } from "../mailbox.js";
+import type { TaskRecord, ControlEvent } from "../types.js";
+
+function freshState(): string {
+  return mkdtempSync(join(tmpdir(), "mbox-"));
+}
+
+const sampleRecord: TaskRecord = {
+  id: "11111111-2222-3333-4444-555555555555",
+  project: "demo",
+  provider: "claude",
+  mode: "interactive",
+  state: "working",
+  task: "smoke test task description",
+  cwd: "/tmp",
+  createdAt: 1000,
+  lastHeartbeat: 1000,
+  lastEvent: "task.progress",
+  heartbeatBudgetMs: 60000,
+  attempts: [],
+};
+
+const doneEvent: ControlEvent = {
+  type: "task.done",
+  id: sampleRecord.id,
+  resultRef: "/tmp/result.txt",
+};
+
+describe("appendToMailbox", () => {
+  it("creates inbox/<project>.log on first append and assigns seq=1", async () => {
+    const stateRoot = freshState();
+    const seq = await appendToMailbox({
+      stateRoot,
+      project: "demo",
+      taskRecord: sampleRecord,
+      event: doneEvent,
+    });
+    expect(seq).toBe(1);
+    const logPath = join(stateRoot, "inbox", "demo.log");
+    expect(existsSync(logPath)).toBe(true);
+    const lines = readFileSync(logPath, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+    const entry = JSON.parse(lines[0]);
+    expect(entry.seq).toBe(1);
+    expect(entry.taskId).toBe(sampleRecord.id);
+    expect(entry.kind).toBe("task.done");
+    expect(entry.provider).toBe("claude");
+    expect(entry.payload.resultRef).toBe("/tmp/result.txt");
+    expect(typeof entry.ts).toBe("string");
+  });
+
+  it("assigns monotonically increasing seq on subsequent appends", async () => {
+    const stateRoot = freshState();
+    const s1 = await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    const s2 = await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    const s3 = await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    expect([s1, s2, s3]).toEqual([1, 2, 3]);
+  });
+
+  it("isolates seq per project", async () => {
+    const stateRoot = freshState();
+    const a = await appendToMailbox({ stateRoot, project: "a", taskRecord: sampleRecord, event: doneEvent });
+    const b = await appendToMailbox({ stateRoot, project: "b", taskRecord: sampleRecord, event: doneEvent });
+    const a2 = await appendToMailbox({ stateRoot, project: "a", taskRecord: sampleRecord, event: doneEvent });
+    expect(a).toBe(1);
+    expect(b).toBe(1);
+    expect(a2).toBe(2);
+  });
+
+  it("resumes seq from max in file after daemon restart simulation", async () => {
+    const stateRoot = freshState();
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    const s3 = await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    expect(s3).toBe(3);
+  });
+});

--- a/src/control/__tests__/mailbox.test.ts
+++ b/src/control/__tests__/mailbox.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { appendToMailbox } from "../mailbox.js";
 import { readCursor, writeCursor } from "../mailbox.js";
+import { readFromCursor } from "../mailbox.js";
 import type { TaskRecord, ControlEvent } from "../types.js";
 
 function freshState(): string {
@@ -132,5 +133,44 @@ describe("cursor read/write", () => {
     const tg = await readCursor({ stateRoot, project: "demo", subscriber: "telegram" });
     expect(cap?.lastAckedSeq).toBe(10);
     expect(tg?.lastAckedSeq).toBe(5);
+  });
+});
+
+async function collect<T>(iter: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const item of iter) out.push(item);
+  return out;
+}
+
+describe("readFromCursor", () => {
+  it("returns empty iterable when file does not exist", async () => {
+    const stateRoot = freshState();
+    const items = await collect(readFromCursor({ stateRoot, project: "demo", fromSeq: 1 }));
+    expect(items).toEqual([]);
+  });
+
+  it("returns all entries with seq >= fromSeq", async () => {
+    const stateRoot = freshState();
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    const items = await collect(readFromCursor({ stateRoot, project: "demo", fromSeq: 2 }));
+    expect(items.map((i) => i.seq)).toEqual([2, 3]);
+  });
+
+  it("skips entries with seq < fromSeq", async () => {
+    const stateRoot = freshState();
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    const items = await collect(readFromCursor({ stateRoot, project: "demo", fromSeq: 100 }));
+    expect(items).toEqual([]);
+  });
+
+  it("tolerates a partial last line (mid-write crash)", async () => {
+    const stateRoot = freshState();
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    const file = join(stateRoot, "inbox", "demo.log");
+    await (await import("node:fs/promises")).appendFile(file, '{"seq":2,"ts":"2026', "utf-8");
+    const items = await collect(readFromCursor({ stateRoot, project: "demo", fromSeq: 1 }));
+    expect(items.map((i) => i.seq)).toEqual([1]);
   });
 });

--- a/src/control/__tests__/mailbox.test.ts
+++ b/src/control/__tests__/mailbox.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { appendToMailbox } from "../mailbox.js";
+import { readCursor, writeCursor } from "../mailbox.js";
 import type { TaskRecord, ControlEvent } from "../types.js";
 
 function freshState(): string {
@@ -96,5 +97,40 @@ describe("appendToMailbox", () => {
     expect(lines).toHaveLength(20);
     const seqs = lines.map((l) => JSON.parse(l).seq as number).sort((a, b) => a - b);
     expect(seqs).toEqual(Array.from({ length: 20 }, (_, i) => i + 1));
+  });
+});
+
+describe("cursor read/write", () => {
+  it("readCursor returns null when file does not exist", async () => {
+    const stateRoot = freshState();
+    const c = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    expect(c).toBeNull();
+  });
+
+  it("writeCursor then readCursor round-trips lastAckedSeq", async () => {
+    const stateRoot = freshState();
+    await writeCursor({ stateRoot, project: "demo", subscriber: "captain", lastAckedSeq: 42 });
+    const c = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    expect(c?.lastAckedSeq).toBe(42);
+  });
+
+  it("writeCursor uses atomic rename (no leftover .tmp file)", async () => {
+    const stateRoot = freshState();
+    await writeCursor({ stateRoot, project: "demo", subscriber: "captain", lastAckedSeq: 1 });
+    await writeCursor({ stateRoot, project: "demo", subscriber: "captain", lastAckedSeq: 2 });
+    const c = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    expect(c?.lastAckedSeq).toBe(2);
+    const tmpExists = existsSync(join(stateRoot, "inbox", "demo.captain.cursor.tmp"));
+    expect(tmpExists).toBe(false);
+  });
+
+  it("isolates cursors per subscriber", async () => {
+    const stateRoot = freshState();
+    await writeCursor({ stateRoot, project: "demo", subscriber: "captain", lastAckedSeq: 10 });
+    await writeCursor({ stateRoot, project: "demo", subscriber: "telegram", lastAckedSeq: 5 });
+    const cap = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    const tg = await readCursor({ stateRoot, project: "demo", subscriber: "telegram" });
+    expect(cap?.lastAckedSeq).toBe(10);
+    expect(tg?.lastAckedSeq).toBe(5);
   });
 });

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -10,7 +10,8 @@ import { startServer, encodeFrame, type AttachFrame, type AttachInbound } from "
 import { runHeadless } from "./headless-launcher.js";
 import { CodexInteractiveDriver } from "./codex/driver.js";
 import { makeGate } from "./codex/gate.js";
-import type { Gate, TaskRecord } from "./types.js";
+import { appendToMailbox } from "./mailbox.js";
+import type { Gate, TaskRecord, ControlEvent } from "./types.js";
 import type { Socket } from "node:net";
 
 export interface CockpitdOpts {
@@ -25,7 +26,12 @@ export interface CockpitdOpts {
    * project→captain workspace lookup via NotifierRegistry + config).
    * Tests inject a fake to assert call shape without spawning.
    */
-  notify?: (args: { project: string; message: string }) => Promise<void> | void;
+  notify?: (args: {
+    project: string;
+    message: string;
+    record: TaskRecord;
+    event: ControlEvent;
+  }) => Promise<void> | void;
   /** Inject a fake driver for tests. Defaults to a real CodexInteractiveDriver. */
   codexDriver?: import("./codex/driver.js").CodexInteractiveDriver | {
     dispatch: (rec: any) => Promise<void>;
@@ -178,15 +184,30 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   const ingest = (project: string) => (e: import("./types.js").ControlEvent) =>
     void d.handle({ kind: "event", project, event: e });
 
-  // Default push-notification wiring (#109 + #111): the daemon CANNOT shell
-  // out to cmux directly — cmux's CLI rejects any caller not descended from
-  // its app process, and the daemon's parent is launchd (or any detached
-  // subprocess), never cmux. Instead the daemon broadcasts push frames to
-  // `subscribe-notify` clients (the `cockpit notify-relay <project>` tab
-  // running inside the captain workspace) and appends to a durable inbox
-  // file for record/debug. Tests inject a fake `notify` to assert call
-  // shape without exercising this delivery path.
-  const defaultNotify = (args: { project: string; message: string }): void => {
+  // Default push-notification wiring (mailbox-injector spec): the daemon
+  // appends a JSON entry to <stateRoot>/inbox/<project>.log. An injector
+  // process running inside the captain workspace tails the file from its
+  // cursor and delivers each entry to the captain pane. The daemon never
+  // shells out to cmux; the captain owns delivery. Tests inject a fake
+  // `notify` to assert call shape without exercising the mailbox path.
+  const defaultNotify = async (args: {
+    project: string;
+    message: string;
+    record: TaskRecord;
+    event: ControlEvent;
+  }): Promise<void> => {
+    try {
+      await appendToMailbox({
+        stateRoot,
+        project: args.project,
+        taskRecord: args.record,
+        event: args.event,
+      });
+    } catch (e) {
+      log(`mailbox append failed project=${args.project}: ${(e as Error).message}`);
+    }
+    // Legacy push-frame broadcast preserved for PR #112's relay tab during the
+    // bridge state. Removed in Task 8 once the file-tailer injector replaces it.
     pushNotify(args.project, args.message);
   };
   const notify = opts.notify ?? defaultNotify;

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -319,8 +319,42 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
     timer.unref?.();
   }
 
+  const rotationInterval = opts.rotationIntervalMs ?? 60_000;
+  const mboxCfg = {
+    maxBytes: opts.mailboxConfig?.maxBytes ?? 5 * 1024 * 1024,
+    maxAgeMs: opts.mailboxConfig?.maxAgeMs ?? 7 * 24 * 60 * 60 * 1000,
+    keepCount: opts.mailboxConfig?.keepCount ?? 3,
+  };
+  let rotationTimer: NodeJS.Timeout | undefined;
+  if (rotationInterval > 0) {
+    const inboxPath = join(stateRoot, "inbox");
+    rotationTimer = setInterval(async () => {
+      try {
+        let entries: string[];
+        try { entries = await readdir(inboxPath); }
+        catch { return; }
+        const projects = new Set(
+          entries
+            .filter((e) => e.endsWith(".log"))
+            .map((e) => e.slice(0, -".log".length)),
+        );
+        for (const project of projects) {
+          await rotateIfNeeded({ stateRoot, project, ...mboxCfg });
+        }
+      } catch (e) {
+        log(`rotation timer error: ${(e as Error).message}`);
+      }
+    }, rotationInterval);
+    rotationTimer.unref?.();
+  }
+
   return {
-    stop() { if (timer) clearInterval(timer); server.close(); log("stopped"); },
+    stop() {
+      if (timer) clearInterval(timer);
+      if (rotationTimer) clearInterval(rotationTimer);
+      server.close();
+      log("stopped");
+    },
   };
 }
 

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -10,7 +10,8 @@ import { startServer, encodeFrame, type AttachFrame, type AttachInbound } from "
 import { runHeadless } from "./headless-launcher.js";
 import { CodexInteractiveDriver } from "./codex/driver.js";
 import { makeGate } from "./codex/gate.js";
-import { appendToMailbox } from "./mailbox.js";
+import { appendToMailbox, rotateIfNeeded } from "./mailbox.js";
+import { readdir } from "node:fs/promises";
 import type { Gate, TaskRecord, ControlEvent } from "./types.js";
 import type { Socket } from "node:net";
 
@@ -32,6 +33,14 @@ export interface CockpitdOpts {
     record: TaskRecord;
     event: ControlEvent;
   }) => Promise<void> | void;
+  /** Background rotation timer interval (ms). 0 disables. Default 60_000. */
+  rotationIntervalMs?: number;
+  /** Mailbox rotation thresholds (size/age/retention). */
+  mailboxConfig?: {
+    maxBytes?: number;
+    maxAgeMs?: number;
+    keepCount?: number;
+  };
   /** Inject a fake driver for tests. Defaults to a real CodexInteractiveDriver. */
   codexDriver?: import("./codex/driver.js").CodexInteractiveDriver | {
     dispatch: (rec: any) => Promise<void>;

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -2,7 +2,7 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { spawn as realSpawn } from "node:child_process";
-import { writeFileSync, mkdirSync, appendFileSync } from "node:fs";
+import { writeFileSync, mkdirSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { createStore } from "./store.js";
 import { createDaemon } from "./daemon.js";
@@ -22,10 +22,10 @@ export interface CockpitdOpts {
   isPidAlive?: (pid: number) => boolean; // injectable for the headless reconcile path (tests)
   spawn?: typeof realSpawn;
   /**
-   * Push-notification hook (#109). Defaults to shelling out to
-   * `cockpit runtime send <project> <message>` (which already does the
-   * project→captain workspace lookup via NotifierRegistry + config).
-   * Tests inject a fake to assert call shape without spawning.
+   * Push-notification hook (#109). Defaults to appending a structured event
+   * to the mailbox file at <stateRoot>/inbox/<project>.log; an injector
+   * process inside the captain workspace tails the file and delivers entries
+   * to the captain pane. Tests inject a fake to assert call shape.
    */
   notify?: (args: {
     project: string;
@@ -78,33 +78,6 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   // Per-task set of live attach connections. Populated in onAttach, cleaned up
   // in onAttachClose. Not exposed outside this closure.
   const attachConns = new Map<string, Set<Socket>>();
-
-  // ── Notify subscribers (#111) ────────────────────────────────────────────
-  // Per-project set of live subscribe-notify connections. The daemon cannot
-  // shell out to `cmux send` directly because cmux refuses any caller not
-  // descended from its app process; instead it pushes frames here and an
-  // in-cmux relay tab (cockpit notify-relay) forwards to the captain pane.
-  const notifySubs = new Map<string, Set<Socket>>();
-  const inboxDir = join(stateRoot, "..", "inbox");
-  mkdirSync(inboxDir, { recursive: true });
-  function pushNotify(project: string, message: string): void {
-    const ts = Date.now();
-    // Durable record (debug/inspection) — even if no subscriber is live, the
-    // file persists what would have been delivered.
-    try {
-      const line = `${new Date(ts).toISOString()}\t${message.replace(/\n/g, " ")}\n`;
-      appendFileSync(join(inboxDir, `${project}.log`), line);
-    } catch (e) {
-      log(`inbox append failed project=${project}: ${(e as Error).message}`);
-    }
-    // Live broadcast to any subscribed relay.
-    const conns = notifySubs.get(project);
-    if (!conns || conns.size === 0) return;
-    const wire = encodeFrame({ type: "push", project, message, ts });
-    for (const conn of conns) {
-      try { conn.write(wire); } catch { /* relay vanished; close handler will clean up */ }
-    }
-  }
 
   function broadcast(taskId: string, f: AttachFrame): void {
     const conns = attachConns.get(taskId);
@@ -215,9 +188,6 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
     } catch (e) {
       log(`mailbox append failed project=${args.project}: ${(e as Error).message}`);
     }
-    // Legacy push-frame broadcast preserved for PR #112's relay tab during the
-    // bridge state. Removed in Task 8 once the file-tailer injector replaces it.
-    pushNotify(args.project, args.message);
   };
   const notify = opts.notify ?? defaultNotify;
 
@@ -300,15 +270,6 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       // Remove the conn from every task's set (the conn only exists in one set,
       // but a linear scan over a small map is fine).
       for (const set of attachConns.values()) set.delete(conn);
-    },
-    onSubscribeNotify: (conn, frame) => {
-      let set = notifySubs.get(frame.project);
-      if (!set) { set = new Set(); notifySubs.set(frame.project, set); }
-      set.add(conn);
-      log(`notify subscribed project=${frame.project}`);
-    },
-    onSubscribeNotifyClose: (conn) => {
-      for (const set of notifySubs.values()) set.delete(conn);
     },
   });
   log(`started pid=${process.pid} sock=${sockPath} stateRoot=${stateRoot}`);

--- a/src/control/daemon.ts
+++ b/src/control/daemon.ts
@@ -45,7 +45,7 @@ function shortId(id: string): string {
 }
 
 function formatMessage(rec: TaskRecord): string | null {
-  const tag = `[${rec.provider}/${shortId(rec.id)}]`;
+  const tag = `[${rec.provider}/${rec.name != null ? rec.name : shortId(rec.id)}]`;
   switch (rec.state) {
     case "done": {
       // Spec: "<resultRef-content-first-line-or-the-task-snippet>".

--- a/src/control/daemon.ts
+++ b/src/control/daemon.ts
@@ -25,13 +25,17 @@ export interface DaemonDeps {
    */
   resolveInteractiveGate?: (taskId: string, payload: unknown) => Promise<void> | void;
   /**
-   * Push notification hook (#109). Called on every state transition into
-   * {done, blocked, failed, stalled}. The implementation in cockpitd shells
-   * out to the runtime so the captain's pane shows the message inline.
-   * Errors are caught + swallowed here so an unhealthy notifier never
-   * breaks the event-ingest path.
+   * Push notification hook (#109, refactored under mailbox-injector spec).
+   * Called on every state transition into {done, blocked, failed, stalled}.
+   * Implementations append to the mailbox; errors are caught + swallowed here
+   * so an unhealthy notifier never breaks the event-ingest path.
    */
-  notify?: (args: { project: string; message: string }) => Promise<void> | void;
+  notify?: (args: {
+    project: string;
+    message: string;
+    record: TaskRecord;
+    event: ControlEvent;
+  }) => Promise<void> | void;
 }
 
 const ATTENTION_STATES: ReadonlySet<TaskState> = new Set(["done", "blocked", "failed", "stalled"]);
@@ -62,7 +66,13 @@ function formatMessage(rec: TaskRecord): string | null {
   }
 }
 
-function firePush(deps: DaemonDeps, project: string, prev: TaskState, next: TaskRecord): void {
+function firePush(
+  deps: DaemonDeps,
+  project: string,
+  prev: TaskState,
+  next: TaskRecord,
+  event: ControlEvent,
+): void {
   if (!deps.notify) return;
   if (prev === next.state) return;
   if (!ATTENTION_STATES.has(next.state)) return;
@@ -71,7 +81,7 @@ function firePush(deps: DaemonDeps, project: string, prev: TaskState, next: Task
   // Fire-and-forget; swallow errors so the daemon never trips on a flaky
   // notifier. Sync throws and async rejections both land here.
   try {
-    const r = deps.notify({ project, message });
+    const r = deps.notify({ project, message, record: next, event });
     if (r && typeof (r as Promise<void>).catch === "function") {
       (r as Promise<void>).catch(() => {});
     }
@@ -130,7 +140,7 @@ export function createDaemon(deps: DaemonDeps) {
           const next = reduce(cur, req.event, now());
           if (next !== cur) {
             store.put(next); // skip redundant write on terminal no-ops
-            firePush(deps, req.project, cur.state, next);
+            firePush(deps, req.project, cur.state, next, req.event);
           }
           return next;
         }
@@ -171,7 +181,16 @@ export function createDaemon(deps: DaemonDeps) {
       const t = now();
       for (const r of store.listAll()) {
         const stalled = evaluateStall(r, t);
-        if (stalled) { store.put(stalled); firePush(deps, r.project, r.state, stalled); continue; }
+        if (stalled) {
+          store.put(stalled);
+          const synthEvent: ControlEvent = {
+            type: "task.stalled",
+            id: r.id,
+            heartbeatBudgetMs: r.heartbeatBudgetMs,
+          };
+          firePush(deps, r.project, r.state, stalled, synthEvent);
+          continue;
+        }
         const recovered = recoverStall(r, t);
         // recoverStall does NOT check heartbeat freshness — guard per its contract
         if (recovered && t - r.lastHeartbeat <= r.heartbeatBudgetMs) store.put(recovered);
@@ -188,11 +207,21 @@ export function createDaemon(deps: DaemonDeps) {
             error: "orphaned by daemon restart; exit unobserved (conservative fail)",
           };
           store.put(failed);
-          firePush(deps, r.project, r.state, failed);
+          const synthEvent: ControlEvent = {
+            type: "task.failed",
+            id: r.id,
+            error: failed.error ?? "reconcile",
+          };
+          firePush(deps, r.project, r.state, failed, synthEvent);
         } else {
           const stalled: TaskRecord = { ...r, state: "stalled", lastEvent: "reconcile" };
           store.put(stalled);
-          firePush(deps, r.project, r.state, stalled);
+          const synthEvent: ControlEvent = {
+            type: "task.reconcile-failed",
+            id: r.id,
+            reason: "interactive task lost on daemon restart",
+          };
+          firePush(deps, r.project, r.state, stalled, synthEvent);
         }
       }
     },

--- a/src/control/mailbox.ts
+++ b/src/control/mailbox.ts
@@ -6,6 +6,9 @@ export interface MailboxEntry {
   seq: number;
   ts: string;
   taskId: string;
+  /** Optional human-readable name carried from TaskRecord. Absent on legacy
+   *  records — readers must fall back to shortId(taskId). */
+  name?: string;
   kind: ControlEvent["type"];
   provider: TaskRecord["provider"];
   payload: Record<string, unknown>;
@@ -105,6 +108,7 @@ export async function appendToMailbox(opts: AppendOpts): Promise<number> {
       seq,
       ts: new Date().toISOString(),
       taskId: opts.taskRecord.id,
+      ...(opts.taskRecord.name !== undefined ? { name: opts.taskRecord.name } : {}),
       kind: opts.event.type,
       provider: opts.taskRecord.provider,
       payload: extractPayload(opts.event),

--- a/src/control/mailbox.ts
+++ b/src/control/mailbox.ts
@@ -49,20 +49,41 @@ async function readMaxSeq(file: string): Promise<number> {
   }
 }
 
+// Per-project serial mutex. Node's event loop is single-threaded but async
+// readFile + writeFile can interleave; chaining all appends for the same
+// project through a single in-process Promise serializes them.
+//
+// For cross-process serialization (multi-daemon scenarios, e.g. launchctl
+// restart races), an OS-level flock would be needed on `<project>.log`.
+// Today cockpit runs a single daemon instance; the in-process mutex covers
+// the realistic concurrency model. flock can be added later if multi-process
+// access becomes a requirement.
+const projectLocks = new Map<string, Promise<unknown>>();
+
+function withProjectLock<T>(project: string, fn: () => Promise<T>): Promise<T> {
+  const prev = projectLocks.get(project) ?? Promise.resolve();
+  const next = prev.catch(() => undefined).then(fn);
+  // Store a tail that does not reject so the chain never breaks on caller failure
+  projectLocks.set(project, next.catch(() => undefined));
+  return next;
+}
+
 export async function appendToMailbox(opts: AppendOpts): Promise<number> {
-  const dir = inboxDir(opts.stateRoot);
-  await fs.mkdir(dir, { recursive: true });
-  const file = logPath(opts.stateRoot, opts.project);
-  const lastSeq = await readMaxSeq(file);
-  const seq = lastSeq + 1;
-  const entry: MailboxEntry = {
-    seq,
-    ts: new Date().toISOString(),
-    taskId: opts.taskRecord.id,
-    kind: opts.event.type,
-    provider: opts.taskRecord.provider,
-    payload: extractPayload(opts.event),
-  };
-  await fs.appendFile(file, JSON.stringify(entry) + "\n", { encoding: "utf-8" });
-  return seq;
+  return withProjectLock(opts.project, async () => {
+    const dir = inboxDir(opts.stateRoot);
+    await fs.mkdir(dir, { recursive: true });
+    const file = logPath(opts.stateRoot, opts.project);
+    const lastSeq = await readMaxSeq(file);
+    const seq = lastSeq + 1;
+    const entry: MailboxEntry = {
+      seq,
+      ts: new Date().toISOString(),
+      taskId: opts.taskRecord.id,
+      kind: opts.event.type,
+      provider: opts.taskRecord.provider,
+      payload: extractPayload(opts.event),
+    };
+    await fs.appendFile(file, JSON.stringify(entry) + "\n", { encoding: "utf-8" });
+    return seq;
+  });
 }

--- a/src/control/mailbox.ts
+++ b/src/control/mailbox.ts
@@ -31,7 +31,20 @@ function extractPayload(event: ControlEvent): Record<string, unknown> {
   return payload;
 }
 
-async function readMaxSeq(file: string): Promise<number> {
+async function listRotatedOldestFirst(stateRoot: string, project: string): Promise<string[]> {
+  const dir = inboxDir(stateRoot);
+  let entries: string[];
+  try { entries = await fs.readdir(dir); }
+  catch { return []; }
+  const prefix = `${project}.log.`;
+  return entries
+    .filter((e) => e.startsWith(prefix) && /^\d+$/.test(e.slice(prefix.length)))
+    .map((e) => ({ name: e, n: Number(e.slice(prefix.length)) }))
+    .sort((a, b) => b.n - a.n) // .3 first (oldest), .1 last (newest rotated)
+    .map((e) => join(dir, e.name));
+}
+
+async function readMaxSeqFromFile(file: string): Promise<number> {
   try {
     const buf = await fs.readFile(file, "utf-8");
     if (!buf.trim()) return 0;
@@ -47,6 +60,19 @@ async function readMaxSeq(file: string): Promise<number> {
     if ((e as NodeJS.ErrnoException).code === "ENOENT") return 0;
     throw e;
   }
+}
+
+async function readMaxSeq(stateRoot: string, project: string): Promise<number> {
+  let max = 0;
+  const files = [
+    logPath(stateRoot, project),
+    ...(await listRotatedOldestFirst(stateRoot, project)),
+  ];
+  for (const file of files) {
+    const seq = await readMaxSeqFromFile(file);
+    if (seq > max) max = seq;
+  }
+  return max;
 }
 
 // Per-project serial mutex. Node's event loop is single-threaded but async
@@ -73,7 +99,7 @@ export async function appendToMailbox(opts: AppendOpts): Promise<number> {
     const dir = inboxDir(opts.stateRoot);
     await fs.mkdir(dir, { recursive: true });
     const file = logPath(opts.stateRoot, opts.project);
-    const lastSeq = await readMaxSeq(file);
+    const lastSeq = await readMaxSeq(opts.stateRoot, opts.project);
     const seq = lastSeq + 1;
     const entry: MailboxEntry = {
       seq,
@@ -140,22 +166,91 @@ interface ReadFromCursorOpts {
 }
 
 export async function* readFromCursor(opts: ReadFromCursorOpts): AsyncIterable<MailboxEntry> {
-  const file = logPath(opts.stateRoot, opts.project);
-  let buf: string;
-  try {
-    buf = await fs.readFile(file, "utf-8");
-  } catch (e) {
-    if ((e as NodeJS.ErrnoException).code === "ENOENT") return;
-    throw e;
-  }
-  for (const line of buf.split("\n")) {
-    if (!line.trim()) continue;
-    let entry: MailboxEntry;
+  // Order: oldest rotated first (.3 → .2 → .1), then current.
+  const rotated = await listRotatedOldestFirst(opts.stateRoot, opts.project);
+  const files = [...rotated, logPath(opts.stateRoot, opts.project)];
+  for (const file of files) {
+    let buf: string;
     try {
-      entry = JSON.parse(line) as MailboxEntry;
-    } catch {
-      continue;
+      buf = await fs.readFile(file, "utf-8");
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === "ENOENT") continue;
+      throw e;
     }
-    if (entry.seq >= opts.fromSeq) yield entry;
+    for (const line of buf.split("\n")) {
+      if (!line.trim()) continue;
+      let entry: MailboxEntry;
+      try {
+        entry = JSON.parse(line) as MailboxEntry;
+      } catch {
+        continue;
+      }
+      if (entry.seq >= opts.fromSeq) yield entry;
+    }
   }
+}
+
+interface RotateOpts {
+  stateRoot: string;
+  project: string;
+  maxBytes: number;
+  maxAgeMs: number;
+  keepCount: number;
+}
+
+export interface RotateResult {
+  rotated: boolean;
+  from?: string;
+  to?: string;
+}
+
+async function oldestEntryAgeMs(file: string): Promise<number> {
+  try {
+    const buf = await fs.readFile(file, "utf-8");
+    const firstLine = buf.split("\n").find((l) => l.trim());
+    if (!firstLine) return 0;
+    const entry = JSON.parse(firstLine) as MailboxEntry;
+    return Date.now() - new Date(entry.ts).getTime();
+  } catch {
+    return 0;
+  }
+}
+
+export async function rotateIfNeeded(opts: RotateOpts): Promise<RotateResult> {
+  return withProjectLock(opts.project, async () => {
+    const file = logPath(opts.stateRoot, opts.project);
+    let size = 0;
+    try { size = (await fs.stat(file)).size; }
+    catch (e) {
+      if ((e as NodeJS.ErrnoException).code === "ENOENT") return { rotated: false };
+      throw e;
+    }
+    const age = await oldestEntryAgeMs(file);
+    if (size < opts.maxBytes && age < opts.maxAgeMs) return { rotated: false };
+
+    // Shift existing .N files down (.N → .N+1), deleting anything beyond keepCount.
+    // Process highest N first so we don't clobber.
+    // Find the existing max N.
+    const existing = await listRotatedOldestFirst(opts.stateRoot, opts.project);
+    // existing is sorted by N desc (oldest first). Extract numbers.
+    const nums = existing.map((p) => Number(p.slice(p.lastIndexOf(".") + 1))).sort((a, b) => b - a);
+    for (const n of nums) {
+      const src = `${file}.${n}`;
+      const dst = `${file}.${n + 1}`;
+      if (n + 1 > opts.keepCount) {
+        try { await fs.unlink(src); } catch (e) {
+          if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+        }
+      } else {
+        try { await fs.rename(src, dst); } catch (e) {
+          if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+        }
+      }
+    }
+    // current → .1
+    await fs.rename(file, `${file}.1`);
+    // create fresh empty current
+    await fs.writeFile(file, "", { encoding: "utf-8" });
+    return { rotated: true, from: file, to: `${file}.1` };
+  });
 }

--- a/src/control/mailbox.ts
+++ b/src/control/mailbox.ts
@@ -87,3 +87,48 @@ export async function appendToMailbox(opts: AppendOpts): Promise<number> {
     return seq;
   });
 }
+
+function cursorPath(stateRoot: string, project: string, subscriber: string): string {
+  return join(inboxDir(stateRoot), `${project}.${subscriber}.cursor`);
+}
+
+interface CursorOpts {
+  stateRoot: string;
+  project: string;
+  subscriber: string;
+}
+
+export interface CursorState {
+  lastAckedSeq: number;
+  subscriber: string;
+  updatedAt: string;
+}
+
+export async function readCursor(opts: CursorOpts): Promise<CursorState | null> {
+  try {
+    const buf = await fs.readFile(cursorPath(opts.stateRoot, opts.project, opts.subscriber), "utf-8");
+    return JSON.parse(buf) as CursorState;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw e;
+  }
+}
+
+export async function writeCursor(opts: CursorOpts & { lastAckedSeq: number }): Promise<void> {
+  await fs.mkdir(inboxDir(opts.stateRoot), { recursive: true });
+  const dest = cursorPath(opts.stateRoot, opts.project, opts.subscriber);
+  const tmp = dest + ".tmp";
+  const data: CursorState = {
+    lastAckedSeq: opts.lastAckedSeq,
+    subscriber: opts.subscriber,
+    updatedAt: new Date().toISOString(),
+  };
+  const handle = await fs.open(tmp, "w");
+  try {
+    await handle.writeFile(JSON.stringify(data), { encoding: "utf-8" });
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  await fs.rename(tmp, dest);
+}

--- a/src/control/mailbox.ts
+++ b/src/control/mailbox.ts
@@ -132,3 +132,30 @@ export async function writeCursor(opts: CursorOpts & { lastAckedSeq: number }): 
   }
   await fs.rename(tmp, dest);
 }
+
+interface ReadFromCursorOpts {
+  stateRoot: string;
+  project: string;
+  fromSeq: number;
+}
+
+export async function* readFromCursor(opts: ReadFromCursorOpts): AsyncIterable<MailboxEntry> {
+  const file = logPath(opts.stateRoot, opts.project);
+  let buf: string;
+  try {
+    buf = await fs.readFile(file, "utf-8");
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw e;
+  }
+  for (const line of buf.split("\n")) {
+    if (!line.trim()) continue;
+    let entry: MailboxEntry;
+    try {
+      entry = JSON.parse(line) as MailboxEntry;
+    } catch {
+      continue;
+    }
+    if (entry.seq >= opts.fromSeq) yield entry;
+  }
+}

--- a/src/control/mailbox.ts
+++ b/src/control/mailbox.ts
@@ -1,0 +1,68 @@
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import type { TaskRecord, ControlEvent } from "./types.js";
+
+export interface MailboxEntry {
+  seq: number;
+  ts: string;
+  taskId: string;
+  kind: ControlEvent["type"];
+  provider: TaskRecord["provider"];
+  payload: Record<string, unknown>;
+}
+
+interface AppendOpts {
+  stateRoot: string;
+  project: string;
+  taskRecord: TaskRecord;
+  event: ControlEvent;
+}
+
+function inboxDir(stateRoot: string): string {
+  return join(stateRoot, "inbox");
+}
+
+function logPath(stateRoot: string, project: string): string {
+  return join(inboxDir(stateRoot), `${project}.log`);
+}
+
+function extractPayload(event: ControlEvent): Record<string, unknown> {
+  const { type: _type, id: _id, ...payload } = event as Record<string, unknown> & { type: string; id: string };
+  return payload;
+}
+
+async function readMaxSeq(file: string): Promise<number> {
+  try {
+    const buf = await fs.readFile(file, "utf-8");
+    if (!buf.trim()) return 0;
+    const lines = buf.trim().split("\n");
+    for (let i = lines.length - 1; i >= 0; i--) {
+      try {
+        const obj = JSON.parse(lines[i]) as MailboxEntry;
+        return obj.seq;
+      } catch { continue; }
+    }
+    return 0;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return 0;
+    throw e;
+  }
+}
+
+export async function appendToMailbox(opts: AppendOpts): Promise<number> {
+  const dir = inboxDir(opts.stateRoot);
+  await fs.mkdir(dir, { recursive: true });
+  const file = logPath(opts.stateRoot, opts.project);
+  const lastSeq = await readMaxSeq(file);
+  const seq = lastSeq + 1;
+  const entry: MailboxEntry = {
+    seq,
+    ts: new Date().toISOString(),
+    taskId: opts.taskRecord.id,
+    kind: opts.event.type,
+    provider: opts.taskRecord.provider,
+    payload: extractPayload(opts.event),
+  };
+  await fs.appendFile(file, JSON.stringify(entry) + "\n", { encoding: "utf-8" });
+  return seq;
+}

--- a/src/control/protocol.ts
+++ b/src/control/protocol.ts
@@ -44,17 +44,6 @@ export interface ServerCallbacks {
   onAttachInbound?: (conn: NetConn, frame: AttachInbound) => void;
   /** Called when a claimed attach connection closes. */
   onAttachClose?: (conn: NetConn) => void;
-  /**
-   * Called once when a connection sends {op:"subscribe-notify",project}.
-   * The conn is claimed for push-broadcast (no further inbound frames are
-   * expected on it). See #111: cmux's CLI rejects any caller not in cmux's
-   * process tree, so the daemon (launchd) can't shell out to cmux send;
-   * instead it broadcasts push frames here and an in-cmux relay tab forwards
-   * them to the captain pane.
-   */
-  onSubscribeNotify?: (conn: NetConn, frame: { op: "subscribe-notify"; project: string }) => void;
-  /** Called when a claimed notify-subscriber connection closes. */
-  onSubscribeNotifyClose?: (conn: NetConn) => void;
 }
 
 /**
@@ -79,7 +68,7 @@ export function startServer(
     typeof handlerOrCallbacks === "function"
       ? { handler: handlerOrCallbacks }
       : handlerOrCallbacks;
-  const { handler, onAttach, onAttachInbound, onAttachClose, onSubscribeNotify, onSubscribeNotifyClose } = callbacks;
+  const { handler, onAttach, onAttachInbound, onAttachClose } = callbacks;
 
   if (existsSync(sockPath)) {
     try { unlinkSync(sockPath); } catch { /* stale socket */ }
@@ -87,7 +76,7 @@ export function startServer(
   const server = createServer((conn) => {
     const dec = createDecoder();
     conn.setEncoding("utf-8");
-    let claimType: "none" | "attach" | "notify" = "none";
+    let claimType: "none" | "attach" = "none";
 
     conn.on("data", async (chunk: string) => {
       for (const msg of dec.push(chunk)) {
@@ -96,8 +85,6 @@ export function startServer(
           onAttachInbound?.(conn, msg as AttachInbound);
           continue;
         }
-        // Notify subscribers send no inbound frames; ignore any that slip through.
-        if (claimType === "notify") continue;
         // Check for attach-claim frame BEFORE falling through to req/res.
         if (
           onAttach &&
@@ -108,18 +95,6 @@ export function startServer(
         ) {
           claimType = "attach";
           onAttach(conn, msg as { op: "attach"; taskId: string });
-          continue;
-        }
-        // Check for subscribe-notify-claim frame (#111).
-        if (
-          onSubscribeNotify &&
-          msg != null &&
-          typeof msg === "object" &&
-          (msg as any).op === "subscribe-notify" &&
-          typeof (msg as any).project === "string"
-        ) {
-          claimType = "notify";
-          onSubscribeNotify(conn, msg as { op: "subscribe-notify"; project: string });
           continue;
         }
         // Normal request/response path.
@@ -135,7 +110,6 @@ export function startServer(
     conn.on("error", () => { /* client vanished; ignore */ });
     conn.on("close", () => {
       if (claimType === "attach") onAttachClose?.(conn);
-      else if (claimType === "notify") onSubscribeNotifyClose?.(conn);
     });
   });
   server.on("error", onListenError); // never let a server error become uncaughtException
@@ -182,8 +156,6 @@ export type AttachFrame =
   | { type: "gate-promoted"; taskId: string; gateId: string }
   | { type: "reattached"; taskId: string }
   | { type: "closed"; taskId: string; reason: string }
-  // #111: pushed by daemon to subscribe-notify claimants.
-  | { type: "push"; project: string; message: string; ts: number }
   | { type: "_keepalive" };
 
 export type AttachInbound =

--- a/src/control/state-machine.ts
+++ b/src/control/state-machine.ts
@@ -70,5 +70,10 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
       return { ...stampAttempt(base, {}, now), state: "blocked", question: ev.question };
     case "task.reattached":
       return stampAttempt(base, {}, now);
+    case "task.stalled":
+    case "task.reconcile-failed":
+      // Synthetic notify-only events; the daemon has already updated state
+      // directly via the watchdog/reconcile paths. Reducer is a no-op.
+      return rec;
   }
 }

--- a/src/control/types.ts
+++ b/src/control/types.ts
@@ -79,7 +79,12 @@ export type ControlEvent =
   | { type: "task.delta"; id: string; turnId: string; chunk: string }
   | { type: "task.input.requested"; id: string; requestId: number; question: string }
   | { type: "task.approval.requested"; id: string; requestId: number; question: string; kind: string }
-  | { type: "task.reattached"; id: string };
+  | { type: "task.reattached"; id: string }
+  // Synthetic events: emitted by the daemon (watchdog / reconcile) purely as
+  // notify payloads. They are never sent over the wire and the reducer treats
+  // them as no-ops; the watchdog has already updated state directly.
+  | { type: "task.stalled"; id: string; heartbeatBudgetMs: number }
+  | { type: "task.reconcile-failed"; id: string; reason: string };
 
 // 'stalled' is intentionally excluded — recoverable by the watchdog.
 export const TERMINAL_STATES: ReadonlySet<TaskState> = new Set([

--- a/src/control/types.ts
+++ b/src/control/types.ts
@@ -35,6 +35,10 @@ export interface Gate {
 
 export interface TaskRecord {
   id: string;
+  /** Human-readable crew name (e.g. the `--name` arg to `cockpit crew spawn`).
+   *  Optional for backward-compat with records written before this field
+   *  existed; relay/daemon fall back to the short id when absent. */
+  name?: string;
   project: string;
   provider: Provider;
   mode: Mode;

--- a/src/control/types.ts
+++ b/src/control/types.ts
@@ -71,7 +71,7 @@ export type ControlEvent =
   | { type: "task.progress"; id: string; note?: string }
   | { type: "heartbeat"; id: string }
   | { type: "task.blocked"; id: string; reason: string; question: string }
-  | { type: "task.done"; id: string; resultRef: string; parseWarning?: boolean }
+  | { type: "task.done"; id: string; resultRef: string; message?: string; parseWarning?: boolean }
   | { type: "task.failed"; id: string; error: string; exitCode?: number }
   | { type: "task.session"; id: string; resumeRef: string }
   | { type: "task.turn.started"; id: string; turnId: string }

--- a/src/reactor/__tests__/auto-status.test.ts
+++ b/src/reactor/__tests__/auto-status.test.ts
@@ -51,6 +51,8 @@ function makeRuntime(screens: Record<string, string>): RuntimeDriver {
     sendToPane: vi.fn(),
     readPaneScreen: vi.fn(),
     listSurfaces: vi.fn(),
+    spawnInjector: vi.fn(),
+    sendToSurface: vi.fn(),
   };
 }
 

--- a/src/runtimes/__tests__/registry.test.ts
+++ b/src/runtimes/__tests__/registry.test.ts
@@ -19,6 +19,8 @@ function stubDriver(name: string): RuntimeDriver {
     sendToPane: vi.fn(async () => {}),
     readPaneScreen: vi.fn(async () => ""),
     listSurfaces: vi.fn(async () => []),
+    spawnInjector: vi.fn(async () => ({ workspaceId: "workspace:1", surfaceId: "surface:1" })),
+    sendToSurface: vi.fn(async () => {}),
   };
 }
 

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -161,6 +161,46 @@ export function createCmuxDriver(): RuntimeDriver {
       }
     },
 
+    async spawnInjector(opts: {
+      captainWorkspace: WorkspaceRef;
+      command: string;
+      title?: string;
+      placement: "hidden" | "visible";
+    }): Promise<PaneRef> {
+      // Use a split-pane for "hidden" (shares a tab, can be resized small) and
+      // a new tab for "visible" (debug ergonomics). The resize-pane verb is
+      // best-effort; if cmux rejects it, the default split size is acceptable.
+      const wsId = opts.captainWorkspace.id;
+      const titleArg = opts.title ? ` --title "${escape(opts.title)}"` : "";
+      const verb =
+        opts.placement === "visible"
+          ? `new-surface --type terminal --workspace "${wsId}"`
+          : `new-pane --type terminal --direction down --workspace "${wsId}"`;
+      const output = cmux(verb);
+      const surfaceId = output.match(/surface:\d+/)?.[0];
+      if (!surfaceId) {
+        throw new Error(`cmux spawnInjector did not return a surface id: ${output}`);
+      }
+      if (opts.title) {
+        try {
+          cmux(`rename-tab --workspace "${wsId}" --surface "${surfaceId}"${titleArg}`);
+        } catch { /* rename is best-effort */ }
+      }
+      cmux(`send --workspace "${wsId}" --surface "${surfaceId}" "${escape(opts.command)}"`);
+      cmux(`send-key --workspace "${wsId}" --surface "${surfaceId}" Enter`);
+      if (opts.placement === "hidden") {
+        try {
+          cmux(`resize-pane --workspace "${wsId}" --surface "${surfaceId}" --rows 1`);
+        } catch { /* resize is best-effort; default split size is the fallback */ }
+      }
+      return { workspaceId: wsId, surfaceId, title: opts.title };
+    },
+
+    async sendToSurface(surface: PaneRef, text: string): Promise<void> {
+      cmux(`send --workspace "${surface.workspaceId}" --surface "${surface.surfaceId}" "${escape(text)}"`);
+      cmux(`send-key --workspace "${surface.workspaceId}" --surface "${surface.surfaceId}" Enter`);
+    },
+
     async listSurfaces(workspaceId: string): Promise<PaneRef[]> {
       let output: string;
       try {

--- a/src/runtimes/types.ts
+++ b/src/runtimes/types.ts
@@ -54,4 +54,23 @@ export interface RuntimeDriver {
   // List all surfaces (tabs/panes) inside a workspace, with their titles.
   // Used to find named crews by tab title (#56).
   listSurfaces(workspaceId: string): Promise<PaneRef[]>;
+
+  // Spawn a long-running process INSIDE the captain workspace's process tree,
+  // so any IPC/socket constraints of the runtime (e.g. cmux's parent-lineage
+  // check) are satisfied. Returns a PaneRef the caller can inspect/clean up.
+  //
+  // placement: "hidden" produces a non-distracting surface (zero/minimal-size
+  // split, off-screen tab — runtime decides). "visible" produces a normal pane.
+  spawnInjector(opts: {
+    captainWorkspace: WorkspaceRef;
+    command: string;
+    title?: string;
+    placement: "hidden" | "visible";
+  }): Promise<PaneRef>;
+
+  // Send text to a specific surface. Unlike `send` (workspace-level) this
+  // targets one surface directly. Used by the notify-relay injector to
+  // deliver messages to the captain's primary surface. Throws if the surface
+  // no longer exists.
+  sendToSurface(surface: PaneRef, text: string): Promise<void>;
 }


### PR DESCRIPTION
## Summary

Replaces PR #112's subscribe/broadcast machinery with a **file-as-source-of-truth mailbox + pull-from-cursor injector**. The cockpit daemon appends `ControlEvent`s to a per-project mailbox file; a `notify-relay` process runs as a hidden split-pane inside each captain workspace and delivers events to the captain pane via the new `RuntimeDriver.sendToSurface`. **Daemon-bounce-tolerant by design; at-least-once delivery; runtime-agnostic.**

## Architecture (one paragraph)

Daemon appends to `~/.config/cockpit/inbox/<project>.log` (JSON-lines, monotonic per-project `seq`, in-process mutex on write, size+age rotation). Injector inside captain workspace (`cockpit notify-relay <project> --as captain`) tails the file from a `lastAckedSeq` cursor (`<project>.captain.cursor`, fsync+atomic-rename), formats each entry, and delivers via `RuntimeDriver.sendToSurface(captainSurface, msg)`. The injector is spawned via the new `RuntimeDriver.spawnInjector({placement:"hidden"})` so it lives inside cmux's process tree (satisfies cmux's CLI lineage check from #111). Subscribe-notify socket protocol + push frames added in PR #112 are deleted. **Anti-#2576 invariant preserved**: terminal state only via explicit `cockpit crew signal`.

## Lessons applied

- **PR #110 lesson:** daemon-from-launchd can't shell out to cmux. Daemon now never invokes cmux-aware commands; only appends to a file.
- **PR #112 lesson:** push-with-no-replay loses events during bounce backoff. Pull-from-cursor model: file is durable, injector resumes from cursor on restart.
- **Research 2026-05-27 lesson:** the relay-tab pattern is the right shape (per Erlang per-process mailbox + Orca's hook receiver); what was missing was a durable queue and cleaner `RuntimeDriver` abstraction. This PR dignifies the relay into a first-class injector.

## Closes / depends

- **Closes #113** (replay-on-reconnect — by construction; the bug cannot occur in this design).
- **Foundation for #114** (hybrid codex: native TUI + hook bridge — codex hooks emit events that flow through the same mailbox).
- **Foundation for #115** (opencode interactive wiring — opencode plugin events flow through the same mailbox).
- **Preserves PR #98** (codex app-server for headless) — untouched.
- **Preserves PR #108** (claude through daemon) — its hook bridge now feeds the mailbox instead of pushing.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npx vitest run` — **577/577 tests pass** (18 new mailbox tests, 4 rewritten cockpitd-notify-default, 4 rewritten notify-relay; subscribe-notify tests deleted)
- [x] E2E smoke: `node scripts/mailbox-injector-smoke.mjs` — all 5 sections pass; evidence in `.mailbox-injector-smoke.local`
- [ ] **Manual live verification (after merge):** spawn Claude crew, signal done, captain pane receives line within ~1s; daemon-bounce mid-second-test, second line STILL arrives after respawn. Evidence to `.mailbox-injector-live-evidence.local`.
- [ ] cmux integration with hidden split-pane visible in captain workspace (requires manual cmux verification).

## Commit shape

17 atomic commits across 4 logical groups:
- **Group 1** (mailbox.ts pure functions): `dd4125d` → `c8fd3e1` → `42c4448` → `9b0b42c` → `cea3f06`
- **Group 2** (daemon switchover): `a50c983` → `d3c3f9b` → `c89db2f` → `474454f` → `5fdd9e8`
- **Group 3** (notify-relay rewrite): `25303f1`
- **Group 4** (RuntimeDriver + cmux + launch): `501eb7b` → `15ff72a` → `f4b7a44` → `493dcac`
- **Final** (smoke + cleanup): `25b993d` → `fa709c2` → `f39c448`

## Spec / plan / research

- Spec: `docs/specs/2026-05-27-mailbox-injector-design.md`
- Plan: `docs/plans/2026-05-27-mailbox-injector.md`
- Motivating research: `docs/research/2026-05-27-multi-session-orchestrator-notification-patterns.{md,html}` (+ VI)
- Cross-provider validation: same docs § *"Provider Coverage Audit"*

## Known cosmetic items

- Hidden split-pane: cmux's `resize-pane --rows 1` may not be supported in all builds; the code best-effort attempts it and falls back to default split size if rejected. **Acceptable degradation** — still less intrusive than PR #112's full visible tab.
