### PR TITLE
rename notify-relay placement 'hidden' -> 'background' (#161)

### DIFF
--- a/src/commands/launch.ts
+++ b/src/commands/launch.ts
@@ -181,7 +181,7 @@ function buildAgentCmd(
 const NOTIFY_RELAY_TAB_TITLE = "✉ notify-relay";
 
 /**
- * Add the notify-relay to a captain workspace as a hidden background tab. The
+ * Add the notify-relay to a captain workspace as a background tab. The
  * relay tails the daemon's per-project mailbox and forwards each new event to
  * the captain pane via runtime.sendToSurface — required because cmux refuses
  * any caller not descended from its app process, so the daemon itself cannot
@@ -204,9 +204,9 @@ async function ensureNotifyRelayTab(
       captainWorkspace: workspace,
       command: `cockpit notify-relay ${project} --as captain`,
       title: NOTIFY_RELAY_TAB_TITLE,
-      placement: "hidden",
+      placement: "background",
     });
-    console.log(chalk.cyan(`  ✔ Added hidden notify-relay for '${project}'`));
+    console.log(chalk.cyan(`  ✔ Added background notify-relay for '${project}'`));
   } catch (e) {
     console.error(chalk.yellow(`  ⚠ notify-relay setup failed: ${(e as Error).message}`));
   }

--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -281,11 +281,11 @@ describe("cmux driver", () => {
     expect(cmds.some((c) => c.includes("send-key") && c.includes("--surface surface:8") && c.includes("Enter"))).toBe(true);
   });
 
-  // #117: hidden placement must NOT create a split-pane. cmux 0.62.2 has no
+  // #117: background placement must NOT create a split-pane. cmux 0.62.2 has no
   // resize-pane verb, so a `new-pane --direction down` split can never be
   // shrunk and stays a full-height 50/50 split forever. A background tab
   // (new-surface) keeps the captain pane full-height with no split.
-  it("spawnInjector hidden uses new-surface (no split-pane, no resize-pane)", async () => {
+  it("spawnInjector background uses new-surface (no split-pane, no resize-pane)", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
       const cmd = args.join(" ");
       if (cmd.includes("tree")) return 'surface surface:5 [terminal] "cap" [selected]';
@@ -296,7 +296,7 @@ describe("cmux driver", () => {
       captainWorkspace: { id: "workspace:1", name: "cap", status: "running" },
       command: "cockpit notify-relay proj --as captain",
       title: "✉ notify-relay",
-      placement: "hidden",
+      placement: "background",
     });
     expect(pane).toEqual({ workspaceId: "workspace:1", surfaceId: "surface:8", title: "✉ notify-relay" });
     const cmds = execFileMock.mock.calls.map(cmdOf);
@@ -306,7 +306,7 @@ describe("cmux driver", () => {
     expect(cmds.every((c) => !c.includes("resize-pane"))).toBe(true);
   });
 
-  it("spawnInjector hidden sends the command + Enter to the new surface", async () => {
+  it("spawnInjector background sends the command + Enter to the new surface", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
       const cmd = args.join(" ");
       if (cmd.includes("tree")) return 'surface surface:5 [terminal] "cap" [selected]';
@@ -316,16 +316,17 @@ describe("cmux driver", () => {
     await driver.spawnInjector({
       captainWorkspace: { id: "workspace:1", name: "cap", status: "running" },
       command: "cockpit notify-relay proj --as captain",
-      placement: "hidden",
+      placement: "background",
     });
     const cmds = execFileMock.mock.calls.map(cmdOf);
     expect(cmds.some((c) => c.includes("send ") && c.includes("--surface surface:8") && c.includes("cockpit notify-relay proj") && !c.includes("send-key"))).toBe(true);
     expect(cmds.some((c) => c.includes("send-key") && c.includes("--surface surface:8") && c.includes("Enter"))).toBe(true);
   });
 
-  // The relay tab must never steal focus from the captain: after spawning it we
-  // re-select whichever surface was selected before, in its original position.
-  it("spawnInjector hidden restores focus to the previously-selected surface", async () => {
+  // The background relay tab must never steal focus from the captain: after
+  // spawning it we re-select whichever surface was selected before, in its
+  // original position.
+  it("spawnInjector background restores focus to the previously-selected surface", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
       const cmd = args.join(" ");
       if (cmd.includes("tree")) {
@@ -340,7 +341,7 @@ describe("cmux driver", () => {
     await driver.spawnInjector({
       captainWorkspace: { id: "workspace:1", name: "cap", status: "running" },
       command: "cockpit notify-relay proj --as captain",
-      placement: "hidden",
+      placement: "background",
     });
     const cmds = execFileMock.mock.calls.map(cmdOf);
     expect(cmds.some((c) =>
@@ -375,7 +376,7 @@ describe("cmux driver", () => {
     await expect(driver.spawnInjector({
       captainWorkspace: { id: "workspace:1", name: "cap", status: "running" },
       command: "x",
-      placement: "hidden",
+      placement: "background",
     })).rejects.toThrow(/did not return a surface/);
   });
 

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -177,7 +177,7 @@ export function createCmuxDriver(): RuntimeDriver {
       captainWorkspace: WorkspaceRef;
       command: string;
       title?: string;
-      placement: "hidden" | "visible";
+      placement: "background" | "visible";
     }): Promise<PaneRef> {
       // Both placements use a background tab (new-surface) in the captain's
       // existing pane — full-height, NO split. A split-pane is wrong here:
@@ -186,13 +186,13 @@ export function createCmuxDriver(): RuntimeDriver {
       // relay still runs as a cmux descendant in the same workspace, preserving
       // the in-cmux delivery requirement (#112).
       //
-      // "hidden" then re-selects whatever surface was focused before, in its
+      // "background" then re-selects whatever surface was focused before, in its
       // original position, so the relay tab never steals focus from the
       // captain. "visible" leaves the new tab focused for debug ergonomics.
       const wsId = opts.captainWorkspace.id;
       let priorSurface: string | undefined;
       let priorIndex = -1;
-      if (opts.placement === "hidden") {
+      if (opts.placement === "background") {
         try {
           const before = parseSurfaceOrder(cmux(["tree", "--workspace", wsId]));
           priorIndex = before.findIndex((s) => s.selected);
@@ -211,7 +211,7 @@ export function createCmuxDriver(): RuntimeDriver {
       }
       cmux(["send", "--workspace", wsId, "--surface", surfaceId, opts.command]);
       cmux(["send-key", "--workspace", wsId, "--surface", surfaceId, "Enter"]);
-      if (opts.placement === "hidden" && priorSurface) {
+      if (opts.placement === "background" && priorSurface) {
         try {
           cmux(["move-surface", "--surface", priorSurface, "--index", String(priorIndex), "--focus", "true"]);
         } catch { /* refocus is best-effort */ }

--- a/src/runtimes/types.ts
+++ b/src/runtimes/types.ts
@@ -59,14 +59,14 @@ export interface RuntimeDriver {
   // so any IPC/socket constraints of the runtime (e.g. cmux's parent-lineage
   // check) are satisfied. Returns a PaneRef the caller can inspect/clean up.
   //
-  // placement: "hidden" produces a non-distracting background tab that does not
-  // steal focus from the captain (runtime decides how). "visible" produces a
-  // normal focused tab for debug ergonomics.
+  // placement: "background" produces a non-distracting background tab that does
+  // not steal focus from the captain (runtime decides how). "visible" produces
+  // a normal focused tab for debug ergonomics.
   spawnInjector(opts: {
     captainWorkspace: WorkspaceRef;
     command: string;
     title?: string;
-    placement: "hidden" | "visible";
+    placement: "background" | "visible";
   }): Promise<PaneRef>;
 
   // Send text to a specific surface. Unlike `send` (workspace-level) this


### PR DESCRIPTION
Honesty fix: `placement: "hidden"` was a misnomer — the notify-relay tab creates a background non-focus-stealing tab, not an invisible one. cmux has no hide verb in its CLI.

Behavior unchanged. All 37 tests pass (34 cmux + 3 launch), tsc clean.

Closes #161.