### PR TITLE
ci: release automation (tag + GitHub release + guarded npm publish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,104 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Determine version
+        id: ver
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag already exists
+        id: check
+        run: |
+          git fetch --tags
+          if git rev-parse -q --verify "refs/tags/${{ steps.ver.outputs.tag }}" >/dev/null; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Detect npm token
+        id: npmtok
+        if: steps.check.outputs.should_release == 'true'
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -n "$NPM_TOKEN" ]; then
+            echo "has_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_token=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install dependencies
+        if: steps.check.outputs.should_release == 'true'
+        run: npm ci
+
+      - name: Build
+        if: steps.check.outputs.should_release == 'true'
+        run: npm run build
+
+      - name: Test
+        if: steps.check.outputs.should_release == 'true'
+        run: npm test
+
+      - name: Extract release notes
+        if: steps.check.outputs.should_release == 'true'
+        run: |
+          VERSION="${{ steps.ver.outputs.version }}"
+          awk -v v="$VERSION" '
+            $0 ~ "^## \\[" v "\\]" { flag=1; print; next }
+            /^## \[/ && flag { flag=0 }
+            flag { print }
+          ' CHANGELOG.md > release_notes.md
+          if [ ! -s release_notes.md ]; then
+            echo "Release ${{ steps.ver.outputs.tag }}" > release_notes.md
+          fi
+
+      - name: Create and push tag
+        if: steps.check.outputs.should_release == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "${{ steps.ver.outputs.tag }}"
+          git push origin "${{ steps.ver.outputs.tag }}"
+
+      - name: Create GitHub Release
+        if: steps.check.outputs.should_release == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.ver.outputs.tag }}
+          name: ${{ steps.ver.outputs.tag }}
+          body_path: release_notes.md
+
+      - name: Publish to npm
+        if: steps.check.outputs.should_release == 'true' && steps.npmtok.outputs.has_token == 'true'
+        continue-on-error: true
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` — on every push to `main`, if `package.json`'s version has no matching `vX.Y.Z` tag yet, CI tags it, creates a GitHub Release with notes pulled from the `CHANGELOG.md` section, and attempts an npm publish.

## Behavior
- **Trigger:** push to `main`. Idempotent — reads version from `package.json`, skips everything if `v<version>` already exists (so non-release commits and re-runs are no-ops).
- **Gate:** `npm ci` → `npm run build` → `npm test` before tagging.
- **Release notes:** awk-extracts the `## [<version>]` block from `CHANGELOG.md` (falls back to `Release v<version>` if absent).
- **npm publish:** guarded on a `NPM_TOKEN` secret + `continue-on-error: true`, so it's a **no-op that can't fail the workflow** until you register npm and add the token.

## Notes / follow-ups (not blocking)
- `npm test` is a release gate — flaky test #146 could occasionally fail a release run; worth resolving #146 before relying on this.
- `package.json` has no `files` field or `prepublishOnly` — when you register npm, consider adding those so the published tarball is the compiled `dist/` only.

## How this reaches v0.4.0
Merge this to develop → rebase `release/v0.4.0` onto develop (so the workflow is present on main when #169 merges) → merging #169 auto-tags & releases v0.4.0 (npm step skipped, no token).

🤖 Built by a claude crew, reviewed step-by-step at diff level by captain. Verified: valid YAML, changelog extraction prints only the target section, single-file/single-commit.