### PR TITLE
fix(runtimes): eliminate cmux shell injection in sendToPane/sendToSurface (closes #118)

### DIFF
--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -1,16 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createCmuxDriver } from "../cmux.js";
 
-const execMock = vi.hoisted(() => vi.fn());
+const execFileMock = vi.hoisted(() => vi.fn());
 vi.mock("node:child_process", () => ({
-  execSync: execMock,
+  execFileSync: execFileMock,
 }));
+
+// cmux() now invokes execFileSync(CMUX_BIN, argv[], opts) with no shell, so the
+// command + its arguments arrive as an argv array (calls[i][1]). These helpers
+// surface the argv for assertions; the binary path itself (calls[i][0]) is
+// irrelevant to behavior.
+const argvOf = (call: unknown[]): string[] => call[1] as string[];
+const cmdOf = (call: unknown[]): string => (call[1] as string[]).join(" ");
 
 describe("cmux driver", () => {
   const driver = createCmuxDriver();
 
   beforeEach(() => {
-    execMock.mockReset();
+    execFileMock.mockReset();
   });
 
   it("has name 'cmux'", () => {
@@ -18,8 +25,8 @@ describe("cmux driver", () => {
   });
 
   it("probe returns installed=true with version when cmux responds", async () => {
-    execMock.mockImplementation((cmd: string) => {
-      if (cmd.includes("--version")) return "cmux 0.12.3\n";
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("--version")) return "cmux 0.12.3\n";
       return "";
     });
     const result = await driver.probe();
@@ -28,15 +35,15 @@ describe("cmux driver", () => {
   });
 
   it("probe returns installed=false when cmux throws", async () => {
-    execMock.mockImplementation(() => { throw new Error("not found"); });
+    execFileMock.mockImplementation(() => { throw new Error("not found"); });
     const result = await driver.probe();
     expect(result.installed).toBe(false);
     expect(result.version).toBe("");
   });
 
   it("list parses list-workspaces output into WorkspaceRefs", async () => {
-    execMock.mockImplementation((cmd: string) => {
-      if (cmd.includes("list-workspaces")) {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("list-workspaces")) {
         return [
           "workspace:1  🏛️ command  (running)",
           "workspace:2  brove-captain  [selected]",
@@ -51,8 +58,8 @@ describe("cmux driver", () => {
   });
 
   it("status returns null when name not in list", async () => {
-    execMock.mockImplementation((cmd: string) => {
-      if (cmd.includes("list-workspaces")) return "workspace:1  other-ws  (running)";
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("list-workspaces")) return "workspace:1  other-ws  (running)";
       return "";
     });
     const ref = await driver.status("brove-captain");
@@ -60,8 +67,8 @@ describe("cmux driver", () => {
   });
 
   it("status returns WorkspaceRef when name matches", async () => {
-    execMock.mockImplementation((cmd: string) => {
-      if (cmd.includes("list-workspaces")) return "workspace:5  brove-captain  (running)";
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("list-workspaces")) return "workspace:5  brove-captain  (running)";
       return "";
     });
     const ref = await driver.status("brove-captain");
@@ -69,67 +76,67 @@ describe("cmux driver", () => {
   });
 
   it("send calls cmux send THEN cmux send-key Enter", async () => {
-    execMock.mockReturnValue("");
+    execFileMock.mockReturnValue("");
     await driver.send("workspace:2", "hello world");
-    const calls = execMock.mock.calls.map((c) => c[0] as string);
-    expect(calls.some((c) => c.includes("send") && c.includes("hello world") && !c.includes("send-key"))).toBe(true);
-    expect(calls.some((c) => c.includes("send-key") && c.includes("Enter"))).toBe(true);
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.includes("send") && c.includes("hello world") && !c.includes("send-key"))).toBe(true);
+    expect(cmds.some((c) => c.includes("send-key") && c.includes("Enter"))).toBe(true);
   });
 
   it("send routes to surface named after workspace when one exists", async () => {
-    let callIndex = 0;
-    execMock.mockImplementation((cmd: string) => {
-      callIndex++;
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      const cmd = args.join(" ");
       if (cmd.includes("list-workspaces")) return "workspace:2  test-ws  (running)";
       if (cmd.includes("tree"))           return '  └── surface surface:5 [terminal] "test-ws"';
       return "";
     });
     await driver.send("workspace:2", "hello tab");
-    // First cmux calls: list → tree → send → send-key
-    const cmuxCalls = execMock.mock.calls.map((c) => c[0] as string).filter((c) => !c.includes("list-workspaces") && !c.includes("tree"));
-    expect(cmuxCalls.some((c) => c.includes("send ") && c.includes("--surface \"surface:5\"") && c.includes("hello tab") && !c.includes("send-key"))).toBe(true);
-    expect(cmuxCalls.some((c) => c.includes("send-key") && c.includes("--surface \"surface:5\"") && c.includes("Enter"))).toBe(true);
+    const cmds = execFileMock.mock.calls.map(cmdOf).filter((c) => !c.includes("list-workspaces") && !c.includes("tree"));
+    expect(cmds.some((c) => c.includes("send ") && c.includes("--surface surface:5") && c.includes("hello tab") && !c.includes("send-key"))).toBe(true);
+    expect(cmds.some((c) => c.includes("send-key") && c.includes("--surface surface:5") && c.includes("Enter"))).toBe(true);
   });
 
   it("send falls back to workspace-level when no surface matches workspace name", async () => {
-    execMock.mockImplementation((cmd: string) => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      const cmd = args.join(" ");
       if (cmd.includes("list-workspaces")) return "workspace:2  test-ws  (running)";
       if (cmd.includes("tree"))           return '  └── surface surface:5 [terminal] "crew-1"';
       return "";
     });
     await driver.send("workspace:2", "fallback message");
-    const cmuxCalls = execMock.mock.calls.map((c) => c[0] as string).filter((c) => !c.includes("list-workspaces") && !c.includes("tree"));
-    expect(cmuxCalls.some((c) => c.includes("send ") && !c.includes("--surface") && c.includes("fallback message"))).toBe(true);
-    expect(cmuxCalls.some((c) => c.includes("send-key") && c.includes("Enter") && !c.includes("--surface"))).toBe(true);
+    const cmds = execFileMock.mock.calls.map(cmdOf).filter((c) => !c.includes("list-workspaces") && !c.includes("tree"));
+    expect(cmds.some((c) => c.includes("send ") && !c.includes("--surface") && c.includes("fallback message"))).toBe(true);
+    expect(cmds.some((c) => c.includes("send-key") && c.includes("Enter") && !c.includes("--surface"))).toBe(true);
   });
 
-  it("send escapes double-quotes in message", async () => {
-    execMock.mockReturnValue("");
+  it("send passes message text as a single literal argv element (no shell escaping)", async () => {
+    execFileMock.mockReturnValue("");
     await driver.send("workspace:2", 'say "hi"');
-    const calls = execMock.mock.calls.map((c) => c[0] as string);
-    expect(calls.some((c) => c.includes('\\"hi\\"'))).toBe(true);
+    const sendCall = execFileMock.mock.calls.find((c) => argvOf(c)[0] === "send");
+    expect(sendCall).toBeDefined();
+    expect(argvOf(sendCall!)).toContain('say "hi"');
   });
 
   it("sendKey sends literal key without Enter", async () => {
-    execMock.mockReturnValue("");
+    execFileMock.mockReturnValue("");
     await driver.sendKey("workspace:2", "Escape");
-    const calls = execMock.mock.calls.map((c) => c[0] as string);
-    expect(calls).toHaveLength(1);
-    expect(calls[0]).toContain("send-key");
-    expect(calls[0]).toContain("Escape");
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds).toHaveLength(1);
+    expect(cmds[0]).toContain("send-key");
+    expect(cmds[0]).toContain("Escape");
   });
 
   it("stop calls close-workspace", async () => {
-    execMock.mockReturnValue("");
+    execFileMock.mockReturnValue("");
     await driver.stop("workspace:2");
-    const calls = execMock.mock.calls.map((c) => c[0] as string);
-    expect(calls[0]).toContain("close-workspace");
-    expect(calls[0]).toContain("workspace:2");
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds[0]).toContain("close-workspace");
+    expect(cmds[0]).toContain("workspace:2");
   });
 
   it("readScreen calls read-screen and returns output", async () => {
-    execMock.mockImplementation((cmd: string) => {
-      if (cmd.includes("read-screen")) return "screen contents\n";
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return "screen contents\n";
       return "";
     });
     const out = await driver.readScreen("workspace:2");
@@ -137,7 +144,8 @@ describe("cmux driver", () => {
   });
 
   it("spawn creates workspace, renames it, pins it, renames and pins its initial tab", async () => {
-    execMock.mockImplementation((cmd: string) => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      const cmd = args.join(" ");
       if (cmd.includes("new-workspace")) return "Created workspace:7\n";
       if (cmd.includes("tree"))        return '  └── surface surface:1 [terminal] ""';
       return "";
@@ -145,118 +153,137 @@ describe("cmux driver", () => {
     const ref = await driver.spawn({ name: "test-ws", workdir: "/tmp", command: "echo hi", pinToTop: true });
     expect(ref.id).toBe("workspace:7");
     expect(ref.name).toBe("test-ws");
-    const calls = execMock.mock.calls.map((c) => c[0] as string);
-    expect(calls.some((c) => c.includes("new-workspace"))).toBe(true);
-    expect(calls.some((c) => c.includes("rename-workspace") && c.includes("test-ws"))).toBe(true);
-    expect(calls.some((c) => c.includes("rename-tab") && c.includes("surface:1") && c.includes("test-ws"))).toBe(true);
-    expect(calls.some((c) => c.includes("workspace-action") && c.includes("--action pin"))).toBe(true);
-    expect(calls.some((c) => c.includes("tab-action") && c.includes("--surface \"surface:1\"") && c.includes("--action pin"))).toBe(true);
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.includes("new-workspace"))).toBe(true);
+    expect(cmds.some((c) => c.includes("rename-workspace") && c.includes("test-ws"))).toBe(true);
+    expect(cmds.some((c) => c.includes("rename-tab") && c.includes("surface:1") && c.includes("test-ws"))).toBe(true);
+    expect(cmds.some((c) => c.includes("workspace-action") && c.includes("--action pin"))).toBe(true);
+    expect(cmds.some((c) => c.includes("tab-action") && c.includes("--surface surface:1") && c.includes("--action pin"))).toBe(true);
   });
 
   it("newPane calls cmux new-pane with direction and workspace, parses surface id", async () => {
-    execMock.mockImplementation((cmd: string) => {
-      if (cmd.includes("new-pane")) return "OK surface:27 pane:25 workspace:1";
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("new-pane")) return "OK surface:27 pane:25 workspace:1";
       return "";
     });
     const pane = await driver.newPane({ workspaceId: "workspace:1", direction: "right" });
     expect(pane).toEqual({ workspaceId: "workspace:1", surfaceId: "surface:27" });
-    const calls = execMock.mock.calls.map((c) => c[0] as string);
-    expect(calls.some((c) => c.includes("new-pane") && c.includes("--direction right") && c.includes("--workspace \"workspace:1\""))).toBe(true);
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.includes("new-pane") && c.includes("--direction right") && c.includes("--workspace workspace:1"))).toBe(true);
   });
 
   it("newPane with direction=tab calls cmux new-surface instead of new-pane", async () => {
-    execMock.mockImplementation((cmd: string) => {
-      if (cmd.includes("new-surface")) return "OK surface:31 workspace:1";
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("new-surface")) return "OK surface:31 workspace:1";
       return "";
     });
     const pane = await driver.newPane({ workspaceId: "workspace:1", direction: "tab" });
     expect(pane).toEqual({ workspaceId: "workspace:1", surfaceId: "surface:31" });
-    const calls = execMock.mock.calls.map((c) => c[0] as string);
-    expect(calls.some((c) => c.includes("new-surface") && c.includes("--workspace \"workspace:1\""))).toBe(true);
-    expect(calls.every((c) => !c.includes("new-pane"))).toBe(true);
-    expect(calls.every((c) => !c.includes("--direction"))).toBe(true);
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.includes("new-surface") && c.includes("--workspace workspace:1"))).toBe(true);
+    expect(cmds.every((c) => !c.includes("new-pane"))).toBe(true);
+    expect(cmds.every((c) => !c.includes("--direction"))).toBe(true);
   });
 
   it("newPane with direction=tab and title renames the new surface", async () => {
-    execMock.mockImplementation((cmd: string) => {
-      if (cmd.includes("new-surface")) return "OK surface:42 workspace:7";
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("new-surface")) return "OK surface:42 workspace:7";
       return "";
     });
     await driver.newPane({ workspaceId: "workspace:7", direction: "tab", title: "🔧 brove-crew" });
-    const calls = execMock.mock.calls.map((c) => c[0] as string);
-    expect(calls.some((c) => c.includes("rename-tab") && c.includes("--surface \"surface:42\"") && c.includes("\"🔧 brove-crew\""))).toBe(true);
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.includes("rename-tab") && c.includes("--surface surface:42") && c.includes("🔧 brove-crew"))).toBe(true);
   });
 
   it("newPane with direction=tab throws when output has no surface id", async () => {
-    execMock.mockReturnValue("garbage");
+    execFileMock.mockReturnValue("garbage");
     await expect(driver.newPane({ workspaceId: "workspace:1", direction: "tab" }))
       .rejects.toThrow(/new-surface did not return a surface/);
   });
 
   it("newPane with title also calls rename-tab on the new surface", async () => {
-    execMock.mockImplementation((cmd: string) => {
-      if (cmd.includes("new-pane")) return "OK surface:9 pane:3 workspace:2";
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("new-pane")) return "OK surface:9 pane:3 workspace:2";
       return "";
     });
     await driver.newPane({ workspaceId: "workspace:2", direction: "down", title: "🔧 fix-bug" });
-    const calls = execMock.mock.calls.map((c) => c[0] as string);
-    expect(calls.some((c) => c.includes("rename-tab") && c.includes("--surface \"surface:9\"") && c.includes("\"🔧 fix-bug\""))).toBe(true);
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.includes("rename-tab") && c.includes("--surface surface:9") && c.includes("🔧 fix-bug"))).toBe(true);
   });
 
   it("newPane throws when cmux output has no surface id", async () => {
-    execMock.mockReturnValue("garbage output");
+    execFileMock.mockReturnValue("garbage output");
     await expect(driver.newPane({ workspaceId: "workspace:1", direction: "right" }))
       .rejects.toThrow(/did not return a surface/);
   });
 
   it("closePane calls cmux close-surface with workspace + surface", async () => {
-    execMock.mockReturnValue("");
+    execFileMock.mockReturnValue("");
     await driver.closePane({ workspaceId: "workspace:1", surfaceId: "surface:9" });
-    const calls = execMock.mock.calls.map((c) => c[0] as string);
-    expect(calls.some((c) => c.includes("close-surface") && c.includes("--surface \"surface:9\"") && c.includes("--workspace \"workspace:1\""))).toBe(true);
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.includes("close-surface") && c.includes("--surface surface:9") && c.includes("--workspace workspace:1"))).toBe(true);
   });
 
   it("closePane swallows errors (already closed is fine)", async () => {
-    execMock.mockImplementation(() => { throw new Error("not found"); });
+    execFileMock.mockImplementation(() => { throw new Error("not found"); });
     await expect(driver.closePane({ workspaceId: "workspace:1", surfaceId: "surface:9" }))
       .resolves.toBeUndefined();
   });
 
   it("sendToPane calls cmux send + send-key Enter scoped to surface", async () => {
-    execMock.mockReturnValue("");
+    execFileMock.mockReturnValue("");
     await driver.sendToPane({ workspaceId: "workspace:1", surfaceId: "surface:9" }, "hello crew");
-    const calls = execMock.mock.calls.map((c) => c[0] as string);
-    expect(calls.some((c) => c.includes("send ") && c.includes("--surface \"surface:9\"") && c.includes("hello crew") && !c.includes("send-key"))).toBe(true);
-    expect(calls.some((c) => c.includes("send-key") && c.includes("--surface \"surface:9\"") && c.includes("Enter"))).toBe(true);
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.includes("send ") && c.includes("--surface surface:9") && c.includes("hello crew") && !c.includes("send-key"))).toBe(true);
+    expect(cmds.some((c) => c.includes("send-key") && c.includes("--surface surface:9") && c.includes("Enter"))).toBe(true);
   });
 
