### PR TITLE
fix(crew): refresh heartbeat mid-turn via PostToolUse hook (fixes false CREW STALLED)

### DIFF
--- a/src/control/__tests__/interactive-claude-hook.test.ts
+++ b/src/control/__tests__/interactive-claude-hook.test.ts
@@ -19,6 +19,14 @@ describe("mapClaudeHookToEvent", () => {
     expect(ev).toEqual({ type: "task.progress", id: TID, note: "sessionend" });
   });
 
+  // PostToolUse fires after every tool call MID-turn, so it keeps the
+  // heartbeat fresh during long working turns (fixes false CREW STALLED).
+  // It must map to liveness, never a terminal state.
+  it("maps PostToolUse → task.progress with note 'posttooluse' (mid-turn liveness, NOT terminal)", () => {
+    const ev = mapClaudeHookToEvent("PostToolUse", { tool_name: "Bash" }, TID);
+    expect(ev).toEqual({ type: "task.progress", id: TID, note: "posttooluse" });
+  });
+
   it("unknown event → null", () => {
     expect(mapClaudeHookToEvent("UserPromptSubmit", {}, TID)).toBeNull();
     expect(mapClaudeHookToEvent("PreToolUse", {}, TID)).toBeNull();

--- a/src/control/__tests__/interactive-claude.test.ts
+++ b/src/control/__tests__/interactive-claude.test.ts
@@ -12,6 +12,12 @@ describe("claude interactive hook merge", () => {
     expect(out.hooks.SessionEnd[0].hooks[0].command).toContain(HOOK_CMD);
   });
 
+  it("adds a PostToolUse hook (mid-turn liveness) so the heartbeat stays fresh during long turns", () => {
+    const out = mergeClaudeHooks({}, HOOK_CMD);
+    expect(out.hooks.PostToolUse[0].hooks[0].command).toContain(HOOK_CMD);
+    expect(out.hooks.PostToolUse[0].hooks[0].command).toContain("PostToolUse");
+  });
+
   it("is idempotent — merging twice yields one cockpit entry per event", () => {
     const once = mergeClaudeHooks({}, HOOK_CMD);
     const twice = mergeClaudeHooks(once, HOOK_CMD);

--- a/src/control/interactive/claude.ts
+++ b/src/control/interactive/claude.ts
@@ -2,7 +2,11 @@ import { execSync } from "node:child_process";
 import type { InteractiveHookAdapter } from "./types.js";
 import type { ControlEvent } from "../types.js";
 
-const EVENTS = ["Stop", "SubagentStop", "SessionEnd"] as const;
+// PostToolUse fires after EVERY tool call mid-turn — it is the only liveness
+// signal that refreshes the heartbeat while a crew is still working. Stop/
+// SubagentStop/SessionEnd fire only at turn boundaries, so a long working turn
+// would otherwise exceed heartbeatBudgetMs and trip a false CREW STALLED alert.
+const EVENTS = ["Stop", "SubagentStop", "SessionEnd", "PostToolUse"] as const;
 
 /**
  * Probe whether the local Claude CLI supports `--settings <path>`. The
@@ -41,8 +45,10 @@ export function mergeClaudeHooks(settings: any, hookCmd: string): any {
  * Map a Claude hook event name to a cockpit ControlEvent. Pure function —
  * isolated for testability and to codify the anti-#2576 invariant in one
  * place: NO Claude hook ever maps to `task.done`/`task.failed`/`task.blocked`.
- * Bare Stop/SubagentStop/SessionEnd = liveness only. Terminal state comes
- * exclusively from explicit `cockpit crew signal` (Task 4).
+ * Stop/SubagentStop/SessionEnd/PostToolUse = liveness only. Terminal state
+ * comes exclusively from explicit `cockpit crew signal` (Task 4).
+ * PostToolUse is the mid-turn heartbeat (fires per tool call); the others are
+ * turn-boundary liveness.
  */
 export function mapClaudeHookToEvent(
   event: string,
@@ -53,6 +59,7 @@ export function mapClaudeHookToEvent(
     case "Stop":
     case "SubagentStop":
     case "SessionEnd":
+    case "PostToolUse":
       return { type: "task.progress", id: taskId, note: event.toLowerCase() };
     default:
       return null;

--- a/src/lib/__tests__/per-crew-settings.test.ts
+++ b/src/lib/__tests__/per-crew-settings.test.ts
@@ -34,6 +34,15 @@ describe("writePerCrewSettings", () => {
     expect(stopCmd).toContain("Stop");
   });
 
+  it("includes a PostToolUse liveness hook (mid-turn heartbeat → fixes false CREW STALLED)", () => {
+    const out = writePerCrewSettings({ stateRoot: tmp, project: "alpha", taskId: "tid-1" });
+    const json = JSON.parse(fs.readFileSync(out, "utf-8"));
+    expect(Array.isArray(json.hooks.PostToolUse)).toBe(true);
+    const cmd = json.hooks.PostToolUse[0].hooks[0].command;
+    expect(cmd).toContain("cockpit crew _hook");
+    expect(cmd).toContain("PostToolUse");
+  });
+
   it("custom hookCmd is honored", () => {
     const out = writePerCrewSettings({
       stateRoot: tmp,


### PR DESCRIPTION
## Summary

Fixes false **CREW STALLED: no heartbeat** alerts on crews that are actively working.

## Root-cause trace (captain-confirmed, verified by crew)

The crew heartbeat was refreshed **only** by Claude's `Stop`/`SubagentStop`/`SessionEnd` hooks, bridged via `cockpit crew _hook` → `task.progress` (liveness). See `src/commands/crew-control.ts:218-249` (the `_hook` command) and the comment at `src/commands/crew.ts:181-184`. Those hooks fire **only at TURN boundaries** (when the crew stops generating), **never mid-turn**.

- **Budget:** `heartbeatBudgetMs ?? 300000` = 5 min (`src/commands/crew-control.ts:65`).
- **Detection:** `daemon.sweep()` → `evaluateStall()` (`src/control/watchdog.ts:13`) flags any `working` task where `now - lastHeartbeat > budget`; `firePush` emits the alert on the `working`→`stalled` transition.

So a single working turn longer than 5 minutes (common for real crew tasks) exceeded the budget while the crew was still healthy, tripping a false stall.

## Fix

Add a `PostToolUse` hook to the per-crew `settings.json`. `PostToolUse` fires after **every tool call mid-turn**, so the heartbeat stays fresh while the crew works.

- `mergeClaudeHooks` now includes `PostToolUse` in its event list (`src/control/interactive/claude.ts`), so the generated per-crew `settings.json` maps `PostToolUse` → `cockpit crew _hook PostToolUse`.
- `mapClaudeHookToEvent` maps `PostToolUse` → `task.progress` (liveness), **preserving the anti-#2576 invariant**: no Claude hook ever maps to a terminal state (`task.done`/`task.failed`/`task.blocked`). Terminal state still comes exclusively from explicit `cockpit crew signal`.

## Test evidence

TDD — tests written first (RED), then implementation (GREEN):
- `interactive-claude-hook.test.ts`: `PostToolUse` → `task.progress` note `posttooluse` (liveness, not terminal); existing anti-#2576 sweep still passes.
- `interactive-claude.test.ts`: `mergeClaudeHooks` emits a `PostToolUse` hook pointing at `cockpit crew _hook PostToolUse`.
- `per-crew-settings.test.ts`: generated `settings.json` includes the `PostToolUse` liveness hook.

`npx vitest run` → 588 passed (1 unrelated flaky temp-dir `ENOTEMPTY` race in `integration-restart.test.ts`, passes in isolation). `npx tsc --noEmit` → clean (exit 0).

## Test plan
- [ ] Spawn a real Claude crew, give it a task with a >5 min working turn, confirm no false CREW STALLED alert fires.
- [ ] Confirm terminal state still arrives only via `cockpit crew signal done`.

Do NOT merge — captain to review.