### PR TITLE
docs: architecture HTML report (inline CSS + SVG, no deps)

### DIFF
--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1,0 +1,1140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Cockpit — Architecture Overview</title>
+<style>
+:root {
+  --bg: #0f1117;
+  --bg2: #1a1b26;
+  --bg3: #24283b;
+  --fg: #c0caf5;
+  --fg2: #a9b1d6;
+  --accent: #7aa2f7;
+  --accent2: #bb9af7;
+  --green: #9ece6a;
+  --orange: #ff9e64;
+  --red: #f7768e;
+  --cyan: #73daca;
+  --yellow: #e0af68;
+  --border: #3b4261;
+  --header-bg: #1a1b26;
+  --code-bg: #1d1f2e;
+  --sidebar-width: 260px;
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+  line-height: 1.7;
+  font-size: 15px;
+  display: flex;
+  min-height: 100vh;
+}
+/* ── Sidebar ── */
+nav.toc {
+  position: fixed; top: 0; left: 0;
+  width: var(--sidebar-width); height: 100vh;
+  background: var(--bg2);
+  border-right: 1px solid var(--border);
+  padding: 24px 16px;
+  overflow-y: auto;
+  z-index: 10;
+}
+nav.toc h2 {
+  font-size: 12px; text-transform: uppercase;
+  letter-spacing: 0.08em; color: var(--fg2);
+  margin-bottom: 16px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+nav.toc a {
+  display: block; color: var(--fg2); text-decoration: none;
+  font-size: 13px; padding: 4px 8px; border-radius: 4px;
+  transition: background .15s, color .15s;
+}
+nav.toc a:hover { background: var(--bg3); color: var(--accent); }
+nav.toc a.toc-h2 { padding-left: 20px; font-size: 12px; color: var(--fg2); opacity: .8; }
+nav.toc a.toc-h3 { padding-left: 32px; font-size: 11px; color: var(--fg2); opacity: .65; }
+
+/* ── Main ── */
+main {
+  margin-left: var(--sidebar-width);
+  flex: 1;
+  padding: 48px 56px;
+  max-width: 960px;
+}
+h1 {
+  font-size: 32px; font-weight: 700; margin-bottom: 6px;
+  color: var(--fg);
+}
+h1 .subtitle {
+  display: block; font-size: 15px; font-weight: 400;
+  color: var(--fg2); margin-top: 4px;
+}
+.header-meta {
+  font-size: 13px; color: var(--fg2);
+  margin-bottom: 40px; padding-bottom: 24px;
+  border-bottom: 1px solid var(--border);
+}
+.header-meta span { display: inline-block; margin-right: 20px; }
+.header-meta code { color: var(--accent); }
+
+h2 {
+  font-size: 22px; font-weight: 600; margin-top: 48px; margin-bottom: 16px;
+  color: var(--fg); border-bottom: 1px solid var(--border); padding-bottom: 8px;
+}
+h3 {
+  font-size: 17px; font-weight: 600; margin-top: 28px; margin-bottom: 10px;
+  color: var(--accent2);
+}
+p { margin-bottom: 14px; color: var(--fg2); }
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+code {
+  font-family: "JetBrains Mono", "Fira Code", "SF Mono", Consolas, monospace;
+  font-size: 13px;
+  background: var(--code-bg);
+  padding: 2px 6px;
+  border-radius: 4px;
+  color: var(--cyan);
+}
+pre {
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px 18px;
+  overflow-x: auto;
+  margin: 14px 0 20px 0;
+  font-size: 13px;
+  line-height: 1.5;
+}
+pre code {
+  background: none; padding: 0;
+  color: var(--fg);
+}
+
+/* ── Tables ── */
+table {
+  width: 100%; border-collapse: collapse;
+  margin: 14px 0 20px 0;
+  font-size: 13px;
+}
+th {
+  background: var(--bg3); color: var(--fg);
+  text-align: left; padding: 8px 12px;
+  border: 1px solid var(--border);
+  font-weight: 600;
+}
+td {
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  color: var(--fg2);
+}
+tr:nth-child(even) td { background: var(--bg2); }
+
+/* ── State diagram / SVG ── */
+.diagram {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 20px;
+  margin: 20px 0;
+  text-align: center;
+}
+.diagram svg { max-width: 100%; height: auto; }
+
+/* ── Info boxes ── */
+.info {
+  background: var(--bg3);
+  border-left: 3px solid var(--accent);
+  padding: 12px 16px;
+  margin: 14px 0 20px 0;
+  border-radius: 0 6px 6px 0;
+  font-size: 13px;
+  color: var(--fg2);
+}
+.info strong { color: var(--accent); }
+
+ul, ol { margin: 8px 0 16px 20px; color: var(--fg2); }
+li { margin-bottom: 4px; }
+
+.footer {
+  margin-top: 60px; padding-top: 20px;
+  border-top: 1px solid var(--border);
+  font-size: 12px; color: var(--fg2);
+}
+
+/* ── Badges ── */
+.badge {
+  display: inline-block;
+  font-size: 11px; font-weight: 600;
+  padding: 1px 8px; border-radius: 10px;
+  text-transform: uppercase; letter-spacing: 0.03em;
+}
+.badge-green { background: #1a3a1a; color: var(--green); }
+.badge-blue { background: #1a243a; color: var(--accent); }
+.badge-purple { background: #241a3a; color: var(--accent2); }
+.badge-orange { background: #3a2a1a; color: var(--orange); }
+
+.tag {
+  display: inline-block;
+  font-size: 11px; padding: 1px 7px; border-radius: 4px;
+  background: var(--bg3); color: var(--fg2);
+  margin-right: 4px; font-family: monospace;
+}
+
+/* ── Responsive ── */
+@media (max-width: 800px) {
+  body { flex-direction: column; }
+  nav.toc { position: static; width: 100%; height: auto; border-right: none; border-bottom: 1px solid var(--border); }
+  main { margin-left: 0; padding: 24px 20px; }
+}
+</style>
+</head>
+<body>
+
+<nav class="toc">
+  <h2>Contents</h2>
+  <a href="#overview">1. What Cockpit Is</a>
+  <a href="#role-hierarchy" class="toc-h2">2. Role Hierarchy</a>
+  <a href="#command" class="toc-h3">Command</a>
+  <a href="#captain" class="toc-h3">Captain</a>
+  <a href="#crew" class="toc-h3">Crew</a>
+  <a href="#reactor" class="toc-h3">Reactor</a>
+  <a href="#plugin-slots" class="toc-h2">3. Plugin Slots</a>
+  <a href="#runtime" class="toc-h3">Runtime</a>
+  <a href="#workspace" class="toc-h3">Workspace</a>
+  <a href="#tracker" class="toc-h3">Tracker</a>
+  <a href="#notifier" class="toc-h3">Notifier</a>
+  <a href="#agent-drivers" class="toc-h2">4. Agent Drivers</a>
+  <a href="#control-plane" class="toc-h2">5. Control Plane</a>
+  <a href="#state-machine" class="toc-h3">Task State Machine</a>
+  <a href="#watchdog" class="toc-h3">Watchdog / Heartbeat</a>
+  <a href="#hook-bridge" class="toc-h3">Hook Bridge</a>
+  <a href="#codex" class="toc-h3">Codex Interactive Driver</a>
+  <a href="#projection" class="toc-h2">6. Cross-Agent Projection</a>
+  <a href="#other-modules" class="toc-h2">7. Other Modules</a>
+  <a href="#commands" class="toc-h3">CLI Commands</a>
+  <a href="#config" class="toc-h3">Configuration</a>
+  <a href="#dashboard" class="toc-h3">Dashboard</a>
+  <a href="#fs-layout" class="toc-h2">8. Filesystem Layout</a>
+  <a href="#footer" class="toc-h2">9. Generation Metadata</a>
+</nav>
+
+<main>
+
+<h1>
+  Cockpit Architecture
+  <span class="subtitle">Multi-agent orchestration layer &mdash; system and module reference</span>
+</h1>
+
+<div class="header-meta">
+  <span>Date: 2026-05-28</span>
+  <span>Branch: develop</span>
+  <span>Commit: <code>50edf94</code></span>
+  <span><span class="badge badge-green">767 files</span> <span class="badge badge-blue">91 processes</span> <span class="badge badge-purple">6,011 edges</span></span>
+</div>
+
+<!-- ============================================================ -->
+<!-- 1. OVERVIEW -->
+<!-- ============================================================ -->
+<h2 id="overview">1. What Cockpit Is</h2>
+
+<p>
+Cockpit is a <strong>multi-agent orchestration layer</strong> for managing AI coding agents across
+multiple software projects. It is not a Claude Code tool &mdash; Claude Code is the <em>reference
+implementation</em>; the system supports Codex, OpenCode, Gemini CLI, and Aider through a pluggable
+driver abstraction.
+</p>
+
+<p>
+Conceptually, Cockpit wraps a terminal multiplexer (<a href="#runtime">cmux</a>) with a role-based
+delegation system: a <strong>Command</strong> session dispatches work to <strong>Captain</strong>
+sessions (one per project), which delegate coding tasks to ephemeral <strong>Crew</strong> sessions
+running in isolated git worktrees. A <strong>Reactor</strong> engine polls GitHub and captain status
+declaratively, matching events against reaction rules.
+</p>
+
+<div class="diagram">
+<svg viewBox="0 0 800 560" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#7aa2f7"/>
+    </marker>
+    <marker id="arrow-green" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#9ece6a"/>
+    </marker>
+    <marker id="arrow-orange" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#ff9e64"/>
+    </marker>
+    <linearGradient id="grad-user" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#bb9af7;stop-opacity:.3"/>
+      <stop offset="100%" style="stop-color:#7aa2f7;stop-opacity:.3"/>
+    </linearGradient>
+    <linearGradient id="grad-cap" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#7aa2f7;stop-opacity:.2"/>
+      <stop offset="100%" style="stop-color:#73daca;stop-opacity:.2"/>
+    </linearGradient>
+    <linearGradient id="grad-crew" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#73daca;stop-opacity:.15"/>
+      <stop offset="100%" style="stop-color:#9ece6a;stop-opacity:.15"/>
+    </linearGradient>
+    <linearGradient id="grad-cp" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#f7768e;stop-opacity:.12"/>
+      <stop offset="100%" style="stop-color:#ff9e64;stop-opacity:.12"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect x="0" y="0" width="800" height="560" rx="8" fill="#1a1b26"/>
+
+  <!-- Title -->
+  <text x="400" y="28" text-anchor="middle" fill="#c0caf5" font-size="14" font-weight="600">Cockpit Architecture &mdash; Role Hierarchy + Plugin Slots</text>
+
+  <!-- Layer labels -->
+  <text x="20" y="62" fill="#565f89" font-size="10" font-weight="600" text-transform="uppercase">User Layer</text>
+  <line x1="20" y1="66" x2="780" y2="66" stroke="#3b4261" stroke-width="1"/>
+
+  <text x="20" y="172" fill="#565f89" font-size="10" font-weight="600">Orchestration Layer</text>
+  <line x1="20" y1="176" x2="780" y2="176" stroke="#3b4261" stroke-width="1"/>
+
+  <text x="20" y="290" fill="#565f89" font-size="10" font-weight="600">Execution Layer</text>
+  <line x1="20" y1="294" x2="780" y2="294" stroke="#3b4261" stroke-width="1"/>
+
+  <text x="20" y="440" fill="#565f89" font-size="10" font-weight="600">Infrastructure (Plugin Slots)</text>
+  <line x1="20" y1="444" x2="780" y2="444" stroke="#3b4261" stroke-width="1"/>
+
+  <!-- User / Terminal -->
+  <rect x="320" y="76" width="160" height="40" rx="8" fill="url(#grad-user)" stroke="#bb9af7" stroke-width="1.5"/>
+  <text x="400" y="101" text-anchor="middle" fill="#c0caf5" font-size="12" font-weight="600">User (Terminal)</text>
+
+  <!-- Command -->
+  <rect x="320" y="130" width="160" height="34" rx="6" fill="#2a1a3a" stroke="#bb9af7" stroke-width="1"/>
+  <text x="400" y="151" text-anchor="middle" fill="#bb9af7" font-size="11" font-weight="600">Command</text>
+
+  <!-- Arrows: User->Command, Command->Captains -->
+  <line x1="400" y1="116" x2="400" y2="130" stroke="#bb9af7" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="410" y="126" fill="#565f89" font-size="9">delegates</text>
+
+  <!-- Command -> Captain arrow -->
+  <line x1="400" y1="164" x2="400" y2="190" stroke="#bb9af7" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="410" y="180" fill="#565f89" font-size="9">dispatches to</text>
+
+  <!-- Reactor (right side) -->
+  <rect x="620" y="130" width="140" height="34" rx="6" fill="#2a2a1a" stroke="#e0af68" stroke-width="1"/>
+  <text x="690" y="151" text-anchor="middle" fill="#e0af68" font-size="11" font-weight="600">Reactor</text>
+  <line x1="590" y1="147" x2="620" y2="147" stroke="#e0af68" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow-orange)"/>
+
+  <!-- Captains (3 boxes) -->
+  <rect x="100" y="196" width="180" height="34" rx="6" fill="url(#grad-cap)" stroke="#7aa2f7" stroke-width="1.2"/>
+  <text x="190" y="217" text-anchor="middle" fill="#7aa2f7" font-size="11" font-weight="600">Captain (Project A)</text>
+
+  <rect x="310" y="196" width="180" height="34" rx="6" fill="url(#grad-cap)" stroke="#7aa2f7" stroke-width="1.2"/>
+  <text x="400" y="217" text-anchor="middle" fill="#7aa2f7" font-size="11" font-weight="600">Captain (Project B)</text>
+
+  <rect x="520" y="196" width="180" height="34" rx="6" fill="url(#grad-cap)" stroke="#7aa2f7" stroke-width="1.2"/>
+  <text x="610" y="217" text-anchor="middle" fill="#7aa2f7" font-size="11" font-weight="600">Captain (Project …)</text>
+
+  <!-- Captains -> Crews -->
+  <line x1="190" y1="230" x2="190" y2="260" stroke="#73daca" stroke-width="1.5" marker-end="url(#arrow-green)"/>
+  <line x1="400" y1="230" x2="400" y2="260" stroke="#73daca" stroke-width="1.5" marker-end="url(#arrow-green)"/>
+  <line x1="610" y1="230" x2="610" y2="260" stroke="#73daca" stroke-width="1.5" marker-end="url(#arrow-green)"/>
+  <text x="280" y="250" fill="#565f89" font-size="9">spawns crews</text>
+
+  <!-- Crews -->
+  <rect x="50" y="266" width="140" height="28" rx="5" fill="url(#grad-crew)" stroke="#73daca" stroke-width="1"/>
+  <text x="120" y="284" text-anchor="middle" fill="#73daca" font-size="10">crew-1</text>
+
+  <rect x="210" y="266" width="140" height="28" rx="5" fill="url(#grad-crew)" stroke="#73daca" stroke-width="1"/>
+  <text x="280" y="284" text-anchor="middle" fill="#73daca" font-size="10">crew-2</text>
+
+  <rect x="370" y="266" width="140" height="28" rx="5" fill="url(#grad-crew)" stroke="#73daca" stroke-width="1"/>
+  <text x="440" y="284" text-anchor="middle" fill="#73daca" font-size="10">crew-N</text>
+
+  <rect x="530" y="266" width="140" height="28" rx="5" fill="url(#grad-crew)" stroke="#73daca" stroke-width="1"/>
+  <text x="600" y="284" text-anchor="middle" fill="#73daca" font-size="10">codex crew</text>
+
+  <rect x="690" y="266" width="90" height="28" rx="5" fill="url(#grad-crew)" stroke="#73daca" stroke-width="1"/>
+  <text x="735" y="284" text-anchor="middle" fill="#73daca" font-size="10">opencode</text>
+
+  <!-- Control Plane (spanning across) -->
+  <rect x="50" y="315" width="700" height="110" rx="8" fill="url(#grad-cp)" stroke="#f7768e" stroke-width="1.2" stroke-dasharray="6,4"/>
+  <text x="400" y="334" text-anchor="middle" fill="#f7768e" font-size="12" font-weight="600">Control Plane (cockpitd daemon)</text>
+
+  <!-- State Machine -->
+  <rect x="80" y="346" width="200" height="32" rx="5" fill="#3a1a1a" stroke="#f7768e" stroke-width="1"/>
+  <text x="180" y="365" text-anchor="middle" fill="#f7768e" font-size="10">Task State Machine (reducer)</text>
+
+  <!-- Watchdog -->
+  <rect x="310" y="346" width="180" height="32" rx="5" fill="#3a2a1a" stroke="#ff9e64" stroke-width="1"/>
+  <text x="400" y="365" text-anchor="middle" fill="#ff9e64" font-size="10">Watchdog / Heartbeat</text>
+
+  <!-- Mailbox -->
+  <rect x="520" y="346" width="200" height="32" rx="5" fill="#1a2a3a" stroke="#7aa2f7" stroke-width="1"/>
+  <text x="620" y="365" text-anchor="middle" fill="#7aa2f7" font-size="10">Mailbox Push Notification</text>
+
+  <!-- Codex Interactive -->
+  <rect x="80" y="386" width="300" height="30" rx="5" fill="#1a1a3a" stroke="#bb9af7" stroke-width="1"/>
+  <text x="230" y="405" text-anchor="middle" fill="#bb9af7" font-size="10">Codex Interactive Driver (AppServer)</text>
+
+  <!-- Unix Socket RPC -->
+  <rect x="420" y="386" width="300" height="30" rx="5" fill="#1a3a2a" stroke="#73daca" stroke-width="1"/>
+  <text x="570" y="405" text-anchor="middle" fill="#73daca" font-size="10">Unix Socket JSON-RPC Protocol</text>
+
+  <!-- Link control plane to captains -->
+  <line x1="400" y1="425" x2="400" y2="445" stroke="#f7768e" stroke-width="1" stroke-dasharray="3,3"/>
+
+  <!-- 4 Plugin Slots -->
+  <rect x="50" y="455" width="160" height="36" rx="6" fill="#1a1a2a" stroke="#7aa2f7" stroke-width="1.2"/>
+  <text x="130" y="468" text-anchor="middle" fill="#7aa2f7" font-size="10" font-weight="600">Runtime</text>
+  <text x="130" y="483" text-anchor="middle" fill="#565f89" font-size="9">cmux / future tmux</text>
+
+  <rect x="230" y="455" width="160" height="36" rx="6" fill="#1a2a1a" stroke="#9ece6a" stroke-width="1.2"/>
+  <text x="310" y="468" text-anchor="middle" fill="#9ece6a" font-size="10" font-weight="600">Workspace</text>
+  <text x="310" y="483" text-anchor="middle" fill="#565f89" font-size="9">Obsidian / future Notion</text>
+
+  <rect x="410" y="455" width="160" height="36" rx="6" fill="#2a1a1a" stroke="#f7768e" stroke-width="1.2"/>
+  <text x="490" y="468" text-anchor="middle" fill="#f7768e" font-size="10" font-weight="600">Tracker</text>
+  <text x="490" y="483" text-anchor="middle" fill="#565f89" font-size="9">GitHub / future Linear</text>
+
+  <rect x="590" y="455" width="160" height="36" rx="6" fill="#2a2a1a" stroke="#e0af68" stroke-width="1.2"/>
+  <text x="670" y="468" text-anchor="middle" fill="#e0af68" font-size="10" font-weight="600">Notifier</text>
+  <text x="670" y="483" text-anchor="middle" fill="#565f89" font-size="9">cmux / future Slack</text>
+
+  <!-- Agent drivers (bottom) -->
+  <rect x="50" y="506" width="700" height="38" rx="6" fill="#1a1b26" stroke="#3b4261" stroke-width="1"/>
+  <text x="400" y="520" text-anchor="middle" fill="#565f89" font-size="9">Agent Drivers:</text>
+  <rect x="140" y="511" width="80" height="24" rx="4" fill="#24283b" stroke="#3b4261" stroke-width="1"/>
+  <text x="180" y="527" text-anchor="middle" fill="#7aa2f7" font-size="10">claude</text>
+  <rect x="230" y="511" width="80" height="24" rx="4" fill="#24283b" stroke="#3b4261" stroke-width="1"/>
+  <text x="270" y="527" text-anchor="middle" fill="#9ece6a" font-size="10">codex</text>
+  <rect x="320" y="511" width="90" height="24" rx="4" fill="#24283b" stroke="#3b4261" stroke-width="1"/>
+  <text x="365" y="527" text-anchor="middle" fill="#e0af68" font-size="10">opencode</text>
+  <rect x="420" y="511" width="80" height="24" rx="4" fill="#24283b" stroke="#3b4261" stroke-width="1"/>
+  <text x="460" y="527" text-anchor="middle" fill="#bb9af7" font-size="10">gemini</text>
+  <rect x="510" y="511" width="70" height="24" rx="4" fill="#24283b" stroke="#3b4261" stroke-width="1"/>
+  <text x="545" y="527" text-anchor="middle" fill="#ff9e64" font-size="10">aider</text>
+  <rect x="{280}" y="{440}" width="0" height="0"/>
+</svg>
+</div>
+
+<!-- ============================================================ -->
+<!-- 2. ROLE HIERARCHY -->
+<!-- ============================================================ -->
+<h2 id="role-hierarchy">2. Role Hierarchy</h2>
+
+<p>
+Cockpit defines four roles that form a strict hierarchy. Each role maps to a distinct agent session
+type, with its own template file in <code>orchestrator/</code> and its own configuration in
+<code>~/.config/cockpit/</code>.
+</p>
+
+<h3 id="command">Command — Orchestration Overseer</h3>
+<p>
+<strong>Template:</strong> <code>orchestrator/command.claude.md</code><br>
+<strong>Spawned by:</strong> <code>cockpit command --task &lt;briefing|learnings-review|wiki-aggregate&gt;</code><br>
+<strong>Skill:</strong> <code>cockpit:command-ops</code>
+</p>
+<p>
+The Command is the top-level dispatcher. It is spawned <strong>on-demand</strong> for a single task
+(no persistent Command session). Its sole job is to delegate work to project Captains and report
+status to the user. It may never read, write, or search project source code. It has access to
+<code>~/.config/cockpit/config.json</code>, the hub vault, and cockpit CLI/ cmux commands.
+</p>
+
+<h3 id="captain">Captain — Project Leader</h3>
+<p>
+<strong>Templates:</strong> <code>orchestrator/captain.claude.md</code> (Claude),
+<code>orchestrator/captain.generic.md</code> (non-Claude agents)<br>
+<strong>Spawned by:</strong> <code>cockpit launch &lt;project&gt;</code><br>
+<strong>Skill:</strong> <code>cockpit:captain-ops</code>
+</p>
+<p>
+One Captain per registered project. The Captain is a <strong>coordinator, never a coder</strong>.
+Its responsibilities:
+</p>
+<ul>
+  <li>Spawn Crew sessions via <code>cockpit crew spawn</code> for every coding task</li>
+  <li>Send follow-up turns to existing Crews via <code>cockpit crew send</code></li>
+  <li>Inspect Crew screens via <code>cockpit crew read</code></li>
+  <li>Review and merge completed Crew work</li>
+  <li>Record learnings; write handoff files at session end</li>
+  <li>Apply Karpathy principles during code review</li>
+</ul>
+
+<h3 id="crew">Crew — Worker Context</h3>
+<p>
+<strong>Templates:</strong> <code>orchestrator/crew.claude.md</code> (Claude),
+<code>orchestrator/crew.generic.md</code> (generic), <code>orchestrator/crew.opencode.md</code>
+(OpenCode)<br>
+<strong>Spawned by:</strong> <code>cockpit crew spawn &lt;project&gt; "&lt;task&gt;" [--agent &lt;agent&gt;]</code><br>
+<strong>Lifecycle:</strong> spawned as a cmux tab, given a task prompt, operates in a git worktree,
+signals completion via <code>cockpit crew signal done</code>.
+</p>
+<p>
+Crews are ephemeral, single-session agents. Each Crew runs in a git worktree (branch isolated from
+main). A Crew must commit its work and send an explicit <code>cockpit crew signal done</code> before
+exiting. If blocked, it signals <code>crew signal blocked</code>; if unrecoverable, <code>crew signal failed</code>.
+All signals are routed through the daemon state machine (see <a href="#control-plane">Control Plane</a>).
+</p>
+<p>
+Crews may be backed by any agent type (<code>--agent claude|codex|opencode|gemini|aider</code>).
+The <code>crew.generic.md</code> template provides the same rules for non-Claude agents. Claude crews
+additionally receive per-crew <code>settings.local.json</code> with Stop/SubagentStop/PostToolUse hooks
+wired for liveness and state tracking.
+</p>
+<p>
+For complex multi-step tasks, Claude Crews may use GSD (Global Step Dispatch) wave-based execution
+(<code>/gsd:plan-phase</code>, <code>/gsd:execute-phase</code>) which spawns subagents per step with
+fresh 200K-token contexts.
+</p>
+
+<h3 id="reactor">Reactor — Reaction Engine</h3>
+<p>
+<strong>Template:</strong> <code>orchestrator/reactor.claude.md</code><br>
+<strong>Spawned by:</strong> <code>cockpit reactor</code><br>
+<strong>Skill:</strong> <code>cockpit:reactor-ops</code>
+</p>
+<p>
+The Reactor is a declarative GitHub polling engine. It runs on a configurable schedule (default 5
+minutes), polls GitHub for events (issues, PRs, check runs, review decisions), matches them against
+<code>~/.config/cockpit/reactions.json</code> rules, and executes configured actions:
+</p>
+<ul>
+  <li><strong>delegate-to-captain</strong> — route a labeled issue to the project's Captain</li>
+  <li><strong>send-to-captain</strong> — send CI failure notification to an existing Captain</li>
+  <li><strong>auto-merge</strong> — merge PR when approved + checks pass (opt-in)</li>
+  <li><strong>escalate</strong> — notify Command when Captains are stale/blocked</li>
+  <li><strong>update-project-status</strong> — move GitHub Project cards through columns</li>
+  <li><strong>send-to-command</strong> — informational notifications to Command</li>
+</ul>
+<p>
+The Reactor is a "signal router, not a decision maker" — it never decides <em>what</em> to build,
+only <em>where</em> to route based on configured rules.
+</p>
+
+<div class="info">
+<strong>Rule:</strong> Captains never code. Captains spawn Crews for every coding task. Even a
+one-line fix gets a Crew session. This is enforced in the Captain templates.
+</div>
+
+<!-- ============================================================ -->
+<!-- 3. PLUGIN SLOTS -->
+<!-- ============================================================ -->
+<h2 id="plugin-slots">3. Four Pluggable Slots</h2>
+
+<p>
+The four plugin slots (runtime, workspace, tracker, notifier) follow an identical
+<strong>registry pattern</strong>. Each slot has:
+</p>
+<ul>
+  <li><code>types.ts</code> — driver interface definition</li>
+  <li><code>registry.ts</code> — factory registry with per-project resolution</li>
+  <li><code>index.ts</code> — barrel exports</li>
+  <li>One or more concrete implementations as factory functions</li>
+</ul>
+
+<p>
+The configuration in <code>~/.config/cockpit/config.json</code> selects which driver to use globally
+(<code>config.runtime</code>, <code>config.workspace</code>, etc.) or per-project
+(<code>config.projects[].runtime</code>, etc.).
+</p>
+
+<table>
+<thead>
+<tr><th>Slot</th><th>Interface</th><th>Methods</th><th>Implementations</th><th>Default</th></tr>
+</thead>
+<tbody>
+<tr>
+  <td><strong id="runtime">Runtime</strong></td>
+  <td><code>RuntimeDriver</code></td>
+  <td><code>probe, list, spawn, send, readScreen, stop, newPane, closePane, spawnInjector, listSurfaces</code></td>
+  <td>cmux</td>
+  <td>cmux</td>
+</tr>
+<tr>
+  <td><strong id="workspace">Workspace</strong></td>
+  <td><code>WorkspaceDriver</code></td>
+  <td><code>probe, read, write, exists, list, mkdir</code></td>
+  <td>obsidian (local fs)</td>
+  <td>obsidian</td>
+</tr>
+<tr>
+  <td><strong id="tracker">Tracker</strong></td>
+  <td><code>TrackerDriver</code></td>
+  <td><code>probe, listIssues, createIssue, listPullRequests, getPullRequestChecks, getPullRequestReviewDecision, getRunLog, mergePullRequest</code></td>
+  <td>github (gh CLI)</td>
+  <td>github</td>
+</tr>
+<tr>
+  <td><strong id="notifier">Notifier</strong></td>
+  <td><code>NotifierDriver</code></td>
+  <td><code>probe, notify</code></td>
+  <td>cmux (routes to Command workspace)</td>
+  <td>cmux</td>
+</tr>
+</tbody>
+</table>
+
+<h3>Runtime Driver (src/runtimes/)</h3>
+<p>
+The runtime abstracts the terminal multiplexer. Today only <strong>cmux</strong> is
+implemented (<code>src/runtimes/cmux.ts</code>). It wraps the <code>cmux</code> binary using
+<code>execFileSync</code> with argv arrays (no shell injection). The <code>RuntimeRegistry</code>
+resolves which driver to use per-project from config.
+</p>
+<p>
+The runtime is the thickest plugin interface: it manages workspaces (captain sessions), panes/tabs
+(crew sessions), injector processes (mailbox tailers), and surface listing. The cmux driver
+implements all 10 interface methods.
+</p>
+
+<h3>Workspace Driver (src/workspaces/)</h3>
+<p>
+The workspace abstracts persistent storage for cockpit's knowledge vaults (wiki, learnings, daily
+logs, handoffs). Today only <strong>Obsidian</strong> is implemented, which is a local filesystem
+driver with path-escape protection. The <code>WorkspaceRegistry</code> resolves both <code>hub()</code>
+(from <code>config.hubVault</code>) and <code>forProject()</code> (from
+<code>config.projects[].spokeVault</code>) drivers. The factory pattern allows future providers
+(e.g., Obsidian Remote, Notion API, S3).
+</p>
+
+<h3>Tracker Driver (src/trackers/)</h3>
+<p>
+The tracker abstracts issue/PR management. Today only <strong>GitHub</strong> is implemented
+(<code>src/trackers/github.ts</code>), wrapping the <code>gh</code> CLI via <code>execSync</code>.
+The <code>TrackerRegistry</code> reads <code>reactions.json</code> to determine owner/repo per
+project, then creates the driver. Future trackers may support Linear, Jira, or GitLab.
+</p>
+
+<h3>Notifier Driver (src/notifiers/)</h3>
+<p>
+The notifier is the simplest plugin slot: a single <code>notify(message)</code> call. Today only
+<strong>cmux</strong> is implemented, which routes notifications through the
+<code>cockpit runtime send --command</code> CLI back to the Command workspace.
+</p>
+
+<!-- ============================================================ -->
+<!-- 4. AGENT DRIVERS -->
+<!-- ============================================================ -->
+<h2 id="agent-drivers">4. Agent Drivers</h2>
+
+<p>
+Agent drivers (<code>src/drivers/</code>) abstract the coding agent CLI. Each driver is a factory
+function returning an <code>AgentDriver</code> interface with four methods: <code>probe</code>,
+<code>buildCommand</code>, <code>parseOutput</code>, and <code>stop</code>. The
+<code>CapabilityRegistry</code> holds all registered drivers, probes each for installed
+version/capabilities, and validates agent suitability per role.
+</p>
+
+<table>
+<thead>
+<tr><th>Driver</th><th>File</th><th>Interactive mode</th><th>Headless mode</th><th>Auto-approve</th></tr>
+</thead>
+<tbody>
+<tr>
+  <td><strong>Claude</strong></td>
+  <td><code>src/drivers/claude.ts</code></td>
+  <td><code>claude</code> (bare TUI, no <code>-p</code>)</td>
+  <td><code>claude -p "..." --print</code></td>
+  <td><code>--dangerously-skip-permissions</code></td>
+</tr>
+<tr>
+  <td><strong>Codex</strong></td>
+  <td><code>src/drivers/codex.ts</code></td>
+  <td><code>codex</code> (via daemon AppServer)</td>
+  <td><code>codex exec "..." --json --full-auto</code></td>
+  <td><code>--full-auto</code></td>
+</tr>
+<tr>
+  <td><strong>OpenCode</strong></td>
+  <td><code>src/drivers/opencode.ts</code></td>
+  <td><code>opencode</code> (bare TUI)</td>
+  <td><code>opencode run "..."</code></td>
+  <td>via per-crew <code>opencode.json</code> config (all-permissions)</td>
+</tr>
+<tr>
+  <td><strong>Gemini</strong></td>
+  <td><code>src/drivers/gemini.ts</code></td>
+  <td>generates Gemini CLI interactive command</td>
+  <td>via prompt flag</td>
+  <td>via driver config</td>
+</tr>
+<tr>
+  <td><strong>Aider</strong></td>
+  <td><code>src/drivers/aider.ts</code></td>
+  <td>generates Aider CLI interactive command</td>
+  <td>via prompt flag</td>
+  <td>via driver config</td>
+</tr>
+</tbody>
+</table>
+
+<h3>Capability-Based Routing</h3>
+<p>
+Each agent driver exposes a set of <code>AgentCapability</code> values: <code>teams</code>,
+<code>json_output</code>, <code>sandbox</code>, <code>model_routing</code>, <code>skills</code>,
+<code>auto_approve</code>, <code>streaming</code>, <code>prompt_file</code>. The <code>ROLE_REQUIREMENTS</code>
+map in <code>src/drivers/types.ts:59</code> defines which capabilities each role requires:
+</p>
+<ul>
+  <li>All roles require <strong>auto_approve</strong></li>
+  <li>Command additionally prefers <code>teams</code> and <code>json_output</code></li>
+  <li>Captain prefers <code>teams</code>, <code>model_routing</code>, <code>skills</code></li>
+  <li>Crew prefers <code>json_output</code>, <code>sandbox</code></li>
+  <li>Reactor requires <code>json_output</code></li>
+</ul>
+
+<!-- ============================================================ -->
+<!-- 5. CONTROL PLANE -->
+<!-- ============================================================ -->
+<h2 id="control-plane">5. Control Plane (cockpitd Daemon)</h2>
+
+<p>
+The control plane daemon (<code>src/control/</code>, 14 files) is a macOS launchd-managed background
+process that supervises all crew execution. It provides a task state machine, watchdog/heartbeat,
+push notification mailbox, interactive hook bridge, and Codex interactive driver.
+</p>
+
+<p>
+The daemon is defined in <code>src/control/launchd.ts</code> as a launchd agent
+(<code>com.cockpit.daemon</code>) with <code>KeepAlive</code> + <code>ThrottleInterval</code> (10s)
+to prevent crash loops. <code>ensureDaemon()</code> writes the plist and bootstraps the service.
+On startup (<code>src/index.ts:47</code>), <code>ensureDaemon()</code> runs before any command.
+</p>
+
+<p>
+The daemon listens on a Unix domain socket at <code>~/.config/cockpit/cockpit.sock</code> using a
+JSON-line protocol (<code>src/control/protocol.ts</code>). Communication includes request/response
+RPC and long-lived attach streaming connections for interactive Codex sessions.
+</p>
+
+<h3 id="state-machine">Task State Machine</h3>
+<p>
+The state machine (<code>src/control/state-machine.ts</code>) is a <strong>pure reducer function</strong>:
+<code>reduce(record: TaskRecord, event: ControlEvent, now: number) =&gt; TaskRecord</code>. It is
+fully testable without I/O. The daemon (<code>src/control/daemon.ts</code>) injects side effects
+(store, clock, process launcher, notifier).
+</p>
+
+<div class="diagram">
+<svg viewBox="0 0 760 260" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arrow2" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#7aa2f7"/>
+    </marker>
+    <marker id="arrow-red" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#f7768e"/>
+    </marker>
+    <marker id="arrow-cyan" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#73daca"/>
+    </marker>
+    <marker id="arrow-yellow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#e0af68"/>
+    </marker>
+  </defs>
+  <rect x="0" y="0" width="760" height="260" rx="8" fill="#1a1b26"/>
+  <text x="380" y="22" text-anchor="middle" fill="#c0caf5" font-size="13" font-weight="600">Task State Machine</text>
+
+  <!-- Submitted -->
+  <ellipse cx="120" cy="90" rx="60" ry="24" fill="#1a1a2a" stroke="#7aa2f7" stroke-width="1.5"/>
+  <text x="120" y="94" text-anchor="middle" fill="#7aa2f7" font-size="11">submitted</text>
+
+  <!-- Working -->
+  <ellipse cx="320" cy="90" rx="55" ry="24" fill="#1a2a1a" stroke="#9ece6a" stroke-width="1.5"/>
+  <text x="320" y="94" text-anchor="middle" fill="#9ece6a" font-size="11">working</text>
+
+  <!-- Blocked -->
+  <ellipse cx="320" cy="180" rx="50" ry="22" fill="#2a1a1a" stroke="#f7768e" stroke-width="1.5"/>
+  <text x="320" y="184" text-anchor="middle" fill="#f7768e" font-size="11">blocked</text>
+
+  <!-- Awaiting Input -->
+  <ellipse cx="500" cy="90" rx="65" ry="22" fill="#1a1a2a" stroke="#bb9af7" stroke-width="1.5"/>
+  <text x="500" y="94" text-anchor="middle" fill="#bb9af7" font-size="11">awaiting-input</text>
+
+  <!-- Stalled -->
+  <ellipse cx="500" cy="180" rx="45" ry="22" fill="#2a2a1a" stroke="#e0af68" stroke-width="1.5"/>
+  <text x="500" y="184" text-anchor="middle" fill="#e0af68" font-size="11">stalled</text>
+
+  <!-- Done / Failed -->
+  <ellipse cx="680" cy="90" rx="45" ry="22" fill="#1a1a1a" stroke="#565f89" stroke-width="1.5"/>
+  <text x="680" y="90" text-anchor="middle" fill="#565f89" font-size="10">done</text>
+  <text x="680" y="100" text-anchor="middle" fill="#565f89" font-size="10">/ failed</text>
+
+  <!-- Transitions: submitted -> working -->
+  <line x1="180" y1="90" x2="263" y2="90" stroke="#7aa2f7" stroke-width="1.5" marker-end="url(#arrow2)"/>
+  <text x="222" y="82" fill="#565f89" font-size="9">task.started</text>
+
+  <!-- working -> blocked -->
+  <line x1="300" y1="114" x2="300" y2="158" stroke="#f7768e" stroke-width="1.2" marker-end="url(#arrow-red)"/>
+  <text x="240" y="140" fill="#565f89" font-size="9">task.blocked / .input/.approval.requested</text>
+
+  <!-- blocked -> working (resume) -->
+  <line x1="345" y1="158" x2="345" y2="114" stroke="#73daca" stroke-width="1.2" marker-end="url(#arrow-cyan)"/>
+  <text x="380" y="140" fill="#565f89" font-size="9">task.started</text>
+
+  <!-- working -> awaiting-input -->
+  <line x1="375" y1="90" x2="433" y2="90" stroke="#bb9af7" stroke-width="1.5" marker-end="url(#arrow2)"/>
+  <text x="404" y="82" fill="#565f89" font-size="9">task.turn.completed</text>
+
+  <!-- awaiting-input -> working -->
+  <line x1="500" y1="112" x2="320" y2="114" stroke="#73daca" stroke-width="1.2" marker-end="url(#arrow-cyan)" stroke-dasharray="5,3"/>
+  <text x="370" y="122" fill="#565f89" font-size="9">heartbeat / task.turn.started</text>
+
+  <!-- working -> stalled -->
+  <line x1="340" y1="114" x2="490" y2="162" stroke="#e0af68" stroke-width="1.2" marker-end="url(#arrow-yellow)" stroke-dasharray="5,3"/>
+  <text x="420" y="142" fill="#565f89" font-size="9">watchdog (heartbeat expired)</text>
+
+  <!-- stalled -> working (recoverable) -->
+  <line x1="530" y1="158" x2="350" y2="114" stroke="#73daca" stroke-width="1" marker-end="url(#arrow-cyan)" stroke-dasharray="3,3"/>
+  <text x="520" y="134" fill="#565f89" font-size="9">watchdog.recover</text>
+
+  <!-- working -> done/failed -->
+  <line x1="375" y1="82" x2="633" y2="82" stroke="#565f89" stroke-width="1.5" marker-end="url(#arrow2)"/>
+  <text x="504" y="73" fill="#565f89" font-size="9">task.done / task.failed</text>
+
+  <!-- blocked -> done/failed -->
+  <line x1="370" y1="180" x2="640" y2="105" stroke="#565f89" stroke-width="1" marker-end="url(#arrow2)" stroke-dasharray="4,3"/>
+</svg>
+</div>
+
+<p>
+Key state machine properties (<code>src/control/state-machine.ts</code>):
+</p>
+<ul>
+  <li><strong>Terminal states</strong> (<code>TERMINAL_STATES</code>): only <code>done</code> and
+  <code>failed</code> are absorbing — any late/duplicate event is ignored.</li>
+  <li><strong>Recoverable stalls:</strong> <code>stalled</code> is <em>not</em> terminal. The
+  watchdog can recover a stalled task to <code>working</code> if a heartbeat arrives.</li>
+  <li><strong>awaiting-input:</strong> the PostToolUse-like state that separates turn completion
+  from task completion (anti-#2576 invariant).</li>
+  <li><strong>Pure function:</strong> the reducer never mutates input; it always returns a new
+  record (spread + targeted overrides).</li>
+</ul>
+
+<h3 id="watchdog">Watchdog / Heartbeat</h3>
+<p>
+The watchdog (<code>src/control/watchdog.ts</code>) implements stall detection as a pure function:
+</p>
+<ul>
+  <li><code>evaluateStall(rec, now)</code> — if a <em>working</em> task has not received a heartbeat
+  within <code>heartbeatBudgetMs</code>, produces a <code>stalled</code> record.</li>
+  <li><code>recoverStall(rec, now)</code> — produces a <code>working</code> record from a
+  <code>stalled</code> record (caller must verify heartbeat freshness).</li>
+</ul>
+<p>
+The daemon sweeps all tasks on a 30-second interval (<code>src/control/cockpitd.ts:287-290</code>).
+Interactive tasks (Claude, OpenCode, Codex) receive heartbeats from the PostToolUse hook
+(Claude), from the daemon's state ledger (OpenCode), or from the AppServer event stream (Codex).
+</p>
+
+<h3 id="hook-bridge">Hook Bridge (Interactive Claude Crews)</h3>
+<p>
+For Claude interactive crews, the daemon does NOT own the process. The crew runs in a cmux tab.
+The daemon's role is purely the <strong>state ledger</strong>:
+</p>
+<ul>
+  <li>On dispatch, emit <code>task.started</code> to transition <code>submitted → working</code></li>
+  <li>On each Claude turn end, the <strong>Stop hook</strong> fires (embedded in per-crew
+  <code>settings.local.json</code>), emitting <code>task.turn.completed</code> →
+  <code>awaiting-input</code></li>
+  <li>On the next Turn, <code>PostToolUse</code> emits a <code>heartbeat</code> →
+  back to <code>working</code></li>
+  <li>On actual task completion, <code>cockpit crew signal done</code> emits
+  <code>task.done</code> → <code>done</code></li>
+</ul>
+<p>
+The hooks are injected per-crew via <code>src/lib/per-crew-settings.ts</code>:
+<code>writePerCrewSettings()</code> writes a <code>--settings</code>-compatible JSON file with
+Stop/SubagentStop/SessionEnd hooks merged. <code>writePerCrewSettingsLocal()</code> writes
+<code>.claude/settings.local.json</code> at the project level (auto-loaded, not clobbered by
+cmux wrapper settings).
+</p>
+
+<h3 id="codex">Codex Interactive Driver</h3>
+<p>
+Codex interactive crews use a fundamentally different architecture: the daemon
+<strong>owns the Codex child process</strong> via its <code>CodexInteractiveDriver</code>
+(<code>src/control/codex/</code>), which manages a single <code>AppServerClient</code> instance.
+Each task maps to a thread inside that child.
+</p>
+<p>
+The Codex architecture supports:
+</p>
+<ul>
+  <li><strong>Attach streaming</strong> — cmux clients can <code>attach</code> to a Codex task and
+  receive real-time delta frames via the Unix socket.</li>
+  <li><strong>Gate promotion</strong> — when Codex requests approval or input and no client is
+  attached, a 5-second timer promotes the request to a persistent <code>Gate</code> in the store.
+  A later-attaching client can see and resolve the gate.</li>
+  <li><strong>Inbound operations</strong> — attached clients can <code>say</code>, <code>steer</code>,
+  <code>interrupt</code>, and <code>answer</code> on the Codex task.</li>
+  <li><strong>Restart-reattach</strong> — on daemon restart, non-terminal interactive Codex tasks
+  with a <code>resumeRef</code> are automatically reattached.</li>
+</ul>
+
+<!-- ============================================================ -->
+<!-- 6. CROSS-AGENT PROJECTION -->
+<!-- ============================================================ -->
+<h2 id="projection">6. Cross-Agent Projection Layer</h2>
+
+<p>
+The projection layer (<code>src/projection/</code>, 9 files) implements <strong>issue #31</strong>:
+synchronizing cockpit's instruction templates into each agent's native configuration format.
+</p>
+
+<p>
+Each supported agent type has an <strong>emitter</strong> that knows where to write its configuration
+files (user-level and project-level):
+</p>
+
+<table>
+<thead>
+<tr><th>Target</th><th>File</th><th>Destination</th><th>Format</th></tr>
+</thead>
+<tbody>
+<tr><td>Cursor</td><td><code>src/projection/cursor.ts</code></td><td><code>.cursor/rules/*.mdc</code></td><td><code>.mdc</code> rule format</td></tr>
+<tr><td>Codex</td><td><code>src/projection/codex.ts</code></td><td><code>AGENTS.md</code></td><td>Markdown (marker merge)</td></tr>
+<tr><td>Gemini CLI</td><td><code>src/projection/gemini.ts</code></td><td><code>GEMINI.md</code></td><td>Markdown (marker merge)</td></tr>
+<tr><td>OpenCode</td><td><code>src/projection/opencode.ts</code></td><td><code>AGENTS.md</code></td><td>Markdown (marker merge)</td></tr>
+</tbody>
+</table>
+
+<p>
+Note: Claude is <strong>not</strong> a projection target. <code>CLAUDE.md</code> is cockpit's
+canonical/source instruction format that Claude Code reads natively — other agents are projected
+<em>from</em> it, not to it.
+</p>
+
+<p>
+All emitters use a <strong>marker-based merge</strong> strategy (<code>src/projection/marker.ts</code>):
+content is inserted between <code>&lt;!-- cockpit:start --&gt;</code> and <code>&lt;!-- cockpit:end --&gt;</code>
+markers. This allows surgical updates without clobbering user content outside the markers.
+</p>
+
+<p>
+The <code>ProjectionRegistry</code> (<code>src/projection/registry.ts</code>) holds emitter factories
+and creates the correct emitter by name. The <code>cockpit projection</code> CLI command
+(<code>src/commands/projection.ts</code>) drives this: it reads user-level source
+(<code>orchestrator/</code> templates + <code>plugin/skills/</code>) and project-level source
+(project <code>AGENTS.md</code>), then emits to all configured targets via
+<code>ProjectionEmitter.emit()</code>.
+</p>
+
+<div class="info">
+<strong>Direction per multi-agent spec (2026-04-24):</strong> <code>AGENTS.md</code> is the
+canonical instruction format. <code>CLAUDE.md</code> becomes a thin wrapper. Skills stay portable
+markdown — Claude reads via Skill tool, others via AGENTS.md inclusion.
+</div>
+
+<!-- ============================================================ -->
+<!-- 7. OTHER MODULES -->
+<!-- ============================================================ -->
+<h2 id="other-modules">7. Other Modules</h2>
+
+<h3 id="commands">CLI Commands (src/commands/)</h3>
+<p>
+25 files implementing the Commander-based CLI. Key commands:
+</p>
+
+<table>
+<thead>
+<tr><th>Command</th><th>File</th><th>Description</th></tr>
+</thead>
+<tbody>
+<tr><td><code>cockpit init</code></td><td><code>commands/init.ts</code></td><td>Initialize a new cockpit project</td></tr>
+<tr><td><code>cockpit launch &lt;project&gt;</code></td><td><code>commands/launch.ts</code></td><td>Spawn a captain workspace for a project</td></tr>
+<tr><td><code>cockpit crew spawn/send/read/close/list</code></td><td><code>commands/crew.ts</code></td><td>Manage crew sessions (largest command, 473 lines)</td></tr>
+<tr><td><code>cockpit crew dispatch/status/tasks/reply/signal</code></td><td><code>commands/crew-control.ts</code></td><td>Control-plane crew verbs (daemon protocol)</td></tr>
+<tr><td><code>cockpit command --task &lt;type&gt;</code></td><td><code>commands/command.ts</code></td><td>Spawn one-shot Command sessions</td></tr>
+<tr><td><code>cockpit dashboard</code></td><td><code>commands/dashboard.ts</code></td><td>View project dashboard</td></tr>
+<tr><td><code>cockpit doctor</code></td><td><code>commands/doctor.ts</code></td><td>System diagnostics</td></tr>
+<tr><td><code>cockpit reactor</code></td><td><code>commands/reactor.ts</code></td><td>Manage/reactor operations</td></tr>
+<tr><td><code>cockpit projection</code></td><td><code>commands/projection.ts</code></td><td>Emit cross-agent projection files</td></tr>
+<tr><td><code>cockpit runtime send &lt;project&gt;</code></td><td><code>commands/runtime.ts</code></td><td>Send messages between workspaces</td></tr>
+<tr><td><code>cockpit notify</code></td><td><code>commands/notify.ts</code></td><td>Send notification</td></tr>
+<tr><td><code>cockpit standup</code></td><td><code>commands/standup.ts</code></td><td>Daily standup</td></tr>
+<tr><td><code>cockpit retro</code></td><td><code>commands/retro.ts</code></td><td>Session retro</td></tr>
+<tr><td><code>cockpit status</code></td><td><code>commands/status.ts</code></td><td>View status</td></tr>
+<tr><td><code>cockpit shutdown</code></td><td><code>commands/shutdown.ts</code></td><td>Shutdown</td></tr>
+<tr><td><code>cockpit doctor</code></td><td><code>commands/doctor.ts</code></td><td>System diagnostics</td></tr>
+</tbody>
+</table>
+
+<h3 id="config">Configuration (src/config.ts)</h3>
+<p>
+The <code>CockpitConfig</code> interface (<code>src/config.ts:110-134</code>) defines the top-level
+configuration shape:
+</p>
+<ul>
+  <li><strong>commandName</strong> — workspace name for the command session</li>
+  <li><strong>hubVault</strong> — path to the cross-project hub vault (~/cockpit-hub by default)</li>
+  <li><strong>projects</strong> — <code>Record&lt;string, ProjectConfig&gt;</code> mapping project
+  names to their path, captain name, spoke vault, host, group, runtime, workspace, and tracker
+  overrides</li>
+  <li><strong>agents</strong> — registered agent CLIs and their driver mappings</li>
+  <li><strong>defaults</strong> — <code>maxCrew</code>, <code>worktreeDir</code>,
+  <code>teammateMode</code>, <code>permissions</code> (auto-approve per role),
+  <code>models</code> (model routing per role), <code>roles</code> (agent + model per role)</li>
+  <li><strong>runtime / workspace / tracker / notifier</strong> — default plugin slot selections</li>
+  <li><strong>projection</strong> — projection target list</li>
+  <li><strong>metrics</strong> — flag + metrics file path</li>
+</ul>
+
+<h3 id="dashboard">Dashboard (src/dashboard/)</h3>
+<p>
+Three files implementing the terminal dashboard:
+</p>
+<ul>
+  <li><code>read-status.ts</code> — reads all project <code>status.md</code> files from spoke
+  vaults, parses YAML frontmatter + fenced excerpts</li>
+  <li><code>render.ts</code> — color-coded terminal rendering with state icons</li>
+  <li><code>sync-hub.ts</code> — mirrors project status to hub vault at
+  <code>{hubVault}/projects/{project}.md</code></li>
+</ul>
+
+<h3>Reactor Module (src/reactor/)</h3>
+<ul>
+  <li><code>auto-status.ts</code> — polls each captain's screen via the runtime, classifies content,
+  writes <code>status.md</code></li>
+  <li><code>status-classifier.ts</code> — regex-based classifier returning
+  <code>idle | busy | blocked | errored | offline</code></li>
+</ul>
+
+<h3>Library (src/lib/)</h3>
+<p>Seven utility files:</p>
+<ul>
+  <li><code>runtime-sync.ts</code> — mirrors <code>plugin/</code>, <code>scripts/</code>,
+  <code>orchestrator/</code> from source to <code>~/.config/cockpit/</code></li>
+  <li><code>cmux-bin.ts</code> — resolves cmux binary path (env → config → PATH → fallback)</li>
+  <li><code>per-crew-settings.ts</code> — writes per-crew Claude settings and OpenCode config</li>
+  <li><code>canonical-source.ts</code> — reads skills and AGENTS.md for projection</li>
+  <li><code>vault-layout.ts</code> — ensures spoke vault directory structure</li>
+  <li><code>daily-logs.ts</code> — read/write daily log files</li>
+</ul>
+
+<h3>Entry Point (src/index.ts)</h3>
+<p>
+The CLI entrypoint (<code>src/index.ts</code>) does two things before registering any command:
+</p>
+<ul>
+  <li>Calls <code>ensureRuntimeSynced()</code> — idempotent mirror of source-managed dirs to
+  runtime (<code>~/.config/cockpit/</code>), so skills, role templates, and scripts can never
+  silently drift.</li>
+  <li>Calls <code>ensureDaemon()</code> — idempotent launchd plist management, ensuring the
+  control-plane daemon is running.</li>
+</ul>
+<p>
+Both are best-effort and never throw — the CLI fails loud later if the socket is unreachable.
+</p>
+
+<!-- ============================================================ -->
+<!-- 8. FILESYSTEM LAYOUT -->
+<!-- ============================================================ -->
+<h2 id="fs-layout">8. Filesystem Layout</h2>
+
+<p>
+Cockpit has three distinct storage areas:
+</p>
+
+<h3>Source Tree (~/me/claude-cockpit)</h3>
+<pre><code>src/                      # TypeScript source
+  index.ts                # CLI entrypoint
+  config.ts               # Configuration interfaces + load/save
+  commands/               # 25 CLI command files
+  control/               # Daemon, state machine, protocol, watchdog, mailbox
+    codex/               # Codex interactive driver
+    headless/            # Headless adapters per provider
+    interactive/         # Interactive hook adapters
+  dashboard/             # Status reader, renderer, hub sync
+  drivers/               # 5 agent drivers + capability registry
+  lib/                   # Utilities (cmux-bin, runtime-sync, per-crew-settings…)
+  notifiers/             # Notification plugin slot
+  projection/            # Cross-agent instruction projection
+  reactor/               # Auto-status poller + classifier
+  runtimes/              # Runtime plugin slot
+  trackers/              # Tracker plugin slot
+  workspaces/            # Workspace plugin slot
+docs/                    # Specs and documentation
+  specs/                 # 25 spec documents
+orchestrator/            # Role templates (8 files)
+  command.claude.md      # Command template (Claude)
+  captain.claude.md      # Captain template (Claude)
+  captain.generic.md     # Captain template (generic)
+  crew.claude.md         # Crew template (Claude)
+  crew.generic.md        # Crew template (generic / Codex / Gemini)
+  crew.opencode.md       # Crew template (OpenCode)
+  reactor.claude.md      # Reactor template
+  learnings.claude.md    # Learnings template
+plugin/skills/           # Portable markdown skills (Karpathy, etc.)
+scripts/                 # Shell scripts (read-handoff, write-status, etc.)
+</code></pre>
+
+<h3>Runtime / State (~/.config/cockpit)</h3>
+<pre><code>config.json              # Project configuration
+reactions.json           # Reactor reaction rules
+state/                   # Control-plane task records (JSON files per project/id)
+inbox/                   # Mailbox push notification logs (*.log per project)
+cockpit.sock             # Unix domain socket for daemon RPC
+plugin/                  # Mirrored from source (plugin/skills/)
+scripts/                 # Mirrored from source (.sh files)
+orchestrator/            # Mirrored from source (role templates)
+dist/                    # Compiled JS
+reactor-state.json       # Reactor's processed event tracker
+metrics.json             # Metrics data
+</code></pre>
+
+<h3>Hub + Spoke Vaults (~/cockpit-hub)</h3>
+<pre><code>cockpit-hub/             # Cross-project hub vault
+  daily-logs/            # Command-level daily logs
+  wiki/                  # Cross-project wiki
+  projects/{project}.md  # Mirrored project status
+  learnings/             # Cross-project learnings
+
+spokes/{project}/        # Per-project spoke vaults
+  handoffs/              # Session handoff files
+  daily-logs/            # Project daily logs
+  wiki/                  # Project wiki pages
+  learnings/             # Project learnings
+  status.md              # Auto-generated status (by reactor)
+</code></pre>
+
+<p>
+The hub and spoke vaults are filesystem-based workspaces managed through the
+<a href="#workspace">workspace plugin slot</a>. The hub vault holds cross-project knowledge;
+each project's spoke vault holds project-specific knowledge. The <code>ensureSpokeLayout()</code>
+function in <code>src/lib/vault-layout.ts</code> idempotently creates the spoke subdirectory
+structure when a project is registered.
+</p>
+
+<!-- ============================================================ -->
+<!-- 9. GENERATION METADATA -->
+<!-- ============================================================ -->
+<h2 id="footer">9. Generation Metadata</h2>
+<div class="footer">
+<table style="max-width: 500px;">
+<tbody>
+<tr><td><strong>Generated</strong></td><td>2026-05-28</td></tr>
+<tr><td><strong>Branch</strong></td><td>develop</td></tr>
+<tr><td><strong>Commit</strong></td><td><code>50edf94</code></td></tr>
+<tr><td><strong>Source</strong></td><td>~/me/claude-cockpit</td></tr>
+<tr><td><strong>Index</strong></td><td>767 files, 3,651 code symbols, 75 communities, 91 processes</td></tr>
+<tr><td><strong>Specs</strong></td><td>25 spec documents in <code>docs/specs/</code></td></tr>
+</tbody>
+</table>
+<p>
+This report reflects the state of the <code>develop</code> branch at commit <code>50edf94</code>.
+Every claim is grounded in the actual source code: src/ tree, docs/specs/, orchestrator/ templates,
+and the GitNexus code knowledge graph (clusters, processes, queries).
+</p>
+<p>
+Generated via <code>docs/architecture.html</code> on branch <code>docs/architecture-report</code>.
+</p>
+</div>
+
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Self-contained HTML report at `docs/architecture.html` documenting cockpit's current architecture on develop.

## Source of Truth

Every claim is grounded in real code:
- `src/` tree: read key files from every module
- `docs/specs/2026-04-24-multi-agent-direction.md`: multi-agent direction
- `orchestrator/` templates: 8 role template files
- GitNexus: queried clusters, processes, and symbol context

## Contents

1. **What Cockpit Is** — multi-agent orchestration layer, not Claude-only
2. **Role Hierarchy** — Command → Captain → Crew + Reactor
3. **Four Plugin Slots** — runtime, workspace, tracker, notifier (registry pattern)
4. **Five Agent Drivers** — claude, codex, opencode, gemini, aider (capability routing)
5. **Control Plane** — cockpitd daemon, task state machine (pure reducer), watchdog/heartbeat, hook bridge, Codex interactive driver
6. **Cross-Agent Projection** — marker-based merge for AGENTS.md/GEMINI.md/CLAUDE.md/Cursor rules
7. **Other Modules** — all 25 CLI commands, config, dashboard, reactor, lib
8. **Filesystem Layout** — source tree, runtime/state (~/.config/cockpit), hub/spoke vaults
9. **Generated at** — 2026-05-28, develop commit 50edf94

## Technical Details

- Single self-contained HTML (inline CSS, inline SVGs for diagrams, no external CDN/JS/font dependencies)
- Dark theme with Tokyo Night palette
- Responsive layout with sidebar ToC
- 1,135 lines, ~38KB
- Two inline SVG diagrams: role hierarchy + task state machine