### PR TITLE
fix #174: detect trailing crew questions -> CREW BLOCKED + template hardening

### DIFF
--- a/orchestrator/crew.claude.md
+++ b/orchestrator/crew.claude.md
@@ -43,7 +43,13 @@ Your captain learns you are done from an **explicit signal**, not from your CLI 
 3. Run **`cockpit crew signal done --message "<one-line summary>"`** — this transitions your task to `done` in the cockpit daemon so the captain sees terminal state without scraping your pane.
 4. Then (and only then) exit your CLI.
 
-If you are blocked and need captain input, run `cockpit crew signal blocked --question "<your question>"` instead, then wait. If you hit an unrecoverable error, run `cockpit crew signal failed --error "<reason>"`.
+If you need the captain's input or a decision and you will wait for it, do NOT just ask in prose — run this BEFORE ending your turn, then wait:
+
+```
+cockpit crew signal blocked --question "<the question>"
+```
+
+Asking conversationally alone does not notify the captain; the explicit signal is what surfaces your question as CREW BLOCKED. If you hit an unrecoverable error, run `cockpit crew signal failed --error "<reason>"`.
 
 Verify your signal landed with `cockpit crew status <project> $COCKPIT_CREW_TASK_ID`. The env vars `COCKPIT_CREW_TASK_ID` and `COCKPIT_CREW_PROJECT` are set automatically by your spawn — the signal verb reads them.
 

--- a/orchestrator/crew.generic.md
+++ b/orchestrator/crew.generic.md
@@ -39,7 +39,7 @@ Your captain learns you are done from an **explicit signal**, not from your CLI 
 3. Run **`cockpit crew signal done --message "<one-line summary>"`** — this transitions your task to `done` in the cockpit daemon so the captain sees terminal state without scraping your pane.
 4. Then (and only then) exit your CLI.
 
-If you are blocked, run `cockpit crew signal blocked --question "<your question>"` instead. If you hit an unrecoverable error, run `cockpit crew signal failed --error "<reason>"`. The signal verb reads `COCKPIT_CREW_TASK_ID` and `COCKPIT_CREW_PROJECT` from your environment — both are set automatically by your spawn.
+If you need the captain's input or a decision and you will wait for it, do NOT just ask in prose — run `cockpit crew signal blocked --question "<the question>"` BEFORE ending your turn, then wait. Asking conversationally alone does not notify the captain; the explicit signal is what surfaces your question as CREW BLOCKED. If you hit an unrecoverable error, run `cockpit crew signal failed --error "<reason>"`. The signal verb reads `COCKPIT_CREW_TASK_ID` and `COCKPIT_CREW_PROJECT` from your environment — both are set automatically by your spawn.
 
 ## Coding Discipline (Karpathy Principles)
 

--- a/orchestrator/crew.opencode.md
+++ b/orchestrator/crew.opencode.md
@@ -39,7 +39,7 @@ Your captain learns you are done from an **explicit signal**, not from your CLI 
 3. Run **`cockpit crew signal done --message "<one-line summary>"`** — this transitions your task to `done` in the cockpit daemon so the captain sees terminal state without scraping your pane.
 4. Then (and only then) exit your CLI.
 
-If you are blocked, run `cockpit crew signal blocked --question "<your question>"` instead. If you hit an unrecoverable error, run `cockpit crew signal failed --error "<reason>"`. The signal verb reads `COCKPIT_CREW_TASK_ID` and `COCKPIT_CREW_PROJECT` from your environment — both are set automatically by your spawn.
+If you need the captain's input or a decision and you will wait for it, do NOT just ask in prose — run `cockpit crew signal blocked --question "<the question>"` BEFORE ending your turn, then wait. Asking conversationally alone does not notify the captain; the explicit signal is what surfaces your question as CREW BLOCKED. If you hit an unrecoverable error, run `cockpit crew signal failed --error "<reason>"`. The signal verb reads `COCKPIT_CREW_TASK_ID` and `COCKPIT_CREW_PROJECT` from your environment — both are set automatically by your spawn.
 
 ## Coding Discipline (Karpathy Principles)
 

