### PR TITLE
test: cap vitest worker pool to bound RAM

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,15 @@ export default defineConfig({
   test: {
     include: ["src/**/*.test.ts"],
     exclude: ["dist/**", "node_modules/**"],
+    // Bound the worker pool so a cockpit test run can't balloon RAM. By default
+    // vitest forks ~one worker per core (12 on this machine, ~80–100 MB each ≈
+    // 1 GB/run). When several project captains (e.g. the oneplan captain) run
+    // their own vitest concurrently on the same machine, those uncapped pools
+    // stack and exhaust RAM. Capping cockpit to 2 forks keeps its footprint
+    // ~200 MB while the suite is small/fast (~3s). teardownTimeout guards
+    // against a hung worker wedging shutdown.
+    pool: "forks",
+    poolOptions: { forks: { minForks: 1, maxForks: 2 } },
+    teardownTimeout: 10_000,
   },
 });


### PR DESCRIPTION
Caps cockpit's vitest pool to `maxForks: 2` (was uncapped → ~1 worker/core = 12 on this machine).

**Why:** repeated/concurrent test runs — especially when another project captain (oneplan) runs its own vitest at the same time — stacked uncapped worker pools and exhausted RAM (force-restart). Capping cockpit to 2 forks keeps its footprint ~200MB; suite is small (~3s) so it stays fast. `teardownTimeout` guards against a hung worker wedging shutdown.

Note: the test suite itself does **not** leak — it injects fake spawners + cleans up in afterEach. This is purely a worker-pool RAM bound.