### PR TITLE
fix(daemon): augment plist PATH with resolved agent bin dirs (fresh-install #5)

### DIFF
--- a/src/control/__tests__/launchd.test.ts
+++ b/src/control/__tests__/launchd.test.ts
@@ -1,6 +1,8 @@
 // src/control/__tests__/launchd.test.ts
-import { describe, it, expect } from "vitest";
-import { renderPlist, LABEL, kickstartArgv, sanitizePathForPlist, programArgsBlock } from "../launchd.js";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+vi.mock("node:child_process", () => ({ execFileSync: vi.fn() }));
+import { execFileSync } from "node:child_process";
+import { renderPlist, LABEL, kickstartArgv, sanitizePathForPlist, programArgsBlock, AGENT_BINS, resolveAgentBinDirs, buildDaemonPath } from "../launchd.js";
 
 describe("launchd plist", () => {
   it("renders a KeepAlive RunAtLoad plist pointing at the daemon entry", () => {
@@ -88,5 +90,88 @@ describe("launchd plist", () => {
   it("programArgsBlock matches the actual array emitted by renderPlist", () => {
     const xml = renderPlist("/nvm/v24/bin/node", "/dist/cockpitd.js");
     expect(xml).toContain(programArgsBlock("/nvm/v24/bin/node", "/dist/cockpitd.js"));
+  });
+});
+
+describe("resolveAgentBinDirs", () => {
+  beforeEach(() => {
+    vi.mocked(execFileSync).mockReset();
+  });
+
+  it("resolves available agent binaries and returns their dirnames", () => {
+    vi.mocked(execFileSync).mockImplementation((cmd: string, args: readonly string[] | undefined) => {
+      if (cmd === "which" && args?.[0] === "cmux") return "/Applications/cmux.app/Contents/Resources/bin/cmux\n";
+      if (cmd === "which" && args?.[0] === "claude") return "/Users/me/.npm-global/bin/claude\n";
+      if (cmd === "which" && args?.[0] === "opencode") return "/Users/me/.npm-global/bin/opencode\n";
+      throw new Error("not found");
+    });
+    const dirs = resolveAgentBinDirs();
+    expect(dirs).toContain("/Applications/cmux.app/Contents/Resources/bin");
+    expect(dirs).toContain("/Users/me/.npm-global/bin");
+    // codex, gemini, aider, node — not found, skipped
+    expect(dirs.length).toBe(2);
+  });
+
+  it("skips missing binaries without error", () => {
+    vi.mocked(execFileSync).mockImplementation(() => { throw new Error("not found"); });
+    expect(resolveAgentBinDirs()).toEqual([]);
+  });
+
+  it("dedupes when multiple binaries resolve to the same directory", () => {
+    vi.mocked(execFileSync).mockImplementation((cmd: string, args: readonly string[] | undefined) => {
+      if (args?.[0] === "node" || args?.[0] === "opencode") return "/Users/me/.npm-global/bin/node\n";
+      throw new Error("not found");
+    });
+    const dirs = resolveAgentBinDirs();
+    expect(dirs).toEqual(["/Users/me/.npm-global/bin"]);
+  });
+});
+
+describe("buildDaemonPath", () => {
+  beforeEach(() => {
+    vi.mocked(execFileSync).mockReset();
+  });
+
+  it("prepends agent bin dirs to sanitized path", () => {
+    vi.mocked(execFileSync).mockImplementation((cmd: string, args: readonly string[] | undefined) => {
+      if (cmd === "which" && args?.[0] === "claude") return "/opt/homebrew/bin/claude\n";
+      if (cmd === "which" && args?.[0] === "node") return "/Users/me/.nvm/versions/node/v24/bin/node\n";
+      throw new Error("not found");
+    });
+    const result = buildDaemonPath("/usr/bin:/bin");
+    expect(result).toContain("/opt/homebrew/bin");
+    expect(result).toContain("/Users/me/.nvm/versions/node/v24/bin");
+    expect(result).toContain("/usr/bin");
+    expect(result).toContain("/bin");
+    expect(result.startsWith("/opt/homebrew/bin")).toBe(true);
+  });
+
+  it("still strips plugin-cache directories from shell PATH", () => {
+    vi.mocked(execFileSync).mockImplementation((cmd: string, args: readonly string[] | undefined) => {
+      if (cmd === "which" && args?.[0] === "node") return "/usr/local/bin/node\n";
+      throw new Error("not found");
+    });
+    const result = buildDaemonPath("/usr/bin:/Users/me/.claude/plugins/cache/foo/bin:/bin");
+    expect(result).not.toContain(".claude/plugins");
+    expect(result).toContain("/usr/bin");
+    expect(result).toContain("/bin");
+  });
+
+  it("returns sanitized path unchanged when no agent binaries found", () => {
+    vi.mocked(execFileSync).mockImplementation(() => { throw new Error("not found"); });
+    expect(buildDaemonPath("/usr/bin:/bin")).toBe("/usr/bin:/bin");
+  });
+
+  it("output is deterministic (stable order, deduped)", () => {
+    vi.mocked(execFileSync).mockImplementation((cmd: string, args: readonly string[] | undefined) => {
+      if (cmd === "which" && args?.[0] === "cmux") return "/opt/bin/cmux\n";
+      if (cmd === "which" && args?.[0] === "node") return "/usr/local/bin/node\n";
+      throw new Error("not found");
+    });
+    const a = buildDaemonPath("/usr/bin:/opt/bin:/bin");
+    const b = buildDaemonPath("/usr/bin:/opt/bin:/bin");
+    expect(a).toBe(b);
+    // /opt/bin from shell PATH is deduped against the cmux agent dir
+    expect(a).toBe("/opt/bin:/usr/local/bin:/usr/bin:/bin");
   });
 });

--- a/src/control/launchd.ts
+++ b/src/control/launchd.ts
@@ -47,6 +47,50 @@ export function sanitizePathForPlist(path: string): string {
   return stable.join(":");
 }
 
+export const AGENT_BINS = ["cmux", "claude", "opencode", "codex", "gemini", "aider", "node"];
+
+/**
+ * Resolve absolute directories for known agent + tool binaries via `which`, so
+ * the launchd daemon's PATH includes them regardless of the install-time shell.
+ * Missing binaries are skipped silently.
+ */
+export function resolveAgentBinDirs(): string[] {
+  const dirs: string[] = [];
+  for (const bin of AGENT_BINS) {
+    try {
+      const out = execFileSync("which", [bin], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] });
+      const resolved = out.trim();
+      if (resolved) dirs.push(dirname(resolved));
+    } catch {
+      // binary not found on this machine — skip
+    }
+  }
+  const seen = new Set<string>();
+  return dirs.filter(d => {
+    if (seen.has(d)) return false;
+    seen.add(d);
+    return true;
+  });
+}
+
+/**
+ * Compose a stable daemon PATH by prepending resolved agent bin dirs to the
+ * sanitized install-shell PATH.  Agent dirs take priority (prepended) and are
+ * deduped against the sanitized entries so the output is deterministic.
+ */
+export function buildDaemonPath(shellPath: string): string {
+  const agentDirs = resolveAgentBinDirs();
+  const sanitized = sanitizePathForPlist(shellPath);
+  if (agentDirs.length === 0) return sanitized;
+  const parts = [...agentDirs, ...sanitized.split(":")];
+  const seen = new Set<string>();
+  return parts.filter(p => {
+    if (!p || seen.has(p)) return false;
+    seen.add(p);
+    return true;
+  }).join(":");
+}
+
 /**
  * Red-team #3 (High): launchd starts the daemon with a minimal PATH that does
  * NOT include where `claude`/`codex`/`opencode` live (nvm/cmux dirs), so every
@@ -109,7 +153,7 @@ export function ensureDaemon(nodeBin: string = process.execPath): void {
   try {
     const p = plistPath();
     const entry = daemonEntryPath();
-    const desired = renderPlist(nodeBin, entry, sanitizePathForPlist(process.env.PATH ?? ""));
+    const desired = renderPlist(nodeBin, entry, buildDaemonPath(process.env.PATH ?? ""));
     const current = existsSync(p) ? readFileSync(p, "utf-8") : null;
     const uid = process.getuid?.() ?? 0;
     const target = `gui/${uid}/${LABEL}`;


### PR DESCRIPTION
**Problem:** `launchd.ts` bakes `process.env.PATH` into the daemon plist, but a fresh install shell may lack dirs containing agent binaries (cmux, claude, opencode, codex, gemini, aider). The daemon spawns ENOENT when trying to launch agents.

**Fix:** When building the plist PATH, prepend resolved absolute directories of known agent binaries via `which(1)`. Missing binaries are skipped silently. The result is deduped against the sanitized shell PATH.

**Changes:**
- New `resolveAgentBinDirs()` — resolves each of 7 known binaries, returns deduped dirnames
- New `buildDaemonPath()` — composes agent dirs + sanitized PATH with dedup
- `ensureDaemon()` now calls `buildDaemonPath()` instead of raw `sanitizePathForPlist()`
- 7 new tests covering: resolution, missing-binaries, dedup, plugin-cache strip, stability

**Verification:**
- `npm run build` — passes
- `vitest run` — 609/609 tests pass (74 files)
- PATH-only changes still don't trigger daemon restart (no semantic change to programArgsBlock)