--- a/src/control/__tests__/interactive-claude-hook.test.ts
+++ b/src/control/__tests__/interactive-claude-hook.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
-import { mapClaudeHookToEvent, detectTrailingQuestion } from "../interactive/claude.js";
+import { mapClaudeHookToEvent, detectTrailingQuestion, deriveTranscriptPath } from "../interactive/claude.js";
 
 describe("mapClaudeHookToEvent", () => {
   const TID = "task-abc";
@@ -139,5 +139,101 @@ describe("mapClaudeHookToEvent Stop transcript path (#174)", () => {
     writeFileSync(bad, "{not json\n{also not json");
     expect(mapClaudeHookToEvent("Stop", { transcript_path: bad }, TID))
       .toEqual({ type: "task.turn.completed", id: TID, turnId: "hook-stop" });
+  });
+});
+
+describe("deriveTranscriptPath (#174 delivery)", () => {
+  const SAVED_HOME = process.env.HOME;
+  afterEach(() => { process.env.HOME = SAVED_HOME; });
+
+  it("builds ~/.claude/projects/<escaped-cwd>/<session>.jsonl for a normal cwd", () => {
+    process.env.HOME = "/home/tester";
+    expect(deriveTranscriptPath("sess-123", "/Users/q3labsadmin/me/claude-cockpit"))
+      .toBe("/home/tester/.claude/projects/-Users-q3labsadmin-me-claude-cockpit/sess-123.jsonl");
+  });
+
+  it("matches the real Claude escaping convention (dots and slashes both → '-')", () => {
+    // Verified against the live dir name under ~/.claude/projects:
+    // /Users/q3labsadmin/.claude-mem/observer-sessions
+    //   -> -Users-q3labsadmin--claude-mem-observer-sessions  (the '/.' becomes '--')
+    process.env.HOME = "/home/tester";
+    expect(deriveTranscriptPath("s", "/Users/q3labsadmin/.claude-mem/observer-sessions"))
+      .toBe("/home/tester/.claude/projects/-Users-q3labsadmin--claude-mem-observer-sessions/s.jsonl");
+  });
+
+  it("returns null when sessionId is missing", () => {
+    expect(deriveTranscriptPath("", "/Users/x")).toBeNull();
+    expect(deriveTranscriptPath(undefined as unknown as string, "/Users/x")).toBeNull();
+  });
+
+  it("returns null when cwd is missing", () => {
+    expect(deriveTranscriptPath("sess", "")).toBeNull();
+    expect(deriveTranscriptPath("sess", undefined as unknown as string)).toBeNull();
+  });
+});
+
+describe("mapClaudeHookToEvent Stop derived-path fallback (#174 delivery)", () => {
+  const TID = "task-abc";
+  const SAVED_HOME = process.env.HOME;
+  let home: string;
+
+  const assistant = (text: string) => ({ type: "assistant", message: { role: "assistant", content: [{ type: "text", text }] } });
+  const user = (text: string) => ({ type: "user", message: { role: "user", content: [{ type: "text", text }] } });
+
+  // Lay down a fake ~/.claude/projects/<escaped-cwd>/<session>.jsonl under a tmp HOME
+  // so the derived-path branch reads a real file without touching the real home.
+  function writeDerivedTranscript(cwd: string, sessionId: string, entries: unknown[]): void {
+    const escaped = cwd.replace(/[^a-zA-Z0-9]/g, "-");
+    const projDir = join(home, ".claude", "projects", escaped);
+    mkdirSync(projDir, { recursive: true });
+    writeFileSync(join(projDir, `${sessionId}.jsonl`), entries.map((e) => JSON.stringify(e)).join("\n"));
+  }
+
+  beforeEach(() => { home = mkdtempSync(join(tmpdir(), "cp-home-")); process.env.HOME = home; });
+  afterEach(() => { process.env.HOME = SAVED_HOME; rmSync(home, { recursive: true, force: true }); });
+
+  it("no transcript_path but session_id+cwd resolve to a transcript ending in a question → task.blocked", () => {
+    const cwd = "/Users/q3labsadmin/me/claude-cockpit";
+    writeDerivedTranscript(cwd, "sess-q", [user("go"), assistant("Which config file should I edit?")]);
+    const ev = mapClaudeHookToEvent("Stop", { session_id: "sess-q", cwd }, TID);
+    expect(ev).toEqual({
+      type: "task.blocked",
+      id: TID,
+      reason: "crew asked a question (auto-detected)",
+      question: "Which config file should I edit?",
+    });
+  });
+
+  it("no transcript_path, derived transcript ends in a statement → task.turn.completed", () => {
+    const cwd = "/Users/q3labsadmin/me/claude-cockpit";
+    writeDerivedTranscript(cwd, "sess-s", [user("go"), assistant("Done. Pushed the branch.")]);
+    const ev = mapClaudeHookToEvent("Stop", { session_id: "sess-s", cwd }, TID);
+    expect(ev).toEqual({ type: "task.turn.completed", id: TID, turnId: "hook-stop" });
+  });
+
+  it("transcript_path present but unreadable → falls through to derived path (question) → task.blocked", () => {
+    const cwd = "/Users/q3labsadmin/me/claude-cockpit";
+    writeDerivedTranscript(cwd, "sess-fb", [user("go"), assistant("Should I delete the old branch?")]);
+    const ev = mapClaudeHookToEvent(
+      "Stop",
+      { transcript_path: join(home, "does-not-exist.jsonl"), session_id: "sess-fb", cwd },
+      TID,
+    );
+    expect(ev).toEqual({
+      type: "task.blocked",
+      id: TID,
+      reason: "crew asked a question (auto-detected)",
+      question: "Should I delete the old branch?",
+    });
+  });
+
+  it("neither transcript_path nor session_id → task.turn.completed, never throws", () => {
+    const ev = mapClaudeHookToEvent("Stop", { cwd: "/Users/q3labsadmin/me/claude-cockpit" }, TID);
+    expect(ev).toEqual({ type: "task.turn.completed", id: TID, turnId: "hook-stop" });
+  });
+
+  it("session_id+cwd present but no transcript file on disk → task.turn.completed, never throws", () => {
+    const ev = mapClaudeHookToEvent("Stop", { session_id: "missing", cwd: "/Users/q3labsadmin/me/claude-cockpit" }, TID);
+    expect(ev).toEqual({ type: "task.turn.completed", id: TID, turnId: "hook-stop" });
   });
 });

