### PR TITLE
fix: stop daemon-bounce loop — separate PATH drift from program-arg changes

### DIFF
--- a/src/control/__tests__/launchd.test.ts
+++ b/src/control/__tests__/launchd.test.ts
@@ -1,6 +1,6 @@
 // src/control/__tests__/launchd.test.ts
 import { describe, it, expect } from "vitest";
-import { renderPlist, LABEL, kickstartArgv, sanitizePathForPlist } from "../launchd.js";
+import { renderPlist, LABEL, kickstartArgv, sanitizePathForPlist, programArgsBlock } from "../launchd.js";
 
 describe("launchd plist", () => {
   it("renders a KeepAlive RunAtLoad plist pointing at the daemon entry", () => {
@@ -69,5 +69,24 @@ describe("launchd plist", () => {
     expect(xml).not.toContain("/x/<y>/cockpitd.js");
     // The only `&` occurrences are well-formed entities.
     expect(xml.replace(/&(amp|lt|gt|quot);/g, "")).not.toContain("&");
+  });
+
+  // programArgsBlock: used by ensureDaemon to detect semantic drift (PATH vs
+  // program-args changes). Only program-arg changes warrant a full restart.
+  it("programArgsBlock renders an XML array with both escaped entries", () => {
+    expect(programArgsBlock("/usr/local/bin/node", "/opt/cockpit/dist/control/cockpitd.js")).toBe(
+      "<array><string>/usr/local/bin/node</string><string>/opt/cockpit/dist/control/cockpitd.js</string></array>"
+    );
+  });
+
+  it("programArgsBlock escapes special chars like renderPlist does", () => {
+    expect(programArgsBlock("/u&s/r/bin/<node>", "/x/y/z.js")).toBe(
+      "<array><string>/u&amp;s/r/bin/&lt;node&gt;</string><string>/x/y/z.js</string></array>"
+    );
+  });
+
+  it("programArgsBlock matches the actual array emitted by renderPlist", () => {
+    const xml = renderPlist("/nvm/v24/bin/node", "/dist/cockpitd.js");
+    expect(xml).toContain(programArgsBlock("/nvm/v24/bin/node", "/dist/cockpitd.js"));
   });
 });

--- a/src/control/launchd.ts
+++ b/src/control/launchd.ts
@@ -76,6 +76,15 @@ export function renderPlist(nodeBin: string, daemonEntry: string, pathEnv = ""):
 }
 
 /**
+ * Semantic fingerprint of the <array> block inside the rendered plist. Used by
+ * ensureDaemon to distinguish program-argument changes (merit a full restart)
+ * from PATH-only changes (write updated plist, don't bounce the daemon).
+ */
+export function programArgsBlock(nodeBin: string, daemonEntry: string): string {
+  return `<array><string>${xmlEscape(nodeBin)}</string><string>${xmlEscape(daemonEntry)}</string></array>`;
+}
+
+/**
  * Pure: which kickstart argv to use. `-k` (kill-then-restart) ONLY when the
  * plist changed. A plain `kickstart` starts a down daemon and is a no-op for a
  * healthy one — so a routine CLI call never bounces a running daemon (this was
@@ -88,32 +97,50 @@ export function kickstartArgv(target: string, plistChanged: boolean): string[] {
 
 /**
  * Idempotent & cheap. Never throws fatally. Writes/reloads the plist ONLY when
- * its content actually changed; otherwise it ensures the daemon is running
- * without killing a healthy one. The daemon entry is resolved internally
- * (see daemonEntryPath) so no caller can pass a wrong path.
+ * its content actually changed; Distinguishes program-argument drift (warrants
+ * a full restart via bootout + bootstrap + kickstart) from PATH-only drift
+ * (write the plist for the next natural restart but never bounce a healthy
+ * daemon). Uses plain `kickstart` (never -k) to avoid the race between -k and
+ * bootout's exit handler that produced exit-113 "service not loaded" errors.
+ * The daemon entry is resolved internally (see daemonEntryPath) so no caller
+ * can pass a wrong path.
  */
 export function ensureDaemon(nodeBin: string = process.execPath): void {
   try {
     const p = plistPath();
-    const desired = renderPlist(nodeBin, daemonEntryPath(), sanitizePathForPlist(process.env.PATH ?? ""));
+    const entry = daemonEntryPath();
+    const desired = renderPlist(nodeBin, entry, sanitizePathForPlist(process.env.PATH ?? ""));
     const current = existsSync(p) ? readFileSync(p, "utf-8") : null;
+    const uid = process.getuid?.() ?? 0;
+    const target = `gui/${uid}/${LABEL}`;
+
     const changed = current !== desired;
+    // Semantic comparison: was the program-arg block itself different (not just
+    // PATH)?  Program-arg changes are rare (rebuild/reinstall) and merit a full
+    // bootout+reload; PATH varies across terminals so it must NOT trigger a
+    // bounce (would orphan in-flight RPCs).
+    const programChanged = current !== null && changed
+      && !current.includes(programArgsBlock(nodeBin, entry));
+
     if (changed) {
       mkdirSync(dirname(p), { recursive: true });
       writeFileSync(p, desired);
     }
-    const uid = process.getuid?.() ?? 0;
-    const target = `gui/${uid}/${LABEL}`;
-    if (changed) {
-      // plist changed → drop the old instance so the new config takes effect
+
+    if (programChanged) {
+      // unload the old instance so bootstrap picks up the new program args
       try { execFileSync("launchctl", ["bootout", target], { stdio: "ignore" }); }
       catch { /* not loaded */ }
     }
+
     try { execFileSync("launchctl", ["bootstrap", `gui/${uid}`, p], { stdio: "ignore" }); }
     catch { /* already bootstrapped */ }
-    // -k only when the plist changed: a routine CLI call must not restart a
-    // healthy daemon (would orphan its in-flight headless children).
-    execFileSync("launchctl", kickstartArgv(target, changed), { stdio: "ignore" });
+
+    // Plain kickstart (never -k): no-op on a healthy daemon, starts one that
+    // was booted-out above or that stopped for other reasons.  -k is avoided
+    // because it races with bootout's exit handler and produces exit-113 when
+    // the service hasn't finished unloading.
+    execFileSync("launchctl", ["kickstart", target], { stdio: "ignore" });
   } catch (e) {
     // daemon ensure is best-effort (still don't throw); CLI fails loud on socket miss
     process.stderr.write(`[cockpit] warn: ensureDaemon failed (${e instanceof Error ? e.message : e})\n`);


### PR DESCRIPTION
## Root Cause (two facets)

### Facet 1 — `kickstart -k` fails (exit 113)
`ensureDaemon` ran `bootout + bootstrap + kickstart -k` when any plist content changed. The `-k` flag sends SIGTERM to the running daemon, but since `bootout` + `bootstrap` already performed a full reload (and `RunAtLoad=true` auto-starts the new instance), `-k` is redundant. Worse, `kickstart -k` races with the daemon exit handler — the daemons `stopped` log and the `kickstart -k` failure fired in the same millisecond in the cockpitd.log. Launchctl reports exit-113 "Could not find service" because the service had not finished unloading.

### Facet 2 — daemon bounces on every CLI call
`process.env.PATH` varies across terminal sessions (nvm, brew, tmux panes, Claude Code shells, etc.) but `sanitizePathForPlist` only filters `~/.claude/plugins/` entries. Every different PATH rewrites the plist → `changed=true` → `kickstart -k` kills the running daemon. 11 bounce cycles on May 28 alone, each forcing all in-flight RPCs to reconnect (likely cause of exit-137 hangs).

## Fix (surgical — only `src/control/launchd.ts` + tests)

1. **New `programArgsBlock()`** — semantic fingerprint of the program-argument `<array>` inside the plist XML.

2. **`ensureDaemon` semantic comparison** — compares program-args separately from full content. Only program-argument changes (reinstall/rebuild) trigger `bootout + bootstrap`. PATH-only changes write the updated plist for the next natural restart but **never bounce a healthy daemon**.

3. **Plain `kickstart` (never `-k`)** — plain kickstart is a no-op on a running daemon and starts a stopped one. This eliminates the exit-113 race entirely.

## Changes
- `src/control/launchd.ts` — added `programArgsBlock()`, rewrote `ensureDaemon` logic
- `src/control/__tests__/launchd.test.ts` — 3 new TDD tests for `programArgsBlock`

## Verification
- `npx vitest run` — 594/594 pass
- `npx tsc --noEmit` — clean