### PR TITLE
fix: scope vitest to src/**/*.test.ts (issue #157)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    exclude: ["dist/**", "node_modules/**"],
+  },
+});


### PR DESCRIPTION
## Problem

vitest's default include glob matches compiled `dist/**/*.test.js` files, causing each test to run twice (src .ts + dist .js) after `npm run build`. Stale compiled tests from removed modules also produce false failures.

## Fix

Added `vitest.config.ts` with:
- `include: ["src/**/*.test.ts"]` — scope to source only
- `exclude: ["dist/**", "node_modules/**"]` — safety net

Config-only change; no test or source logic modified.

## Verification

- `npm test`: 68 files / 565 passed (green) — single count, no dist tests
- `npm run build`: tsc clean (zero errors)
- Same result with dist/ populated with 68 compiled .test.js files

Closes #157