### PR TITLE
fix(crew-signals): detect fatal session errors in pane probe (#196)

### DIFF
--- a/src/commands/__tests__/notify-relay-probe.test.ts
+++ b/src/commands/__tests__/notify-relay-probe.test.ts
@@ -129,6 +129,29 @@ describe("createInteractiveProbe", () => {
     });
   });
 
+  it("sends exactly one task.failed when a quiet working crew's pane shows an API error banner", async () => {
+    const errorTail = [
+      "● Starting the first turn.",
+      '⎿ API Error: 529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+    ].join("\n");
+    const h = harness({ tasks: [task()], readPaneTail: async () => errorTail });
+    await h.tick();
+    expect(h.sendEvent).toHaveBeenCalledTimes(1);
+    const ev = h.sendEvent.mock.calls[0][0] as ControlEvent;
+    expect(ev.type).toBe("task.failed");
+    expect((ev as { id: string }).id).toBe("task-1");
+    expect((ev as { error: string }).error).toContain("API Error: 529");
+  });
+
+  it("does not re-send task.failed when the error tail is unchanged on the next tick", async () => {
+    const errorTail = "  503 Service Unavailable";
+    const h = harness({ tasks: [task()], readPaneTail: async () => errorTail });
+    await h.tick();
+    await h.tick();
+    expect(h.sendEvent).toHaveBeenCalledTimes(1);
+    expect((h.sendEvent.mock.calls[0][0] as ControlEvent).type).toBe("task.failed");
+  });
+
   it("does not block a working pane with no prompt or question", async () => {
     const h = harness({ tasks: [task()], readPaneTail: async () => "● running the tests next" });
     await h.tick();

--- a/src/commands/notify-relay.ts
+++ b/src/commands/notify-relay.ts
@@ -95,7 +95,9 @@ interface InteractiveProbeDeps {
  *     lastHeartbeat) candidates,
  *  3. read each candidate's pane tail and skip it if the tail is unchanged
  *     since the last tick (per-task change-detection → fires once per prompt),
- *  4. classify the tail; a permission/question verdict → one task.blocked.
+ *  4. classify the tail; a permission/question verdict → one task.blocked, a
+ *     fatal error-banner verdict → one task.failed (#196 — a turn that died on a
+ *     transient API error leaves the process alive and silently stuck).
  *
  * Best-effort throughout: every read/daemon call is caught and logged; the tick
  * never throws, so a transient cmux/daemon failure can't crash the relay. The
@@ -136,18 +138,30 @@ export function createInteractiveProbe(deps: InteractiveProbeDeps): {
 
       const verdict = classifyPaneTail(tail);
       if (!verdict) continue;
-      const reason =
-        verdict.kind === "approval"
-          ? "crew awaiting permission (pane-detected)"
-          : "crew asked a question (pane-detected)";
+      // #196: a fatal error banner on a quiet working pane means the turn died
+      // (transient API error / crash) and the crew is silently stuck — fire the
+      // terminal task.failed so the captain gets CREW FAILED, not just an
+      // eventual non-alarming idle. Recoverable via `crew send` (task.reopened).
+      const event: ControlEvent =
+        verdict.kind === "error"
+          ? {
+              type: "task.failed",
+              id: rec.id,
+              error: `crew session error (pane-detected): ${verdict.text}`,
+            }
+          : {
+              type: "task.blocked",
+              id: rec.id,
+              reason:
+                verdict.kind === "approval"
+                  ? "crew awaiting permission (pane-detected)"
+                  : "crew asked a question (pane-detected)",
+              question: verdict.text,
+            };
       try {
-        await deps.sendEvent({
-          type: "task.blocked",
-          id: rec.id,
-          reason,
-          question: verdict.text,
-        });
-        deps.log(`probe -> CREW BLOCKED ${rec.name} (${verdict.kind})`);
+        await deps.sendEvent(event);
+        const label = verdict.kind === "error" ? "CREW FAILED" : "CREW BLOCKED";
+        deps.log(`probe -> ${label} ${rec.name} (${verdict.kind})`);
       } catch (e) {
         deps.log(`probe sendEvent failed for ${rec.id}: ${(e as Error).message}`);
       }

--- a/src/control/__tests__/pane-classifier.test.ts
+++ b/src/control/__tests__/pane-classifier.test.ts
@@ -65,6 +65,67 @@ describe("classifyPaneTail", () => {
     expect(classifyPaneTail(chromeOnly)).toBeNull();
   });
 
+  it("classifies a Claude API 529 overloaded banner as error", () => {
+    const tail = [
+      "● Patching the reducer next.",
+      '⎿ API Error: 529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+      "╭────────────────────────────╮",
+      "│ >                          │",
+      "╰────────────────────────────╯",
+    ].join("\n");
+    const r = classifyPaneTail(tail);
+    expect(r?.kind).toBe("error");
+    expect(r?.text).toContain("API Error: 529");
+  });
+
+  it("classifies an HTTP 503 service-unavailable banner as error", () => {
+    const tail = [
+      "● Calling the model...",
+      "  503 Service Unavailable",
+      "╭────────────────────────────╮",
+      "│ >                          │",
+      "╰────────────────────────────╯",
+    ].join("\n");
+    expect(classifyPaneTail(tail)?.kind).toBe("error");
+  });
+
+  it("classifies a retry-exhaustion banner as error", () => {
+    const tail = [
+      "  Request failed after maximum retries",
+      "╭────────────────────────────╮",
+      "│ >                          │",
+      "╰────────────────────────────╯",
+    ].join("\n");
+    expect(classifyPaneTail(tail)?.kind).toBe("error");
+  });
+
+  it("does not misfire error on prose that merely mentions errors", () => {
+    const tail = [
+      "● I added error handling for the 500 most common cases.",
+      "● The tests cover the unavailable-network path too.",
+      "╭────────────────────────────╮",
+      "│ >                          │",
+      "╰────────────────────────────╯",
+    ].join("\n");
+    expect(classifyPaneTail(tail)).toBeNull();
+  });
+
+  it("prefers a trailing question over error so a recoverable wait is never mis-failed", () => {
+    // A genuine question that happens to mention an error term must stay a
+    // (recoverable) question, not become a terminal failure.
+    const tail = [
+      "The last call hit an API Error earlier.",
+      "Should I retry the request now?",
+      "╭────────────────────────────╮",
+      "│ >                          │",
+      "╰────────────────────────────╯",
+    ].join("\n");
+    expect(classifyPaneTail(tail)).toEqual({
+      kind: "question",
+      text: "Should I retry the request now?",
+    });
+  });
+
   it("does not misfire approval on a numbered list that lacks a Yes/No block", () => {
     const numberedList = [
       "Here is the plan:",

--- a/src/control/interactive/pane-classifier.ts
+++ b/src/control/interactive/pane-classifier.ts
@@ -13,12 +13,20 @@ import { detectTrailingQuestion } from "./claude.js";
  *  - "question": the agent's output region (TUI chrome stripped) ends in a
  *    direct question. Mainly the opencode path; Claude turn-end questions are
  *    already handled by the #174 Stop-hook transcript path.
+ *  - "error": the pane shows a fatal CLI error banner (e.g. Anthropic
+ *    `API Error: 529 Overloaded`, an HTTP 5xx, retry exhaustion). A turn that
+ *    dies on a transient API error leaves the process ALIVE with the banner
+ *    frozen in the pane and no further heartbeat — the probe's only window onto
+ *    it (#196). text = the banner line. Checked LAST so a genuine approval /
+ *    question that merely mentions an error stays recoverable, never terminal.
  *  - else null.
  *
  * Conservative by design: it only runs against a quiet working pane and must not
  * false-block, so an ambiguous tail returns null.
  */
-export function classifyPaneTail(tail: string): { kind: "approval" | "question"; text: string } | null {
+export function classifyPaneTail(
+  tail: string,
+): { kind: "approval" | "question" | "error"; text: string } | null {
   if (!tail) return null;
   const raw = tail.split(/\r?\n/);
   // cleaned[i] is the agent-region text of line i, or null if the line is pure
@@ -52,8 +60,30 @@ export function classifyPaneTail(tail: string): { kind: "approval" | "question";
   const q = detectTrailingQuestion(region);
   if (q) return { kind: "question", text: q };
 
+  // ── error: a fatal CLI error banner (#196), checked LAST so a recoverable
+  // approval/question above always wins. Match the LAST banner line (the final
+  // error after any retry chatter is the most informative).
+  let errLine: string | null = null;
+  for (const c of cleaned) {
+    if (c != null && ERROR_BANNER_RE.some((re) => re.test(c))) errLine = c;
+  }
+  if (errLine) return { kind: "error", text: errLine.slice(0, 200) };
+
   return null;
 }
+
+// Distinctive fatal-error-banner signatures a crew's CLI prints when a turn
+// dies (Anthropic / OpenAI / opencode). Anchored to CLI banner SHAPES — never a
+// bare "error" / lone status code — so a crew merely discussing errors in prose
+// is never mis-failed. Combined with the probe's working+quiet precondition,
+// these only fire on a genuinely stalled, error-frozen pane.
+const ERROR_BANNER_RE: RegExp[] = [
+  /\bAPI Error\b/i,                                    // Claude: "API Error: 529 ..."
+  /\bOverloaded\b/,                                    // Anthropic overloaded_error message
+  /\b(?:429|500|502|503|504|529)\b[^?]*\b(?:overloaded|unavailable|internal server error|bad gateway|gateway timeout|too many requests|service unavailable)\b/i,
+  /\bretr(?:y|ies)\s+(?:exhausted|limit\s+(?:reached|exceeded))\b/i,
+  /\bmaximum\s+retries\b/i,
+];
 
 // A numbered option line, after chrome stripping: an optional cursor marker
 // (❯ / > / ›), a number, a dot, then the label. e.g. "❯ 1. Yes".


### PR DESCRIPTION
## Problem
When a crew's CLI session errors out (Anthropic API 5xx/529, retry exhaustion, fatal banner) while the task is non-terminal, no CREW signal reached the captain — the crew silently stalled (closes #196).

## Fix
- `pane-classifier.ts`: `classifyPaneTail` gains an "error" verdict for **fatal CLI banners** (API Error, Overloaded, 5xx+error-noun, maximum retries) — anchored to banner shapes (never a bare 'error'), checked **last** so a recoverable approval/question that merely mentions an error stays a block.
- `notify-relay.ts`: an "error" verdict emits the existing terminal `task.failed` → CREW FAILED (recoverable via crew send → `task.reopened`).
- **No new event type, no state-machine change** — `task.failed` already transitions non-terminal→failed and is absorbed once terminal.

## Tradeoff (flagged for review)
`task.failed` is terminal, so a 529 still mid-auto-retry when probed would mark the crew failed early. The 20s quiet gate (PROBE_QUIET_MS) gives retries time; `task.reopened` recovers. Swappable to `task.blocked` (one line) if you prefer non-terminal.

## Verification
4 files +141/−13. TDD (5 tests RED→GREEN). Full suite 718 pass, tsc clean. gitnexus impact (both LOW) + detect_changes confirmed scope.

🤖 cockpit-captain — chosen over the sonnet variant for its smaller, reuse-first design.