### PR TITLE
fix: replace hardcoded cmux binary path with detection cascade

### DIFF
--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -14,10 +14,9 @@ import {
   CapabilityRegistry,
 } from "../drivers/index.js";
 import type { PaneRef } from "../runtimes/types.js";
+import { resolveCmuxBin } from "../lib/cmux-bin.js";
 
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "cockpit", "templates");
-// TODO(runtime): current-workspace not yet abstracted by RuntimeDriver — direct cmux call retained.
-const CMUX_BIN = "/Applications/cmux.app/Contents/Resources/bin/cmux";
 
 type CommandTask = "briefing" | "learnings-review" | "wiki-aggregate";
 
@@ -37,7 +36,7 @@ export interface CommandSpawnInput {
 }
 
 function detectCurrentWorkspace(): string {
-  const out = execSync(`"${CMUX_BIN}" current-workspace`, { encoding: "utf-8" }).trim();
+  const out = execSync(`"${resolveCmuxBin()}" current-workspace`, { encoding: "utf-8" }).trim();
   const match = out.match(/workspace:\d+/);
   if (!match) {
     throw new Error("Could not detect current cmux workspace. Run `cockpit command` from inside a cmux workspace.");

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -8,13 +8,12 @@ import { readAllStatuses } from "../dashboard/read-status.js";
 import { renderDashboard } from "../dashboard/render.js";
 import { syncHub, type SyncHubResult } from "../dashboard/sync-hub.js";
 import type { PaneRef } from "../runtimes/types.js";
+import { resolveCmuxBin } from "../lib/cmux-bin.js";
 
 // TODO(runtime): current-workspace not yet abstracted by RuntimeDriver — direct cmux call retained,
 // matching the existing pattern in src/commands/command.ts.
-const CMUX_BIN = "/Applications/cmux.app/Contents/Resources/bin/cmux";
-
 function detectCurrentWorkspace(): string {
-  const out = execSync(`"${CMUX_BIN}" current-workspace`, { encoding: "utf-8" }).trim();
+  const out = execSync(`"${resolveCmuxBin()}" current-workspace`, { encoding: "utf-8" }).trim();
   const match = out.match(/workspace:\d+/);
   if (!match) {
     throw new Error("Could not detect current cmux workspace. Run `cockpit dashboard --pane` from inside a cmux workspace.");

--- a/src/commands/launch.ts
+++ b/src/commands/launch.ts
@@ -12,10 +12,9 @@ import { RuntimeRegistry, createCmuxDriver } from "../runtimes/index.js";
 import type { RuntimeDriver, WorkspaceRef } from "../runtimes/index.js";
 import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
 import { ensureSpokeLayout } from "../lib/vault-layout.js";
+import { resolveCmuxBin } from "../lib/cmux-bin.js";
 
 const CMUX_APP = "/Applications/cmux.app";
-// Retained for the select-workspace / current-workspace calls that are not yet abstracted by RuntimeDriver.
-const CMUX_BIN = "/Applications/cmux.app/Contents/Resources/bin/cmux";
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "cockpit", "templates");
 const SESSIONS_PATH = path.join(os.homedir(), ".config", "cockpit", "sessions.json");
 
@@ -28,7 +27,7 @@ const SESSIONS_PATH = path.join(os.homedir(), ".config", "cockpit", "sessions.js
 // terminal, which is exactly the #121 Issue B leak. Capturing fd 2 here
 // swallows it. Returns trimmed stdout for callers that need it.
 export function cmuxLocal(args: string[]): string {
-  return execFileSync(CMUX_BIN, args, { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+  return execFileSync(resolveCmuxBin(), args, { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }).trim();
 }
 
 interface SessionRecord {

--- a/src/lib/cmux-bin.ts
+++ b/src/lib/cmux-bin.ts
@@ -1,0 +1,39 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+let _cached: string | undefined;
+
+function resolveBin(): string {
+  // 1. Env var override
+  const envBin = process.env.COCKPIT_CMUX_BIN;
+  if (envBin && existsSync(envBin)) return envBin;
+
+  // 2. Optional cmuxBin field in config.json
+  try {
+    const configPath = join(homedir(), ".config", "cockpit", "config.json");
+    if (existsSync(configPath)) {
+      const cfg = JSON.parse(readFileSync(configPath, "utf-8"));
+      const cfgBin: unknown = cfg.cmuxBin;
+      if (typeof cfgBin === "string" && existsSync(cfgBin)) return cfgBin;
+    }
+  } catch { /* config read is best-effort */ }
+
+  // 3. PATH lookup
+  try {
+    const which = execFileSync("which", ["cmux"], { encoding: "utf-8" }).trim();
+    if (which && existsSync(which)) return which;
+  } catch { /* not on PATH */ }
+
+  // 4. Fallback (backward compat for macOS .app install)
+  return "/Applications/cmux.app/Contents/Resources/bin/cmux";
+}
+
+export function resolveCmuxBin(): string {
+  return _cached ??= resolveBin();
+}
+
+export function resetCmuxBinCache(): void {
+  _cached = undefined;
+}

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -1,13 +1,12 @@
 import { execFileSync } from "node:child_process";
 import type { RuntimeDriver, RuntimeProbeResult, RuntimeSpawnOptions, WorkspaceRef, PaneRef, RuntimePaneOptions } from "./types.js";
-
-const CMUX_BIN = "/Applications/cmux.app/Contents/Resources/bin/cmux";
+import { resolveCmuxBin } from "../lib/cmux-bin.js";
 
 // Invoke cmux with an argv array and NO shell. Every element (especially crew
 // prompt text passed through send/send-to-surface) reaches cmux as a single
 // literal argument — backticks, $(), quotes are never parsed. See #118.
 function cmux(args: string[]): string {
-  return execFileSync(CMUX_BIN, args, { encoding: "utf-8" }).trim();
+  return execFileSync(resolveCmuxBin(), args, { encoding: "utf-8" }).trim();
 }
 
 function parseList(output: string): WorkspaceRef[] {


### PR DESCRIPTION
## Problem

`src/runtimes/cmux.ts`, `src/commands/launch.ts`, `src/commands/dashboard.ts`, and `src/commands/command.ts` all hardcode `CMUX_BIN = "/Applications/cmux.app/Contents/Resources/bin/cmux"`. This breaks for any cmux not installed as the macOS .app (npm-global, homebrew, Linux).

## Solution

New `src/lib/cmux-bin.ts` with `resolveCmuxBin()` that picks the FIRST available:

1. **`COCKPIT_CMUX_BIN`** env var (if set and exists)
2. **`cmuxBin`** field in `~/.config/cockpit/config.json` (if present and exists)
3. **PATH lookup** via `which cmux` (if found)
4. **Fallback** to `/Applications/cmux.app/Contents/Resources/bin/cmux` (backward compat)

Cached after first resolution. Exports `resetCmuxBinCache()` for test use.

## Verification

- All 34 cmux runtime tests pass
- `npm run lint` (tsc --noEmit) passes (pre-existing warnings unrelated)
- No new dependencies introduced