### PR TITLE
Add process-cleanup rule to crew templates + captain-ops

### DIFF
--- a/orchestrator/crew.claude.md
+++ b/orchestrator/crew.claude.md
@@ -30,6 +30,10 @@ When your captain assigns a **multi-step implementation task** (3+ distinct step
 
 GSD creates a `.planning/` directory in your worktree — this is normal and expected.
 
+## Clean Up Before Finishing
+
+Before signaling done, TERMINATE every process you started — test runners, dev servers, file watchers, background jobs. Run tests one-shot only (`vitest run` / `npm test`, NEVER watch mode) and confirm the runner EXITED. Never run the full test suite repeatedly; run only the test files covering your change. Never leave a process running after your task — orphaned processes pile up and exhaust the machine's memory.
+
 ## Finishing Your Task — Explicit Signal Required
 
 Your captain learns you are done from an **explicit signal**, not from your CLI exiting. Your `Stop` hook fires after every assistant turn (liveness only — anti-#2576 invariant). When you are actually finished:

--- a/orchestrator/crew.generic.md
+++ b/orchestrator/crew.generic.md
@@ -26,6 +26,10 @@ When done:
 
 You were started by `cockpit crew spawn` as a new tab in the captain's workspace (or as a split pane if `--direction` was passed). Your task is in your initial prompt. When you finish, exit cleanly — the surface is disposable.
 
+## Clean Up Before Finishing
+
+Before signaling done, TERMINATE every process you started — test runners, dev servers, file watchers, background jobs. Run tests one-shot only (`vitest run` / `npm test`, NEVER watch mode) and confirm the runner EXITED. Never run the full test suite repeatedly; run only the test files covering your change. Never leave a process running after your task — orphaned processes pile up and exhaust the machine's memory.
+
 ## Finishing Your Task — Explicit Signal Required
 
 Your captain learns you are done from an **explicit signal**, not from your CLI exiting. When you are actually finished:

--- a/orchestrator/crew.opencode.md
+++ b/orchestrator/crew.opencode.md
@@ -26,6 +26,10 @@ When done:
 
 You were started by `cockpit crew spawn --agent opencode` as a new tab in the captain's workspace (or as a split pane if `--direction` was passed). Your task is in your initial prompt. When you finish, exit cleanly — the surface is disposable.
 
+## Clean Up Before Finishing
+
+Before signaling done, TERMINATE every process you started — test runners, dev servers, file watchers, background jobs. Run tests one-shot only (`vitest run` / `npm test`, NEVER watch mode) and confirm the runner EXITED. Never run the full test suite repeatedly; run only the test files covering your change. Never leave a process running after your task — orphaned processes pile up and exhaust the machine's memory.
+
 ## Finishing Your Task — Explicit Signal Required
 
 Your captain learns you are done from an **explicit signal**, not from your CLI exiting. When you are actually finished:

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -162,8 +162,9 @@ After a crew task completes:
 1. Review the work — read the diff, check the branch.
 2. Merge their branch if appropriate.
 3. Close the crew with `cockpit crew close <project> <name>` once the work track is done. (Or let the crew exit itself — the tab closes when the CLI ends.)
-4. Record learnings if any (see "Recording Learnings" below).
-5. Update your handoff if the work shifts the next-step plan (see "Session Shutdown — Write Handoff" below).
+4. After closing a crew, VERIFY no orphaned processes remain — e.g. `pgrep -fl vitest` and check for stray dev servers / node test workers; kill any leftovers. Do NOT run the full test suite repeatedly or concurrently across worktrees (a single `vitest run` spawns a ~per-CPU worker pool that uses gigabytes; several at once exhaust RAM). Prefer one verification on the authoritative checkout.
+5. Record learnings if any (see "Recording Learnings" below).
+6. Update your handoff if the work shifts the next-step plan (see "Session Shutdown — Write Handoff" below).
 
 Status writes (`write-status.sh`) are opt-in; you don't need to write status after every event.
 


### PR DESCRIPTION
Crews were leaving orphaned vitest worker pools running after tasks, exhausting RAM. Adds a durable cleanup rule to all three crew templates and a verification step for the captain after closing crews.