### PR TITLE
fix(crew): codex crews can signal terminal state (--task-id/--project flags + developerInstructions)

### DIFF
--- a/src/commands/__tests__/crew-signal.test.ts
+++ b/src/commands/__tests__/crew-signal.test.ts
@@ -76,4 +76,28 @@ describe("buildSignalRequest", () => {
     delete process.env.COCKPIT_CREW_PROJECT;
     expect(() => buildSignalRequest("done", {})).toThrow(/COCKPIT_CREW_PROJECT/);
   });
+
+  // The codex case: a long-lived shared app-server serves all codex tasks as
+  // threads, so a process-level env var is unsafe. Explicit flags let a codex
+  // crew signal its own task with NO env vars set.
+  it("explicit taskId+project flags build a targeted request with NO env set (codex case)", () => {
+    delete process.env.COCKPIT_CREW_TASK_ID;
+    delete process.env.COCKPIT_CREW_PROJECT;
+    const req = buildSignalRequest("done", { taskId: "X", project: "P", message: "m" });
+    expect(req.project).toBe("P");
+    expect(req.event).toMatchObject({ type: "task.done", id: "X", message: "m" });
+  });
+
+  // Regression guard: claude/opencode keep using env when no flags are given.
+  it("no flags + env set → unchanged env-based behavior (claude/opencode guard)", () => {
+    const req = buildSignalRequest("done", { message: "m" });
+    expect(req.project).toBe("alpha");
+    expect(req.event).toMatchObject({ type: "task.done", id: "task-xyz" });
+  });
+
+  it("flags take precedence over env when both present", () => {
+    const req = buildSignalRequest("done", { taskId: "flag-id", project: "flag-proj" });
+    expect(req.project).toBe("flag-proj");
+    expect((req.event as { id: string }).id).toBe("flag-id");
+  });
 });

