### PR TITLE
feat: migrate dashboard status grid from status.md to daemon task state

### DIFF
--- a/src/commands/__tests__/dashboard.test.ts
+++ b/src/commands/__tests__/dashboard.test.ts
@@ -28,6 +28,11 @@ vi.mock("../../config.js", () => ({
   resolveHome: (p: string) => p.replace(/^~/, process.env.HOME ?? ""),
 }));
 
+const mockReadAllStatuses = vi.hoisted(() => vi.fn());
+vi.mock("../../dashboard/read-status.js", () => ({
+  readAllStatuses: mockReadAllStatuses,
+}));
+
 import { runDashboardOnce, runDashboardPane, runSyncHub } from "../dashboard.js";
 
 const cfg = () => ({
@@ -40,45 +45,30 @@ const cfg = () => ({
   metrics: { enabled: false, path: "" },
 });
 
-const SAMPLE = [
-  "---",
-  "project: brove",
-  "auto_state: idle",
-  'auto_last_checked: "2026-05-05T12:00:00.000Z"',
-  "captain_workspace: brove-captain",
-  "---",
-  "",
-  "## Last activity excerpt",
-  "",
-  "```",
-  "│ > ",
-  "```",
-  "",
-].join("\n");
-
 describe("runDashboardOnce", () => {
   let writes: string[];
   beforeEach(() => {
     writes = [];
     loadConfig.mockReturnValue(cfg());
+    mockReadAllStatuses.mockResolvedValue([
+      { project: "brove", state: "idle", lastChecked: "2026-05-05T12:00:00.000Z", captainWorkspace: "brove-captain", excerpt: "" },
+    ]);
   });
 
-  it("renders the grid for every registered project", () => {
-    runDashboardOnce({
-      readFile: () => SAMPLE,
+  it("renders the grid for every registered project", async () => {
+    await runDashboardOnce({
       now: () => "2026-05-05T12:00:30.000Z",
       write: (s) => writes.push(s),
     });
     const out = writes.join("");
     expect(out).toContain("brove");
     expect(out).toContain("idle");
-    expect(out).toContain("30s");
   });
 
-  it("renders the empty-projects message when no projects are registered", () => {
+  it("renders the empty-projects message when no projects are registered", async () => {
     loadConfig.mockReturnValueOnce({ ...cfg(), projects: {} });
-    runDashboardOnce({
-      readFile: () => "",
+    mockReadAllStatuses.mockResolvedValueOnce([]);
+    await runDashboardOnce({
       now: () => "2026-05-05T12:00:30.000Z",
       write: (s) => writes.push(s),
     });
@@ -94,11 +84,13 @@ describe("runSyncHub", () => {
     writes = [];
     mkdirs = [];
     loadConfig.mockReturnValue(cfg());
+    mockReadAllStatuses.mockResolvedValue([
+      { project: "brove", state: "idle", lastChecked: "2026-05-05T12:00:00.000Z", captainWorkspace: "brove-captain", excerpt: "" },
+    ]);
   });
 
-  it("writes a hub mirror per project", () => {
-    const result = runSyncHub({
-      readFile: () => SAMPLE,
+  it("writes a hub mirror per project", async () => {
+    const result = await runSyncHub({
       writeFile: (p, c) => { writes.push({ path: p, content: c }); },
       mkdir: (p) => { mkdirs.push(p); },
     });

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -1,6 +1,5 @@
 import { Command } from "commander";
 import { execSync } from "node:child_process";
-import fs from "node:fs";
 import chalk from "chalk";
 import { loadConfig } from "../config.js";
 import { createCmuxDriver, RuntimeRegistry } from "../runtimes/index.js";
@@ -10,8 +9,6 @@ import { syncHub, type SyncHubResult } from "../dashboard/sync-hub.js";
 import type { PaneRef } from "../runtimes/types.js";
 import { resolveCmuxBin } from "../lib/cmux-bin.js";
 
-// TODO(runtime): current-workspace not yet abstracted by RuntimeDriver — direct cmux call retained,
-// matching the existing pattern in src/commands/command.ts.
 function detectCurrentWorkspace(): string {
   const out = execSync(`"${resolveCmuxBin()}" current-workspace`, { encoding: "utf-8" }).trim();
   const match = out.match(/workspace:\d+/);
@@ -22,33 +19,29 @@ function detectCurrentWorkspace(): string {
 }
 
 export interface DashboardOnceDeps {
-  readFile?: (path: string) => string;
   now?: () => string;
   write?: (s: string) => void;
 }
 
-export function runDashboardOnce(deps: DashboardOnceDeps = {}): void {
+export async function runDashboardOnce(deps: DashboardOnceDeps = {}): Promise<void> {
   const config = loadConfig();
-  const readFile = deps.readFile ?? ((p) => fs.readFileSync(p, "utf-8"));
   const now = (deps.now ?? (() => new Date().toISOString()))();
   const write = deps.write ?? ((s) => process.stdout.write(s));
 
-  const statuses = readAllStatuses({ config, readFile });
+  const statuses = await readAllStatuses({ config });
   const width = process.stdout.columns ?? 100;
   write(renderDashboard(statuses, { now, width }));
   write("\n");
 }
 
 export interface SyncHubCliDeps {
-  readFile?: (path: string) => string;
   writeFile?: (path: string, content: string) => void;
   mkdir?: (path: string) => void;
 }
 
-export function runSyncHub(deps: SyncHubCliDeps = {}): SyncHubResult[] {
+export async function runSyncHub(deps: SyncHubCliDeps = {}): Promise<SyncHubResult[]> {
   const config = loadConfig();
-  const readFile = deps.readFile ?? ((p) => fs.readFileSync(p, "utf-8"));
-  const statuses = readAllStatuses({ config, readFile });
+  const statuses = await readAllStatuses({ config });
   return syncHub({ config, statuses, writeFile: deps.writeFile, mkdir: deps.mkdir });
 }
 
@@ -76,7 +69,7 @@ export async function runDashboardPane(input: DashboardPaneInput): Promise<PaneR
 }
 
 export const dashboardCommand = new Command("dashboard")
-  .description("Live status grid of all projects (auto-derived from spoke status.md)")
+  .description("Live status grid of all projects (derived from daemon task state)")
   .option("--once", "Print one snapshot and exit (used by --pane's refresh loop)")
   .option("--pane", "Open a refreshing sidebar pane in the current cmux workspace")
   .option("--direction <dir>", "Pane split direction (right|left|up|down)", "right")
@@ -89,7 +82,7 @@ export const dashboardCommand = new Command("dashboard")
         return;
       }
       // Default behaviour: --once. (Bare `cockpit dashboard` prints once and exits.)
-      runDashboardOnce();
+      await runDashboardOnce();
     } catch (err) {
       console.error(chalk.red((err as Error).message));
       process.exit(1);
@@ -100,8 +93,8 @@ dashboardCommand
   .command("sync-hub")
   .description("Mirror each spoke status.md into {hubVault}/projects/<name>.md for Obsidian Dataview")
   .option("--json", "Emit results as JSON")
-  .action((opts: { json?: boolean }) => {
-    const results = runSyncHub();
+  .action(async (opts: { json?: boolean }) => {
+    const results = await runSyncHub();
     if (opts.json) {
       console.log(JSON.stringify(results, null, 2));
       return;

--- a/src/dashboard/__tests__/read-status.test.ts
+++ b/src/dashboard/__tests__/read-status.test.ts
@@ -1,25 +1,7 @@
 import { describe, it, expect } from "vitest";
 import type { CockpitConfig } from "../../config.js";
-import { parseStatusFile, readAllStatuses } from "../read-status.js";
-
-const SAMPLE = [
-  "---",
-  "project: brove",
-  "auto_state: idle",
-  'auto_last_checked: "2026-05-05T12:00:00.000Z"',
-  "captain_workspace: brove-captain",
-  "---",
-  "",
-  "# Status (auto-derived)",
-  "",
-  "## Last activity excerpt",
-  "",
-  "```",
-  "alpha",
-  "│ > ",
-  "```",
-  "",
-].join("\n");
+import type { TaskRecord } from "../../control/types.js";
+import { readAllStatuses } from "../read-status.js";
 
 function makeConfig(): CockpitConfig {
   return {
@@ -34,85 +16,190 @@ function makeConfig(): CockpitConfig {
   };
 }
 
-describe("parseStatusFile", () => {
-  it("extracts frontmatter + excerpt", () => {
-    const out = parseStatusFile(SAMPLE);
-    expect(out).toEqual({
-      project: "brove",
-      state: "idle",
-      lastChecked: "2026-05-05T12:00:00.000Z",
-      captainWorkspace: "brove-captain",
-      excerpt: "alpha\n│ > ",
-    });
-  });
-
-  it("strips quotes around frontmatter values", () => {
-    const text = SAMPLE.replace("captain_workspace: brove-captain", 'captain_workspace: "brove-captain"');
-    expect(parseStatusFile(text)?.captainWorkspace).toBe("brove-captain");
-  });
-
-  it("returns null when the file has no frontmatter", () => {
-    expect(parseStatusFile("# random\nno fm here\n")).toBeNull();
-  });
-
-  it("falls back to empty excerpt when no fenced block", () => {
-    const text = [
-      "---",
-      "project: x",
-      "auto_state: busy",
-      'auto_last_checked: "2026-05-05T12:00:00.000Z"',
-      "captain_workspace: x-captain",
-      "---",
-      "",
-      "no excerpt here",
-    ].join("\n");
-    expect(parseStatusFile(text)?.excerpt).toBe("");
-  });
-
-  it("treats unknown auto_state as 'unknown'", () => {
-    const text = SAMPLE.replace("auto_state: idle", "auto_state: weird-value");
-    expect(parseStatusFile(text)?.state).toBe("unknown");
-  });
-});
+function mkTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    id: "t1",
+    project: "brove",
+    provider: "claude",
+    mode: "headless",
+    state: "done",
+    task: "some task",
+    createdAt: Date.now(),
+    lastHeartbeat: Date.now(),
+    lastEvent: "task.done",
+    heartbeatBudgetMs: 300000,
+    attempts: [],
+    ...overrides,
+  };
+}
 
 describe("readAllStatuses", () => {
-  it("returns one row per registered project", () => {
-    const reads: string[] = [];
-    const readFile = (p: string) => {
-      reads.push(p);
-      if (p.includes("brove"))  return SAMPLE;
-      if (p.includes("solder")) return SAMPLE.replace("project: brove", "project: solder")
-                                            .replace("auto_state: idle", "auto_state: busy")
-                                            .replace("brove-captain", "solder-captain");
-      throw new Error("not found");
-    };
+  it("returns one row per registered project", async () => {
+    const rows = await readAllStatuses({
+      config: makeConfig(),
+      listTasks: async () => [],
+    });
 
-    const rows = readAllStatuses({ config: makeConfig(), readFile });
-
-    expect(rows.map((r) => r.project)).toEqual(["brove", "solder"]);
-    expect(rows[0].state).toBe("idle");
-    expect(rows[1].state).toBe("busy");
-    expect(reads).toEqual(["/tmp/spokes/brove/status.md", "/tmp/spokes/solder/status.md"]);
-  });
-
-  it("yields state='unknown' when status.md is missing", () => {
-    const readFile = () => { throw new Error("ENOENT"); };
-    const rows = readAllStatuses({ config: makeConfig(), readFile });
     expect(rows).toHaveLength(2);
-    expect(rows[0].state).toBe("unknown");
-    expect(rows[0].lastChecked).toBe("");
-  });
-
-  it("yields state='unknown' when status.md has no parseable frontmatter", () => {
-    const readFile = () => "# garbage\n";
-    const rows = readAllStatuses({ config: makeConfig(), readFile });
-    expect(rows[0].state).toBe("unknown");
-  });
-
-  it("preserves the project name from config even when the file uses a different one", () => {
-    const readFile = () => SAMPLE; // file says project: brove for both reads
-    const rows = readAllStatuses({ config: makeConfig(), readFile });
     expect(rows[0].project).toBe("brove");
     expect(rows[1].project).toBe("solder");
+  });
+
+  it("maps state to idle when no tasks or all done", async () => {
+    const rows = await readAllStatuses({
+      config: makeConfig(),
+      listTasks: async () => [mkTask({ state: "done" }), mkTask({ state: "submitted" })],
+    });
+
+    expect(rows[0].state).toBe("idle");
+  });
+
+  it("maps state to busy when any task is working", async () => {
+    const rows = await readAllStatuses({
+      config: makeConfig(),
+      listTasks: async () => [mkTask({ state: "working" })],
+    });
+
+    expect(rows[0].state).toBe("busy");
+  });
+
+  it("maps state to blocked when any task is blocked", async () => {
+    const rows = await readAllStatuses({
+      config: makeConfig(),
+      listTasks: async () => [mkTask({ state: "blocked" })],
+    });
+
+    expect(rows[0].state).toBe("blocked");
+  });
+
+  it("maps state to blocked when any task is awaiting-input", async () => {
+    const rows = await readAllStatuses({
+      config: makeConfig(),
+      listTasks: async () => [mkTask({ state: "awaiting-input" })],
+    });
+
+    expect(rows[0].state).toBe("blocked");
+  });
+
+  it("maps state to errored when any task has failed", async () => {
+    const rows = await readAllStatuses({
+      config: makeConfig(),
+      listTasks: async () => [mkTask({ state: "failed" })],
+    });
+
+    expect(rows[0].state).toBe("errored");
+  });
+
+  it("maps state to errored when any task is stalled", async () => {
+    const rows = await readAllStatuses({
+      config: makeConfig(),
+      listTasks: async () => [mkTask({ state: "stalled" })],
+    });
+
+    expect(rows[0].state).toBe("errored");
+  });
+
+  it("state precedence: blocked beats errored", async () => {
+    const rows = await readAllStatuses({
+      config: makeConfig(),
+      listTasks: async () => [
+        mkTask({ state: "blocked" }),
+        mkTask({ state: "failed" }),
+        mkTask({ state: "working" }),
+      ],
+    });
+
+    expect(rows[0].state).toBe("blocked");
+  });
+
+  it("state precedence: errored beats busy", async () => {
+    const rows = await readAllStatuses({
+      config: makeConfig(),
+      listTasks: async () => [
+        mkTask({ state: "failed" }),
+        mkTask({ state: "working" }),
+      ],
+    });
+
+    expect(rows[0].state).toBe("errored");
+  });
+
+  it("yields offline when daemon rejects", async () => {
+    const rows = await readAllStatuses({
+      config: makeConfig(),
+      listTasks: async () => { throw new Error("daemon unreachable"); },
+    });
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0].state).toBe("offline");
+    expect(rows[0].lastChecked).toBeTruthy();
+    expect(rows[0].captainWorkspace).toBe("brove-captain");
+  });
+
+  it("preserves project name from config", async () => {
+    const rows = await readAllStatuses({
+      config: makeConfig(),
+      listTasks: async (project) => {
+        if (project === "brove") return [mkTask({ state: "working", task: "brove task" })];
+        return [mkTask({ state: "done", task: "solder task" })];
+      },
+    });
+
+    expect(rows[0].project).toBe("brove");
+    expect(rows[1].project).toBe("solder");
+  });
+
+  it("builds excerpt with active task titles", async () => {
+    const rows = await readAllStatuses({
+      config: makeConfig(),
+      listTasks: async () => [
+        mkTask({ state: "working", name: "feat-x", task: "build feature x" }),
+        mkTask({ state: "blocked", name: "fix-y", task: "fix bug y" }),
+      ],
+    });
+
+    expect(rows[0].excerpt).toContain("1 working");
+    expect(rows[0].excerpt).toContain("1 blocked");
+    expect(rows[0].excerpt).toContain("feat-x");
+    expect(rows[0].excerpt).toContain("fix-y");
+  });
+
+  it("builds summary-only excerpt when no active tasks", async () => {
+    const rows = await readAllStatuses({
+      config: makeConfig(),
+      listTasks: async () => [mkTask({ state: "done" })],
+    });
+
+    expect(rows[0].excerpt).toBe("idle");
+  });
+
+  it("sets lastChecked to current ISO timestamp", async () => {
+    const before = Date.now();
+    const rows = await readAllStatuses({
+      config: makeConfig(),
+      listTasks: async () => [],
+    });
+    const after = Date.now();
+    const ts = Date.parse(rows[0].lastChecked);
+
+    expect(ts).not.toBeNaN();
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+
+  it("per-project daemon isolation: one offline, one busy", async () => {
+    let callCount = 0;
+    const rows = await readAllStatuses({
+      config: makeConfig(),
+      listTasks: async (project) => {
+        callCount++;
+        if (project === "brove") throw new Error("down");
+        return [mkTask({ state: "working" })];
+      },
+    });
+
+    expect(rows[0].state).toBe("offline");
+    expect(rows[1].state).toBe("busy");
+    expect(callCount).toBe(2);
   });
 });

--- a/src/dashboard/read-status.ts
+++ b/src/dashboard/read-status.ts
@@ -1,82 +1,74 @@
-import fs from "node:fs";
-import path from "node:path";
 import type { CockpitConfig } from "../config.js";
-import { resolveHome } from "../config.js";
+import type { TaskRecord } from "../control/types.js";
+import { cockpitdCall } from "../commands/crew-control.js";
 
 export type DashboardState = "idle" | "busy" | "blocked" | "errored" | "offline" | "unknown";
-
-const KNOWN_STATES: ReadonlyArray<DashboardState> = [
-  "idle", "busy", "blocked", "errored", "offline", "unknown",
-];
 
 export interface ProjectStatus {
   project: string;
   state: DashboardState;
-  lastChecked: string;       // ISO-8601 string, "" if unknown
-  captainWorkspace: string;  // "" if unknown
-  excerpt: string;           // multi-line, possibly ""
+  lastChecked: string;
+  captainWorkspace: string;
+  excerpt: string;
 }
 
 export interface ReadStatusDeps {
   config: CockpitConfig;
-  readFile?: (path: string) => string;
+  listTasks?: (project: string) => Promise<TaskRecord[]>;
 }
 
-function unquote(s: string): string {
-  const t = s.trim();
-  if ((t.startsWith('"') && t.endsWith('"')) || (t.startsWith("'") && t.endsWith("'"))) {
-    return t.slice(1, -1);
-  }
-  return t;
+function deriveState(tasks: TaskRecord[]): DashboardState {
+  if (tasks.some(t => t.state === "blocked" || t.state === "awaiting-input")) return "blocked";
+  if (tasks.some(t => t.state === "failed" || t.state === "stalled")) return "errored";
+  if (tasks.some(t => t.state === "working")) return "busy";
+  return "idle";
 }
 
-export function parseStatusFile(text: string): ProjectStatus | null {
-  const lines = text.split(/\r?\n/);
-  if (lines[0]?.trim() !== "---") return null;
+function buildExcerpt(tasks: TaskRecord[]): string {
+  const working = tasks.filter(t => t.state === "working").length;
+  const blocked = tasks.filter(t => t.state === "blocked" || t.state === "awaiting-input").length;
+  const parts: string[] = [];
+  if (working > 0) parts.push(`${working} working`);
+  if (blocked > 0) parts.push(`${blocked} blocked`);
+  const summary = parts.length > 0 ? parts.join(", ") : "idle";
 
-  const fm: Record<string, string> = {};
-  let i = 1;
-  for (; i < lines.length; i++) {
-    if (lines[i].trim() === "---") { i++; break; }
-    const m = lines[i].match(/^([a-z_]+):\s*(.*)$/i);
-    if (m) fm[m[1]] = unquote(m[2]);
-  }
-  if (!fm.auto_state) return null;
+  const active = tasks.filter(t =>
+    ["working", "blocked", "awaiting-input", "submitted"].includes(t.state)
+  );
+  const titles = active.slice(0, 3).map(t => {
+    const firstLine = t.task ? t.task.split("\n")[0] : "";
+    return t.name ?? (firstLine || t.id.slice(0, 8));
+  }).join("; ");
 
-  // Find the first fenced block after "## Last activity excerpt"
-  let excerpt = "";
-  const headerIdx = lines.findIndex((l, idx) => idx >= i && /##\s+Last activity excerpt/i.test(l));
-  if (headerIdx >= 0) {
-    const fenceStart = lines.findIndex((l, idx) => idx > headerIdx && l.trim() === "```");
-    if (fenceStart >= 0) {
-      const fenceEnd = lines.findIndex((l, idx) => idx > fenceStart && l.trim() === "```");
-      if (fenceEnd > fenceStart) excerpt = lines.slice(fenceStart + 1, fenceEnd).join("\n");
-    }
-  }
-
-  const rawState = (fm.auto_state || "unknown") as DashboardState;
-  const state = KNOWN_STATES.includes(rawState) ? rawState : "unknown";
-
-  return {
-    project: fm.project ?? "",
-    state,
-    lastChecked: fm.auto_last_checked ?? "",
-    captainWorkspace: fm.captain_workspace ?? "",
-    excerpt,
-  };
+  return titles ? `${summary} — ${titles}` : summary;
 }
 
-export function readAllStatuses(deps: ReadStatusDeps): ProjectStatus[] {
-  const readFile = deps.readFile ?? ((p) => fs.readFileSync(p, "utf-8"));
+export async function readAllStatuses(deps: ReadStatusDeps): Promise<ProjectStatus[]> {
+  const listTasks = deps.listTasks ?? (async (project: string) => {
+    const result = await cockpitdCall({ kind: "list", project });
+    return result as TaskRecord[];
+  });
+
   const rows: ProjectStatus[] = [];
   for (const [name, project] of Object.entries(deps.config.projects)) {
-    const statusPath = path.join(resolveHome(project.spokeVault), "status.md");
-    let text = "";
-    try { text = readFile(statusPath); } catch { /* missing — leave text empty */ }
-    const parsed = text ? parseStatusFile(text) : null;
-    rows.push(parsed
-      ? { ...parsed, project: name }
-      : { project: name, state: "unknown", lastChecked: "", captainWorkspace: project.captainName, excerpt: "" });
+    try {
+      const tasks = await listTasks(name);
+      rows.push({
+        project: name,
+        state: deriveState(tasks),
+        lastChecked: new Date().toISOString(),
+        captainWorkspace: project.captainName,
+        excerpt: buildExcerpt(tasks),
+      });
+    } catch {
+      rows.push({
+        project: name,
+        state: "offline",
+        lastChecked: new Date().toISOString(),
+        captainWorkspace: project.captainName,
+        excerpt: "",
+      });
+    }
   }
   return rows;
 }


### PR DESCRIPTION
## Summary

Migrates the dashboard status grid (`readAllStatuses`) to read from the daemon's authoritative task state via `cockpitdCall({kind:\list\, project})` instead of parsing each spoke's `status.md`.

## Changes

- **`src/dashboard/read-status.ts`**: Rewrote `readAllStatuses` as `async`. Queries the daemon per-project. Derives `DashboardState` from task records with precedence: `offline > blocked > errored > busy > idle`. Replaces `readFile` injection with `listTasks` injection for testability. Removed `parseStatusFile`, `unquote`, `KNOWN_STATES`, and file-reading path.
- **`src/commands/dashboard.ts`**: `runDashboardOnce` and `runSyncHub` are now `async` with `await readAllStatuses`. Removed `fs` import. Updated CLI description.
- **`src/dashboard/__tests__/read-status.test.ts`**: Full rewrite — 15 tests covering all state mappings (`busy`, `blocked`, `errored`, `idle`, `offline`), precedence rules, excerpt building, per-project isolation, and timestamp correctness.
- **`src/commands/__tests__/dashboard.test.ts`**: Mocks `readAllStatuses` module instead of injecting `readFile`.

## Verification

- `npm run build` — clean
- `npm test` — 73 files, 620 tests, all green

## Not touched

- Reactor, tracker, sync-hub (handled in separate reactor-removal step)