-  it("sendToPane escapes double quotes in the message", async () => {
-    execMock.mockReturnValue("");
-    await driver.sendToPane({ workspaceId: "workspace:1", surfaceId: "surface:9" }, 'task "X"');
-    const calls = execMock.mock.calls.map((c) => c[0] as string);
-    expect(calls.some((c) => c.includes('task \\"X\\"'))).toBe(true);
+  // Regression for #118: a crew prompt containing a backtick-wrapped destructive
+  // command must reach cmux as ONE literal argv element, never parsed by a shell.
+  it("sendToPane delivers backtick/$ shell metacharacters as literal text, not executed", async () => {
+    execFileMock.mockReturnValue("");
+    const malicious = 'fix the bug, run `cmux close-workspace` and $(rm -rf /) to verify';
+    await driver.sendToPane({ workspaceId: "workspace:1", surfaceId: "surface:9" }, malicious);
+    const sendCall = execFileMock.mock.calls.find((c) => argvOf(c)[0] === "send");
+    expect(sendCall).toBeDefined();
+    // The entire message — backticks, $(), and all — is a single argv element.
+    expect(argvOf(sendCall!)).toContain(malicious);
+    // And no escaping was applied to it.
+    expect(argvOf(sendCall!).join(" ")).toContain("`cmux close-workspace`");
   });
 
   it("readPaneScreen calls cmux read-screen scoped to surface", async () => {
-    execMock.mockImplementation((cmd: string) => {
-      if (cmd.includes("read-screen")) return "  some pane content  ";
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return "  some pane content  ";
       return "";
     });
     const text = await driver.readPaneScreen({ workspaceId: "workspace:1", surfaceId: "surface:9" });
     expect(text).toBe("some pane content");
-    const calls = execMock.mock.calls.map((c) => c[0] as string);
-    expect(calls.some((c) => c.includes("read-screen") && c.includes("--surface \"surface:9\"") && c.includes("--workspace \"workspace:1\""))).toBe(true);
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.includes("read-screen") && c.includes("--surface surface:9") && c.includes("--workspace workspace:1"))).toBe(true);
   });
 
   it("readPaneScreen returns empty string when cmux throws", async () => {
-    execMock.mockImplementation(() => { throw new Error("dead"); });
+    execFileMock.mockImplementation(() => { throw new Error("dead"); });
     const text = await driver.readPaneScreen({ workspaceId: "workspace:1", surfaceId: "surface:9" });
     expect(text).toBe("");
   });
 
