### PR TITLE
fix(runtimes): notify-relay as hidden background tab, not split-pane (#117)

### DIFF
--- a/scripts/notify-relay-placement-smoke.mjs
+++ b/scripts/notify-relay-placement-smoke.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// Live E2E for #117: spawnInjector("hidden") must NOT create a split-pane and
+// must NOT steal focus. Drives the real built cmux driver against a throwaway
+// cmux workspace, then inspects `cmux tree` to assert:
+//   1. the workspace has exactly ONE pane (a split would create a second)
+//   2. the relay surface exists as a background tab in that pane
+//   3. the surface selected before spawn is still [selected] afterward
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+
+const CMUX = "/Applications/cmux.app/Contents/Resources/bin/cmux";
+const cmux = (args) => execFileSync(CMUX, args, { encoding: "utf-8" }).trim();
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const { createCmuxDriver } = await import(
+  "file://" + join(__dirname, "..", "dist", "runtimes", "cmux.js")
+);
+
+let failures = 0;
+const assert = (cond, label) => {
+  console.log(`  ${cond ? "✓" : "✗"} ${label}`);
+  if (!cond) failures++;
+};
+
+const out = cmux(["new-workspace", "--cwd", "/tmp", "--command", "bash"]);
+const ws = out.match(/workspace:\d+/)?.[0];
+cmux(["rename-workspace", "--workspace", ws, "zz-117-smoke"]);
+const driver = createCmuxDriver();
+
+try {
+  const treeBefore = cmux(["tree", "--workspace", ws]);
+  const capSurface = treeBefore.match(/(surface:\d+)\s+\[terminal\][^\n]*\[selected\]/)?.[1];
+  console.log(`workspace=${ws} captain surface=${capSurface}`);
+
+  const pane = await driver.spawnInjector({
+    captainWorkspace: { id: ws, name: "zz-117-smoke", status: "running" },
+    command: "echo notify-relay-stub; sleep 30",
+    title: "✉ notify-relay",
+    placement: "hidden",
+  });
+  console.log(`spawnInjector returned ${pane.surfaceId}`);
+
+  const tree = cmux(["tree", "--workspace", ws]);
+  console.log("--- tree after spawnInjector(hidden) ---\n" + tree);
+
+  const paneCount = (tree.match(/^\s*[├└]?[─ ]*pane\s+pane:\d+/gm) || []).length;
+  assert(paneCount === 1, `exactly ONE pane — no split (got ${paneCount})`);
+
+  const surfaces = (tree.match(/surface:\d+/g) || []);
+  assert(surfaces.includes(pane.surfaceId), `relay surface ${pane.surfaceId} present as a tab`);
+
+  const selected = tree.match(/(surface:\d+)\s+\[terminal\][^\n]*\[selected\]/)?.[1];
+  assert(selected === capSurface, `captain surface ${capSurface} still [selected] (relay did NOT steal focus; got ${selected})`);
+
+  console.log(`\n${failures === 0 ? "✔ PLACEMENT SMOKE PASSED" : `✗ ${failures} FAILURES`}`);
+} finally {
+  cmux(["close-workspace", "--workspace", ws]);
+  process.exit(failures > 0 ? 1 : 0);
+}

--- a/src/commands/launch.ts
+++ b/src/commands/launch.ts
@@ -170,13 +170,12 @@ function buildAgentCmd(
 const NOTIFY_RELAY_TAB_TITLE = "✉ notify-relay";
 
 /**
- * Add the notify-relay to a captain workspace as a hidden split-pane. The
+ * Add the notify-relay to a captain workspace as a hidden background tab. The
  * relay tails the daemon's per-project mailbox and forwards each new event to
  * the captain pane via runtime.sendToSurface — required because cmux refuses
  * any caller not descended from its app process, so the daemon itself cannot
- * deliver. Dedups by closing any pre-existing relay surface (visible tab or
- * hidden split) before respawning, so the relay always boots fresh with the
- * current cockpit binary.
+ * deliver. Dedups by closing any pre-existing relay surface before respawning,
+ * so the relay always boots fresh with the current cockpit binary.
  */
 async function ensureNotifyRelayTab(
   runtime: RuntimeDriver,

--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -281,6 +281,104 @@ describe("cmux driver", () => {
     expect(cmds.some((c) => c.includes("send-key") && c.includes("--surface surface:8") && c.includes("Enter"))).toBe(true);
   });
 
+  // #117: hidden placement must NOT create a split-pane. cmux 0.62.2 has no
+  // resize-pane verb, so a `new-pane --direction down` split can never be
+  // shrunk and stays a full-height 50/50 split forever. A background tab
+  // (new-surface) keeps the captain pane full-height with no split.
+  it("spawnInjector hidden uses new-surface (no split-pane, no resize-pane)", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      const cmd = args.join(" ");
+      if (cmd.includes("tree")) return 'surface surface:5 [terminal] "cap" [selected]';
+      if (cmd.includes("new-surface")) return "OK surface:8 pane:2 workspace:1";
+      return "";
+    });
+    const pane = await driver.spawnInjector({
+      captainWorkspace: { id: "workspace:1", name: "cap", status: "running" },
+      command: "cockpit notify-relay proj --as captain",
+      title: "✉ notify-relay",
+      placement: "hidden",
+    });
+    expect(pane).toEqual({ workspaceId: "workspace:1", surfaceId: "surface:8", title: "✉ notify-relay" });
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.includes("new-surface") && c.includes("--workspace workspace:1"))).toBe(true);
+    expect(cmds.every((c) => !c.includes("new-pane"))).toBe(true);
+    expect(cmds.every((c) => !c.includes("--direction down"))).toBe(true);
+    expect(cmds.every((c) => !c.includes("resize-pane"))).toBe(true);
+  });
+
+  it("spawnInjector hidden sends the command + Enter to the new surface", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      const cmd = args.join(" ");
+      if (cmd.includes("tree")) return 'surface surface:5 [terminal] "cap" [selected]';
+      if (cmd.includes("new-surface")) return "OK surface:8 pane:2 workspace:1";
+      return "";
+    });
+    await driver.spawnInjector({
+      captainWorkspace: { id: "workspace:1", name: "cap", status: "running" },
+      command: "cockpit notify-relay proj --as captain",
+      placement: "hidden",
+    });
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.includes("send ") && c.includes("--surface surface:8") && c.includes("cockpit notify-relay proj") && !c.includes("send-key"))).toBe(true);
+    expect(cmds.some((c) => c.includes("send-key") && c.includes("--surface surface:8") && c.includes("Enter"))).toBe(true);
+  });
+
+  // The relay tab must never steal focus from the captain: after spawning it we
+  // re-select whichever surface was selected before, in its original position.
+  it("spawnInjector hidden restores focus to the previously-selected surface", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      const cmd = args.join(" ");
+      if (cmd.includes("tree")) {
+        return [
+          'surface surface:5 [terminal] "cap" [selected]',
+          'surface surface:6 [terminal] "crew-1"',
+        ].join("\n");
+      }
+      if (cmd.includes("new-surface")) return "OK surface:8 pane:2 workspace:1";
+      return "";
+    });
+    await driver.spawnInjector({
+      captainWorkspace: { id: "workspace:1", name: "cap", status: "running" },
+      command: "cockpit notify-relay proj --as captain",
+      placement: "hidden",
+    });
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) =>
+      c.includes("move-surface") &&
+      c.includes("--surface surface:5") &&
+      c.includes("--index 0") &&
+      c.includes("--focus true"))).toBe(true);
+  });
+
+  it("spawnInjector visible uses new-surface and leaves the new tab focused (no refocus)", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      const cmd = args.join(" ");
+      if (cmd.includes("tree")) return 'surface surface:5 [terminal] "cap" [selected]';
+      if (cmd.includes("new-surface")) return "OK surface:8 pane:2 workspace:1";
+      return "";
+    });
+    await driver.spawnInjector({
+      captainWorkspace: { id: "workspace:1", name: "cap", status: "running" },
+      command: "cockpit notify-relay proj --as captain",
+      placement: "visible",
+    });
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.includes("new-surface"))).toBe(true);
+    expect(cmds.every((c) => !c.includes("move-surface"))).toBe(true);
+  });
+
+  it("spawnInjector throws when new-surface returns no surface id", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.join(" ").includes("tree")) return "";
+      return "garbage";
+    });
+    await expect(driver.spawnInjector({
+      captainWorkspace: { id: "workspace:1", name: "cap", status: "running" },
+      command: "x",
+      placement: "hidden",
+    })).rejects.toThrow(/did not return a surface/);
+  });
+
   it("listSurfaces parses cmux tree output and returns surfaces with titles", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
       if (args.includes("tree")) {

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -25,6 +25,20 @@ function parseList(output: string): WorkspaceRef[] {
   return refs;
 }
 
+// Parse `cmux tree` into the ordered list of surfaces in a workspace, marking
+// which one is currently selected. Order matches the tab strip, so the array
+// index doubles as the surface's position for move-surface --index.
+function parseSurfaceOrder(tree: string): { id: string; selected: boolean }[] {
+  const surfaces: { id: string; selected: boolean }[] = [];
+  for (const line of tree.split("\n")) {
+    const match = line.match(/surface\s+(surface:\d+)/);
+    if (match) {
+      surfaces.push({ id: match[1], selected: line.includes("[selected]") });
+    }
+  }
+  return surfaces;
+}
+
 export function createCmuxDriver(): RuntimeDriver {
   return {
     name: "cmux",
@@ -166,15 +180,27 @@ export function createCmuxDriver(): RuntimeDriver {
       title?: string;
       placement: "hidden" | "visible";
     }): Promise<PaneRef> {
-      // Use a split-pane for "hidden" (shares a tab, can be resized small) and
-      // a new tab for "visible" (debug ergonomics). The resize-pane verb is
-      // best-effort; if cmux rejects it, the default split size is acceptable.
+      // Both placements use a background tab (new-surface) in the captain's
+      // existing pane — full-height, NO split. A split-pane is wrong here:
+      // cmux 0.62.2 has no resize/hide verb, so a `new-pane` split can never be
+      // shrunk and stays an ugly full-height 50/50 split forever (#117). The
+      // relay still runs as a cmux descendant in the same workspace, preserving
+      // the in-cmux delivery requirement (#112).
+      //
+      // "hidden" then re-selects whatever surface was focused before, in its
+      // original position, so the relay tab never steals focus from the
+      // captain. "visible" leaves the new tab focused for debug ergonomics.
       const wsId = opts.captainWorkspace.id;
-      const verb =
-        opts.placement === "visible"
-          ? ["new-surface", "--type", "terminal", "--workspace", wsId]
-          : ["new-pane", "--type", "terminal", "--direction", "down", "--workspace", wsId];
-      const output = cmux(verb);
+      let priorSurface: string | undefined;
+      let priorIndex = -1;
+      if (opts.placement === "hidden") {
+        try {
+          const before = parseSurfaceOrder(cmux(["tree", "--workspace", wsId]));
+          priorIndex = before.findIndex((s) => s.selected);
+          if (priorIndex >= 0) priorSurface = before[priorIndex].id;
+        } catch { /* best-effort: if we can't read the tree, skip refocus */ }
+      }
+      const output = cmux(["new-surface", "--type", "terminal", "--workspace", wsId]);
       const surfaceId = output.match(/surface:\d+/)?.[0];
       if (!surfaceId) {
         throw new Error(`cmux spawnInjector did not return a surface id: ${output}`);
@@ -186,10 +212,10 @@ export function createCmuxDriver(): RuntimeDriver {
       }
       cmux(["send", "--workspace", wsId, "--surface", surfaceId, opts.command]);
       cmux(["send-key", "--workspace", wsId, "--surface", surfaceId, "Enter"]);
-      if (opts.placement === "hidden") {
+      if (opts.placement === "hidden" && priorSurface) {
         try {
-          cmux(["resize-pane", "--workspace", wsId, "--surface", surfaceId, "--rows", "1"]);
-        } catch { /* resize is best-effort; default split size is the fallback */ }
+          cmux(["move-surface", "--surface", priorSurface, "--index", String(priorIndex), "--focus", "true"]);
+        } catch { /* refocus is best-effort */ }
       }
       return { workspaceId: wsId, surfaceId, title: opts.title };
     },

--- a/src/runtimes/types.ts
+++ b/src/runtimes/types.ts
@@ -59,8 +59,9 @@ export interface RuntimeDriver {
   // so any IPC/socket constraints of the runtime (e.g. cmux's parent-lineage
   // check) are satisfied. Returns a PaneRef the caller can inspect/clean up.
   //
-  // placement: "hidden" produces a non-distracting surface (zero/minimal-size
-  // split, off-screen tab — runtime decides). "visible" produces a normal pane.
+  // placement: "hidden" produces a non-distracting background tab that does not
+  // steal focus from the captain (runtime decides how). "visible" produces a
+  // normal focused tab for debug ergonomics.
   spawnInjector(opts: {
     captainWorkspace: WorkspaceRef;
     command: string;


### PR DESCRIPTION
## Summary

Closes #117. The notify-relay was showing up as an ugly full-height 50/50 split-pane under the captain.

**Root cause:** `spawnInjector({ placement: "hidden" })` created a split via `cmux new-pane --direction down`, then tried `cmux resize-pane --rows 1` to shrink it. cmux 0.62.2 has **no `resize-pane` verb at all**, so the `try/catch` silently swallowed the error and the split stayed full-height forever.

**Fix:** `placement: "hidden"` now uses a **background tab** (`cmux new-surface`) in the captain's existing pane — full-height, no split — then re-selects whichever surface was focused before (`move-surface --surface <prior> --index <N> --focus true`) so the relay tab never steals focus. `"visible"` keeps the focused-tab behavior for debug ergonomics.

The relay stays a cmux descendant in the same workspace, so the in-cmux delivery requirement from #112 is preserved.

## Changes
- `src/runtimes/cmux.ts` — rewrite `spawnInjector` hidden path (tab, not split); add `parseSurfaceOrder` helper to find the previously-selected surface + its index
- `src/runtimes/types.ts`, `src/commands/launch.ts` — update stale "split-pane" doc comments
- `src/runtimes/__tests__/cmux.test.ts` — 5 new tests: hidden uses new-surface (no `new-pane`/`--direction down`/`resize-pane`), sends command to the relay surface, restores focus to the prior surface; visible leaves the new tab focused; throws on missing surface id
- `scripts/notify-relay-placement-smoke.mjs` — live cmux E2E asserting single pane / relay-as-tab / captain keeps focus

## Verification
- `npx vitest run` — **585 passed** (incl. 5 new spawnInjector tests)
- `npx tsc --noEmit` — clean
- `node scripts/mailbox-injector-smoke.mjs` — mailbox→relay→captain delivery pipeline still passes (unchanged by this fix)
- `node scripts/notify-relay-placement-smoke.mjs` — live cmux 0.62.2, built dist:
  - ✓ exactly ONE pane — no split
  - ✓ relay surface present as a background tab
  - ✓ captain surface still `[selected]` (relay did NOT steal focus)
- gitnexus impact on `spawnInjector`: **LOW** (no graph callers; reached via `RuntimeDriver` interface)

## Test plan
- [ ] `cockpit launch <project>` → captain pane is full-height with no visible split, `✉ notify-relay` present as a background tab
- [ ] Trigger a CREW DONE event → captain receives the relayed message