### PR TITLE
fix(codex-crew): resolve model from codex config to fix ChatGPT OAuth 400

### DIFF
--- a/src/control/codex/__tests__/config.test.ts
+++ b/src/control/codex/__tests__/config.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { resolveCodexModel } from "../config.js";
+
+// All tests mock fs/promises so no real file I/O occurs.
+vi.mock("node:fs/promises");
+
+import { readFile } from "node:fs/promises";
+const readFileMock = vi.mocked(readFile);
+
+afterEach(() => { vi.resetAllMocks(); delete process.env["CODEX_HOME"]; });
+
+describe("resolveCodexModel", () => {
+  it("returns undefined when config file is missing", async () => {
+    readFileMock.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+    await expect(resolveCodexModel()).resolves.toBeUndefined();
+  });
+
+  it("returns the raw model when no migrations section exists", async () => {
+    readFileMock.mockResolvedValue('model = "gpt-5.5"\nmodel_reasoning_effort = "medium"\n');
+    await expect(resolveCodexModel()).resolves.toBe("gpt-5.5");
+  });
+
+  it("applies [notice.model_migrations] to the model", async () => {
+    const toml = [
+      'model = "gpt-5.3-codex"',
+      'model_reasoning_effort = "medium"',
+      "",
+      "[notice.model_migrations]",
+      '"gpt-5.3-codex" = "gpt-5.5"',
+      "",
+      "[tui.model_availability_nux]",
+      '"gpt-5.5" = 4',
+    ].join("\n");
+    readFileMock.mockResolvedValue(toml);
+    await expect(resolveCodexModel()).resolves.toBe("gpt-5.5");
+  });
+
+  it("returns the model unchanged when it is not in the migrations map", async () => {
+    const toml = [
+      'model = "gpt-5.5"',
+      "",
+      "[notice.model_migrations]",
+      '"gpt-5.3-codex" = "gpt-5.5"',
+    ].join("\n");
+    readFileMock.mockResolvedValue(toml);
+    await expect(resolveCodexModel()).resolves.toBe("gpt-5.5");
+  });
+
+  it("returns undefined when config has no model key", async () => {
+    readFileMock.mockResolvedValue('model_reasoning_effort = "medium"\n');
+    await expect(resolveCodexModel()).resolves.toBeUndefined();
+  });
+
+  it("reads from CODEX_HOME when set", async () => {
+    process.env["CODEX_HOME"] = "/custom/codex";
+    readFileMock.mockResolvedValue('model = "gpt-5.5"\n');
+    await resolveCodexModel();
+    expect(readFileMock).toHaveBeenCalledWith("/custom/codex/config.toml", "utf8");
+  });
+
+  it("reads from ~/.codex/config.toml by default", async () => {
+    readFileMock.mockResolvedValue('model = "gpt-5.5"\n');
+    const { homedir } = await import("node:os");
+    const expected = `${homedir()}/.codex/config.toml`;
+    await resolveCodexModel();
+    expect(readFileMock).toHaveBeenCalledWith(expected, "utf8");
+  });
+});

--- a/src/control/codex/__tests__/config.test.ts
+++ b/src/control/codex/__tests__/config.test.ts
@@ -35,6 +35,18 @@ describe("resolveCodexModel", () => {
     await expect(resolveCodexModel()).resolves.toBe("gpt-5.5");
   });
 
