### PR TITLE
docs: document reactor + status-script removal in changelog/roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **Reactor subsystem and status-writing scripts.** The GitHub reaction engine
+  and auto-status poller have been removed: the `cockpit reactor` command,
+  `src/reactor/`, the reactor shell scripts (`poll-github.sh`,
+  `match-reactions.sh`, `execute-reaction.sh`, `reactor-cycle.sh`),
+  `reactions.json`, the reaction config types (`ReactionsConfig`, `ReactionRule`,
+  `ReactionTrigger`, `AutoStatusConfig`) and `loadReactions`/`saveReactions`, the
+  `reactor` role (model routing, permission, driver requirements), and the
+  `reactor-ops` skill. Because the auto-status poller was the writer of
+  `{spokeVault}/status.md`, the status-writing scripts went with it:
+  `write-status.sh`, `read-status.sh`, and the `status-writer.sh` hook. The
+  dashboard now reads live state from the cockpit daemon's task records rather
+  than from `status.md`. `cockpit launch --all` now launches captains only.
 - **Aider runtime driver and support.** The `aider` driver, its tests, and all
   spawn/launch/doctor/template wiring have been removed. Aider was never wired
   into `src/config.ts` and saw no active use; cockpit's supported agents are now

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,6 +59,7 @@ Cockpit v0.1.x is a working multi-project agent orchestration system with:
 **Effort:** ~1-2 hours (config + template changes)
 
 #### 5. CI Feedback Reactor Extension
+**Status:** ❌ Dropped (2026-05-28) — the reactor subsystem was removed from cockpit, so there is no reactor architecture to extend.
 **Why:** Composio AO auto-routes CI failures back to agents. Cockpit reactor detects CI failure but only notifies — doesn't auto-fix.
 **What:**
 - New reaction action: `auto-fix-ci` — on CI failure, re-delegate to captain with failure logs
@@ -107,6 +108,7 @@ Cockpit v0.1.x is a working multi-project agent orchestration system with:
 **Effort:** ~2-3 hours
 
 #### 9. Linear Integration
+**Status:** ❌ Dropped (2026-05-28) — depended on the reactor source/polling model, which has been removed from cockpit.
 **Why:** Composio AO supports Linear+GitHub+GitLab. Cockpit only has GitHub reactor. Some projects may use Linear for tracking.
 **What:**
 - New reactor source: `linear-issues` (poll via Linear MCP tools already available)


### PR DESCRIPTION
## Summary
- PR #155 ("chore: retire the reactor") removed the reactor subsystem **and** the status-writing scripts (`write-status.sh`, `read-status.sh`, `status-writer.sh`, which were driven by the auto-status poller), but never documented it in the changelog. This adds the missing `[Unreleased] → Removed` entry.
- Marks the two reactor-dependent roadmap items — **#5 CI Feedback Reactor Extension** and **#9 Linear Integration** — as ❌ Dropped, since the reactor architecture they extended no longer exists.

## Context
A crew independently re-did the reactor removal in branch `worktree-rm-reactor` (PR #156) before noticing #155 had already landed it. #156 is redundant (and stale — it still carries the deleted status scripts), so it's being closed. The only non-duplicate value from that work was the changelog/roadmap documentation, salvaged here on a clean branch off develop.

## Follow-up (not in this PR)
README.md:139 and captain-ops/SKILL.md:31,168 still instruct users to run `write-status.sh`, which #155 deleted. Those stale references should be cleaned up separately.

## Test plan
- [x] Docs-only change; `npm run build` + full suite already green on develop (565 tests).