### PR TITLE
fix: add task.reopened semantic so re-tasking a done crew fires CREW DONE again (#148)

### DIFF
--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -440,6 +440,7 @@ describe("cockpit crew send/read/close/list", () => {
     loadConfig.mockReset();
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    cockpitdCall.mockReset();
   });
 
   it("send delivers a message to the matching crew tab", async () => {
@@ -459,6 +460,74 @@ describe("cockpit crew send/read/close/list", () => {
     listSurfaces.mockResolvedValue([]);
     await expect(runCrewSend("brove", "ghost", "msg"))
       .rejects.toThrow(/Crew 'ghost' not found/);
+  });
+
+  it("send emits task.reopened when the crew's daemon task is terminal", async () => {
+    listSurfaces.mockResolvedValue([
+      { workspaceId: "workspace:5", surfaceId: "surface:10", title: "🔧 brove:crew-1" },
+    ]);
+    // Simulate a daemon with a done task matching the crew name.
+    cockpitdCall.mockImplementation(async (req: unknown) => {
+      const r = req as { kind: string; project?: string };
+      if (r.kind === "list") {
+        return [{ id: "task-done-1", name: "crew-1", project: "brove", state: "done", provider: "claude", mode: "interactive", task: "old task", createdAt: 1000, lastHeartbeat: 1000, lastEvent: "task.done", heartbeatBudgetMs: 300000, attempts: [] }];
+      }
+      return undefined;
+    });
+
+    await runCrewSend("brove", "crew-1", "follow up");
+
+    // Should have called list then event (task.reopened)
+    expect(cockpitdCall).toHaveBeenCalledWith(expect.objectContaining({ kind: "list", project: "brove" }));
+    expect(cockpitdCall).toHaveBeenCalledWith(expect.objectContaining({
+      kind: "event",
+      project: "brove",
+      event: { type: "task.reopened", id: "task-done-1" },
+    }));
+    expect(sendToPane).toHaveBeenCalledWith(
+      { workspaceId: "workspace:5", surfaceId: "surface:10", title: "🔧 brove:crew-1" },
+      "follow up",
+    );
+  });
+
+  it("send does NOT emit task.reopened when the crew's task is working (non-terminal)", async () => {
+    listSurfaces.mockResolvedValue([
+      { workspaceId: "workspace:5", surfaceId: "surface:10", title: "🔧 brove:crew-1" },
+    ]);
+    cockpitdCall.mockImplementation(async (req: unknown) => {
+      const r = req as { kind: string };
+      if (r.kind === "list") {
+        return [{ id: "task-w-1", name: "crew-1", project: "brove", state: "working", provider: "claude", mode: "interactive", task: "current", createdAt: 2000, lastHeartbeat: 2000, lastEvent: "task.started", heartbeatBudgetMs: 300000, attempts: [] }];
+      }
+      return undefined;
+    });
+
+    await runCrewSend("brove", "crew-1", "follow up");
+
+    // Only one call to cockpitdCall — the list to check state; no event emitted.
+    const callKinds = (cockpitdCall.mock.calls as Array<[{ kind: string }]>)
+      .map(([req]) => req.kind);
+    expect(callKinds).toEqual(["list"]);
+    expect(sendToPane).toHaveBeenCalledWith(
+      { workspaceId: "workspace:5", surfaceId: "surface:10", title: "🔧 brove:crew-1" },
+      "follow up",
+    );
+  });
+
+  it("send tolerates daemon being down (best-effort, caught)", async () => {
+    listSurfaces.mockResolvedValue([
+      { workspaceId: "workspace:5", surfaceId: "surface:10", title: "🔧 brove:crew-1" },
+    ]);
+    // Daemon throws on every call.
+    cockpitdCall.mockRejectedValue(new Error("daemon unreachable"));
+
+    await runCrewSend("brove", "crew-1", "follow up");
+
+    // sendToPane still fires even with daemon errors.
+    expect(sendToPane).toHaveBeenCalledWith(
+      { workspaceId: "workspace:5", surfaceId: "surface:10", title: "🔧 brove:crew-1" },
+      "follow up",
+    );
   });
 
   it("read returns the crew's screen content", async () => {

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -17,7 +17,7 @@ import {
 import type { PaneRef, PanePlacement, RuntimeDriver } from "../runtimes/types.js";
 import { buildDispatchRequest, cockpitdCall, sendCodexFirstTurn } from "./crew-control.js";
 import { writePerCrewSettingsLocal, writePerCrewOpencodeConfig } from "../lib/per-crew-settings.js";
-import type { TaskRecord } from "../control/types.js";
+import { TERMINAL_STATES, type TaskRecord } from "../control/types.js";
 
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "cockpit", "templates");
 
@@ -337,6 +337,18 @@ export async function runCrewSend(project: string, name: string, message: string
   const crew = await findCrew(runtime, workspaceId, project, name);
   if (!crew) {
     throw new Error(`Crew '${name}' not found for ${project}. Run 'cockpit crew list ${project}'.`);
+  }
+  // Best-effort: if the daemon task for this crew is terminal, reopen it so
+  // the next signal done is a real transition and fires CREW DONE (#148).
+  try {
+    const tasks = (await cockpitdCall({ kind: "list", project })) as TaskRecord[];
+    const task = tasks.find((t) => t.name === name && TERMINAL_STATES.has(t.state));
+    if (task) {
+      await cockpitdCall({ kind: "event", project, event: { type: "task.reopened", id: task.id } });
+    }
+  } catch {
+    // Swallow daemon errors so crews without a daemon or offline daemon
+    // still receive the sent message.
   }
   await runtime.sendToPane(crew, message);
 }

--- a/src/control/__tests__/state-machine.test.ts
+++ b/src/control/__tests__/state-machine.test.ts
@@ -67,6 +67,57 @@ describe("state-machine reduce", () => {
     expect(next).toBe(done); // same reference — no-op
   });
 
+  it("task.reopened revives done → working, clears question and error", () => {
+    const d = rec({ state: "done", resultRef: "/r", question: "old question", error: undefined });
+    const next = reduce(d, { type: "task.reopened", id: "t1" }, 7000);
+    expect(next.state).toBe("working");
+    expect(next.question).toBeUndefined();
+    expect(next.error).toBeUndefined();
+    expect(next.lastHeartbeat).toBe(7000);
+    expect(next.lastEvent).toBe("task.reopened");
+    // resultRef is preserved even after reopen (informational)
+    expect(next.resultRef).toBe("/r");
+  });
+
+  it("task.reopened revives failed → working, clears error", () => {
+    const f = rec({ state: "failed", error: "boom", exitCode: 1 });
+    const next = reduce(f, { type: "task.reopened", id: "t1" }, 8000);
+    expect(next.state).toBe("working");
+    expect(next.error).toBeUndefined();
+    expect(next.exitCode).toBe(1); // preserved, informational
+    expect(next.lastEvent).toBe("task.reopened");
+  });
+
+  it("task.reopened on working stays working (already active)", () => {
+    const w = rec({ state: "working" });
+    const next = reduce(w, { type: "task.reopened", id: "t1" }, 9000);
+    expect(next.state).toBe("working");
+    expect(next.lastHeartbeat).toBe(9000);
+    expect(next.lastEvent).toBe("task.reopened");
+  });
+
+  it("task.reopened on stalled transitions to working", () => {
+    const s = rec({ state: "stalled" });
+    const next = reduce(s, { type: "task.reopened", id: "t1" }, 10000);
+    expect(next.state).toBe("working");
+    expect(next.lastEvent).toBe("task.reopened");
+  });
+
+  it("task.reopened on blocked transitions to working, clears question", () => {
+    const b = rec({ state: "blocked", question: "which path?" });
+    const next = reduce(b, { type: "task.reopened", id: "t1" }, 11000);
+    expect(next.state).toBe("working");
+    expect(next.question).toBeUndefined();
+    expect(next.lastEvent).toBe("task.reopened");
+  });
+
+  it("terminal state STILL absorbs non-reopened events after task.reopened handling", () => {
+    // Regression: opening one event does not disable the absorbing guard.
+    const done = rec({ state: "done", resultRef: "/r" });
+    const next = reduce(done, { type: "heartbeat", id: "t1" }, 12000);
+    expect(next).toBe(done); // same reference — no-op
+  });
+
   it("task.progress on working stays working (liveness tick, never terminal)", () => {
     const next = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "PostToolUse" }, 7000);
     expect(next.state).toBe("working");

--- a/src/control/state-machine.ts
+++ b/src/control/state-machine.ts
@@ -23,6 +23,13 @@ function stampAttempt(
  * Returns a new record; never mutates the input.
  */
 export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskRecord {
+  // task.reopened is the ONE event allowed to escape a terminal state.
+  // From ANY state (done/failed/stalled/awaiting-input/working) → working.
+  // Clears question and error so the revived task looks fresh.
+  if (ev.type === "task.reopened") {
+    return { ...rec, state: "working", question: undefined, error: undefined, lastHeartbeat: now, lastEvent: ev.type };
+  }
+
   // Terminal states are absorbing: ignore any late/duplicate event idempotently.
   if (TERMINAL_STATES.has(rec.state)) return rec;
 

--- a/src/control/types.ts
+++ b/src/control/types.ts
@@ -84,6 +84,10 @@ export type ControlEvent =
   | { type: "task.input.requested"; id: string; requestId: number; question: string }
   | { type: "task.approval.requested"; id: string; requestId: number; question: string; kind: string }
   | { type: "task.reattached"; id: string }
+  // Reopen: the only event allowed to revive a terminal task. Emitted by
+  // `cockpit crew send` when the target crew's daemon task is in a terminal
+  // state, allowing the next `signal done` to be a real transition.
+  | { type: "task.reopened"; id: string }
   // Synthetic events: emitted by the daemon (watchdog / reconcile) purely as
   // notify payloads. They are never sent over the wire and the reducer treats
   // them as no-ops; the watchdog has already updated state directly.


### PR DESCRIPTION
## Summary

Fixes #148 — when a captain sends follow-up work to a crew whose control-plane task already reached a terminal state (`done`/`failed`), the crew's subsequent `cockpit crew signal done` fired NO notification because the terminal-absorbing guard blocked the state machine transition and `firePush` is transition-gated.

## Changes

### `types.ts`
- Added `{ type: "task.reopened"; id: string }` to the `ControlEvent` union

### `state-machine.ts`
- `task.reopened` is handled **before** the terminal-absorbing guard — it is the ONE event allowed to revive from any state (`done`, `failed`, `stalled`, `blocked`, `awaiting-input`, `working`) into `working`, clearing `question` and `error`
- All other events on terminal tasks remain absorbed (no regression)

### `crew.ts` (`runCrewSend`)
- Best-effort daemon call before `sendToPane`: lists tasks for the project, finds a task whose `name` matches the crew name and whose state is terminal, emits `task.reopened`
- Errors silently swallowed — the send succeeds even without a daemon

### Tests
- **state-machine**: 6 new tests for `task.reopened` from every state + regression that other events are still absorbed
- **crew**: 3 new tests — `task.reopened` emitted for terminal task, skipped for working task, tolerant of daemon-down

## Verification
- `npm run build` (tsc) clean
- Full test suite: **618 tests, 74 files — all green**

## After merge
The daemon must be restarted to pick up the new event type.