### PR TITLE
docs: reflect reactor removal in CHANGELOG and ROADMAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **Reactor engine.** The always-on GitHub poller / auto-delegation engine has
+  been retired — reaction rules (`reactions.json`), the polling and matching
+  scripts, the auto-status poller and status classifier, the `reactor` role and
+  its skill, and the `cockpit reactor` command are all gone. Event-driven
+  auto-delegation is no longer part of cockpit; agents are launched explicitly.
 - **Aider runtime driver and support.** The `aider` driver, its tests, and all
   spawn/launch/doctor/template wiring have been removed. Aider was never wired
   into `src/config.ts` and saw no active use; cockpit's supported agents are now

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,11 +7,10 @@
 
 Cockpit v0.1.x is a working multi-project agent orchestration system with:
 - 3-tier hierarchy (Command → Captain → Crew) via cmux + Agent Teams
-- GitHub reactor engine (event polling → auto-delegation)
 - Obsidian hub/spoke vaults for offline status dashboards
 - Session freshness logic (daily + template hash)
 - Self-enhancement via learnings system
-- CLI: init, launch, status, doctor, projects, shutdown, reactor, feedback
+- CLI: init, launch, status, doctor, projects, shutdown, feedback
 
 ## Roadmap
 
@@ -55,10 +54,10 @@ Cockpit v0.1.x is a working multi-project agent orchestration system with:
 **What:**
 - Add to config.json: `"models": { "exploration": "haiku", "planning": "opus", "execution": "sonnet", "review": "opus" }`
 - Captain passes `model` param when spawning crew via Agent tool
-- Command uses Opus (always), Reactor uses Sonnet
+- Command uses Opus (always)
 **Effort:** ~1-2 hours (config + template changes)
 
-#### 5. CI Feedback Reactor Extension
+#### 5. CI Feedback Reactor Extension — **OBSOLETE** (reactor engine removed; would need a new auto-delegation mechanism)
 **Why:** Composio AO auto-routes CI failures back to agents. Cockpit reactor detects CI failure but only notifies — doesn't auto-fix.
 **What:**
 - New reaction action: `auto-fix-ci` — on CI failure, re-delegate to captain with failure logs
@@ -106,7 +105,7 @@ Cockpit v0.1.x is a working multi-project agent orchestration system with:
 - Output: formatted markdown for sharing
 **Effort:** ~2-3 hours
 
-#### 9. Linear Integration
+#### 9. Linear Integration — **OBSOLETE as specified** (depended on the now-removed reactor engine)
 **Why:** Composio AO supports Linear+GitHub+GitLab. Cockpit only has GitHub reactor. Some projects may use Linear for tracking.
 **What:**
 - New reactor source: `linear-issues` (poll via Linear MCP tools already available)


### PR DESCRIPTION
## Summary
- PR #155 removed the reactor engine code but left the docs describing it as a live component.
- Add a **Removed** entry to the changelog for the reactor engine (reaction rules, polling/matching scripts, auto-status poller + classifier, `reactor` role/skill, `cockpit reactor` command).
- Drop the reactor from the ROADMAP current-state and CLI lists.
- Mark the two reactor-dependent roadmap proposals (CI Feedback Reactor Extension #5, Linear Integration #9) as **OBSOLETE**.

## Test plan
- [x] Docs-only change — no code affected.
- [ ] Verify CHANGELOG/ROADMAP read correctly after merge.