### PR TITLE
feat(2b): in-cmux notify-relay detects crews blocked at prompts -> CREW BLOCKED

### DIFF
--- a/src/commands/__tests__/notify-relay-probe.test.ts
+++ b/src/commands/__tests__/notify-relay-probe.test.ts
@@ -1,0 +1,169 @@
+// src/commands/__tests__/notify-relay-probe.test.ts
+//
+// Phase 2b (relocated): the in-cmux notify-relay runs a probe loop that scrapes
+// quiet interactive crew panes and surfaces a permission/question wait as
+// task.blocked. The daemon can't do this (launchd can't connect to cmux), so the
+// detection lives here, where createCmuxDriver works.
+//
+// These tests drive the PURE probe core: createInteractiveProbe takes injected
+// {listTasks, readPaneTail, sendEvent, now} so the cmux + daemon I/O is faked.
+
+import { describe, it, expect, vi } from "vitest";
+import { createInteractiveProbe } from "../notify-relay.js";
+import type { TaskRecord, ControlEvent } from "../../control/types.js";
+
+// A claude permission dialog (box-drawing chrome included) — classifyPaneTail
+// recognises this as an approval wait.
+const APPROVAL_TAIL = [
+  "● I'll create the file now.",
+  "╭──────────────────────────────────────────────────────╮",
+  "│ Do you want to create newfile.txt?                     │",
+  "│ ❯ 1. Yes                                               │",
+  "│   2. No, and tell Claude what to do differently        │",
+  "╰──────────────────────────────────────────────────────╯",
+  "  accept edits on (shift+tab to cycle)                    ",
+].join("\n");
+
+const NOW = 1_000_000;
+const QUIET = 20_000;
+
+function task(over: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    id: "task-1",
+    name: "alpha",
+    project: "demo",
+    provider: "claude",
+    mode: "interactive",
+    state: "working",
+    task: "do a thing",
+    createdAt: 0,
+    lastHeartbeat: NOW - QUIET - 1, // quiet by default
+    lastEvent: "heartbeat",
+    heartbeatBudgetMs: 60000,
+    attempts: [],
+    ...over,
+  };
+}
+
+interface Harness {
+  sendEvent: ReturnType<typeof vi.fn>;
+  readPaneTail: ReturnType<typeof vi.fn>;
+  tick: () => Promise<void>;
+}
+
+function harness(opts: {
+  tasks: TaskRecord[];
+  readPaneTail?: (rec: TaskRecord) => Promise<string | null>;
+  listTasks?: () => Promise<TaskRecord[]>;
+  sendEvent?: (e: ControlEvent) => Promise<void>;
+}): Harness {
+  const sendEvent = vi.fn(opts.sendEvent ?? (async () => {}));
+  const readPaneTail = vi.fn(opts.readPaneTail ?? (async () => APPROVAL_TAIL));
+  const probe = createInteractiveProbe({
+    project: "demo",
+    listTasks: opts.listTasks ?? (async () => opts.tasks),
+    readPaneTail,
+    sendEvent,
+    now: () => NOW,
+    log: () => {},
+    quietMs: QUIET,
+  });
+  return { sendEvent, readPaneTail, tick: probe.tick };
+}
+
+describe("createInteractiveProbe", () => {
+  it("sends exactly one task.blocked for a quiet working interactive crew at a prompt", async () => {
+    const h = harness({ tasks: [task()] });
+    await h.tick();
+    expect(h.sendEvent).toHaveBeenCalledTimes(1);
+    const ev = h.sendEvent.mock.calls[0][0] as ControlEvent;
+    expect(ev).toMatchObject({
+      type: "task.blocked",
+      id: "task-1",
+      reason: "crew awaiting permission (pane-detected)",
+      question: "Do you want to create newfile.txt?",
+    });
+  });
+
+  it("does not re-send when the tail is unchanged on the next tick (change-detection)", async () => {
+    const h = harness({ tasks: [task()] });
+    await h.tick();
+    await h.tick();
+    expect(h.sendEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not read a task whose heartbeat is recent (not quiet)", async () => {
+    const h = harness({ tasks: [task({ lastHeartbeat: NOW - 5_000 })] });
+    await h.tick();
+    expect(h.readPaneTail).not.toHaveBeenCalled();
+    expect(h.sendEvent).not.toHaveBeenCalled();
+  });
+
+  it("skips non-interactive, non-working, and unnamed tasks", async () => {
+    const h = harness({
+      tasks: [
+        task({ id: "a", mode: "headless" }),
+        task({ id: "b", state: "blocked" }),
+        task({ id: "c", state: "done" }),
+        task({ id: "d", name: undefined }),
+      ],
+    });
+    await h.tick();
+    expect(h.readPaneTail).not.toHaveBeenCalled();
+    expect(h.sendEvent).not.toHaveBeenCalled();
+  });
+
+  it("sends a question-reason block when the pane ends in a trailing question", async () => {
+    const questionTail = [
+      "I looked at both options for the cache layer.",
+      "Should I use Redis or an in-memory LRU for this?",
+    ].join("\n");
+    const h = harness({ tasks: [task()], readPaneTail: async () => questionTail });
+    await h.tick();
+    expect(h.sendEvent).toHaveBeenCalledTimes(1);
+    const ev = h.sendEvent.mock.calls[0][0] as ControlEvent;
+    expect(ev).toMatchObject({
+      type: "task.blocked",
+      reason: "crew asked a question (pane-detected)",
+      question: "Should I use Redis or an in-memory LRU for this?",
+    });
+  });
+
+  it("does not block a working pane with no prompt or question", async () => {
+    const h = harness({ tasks: [task()], readPaneTail: async () => "● running the tests next" });
+    await h.tick();
+    expect(h.sendEvent).not.toHaveBeenCalled();
+  });
+
+  it("swallows a readPaneTail error and never throws", async () => {
+    const h = harness({
+      tasks: [task()],
+      readPaneTail: async () => {
+        throw new Error("cmux down");
+      },
+    });
+    await expect(h.tick()).resolves.toBeUndefined();
+    expect(h.sendEvent).not.toHaveBeenCalled();
+  });
+
+  it("swallows a listTasks error and never throws", async () => {
+    const h = harness({
+      tasks: [],
+      listTasks: async () => {
+        throw new Error("daemon down");
+      },
+    });
+    await expect(h.tick()).resolves.toBeUndefined();
+    expect(h.sendEvent).not.toHaveBeenCalled();
+  });
+
+  it("swallows a sendEvent error and never throws", async () => {
+    const h = harness({
+      tasks: [task()],
+      sendEvent: async () => {
+        throw new Error("daemon refused");
+      },
+    });
+    await expect(h.tick()).resolves.toBeUndefined();
+  });
+});

--- a/src/commands/notify-relay.ts
+++ b/src/commands/notify-relay.ts
@@ -20,8 +20,20 @@ import {
   readFromCursor,
   type MailboxEntry,
 } from "../control/mailbox.js";
+import { classifyPaneTail } from "../control/interactive/pane-classifier.js";
+import { createCrewPaneReader } from "../control/crew-pane-reader.js";
+import { cockpitdCall } from "./crew-control.js";
+import type { TaskRecord, ControlEvent } from "../control/types.js";
 
 export const DEFAULT_STATE_ROOT = join(homedir(), ".config", "cockpit", "state");
+
+// How often the in-cmux probe scrapes interactive crew panes for a block. The
+// daemon can't do this (launchd can't connect to cmux), so it lives here.
+export const PROBE_INTERVAL_MS = 10_000;
+// A working interactive task with no heartbeat for this long is a probe
+// candidate: PostToolUse never fires while a permission prompt is up, so a
+// genuinely-blocked crew goes quiet well before the multi-minute stall budget.
+export const PROBE_QUIET_MS = 20_000;
 
 function shortId(id: string): string {
   return id.slice(0, 8);
@@ -51,6 +63,97 @@ export function formatEntry(entry: MailboxEntry): string | null {
   }
 }
 
+// ── Phase 2b: in-cmux interactive-block probe ───────────────────────────────
+// A claude/opencode crew parked at a permission prompt (or ending a turn with a
+// question) sits at daemon state=working with NO heartbeat — the hook bridge
+// only fires PostToolUse, which never happens while a prompt is up. The daemon
+// can't scrape the pane to notice (launchd can't connect to cmux). The relay
+// runs INSIDE the captain's cmux workspace, so it can read panes AND reach the
+// daemon socket — it is the right place to detect this and surface CREW BLOCKED.
+
+interface InteractiveProbeDeps {
+  project: string;
+  /** Daemon task list (the `kind:"list"` request `cockpit crew tasks` uses). */
+  listTasks: () => Promise<TaskRecord[]>;
+  /** Best-effort crew-pane tail reader (in-cmux); returns null on any failure. */
+  readPaneTail: (rec: TaskRecord) => Promise<string | null>;
+  /** Emit a control event to the daemon (the `kind:"event"` path). */
+  sendEvent: (event: ControlEvent) => Promise<void>;
+  now: () => number;
+  log: (m: string) => void;
+  /** No-heartbeat threshold before a working task is probed. */
+  quietMs?: number;
+}
+
+/**
+ * Pure-ish probe core (I/O injected for tests). One `tick`:
+ *  1. list the project's daemon tasks,
+ *  2. keep only interactive + working + named + quiet (> quietMs since
+ *     lastHeartbeat) candidates,
+ *  3. read each candidate's pane tail and skip it if the tail is unchanged
+ *     since the last tick (per-task change-detection → fires once per prompt),
+ *  4. classify the tail; a permission/question verdict → one task.blocked.
+ *
+ * Best-effort throughout: every read/daemon call is caught and logged; the tick
+ * never throws, so a transient cmux/daemon failure can't crash the relay. The
+ * daemon's applyEvent + #176 idempotency make a re-sent block harmless.
+ */
+export function createInteractiveProbe(deps: InteractiveProbeDeps): {
+  tick: () => Promise<void>;
+} {
+  const quietMs = deps.quietMs ?? PROBE_QUIET_MS;
+  // taskId → last pane tail seen, so an unchanged prompt fires exactly once.
+  const lastTail = new Map<string, string>();
+
+  async function tick(): Promise<void> {
+    let tasks: TaskRecord[];
+    try {
+      tasks = await deps.listTasks();
+    } catch (e) {
+      deps.log(`probe listTasks failed: ${(e as Error).message}`);
+      return;
+    }
+    const now = deps.now();
+    for (const rec of tasks) {
+      if (rec.mode !== "interactive") continue;
+      if (rec.state !== "working") continue;
+      if (!rec.name) continue;
+      if (now - rec.lastHeartbeat <= quietMs) continue; // still lively
+
+      let tail: string | null;
+      try {
+        tail = await deps.readPaneTail(rec);
+      } catch (e) {
+        deps.log(`probe read failed for ${rec.id}: ${(e as Error).message}`);
+        continue;
+      }
+      if (!tail) continue;
+      if (lastTail.get(rec.id) === tail) continue; // unchanged → already handled
+      lastTail.set(rec.id, tail);
+
+      const verdict = classifyPaneTail(tail);
+      if (!verdict) continue;
+      const reason =
+        verdict.kind === "approval"
+          ? "crew awaiting permission (pane-detected)"
+          : "crew asked a question (pane-detected)";
+      try {
+        await deps.sendEvent({
+          type: "task.blocked",
+          id: rec.id,
+          reason,
+          question: verdict.text,
+        });
+        deps.log(`probe -> CREW BLOCKED ${rec.name} (${verdict.kind})`);
+      } catch (e) {
+        deps.log(`probe sendEvent failed for ${rec.id}: ${(e as Error).message}`);
+      }
+    }
+  }
+
+  return { tick };
+}
+
 interface RunOpts {
   project: string;
   subscriber: string;
@@ -58,6 +161,8 @@ interface RunOpts {
   runtime: RuntimeDriver;
   captainName: string;
   pollMs?: number;
+  /** Probe cadence override (default PROBE_INTERVAL_MS); 0 disables the probe. */
+  probeMs?: number;
   log?: (m: string) => void;
 }
 
@@ -128,11 +233,35 @@ export async function runNotifyRelay(opts: RunOpts): Promise<() => void> {
     if (!stopped) drain().catch((e) => log(`drain error: ${(e as Error).message}`));
   }, opts.pollMs ?? 1000);
 
+  // Separate probe interval (additive — does not disturb mailbox tailing).
+  // Detects crews blocked at a permission prompt / trailing question by reading
+  // their pane, which only works from inside cmux (here), not from the daemon.
+  const probeMs = opts.probeMs ?? PROBE_INTERVAL_MS;
+  const readPaneTail = createCrewPaneReader();
+  const probe = createInteractiveProbe({
+    project: opts.project,
+    listTasks: async () =>
+      (await cockpitdCall({ kind: "list", project: opts.project })) as TaskRecord[],
+    readPaneTail,
+    sendEvent: async (event) => {
+      await cockpitdCall({ kind: "event", project: opts.project, event });
+    },
+    now: () => Date.now(),
+    log,
+  });
+  const probeInterval =
+    probeMs > 0
+      ? setInterval(() => {
+          if (!stopped) probe.tick().catch((e) => log(`probe error: ${(e as Error).message}`));
+        }, probeMs)
+      : undefined;
+
   await drain(); // initial drain
 
   return () => {
     stopped = true;
     clearInterval(interval);
+    if (probeInterval) clearInterval(probeInterval);
   };
 }
 

