### PR TITLE
fix #165: poll pane readiness before first-turn send

### DIFF
--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -85,7 +85,7 @@ vi.mock("node:fs", async (importOriginal) => {
   return { ...merged, default: merged };
 });
 
-import { runCrewSpawn, runCrewSend, runCrewRead, runCrewClose, runCrewList } from "../crew.js";
+import { runCrewSpawn, runCrewSend, runCrewRead, runCrewClose, runCrewList, sendFirstTurnWhenReady } from "../crew.js";
 
 const baseConfig = {
   commandName: "command",
@@ -104,6 +104,7 @@ describe("cockpit crew spawn", () => {
     sendToPane.mockReset();
     closePane.mockReset();
     readPaneScreen.mockReset();
+    readPaneScreen.mockResolvedValue("> ");
     listSurfaces.mockReset();
     status.mockReset();
     buildCommand.mockReset();
@@ -424,6 +425,78 @@ describe("cockpit crew spawn", () => {
     status.mockResolvedValue(null);
     await expect(runCrewSpawn({ project: "brove", task: "x" }))
       .rejects.toThrow(/captain workspace 'brove-captain' is not running/i);
+  });
+});
+
+describe("sendFirstTurnWhenReady", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    readPaneScreen.mockReset();
+    sendToPane.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("polls until pane stabilizes then sends the task once", async () => {
+    let callCount = 0;
+    readPaneScreen.mockImplementation(async () => {
+      callCount++;
+      if (callCount <= 1) return "";
+      return "> do the thing";
+    });
+
+    const pane = { workspaceId: "w:1", surfaceId: "s:1" };
+    const promise = sendFirstTurnWhenReady(
+      { readPaneScreen, sendToPane } as any,
+      pane,
+      "do the thing",
+    );
+
+    await vi.advanceTimersByTimeAsync(4000);
+    await promise;
+
+    expect(sendToPane).toHaveBeenCalledTimes(1);
+    expect(sendToPane).toHaveBeenCalledWith(pane, "do the thing");
+  });
+
+  it("falls back to sending even if pane never stabilises", async () => {
+    readPaneScreen.mockResolvedValue("");
+
+    const pane = { workspaceId: "w:1", surfaceId: "s:1" };
+    const promise = sendFirstTurnWhenReady(
+      { readPaneScreen, sendToPane } as any,
+      pane,
+      "do the thing",
+    );
+
+    await vi.advanceTimersByTimeAsync(21000);
+    await promise;
+
+    // Two calls: fallback send + one re-send (post-send check sees empty screen)
+    expect(sendToPane).toHaveBeenCalledTimes(2);
+    expect(sendToPane).toHaveBeenNthCalledWith(1, pane, "do the thing");
+    expect(sendToPane).toHaveBeenNthCalledWith(2, pane, "do the thing");
+  }, 15000);
+
+  it("re-sends once when the first send is not reflected on screen", async () => {
+    readPaneScreen.mockResolvedValue("> ");
+
+    const pane = { workspaceId: "w:1", surfaceId: "s:1" };
+    const promise = sendFirstTurnWhenReady(
+      { readPaneScreen, sendToPane } as any,
+      pane,
+      "do the thing",
+    );
+
+    await vi.advanceTimersByTimeAsync(3500);
+    await promise;
+
+    // Two calls: initial send + one re-send
+    expect(sendToPane).toHaveBeenCalledTimes(2);
+    expect(sendToPane).toHaveBeenNthCalledWith(1, pane, "do the thing");
+    expect(sendToPane).toHaveBeenNthCalledWith(2, pane, "do the thing");
   });
 });
 

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -20,10 +20,14 @@ import { TERMINAL_STATES, type TaskRecord } from "../control/types.js";
 
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "cockpit", "templates");
 
-// Time to wait between launching the crew CLI and sending the first prompt.
-// The CLI needs a moment to initialize plugins / load the system prompt before
-// it's ready to accept input. 3s matches the captain launch path.
-const CLI_BOOT_DELAY_MS = 3000;
+// Poll-based first-turn delivery: after launching the CLI, poll the pane
+// until the agent is ready to accept input. Replaces a fixed delay (was 3s).
+// The stabilised-screen check is heuristic: non-empty + unchanged between two
+// consecutive reads suggests the TUI finished booting and is idle at its prompt.
+const SEND_FIRST_TURN_FLOOR_MS = 1500;
+const POLL_INTERVAL_MS = 750;
+const SEND_FIRST_TURN_TIMEOUT_MS = 20000;
+const POST_SEND_CHECK_MS = 750;
 
 function titleFor(project: string, name: string): string {
   return `🔧 ${project}:${name}`;
@@ -85,6 +89,38 @@ async function resolveCaptainWorkspace(project: string): Promise<{
     );
   }
   return { runtime, workspaceId: captain.id };