+  it("applies migrations when the section is the last one in the file", async () => {
+    const toml = [
+      'model = "gpt-5.3-codex"',
+      "",
+      "[notice.model_migrations]",
+      '"gpt-5.3-codex" = "gpt-5.5"',
+      "",
+    ].join("\n");
+    readFileMock.mockResolvedValue(toml);
+    await expect(resolveCodexModel()).resolves.toBe("gpt-5.5");
+  });
+
   it("returns the model unchanged when it is not in the migrations map", async () => {
     const toml = [
       'model = "gpt-5.5"',

--- a/src/control/codex/__tests__/driver.test.ts
+++ b/src/control/codex/__tests__/driver.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { CodexInteractiveDriver, shouldReattachCodex } from "../driver.js";
 import { EventEmitter } from "node:events";
+
+vi.mock("../config.js", () => ({ resolveCodexModel: vi.fn() }));
+import { resolveCodexModel } from "../config.js";
+const resolveCodexModelMock = vi.mocked(resolveCodexModel);
+afterEach(() => vi.resetAllMocks());
 
 describe("shouldReattachCodex (boot reattach guard — anti-MCP-storm)", () => {
   const NOW = 1_000_000;
@@ -52,6 +57,7 @@ function fakeClient() {
 
 describe("CodexInteractiveDriver.dispatch", () => {
   it("ensures handshake, starts a thread, emits task.session + task.started", async () => {
+    resolveCodexModelMock.mockResolvedValue(undefined);
     const client = fakeClient();
     const events: any[] = [];
     const drv = new CodexInteractiveDriver({
@@ -73,6 +79,40 @@ describe("CodexInteractiveDriver.dispatch", () => {
       { type: "task.session", id: "t1", resumeRef: "TH-1" },
       { type: "task.started", id: "t1" },
     ]);
+  });
+
+  it("resolves model from codex config when rec.model is undefined (fixes ChatGPT 400)", async () => {
+    resolveCodexModelMock.mockResolvedValue("gpt-5.5");
+    const client = fakeClient();
+    const drv = new CodexInteractiveDriver({ makeClient: () => client, emit: () => {} });
+    await drv.dispatch({
+      id: "t1", project: "p", provider: "codex", mode: "interactive",
+      state: "submitted", task: "x", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000,
+      attempts: [{ attemptId: "a1", startedAt: 1, lastHeartbeatAt: 1 }],
+      cwd: "/tmp/work",
+    } as any);
+    expect(client.startThread).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "gpt-5.5" }),
+    );
+  });
+
+  it("uses rec.model directly when explicitly set (crew-role model override)", async () => {
+    resolveCodexModelMock.mockResolvedValue("gpt-5.5");
+    const client = fakeClient();
+    const drv = new CodexInteractiveDriver({ makeClient: () => client, emit: () => {} });
+    await drv.dispatch({
+      id: "t1", project: "p", provider: "codex", mode: "interactive",
+      state: "submitted", task: "x", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000,
+      attempts: [{ attemptId: "a1", startedAt: 1, lastHeartbeatAt: 1 }],
+      cwd: "/tmp/work", model: "o4-mini",
+    } as any);
+    expect(client.startThread).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "o4-mini" }),
+    );
+    // Config resolution not needed when rec.model is already set
+    expect(resolveCodexModelMock).not.toHaveBeenCalled();
   });
 
   it("runs codex crews with danger-full-access (parity with unsandboxed claude/opencode) so `cockpit crew signal` reaches the daemon socket", async () => {

--- a/src/control/codex/config.ts
+++ b/src/control/codex/config.ts
@@ -1,0 +1,41 @@
+// src/control/codex/config.ts
+// Read the user's codex config (~/.codex/config.toml or $CODEX_HOME/config.toml)
+// and resolve the active model, applying [notice.model_migrations] so cockpit
+// uses the same model the TUI would use (e.g. gpt-5.3-codex → gpt-5.5).
+
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export async function resolveCodexModel(): Promise<string | undefined> {
+  const home = process.env["CODEX_HOME"] ?? join(homedir(), ".codex");
+  const configPath = join(home, "config.toml");
+
+  let text: string;
+  try {
+    text = await readFile(configPath, "utf8");
+  } catch {
+    return undefined;
+  }
+
+  // Extract top-level `model = "..."` (only before the first section header).
+  const topLevel = text.split(/^\[/m)[0] ?? "";
+  const modelMatch = topLevel.match(/^model\s*=\s*"([^"]+)"/m);
+  if (!modelMatch) return undefined;
+  let model = modelMatch[1]!;
+
+  // Apply [notice.model_migrations] — the TUI uses this map to upgrade legacy
+  // model names (e.g. gpt-5.3-codex → gpt-5.5) before calling thread/start.
+  // Without this, the app-server sends the stale name and ChatGPT OAuth rejects
+  // it with a 400: "The 'gpt-5.3-codex' model is not supported".
+  const migSection = text.match(/^\[notice\.model_migrations\]([\s\S]*?)(?=^\[|\z)/m);
+  if (migSection) {
+    const migRe = /^"([^"]+)"\s*=\s*"([^"]+)"/mg;
+    let m: RegExpExecArray | null;
+    while ((m = migRe.exec(migSection[1]!)) !== null) {
+      if (m[1] === model) { model = m[2]!; break; }
+    }
+  }
+
+  return model;
+}

--- a/src/control/codex/config.ts
+++ b/src/control/codex/config.ts
@@ -28,7 +28,10 @@ export async function resolveCodexModel(): Promise<string | undefined> {
   // model names (e.g. gpt-5.3-codex → gpt-5.5) before calling thread/start.
   // Without this, the app-server sends the stale name and ChatGPT OAuth rejects
   // it with a 400: "The 'gpt-5.3-codex' model is not supported".
-  const migSection = text.match(/^\[notice\.model_migrations\]([\s\S]*?)(?=^\[|\z)/m);
+  // Capture the section body up to the next section header (`^[`) or end of
+  // input. JS regex has no `\z`; `(?![\s\S])` is the end-of-input assertion so
+  // migrations still resolve when the section is the last one in the file.
+  const migSection = text.match(/^\[notice\.model_migrations\]([\s\S]*?)(?=^\[|(?![\s\S]))/m);
   if (migSection) {
     const migRe = /^"([^"]+)"\s*=\s*"([^"]+)"/mg;
     let m: RegExpExecArray | null;

--- a/src/control/codex/driver.ts
+++ b/src/control/codex/driver.ts
@@ -6,6 +6,7 @@
 // requests and lifecycle. Spec §4.1/§4.6/§4.7.
 
 import { AppServerClient } from "./app-server-client.js";
+import { resolveCodexModel } from "./config.js";
 import { normalizeAppServerNotification } from "./normalize.js";
 import type { ControlEvent, TaskRecord } from "../types.js";
 import { TERMINAL_STATES } from "../types.js";
@@ -71,9 +72,14 @@ export class CodexInteractiveDriver {
     try {
       const c = await this.ensureClient();
       await withTimeout(this.ensureHandshake(), 10_000, "handshake timed out");
+      // When no model is explicitly set on the task record, read the user's
+      // codex config and apply model migrations (e.g. gpt-5.3-codex → gpt-5.5).
+      // Without this the app-server falls back to the raw config value and
+      // ChatGPT OAuth rejects it with a 400 (verified: gpt-5.5 succeeds).
+      const model = rec.model ?? await resolveCodexModel();
       const { threadId } = await c.startThread({
         cwd: rec.cwd ?? process.cwd(),
-        model: rec.model,
+        model,
         // Parity with claude/opencode crews, which run UNSANDBOXED (no Seatbelt).
         // Codex was the only agent under `workspace-write`, and that FS sandbox
         // blocked `cockpit crew signal …` from reaching the daemon socket (which


### PR DESCRIPTION
## Problem

Codex crews dispatched without an explicit `rec.model` let the app-server fall back to the raw `~/.codex/config.toml` value (`gpt-5.3-codex`). On ChatGPT OAuth accounts, every `turn/start` then fails with a 400:

> The 'gpt-5.3-codex' model is not supported

This broke codex crews on every turn. Verified via probe script: `gpt-5.3-codex` 400s, `gpt-5.5` succeeds — and `gpt-5.5` is exactly what the codex TUI uses, because it applies the `[notice.model_migrations]` map before calling the app-server.

## Fix

New `resolveCodexModel()` reads `~/.codex/config.toml` (honoring `$CODEX_HOME`), extracts the top-level `model`, and applies `[notice.model_migrations]` so cockpit dispatches the same model the TUI would. `driver.dispatch` now uses `rec.model ?? await resolveCodexModel()` — an explicit crew-role model override still wins and skips config resolution entirely.

The migrations capture uses a proper JS end-of-input assertion `(?![\s\S])` rather than `\z` (which JS treats as a literal `z`), so migrations still resolve when `[notice.model_migrations]` is the last section in the file.

## Tests

- `config.test.ts` — 8 cases: missing file, no migrations, migration applied, **migration when section is last**, no-match passthrough, missing model key, `CODEX_HOME` vs default path
- `driver.test.ts` — resolves from config when `rec.model` is undefined; uses `rec.model` directly (and skips config read) when set

Full suite: **711/711 pass**, `tsc --noEmit` clean. `gitnexus detect_changes`: low risk, no affected execution flows.