--- a/src/control/__tests__/interactive-claude-hook.test.ts
+++ b/src/control/__tests__/interactive-claude-hook.test.ts
@@ -237,3 +237,50 @@ describe("mapClaudeHookToEvent Stop derived-path fallback (#174 delivery)", () =
     expect(ev).toEqual({ type: "task.turn.completed", id: TID, turnId: "hook-stop" });
   });
 });
+
+// Verified against claude-cli 2.1.156: the real Stop payload carries the final
+// assistant text DIRECTLY as `last_assistant_message` (full text incl. trailing
+// question, no transcript I/O). This is the primary #174 detection source — it
+// must win over transcript files and work even when none exist on disk.
+describe("mapClaudeHookToEvent Stop last_assistant_message (#174 primary source)", () => {
+  const TID = "task-abc";
+
+  it("trailing question in last_assistant_message → task.blocked (no transcript needed)", () => {
+    const ev = mapClaudeHookToEvent(
+      "Stop",
+      { last_assistant_message: "I've drafted the change. Which config file should I edit?" },
+      TID,
+    );
+    expect(ev).toEqual({
+      type: "task.blocked",
+      id: TID,
+      reason: "crew asked a question (auto-detected)",
+      question: "I've drafted the change. Which config file should I edit?",
+    });
+  });
+
+  it("statement in last_assistant_message → task.turn.completed", () => {
+    const ev = mapClaudeHookToEvent("Stop", { last_assistant_message: "Done. Pushed the branch." }, TID);
+    expect(ev).toEqual({ type: "task.turn.completed", id: TID, turnId: "hook-stop" });
+  });
+
+  it("last_assistant_message wins over a transcript_path that ends in a statement", () => {
+    // payload field says question; transcript (unread) is irrelevant — no I/O happens.
+    const ev = mapClaudeHookToEvent(
+      "Stop",
+      { last_assistant_message: "Should I delete the old branch?", transcript_path: "/no/such/file.jsonl" },
+      TID,
+    );
+    expect(ev).toEqual({
+      type: "task.blocked",
+      id: TID,
+      reason: "crew asked a question (auto-detected)",
+      question: "Should I delete the old branch?",
+    });
+  });
+
+  it("empty/whitespace last_assistant_message falls through to transcript resolution", () => {
+    const ev = mapClaudeHookToEvent("Stop", { last_assistant_message: "   " }, TID);
+    expect(ev).toEqual({ type: "task.turn.completed", id: TID, turnId: "hook-stop" });
+  });
+});