+  it("sendToSurface delivers shell metacharacters as literal text scoped to surface", async () => {
+    execFileMock.mockReturnValue("");
+    const text = 'done: `cmux close-workspace` $(whoami)';
+    await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, text);
+    const sendCall = execFileMock.mock.calls.find((c) => argvOf(c)[0] === "send");
+    expect(sendCall).toBeDefined();
+    expect(argvOf(sendCall!)).toContain(text);
+    expect(cmdOf(sendCall!)).toContain("--surface surface:8");
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.includes("send-key") && c.includes("--surface surface:8") && c.includes("Enter"))).toBe(true);
+  });
+
   it("listSurfaces parses cmux tree output and returns surfaces with titles", async () => {
-    execMock.mockImplementation((cmd: string) => {
-      if (cmd.includes("tree")) {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("tree")) {
         return [
           'window window:1 [current] ◀ active',
           '└── workspace workspace:10 "⚓ pact-network-captain"',
@@ -277,7 +304,7 @@ describe("cmux driver", () => {
   });
 
   it("listSurfaces returns empty array when cmux throws", async () => {
-    execMock.mockImplementation(() => { throw new Error("workspace not found"); });
+    execFileMock.mockImplementation(() => { throw new Error("workspace not found"); });
     const surfaces = await driver.listSurfaces("workspace:99");
     expect(surfaces).toEqual([]);
   });

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -1,10 +1,13 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import type { RuntimeDriver, RuntimeProbeResult, RuntimeSpawnOptions, WorkspaceRef, PaneRef, RuntimePaneOptions } from "./types.js";
 
 const CMUX_BIN = "/Applications/cmux.app/Contents/Resources/bin/cmux";
 
-function cmux(args: string): string {
-  return execSync(`"${CMUX_BIN}" ${args}`, { encoding: "utf-8" }).trim();
+// Invoke cmux with an argv array and NO shell. Every element (especially crew
+// prompt text passed through send/send-to-surface) reaches cmux as a single
+// literal argument — backticks, $(), quotes are never parsed. See #118.
+function cmux(args: string[]): string {
+  return execFileSync(CMUX_BIN, args, { encoding: "utf-8" }).trim();
 }
 
 function parseList(output: string): WorkspaceRef[] {
@@ -22,17 +25,13 @@ function parseList(output: string): WorkspaceRef[] {
   return refs;
 }
 
-function escape(s: string): string {
-  return s.replace(/"/g, '\\"');
-}
-
 export function createCmuxDriver(): RuntimeDriver {
   return {
     name: "cmux",
 
     async probe(): Promise<RuntimeProbeResult> {
       try {
-        const version = cmux("--version");
+        const version = cmux(["--version"]);
         return { installed: true, version };
       } catch {
         return { installed: false, version: "" };
@@ -41,7 +40,7 @@ export function createCmuxDriver(): RuntimeDriver {
 
     async list(): Promise<WorkspaceRef[]> {
       try {
-        return parseList(cmux("list-workspaces"));
+        return parseList(cmux(["list-workspaces"]));
       } catch {
         return [];
       }
@@ -54,30 +53,31 @@ export function createCmuxDriver(): RuntimeDriver {
     },
 
     async spawn(opts: RuntimeSpawnOptions): Promise<WorkspaceRef> {
-      const cwdFlag = opts.workdir ? ` --cwd "${opts.workdir}"` : "";
-      const output = cmux(`new-workspace --command "${escape(opts.command)}"${cwdFlag}`);
+      const newWorkspaceArgs = ["new-workspace", "--command", opts.command];
+      if (opts.workdir) newWorkspaceArgs.push("--cwd", opts.workdir);
+      const output = cmux(newWorkspaceArgs);
       const id = output.match(/workspace:\d+/)?.[0] || output.split(/\s+/).pop() || "";
       if (!id) {
         throw new Error(`cmux spawn did not return a workspace id: ${output}`);
       }
-      cmux(`rename-workspace --workspace "${id}" "${escape(opts.name)}"`);
+      cmux(["rename-workspace", "--workspace", id, opts.name]);
       // Rename the initial tab to the workspace name so send() can route to it
       let initialSurface: string | undefined;
       try {
-        const tree = cmux(`tree --workspace "${id}"`);
+        const tree = cmux(["tree", "--workspace", id]);
         const m = tree.match(/surface\s+(surface:\d+)\s+\[\w+\]\s+"([^"]*)"/);
         if (m) {
           initialSurface = m[1];
-          cmux(`rename-tab --workspace "${id}" --surface "${m[1]}" "${escape(opts.name)}"`);
+          cmux(["rename-tab", "--workspace", id, "--surface", m[1], opts.name]);
         }
       } catch { /* rename is best-effort */ }
       if (opts.pinToTop) {
         try {
-          cmux(`workspace-action --workspace "${id}" --action pin`);
+          cmux(["workspace-action", "--workspace", id, "--action", "pin"]);
         } catch { /* pin is best-effort */ }
         if (initialSurface) {
           try {
-            cmux(`tab-action --workspace "${id}" --surface "${initialSurface}" --action pin`);
+            cmux(["tab-action", "--workspace", id, "--surface", initialSurface, "--action", "pin"]);
           } catch { /* tab pin is best-effort */ }
         }
       }
@@ -95,23 +95,23 @@ export function createCmuxDriver(): RuntimeDriver {
           const surfaces = await this.listSurfaces(ws.id);
           const target = surfaces.find((s) => s.title === ws.name);
           if (target) {
-            cmux(`send --workspace "${ws.id}" --surface "${target.surfaceId}" "${escape(message)}"`);
-            cmux(`send-key --workspace "${ws.id}" --surface "${target.surfaceId}" Enter`);
+            cmux(["send", "--workspace", ws.id, "--surface", target.surfaceId, message]);
+            cmux(["send-key", "--workspace", ws.id, "--surface", target.surfaceId, "Enter"]);
             return;
           }
         } catch { /* fall through to default */ }
       }
-      cmux(`send --workspace "${ref}" "${escape(message)}"`);
-      cmux(`send-key --workspace "${ref}" Enter`);
+      cmux(["send", "--workspace", ref, message]);
+      cmux(["send-key", "--workspace", ref, "Enter"]);
     },
 
     async sendKey(ref: string, key: string): Promise<void> {
-      cmux(`send-key --workspace "${ref}" ${key}`);
+      cmux(["send-key", "--workspace", ref, key]);
     },
 
     async readScreen(ref: string): Promise<string> {
       try {
-        return cmux(`read-screen --workspace "${ref}"`);
+        return cmux(["read-screen", "--workspace", ref]);
       } catch {
         return "";
       }
@@ -119,15 +119,14 @@ export function createCmuxDriver(): RuntimeDriver {
 
     async stop(ref: string): Promise<void> {
       try {
-        cmux(`close-workspace --workspace "${ref}"`);
+        cmux(["close-workspace", "--workspace", ref]);
       } catch { /* may already be closed */ }
     },
 
     async newPane(opts: RuntimePaneOptions): Promise<PaneRef> {
-      const titleArg = opts.title ? ` --title "${escape(opts.title)}"` : "";
       const cmd = opts.direction === "tab"
-        ? `new-surface --type terminal --workspace "${opts.workspaceId}"`
-        : `new-pane --type terminal --direction ${opts.direction} --workspace "${opts.workspaceId}"`;
+        ? ["new-surface", "--type", "terminal", "--workspace", opts.workspaceId]
+        : ["new-pane", "--type", "terminal", "--direction", opts.direction, "--workspace", opts.workspaceId];
       const output = cmux(cmd);
       const surfaceId = output.match(/surface:\d+/)?.[0];
       if (!surfaceId) {
@@ -136,7 +135,7 @@ export function createCmuxDriver(): RuntimeDriver {
       }
       if (opts.title) {
         try {
-          cmux(`rename-tab --workspace "${opts.workspaceId}" --surface "${surfaceId}"${titleArg}`);
+          cmux(["rename-tab", "--workspace", opts.workspaceId, "--surface", surfaceId, "--title", opts.title]);
         } catch { /* rename is best-effort */ }
       }
       return { workspaceId: opts.workspaceId, surfaceId };
@@ -144,18 +143,18 @@ export function createCmuxDriver(): RuntimeDriver {
 
     async closePane(pane: PaneRef): Promise<void> {
       try {
-        cmux(`close-surface --workspace "${pane.workspaceId}" --surface "${pane.surfaceId}"`);
+        cmux(["close-surface", "--workspace", pane.workspaceId, "--surface", pane.surfaceId]);
       } catch { /* may already be closed */ }
     },
 
     async sendToPane(pane: PaneRef, message: string): Promise<void> {
-      cmux(`send --workspace "${pane.workspaceId}" --surface "${pane.surfaceId}" "${escape(message)}"`);
-      cmux(`send-key --workspace "${pane.workspaceId}" --surface "${pane.surfaceId}" Enter`);
+      cmux(["send", "--workspace", pane.workspaceId, "--surface", pane.surfaceId, message]);
+      cmux(["send-key", "--workspace", pane.workspaceId, "--surface", pane.surfaceId, "Enter"]);
     },
 
     async readPaneScreen(pane: PaneRef): Promise<string> {
       try {
-        return cmux(`read-screen --workspace "${pane.workspaceId}" --surface "${pane.surfaceId}"`);
+        return cmux(["read-screen", "--workspace", pane.workspaceId, "--surface", pane.surfaceId]);
       } catch {
         return "";
       }
@@ -171,11 +170,10 @@ export function createCmuxDriver(): RuntimeDriver {
       // a new tab for "visible" (debug ergonomics). The resize-pane verb is
       // best-effort; if cmux rejects it, the default split size is acceptable.
       const wsId = opts.captainWorkspace.id;
-      const titleArg = opts.title ? ` --title "${escape(opts.title)}"` : "";
       const verb =
         opts.placement === "visible"
-          ? `new-surface --type terminal --workspace "${wsId}"`
-          : `new-pane --type terminal --direction down --workspace "${wsId}"`;
+          ? ["new-surface", "--type", "terminal", "--workspace", wsId]
+          : ["new-pane", "--type", "terminal", "--direction", "down", "--workspace", wsId];
       const output = cmux(verb);
       const surfaceId = output.match(/surface:\d+/)?.[0];
       if (!surfaceId) {
@@ -183,28 +181,28 @@ export function createCmuxDriver(): RuntimeDriver {
       }
       if (opts.title) {
         try {
-          cmux(`rename-tab --workspace "${wsId}" --surface "${surfaceId}"${titleArg}`);
+          cmux(["rename-tab", "--workspace", wsId, "--surface", surfaceId, "--title", opts.title]);
         } catch { /* rename is best-effort */ }
       }
-      cmux(`send --workspace "${wsId}" --surface "${surfaceId}" "${escape(opts.command)}"`);
-      cmux(`send-key --workspace "${wsId}" --surface "${surfaceId}" Enter`);
+      cmux(["send", "--workspace", wsId, "--surface", surfaceId, opts.command]);
+      cmux(["send-key", "--workspace", wsId, "--surface", surfaceId, "Enter"]);
       if (opts.placement === "hidden") {
         try {
-          cmux(`resize-pane --workspace "${wsId}" --surface "${surfaceId}" --rows 1`);
+          cmux(["resize-pane", "--workspace", wsId, "--surface", surfaceId, "--rows", "1"]);
         } catch { /* resize is best-effort; default split size is the fallback */ }
       }
       return { workspaceId: wsId, surfaceId, title: opts.title };
     },
 
     async sendToSurface(surface: PaneRef, text: string): Promise<void> {
-      cmux(`send --workspace "${surface.workspaceId}" --surface "${surface.surfaceId}" "${escape(text)}"`);
-      cmux(`send-key --workspace "${surface.workspaceId}" --surface "${surface.surfaceId}" Enter`);
+      cmux(["send", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, text]);
+      cmux(["send-key", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, "Enter"]);
     },
 
     async listSurfaces(workspaceId: string): Promise<PaneRef[]> {
       let output: string;
       try {
-        output = cmux(`tree --workspace "${workspaceId}"`);
+        output = cmux(["tree", "--workspace", workspaceId]);
       } catch {
         return [];
       }


### PR DESCRIPTION
## Summary

P0 data-loss fix. `src/runtimes/cmux.ts` built shell command strings and ran them via `execSync`, so untrusted crew-prompt text containing backticks or `$()` was command-injected by `/bin/sh`. A prompt with a backtick-wrapped destructive command (e.g. `cmux close-workspace`) executed it, tearing down the live captain workspace and all its crew tabs — the root cause of the "captain workspace closes suddenly" / `exit 137` reports.

- Convert the `cmux()` helper and **all 12 call sites** to `execFileSync(CMUX_BIN, argv[])` with **no shell**, so every argument (especially message text via `sendToPane`/`sendToSurface`/`send`/`spawnInjector`) is passed as a single literal argv element and never parsed for shell metacharacters.
- Drop the `escape()` double-quote hack — unnecessary with argv arrays, and it never covered backticks/`$` anyway.
- Public `RuntimeDriver` method signatures are unchanged; the fix is entirely internal to the driver (impact analysis: MEDIUM, all callers contained in `cmux.ts`).

## Test plan

- [x] Regression test: `sendToPane` / `sendToSurface` with a message containing `` `cmux close-workspace` `` and `$(rm -rf /)` asserts the message reaches cmux as one literal argv element, not executed.
- [x] Rewrote the existing cmux test suite to the argv contract (mock `execFileSync`, inspect argv instead of shell strings).
- [x] `npm run lint` (tsc) clean.
- [x] Full suite green: 580 passed (73 files).

## Follow-up (out of scope, flagging)

`src/notifiers/cmux.ts:32` has the **same injection class** — `escape(message)` interpolated into an `execSync` shell string. Not touched here to keep this PR surgical to #118; recommend a follow-up issue to apply the same `execFileSync` treatment.