--- a/src/control/__tests__/pane-classifier.test.ts
+++ b/src/control/__tests__/pane-classifier.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { classifyPaneTail } from "../interactive/pane-classifier.js";
+
+// A representative Claude permission-prompt pane, with the box-drawing TUI
+// chrome that wraps it (the input box + the "accept edits on" status line).
+const CLAUDE_APPROVAL = [
+  "● I'll create the file now.",
+  "",
+  "╭──────────────────────────────────────────────────────╮",
+  "│ Do you want to create newfile.txt?                     │",
+  "│                                                        │",
+  "│ ❯ 1. Yes                                               │",
+  "│   2. Yes, allow all edits during this session          │",
+  "│   3. No, and tell Claude what to do differently        │",
+  "╰──────────────────────────────────────────────────────╯",
+  "╭──────────────────────────────────────────────────────╮",
+  "│ >                                                      │",
+  "╰──────────────────────────────────────────────────────╯",
+  "  accept edits on (shift+tab to cycle)                    ",
+].join("\n");
+
+// A normal working pane: assistant output and the input box, no prompt/options.
+const WORKING_PANE = [
+  "● Reading src/index.ts...",
+  "● The function looks correct; running the tests next.",
+  "╭──────────────────────────────────────────────────────╮",
+  "│ >                                                      │",
+  "╰──────────────────────────────────────────────────────╯",
+  "  accept edits on (shift+tab to cycle)                    ",
+].join("\n");
+
+// A pane whose agent output ends in a direct question (mainly the opencode
+// path — opencode has no Stop hook so the daemon never sees a turn-end block).
+const QUESTION_PANE = [
+  "I looked at both options for the cache layer.",
+  "Should I use Redis or an in-memory LRU for this?",
+  "╭──────────────────────────────────────────────────────╮",
+  "│ >                                                      │",
+  "╰──────────────────────────────────────────────────────╯",
+].join("\n");
+
+describe("classifyPaneTail", () => {
+  it("classifies a Claude permission dialog as approval with the prompt text", () => {
+    const r = classifyPaneTail(CLAUDE_APPROVAL);
+    expect(r).toEqual({ kind: "approval", text: "Do you want to create newfile.txt?" });
+  });
+
+  it("returns null for a normal working pane (no prompt, no options)", () => {
+    expect(classifyPaneTail(WORKING_PANE)).toBeNull();
+  });
+
+  it("classifies a trailing-question pane as question with the question text", () => {
+    const r = classifyPaneTail(QUESTION_PANE);
+    expect(r).toEqual({ kind: "question", text: "Should I use Redis or an in-memory LRU for this?" });
+  });
+
+  it("returns null for chrome-only or empty input", () => {
+    expect(classifyPaneTail("")).toBeNull();
+    const chromeOnly = [
+      "╭────────────────────────────╮",
+      "│ >                          │",
+      "╰────────────────────────────╯",
+      "  accept edits on             ",
+    ].join("\n");
+    expect(classifyPaneTail(chromeOnly)).toBeNull();
+  });
+
+  it("does not misfire approval on a numbered list that lacks a Yes/No block", () => {
+    const numberedList = [
+      "Here is the plan:",
+      "1. Read the config",
+      "2. Patch the reducer",
+      "3. Run the tests",
+      "╭────────────────────────────╮",
+      "│ >                          │",
+      "╰────────────────────────────╯",
+    ].join("\n");
+    expect(classifyPaneTail(numberedList)).toBeNull();
+  });
+});

