### PR TITLE
fix(crew): default codex approvalPolicy to never for unattended crews

### DIFF
--- a/src/control/codex/driver.ts
+++ b/src/control/codex/driver.ts
@@ -52,7 +52,7 @@ export class CodexInteractiveDriver {
         cwd: rec.cwd ?? process.cwd(),
         model: rec.model,
         sandbox: "workspace-write",
-        ...(rec.approvalPolicy ? { approvalPolicy: rec.approvalPolicy } : {}),
+        approvalPolicy: rec.approvalPolicy ?? "never",
         ...(rec.roleInstructions ? { developerInstructions: rec.roleInstructions } : {}),
       });
       this.threadByTask.set(rec.id, threadId);


### PR DESCRIPTION
## Problem

Issue #130: codex crews dispatched via the control plane without `--approval` would use the protocol-level default for `approvalPolicy`, which prompts for approval on tool/shell calls. This blocks unattended crew operation — a codex crew dispatched by the captain would hang waiting for approval.

## Root cause

`src/control/codex/driver.ts` line 55 forwarded `approvalPolicy` from the `TaskRecord` only when explicitly set (`...(rec.approvalPolicy ? ...)`). When unset (the common case for crew dispatches), the `approvalPolicy` was omitted from `startThread`, so the codex `app-server` used its default behavior (asking for approval).

## Fix

Default `approvalPolicy` to `"never"` (a valid `AskForApproval` value from `src/control/codex/protocol/v2/AskForApproval.ts`) when the `TaskRecord` doesn't carry an explicit policy. This means:

- **Normal crew dispatch** (no `--approval`): `approvalPolicy: "never"` → codex never asks for approval, crew runs unattended
- **Explicit `--approval`**: `approvalPolicy: "untrusted"` → overrides the default, exercises the gate-primitive flow

This mirrors how headless codex uses `--full-auto` for unattended execution (see `src/drivers/codex.ts` line 31), and satisfies the `ROLE_REQUIREMENTS.crew` required capability `auto_approve` (`src/drivers/types.ts` line 62).

## Verification

- Type check passes (`tsc --noEmit`)
- All 598 tests pass across 74 test files
- Existing driver tests (4) pass without modification (use `expect.objectContaining`)