### PR TITLE
fix(launch): stop cmux stderr leaking to captain terminal (#121 Issue B)

### DIFF
--- a/src/commands/__tests__/launch.test.ts
+++ b/src/commands/__tests__/launch.test.ts
@@ -1,0 +1,51 @@
+// src/commands/__tests__/launch.test.ts
+//
+// #121 Issue B: a raw "Error: not_found: Pane not found" line leaked to the
+// captain's terminal on `cockpit launch <project> --fresh`. Root cause: the
+// select-workspace / current-workspace calls in launch.ts used the default
+// execSync/execFileSync stdio, which forwards the child's stderr straight to
+// the parent terminal. The fix routes them through cmuxLocal, which pipes
+// (captures) fd 2 instead of inheriting it. These tests pin that contract.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const execFileMock = vi.hoisted(() => vi.fn());
+vi.mock("node:child_process", () => ({
+  // launch.ts imports both; only execFileSync is exercised by cmuxLocal.
+  execFileSync: execFileMock,
+  execSync: vi.fn(),
+}));
+
+import { cmuxLocal } from "../launch.js";
+
+describe("cmuxLocal (launch.ts direct-cmux helper)", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  it("invokes cmux via execFileSync with the argv array (no shell)", () => {
+    execFileMock.mockReturnValue("");
+    cmuxLocal(["select-workspace", "--workspace", "workspace:3"]);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    const [bin, args] = execFileMock.mock.calls[0];
+    expect(bin).toContain("cmux");
+    expect(args).toEqual(["select-workspace", "--workspace", "workspace:3"]);
+  });
+
+  it("pipes the child's stderr instead of inheriting it (the #121 leak fix)", () => {
+    execFileMock.mockReturnValue("");
+    cmuxLocal(["current-workspace"]);
+    const opts = execFileMock.mock.calls[0][2] as { stdio?: unknown };
+    expect(Array.isArray(opts.stdio)).toBe(true);
+    const stdio = opts.stdio as unknown[];
+    // fd 2 (stderr) must be captured, never forwarded to the parent terminal.
+    expect(stdio[2]).toBe("pipe");
+    expect(stdio[2]).not.toBe("inherit");
+    expect(stdio).not.toContain("inherit");
+  });
+
+  it("returns trimmed stdout for callers that need the output", () => {
+    execFileMock.mockReturnValue("  workspace:7 cockpit-captain  \n");
+    expect(cmuxLocal(["current-workspace"])).toBe("workspace:7 cockpit-captain");
+  });
+});

--- a/src/commands/launch.ts
+++ b/src/commands/launch.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
@@ -18,6 +18,18 @@ const CMUX_APP = "/Applications/cmux.app";
 const CMUX_BIN = "/Applications/cmux.app/Contents/Resources/bin/cmux";
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "cockpit", "templates");
 const SESSIONS_PATH = path.join(os.homedir(), ".config", "cockpit", "sessions.json");
+
+// Direct cmux invocation for the select-workspace / current-workspace calls
+// not yet abstracted behind RuntimeDriver. Uses execFileSync (no shell) with
+// stderr piped, NOT inherited — cmux prints diagnostics like
+// "Error: not_found: Pane not found" to stderr and exits 0 when focusing a
+// surface that vanished mid-launch (e.g. --fresh closes a stale workspace).
+// The default execSync/execFileSync stdio forwards that stderr to the parent
+// terminal, which is exactly the #121 Issue B leak. Capturing fd 2 here
+// swallows it. Returns trimmed stdout for callers that need it.
+export function cmuxLocal(args: string[]): string {
+  return execFileSync(CMUX_BIN, args, { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+}
 
 interface SessionRecord {
   lastLaunched: string; // YYYY-MM-DD
@@ -222,14 +234,14 @@ async function launchWorkspace(
     console.log(chalk.yellow(`  Workspace '${name}' already exists — switching to it`));
     if (notifyRelayProject) await ensureNotifyRelayTab(runtime, existing, notifyRelayProject);
     // TODO(runtime): select/focus not yet abstracted; direct cmux call retained intentionally
-    execSync(`"${CMUX_BIN}" select-workspace --workspace "${existing.id}"`);
+    cmuxLocal(["select-workspace", "--workspace", existing.id]);
     return;
   }
 
   let currentRef: string | undefined;
   try {
     // TODO(runtime): current-workspace not yet abstracted
-    const cur = execSync(`"${CMUX_BIN}" current-workspace`, { encoding: "utf-8" }).trim();
+    const cur = cmuxLocal(["current-workspace"]);
     currentRef = cur.match(/workspace:\d+/)?.[0];
   } catch { /* ignore */ }
 
@@ -251,10 +263,10 @@ async function launchWorkspace(
 
   if (navigate) {
     // TODO(runtime): select not yet abstracted
-    execSync(`"${CMUX_BIN}" select-workspace --workspace "${ref.id}"`);
+    cmuxLocal(["select-workspace", "--workspace", ref.id]);
   } else if (currentRef) {
     // TODO(runtime): select not yet abstracted
-    execSync(`"${CMUX_BIN}" select-workspace --workspace "${currentRef}"`);
+    cmuxLocal(["select-workspace", "--workspace", currentRef]);
   }
 
   console.log(chalk.green(`  ✔ Workspace '${name}' created`));


### PR DESCRIPTION
## Summary

Fixes **#121 Issue B**: a raw `Error: not_found: Pane not found` line leaks to the captain's terminal on `cockpit launch <project> --fresh`.

### Refined root cause (supersedes the issue body's hypothesis)
The leak is **not** in the `cmux()` runtime helper — #119 already moved that to `execFileSync` (argv, no shell). The actual leak is in `src/commands/launch.ts`, which imported raw `execSync` and called cmux **directly** at the `select-workspace` / `current-workspace` sites, **bypassing the hardened helper**.

`execSync`/`execFileSync` forward the child's stderr to the parent terminal by default (verified empirically: only an explicit `stdio` pipe on fd 2 suppresses it). On `--fresh`, the stale workspace is closed first, so cmux's subsequent focus call hits a surface that no longer exists: it prints `Error: not_found: Pane not found` to stderr **and exits 0** — so no JS error is thrown, the line just leaks to the terminal.

### Fix
Route those four direct calls through a new `cmuxLocal` helper that uses `execFileSync` (no shell) with `stdio: ["ignore", "pipe", "pipe"]` — capturing fd 2 instead of inheriting it. The intentional `open` call in `ensureCmuxReady` (which legitimately uses `stdio: "inherit"`) is left untouched.

## Test plan
- [x] New unit tests (`src/commands/__tests__/launch.test.ts`) pin the contract: cmux is invoked via `execFileSync` with an argv array (no shell), stderr is piped (never `inherit`), and stdout is returned trimmed.
- [x] `npx vitest run` — 591/591 pass.
- [x] `npx tsc --noEmit` — clean.
- [x] Exact-scenario simulation: a command that writes `Error: not_found: Pane not found` to stderr and exits 0 leaks under the old `execSync` pattern but **not** under the new `cmuxLocal` pattern.
- [ ] **Not verified live**: driving a real `cockpit launch cockpit --fresh` twice was not safe from the crew tab (it spawns/closes captain workspaces). Fix is verified by unit test + scenario simulation + code reasoning.

Scope: Issue B only. Do not merge — captain reviews.