### PR TITLE
fix: mock cmux-bin in launch.test.ts for PR #144 compat

### DIFF
--- a/src/commands/__tests__/launch.test.ts
+++ b/src/commands/__tests__/launch.test.ts
@@ -16,6 +16,11 @@ vi.mock("node:child_process", () => ({
   execSync: vi.fn(),
 }));
 
+vi.mock("../../lib/cmux-bin.js", () => ({
+  resolveCmuxBin: () => "/Applications/cmux.app/Contents/Resources/bin/cmux",
+  resetCmuxBinCache: vi.fn(),
+}));
+
 import { cmuxLocal } from "../launch.js";
 
 describe("cmuxLocal (launch.ts direct-cmux helper)", () => {


### PR DESCRIPTION
## Problem

PR #144 changed `cmuxLocal` to call `resolveCmuxBin()` from `src/lib/cmux-bin.ts`, which internally calls `execFileSync("which", ["cmux"])`. This adds an extra `execFileSync` call before the actual cmux invocation, breaking the launch.test.ts assertions:

- `toHaveBeenCalledTimes(1)` fails because there are now 2 calls
- First call's `bin` is `"which"` instead of containing `"cmux"`

## Fix

Mocked `../../lib/cmux-bin.js` so `resolveCmuxBin()` returns a fixed cmux path without any internal `execFileSync` call. The three cmuxLocal tests now see exactly one `execFileSync` call with the correct cmux binary path.

## Verification

- All 74 test files, 602 tests pass (green)
- `tsc --noEmit` clean