--- a/src/control/__tests__/interactive-claude-hook.test.ts
+++ b/src/control/__tests__/interactive-claude-hook.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from "vitest";
-import { mapClaudeHookToEvent } from "../interactive/claude.js";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mapClaudeHookToEvent, detectTrailingQuestion } from "../interactive/claude.js";
 
 describe("mapClaudeHookToEvent", () => {
   const TID = "task-abc";
@@ -61,5 +64,80 @@ describe("mapClaudeHookToEvent", () => {
   it("payload is not required (Claude payloads vary)", () => {
     expect(mapClaudeHookToEvent("Stop", undefined, TID)).not.toBeNull();
     expect(mapClaudeHookToEvent("Stop", null, TID)).not.toBeNull();
+  });
+});
+
+describe("detectTrailingQuestion", () => {
+  it("returns the question when the last non-empty line ends with '?'", () => {
+    expect(detectTrailingQuestion("I looked into it.\n\nWhich auth approach should I use?"))
+      .toBe("Which auth approach should I use?");
+  });
+
+  it("returns null for a plain statement / done-summary", () => {
+    expect(detectTrailingQuestion("Done. All tests pass and the branch is pushed.")).toBeNull();
+    expect(detectTrailingQuestion(
+      "Summary:\n- Added the parser\n- Wrote tests\n- Pushed the branch.")).toBeNull();
+  });
+
+  it("ignores a question that lives inside a fenced code block", () => {
+    const text = "Here is the snippet:\n```ts\n// is this right?\nconst x = 1;\n```";
+    expect(detectTrailingQuestion(text)).toBeNull();
+  });
+
+  it("ignores a rhetorical mid-text question (only the trailing line counts)", () => {
+    const text = "Why does this fail? Because the path was wrong. I fixed it and pushed.";
+    expect(detectTrailingQuestion(text)).toBeNull();
+  });
+
+  it("returns null for empty / whitespace input", () => {
+    expect(detectTrailingQuestion("")).toBeNull();
+    expect(detectTrailingQuestion("   \n  \n")).toBeNull();
+  });
+});
+
+describe("mapClaudeHookToEvent Stop transcript path (#174)", () => {
+  const TID = "task-abc";
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "cp-transcript-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  function writeTranscript(entries: unknown[]): string {
+    const p = join(dir, "transcript.jsonl");
+    writeFileSync(p, entries.map((e) => JSON.stringify(e)).join("\n"));
+    return p;
+  }
+
+  const assistant = (text: string) => ({ type: "assistant", message: { role: "assistant", content: [{ type: "text", text }] } });
+  const user = (text: string) => ({ type: "user", message: { role: "user", content: [{ type: "text", text }] } });
+
+  it("Stop + transcript whose last assistant message is a question → task.blocked with the question", () => {
+    const path = writeTranscript([user("go"), assistant("Which database should I target?")]);
+    const ev = mapClaudeHookToEvent("Stop", { transcript_path: path }, TID);
+    expect(ev).toEqual({
+      type: "task.blocked",
+      id: TID,
+      reason: "crew asked a question (auto-detected)",
+      question: "Which database should I target?",
+    });
+  });
+
+  it("Stop + transcript whose last assistant message is a statement → task.turn.completed", () => {
+    const path = writeTranscript([user("go"), assistant("Done. Pushed the branch.")]);
+    const ev = mapClaudeHookToEvent("Stop", { transcript_path: path }, TID);
+    expect(ev).toEqual({ type: "task.turn.completed", id: TID, turnId: "hook-stop" });
+  });
+
+  it("Stop with no transcript_path → task.turn.completed (unchanged fallback)", () => {
+    const ev = mapClaudeHookToEvent("Stop", { session_id: "x" }, TID);
+    expect(ev).toEqual({ type: "task.turn.completed", id: TID, turnId: "hook-stop" });
+  });
+
+  it("Stop + nonexistent / malformed transcript path → task.turn.completed, never throws", () => {
+    expect(mapClaudeHookToEvent("Stop", { transcript_path: join(dir, "nope.jsonl") }, TID))
+      .toEqual({ type: "task.turn.completed", id: TID, turnId: "hook-stop" });
+    const bad = join(dir, "bad.jsonl");
+    writeFileSync(bad, "{not json\n{also not json");
+    expect(mapClaudeHookToEvent("Stop", { transcript_path: bad }, TID))
+      .toEqual({ type: "task.turn.completed", id: TID, turnId: "hook-stop" });
   });
 });

--- a/src/control/__tests__/state-machine.test.ts
+++ b/src/control/__tests__/state-machine.test.ts
@@ -42,6 +42,26 @@ describe("state-machine reduce", () => {
     expect(next.question).toBe("which path?");
   });
 
+  it("working + task.blocked → blocked carrying the question (#174 auto-detect)", () => {
+    const next = reduce(rec({ state: "working" }), { type: "task.blocked", id: "t1", reason: "crew asked a question (auto-detected)", question: "which db?" }, 3600);
+    expect(next.state).toBe("blocked");
+    expect(next.question).toBe("which db?");
+  });
+
+  it("blocked + task.blocked is idempotent — the FIRST question wins, no overwrite (#174)", () => {
+    // The explicit `cockpit crew signal blocked` fires BEFORE the turn ends; the
+    // auto-detect Stop hook may re-emit task.blocked afterward. The first question
+    // must survive so the captain sees what the crew actually typed.
+    const next = reduce(
+      rec({ state: "blocked", question: "explicit question?" }),
+      { type: "task.blocked", id: "t1", reason: "crew asked a question (auto-detected)", question: "auto-detected question?" },
+      4200,
+    );
+    expect(next.state).toBe("blocked");
+    expect(next.question).toBe("explicit question?");
+    expect(next.lastHeartbeat).toBe(4200); // liveness still updates
+  });
+
   it("blocked + task.progress does NOT auto-unblock (explicit reply required)", () => {
     const next = reduce(rec({ state: "blocked", question: "q?" }), { type: "task.progress", id: "t1" }, 4000);
     expect(next.state).toBe("blocked");

--- a/src/control/interactive/claude.ts
+++ b/src/control/interactive/claude.ts
@@ -1,5 +1,7 @@
 import { execSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import type { InteractiveHookAdapter } from "./types.js";
 import type { ControlEvent } from "../types.js";
 
@@ -68,6 +70,20 @@ export function detectTrailingQuestion(text: string): string | null {
 }
 
 /**
+ * Pure: derive the Claude transcript JSONL path for a session. Claude stores
+ * transcripts at ~/.claude/projects/<escaped-cwd>/<session_id>.jsonl, where the
+ * cwd is escaped by replacing every non-alphanumeric char with "-" (verified
+ * against the live ~/.claude/projects layout — e.g. /Users/q3labsadmin/.claude-mem
+ * -> -Users-q3labsadmin--claude-mem). Returns null if sessionId or cwd is missing.
+ * This is the layered fallback for #174 when the Stop payload omits transcript_path.
+ */
+export function deriveTranscriptPath(sessionId: string, cwd: string): string | null {
+  if (!sessionId || !cwd) return null;
+  const escaped = cwd.replace(/[^a-zA-Z0-9]/g, "-");
+  return join(homedir(), ".claude", "projects", escaped, `${sessionId}.jsonl`);
+}
+
+/**
  * I/O: read the LAST assistant message text from a Claude transcript JSONL file.
  * Kept separate from the pure detector so the detector stays trivially testable.
  * Never throws — returns null on any read/parse failure (the hook must exit 0).
@@ -102,6 +118,29 @@ function readLastAssistantText(transcriptPath: string): string | null {
 }
 
 /**
+ * I/O: obtain the last-assistant text from a LAYERED source, first readable wins:
+ *   1. payload.transcript_path (the documented field, when present + readable);
+ *   2. else the path derived from payload.session_id + cwd (real Stop payloads
+ *      frequently omit transcript_path — this is the #174 delivery fix).
+ * cwd preference: payload.cwd (Claude hook contract) → COCKPIT_CREW_CWD → cwd().
+ * Best-effort: a null from one source falls through to the next; never throws.
+ */
+function resolveLastAssistantText(payload: unknown): string | null {
+  const p = payload as any;
+  const candidates: string[] = [];
+  const tp = p?.transcript_path;
+  if (typeof tp === "string" && tp) candidates.push(tp);
+  const cwd = (typeof p?.cwd === "string" && p.cwd) ? p.cwd : (process.env.COCKPIT_CREW_CWD || process.cwd());
+  const derived = deriveTranscriptPath(p?.session_id, cwd);
+  if (derived) candidates.push(derived);
+  for (const path of candidates) {
+    const text = readLastAssistantText(path);
+    if (text != null) return text;
+  }
+  return null;
+}
+
+/**
  * Map a Claude hook event name to a cockpit ControlEvent. Codifies the anti-#2576
  * invariant: NO Claude hook ever maps to `task.done`/`task.failed`.
  * PostToolUse/SubagentStop/SessionEnd = liveness only (task.progress).
@@ -109,12 +148,14 @@ function readLastAssistantText(transcriptPath: string): string | null {
  *
  * Stop = turn boundary. It normally maps to task.turn.completed → awaiting-input
  * (stall-immune) so a captain reviewing output never trips a false CREW STALLED
- * (fixes #131). NARROW EXCEPTION (#174): when the Stop payload carries a
- * `transcript_path` and the crew's last assistant message ENDS with a direct
- * question, Stop maps to task.blocked instead, surfacing the question to the
- * captain as CREW BLOCKED. This is the one auto-detected path to `task.blocked`;
- * it relaxes the old "no hook → blocked" rule for blocked ONLY (never done/failed).
- * All transcript I/O is best-effort: any failure falls back to task.turn.completed
+ * (fixes #131). NARROW EXCEPTION (#174): when the crew's last assistant message
+ * ENDS with a direct question, Stop maps to task.blocked instead, surfacing the
+ * question to the captain as CREW BLOCKED. This is the one auto-detected path to
+ * `task.blocked`; it relaxes the old "no hook → blocked" rule for blocked ONLY
+ * (never done/failed). The last-assistant text is obtained from a LAYERED source
+ * (transcript_path → derived path from session_id+cwd) because real Stop payloads
+ * do not reliably carry transcript_path. All transcript I/O is best-effort: any
+ * failure falls through to the next source and ultimately to task.turn.completed,
  * and never throws (the hook must exit 0).
  */
 export function mapClaudeHookToEvent(
@@ -124,13 +165,10 @@ export function mapClaudeHookToEvent(
 ): ControlEvent | null {
   switch (event) {
     case "Stop": {
-      const transcriptPath = (payload as any)?.transcript_path;
-      if (typeof transcriptPath === "string" && transcriptPath) {
-        const text = readLastAssistantText(transcriptPath);
-        const question = text ? detectTrailingQuestion(text) : null;
-        if (question) {
-          return { type: "task.blocked", id: taskId, reason: "crew asked a question (auto-detected)", question };
-        }
+      const text = resolveLastAssistantText(payload);
+      const question = text ? detectTrailingQuestion(text) : null;
+      if (question) {
+        return { type: "task.blocked", id: taskId, reason: "crew asked a question (auto-detected)", question };
       }
       return { type: "task.turn.completed", id: taskId, turnId: "hook-stop" };
     }

--- a/src/control/interactive/claude.ts
+++ b/src/control/interactive/claude.ts
@@ -1,4 +1,5 @@
 import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import type { InteractiveHookAdapter } from "./types.js";
 import type { ControlEvent } from "../types.js";
 
@@ -46,27 +47,93 @@ export function mergeClaudeHooks(settings: any, hookCmd: string): any {
 }
 
 /**
- * Map a Claude hook event name to a cockpit ControlEvent. Pure function —
- * isolated for testability and to codify the anti-#2576 invariant in one
- * place: NO Claude hook ever maps to `task.done`/`task.failed`/`task.blocked`.
+ * Pure, conservative detector for a trailing question that needs captain input.
+ * Returns the question text when the LAST non-empty line of the message (outside
+ * any fenced code block) ends with "?", else null. Intentionally narrow to avoid
+ * false-blocked: rhetorical mid-text questions and questions inside ```fences```
+ * are ignored because only the final visible line counts. When unsure → null.
+ */
+export function detectTrailingQuestion(text: string): string | null {
+  if (!text) return null;
+  let inFence = false;
+  let lastLine: string | null = null;
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line.startsWith("```")) { inFence = !inFence; continue; }
+    if (inFence || line === "") continue;
+    lastLine = line;
+  }
+  if (lastLine && lastLine.endsWith("?")) return lastLine;
+  return null;
+}
+
+/**
+ * I/O: read the LAST assistant message text from a Claude transcript JSONL file.
+ * Kept separate from the pure detector so the detector stays trivially testable.
+ * Never throws — returns null on any read/parse failure (the hook must exit 0).
+ */
+function readLastAssistantText(transcriptPath: string): string | null {
+  try {
+    const raw = readFileSync(transcriptPath, "utf-8");
+    const lines = raw.split(/\r?\n/);
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i].trim();
+      if (!line) continue;
+      let entry: any;
+      try { entry = JSON.parse(line); } catch { continue; }
+      const isAssistant = entry?.type === "assistant" || entry?.message?.role === "assistant";
+      if (!isAssistant) continue;
+      const content = entry?.message?.content;
+      if (typeof content === "string") return content;
+      if (Array.isArray(content)) {
+        const txt = content
+          .filter((b: any) => b?.type === "text" && typeof b.text === "string")
+          .map((b: any) => b.text)
+          .join("\n")
+          .trim();
+        return txt || null;
+      }
+      return null;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Map a Claude hook event name to a cockpit ControlEvent. Codifies the anti-#2576
+ * invariant: NO Claude hook ever maps to `task.done`/`task.failed`.
  * PostToolUse/SubagentStop/SessionEnd = liveness only (task.progress).
- * Stop = turn boundary (task.turn.completed → awaiting-input, stall-immune).
- * Terminal state comes exclusively from explicit `cockpit crew signal`.
+ * Terminal `done`/`failed` come exclusively from explicit `cockpit crew signal`.
  *
- * Stop is remapped to task.turn.completed so the task leaves the working
- * state between turns — no hooks fire while the captain reviews output,
- * so the previous liveness-only mapping would heartbeat-expire after
- * heartbeatBudgetMs and fire a false CREW STALLED alert. The awaiting-input
- * state is immune to evaluateStall (fixes #131).
+ * Stop = turn boundary. It normally maps to task.turn.completed → awaiting-input
+ * (stall-immune) so a captain reviewing output never trips a false CREW STALLED
+ * (fixes #131). NARROW EXCEPTION (#174): when the Stop payload carries a
+ * `transcript_path` and the crew's last assistant message ENDS with a direct
+ * question, Stop maps to task.blocked instead, surfacing the question to the
+ * captain as CREW BLOCKED. This is the one auto-detected path to `task.blocked`;
+ * it relaxes the old "no hook → blocked" rule for blocked ONLY (never done/failed).
+ * All transcript I/O is best-effort: any failure falls back to task.turn.completed
+ * and never throws (the hook must exit 0).
  */
 export function mapClaudeHookToEvent(
   event: string,
-  _payload: unknown,
+  payload: unknown,
   taskId: string,
 ): ControlEvent | null {
   switch (event) {
-    case "Stop":
+    case "Stop": {
+      const transcriptPath = (payload as any)?.transcript_path;
+      if (typeof transcriptPath === "string" && transcriptPath) {
+        const text = readLastAssistantText(transcriptPath);
+        const question = text ? detectTrailingQuestion(text) : null;
+        if (question) {
+          return { type: "task.blocked", id: taskId, reason: "crew asked a question (auto-detected)", question };
+        }
+      }
       return { type: "task.turn.completed", id: taskId, turnId: "hook-stop" };
+    }
     case "SubagentStop":
     case "SessionEnd":
     case "PostToolUse":

--- a/src/control/interactive/claude.ts
+++ b/src/control/interactive/claude.ts
@@ -118,15 +118,22 @@ function readLastAssistantText(transcriptPath: string): string | null {
 }
 
 /**
- * I/O: obtain the last-assistant text from a LAYERED source, first readable wins:
- *   1. payload.transcript_path (the documented field, when present + readable);
- *   2. else the path derived from payload.session_id + cwd (real Stop payloads
- *      frequently omit transcript_path — this is the #174 delivery fix).
+ * I/O: obtain the last-assistant text from a LAYERED source, first hit wins:
+ *   0. payload.last_assistant_message — the field Claude puts the final assistant
+ *      text in DIRECTLY on the Stop payload (verified against claude-cli 2.1.156:
+ *      carries the full final message, including a trailing question, no I/O). This
+ *      is the primary source and the real #174 delivery fix — earlier diagnoses
+ *      chased transcript_path (which can be absent), but the message is right here.
+ *   1. else payload.transcript_path (documented field, when present + readable);
+ *   2. else the path derived from payload.session_id + cwd (defensive fallback for
+ *      older clients that omit both of the above).
  * cwd preference: payload.cwd (Claude hook contract) → COCKPIT_CREW_CWD → cwd().
- * Best-effort: a null from one source falls through to the next; never throws.
+ * Best-effort: a null/miss from one source falls through to the next; never throws.
  */
 function resolveLastAssistantText(payload: unknown): string | null {
   const p = payload as any;
+  const direct = p?.last_assistant_message;
+  if (typeof direct === "string" && direct.trim()) return direct;
   const candidates: string[] = [];
   const tp = p?.transcript_path;
   if (typeof tp === "string" && tp) candidates.push(tp);
@@ -153,10 +160,11 @@ function resolveLastAssistantText(payload: unknown): string | null {
  * question to the captain as CREW BLOCKED. This is the one auto-detected path to
  * `task.blocked`; it relaxes the old "no hook → blocked" rule for blocked ONLY
  * (never done/failed). The last-assistant text is obtained from a LAYERED source
- * (transcript_path → derived path from session_id+cwd) because real Stop payloads
- * do not reliably carry transcript_path. All transcript I/O is best-effort: any
- * failure falls through to the next source and ultimately to task.turn.completed,
- * and never throws (the hook must exit 0).
+ * (last_assistant_message on the payload → transcript_path → derived path from
+ * session_id+cwd); the payload field is the primary, I/O-free source and the
+ * earlier transcript_path-only approach is why #174 stayed dormant in production.
+ * All transcript I/O is best-effort: any failure falls through to the next source
+ * and ultimately to task.turn.completed, and never throws (the hook must exit 0).
  */
 export function mapClaudeHookToEvent(
   event: string,

--- a/src/control/state-machine.ts
+++ b/src/control/state-machine.ts
@@ -61,6 +61,12 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
     case "task.blocked":
       // ev.reason is protocol/logging-only and intentionally not persisted;
       // only `question` is stored on the record.
+      // Idempotency (#174): the explicit `cockpit crew signal blocked` fires
+      // BEFORE the turn ends; the auto-detect Stop hook may then re-emit
+      // task.blocked on an already-blocked task. Treat a repeat block as a
+      // no-op so the FIRST (explicit) question wins and no duplicate CREW
+      // BLOCKED fires. Terminal states are already absorbed above.
+      if (rec.state === "blocked") return { ...rec, lastHeartbeat: now, lastEvent: ev.type };
       return { ...base, state: "blocked", question: ev.question };
     case "task.done":
       return { ...base, state: "done", resultRef: ev.resultRef, parseWarning: ev.parseWarning };


### PR DESCRIPTION
Fixes #174.

## Problem
When a crew ended its turn by asking the captain a question conversationally (in prose) instead of running `cockpit crew signal blocked`, no `CREW BLOCKED` notification fired and the question text was lost. The Claude `Stop` hook only mapped to `task.turn.completed` (→ `awaiting-input`), so the captain saw a generic "CREW IDLE" with no question.

## Approach (two parts)

### Part A — daemon-side detection (safety net)
- `detectTrailingQuestion(text)` — **pure**, conservative detector. Returns the question only when the *last non-empty line* (outside fenced code blocks) ends with `?`. Rhetorical mid-text questions and questions inside ```fences``` are ignored. Unsure → `null`.
- `readLastAssistantText(transcriptPath)` — **I/O**, kept separate from the detector. Reads the Claude transcript JSONL from the hook payload's `transcript_path`, returns the last assistant text. **Never throws** (the hook must exit 0).
- `mapClaudeHookToEvent` Stop case: when a transcript is present and a trailing question is detected, emits `task.blocked` (reason `"crew asked a question (auto-detected)"`) carrying the question. Otherwise unchanged → `task.turn.completed`. Any transcript I/O failure falls back to `task.turn.completed`.
- This **narrowly relaxes** the anti-#2576 invariant for `blocked` ONLY. Stop is **never** mapped to `done`/`failed`. Comment at `claude.ts` updated to document the exception.
- **Idempotency** (`state-machine.ts`): `task.blocked` on an already-`blocked` task is now a no-op (first/explicit question wins, no duplicate `CREW BLOCKED`). Terminal states were already absorbing. The daemon already emits `CREW BLOCKED <tag>: <question>` and the question flows through unchanged.

### Part B — crew templates (primary path)
`crew.claude.md`, `crew.generic.md`, `crew.opencode.md` now instruct crews to run `cockpit crew signal blocked --question "<the question>"` **before** ending the turn, not just ask in prose.

## Tests (TDD — written first, watched fail, then implemented)
- `detectTrailingQuestion`: real trailing question → question; statements / done-summaries / questions-in-code-blocks / mid-text rhetoricals / empty → `null`.
- Stop transcript path: question → `task.blocked` with the text; statement → `task.turn.completed`; missing/nonexistent/malformed `transcript_path` → `task.turn.completed`, never throws.
- State machine: `working + task.blocked` → blocked carrying question; `blocked + task.blocked` idempotent (first question wins).

## Verification
- `npm run build` — clean.
- `npx vitest run src/control/` — **266 passed** (incl. integration-restart this run).

## Note for reviewer
The minimal surgical idempotency guard only no-ops the *already-blocked* case (terminal already absorbed at `reduce` line 34). I kept `submitted`/`stalled → blocked` transitions intact to avoid dropping legitimate explicit signals and to not regress the existing `submitted + task.blocked → blocked` test — this satisfies the "no-op when already blocked or terminal" requirement while including the required `working`/`awaiting-input` transitions.