--- a/src/control/crew-pane-reader.ts
+++ b/src/control/crew-pane-reader.ts
@@ -1,0 +1,41 @@
+import { loadConfig } from "../config.js";
+import { createCmuxDriver, RuntimeRegistry } from "../runtimes/index.js";
+import type { TaskRecord } from "./types.js";
+
+const TAIL_LINES = 25;
+
+// MUST match `titleFor` in src/commands/crew.ts — the crew tab title convention
+// the daemon uses to find a crew's pane (🔧 <project>:<name>).
+function crewPaneTitle(project: string, name: string): string {
+  return `🔧 ${project}:${name}`;
+}
+
+/**
+ * Build the daemon's best-effort crew-pane reader (Phase 2b). Resolves the
+ * crew's cmux pane the same way `cockpit crew read` does — captain workspace →
+ * surfaces → the crew tab by title — and returns the LAST ~25 lines of its
+ * screen. Returns null on ANY failure (cmux down, no captain, pane gone, no
+ * name) and NEVER throws, so the probe loop can't take the daemon down.
+ */
+export function createCrewPaneReader(): (rec: TaskRecord) => Promise<string | null> {
+  return async (rec) => {
+    try {
+      if (!rec.name) return null;
+      const config = loadConfig();
+      const proj = config.projects[rec.project];
+      if (!proj) return null;
+      const runtime = new RuntimeRegistry({ cmux: createCmuxDriver() }).forProject(rec.project, config);
+      const captain = await runtime.status(proj.captainName);
+      if (!captain) return null;
+      const surfaces = await runtime.listSurfaces(captain.id);
+      const want = crewPaneTitle(rec.project, rec.name);
+      const pane = surfaces.find((s) => s.title === want);
+      if (!pane) return null;
+      const screen = await runtime.readPaneScreen(pane);
+      if (!screen) return null;
+      return screen.split(/\r?\n/).slice(-TAIL_LINES).join("\n");
+    } catch {
+      return null;
+    }
+  };
+}

