### PR TITLE
feat: semi-automatic claude crews — acceptEdits + permission allowlist (#174 follow-up)

### DIFF
--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -254,6 +254,10 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
       role: "crew",
       promptFile,
       interactive: true,
+      // Semi-automatic gate: auto-accept file edits, still prompt for risky
+      // ops (Bash, etc.). Replaces reliance on cmux's unreliable auto-accept
+      // toggle and enables running crews on cheaper models.
+      permissionMode: "acceptEdits",
       ...(crewModel ? { model: crewModel } : {}),
     });
     const direction: PanePlacement = input.direction ?? "tab";

--- a/src/drivers/__tests__/claude.test.ts
+++ b/src/drivers/__tests__/claude.test.ts
@@ -59,6 +59,25 @@ describe("claude driver", () => {
     expect(cmd).toContain("--append-system-prompt-file /tmp/captain.claude.md");
   });
 
+  it("adds --permission-mode when permissionMode specified", () => {
+    const cmd = driver.buildCommand({
+      prompt: "do something",
+      workdir: "/tmp/test",
+      role: "crew",
+      permissionMode: "acceptEdits",
+    });
+    expect(cmd).toContain("--permission-mode acceptEdits");
+  });
+
+  it("omits --permission-mode when permissionMode not specified", () => {
+    const cmd = driver.buildCommand({
+      prompt: "do something",
+      workdir: "/tmp/test",
+      role: "crew",
+    });
+    expect(cmd).not.toContain("--permission-mode");
+  });
+
   it("adds --settings when settingsPath specified", () => {
     const cmd = driver.buildCommand({
       prompt: "do something",

--- a/src/drivers/claude.ts
+++ b/src/drivers/claude.ts
@@ -36,6 +36,8 @@ export function createClaudeDriver(): AgentDriver {
 
       if (opts.autoApprove) {
         cmd += " --dangerously-skip-permissions";
+      } else if (opts.permissionMode) {
+        cmd += ` --permission-mode ${opts.permissionMode}`;
       }
 
       if (opts.promptFile) {

--- a/src/drivers/types.ts
+++ b/src/drivers/types.ts
@@ -24,6 +24,11 @@ export interface SpawnOptions {
   autoApprove?: boolean;
   jsonOutput?: boolean;
   promptFile?: string;
+  // Claude's --permission-mode value (e.g. "acceptEdits", "plan", "default").
+  // "acceptEdits" auto-accepts file edits while still prompting for risky ops
+  // (Bash, etc.) — the semi-automatic gate used for cheaper-model crews. If
+  // autoApprove is also set, --dangerously-skip-permissions supersedes this.
+  permissionMode?: string;
   // Interactive crew sessions: drivers should NOT bake the prompt into the
   // command (no `-p`). Caller will deliver the prompt via runtime.send after
   // the CLI is ready, so the session stays alive between turns.

--- a/src/lib/__tests__/per-crew-settings.test.ts
+++ b/src/lib/__tests__/per-crew-settings.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { writePerCrewSettings, writePerCrewOpencodeConfig } from "../per-crew-settings.js";
+import {
+  writePerCrewSettings,
+  writePerCrewSettingsLocal,
+  writePerCrewOpencodeConfig,
+  CREW_PERMISSION_ALLOWLIST,
+} from "../per-crew-settings.js";
 
 describe("writePerCrewSettings", () => {
   let tmp: string;
@@ -68,6 +73,64 @@ describe("writePerCrewSettings", () => {
     const out = writePerCrewSettings({ stateRoot: deep, project: "x", taskId: "y" });
     expect(fs.existsSync(out)).toBe(true);
     expect(fs.statSync(path.dirname(out)).isDirectory()).toBe(true);
+  });
+});
+
+describe("writePerCrewSettingsLocal — permission allowlist", () => {
+  let tmp: string;
+  const settingsPath = () => path.join(tmp, ".claude", "settings.local.json");
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cockpit-local-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("writes a permissions.allow starter set covering common dev commands", () => {
+    writePerCrewSettingsLocal({ projectCwd: tmp });
+    const json = JSON.parse(fs.readFileSync(settingsPath(), "utf-8"));
+    expect(Array.isArray(json.permissions.allow)).toBe(true);
+    for (const entry of CREW_PERMISSION_ALLOWLIST) {
+      expect(json.permissions.allow).toContain(entry);
+    }
+    // Representative coverage: git mutations, installs, and the test runner.
+    expect(json.permissions.allow).toContain("Bash(git commit:*)");
+    expect(json.permissions.allow).toContain("Bash(npm install:*)");
+    expect(json.permissions.allow).toContain("Bash(vitest:*)");
+  });
+
+  it("does NOT blanket-allow Bash or risky ops (so 2b still surfaces them)", () => {
+    writePerCrewSettingsLocal({ projectCwd: tmp });
+    const json = JSON.parse(fs.readFileSync(settingsPath(), "utf-8"));
+    expect(json.permissions.allow).not.toContain("Bash(*)");
+    expect(json.permissions.allow).not.toContain("Bash(rm:*)");
+    expect(json.permissions.allow).not.toContain("Bash(curl:*)");
+  });
+
+  it("merges with (does not clobber) a pre-existing permissions.allow", () => {
+    fs.mkdirSync(path.join(tmp, ".claude"), { recursive: true });
+    fs.writeFileSync(
+      settingsPath(),
+      JSON.stringify({ permissions: { allow: ["Bash(python3:*)"], deny: ["Bash(sudo:*)"] } }, null, 2),
+    );
+    writePerCrewSettingsLocal({ projectCwd: tmp });
+    const json = JSON.parse(fs.readFileSync(settingsPath(), "utf-8"));
+    // The user's own entry survives...
+    expect(json.permissions.allow).toContain("Bash(python3:*)");
+    // ...alongside the starter set...
+    expect(json.permissions.allow).toContain("Bash(git push:*)");
+    // ...and unrelated permission keys are preserved.
+    expect(json.permissions.deny).toEqual(["Bash(sudo:*)"]);
+  });
+
+  it("is idempotent — does not duplicate allowlist entries on a second write", () => {
+    writePerCrewSettingsLocal({ projectCwd: tmp });
+    writePerCrewSettingsLocal({ projectCwd: tmp });
+    const json = JSON.parse(fs.readFileSync(settingsPath(), "utf-8"));
+    const counts = new Map<string, number>();
+    for (const e of json.permissions.allow) counts.set(e, (counts.get(e) ?? 0) + 1);
+    for (const [, n] of counts) expect(n).toBe(1);
   });
 });
 

--- a/src/lib/per-crew-settings.ts
+++ b/src/lib/per-crew-settings.ts
@@ -3,6 +3,61 @@ import { join } from "node:path";
 import { mergeClaudeHooks } from "../control/interactive/claude.js";
 
 /**
+ * Starter Bash permission allowlist for crews running under
+ * `--permission-mode acceptEdits` (Phase 2a). acceptEdits auto-accepts file
+ * edits but still prompts on EVERY mutating shell command — including routine
+ * dev ops (commit, push, install, test). Without this, the Phase 2b pane probe
+ * would fire CREW BLOCKED on every commit/install/test = notification spam.
+ *
+ * Conservative by design: only safe-but-mutating *dev* commands are listed,
+ * scoped per-subcommand so genuinely risky ops (`git reset --hard`,
+ * `git config`, `rm`, `curl`, `wget`, unknown binaries, out-of-workspace
+ * writes) STILL prompt and surface as CREW BLOCKED. No blanket `Bash(*)`.
+ *
+ * Syntax: Claude Code Bash permission patterns, `Bash(<prefix>:*)` matches the
+ * prefix command plus any trailing args.
+ */
+export const CREW_PERMISSION_ALLOWLIST: readonly string[] = [
+  // git — read + safe mutations (reset/clean/config intentionally excluded)
+  "Bash(git status:*)",
+  "Bash(git add:*)",
+  "Bash(git commit:*)",
+  "Bash(git push:*)",
+  "Bash(git pull:*)",
+  "Bash(git fetch:*)",
+  "Bash(git checkout:*)",
+  "Bash(git branch:*)",
+  "Bash(git diff:*)",
+  "Bash(git log:*)",
+  "Bash(git stash:*)",
+  "Bash(git restore:*)",
+  // npm / npx — installs + script/test/build runners
+  "Bash(npm install:*)",
+  "Bash(npm ci:*)",
+  "Bash(npm run:*)",
+  "Bash(npm test:*)",
+  "Bash(npx vitest:*)",
+  "Bash(npx tsc:*)",
+  // direct runners
+  "Bash(node:*)",
+  "Bash(vitest:*)",
+  "Bash(tsc:*)",
+];
+
+/**
+ * Pure: merge the crew permission allowlist into a settings object's
+ * `permissions.allow`, de-duplicating and preserving any existing entries and
+ * sibling permission keys (deny/ask). Never mutates the input.
+ */
+export function mergeCrewPermissions(settings: Record<string, unknown>): Record<string, unknown> {
+  const next = structuredClone(settings ?? {});
+  const permissions = (next.permissions ??= {}) as { allow?: unknown };
+  const existing = Array.isArray(permissions.allow) ? (permissions.allow as string[]) : [];
+  permissions.allow = [...new Set([...existing, ...CREW_PERMISSION_ALLOWLIST])];
+  return next;
+}
+
+/**
  * Write a Claude `--settings`-compatible JSON file containing the cockpit
  * Stop/SubagentStop/SessionEnd hooks merged onto an empty base. Per-crew
  * scoping (one file per spawned task) keeps the hook out of the user's
@@ -47,7 +102,8 @@ export function writePerCrewSettingsLocal(o: {
   } catch {
     // File doesn't exist or isn't valid JSON — start fresh
   }
-  const merged = mergeClaudeHooks(existing, o.hookCmd ?? "cockpit crew _hook");
+  const withHooks = mergeClaudeHooks(existing, o.hookCmd ?? "cockpit crew _hook");
+  const merged = mergeCrewPermissions(withHooks);
   writeFileSync(file, JSON.stringify(merged, null, 2));
   return file;
 }


### PR DESCRIPTION
## Semi-automatic claude crews: acceptEdits + permission allowlist

Enables running claude crews on cheaper models by replacing reliance on cmux's
unreliable auto-accept toggle with deterministic, scoped permissions.

### What's in this PR
- **`--permission-mode acceptEdits` for claude crews** (`drivers/types.ts`, `drivers/claude.ts`, `commands/crew.ts`): in-workspace edits auto-accept; risky/out-of-workspace ops still prompt. `--dangerously-skip-permissions` (autoApprove) still takes precedence when set.
- **Starter Bash permission allowlist** (`lib/per-crew-settings.ts`): common safe-but-mutating dev commands auto-accept (git status/add/commit/push/pull/fetch/checkout/branch/diff/log/stash/restore, npm/npx install/ci/run/test, node, vitest, tsc). Conservative — `git reset --hard`/`clean`/`config`, `rm`, `curl`/`wget`, unknown binaries, and out-of-workspace writes still prompt. Merges with (does not clobber) existing `permissions.allow`.

### Live-validated
- Status line confirms `accept edits on`; in-workspace edit auto-accepts; `git status` runs unprompted; out-of-workspace write prompts; a captain can resolve a prompt via `cockpit crew send <project> <name> "1"`.

### Deferred (follow-up)
The originally-bundled **2b daemon pane-scrape block detection was removed** — live testing proved the launchd daemon cannot connect to cmux to read panes ("only processes started inside cmux can connect"). It will be reworked into the in-cmux **notify-relay** (which can read panes and reach the daemon socket) in a separate PR. The pure classifier logic from that work is preserved for reuse.
