### PR TITLE
fix(crew): stop false CREW STALLED alerts by mapping Stop → awaiting-input (fixes #131)

### DIFF
--- a/src/control/__tests__/interactive-claude-hook.test.ts
+++ b/src/control/__tests__/interactive-claude-hook.test.ts
@@ -4,9 +4,9 @@ import { mapClaudeHookToEvent } from "../interactive/claude.js";
 describe("mapClaudeHookToEvent", () => {
   const TID = "task-abc";
 
-  it("maps Stop → task.progress with note 'stop'", () => {
+  it("maps Stop → task.turn.completed (turn boundary → awaiting-input, #131)", () => {
     const ev = mapClaudeHookToEvent("Stop", { session_id: "x" }, TID);
-    expect(ev).toEqual({ type: "task.progress", id: TID, note: "stop" });
+    expect(ev).toEqual({ type: "task.turn.completed", id: TID, turnId: "hook-stop" });
   });
 
   it("maps SubagentStop → task.progress with note 'subagentstop'", () => {

--- a/src/control/__tests__/state-machine.test.ts
+++ b/src/control/__tests__/state-machine.test.ts
@@ -67,9 +67,35 @@ describe("state-machine reduce", () => {
     expect(next).toBe(done); // same reference — no-op
   });
 
-  it("bare Stop modelled as task.progress never yields done", () => {
-    const next = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "Stop" }, 7000);
+  it("task.progress on working stays working (liveness tick, never terminal)", () => {
+    const next = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "PostToolUse" }, 7000);
     expect(next.state).toBe("working");
+    expect(next.lastHeartbeat).toBe(7000);
+  });
+
+  it("task.turn.completed transitions working → awaiting-input (#131 false-stall fix)", () => {
+    const next = reduce(rec({ state: "working" }), { type: "task.turn.completed", id: "t1", turnId: "hook-stop" }, 8000);
+    expect(next.state).toBe("awaiting-input");
+    expect(next.lastHeartbeat).toBe(8000);
+  });
+
+  it("task.progress on awaiting-input transitions back to working (#131 fix: next turn resumes)", () => {
+    const taskTurnEnd = reduce(rec({ state: "working" }), { type: "task.turn.completed", id: "t1", turnId: "hook-stop" }, 8000);
+    expect(taskTurnEnd.state).toBe("awaiting-input");
+    const postToolUse = reduce(taskTurnEnd, { type: "task.progress", id: "t1", note: "posttooluse" }, 9000);
+    expect(postToolUse.state).toBe("working");
+    expect(postToolUse.lastHeartbeat).toBe(9000);
+    expect(postToolUse.lastEvent).toBe("task.progress");
+  });
+
+  it("awaiting-input + task.done still transitions to done (terminal not blocked)", () => {
+    const next = reduce(rec({ state: "awaiting-input" }), { type: "task.done", id: "t1", resultRef: "/r" }, 10000);
+    expect(next.state).toBe("done");
+  });
+
+  it("awaiting-input + task.failed still transitions to failed", () => {
+    const next = reduce(rec({ state: "awaiting-input" }), { type: "task.failed", id: "t1", error: "boom" }, 11000);
+    expect(next.state).toBe("failed");
   });
 });
 

--- a/src/control/interactive/claude.ts
+++ b/src/control/interactive/claude.ts
@@ -3,9 +3,13 @@ import type { InteractiveHookAdapter } from "./types.js";
 import type { ControlEvent } from "../types.js";
 
 // PostToolUse fires after EVERY tool call mid-turn — it is the only liveness
-// signal that refreshes the heartbeat while a crew is still working. Stop/
-// SubagentStop/SessionEnd fire only at turn boundaries, so a long working turn
-// would otherwise exceed heartbeatBudgetMs and trip a false CREW STALLED alert.
+// signal that refreshes the heartbeat while a crew is still working.
+// Stop fires at turn completion and maps to task.turn.completed so the task
+// transitions to awaiting-input (immune to stall detection) — without this,
+// a captain AFK for >heartbeatBudgetMs would get a false CREW STALLED.
+// SubagentStop/SessionEnd fire only at turn boundaries but are liveness-only:
+// SubagentStop fires while the parent agent still owns the turn, and SessionEnd
+// is an unreliable signal (crash / Ctrl-C / /exit).
 const EVENTS = ["Stop", "SubagentStop", "SessionEnd", "PostToolUse"] as const;
 
 /**
@@ -45,10 +49,15 @@ export function mergeClaudeHooks(settings: any, hookCmd: string): any {
  * Map a Claude hook event name to a cockpit ControlEvent. Pure function —
  * isolated for testability and to codify the anti-#2576 invariant in one
  * place: NO Claude hook ever maps to `task.done`/`task.failed`/`task.blocked`.
- * Stop/SubagentStop/SessionEnd/PostToolUse = liveness only. Terminal state
- * comes exclusively from explicit `cockpit crew signal` (Task 4).
- * PostToolUse is the mid-turn heartbeat (fires per tool call); the others are
- * turn-boundary liveness.
+ * PostToolUse/SubagentStop/SessionEnd = liveness only (task.progress).
+ * Stop = turn boundary (task.turn.completed → awaiting-input, stall-immune).
+ * Terminal state comes exclusively from explicit `cockpit crew signal`.
+ *
+ * Stop is remapped to task.turn.completed so the task leaves the working
+ * state between turns — no hooks fire while the captain reviews output,
+ * so the previous liveness-only mapping would heartbeat-expire after
+ * heartbeatBudgetMs and fire a false CREW STALLED alert. The awaiting-input
+ * state is immune to evaluateStall (fixes #131).
  */
 export function mapClaudeHookToEvent(
   event: string,
@@ -57,6 +66,7 @@ export function mapClaudeHookToEvent(
 ): ControlEvent | null {
   switch (event) {
     case "Stop":
+      return { type: "task.turn.completed", id: taskId, turnId: "hook-stop" };
     case "SubagentStop":
     case "SessionEnd":
     case "PostToolUse":

--- a/src/control/state-machine.ts
+++ b/src/control/state-machine.ts
@@ -45,9 +45,12 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
       // Anti-#2576: liveness only. A turn-end is NOT completion.
       // From blocked, a bare progress/heartbeat does not auto-unblock
       // (state stays "blocked"); only lastEvent + lastHeartbeat update.
-      return rec.state === "blocked"
-        ? { ...rec, lastHeartbeat: now, lastEvent: ev.type }
-        : base;
+      // From awaiting-input, transition back to working — the Stop hook
+      // puts the task into awaiting-input between turns (fixes #131 false
+      // stall); PostToolUse on the next turn resumes the working state.
+      if (rec.state === "blocked") return { ...rec, lastHeartbeat: now, lastEvent: ev.type };
+      if (rec.state === "awaiting-input") return { ...base, state: "working" };
+      return base;
     case "task.blocked":
       // ev.reason is protocol/logging-only and intentionally not persisted;
       // only `question` is stored on the record.


### PR DESCRIPTION
## Root Cause

Claude `Stop` hook (turn boundary) mapped to `task.progress`, keeping the task in `working` state between turns. No hooks fire while the captain reviews output, so a captain AFK for >`heartbeatBudgetMs` (default 5 min) would heartbeat-expire and fire a false `CREW STALLED` alert.

## Fix

**Two surgical changes** preserving all anti-#2576 invariants:

1. **`mapClaudeHookToEvent`** (`src/control/interactive/claude.ts`): Remap `Stop` → `task.turn.completed` (instead of `task.progress`). This transitions the task to `awaiting-input`, which is immune to `evaluateStall` (only `working` tasks are checked).

2. **`reduce`** (`src/control/state-machine.ts`): `task.progress`/`heartbeat` now transitions `awaiting-input` → `working`. When the next turn starts and PostToolUse fires, the task automatically resumes `working`.

Unchanged:
- `SubagentStop`/ `SessionEnd`/ `PostToolUse` remain `task.progress` (correct per spec)
- `cockpit crew signal done|blocked|failed` works identically from `awaiting-input`
- Daemon watchdog untouched (correctly skips non-working states)

## Verification

- All 515 tests pass (+4 new tests for the awaiting-input transitions)
- Terminal signaling verified: `awaiting-input + task.done → done`, `awaiting-input + task.failed → failed`