### PR TITLE
feat(crew-permissions): expand Bash allowlist with read-only and safe dev commands

### DIFF
--- a/src/lib/__tests__/per-crew-settings.test.ts
+++ b/src/lib/__tests__/per-crew-settings.test.ts
@@ -7,6 +7,7 @@ import {
   writePerCrewSettingsLocal,
   writePerCrewOpencodeConfig,
   CREW_PERMISSION_ALLOWLIST,
+  mergeCrewPermissions,
 } from "../per-crew-settings.js";
 
 describe("writePerCrewSettings", () => {
@@ -131,6 +132,121 @@ describe("writePerCrewSettingsLocal — permission allowlist", () => {
     const counts = new Map<string, number>();
     for (const e of json.permissions.allow) counts.set(e, (counts.get(e) ?? 0) + 1);
     for (const [, n] of counts) expect(n).toBe(1);
+  });
+});
+
+describe("CREW_PERMISSION_ALLOWLIST — read-only and safe dev commands", () => {
+  it("includes process/system read commands", () => {
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(ps:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(pgrep:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(lsof:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(top -l:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(uptime:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(whoami:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(uname:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(date:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(env:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(sysctl:*)");
+  });
+
+  it("includes file read/nav commands", () => {
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(ls:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(cat:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(head:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(tail:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(wc:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(grep:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(rg:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(find:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(pwd:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(stat:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(file:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(realpath:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(basename:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(dirname:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(du:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(df:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(tree:*)");
+  });
+
+  it("includes read-only text processing commands", () => {
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(sort:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(uniq:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(cut:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(tr:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(jq:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(diff:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(column:*)");
+  });
+
+  it("includes harmless utility commands", () => {
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(echo:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(which:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(true:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(sleep:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(printf:*)");
+  });
+
+  it("includes safe dev query commands", () => {
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(git show:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(git rev-parse:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(git remote -v:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(git stash list:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(npm ls:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(npm view:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(node --version:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).toContain("Bash(pnpm ls:*)");
+  });
+
+  it("does NOT include destructive, network, or privilege-escalation commands", () => {
+    expect(CREW_PERMISSION_ALLOWLIST).not.toContain("Bash(*)");
+    expect(CREW_PERMISSION_ALLOWLIST).not.toContain("Bash(rm:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).not.toContain("Bash(curl:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).not.toContain("Bash(wget:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).not.toContain("Bash(sudo:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).not.toContain("Bash(kill:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).not.toContain("Bash(pkill:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).not.toContain("Bash(git reset:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).not.toContain("Bash(git clean:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).not.toContain("Bash(git config:*)");
+    expect(CREW_PERMISSION_ALLOWLIST).not.toContain("Bash(npm publish:*)");
+  });
+});
+
+describe("mergeCrewPermissions", () => {
+  it("adds all CREW_PERMISSION_ALLOWLIST entries to an empty settings object", () => {
+    const result = mergeCrewPermissions({});
+    const perms = result.permissions as { allow: string[] };
+    for (const entry of CREW_PERMISSION_ALLOWLIST) {
+      expect(perms.allow).toContain(entry);
+    }
+  });
+
+  it("de-duplicates when existing allow already contains some allowlist entries", () => {
+    const existing = { permissions: { allow: ["Bash(git commit:*)", "Bash(custom:*)"] } };
+    const result = mergeCrewPermissions(existing);
+    const perms = result.permissions as { allow: string[] };
+    const counts = new Map<string, number>();
+    for (const e of perms.allow) counts.set(e, (counts.get(e) ?? 0) + 1);
+    for (const [, n] of counts) expect(n).toBe(1);
+  });
+
+  it("preserves existing deny and ask keys alongside the merged allow", () => {
+    const existing = {
+      permissions: { allow: [], deny: ["Bash(sudo:*)"], ask: ["Bash(ssh:*)"] },
+    };
+    const result = mergeCrewPermissions(existing) as {
+      permissions: { allow: string[]; deny: string[]; ask: string[] };
+    };
+    expect(result.permissions.deny).toEqual(["Bash(sudo:*)"]);
+    expect(result.permissions.ask).toEqual(["Bash(ssh:*)"]);
+  });
+
+  it("does not mutate the input object", () => {
+    const input = { permissions: { allow: ["Bash(python3:*)"] } };
+    const snapshot = JSON.stringify(input);
+    mergeCrewPermissions(input);
+    expect(JSON.stringify(input)).toBe(snapshot);
   });
 });
 

--- a/src/lib/per-crew-settings.ts
+++ b/src/lib/per-crew-settings.ts
@@ -3,19 +3,26 @@ import { join } from "node:path";
 import { mergeClaudeHooks } from "../control/interactive/claude.js";
 
 /**
- * Starter Bash permission allowlist for crews running under
- * `--permission-mode acceptEdits` (Phase 2a). acceptEdits auto-accepts file
- * edits but still prompts on EVERY mutating shell command — including routine
- * dev ops (commit, push, install, test). Without this, the Phase 2b pane probe
- * would fire CREW BLOCKED on every commit/install/test = notification spam.
+ * Bash permission allowlist for crews running under `--permission-mode
+ * acceptEdits` (Phase 2a). acceptEdits auto-accepts file edits but still
+ * prompts on EVERY shell command. Without this, the Phase 2b pane probe fires
+ * CREW BLOCKED on every commit/install/test/grep = notification spam.
  *
- * Conservative by design: only safe-but-mutating *dev* commands are listed,
- * scoped per-subcommand so genuinely risky ops (`git reset --hard`,
- * `git config`, `rm`, `curl`, `wget`, unknown binaries, out-of-workspace
- * writes) STILL prompt and surface as CREW BLOCKED. No blanket `Bash(*)`.
+ * Conservative by design: two tiers —
+ *   1. Read-only inspection (ps, ls, grep, jq, …) — never mutates anything.
+ *   2. Safe-but-mutating dev ops (git commit, npm install, vitest, …) — needed
+ *      for normal crew work; scoped to safe subcommands.
+ * Genuinely risky ops (`git reset --hard`, `git config`, `rm`, `curl`, `wget`,
+ * `sudo`, `kill`, unknown binaries, out-of-workspace writes) STILL prompt and
+ * surface as CREW BLOCKED. No blanket `Bash(*)`.
  *
- * Syntax: Claude Code Bash permission patterns, `Bash(<prefix>:*)` matches the
- * prefix command plus any trailing args.
+ * Syntax: `Bash(<prefix>:*)` allows any command whose text starts with
+ * <prefix>. Patterns match the raw command string — NOT the resolved binary.
+ *
+ * Known limitation: commands with a leading env-var assignment
+ * (e.g. `COCKPIT_CREW_TASK_ID=x sleep 5`) still prompt because the line
+ * starts with the variable name, not the command. This is rare and acceptable;
+ * it's not a bug.
  */
 export const CREW_PERMISSION_ALLOWLIST: readonly string[] = [
   // git — read + safe mutations (reset/clean/config intentionally excluded)
@@ -31,17 +38,70 @@ export const CREW_PERMISSION_ALLOWLIST: readonly string[] = [
   "Bash(git log:*)",
   "Bash(git stash:*)",
   "Bash(git restore:*)",
+  // git — read-only queries (no-mutation subcommands)
+  "Bash(git show:*)",
+  "Bash(git rev-parse:*)",
+  "Bash(git remote -v:*)",
+  "Bash(git stash list:*)",
   // npm / npx — installs + script/test/build runners
   "Bash(npm install:*)",
   "Bash(npm ci:*)",
   "Bash(npm run:*)",
   "Bash(npm test:*)",
+  "Bash(npm ls:*)",
+  "Bash(npm view:*)",
   "Bash(npx vitest:*)",
   "Bash(npx tsc:*)",
   // direct runners
   "Bash(node:*)",
+  "Bash(node --version:*)",
   "Bash(vitest:*)",
   "Bash(tsc:*)",
+  // pnpm
+  "Bash(pnpm ls:*)",
+  // process / system read — non-interactive, read-only
+  "Bash(ps:*)",
+  "Bash(pgrep:*)",
+  "Bash(lsof:*)",
+  "Bash(top -l:*)",
+  "Bash(uptime:*)",
+  "Bash(whoami:*)",
+  "Bash(uname:*)",
+  "Bash(date:*)",
+  "Bash(env:*)",
+  "Bash(sysctl:*)",
+  // file read / navigation
+  "Bash(ls:*)",
+  "Bash(cat:*)",
+  "Bash(head:*)",
+  "Bash(tail:*)",
+  "Bash(wc:*)",
+  "Bash(grep:*)",
+  "Bash(rg:*)",
+  "Bash(find:*)",
+  "Bash(pwd:*)",
+  "Bash(stat:*)",
+  "Bash(file:*)",
+  "Bash(realpath:*)",
+  "Bash(basename:*)",
+  "Bash(dirname:*)",
+  "Bash(du:*)",
+  "Bash(df:*)",
+  "Bash(tree:*)",
+  // read-only text processing
+  "Bash(sort:*)",
+  "Bash(uniq:*)",
+  "Bash(cut:*)",
+  "Bash(tr:*)",
+  "Bash(jq:*)",
+  "Bash(diff:*)",
+  "Bash(column:*)",
+  // harmless utilities
+  "Bash(echo:*)",
+  "Bash(which:*)",
+  "Bash(true:*)",
+  "Bash(sleep:*)",
+  "Bash(printf:*)",
 ];
 
 /**


### PR DESCRIPTION
## What
Expands `CREW_PERMISSION_ALLOWLIST` (src/lib/per-crew-settings.ts) so claude crews under `--permission-mode acceptEdits` stop prompting on safe commands.

**Added:** read-only inspection (ps, pgrep, lsof, ls, cat, head, tail, wc, grep, rg, find, stat, file, sort, uniq, cut, tr, jq, diff, env, sysctl, date, whoami, uname, …), harmless utils (echo, which, true, sleep, printf), and safe dev queries (git show/rev-parse/remote -v/stash list, npm ls/view, node --version, pnpm ls).

**Still prompting (unchanged):** rm, rmdir, mv, cp, chmod, chown, kill, pkill, sudo, dd, curl, wget, ssh, scp, git reset, git clean, git config, git push --force, npm publish, gh, eval.

## Notes
- Documented known limitation: env-var-prefixed commands (`FOO=x cmd`) still prompt (prefix match).
- Known residual: `find -exec` / `env <cmd>` can run commands unprompted — acceptable for now, candidate to tighten later.

## Verification
Full suite green: 71 files / 701 tests, tsc clean.

🤖 Reviewed by cockpit-captain.