### PR TITLE
fix(notifiers): eliminate cmux notify shell injection (closes #120)

### DIFF
--- a/src/notifiers/__tests__/cmux.test.ts
+++ b/src/notifiers/__tests__/cmux.test.ts
@@ -2,37 +2,49 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createCmuxNotifier } from "../cmux.js";
 
 const execMock = vi.hoisted(() => vi.fn());
+const execFileMock = vi.hoisted(() => vi.fn());
 vi.mock("node:child_process", () => ({
   execSync: execMock,
+  execFileSync: execFileMock,
 }));
 
 describe("CmuxNotifier", () => {
   beforeEach(() => {
     execMock.mockReset();
+    execFileMock.mockReset();
   });
 
   it("has name 'cmux'", () => {
     expect(createCmuxNotifier({}).name).toBe("cmux");
   });
 
-  it("notify shells out to 'cockpit runtime send --command'", async () => {
-    execMock.mockReturnValue("");
+  it("notify invokes 'cockpit runtime send --command' with the message as one argv element", async () => {
+    execFileMock.mockReturnValue("");
     await createCmuxNotifier({}).notify("hello world");
-    const calls = execMock.mock.calls.map((c) => c[0] as string);
-    expect(calls[0]).toContain("cockpit runtime send");
-    expect(calls[0]).toContain("--command");
-    expect(calls[0]).toContain("hello world");
+    expect(execFileMock).toHaveBeenCalledWith(
+      "cockpit",
+      ["runtime", "send", "--command", "hello world"],
+      expect.anything(),
+    );
   });
 
-  it("notify escapes double-quotes in the message", async () => {
-    execMock.mockReturnValue("");
-    await createCmuxNotifier({}).notify('say "hi"');
-    const calls = execMock.mock.calls.map((c) => c[0] as string);
-    expect(calls[0]).toContain('\\"hi\\"');
+  // Regression for #120: notification text containing backtick-wrapped or $()
+  // commands must reach the spawn as a single literal argv element, never parsed
+  // by a shell. Same class as #118/#119.
+  it("notify delivers backtick/$() shell metacharacters as a literal argv element, not executed", async () => {
+    execFileMock.mockReturnValue("");
+    const malicious = 'done `cmux close-workspace` and $(rm -rf /)';
+    await createCmuxNotifier({}).notify(malicious);
+    const call = execFileMock.mock.calls[0];
+    expect(call[0]).toBe("cockpit");
+    const argv = call[1] as string[];
+    // The entire message — backticks, $(), and all — is one untouched argv element.
+    expect(argv).toEqual(["runtime", "send", "--command", malicious]);
+    expect(argv[argv.length - 1]).toBe(malicious);
   });
 
   it("notify throws when cockpit runtime send fails", async () => {
-    execMock.mockImplementation(() => { throw new Error("send failed"); });
+    execFileMock.mockImplementation(() => { throw new Error("send failed"); });
     await expect(createCmuxNotifier({}).notify("x")).rejects.toThrow(/send failed/);
   });
 

--- a/src/notifiers/cmux.ts
+++ b/src/notifiers/cmux.ts
@@ -1,13 +1,9 @@
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import type {
   NotifierDriver,
   NotifierProbeResult,
   NotifierScope,
 } from "./types.js";
-
-function escape(s: string): string {
-  return s.replace(/"/g, '\\"');
-}
 
 export function createCmuxNotifier(_scope: NotifierScope): NotifierDriver {
   return {
@@ -29,7 +25,10 @@ export function createCmuxNotifier(_scope: NotifierScope): NotifierDriver {
     },
 
     async notify(message: string): Promise<void> {
-      execSync(`cockpit runtime send --command "${escape(message)}"`, { encoding: "utf-8" });
+      // execFileSync with an argv array and NO shell: the message is one literal
+      // argv element, so backticks / $() in notification text are never parsed
+      // by a shell. See #120 (same class as #118/#119).
+      execFileSync("cockpit", ["runtime", "send", "--command", message], { encoding: "utf-8" });
     },
   };
 }


### PR DESCRIPTION
## Summary
- `CmuxNotifier.notify` built a shell command string and ran it via `execSync`, with an `escape()` helper that only escaped double-quotes — so notification text containing backticks or `$()` was command-substituted by `/bin/sh`. Same injection class as #118 (fixed in #119), now in the notifier.
- Replaced the `execSync(string)` call with `execFileSync("cockpit", ["runtime", "send", "--command", message], …)` and no shell, so the message is a single literal argv element that is never parsed for shell metacharacters.
- Removed the now-unused `escape()` helper. `probe()` still uses `execSync` with a constant command string (no untrusted input).

## Test plan
- [x] New regression test: a notify message containing `` `cmux close-workspace` `` / `$(rm -rf /)` reaches the spawn as one literal argv element, not executed.
- [x] `npx tsc --noEmit` clean.
- [x] Full suite green (`npx vitest run` — 580 tests passed).

closes #120