--- a/src/control/interactive/pane-classifier.ts
+++ b/src/control/interactive/pane-classifier.ts
@@ -1,0 +1,84 @@
+import { detectTrailingQuestion } from "./claude.js";
+
+/**
+ * Pure classifier for a crew pane's TAIL (last ~25 lines), used by the daemon's
+ * fast interactive-prompt probe (Phase 2b). A crew blocked at a permission
+ * prompt shows daemon state=working with NO heartbeat — the hook bridge only
+ * fires PostToolUse, which never happens while the prompt is up — so the daemon
+ * cannot see the block until the multi-minute stall budget. This detector lets
+ * the probe surface that wait as CREW BLOCKED within one probe cadence.
+ *
+ *  - "approval": a permission-dialog shape — a "Do you want to ...?" prompt line
+ *    plus a numbered Yes/No option block. text = the human-readable prompt line.
+ *  - "question": the agent's output region (TUI chrome stripped) ends in a
+ *    direct question. Mainly the opencode path; Claude turn-end questions are
+ *    already handled by the #174 Stop-hook transcript path.
+ *  - else null.
+ *
+ * Conservative by design: it only runs against a quiet working pane and must not
+ * false-block, so an ambiguous tail returns null.
+ */
+export function classifyPaneTail(tail: string): { kind: "approval" | "question"; text: string } | null {
+  if (!tail) return null;
+  const raw = tail.split(/\r?\n/);
+  // cleaned[i] is the agent-region text of line i, or null if the line is pure
+  // TUI chrome (box border, empty input prompt, status line) and should be ignored.
+  const cleaned = raw.map(stripChrome);
+
+  // ── approval: numbered Yes/No option block + a "?"-terminated prompt above ──
+  const options: { label: string; ci: number }[] = [];
+  for (let i = 0; i < cleaned.length; i++) {
+    const c = cleaned[i];
+    if (c == null) continue;
+    const m = c.match(OPTION_RE);
+    if (m) options.push({ label: m[2], ci: i });
+  }
+  const hasYes = options.some((o) => /\byes\b/i.test(o.label));
+  const hasNo = options.some((o) => /\bno\b/i.test(o.label));
+  if (options.length >= 2 && hasYes && hasNo) {
+    // The prompt is the nearest "?"-terminated agent line above the first option.
+    const firstOptCi = options[0].ci;
+    for (let i = firstOptCi - 1; i >= 0; i--) {
+      const c = cleaned[i];
+      if (c == null) continue;
+      if (c.endsWith("?")) return { kind: "approval", text: c };
+    }
+    // Unmistakable Yes/No dialog but no "?"-line extracted → still actionable.
+    return { kind: "approval", text: "Crew is awaiting permission approval." };
+  }
+
+  // ── question: trailing question in the chrome-stripped agent output region ──
+  const region = cleaned.filter((c): c is string => c != null).join("\n");
+  const q = detectTrailingQuestion(region);
+  if (q) return { kind: "question", text: q };
+
+  return null;
+}
+
+// A numbered option line, after chrome stripping: an optional cursor marker
+// (❯ / > / ›), a number, a dot, then the label. e.g. "❯ 1. Yes".
+const OPTION_RE = /^[❯>›]?\s*(\d+)\.\s+(.*\S)\s*$/;
+
+// Box-drawing / rule characters that make up a pure-chrome line.
+const PURE_CHROME_RE = /^[\s─━│┃╭╮╰╯┌┐└┘├┤┬┴┼═║╔╗╚╝╠╣╦╩╬▁▂▃▄▅▆▇█▔▏▕]+$/;
+const STATUS_LINE_RE = /accept edits on|shift\+tab|⏵⏵|\? for shortcuts|esc to interrupt|tokens? (used|left)|context left/i;
+
+/**
+ * Strip the box-drawing border / cursor padding from one pane line and decide
+ * whether it carries agent content. Returns the trimmed content, or null if the
+ * line is pure TUI chrome (border, empty input prompt, status line) that the
+ * classifier must ignore.
+ */
+function stripChrome(raw: string): string | null {
+  // Defensive ANSI strip — cmux read-screen is usually plain text, but a stray
+  // escape would otherwise leak into the extracted prompt text.
+  let line = raw.replace(/\[[0-9;]*m/g, "");
+  // Peel leading/trailing vertical box borders and surrounding whitespace.
+  line = line.replace(/^[\s│┃▏▕|]+/, "").replace(/[\s│┃▏▕|]+$/, "");
+  const trimmed = line.trim();
+  if (trimmed === "") return null;
+  if (PURE_CHROME_RE.test(trimmed)) return null;
+  if (/^>\s*$/.test(trimmed)) return null; // empty input prompt
+  if (STATUS_LINE_RE.test(trimmed)) return null;
+  return trimmed;
+}


### PR DESCRIPTION
## Phase 2b (relocated): in-cmux pane-block detection

A claude/opencode crew parked at a **permission prompt** (or ending a turn with a **question**) sits at daemon `state=working` with **no heartbeat** — the hook bridge only fires `PostToolUse`, which never happens while a prompt is up. So the stall watchdog won't catch it for minutes.

A prior attempt put the pane-scrape probe **in the daemon** (PR #178's 2b slice). Live testing proved that fails: the launchd-managed `cockpitd` **cannot connect to cmux** (`"only processes started inside cmux can connect"`). That slice was dropped from develop.

**This PR relocates the detection to the notify-relay**, which runs as a background tab **inside the captain's cmux workspace** — so it CAN read panes AND reach the daemon socket. The reusable *pure* classifier logic from the dropped daemon commit (`7a4e265`) is restored unchanged.

### What's here

**Restored pure logic (from `7a4e265`)**
- `src/control/interactive/pane-classifier.ts` — pure `classifyPaneTail`: `approval` = numbered Yes/No block + a `?`-prompt line above; `question` = chrome-stripped trailing question via `detectTrailingQuestion`; strips TUI chrome/ANSI/status-line; conservative, `null` on ambiguity.
- `src/control/crew-pane-reader.ts` — best-effort in-cmux reader: captain workspace → `listSurfaces` → crew tab by title `🔧 <project>:<name>` → `readPaneScreen`, last ~25 lines; never throws.

**Probe in the relay (`src/commands/notify-relay.ts`)**
- `createInteractiveProbe` — pure-ish core (I/O injected: `listTasks` / `readPaneTail` / `sendEvent` / `now`). Each tick:
  1. lists the project's daemon tasks (same `kind:"list"` request `cockpit crew tasks` uses),
  2. keeps only `interactive` + `working` + named + **quiet** (`now - lastHeartbeat > 20s`),
  3. reads each candidate's pane tail, **skips unchanged tails** (per-task change-detection → fires once per prompt),
  4. classifies; on a verdict sends `task.blocked` via the daemon `kind:"event"` path.
- `runNotifyRelay` wires a **separate ~10s probe interval** (additive — does not disturb the mailbox tailer) and clears it on stop.

**Safety**
- Best-effort throughout: every read/daemon call is caught and logged; a tick **never throws**, so cmux/daemon hiccups can't crash the relay.
- Reasons: `"crew awaiting permission (pane-detected)"` (approval) / `"crew asked a question (pane-detected)"` (question).
- The daemon's existing `applyEvent` + #176 idempotency make a re-sent block harmless (no duplicate CREW BLOCKED).
- Applies to **opencode interactive crews** too — their 24h budget disables the stall watchdog, so this is their first interaction signal.

The daemon stays free of cmux access (develop has no daemon-side scan after the split; none re-added here).

### Tests (TDD, failing-first)
- `src/control/__tests__/pane-classifier.test.ts` (5) — restored.
- `src/commands/__tests__/notify-relay-probe.test.ts` (9) — single-fire; change-detection (no re-send on unchanged tail); quiet filter (recent heartbeat not read); mode/state/name filters; question path; no-prompt working pane → no block; swallowed `listTasks`/`readPaneTail`/`sendEvent` errors.
- `npm run build` clean; `npm test` (command + control) → **368 passed**.

### ⚠️ Captain must, before merge
1. **Restart the notify-relay** so it runs this new code (the running relay predates this branch).
2. **Live-test:** spawn a crew → force an out-of-workspace write to trigger a permission prompt → confirm **CREW BLOCKED fires within ~30s** → resolve via `cockpit crew send`.

Do **not** merge before the live test.
