### PR TITLE
captain templates: add opencode to --agent flag listing

### DIFF
--- a/orchestrator/captain.claude.md
+++ b/orchestrator/captain.claude.md
@@ -18,7 +18,7 @@ Use the `cockpit:captain-ops` skill — it has your full startup checklist, crew
 1. **Crew = interactive sub-session.** Each crew is a long-lived Claude session in a tab inside your workspace, named `crew-1`, `crew-2`, … (or a name you pick). It stays idle between turns waiting for your next message — exactly like an Agent Team subagent.
 2. **Spawn a NEW crew** with `cockpit crew spawn`:
    ```bash
-   cockpit crew spawn <project> "<task description>" [--name <n>] [--direction tab|right|left|up|down] [--agent claude|codex|gemini|aider]
+   cockpit crew spawn <project> "<task description>" [--name <n>] [--direction tab|right|left|up|down] [--agent claude|codex|gemini|aider|opencode]
    ```
    Opens a new tab titled `🔧 <project>:<name>`, boots an interactive Claude (no `-p`), then sends the task as the first turn. `--name` is optional; auto-picks the next free `crew-N`.
 3. **Send a follow-up turn** to an existing crew:

--- a/orchestrator/captain.generic.md
+++ b/orchestrator/captain.generic.md
@@ -7,7 +7,7 @@ You are a project captain coordinating work via cmux workspaces. You are a coord
 1. Crews are **interactive sub-sessions** running in tabs inside your workspace. Each one stays idle between turns waiting for your next message.
 2. **Spawn a NEW crew** with `cockpit crew spawn`:
    ```bash
-   cockpit crew spawn <project> "<task>" [--name <n>] [--direction tab|right|left|up|down] [--agent claude|codex|gemini|aider]
+   cockpit crew spawn <project> "<task>" [--name <n>] [--direction tab|right|left|up|down] [--agent claude|codex|gemini|aider|opencode]
    ```
 3. **Send a follow-up turn** to an existing crew (don't spawn a new tab for every turn):
    ```bash


### PR DESCRIPTION
## Changes

Both `captain.claude.md` and `captain.generic.md` listed `--agent claude|codex|gemini|aider` but omitted `opencode`, which is a fully supported interactive crew agent (driver exists, template exists, `cockpit crew spawn --agent opencode` works today).

## Gap Report

This PR fixes one of the unambiguous gaps found in the fresh-install audit:

1. Fix: `--agent` flag listing in both captain templates missing `opencode`

## Design-level gaps flagged (not fixed):

1. **cmux binary path hardcoded** — `src/runtimes/cmux.ts` line 4 hardcodes `/Applications/cmux.app/Contents/Resources/bin/cmux`. A fresh user with npm-global or homebrew cmux would get a different path. Needs a path-detection mechanism.

2. **README prerequisite mismatch** — says Node.js >= 22 but `doctor.ts` checks >= 18.

3. **init does not mention opencode** — `cockpit init` prints manual steps for Claude plugins but nothing about opencode setup.

4. **Per-crew opencode config merge dependency** — `writePerCrewOpencodeConfig` writes a permissions-only config meant to deep-merge with `~/.config/opencode/opencode.json`. If that global doesn't exist, opencode should still work with defaults, but this dependency is undocumented.

5. **Daemon PATH may lack opencode** — `sanitizePathForPlist` filters Claude plugin dirs but may not include where opencode is installed if the user's PATH differs from the spawning process's PATH.