--- a/src/commands/crew-control.ts
+++ b/src/commands/crew-control.ts
@@ -109,9 +109,15 @@ export async function cockpitdCall(req: unknown): Promise<unknown> {
 
 /**
  * Build an explicit terminal/blocked event request from a crew's `signal`
- * verb. Reads `COCKPIT_CREW_TASK_ID` and `COCKPIT_CREW_PROJECT` from env so
- * the crew template can run e.g. `cockpit crew signal done --message "…"`
- * without having to know its own task id or project.
+ * verb. Defaults to reading `COCKPIT_CREW_TASK_ID` and `COCKPIT_CREW_PROJECT`
+ * from env so the claude/opencode crew templates can run e.g.
+ * `cockpit crew signal done --message "…"` without knowing their own ids.
+ *
+ * Explicit `taskId`/`project` (from `--task-id`/`--project` flags) take
+ * precedence over env. This is the codex path: a single long-lived app-server
+ * child serves all codex tasks as threads, so a process-level env var is
+ * unsafe (wrong for concurrent tasks). The codex crew is told its concrete ids
+ * via per-thread developerInstructions and signals with the explicit flags.
  *
  * Anti-#2576 invariant lives at the OTHER end (the hook bridge in
  * `_hook`). This builder is the *explicit* path: a crew running this verb
@@ -123,12 +129,16 @@ export function buildSignalRequest(
     message?: string;
     question?: string;
     error?: string;
+    /** Explicit override (codex); falls back to COCKPIT_CREW_TASK_ID env. */
+    taskId?: string;
+    /** Explicit override (codex); falls back to COCKPIT_CREW_PROJECT env. */
+    project?: string;
     /** Injectable for tests; defaults to writing under ~/.config/cockpit/state/_results. */
     writeResult?: (id: string, payload: string) => string;
   },
 ): { kind: "event"; project: string; event: ControlEvent } {
-  const taskId = process.env.COCKPIT_CREW_TASK_ID;
-  const project = process.env.COCKPIT_CREW_PROJECT;
+  const taskId = o.taskId ?? process.env.COCKPIT_CREW_TASK_ID;
+  const project = o.project ?? process.env.COCKPIT_CREW_PROJECT;
   if (!taskId)
     throw new Error("not running under a crew (COCKPIT_CREW_TASK_ID unset)");
   if (!project)
@@ -253,11 +263,13 @@ export function addControlPlaneCrewCommands(crew: Command): void {
   // (git status clean, etc.) to declare terminal state to the captain.
   crew
     .command("signal <state>")
-    .description("Emit explicit terminal signal from a crew session: done|blocked|failed (reads COCKPIT_CREW_* env)")
+    .description("Emit explicit terminal signal from a crew session: done|blocked|failed (reads COCKPIT_CREW_* env, or --task-id/--project for codex)")
     .option("--message <m>", "Summary written to resultRef (done)")
     .option("--question <q>", "Question to surface to captain (blocked)")
     .option("--error <e>", "Error message (failed)")
-    .action(async (state: string, opts: { message?: string; question?: string; error?: string }) => {
+    .option("--task-id <id>", "Explicit task id (codex; overrides COCKPIT_CREW_TASK_ID env)")
+    .option("--project <p>", "Explicit project (codex; overrides COCKPIT_CREW_PROJECT env)")
+    .action(async (state: string, opts: { message?: string; question?: string; error?: string; taskId?: string; project?: string }) => {
       if (state !== "done" && state !== "blocked" && state !== "failed") {
         process.stderr.write(`unknown signal '${state}' (expected: done|blocked|failed)\n`);
         process.exit(2);
@@ -267,6 +279,8 @@ export function addControlPlaneCrewCommands(crew: Command): void {
           ...(opts.message !== undefined ? { message: opts.message } : {}),
           ...(opts.question !== undefined ? { question: opts.question } : {}),
           ...(opts.error !== undefined ? { error: opts.error } : {}),
+          ...(opts.taskId !== undefined ? { taskId: opts.taskId } : {}),
+          ...(opts.project !== undefined ? { project: opts.project } : {}),
           writeResult: defaultWriteResult,
         });
         await cockpitdCall(req);

--- a/src/control/codex/__tests__/driver.test.ts
+++ b/src/control/codex/__tests__/driver.test.ts
@@ -41,6 +41,26 @@ describe("CodexInteractiveDriver.dispatch", () => {
     ]);
   });
 
+  it("injects task id, project, and the explicit-flag signal command into developerInstructions", async () => {
+    const client = fakeClient();
+    const drv = new CodexInteractiveDriver({
+      makeClient: () => client,
+      emit: () => {},
+    });
+    await drv.dispatch({
+      id: "task-42", project: "demo", provider: "codex", mode: "interactive",
+      state: "submitted", task: "x", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000,
+      attempts: [{ attemptId: "a1", startedAt: 1, lastHeartbeatAt: 1 }],
+      cwd: "/tmp/work", roleInstructions: "ROLE BODY",
+    } as any);
+    const dev = client.startThread.mock.calls[0][0].developerInstructions as string;
+    expect(dev).toContain("ROLE BODY");
+    expect(dev).toContain("task-42");
+    expect(dev).toContain("demo");
+    expect(dev).toContain("cockpit crew signal done --task-id task-42 --project demo");
+  });
+
   it("routes serverRequest with no threadId to the sole active task", async () => {
     const client = fakeClient();
     const events: any[] = [];

--- a/src/control/codex/driver.ts
+++ b/src/control/codex/driver.ts
@@ -53,7 +53,7 @@ export class CodexInteractiveDriver {
         model: rec.model,
         sandbox: "workspace-write",
         approvalPolicy: rec.approvalPolicy ?? "never",
-        ...(rec.roleInstructions ? { developerInstructions: rec.roleInstructions } : {}),
+        developerInstructions: buildCodexDeveloperInstructions(rec),
       });
       this.threadByTask.set(rec.id, threadId);
       this.taskByThread.set(threadId, rec.id);
@@ -149,6 +149,25 @@ export class CodexInteractiveDriver {
       });
     }
   }
+}
+
+/**
+ * Build the per-thread developerInstructions for a codex crew. Unlike
+ * claude/opencode (which get COCKPIT_CREW_* env vars on their shell launch
+ * line), codex tasks share ONE long-lived app-server child, so a process-level
+ * env var would be wrong for concurrent tasks. Instead we tell each thread its
+ * concrete task id + project and the exact flag-based signal command, so the
+ * codex crew can report terminal state via `cockpit crew signal`. Appended
+ * after the crew role body (when present) so the role still leads.
+ */
+export function buildCodexDeveloperInstructions(
+  rec: { id: string; project: string; roleInstructions?: string },
+): string {
+  const directive =
+    `You are cockpit crew task ${rec.id} in project ${rec.project}. ` +
+    `When you finish, run EXACTLY: cockpit crew signal done --task-id ${rec.id} --project ${rec.project} --message "<one-line summary>". ` +
+    `If you are blocked or fail, run cockpit crew signal blocked|failed with the same --task-id ${rec.id} --project ${rec.project} flags.`;
+  return rec.roleInstructions ? `${rec.roleInstructions}\n\n${directive}` : directive;
 }
 
 function withTimeout<T>(p: Promise<T>, ms: number, msg: string): Promise<T> {


### PR DESCRIPTION
## Problem (release-blocker for v0.4.0)

In the 3-agent parallel test, **codex crews errored** when reporting completion:
`cockpit crew signal done` → `not running under a crew (COCKPIT_CREW_TASK_ID unset)`.

claude/opencode get `COCKPIT_CREW_TASK_ID`/`COCKPIT_CREW_PROJECT` on their shell launch line. codex can't: a **single shared app-server child** serves all codex tasks as separate threads, so a process-level env var would be wrong for concurrent tasks (hit live when running 3 agents in parallel). `startThread` has no per-thread `env` param.

## Fix (two coordinated changes)

1. **`cockpit crew signal` gains `--task-id`/`--project` flags** (`crew-control.ts`): `buildSignalRequest` uses `o.taskId ?? process.env.COCKPIT_CREW_TASK_ID` — explicit flags take precedence, env is the fallback. **claude/opencode unchanged** (no flags → env, exactly as before).
2. **Per-thread `developerInstructions` injection** (`driver.ts`): new `buildCodexDeveloperInstructions(rec)` appends — after the crew role body — the crew's concrete task id + project and the exact flag-based signal command, so codex knows its identity and signals correctly.

## Scope & verification
- 4 files: `crew-control.ts`, `codex/driver.ts` + 2 test files. Surgical.
- `tsc` clean; **17/17 targeted tests pass** (`crew-signal.test.ts`, `codex/driver.test.ts`) — covers flag precedence, env fallback regression guard, and the injected directive contents. Independently re-verified by captain on the branch.
- **Live codex e2e smoke test pending** post-merge (rebuild + daemon restart) — unit tests prove injection + precedence, not that the model obeys at runtime; I'll confirm that live.

## ⚠️ Deploy note
Daemon-side change (CodexInteractiveDriver) — restart daemon after merge: `launchctl kickstart -k gui/$(id -u)/com.cockpit.daemon`

🤖 Built by a claude crew (TDD), reviewed at diff level + type/test-verified by captain.