### PR TITLE
fix #168: exactly-once first-turn delivery + opencode boot-race readiness gate

### DIFF
--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -104,7 +104,16 @@ describe("cockpit crew spawn", () => {
     sendToPane.mockReset();
     closePane.mockReset();
     readPaneScreen.mockReset();
-    readPaneScreen.mockResolvedValue("> ");
+    // Staged boot: first read (the call-site preLaunch snapshot) shows the
+    // un-entered launch line; subsequent reads show a stable TUI prompt that
+    // has advanced past it, so sendFirstTurnWhenReady's readiness gate fires.
+    let reads = 0;
+    readPaneScreen.mockImplementation(async () => {
+      reads++;
+      if (reads === 1) return "booting…";
+      if (reads <= 4) return "> ready";
+      return "> ready\nworking…";
+    });
     listSurfaces.mockReset();
     status.mockReset();
     buildCommand.mockReset();
@@ -444,7 +453,9 @@ describe("sendFirstTurnWhenReady", () => {
     readPaneScreen.mockImplementation(async () => {
       callCount++;
       if (callCount <= 1) return "";
-      return "> do the thing";
+      if (callCount <= 3) return "> ";        // stable prompt, advanced past launch
+      if (callCount === 4) return "> ";       // preSend snapshot
+      return "> do the thing";                // after-send: screen changed → no re-send
     });
 
     const pane = { workspaceId: "w:1", surfaceId: "s:1" };
@@ -452,6 +463,7 @@ describe("sendFirstTurnWhenReady", () => {
       { readPaneScreen, sendToPane } as any,
       pane,
       "do the thing",
+      "$ launch",
     );
 
     await vi.advanceTimersByTimeAsync(4000);
@@ -469,18 +481,19 @@ describe("sendFirstTurnWhenReady", () => {
       { readPaneScreen, sendToPane } as any,
       pane,
       "do the thing",
+      "$ launch",
     );
 
     await vi.advanceTimersByTimeAsync(21000);
     await promise;
 
-    // Two calls: fallback send + one re-send (post-send check sees empty screen)
+    // Two calls: fallback send + one re-send (post-send check sees an unchanged screen)
     expect(sendToPane).toHaveBeenCalledTimes(2);
     expect(sendToPane).toHaveBeenNthCalledWith(1, pane, "do the thing");
     expect(sendToPane).toHaveBeenNthCalledWith(2, pane, "do the thing");
   }, 15000);
 
-  it("re-sends once when the first send is not reflected on screen", async () => {
+  it("re-sends once when the screen is unchanged after the first send", async () => {
     readPaneScreen.mockResolvedValue("> ");
 
     const pane = { workspaceId: "w:1", surfaceId: "s:1" };
@@ -488,16 +501,74 @@ describe("sendFirstTurnWhenReady", () => {
       { readPaneScreen, sendToPane } as any,
       pane,
       "do the thing",
+      "$ launch",
     );
 
     await vi.advanceTimersByTimeAsync(3500);
     await promise;
 
-    // Two calls: initial send + one re-send
+    // Two calls: initial send + one re-send (preSend === afterScreen)
     expect(sendToPane).toHaveBeenCalledTimes(2);
     expect(sendToPane).toHaveBeenNthCalledWith(1, pane, "do the thing");
     expect(sendToPane).toHaveBeenNthCalledWith(2, pane, "do the thing");
   });
+
+  // #168: sendToPane (since #136) collapses newlines to spaces, so a multi-line
+  // task never appears verbatim in the pane render. The old post-send check
+  // `!afterScreen.includes(task)` therefore always re-sent → duplicate first
+  // turn. The fix compares the screen before vs after sending instead.
+  it("does NOT re-send a multi-line task when the pane render collapses newlines", async () => {
+    const task = "line one\nline two\nline three";
+    let callCount = 0;
+    readPaneScreen.mockImplementation(async () => {
+      callCount++;
+      // reads 1-2: poll (stable), read 3: preSend snapshot — all the bare prompt.
+      if (callCount <= 3) return "> ";
+      return "> line one line two line three";               // after-send: collapsed render
+    });
+
+    const pane = { workspaceId: "w:1", surfaceId: "s:1" };
+    const promise = sendFirstTurnWhenReady(
+      { readPaneScreen, sendToPane } as any,
+      pane,
+      task,
+      "$ launch",
+    );
+
+    await vi.advanceTimersByTimeAsync(4000);
+    await promise;
+
+    // The screen changed after the send (task was received), so no re-send —
+    // even though `afterScreen.includes(task)` is false for the multi-line task.
+    expect(sendToPane).toHaveBeenCalledTimes(1);
+    expect(sendToPane).toHaveBeenCalledWith(pane, task);
+  });
+
+  // opencode boot-race: the screen can be momentarily static while the launch
+  // command still sits un-entered on the shell line. Sending then concatenates
+  // onto that line → shell parse error. The readiness gate must require the
+  // screen to ADVANCE past the launch-line snapshot, not merely be static.
+  it("does NOT send the first turn while the pane still shows the un-entered launch line", async () => {
+    const launchLine = "$ COCKPIT_CREW_TASK_ID=t1 opencode";
+    readPaneScreen.mockResolvedValue(launchLine);
+
+    const pane = { workspaceId: "w:1", surfaceId: "s:1" };
+    const promise = sendFirstTurnWhenReady(
+      { readPaneScreen, sendToPane } as any,
+      pane,
+      "do the thing",
+      launchLine,
+    );
+
+    // Well under the 20s timeout: the screen never advanced past the launch
+    // line, so the readiness gate must not have fired yet.
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(sendToPane).not.toHaveBeenCalled();
+
+    // Drain to the timeout so the fallback send fires and the promise resolves.
+    await vi.advanceTimersByTimeAsync(20000);
+    await promise;
+  }, 15000);
 });
 
 describe("cockpit crew send/read/close/list", () => {

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -95,6 +95,7 @@ export async function sendFirstTurnWhenReady(
   runtime: RuntimeDriver,
   pane: PaneRef,
   task: string,
+  preLaunchScreen: string,
 ): Promise<void> {
   await new Promise((r) => setTimeout(r, SEND_FIRST_TURN_FLOOR_MS));
 
@@ -106,7 +107,13 @@ export async function sendFirstTurnWhenReady(
 
   for (let i = 0; i < maxPolls && !stable; i++) {
     const screen = (await runtime.readPaneScreen(pane)) ?? "";
-    if (screen.length > 0 && screen === previousScreen) {
+    // Ready = the agent prompt is actually up: screen is non-empty, settled
+    // (unchanged between two consecutive reads), AND has advanced past the
+    // un-entered launch command line. The last condition prevents sending the
+    // task onto the shell line before the TUI takes over — which concatenates
+    // onto the launch command and triggers a shell parse error (opencode
+    // boot-race). A momentarily static launch line is not readiness.
+    if (screen.length > 0 && screen === previousScreen && screen !== preLaunchScreen) {
       stable = true;
     } else {
       previousScreen = screen;
@@ -114,11 +121,18 @@ export async function sendFirstTurnWhenReady(
     }
   }
 
+  // Snapshot the screen immediately before sending so the post-send check can
+  // tell whether the keystrokes were received. Comparing against the raw task
+  // text is unreliable: sendToPane collapses newlines to spaces (#136), so a
+  // multi-line task never appears verbatim in the single-line pane render and
+  // the check would always re-send a duplicate first turn (#168).
+  const preSendScreen = (await runtime.readPaneScreen(pane)) ?? "";
   await runtime.sendToPane(pane, task);
 
   await new Promise((r) => setTimeout(r, POST_SEND_CHECK_MS));
   const afterScreen = (await runtime.readPaneScreen(pane)) ?? "";
-  if (!afterScreen.includes(task)) {
+  if (afterScreen === preSendScreen) {
+    // Screen unchanged after sending → nothing was received at all; re-send once.
     await runtime.sendToPane(pane, task);
   }
 }
@@ -249,7 +263,8 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
     // running inside the crew's cmux tab can identify their task.
     const envPrefix = `COCKPIT_CREW_TASK_ID=${rec.id} COCKPIT_CREW_PROJECT=${input.project}`;
     await runtime.sendToPane(pane, `${envPrefix} ${cliCommand}`);
-    await sendFirstTurnWhenReady(runtime, pane, input.task);
+    const preLaunchScreen = (await runtime.readPaneScreen(pane)) ?? "";
+    await sendFirstTurnWhenReady(runtime, pane, input.task, preLaunchScreen);
     return { ...pane, title };
   }
 
@@ -290,7 +305,8 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
     const pane = await runtime.newPane({ workspaceId: captain.id, direction, title });
     const envPrefix = `COCKPIT_CREW_TASK_ID=${rec.id} COCKPIT_CREW_PROJECT=${input.project}`;
     await runtime.sendToPane(pane, `${envPrefix} OPENCODE_CONFIG=${opencodeConfigPath} ${cliCommand}`);
-    await sendFirstTurnWhenReady(runtime, pane, input.task);
+    const preLaunchScreen = (await runtime.readPaneScreen(pane)) ?? "";
+    await sendFirstTurnWhenReady(runtime, pane, input.task, preLaunchScreen);
     return { ...pane, title };
   }
 
@@ -314,7 +330,8 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
   // the task as the first prompt. For non-interactive (legacy) the prompt is
   // already baked into cliCommand, so we're done.
   if (interactive) {
-    await sendFirstTurnWhenReady(runtime, pane, input.task);
+    const preLaunchScreen = (await runtime.readPaneScreen(pane)) ?? "";
+    await sendFirstTurnWhenReady(runtime, pane, input.task, preLaunchScreen);
   }
 
   return { ...pane, title };


### PR DESCRIPTION
Hardens first-turn delivery in `sendFirstTurnWhenReady` (`src/commands/crew.ts`). Fixes two diagnosed root causes; the codex path (`sendCodexFirstTurn`) is out of scope and untouched.

## Root cause 1 — #168 double-send
The post-send guard `if (!afterScreen.includes(task)) re-send` always false-negatives: since #136, `sendToPane` collapses newlines to spaces, so a multi-line `task` never appears verbatim in the single-line pane render → `includes(task)` is always false → a **duplicate first turn** is sent on (effectively) every spawn.

**Fix:** snapshot `preSendScreen` immediately before the first `sendToPane(task)`, and only re-send if the screen is **unchanged** afterward (`afterScreen === preSendScreen`, i.e. nothing was received at all). No longer compares against the raw task text.

## Root cause 2 — opencode boot-race
The stability heuristic (non-empty + two equal consecutive reads) can mark the screen "stable" while the `opencode …` launch command still sits un-entered on the shell line (the TUI hasn't taken over). The task then concatenates onto the launch line → zsh parse error → dispatch dies. The #165/#167 readiness fix was only ever verified for claude.

**Fix:** the readiness gate now also requires the polled screen to have **advanced past** the launch-line snapshot (`screen !== preLaunchScreen`) in addition to being stable. `preLaunchScreen` is captured right after the launch-command send and threaded into `sendFirstTurnWhenReady` from all three interactive call sites (claude, opencode, generic). Works for all agents.

Existing FLOOR/TIMEOUT/INTERVAL constants unchanged.

## Tests
Added to `src/commands/__tests__/crew.test.ts`:
- multi-line task whose pane render is single-lined does **not** trigger a re-send;
- a screen still showing the launch line is **not** treated as ready (no premature send).

Both were written failing-first and reproduce the bugs against the old code.

## Verification
- `npm run build` — clean
- `npm test` (crew + control suites) — **281 passed (31 files)**, including `integration-restart`
