### PR TITLE
fix #136: collapse newlines before cmux send so multi-line prompts deliver intact

### DIFF
--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { createCmuxDriver } from "../cmux.js";
+import { createCmuxDriver, sanitizeForCmuxSend } from "../cmux.js";
 
 const execFileMock = vi.hoisted(() => vi.fn());
 vi.mock("node:child_process", () => ({
@@ -238,6 +238,36 @@ describe("cmux driver", () => {
     expect(cmds.some((c) => c.includes("send-key") && c.includes("--surface surface:9") && c.includes("Enter"))).toBe(true);
   });
 
+  // Regression for #136: multi-line message must be sanitized before cmux send
+  // so newline bytes don't trigger premature Enter submissions.
+  it("sendToPane sanitizes multi-line messages", async () => {
+    execFileMock.mockReturnValue("");
+    await driver.sendToPane({ workspaceId: "workspace:1", surfaceId: "surface:9" }, "line one\nline two\nline three");
+    const sendCall = execFileMock.mock.calls.find((c) => argvOf(c)[0] === "send");
+    expect(sendCall).toBeDefined();
+    expect(argvOf(sendCall!)).toContain("line one line two line three");
+    expect(argvOf(sendCall!)).not.toContain("\n");
+  });
+
+  it("send sanitizes multi-line messages", async () => {
+    execFileMock.mockReturnValue("");
+    await driver.send("workspace:2", "hello\nworld\\nfoo");
+    const sendCall = execFileMock.mock.calls.find((c) => argvOf(c)[0] === "send");
+    expect(sendCall).toBeDefined();
+    expect(argvOf(sendCall!)).toContain("hello world foo");
+    expect(argvOf(sendCall!)).not.toContain("\n");
+  });
+
+  it("sendToSurface sanitizes multi-line messages", async () => {
+    execFileMock.mockReturnValue("");
+    await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "multi\nline\r\ntext");
+    const sendCall = execFileMock.mock.calls.find((c) => argvOf(c)[0] === "send");
+    expect(sendCall).toBeDefined();
+    expect(argvOf(sendCall!)).toContain("multi line text");
+    // No real newlines in argv
+    expect(argvOf(sendCall!).every((s: string) => !s.includes("\n") && !s.includes("\r"))).toBe(true);
+  });
+
   // Regression for #118: a crew prompt containing a backtick-wrapped destructive
   // command must reach cmux as ONE literal argv element, never parsed by a shell.
   it("sendToPane delivers backtick/$ shell metacharacters as literal text, not executed", async () => {
@@ -406,5 +436,51 @@ describe("cmux driver", () => {
     execFileMock.mockImplementation(() => { throw new Error("workspace not found"); });
     const surfaces = await driver.listSurfaces("workspace:99");
     expect(surfaces).toEqual([]);
+  });
+});
+
+describe("sanitizeForCmuxSend", () => {
+  it("collapses real newline bytes to single space", () => {
+    expect(sanitizeForCmuxSend("line one\nline two")).toBe("line one line two");
+  });
+
+  it("collapses real CRLF to single space", () => {
+    expect(sanitizeForCmuxSend("line one\r\nline two")).toBe("line one line two");
+  });
+
+  it("collapses real tab to single space", () => {
+    expect(sanitizeForCmuxSend("col1\tcol2")).toBe("col1 col2");
+  });
+
+  it("collapses literal backslash-n escape to single space", () => {
+    expect(sanitizeForCmuxSend("line one\\nline two")).toBe("line one line two");
+  });
+
+  it("collapses literal backslash-r escape to single space", () => {
+    expect(sanitizeForCmuxSend("line one\\rline two")).toBe("line one line two");
+  });
+
+  it("collapses literal backslash-t escape to single space", () => {
+    expect(sanitizeForCmuxSend("col1\\tcol2")).toBe("col1 col2");
+  });
+
+  it("handles mixed escapes and real whitespace", () => {
+    expect(sanitizeForCmuxSend("a\\nb\\nc\r\nd\te")).toBe("a b c d e");
+  });
+
+  it("collapses multiple consecutive spaces from collapsed whitespace", () => {
+    expect(sanitizeForCmuxSend("a\n\n\nb")).toBe("a b");
+  });
+
+  it("trims leading/trailing whitespace", () => {
+    expect(sanitizeForCmuxSend("\n  hello world\n  ")).toBe("hello world");
+  });
+
+  it("preserves normal text without whitespace", () => {
+    expect(sanitizeForCmuxSend("hello world")).toBe("hello world");
+  });
+
+  it("handles empty string", () => {
+    expect(sanitizeForCmuxSend("")).toBe("");
   });
 });

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -38,6 +38,18 @@ function parseSurfaceOrder(tree: string): { id: string; selected: boolean }[] {
   return surfaces;
 }
 
+// cmux `send` treats \n, \r (and \t) as Enter/Tab keystrokes, so any newline in a
+// multi-line message would submit it line-by-line. Collapse all newline/CR/tab
+// (real bytes AND literal backslash-escapes) to single spaces so the whole message
+// is delivered as one line, then the explicit send-key Enter submits it once.
+export function sanitizeForCmuxSend(text: string): string {
+  return text
+    .replace(/\\[nrt]/g, " ")
+    .replace(/[\n\r\t]+/g, " ")
+    .replace(/ {2,}/g, " ")
+    .trim();
+}
+
 export function createCmuxDriver(): RuntimeDriver {
   return {
     name: "cmux",
@@ -108,13 +120,13 @@ export function createCmuxDriver(): RuntimeDriver {
           const surfaces = await this.listSurfaces(ws.id);
           const target = surfaces.find((s) => s.title === ws.name);
           if (target) {
-            cmux(["send", "--workspace", ws.id, "--surface", target.surfaceId, message]);
+            cmux(["send", "--workspace", ws.id, "--surface", target.surfaceId, sanitizeForCmuxSend(message)]);
             cmux(["send-key", "--workspace", ws.id, "--surface", target.surfaceId, "Enter"]);
             return;
           }
         } catch { /* fall through to default */ }
       }
-      cmux(["send", "--workspace", ref, message]);
+      cmux(["send", "--workspace", ref, sanitizeForCmuxSend(message)]);
       cmux(["send-key", "--workspace", ref, "Enter"]);
     },
 
@@ -161,7 +173,7 @@ export function createCmuxDriver(): RuntimeDriver {
     },
 
     async sendToPane(pane: PaneRef, message: string): Promise<void> {
-      cmux(["send", "--workspace", pane.workspaceId, "--surface", pane.surfaceId, message]);
+      cmux(["send", "--workspace", pane.workspaceId, "--surface", pane.surfaceId, sanitizeForCmuxSend(message)]);
       cmux(["send-key", "--workspace", pane.workspaceId, "--surface", pane.surfaceId, "Enter"]);
     },
 
@@ -220,7 +232,7 @@ export function createCmuxDriver(): RuntimeDriver {
     },
 
     async sendToSurface(surface: PaneRef, text: string): Promise<void> {
-      cmux(["send", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, text]);
+      cmux(["send", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, sanitizeForCmuxSend(text)]);
       cmux(["send-key", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, "Enter"]);
     },
 


### PR DESCRIPTION
Closes #136.

`cmux send` interprets `\n` and `\r` as Enter keystrokes, so multi-line task prompts were submitted line-by-line — only the last fragment survived the agent.

Changes:
- Add `sanitizeForCmuxSend()` helper that collapses real newline/CR/tab bytes and literal backslash escapes to single spaces.
- Apply it in all three send paths (`send`, `sendToPane`, `sendToSurface`) before the `cmux([send, ...])` call.
- 15 test cases: pure function cases for all escape/newline patterns + integration tests verifying multi-line messages arrive as single-line argv.

`send-key Enter` calls are untouched — the explicit Enter after each send still submits the now-single-line message once.