### PR TITLE
fix(crew): add all opencode permission keys + external_directory wildcard to per-crew config

### DIFF
--- a/src/lib/__tests__/per-crew-settings.test.ts
+++ b/src/lib/__tests__/per-crew-settings.test.ts
@@ -88,14 +88,21 @@ describe("writePerCrewOpencodeConfig", () => {
     expect(fs.existsSync(out)).toBe(true);
   });
 
-  it("emits permission block with edit/bash/webfetch allowed", () => {
+  it("emits comprehensive permission block for autonomous crews", () => {
     const out = writePerCrewOpencodeConfig({ stateRoot: tmp, project: "alpha", taskId: "tid-1" });
     const json = JSON.parse(fs.readFileSync(out, "utf-8"));
     expect(json).toEqual({
       permission: {
+        read: "allow",
         edit: "allow",
+        glob: "allow",
+        grep: "allow",
         bash: "allow",
         webfetch: "allow",
+        websearch: "allow",
+        task: "allow",
+        lsp: "allow",
+        external_directory: { "**": "allow" },
       },
     });
   });

--- a/src/lib/per-crew-settings.ts
+++ b/src/lib/per-crew-settings.ts
@@ -42,9 +42,16 @@ export function writePerCrewOpencodeConfig(o: {
   const file = join(dir, "opencode.json");
   const config = {
     permission: {
+      read: "allow",
       edit: "allow",
+      glob: "allow",
+      grep: "allow",
       bash: "allow",
       webfetch: "allow",
+      websearch: "allow",
+      task: "allow",
+      lsp: "allow",
+      external_directory: { "**": "allow" },
     },
   };
   writeFileSync(file, JSON.stringify(config, null, 2));


### PR DESCRIPTION
## Problem

`writePerCrewOpencodeConfig` (shipped in #127) only set `{ edit: "allow", bash: "allow", webfetch: "allow" }`. OpenCode's permission schema has many more keys. Crews blocked on a separate **'Access external directory'** prompt whenever reading paths outside the project cwd (e.g. `~/.config/cockpit/templates`). Confirmed live: a crew hung on exactly that.

## Fix

Change the permission object to the full set needed for unattended crews:

```jsonc
{
  permission: {
    read: "allow",
    edit: "allow",
    glob: "allow",
    grep: "allow",
    bash: "allow",
    webfetch: "allow",
    websearch: "allow",
    task: "allow",
    lsp: "allow",
    external_directory: { "**": "allow" },
  },
}
```

- `question`, `skill`, `doom_loop` left out — defaults (ask) are fine for interactive-only features.
- `external_directory: {"**": "allow"}` stops the external-dir prompt entirely. Cockpit crews are trusted internal automation.
- OPENCODE_CONFIG deep-merges with global config, so model/plugin/mcp survive unchanged.

## Verification

- `npx vitest run` — 10/10 passed
- `npx tsc --noEmit` — clean