### PR TITLE
fix(crew): notify captain on idle (awaiting-input) instead of misleading stall

### DIFF
--- a/src/control/__tests__/cockpitd-push.test.ts
+++ b/src/control/__tests__/cockpitd-push.test.ts
@@ -87,9 +87,9 @@ describe("cockpitd push notifications (#109)", () => {
     expect(n.calls[0]?.message).toContain("boom: subprocess crashed");
   });
 
-  it("stalled (from sweep) triggers CREW STALLED with budget", async () => {
+  it("HEADLESS stall (from sweep) triggers CREW STALLED with budget", async () => {
     const store = createStore(dir);
-    store.put(rec("task-stall-1", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250 }));
+    store.put(rec("task-stall-1", { mode: "headless", state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250 }));
     const n = fakeNotify();
     const d = createDaemon({ store, now: () => 5000, notify: n.notify });
     d.sweep();
@@ -97,6 +97,43 @@ describe("cockpitd push notifications (#109)", () => {
     expect(n.calls).toHaveLength(1);
     expect(n.calls[0]?.message).toMatch(/^CREW STALLED \[claude\/task-sta/);
     expect(n.calls[0]?.message).toMatch(/no heartbeat/i);
+  });
+
+  it("INTERACTIVE idle (from sweep) triggers exactly one CREW IDLE notify", async () => {
+    const store = createStore(dir);
+    // rec() defaults to mode: "interactive"
+    store.put(rec("task-idle-1", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250 }));
+    const n = fakeNotify();
+    const d = createDaemon({ store, now: () => 5000, notify: n.notify });
+    d.sweep();
+    expect(store.get("p", "task-idle-1")?.state).toBe("awaiting-input");
+    expect(n.calls).toHaveLength(1);
+    expect(n.calls[0]?.message).toMatch(/^CREW IDLE \[claude\/task-idl/);
+    expect(n.calls[0]?.message).not.toMatch(/stall/i); // reads as idle, not failure
+    expect(n.calls[0]?.message).toMatch(/awaiting your input/i);
+  });
+
+  it("awaiting-input sits idle across repeated sweeps → no notification storm", async () => {
+    const store = createStore(dir);
+    store.put(rec("task-idle-2", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250 }));
+    const n = fakeNotify();
+    const d = createDaemon({ store, now: () => 5000, notify: n.notify });
+    d.sweep(); // working → awaiting-input, one push
+    d.sweep(); // awaiting-input is not 'working' → no re-stall, no re-notify
+    d.sweep();
+    expect(store.get("p", "task-idle-2")?.state).toBe("awaiting-input");
+    expect(n.calls).toHaveLength(1);
+  });
+
+  it("awaiting-input + task.started (captain resumes) → working, no extra notify", async () => {
+    const store = createStore(dir);
+    store.put(rec("task-idle-3", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250 }));
+    const n = fakeNotify();
+    const d = createDaemon({ store, now: () => 5000, notify: n.notify });
+    d.sweep(); // → awaiting-input, push #1 (CREW IDLE)
+    await d.handle({ kind: "event", project: "p", event: { type: "task.started", id: "task-idle-3" } });
+    expect(store.get("p", "task-idle-3")?.state).toBe("working");
+    expect(n.calls).toHaveLength(1); // working is not an attention state → no extra push
   });
 
   it("redundant terminal event does NOT re-notify (state-change guard)", async () => {

--- a/src/control/__tests__/daemon.test.ts
+++ b/src/control/__tests__/daemon.test.ts
@@ -73,12 +73,20 @@ describe("daemon handler", () => {
     expect(store.get("p", "h2")?.state).toBe("working");
   });
 
-  it("sweep: marks an over-budget working task stalled", async () => {
+  it("sweep: marks an over-budget working HEADLESS task stalled", async () => {
     const store = createStore(dir);
-    store.put(rec("s1", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 100 }));
+    store.put(rec("s1", { mode: "headless", state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 100 }));
     const d = createDaemon({ store, now: () => 1000 });
     d.sweep();
     expect(store.get("p", "s1")?.state).toBe("stalled");
+  });
+
+  it("sweep: marks an over-budget working INTERACTIVE task awaiting-input (not stalled)", async () => {
+    const store = createStore(dir);
+    store.put(rec("s1i", { mode: "interactive", state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 100 }));
+    const d = createDaemon({ store, now: () => 1000 });
+    d.sweep();
+    expect(store.get("p", "s1i")?.state).toBe("awaiting-input");
   });
 
   it("sweep: recovers a stalled task that has a fresh heartbeat", async () => {

--- a/src/control/__tests__/watchdog.test.ts
+++ b/src/control/__tests__/watchdog.test.ts
@@ -14,10 +14,21 @@ function rec(o: Partial<TaskRecord> = {}): TaskRecord {
 }
 
 describe("evaluateStall", () => {
-  it("working past budget → stalled", () => {
+  it("working HEADLESS past budget → stalled", () => {
     const out = evaluateStall(rec(), 6001);
     expect(out?.state).toBe("stalled");
     expect(out?.lastEvent).toBe("watchdog.stall");
+  });
+
+  it("working INTERACTIVE past budget → awaiting-input, not stalled", () => {
+    // An idle interactive crew has simply ended a turn and is awaiting the
+    // captain's next message — that is NOT a stall. Surface it as the
+    // answerable 'awaiting-input' state so the captain gets an accurate,
+    // non-alarming nudge instead of a misleading CREW STALLED.
+    const out = evaluateStall(rec({ mode: "interactive" }), 6001);
+    expect(out?.state).toBe("awaiting-input");
+    expect(out?.state).not.toBe("stalled");
+    expect(out?.lastEvent).toBe("watchdog.idle");
   });
 
   it("working within budget → no change (null)", () => {
@@ -48,7 +59,12 @@ describe("recoverStall", () => {
   });
 });
 
-describe("stalled = warn-don't-autofail for interactive-codex (spec §4.8, #90 slice)", () => {
+describe("idle interactive-codex = warn-don't-autofail (spec §4.8, #90 slice)", () => {
+  // #90's intent ("warn-don't-autofail") was that an idle interactive-codex
+  // task must remain answerable, never auto-failed. We now express that as
+  // 'awaiting-input' rather than 'stalled': both are non-terminal & answerable,
+  // but 'awaiting-input' reads to the captain as normal idle (turn ended)
+  // instead of a failure, and resumes to 'working' on the next liveness/turn.
   function rec(overrides: Partial<TaskRecord> = {}): TaskRecord {
     return {
       id: "t1", project: "p", provider: "codex", mode: "interactive",
@@ -59,18 +75,19 @@ describe("stalled = warn-don't-autofail for interactive-codex (spec §4.8, #90 s
     };
   }
 
-  it("a stalled interactive-codex task is non-terminal (never failed)", () => {
-    const stalled = evaluateStall(rec(), 100_000);
-    expect(stalled).not.toBeNull();
-    expect(stalled!.state).toBe("stalled");
-    expect(stalled!.state).not.toBe("failed");
-    expect(stalled!.state).not.toBe("done");
+  it("an idle interactive-codex task is non-terminal & answerable (awaiting-input, never failed)", () => {
+    const idle = evaluateStall(rec(), 100_000);
+    expect(idle).not.toBeNull();
+    expect(idle!.state).toBe("awaiting-input");
+    expect(idle!.state).not.toBe("failed");
+    expect(idle!.state).not.toBe("done");
   });
 
-  it("a stalled interactive-codex task recovers to working on next liveness", () => {
-    const stalled = evaluateStall(rec(), 100_000)!;
-    const recovered = recoverStall(stalled, 101_000);
-    expect(recovered).not.toBeNull();
-    expect(recovered!.state).toBe("working");
+  it("an idle interactive-codex task resumes to working on the next turn (task.started/PostToolUse)", () => {
+    // awaiting-input → working is the reducer's job (task.started / task.progress);
+    // the watchdog itself never re-stalls an awaiting-input task.
+    const idle = evaluateStall(rec(), 100_000)!;
+    expect(evaluateStall(idle, 200_000)).toBeNull(); // no re-stall while idle
+    expect(recoverStall(idle, 101_000)).toBeNull();  // recoverStall only acts on 'stalled'
   });
 });

--- a/src/control/daemon.ts
+++ b/src/control/daemon.ts
@@ -38,7 +38,10 @@ export interface DaemonDeps {
   }) => Promise<void> | void;
 }
 
-const ATTENTION_STATES: ReadonlySet<TaskState> = new Set(["done", "blocked", "failed", "stalled"]);
+// 'awaiting-input' is an attention state: entering it (idle watchdog OR a
+// Stop-hook turn boundary) fires exactly one accurate CREW IDLE push. The
+// firePush prev===next guard keeps it from re-firing while the task sits idle.
+const ATTENTION_STATES: ReadonlySet<TaskState> = new Set(["done", "blocked", "failed", "stalled", "awaiting-input"]);
 
 function shortId(id: string): string {
   return id.slice(0, 8);
@@ -61,6 +64,8 @@ function formatMessage(rec: TaskRecord): string | null {
       return `CREW FAILED ${tag}: ${(rec.error ?? "(no error)").trim()}`;
     case "stalled":
       return `CREW STALLED ${tag}: no heartbeat in ${rec.heartbeatBudgetMs}ms`;
+    case "awaiting-input":
+      return `CREW IDLE ${tag}: turn ended / awaiting your input — review and reply or close.`;
     default:
       return null;
   }
@@ -180,15 +185,17 @@ export function createDaemon(deps: DaemonDeps) {
     sweep(): void {
       const t = now();
       for (const r of store.listAll()) {
-        const stalled = evaluateStall(r, t);
-        if (stalled) {
-          store.put(stalled);
-          const synthEvent: ControlEvent = {
-            type: "task.stalled",
-            id: r.id,
-            heartbeatBudgetMs: r.heartbeatBudgetMs,
-          };
-          firePush(deps, r.project, r.state, stalled, synthEvent);
+        const idle = evaluateStall(r, t);
+        if (idle) {
+          store.put(idle);
+          // Interactive idle → awaiting-input (task.idle); headless → stalled
+          // (task.stalled). The synth event only carries the notify payload;
+          // the reducer treats both as no-ops (state already updated above).
+          const synthEvent: ControlEvent =
+            idle.state === "awaiting-input"
+              ? { type: "task.idle", id: r.id, heartbeatBudgetMs: r.heartbeatBudgetMs }
+              : { type: "task.stalled", id: r.id, heartbeatBudgetMs: r.heartbeatBudgetMs };
+          firePush(deps, r.project, r.state, idle, synthEvent);
           continue;
         }
         const recovered = recoverStall(r, t);

--- a/src/control/state-machine.ts
+++ b/src/control/state-machine.ts
@@ -81,6 +81,7 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
     case "task.reattached":
       return stampAttempt(base, {}, now);
     case "task.stalled":
+    case "task.idle":
     case "task.reconcile-failed":
       // Synthetic notify-only events; the daemon has already updated state
       // directly via the watchdog/reconcile paths. Reducer is a no-op.

--- a/src/control/types.ts
+++ b/src/control/types.ts
@@ -92,6 +92,10 @@ export type ControlEvent =
   // notify payloads. They are never sent over the wire and the reducer treats
   // them as no-ops; the watchdog has already updated state directly.
   | { type: "task.stalled"; id: string; heartbeatBudgetMs: number }
+  // task.idle is the interactive analogue of task.stalled: the watchdog has
+  // already moved an idle interactive task to 'awaiting-input', and this carries
+  // the accurate (non-alarming) notify payload to the captain.
+  | { type: "task.idle"; id: string; heartbeatBudgetMs: number }
   | { type: "task.reconcile-failed"; id: string; reason: string };
 
 // 'stalled' is intentionally excluded — recoverable by the watchdog.

--- a/src/control/watchdog.ts
+++ b/src/control/watchdog.ts
@@ -2,17 +2,26 @@
 import type { TaskRecord } from "./types.js";
 
 /**
- * Pure. Returns a stalled record if a `working` task has exceeded its
- * heartbeat budget at time `now` (epoch ms), else null. No I/O, no clock.
+ * Pure. Returns an idle-transitioned record if a `working` task has exceeded
+ * its heartbeat budget at time `now` (epoch ms), else null. No I/O, no clock.
  *
- * Policy: `stalled` is RECOVERABLE, not terminal (spec §4.8, #90).
- * Interactive-codex tasks in particular surface to the Captain via the
- * 'stalled' state and remain answerable; this function never produces
- * `failed` directly.
+ * Mode decides what "idle" means:
+ *  - interactive → 'awaiting-input'. An idle interactive crew has merely ended
+ *    a turn and is awaiting the captain's next message — answerable, NOT a
+ *    failure. This reframes the old interactive-codex 'stalled' surfacing
+ *    (#90 "warn-don't-autofail", spec §4.8) into an explicitly answerable
+ *    state that reads as normal idle and resumes to 'working' on next liveness.
+ *  - headless → 'stalled'. A batch child that stops heartbeating is genuinely
+ *    stuck; there is no captain turn to await, so surface it as a stall.
+ *
+ * Neither state is terminal; this function never produces `failed` directly.
  */
 export function evaluateStall(rec: TaskRecord, now: number): TaskRecord | null {
   if (rec.state !== "working") return null;
   if (now - rec.lastHeartbeat <= rec.heartbeatBudgetMs) return null;
+  if (rec.mode === "interactive") {
+    return { ...rec, state: "awaiting-input", lastEvent: "watchdog.idle" };
+  }
   return { ...rec, state: "stalled", lastEvent: "watchdog.stall" };
 }
 


### PR DESCRIPTION
## Problem
When an **interactive** crew finished a turn and went quiet, the watchdog moved it to `stalled` and pushed a `CREW STALLED … no heartbeat` notification to the captain. But an idle interactive crew hasn't stalled — it has merely ended a turn and is *awaiting the captain's next message*. The "STALLED" framing was misleading and alarming for the normal idle case.

## Fix
Split the watchdog's idle outcome by mode:

- **interactive** idle → `awaiting-input` (`watchdog.idle`). Answerable, reads as normal idle, resumes to `working` on next liveness. Not a failure.
- **headless** idle → `stalled` (`watchdog.stall`). A batch child that stops heartbeating is genuinely stuck — no captain turn to await.

Neither state is terminal; the watchdog never produces `failed` directly (spec §4.8, #90).

### Notify path
- `awaiting-input` is now an **attention state** → fires exactly one accurate push:
  `CREW IDLE <tag>: turn ended / awaiting your input — review and reply or close.`
- The `firePush` prev===next guard prevents re-firing while the task sits idle.
- New synthetic `task.idle` event carries the non-alarming notify payload (interactive analogue of `task.stalled`). Reducer treats it as a no-op — the watchdog already updated state.

## Tests
All 254 control-plane tests pass (`vitest run src/control/`), including updated `watchdog`, `daemon`, and `cockpitd-push` specs covering the interactive→`awaiting-input` path and the `CREW IDLE` push.

## Related
- Related to #139 (SessionEnd resuming `working` → false stall) and #137 (hook delivery). This PR addresses the *idle classification + notify* regression; #139's SessionEnd resume bug is separate and remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)