### PR TITLE
feat(crew): config-driven permission mode; default crews to opus + auto

### DIFF
--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -408,6 +408,45 @@ describe("cockpit crew spawn", () => {
     expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ model: undefined }));
   });
 
+  it("passes the configured crew permission mode to buildCommand", async () => {
+    loadConfig.mockReturnValue({
+      ...baseConfig,
+      defaults: {
+        ...baseConfig.defaults,
+        permissions: { command: "auto", captain: "auto", crew: "auto" },
+      },
+    });
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude --permission-mode auto ...");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-pm" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-pm" });
+
+    const promise = runCrewSpawn({ project: "brove", task: "task" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ permissionMode: "auto" }));
+  });
+
+  it("falls back to acceptEdits when no crew permission mode is configured", async () => {
+    // baseConfig.defaults.permissions = {} → no crew key set.
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude ...");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-pmf" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-pmf" });
+
+    const promise = runCrewSpawn({ project: "brove", task: "task" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ permissionMode: "acceptEdits" }));
+  });
+
   it("respects --direction override", async () => {
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -272,10 +272,11 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
       role: "crew",
       promptFile,
       interactive: true,
-      // Semi-automatic gate: auto-accept file edits, still prompt for risky
-      // ops (Bash, etc.). Replaces reliance on cmux's unreliable auto-accept
-      // toggle and enables running crews on cheaper models.
-      permissionMode: "acceptEdits",
+      // Permission mode is config-driven (defaults.permissions.crew) so cockpit
+      // can default crews to 'auto' or keep the semi-automatic 'acceptEdits'
+      // gate (auto-accept edits, still prompt for risky ops). Falls back to
+      // 'acceptEdits' when unset.
+      permissionMode: config.defaults.permissions?.crew ?? "acceptEdits",
       ...(crewModel ? { model: crewModel } : {}),
     });
     const direction: PanePlacement = input.direction ?? "tab";

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -51,7 +51,13 @@ describe("config", () => {
     const config = getDefaultConfig();
     expect(config.defaults.roles).toBeDefined();
     expect(config.defaults.roles!.command).toEqual({ agent: "claude", model: "opus" });
-    expect(config.defaults.roles!.crew).toEqual({ agent: "claude", model: "sonnet" });
+    expect(config.defaults.roles!.crew).toEqual({ agent: "claude", model: "opus" });
+  });
+
+  it("defaults crews to opus + auto permission mode", () => {
+    const config = getDefaultConfig();
+    expect(config.defaults.models!.crew).toBe("opus");
+    expect(config.defaults.permissions.crew).toBe("auto");
   });
 
   it("migrates old models config to roles on load", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,18 +87,19 @@ export function getDefaultConfig(): CockpitConfig {
       permissions: {
         command: "auto",
         captain: "auto",
+        crew: "auto",
       },
       models: {
         command: "opus",
         captain: "opus",
-        crew: "sonnet",
+        crew: "opus",
         exploration: "haiku",
         review: "opus",
       },
       roles: {
         command: { agent: "claude", model: "opus" },
         captain: { agent: "claude", model: "opus" },
-        crew: { agent: "claude", model: "sonnet" },
+        crew: { agent: "claude", model: "opus" },
         exploration: { agent: "claude", model: "haiku" },
       },
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,9 @@ export interface ProjectConfig {
 export interface PermissionConfig {
   command: string;   // permission mode for the command session
   captain: string;   // permission mode for captain sessions
+  crew?: string;     // permission mode for crew sessions (default: acceptEdits)
+  // Flexible role->mode map so future roles don't need a type change.
+  [role: string]: string | undefined;
 }
 
 export type ModelAlias = "opus" | "sonnet" | "haiku";


### PR DESCRIPTION
## What
Makes the claude-crew permission mode config-driven and flips the **repo defaults** so fresh installs (`cockpit init`/update) get **opus + auto** crews.

- `crew.ts`: reads `config.defaults.permissions?.crew ?? "acceptEdits"` (was hardcoded `acceptEdits`).
- `config.ts` defaults: `models.crew` & `roles.crew` → **opus**; `permissions` gains **`crew: "auto"`**; `PermissionConfig` type extended.
- Driver already maps `auto` → `--permission-mode auto` (no driver change).

## Why
Benchmark (#196 task, sonnet acceptEdits vs opus auto): opus-auto = ~3× fewer tokens, faster, zero approval interruptions. User opted to optimize tokens over cost and make opus+auto the crew default. `auto` mode (not `--dangerously-skip-permissions`, which is explicitly rejected).

## Verification
3 files, +47. TDD (crew uses configured mode; falls back to acceptEdits). Full suite 721/721, tsc clean. gitnexus impact (LOW) + detect_changes confirmed scope.

🤖 cockpit-captain