### PR TITLE
chore: finish Aider removal (spawn script, docs, changelog)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ To check whether embeddings exist, inspect `.gitnexus/meta.json` — the `stats.
 
 ## Project Direction: Multi-Agent
 
-Cockpit is a **multi-agent orchestration layer**, not a Claude-Code-only tool. Claude Code is the reference implementation today; Codex, Cursor, Gemini CLI, and Aider are supported (or in progress) through the runtime driver abstraction and the upcoming cross-agent projection layer (issue #31).
+Cockpit is a **multi-agent orchestration layer**, not a Claude-Code-only tool. Claude Code is the reference implementation today; Codex, Cursor, and Gemini CLI are supported (or in progress) through the runtime driver abstraction and the upcoming cross-agent projection layer (issue #31).
 
 When working on cockpit:
 - Prefer **`AGENTS.md`** as the canonical instruction format. `CLAUDE.md` is becoming a thin wrapper.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **Aider runtime driver and support.** The `aider` driver, its tests, and all
+  spawn/launch/doctor/template wiring have been removed. Aider was never wired
+  into `src/config.ts` and saw no active use; cockpit's supported agents are now
+  Claude Code, Codex, Gemini CLI, and opencode. The `--agent aider` option no
+  longer exists.
+
 ## [0.3.3] - 2026-05-15
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ To check whether embeddings exist, inspect `.gitnexus/meta.json` — the `stats.
 
 ## Project Direction: Multi-Agent
 
-Cockpit is a **multi-agent orchestration layer**, not a Claude-Code-only tool. Claude Code is the reference implementation today; Codex, Cursor, Gemini CLI, and Aider are supported (or in progress) through the runtime driver abstraction and the upcoming cross-agent projection layer (issue #31).
+Cockpit is a **multi-agent orchestration layer**, not a Claude-Code-only tool. Claude Code is the reference implementation today; Codex, Cursor, and Gemini CLI are supported (or in progress) through the runtime driver abstraction and the upcoming cross-agent projection layer (issue #31).
 
 When working on cockpit:
 - Prefer **`AGENTS.md`** as the canonical instruction format. `CLAUDE.md` is becoming a thin wrapper.

--- a/scripts/spawn-workspace.sh
+++ b/scripts/spawn-workspace.sh
@@ -154,14 +154,6 @@ case "$AGENT" in
     fi
     ;;
 
-  aider)
-    ROLE_FILE="${TEMPLATES_DIR}/${ROLE}.generic.md"
-    AGENT_CMD="aider --yes --no-stream"
-    if [ -n "$MODEL" ]; then
-      AGENT_CMD="${AGENT_CMD} --model ${MODEL}"
-    fi
-    ;;
-
   *)
     echo "ERROR: Unknown agent '${AGENT}' for role '${ROLE}'"
     exit 1


### PR DESCRIPTION
## Summary
Completes the Aider removal that PR #151 started. That PR merged before these gaps were caught:

- `scripts/spawn-workspace.sh` still had a **functional** `aider)` dispatch case (`aider --yes --no-stream`).
- `AGENTS.md` / `CLAUDE.md` still listed Aider as a supported agent in the multi-agent direction statement.
- Added an `[Unreleased] > Removed` CHANGELOG entry documenting the removal.

The reactor spinner-glyph comment (`src/reactor/status-classifier.ts:36`) is intentionally left intact — it describes aider-the-tool's terminal output, not driver support, and reactor was out of scope.

## Test plan
- [x] `npm run build` clean (tsc)
- [x] `npm test` — 614 passed
- [x] `git grep -i aider` in `src/` and `scripts/` returns only the intentional reactor comment