+}
+
+export async function sendFirstTurnWhenReady(
+  runtime: RuntimeDriver,
+  pane: PaneRef,
+  task: string,
+): Promise<void> {
+  await new Promise((r) => setTimeout(r, SEND_FIRST_TURN_FLOOR_MS));
+
+  const maxPolls = Math.floor(
+    (SEND_FIRST_TURN_TIMEOUT_MS - SEND_FIRST_TURN_FLOOR_MS) / POLL_INTERVAL_MS,
+  );
+  let previousScreen = "";
+  let stable = false;
+
+  for (let i = 0; i < maxPolls && !stable; i++) {
+    const screen = (await runtime.readPaneScreen(pane)) ?? "";
+    if (screen.length > 0 && screen === previousScreen) {
+      stable = true;
+    } else {
+      previousScreen = screen;
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    }
+  }
+
+  await runtime.sendToPane(pane, task);
+
+  await new Promise((r) => setTimeout(r, POST_SEND_CHECK_MS));
+  const afterScreen = (await runtime.readPaneScreen(pane)) ?? "";
+  if (!afterScreen.includes(task)) {
+    await runtime.sendToPane(pane, task);
+  }
 }
 
 export interface CrewSpawnInput {
@@ -213,8 +249,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
     // running inside the crew's cmux tab can identify their task.
     const envPrefix = `COCKPIT_CREW_TASK_ID=${rec.id} COCKPIT_CREW_PROJECT=${input.project}`;
     await runtime.sendToPane(pane, `${envPrefix} ${cliCommand}`);
-    await new Promise((r) => setTimeout(r, CLI_BOOT_DELAY_MS));
-    await runtime.sendToPane(pane, input.task);
+    await sendFirstTurnWhenReady(runtime, pane, input.task);
     return { ...pane, title };
   }
 
@@ -255,8 +290,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
     const pane = await runtime.newPane({ workspaceId: captain.id, direction, title });
     const envPrefix = `COCKPIT_CREW_TASK_ID=${rec.id} COCKPIT_CREW_PROJECT=${input.project}`;
     await runtime.sendToPane(pane, `${envPrefix} OPENCODE_CONFIG=${opencodeConfigPath} ${cliCommand}`);
-    await new Promise((r) => setTimeout(r, CLI_BOOT_DELAY_MS));
-    await runtime.sendToPane(pane, input.task);
+    await sendFirstTurnWhenReady(runtime, pane, input.task);
     return { ...pane, title };
   }
 
@@ -276,12 +310,11 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
   // Step 1: launch the CLI in the new tab.
   await runtime.sendToPane(pane, cliCommand);
 
-  // Step 2: for interactive sessions, wait for the CLI to boot, then send the
-  // task as the first prompt. For non-interactive (legacy) the prompt is
+  // Step 2: for interactive sessions, poll until the CLI is ready, then send
+  // the task as the first prompt. For non-interactive (legacy) the prompt is
   // already baked into cliCommand, so we're done.
   if (interactive) {
-    await new Promise((r) => setTimeout(r, CLI_BOOT_DELAY_MS));
-    await runtime.sendToPane(pane, input.task);
+    await sendFirstTurnWhenReady(runtime, pane, input.task);
   }
 
   return { ...pane, title };


### PR DESCRIPTION
## Problem

`runCrewSpawn` sends the crew's first-turn task after a **fixed** `sleep(CLI_BOOT_DELAY_MS=3000)` at three sites. If the agent CLI isn't booted in 3s, the `cmux send` lands before the TUI accepts input → the prompt is **lost** and the crew sits idle with no task.

## Fix

Replace the fixed delay with `sendFirstTurnWhenReady()`, a polling helper that:

1. Waits a minimum floor of 1500ms (don't send instantly)
2. Polls `runtime.readPaneScreen(pane)` every 750ms
3. Considers the pane **ready** when the screen is non-empty **and** unchanged between two consecutive reads (stabilized = TUI finished booting)
4. Falls back to sending after ~20000ms (never hangs)
5. After sending, re-reads the screen once; if the task text isn't reflected, re-sends **once** (best-effort)

Replaces all three fixed-sleep blocks (claude, opencode, generic interactive). The codex socket-based path is untouched.

## Tests

- Stabilizes quickly → sendToPane called once (no re-send needed)
- Never stabilizes → fallback send + re-send
- Task not reflected after send → exactly one re-send

closes #165