### PR TITLE
fix(node-version): reconcile Node floor to >=18 across README/doctor/package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ cockpit doctor
 - [Claude Code](https://claude.ai/code) >= 2.1.32
 - [cmux](https://cmux.dev) (macOS terminal for coding agents)
 - [Obsidian](https://obsidian.md) (status tracking)
-- Node.js >= 22
+- Node.js >= 18
 
 ### Required Integrations
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-cockpit",
-  "version": "0.1.0",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-cockpit",
-      "version": "0.1.0",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.0",
@@ -20,6 +20,9 @@
         "@types/node": "^22.0.0",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   ],
   "author": "",
   "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
     "chalk": "^5.4.0",
     "commander": "^13.0.0",


### PR DESCRIPTION
**Problem:** Node.js version floor is inconsistent — README says >=22, doctor.ts checks >=18, package.json has no engines field.

**Fix:** Standardized on **>=18** everywhere:
- README.md: `>=22` → `>=18`
- package.json: added `engines.node: >=18`
- doctor.ts: unchanged (already correct, checks >=18)

**Why >=18:** No Node 22+ specific APIs in the codebase. The only borderline API used (`structuredClone`) is available from Node 17. doctor.ts was already correct — README was the sole outlier.

**Verification:** `npm run build` passes, all 602 tests pass.

Closes fresh-install gap #2.