### PR TITLE
feat: event-driven claude permission detection via Notification hook (instant CREW BLOCKED)

### DIFF
--- a/src/control/__tests__/interactive-claude-hook.test.ts
+++ b/src/control/__tests__/interactive-claude-hook.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
-import { mapClaudeHookToEvent, detectTrailingQuestion, deriveTranscriptPath } from "../interactive/claude.js";
+import { mapClaudeHookToEvent, detectTrailingQuestion, deriveTranscriptPath, isPermissionNotification } from "../interactive/claude.js";
 
 describe("mapClaudeHookToEvent", () => {
   const TID = "task-abc";
@@ -39,6 +39,11 @@ describe("mapClaudeHookToEvent", () => {
   it("anti-#2576 invariant: NO input produces task.done or task.failed", () => {
     // Walk the entire known Claude hook event surface plus the bare-name aliases
     // a careless implementation might emit.
+    // NARROW EXCEPTIONS to task.blocked (never task.done/task.failed):
+    //   #174: Stop + trailing question → task.blocked
+    //   #notification-hook: Notification + permission message → task.blocked
+    // This sweep uses {} payloads (no message/question) so neither exception fires —
+    // Notification with {} has no message → task.progress, not task.blocked.
     const ALL_KNOWN = [
       "Stop",
       "SubagentStop",
@@ -235,6 +240,90 @@ describe("mapClaudeHookToEvent Stop derived-path fallback (#174 delivery)", () =
   it("session_id+cwd present but no transcript file on disk → task.turn.completed, never throws", () => {
     const ev = mapClaudeHookToEvent("Stop", { session_id: "missing", cwd: "/Users/q3labsadmin/me/claude-cockpit" }, TID);
     expect(ev).toEqual({ type: "task.turn.completed", id: TID, turnId: "hook-stop" });
+  });
+});
+
+describe("isPermissionNotification", () => {
+  it("returns true when message contains 'permission'", () => {
+    expect(isPermissionNotification("Claude needs your permission to use Bash")).toBe(true);
+    expect(isPermissionNotification("This operation requires permission")).toBe(true);
+    expect(isPermissionNotification("permission to write file")).toBe(true);
+  });
+
+  it("returns true when message contains 'approve'", () => {
+    expect(isPermissionNotification("Please approve this action")).toBe(true);
+    expect(isPermissionNotification("Approve the tool use to continue")).toBe(true);
+  });
+
+  it("returns false for idle/liveness notifications (not permission requests)", () => {
+    expect(isPermissionNotification("Waiting for your input")).toBe(false);
+    expect(isPermissionNotification("Claude is thinking...")).toBe(false);
+    expect(isPermissionNotification("I've finished the task and pushed the branch.")).toBe(false);
+  });
+
+  it("returns false for empty or whitespace string", () => {
+    expect(isPermissionNotification("")).toBe(false);
+    expect(isPermissionNotification("   ")).toBe(false);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isPermissionNotification("Claude Needs Your PERMISSION to run")).toBe(true);
+    expect(isPermissionNotification("APPROVE this command")).toBe(true);
+  });
+});
+
+describe("mapClaudeHookToEvent Notification (instant permission detection, #notification-hook)", () => {
+  const TID = "task-abc";
+
+  it("permission message → task.blocked with reason='crew awaiting permission (notification hook)' and question=message", () => {
+    const msg = "Claude needs your permission to use Bash";
+    const ev = mapClaudeHookToEvent("Notification", { message: msg }, TID);
+    expect(ev).toEqual({
+      type: "task.blocked",
+      id: TID,
+      reason: "crew awaiting permission (notification hook)",
+      question: msg,
+    });
+  });
+
+  it("idle/non-permission message → task.progress with note 'notification'", () => {
+    expect(mapClaudeHookToEvent("Notification", { message: "Waiting for your input" }, TID))
+      .toEqual({ type: "task.progress", id: TID, note: "notification" });
+  });
+
+  it("missing message field → task.progress, never throws", () => {
+    expect(mapClaudeHookToEvent("Notification", {}, TID))
+      .toEqual({ type: "task.progress", id: TID, note: "notification" });
+  });
+
+  it("null payload → task.progress, never throws", () => {
+    expect(mapClaudeHookToEvent("Notification", null, TID))
+      .toEqual({ type: "task.progress", id: TID, note: "notification" });
+  });
+
+  it("undefined payload → task.progress, never throws", () => {
+    expect(mapClaudeHookToEvent("Notification", undefined, TID))
+      .toEqual({ type: "task.progress", id: TID, note: "notification" });
+  });
+
+  it("non-string message (e.g. a number) → task.progress, never throws", () => {
+    expect(mapClaudeHookToEvent("Notification", { message: 42 }, TID))
+      .toEqual({ type: "task.progress", id: TID, note: "notification" });
+  });
+
+  it("empty message string → task.progress (not a permission request)", () => {
+    expect(mapClaudeHookToEvent("Notification", { message: "" }, TID))
+      .toEqual({ type: "task.progress", id: TID, note: "notification" });
+  });
+
+  it("NEVER emits task.done or task.failed regardless of message", () => {
+    for (const msg of ["needs your permission", "please approve", "approve this", ""]) {
+      const ev = mapClaudeHookToEvent("Notification", { message: msg }, TID);
+      if (ev) {
+        expect(ev.type).not.toBe("task.done");
+        expect(ev.type).not.toBe("task.failed");
+      }
+    }
   });
 });
 

--- a/src/control/__tests__/interactive-claude.test.ts
+++ b/src/control/__tests__/interactive-claude.test.ts
@@ -75,4 +75,11 @@ describe("claude interactive hook merge", () => {
     expect(out.hooks.SubagentStop[0].hooks[0].command).toContain(HOOK_CMD);
     expect(out.hooks.SessionEnd[0].hooks[0].command).toContain(HOOK_CMD);
   });
+
+  it("registers a Notification hook for instant permission-prompt detection (#notification-hook)", () => {
+    const out = mergeClaudeHooks({}, HOOK_CMD);
+    expect(out.hooks.Notification).toBeDefined();
+    expect(out.hooks.Notification[0].hooks[0].command).toContain(HOOK_CMD);
+    expect(out.hooks.Notification[0].hooks[0].command).toContain("Notification");
+  });
 });

--- a/src/control/interactive/claude.ts
+++ b/src/control/interactive/claude.ts
@@ -13,7 +13,7 @@ import type { ControlEvent } from "../types.js";
 // SubagentStop/SessionEnd fire only at turn boundaries but are liveness-only:
 // SubagentStop fires while the parent agent still owns the turn, and SessionEnd
 // is an unreliable signal (crash / Ctrl-C / /exit).
-const EVENTS = ["Stop", "SubagentStop", "SessionEnd", "PostToolUse"] as const;
+const EVENTS = ["Stop", "SubagentStop", "SessionEnd", "PostToolUse", "Notification"] as const;
 
 /**
  * Probe whether the local Claude CLI supports `--settings <path>`. The
@@ -30,6 +30,18 @@ export function probeClaudeSettingsFlag(): "flag" | "project-dir" {
   } catch {
     return "project-dir";
   }
+}
+
+/**
+ * Pure: returns true when a Notification hook message indicates Claude is waiting
+ * for the user to grant a tool-use permission. Idle notifications ("Waiting for
+ * your input", "Claude is thinking") return false — only permission/approval
+ * language triggers the fast-path task.blocked path.
+ */
+export function isPermissionNotification(message: string): boolean {
+  if (!message || !message.trim()) return false;
+  const lower = message.toLowerCase();
+  return lower.includes("permission") || lower.includes("approve");
 }
 
 /** Pure, idempotent merge of cockpit hooks into a Claude settings object. */
@@ -155,16 +167,21 @@ function resolveLastAssistantText(payload: unknown): string | null {
  *
  * Stop = turn boundary. It normally maps to task.turn.completed → awaiting-input
  * (stall-immune) so a captain reviewing output never trips a false CREW STALLED
- * (fixes #131). NARROW EXCEPTION (#174): when the crew's last assistant message
+ * (fixes #131). NARROW EXCEPTION #1 (#174): when the crew's last assistant message
  * ENDS with a direct question, Stop maps to task.blocked instead, surfacing the
- * question to the captain as CREW BLOCKED. This is the one auto-detected path to
- * `task.blocked`; it relaxes the old "no hook → blocked" rule for blocked ONLY
- * (never done/failed). The last-assistant text is obtained from a LAYERED source
- * (last_assistant_message on the payload → transcript_path → derived path from
- * session_id+cwd); the payload field is the primary, I/O-free source and the
- * earlier transcript_path-only approach is why #174 stayed dormant in production.
- * All transcript I/O is best-effort: any failure falls through to the next source
- * and ultimately to task.turn.completed, and never throws (the hook must exit 0).
+ * question to the captain as CREW BLOCKED. The last-assistant text is obtained from
+ * a LAYERED source (last_assistant_message on the payload → transcript_path →
+ * derived path from session_id+cwd); the payload field is the primary, I/O-free
+ * source. All transcript I/O is best-effort and never throws (hook must exit 0).
+ *
+ * Notification = Claude needs user attention. NARROW EXCEPTION #2
+ * (#notification-hook): when the payload.message indicates a permission request
+ * (isPermissionNotification), this maps to task.blocked instantly — bypassing the
+ * ~20-30s relay poll. The relay poll remains as a fallback for opencode crews and
+ * as a safety net; both may fire task.blocked for the same prompt, but the
+ * state-machine idempotency (already-blocked → no-op, from #176) deduplicates.
+ * Non-permission notifications (idle liveness) → task.progress. Missing/non-string
+ * message → task.progress (never throws, hook must exit 0).
  */
 export function mapClaudeHookToEvent(
   event: string,
@@ -179,6 +196,13 @@ export function mapClaudeHookToEvent(
         return { type: "task.blocked", id: taskId, reason: "crew asked a question (auto-detected)", question };
       }
       return { type: "task.turn.completed", id: taskId, turnId: "hook-stop" };
+    }
+    case "Notification": {
+      const msg = (payload as any)?.message;
+      if (typeof msg === "string" && isPermissionNotification(msg)) {
+        return { type: "task.blocked", id: taskId, reason: "crew awaiting permission (notification hook)", question: msg };
+      }
+      return { type: "task.progress", id: taskId, note: "notification" };
     }
     case "SubagentStop":
     case "SessionEnd":


### PR DESCRIPTION
## Summary

- Adds `"Notification"` to `EVENTS` so `mergeClaudeHooks` registers a cockpit Notification hook per-crew (via `cockpit crew _hook Notification`)
- Exports `isPermissionNotification(message)` — pure heuristic: true when message contains `"permission"` or `"approve"` (case-insensitive); false for idle/empty
- `mapClaudeHookToEvent` handles `case "Notification"`: permission msg → `task.blocked` instantly; all other payloads → `task.progress` (liveness only, never throws)
- Anti-#2576 doc comment updated to record this as **NARROW EXCEPTION #2** (first is the #174 Stop trailing-question path)

## How it fits the existing architecture

The relay poll (PR #180) stays as-is — it's the fallback for opencode crews and a safety net for any case where the Notification hook doesn't fire. Both paths may independently emit `task.blocked` for the same prompt; the state-machine idempotency from #176 (already-blocked → no-op) deduplicates without any new code.

## Live-test note for captain

**Captain must verify before merging** whether Claude Code's `Notification` hook actually fires for the inline permission prompt in a cmux-wrapped crew session. The hook fires in the crew's Claude process and calls `cockpit crew _hook Notification` — confirm this reaches the daemon and surfaces CREW BLOCKED in the cockpit dashboard within ~1s of the permission prompt appearing.

If the Notification hook does not fire inside cmux (similar to the earlier daemon pane-scrape limitation), the relay poll fallback still covers it and this PR can be de-scoped to just the test coverage.

## Test plan

- [ ] 13 new tests: `isPermissionNotification` (5 cases), `mapClaudeHookToEvent Notification` (7 cases), `mergeClaudeHooks Notification registration` (1 case)
- [ ] Anti-#2576 sweep still passes: `Notification` with `{}` payload → `task.progress`, never `task.done/task.failed/task.blocked`
- [ ] `npm run build` clean, `npm test` 53/53 passing
- [ ] Live-test: spawn a crew with a risky tool call, confirm CREW BLOCKED fires within ~1s (not ~20-30s) via the Notification hook