### PR TITLE
fix(relay): self-restarting notify-relay so captain never goes blind (#186)

### DIFF
--- a/src/commands/__tests__/launch.test.ts
+++ b/src/commands/__tests__/launch.test.ts
@@ -21,7 +21,7 @@ vi.mock("../../lib/cmux-bin.js", () => ({
   resetCmuxBinCache: vi.fn(),
 }));
 
-import { cmuxLocal } from "../launch.js";
+import { cmuxLocal, buildRelaySupervisorCommand } from "../launch.js";
 
 describe("cmuxLocal (launch.ts direct-cmux helper)", () => {
   beforeEach(() => {
@@ -52,5 +52,30 @@ describe("cmuxLocal (launch.ts direct-cmux helper)", () => {
   it("returns trimmed stdout for callers that need the output", () => {
     execFileMock.mockReturnValue("  workspace:7 cockpit-captain  \n");
     expect(cmuxLocal(["current-workspace"])).toBe("workspace:7 cockpit-captain");
+  });
+});
+
+// #186: the relay can die (e.g. a boot race during a daemon restart throws
+// "captain workspace not running" → process.exit(1)) and, with no supervisor,
+// stays dead — silently blinding the captain to all crew notifications. The
+// relay tab therefore runs a self-restarting shell loop so any exit respawns.
+describe("buildRelaySupervisorCommand (#186 self-healing relay)", () => {
+  it("wraps the relay in an infinite restart loop, not a bare invocation", () => {
+    const cmd = buildRelaySupervisorCommand("cockpit");
+    // A bare `cockpit notify-relay ...` would die-and-stay-dead. The loop must
+    // re-run it after every exit.
+    expect(cmd).toMatch(/while .*; do .*; done/);
+    expect(cmd).toContain("cockpit notify-relay cockpit --as captain");
+  });
+
+  it("sleeps between restarts so a crash-loop doesn't spin hot", () => {
+    const cmd = buildRelaySupervisorCommand("cockpit");
+    expect(cmd).toMatch(/sleep \d+/);
+  });
+
+  it("re-runs the relay (relay invocation appears inside the loop body)", () => {
+    const cmd = buildRelaySupervisorCommand("brove");
+    const body = cmd.replace(/^while .*?; do /, "").replace(/; done$/, "");
+    expect(body).toContain("cockpit notify-relay brove --as captain");
   });
 });

--- a/src/commands/launch.ts
+++ b/src/commands/launch.ts
@@ -180,6 +180,30 @@ function buildAgentCmd(
 
 const NOTIFY_RELAY_TAB_TITLE = "✉ notify-relay";
 
+const RELAY_RESTART_DELAY_S = 3;
+
+/**
+ * Build the command for the relay tab as a self-restarting shell supervisor
+ * loop (#186). The relay process can exit on its own — most commonly a boot
+ * race during a daemon/session restart, where `runNotifyRelay` throws "captain
+ * workspace 'X' not running" and the CLI does `process.exit(1)`. With a bare
+ * `cockpit notify-relay …` invocation it then stays dead, and the captain is
+ * silently blind to every CREW BLOCKED/DONE event (the documented 2026-05-31
+ * failure). Wrapping it in `while true; do …; sleep N; done` makes any exit
+ * respawn the relay — and rides out the boot race until the captain workspace
+ * appears. The loop is typed into the tab's shell by spawnInjector, so the cmux
+ * tab is the supervisor; this needs no daemon (which can't spawn into cmux) and
+ * no captain-side hook (cmux owns the captain's settings).
+ */
+export function buildRelaySupervisorCommand(project: string): string {
+  const relay = `cockpit notify-relay ${project} --as captain`;
+  return (
+    `while true; do ${relay}; ` +
+    `echo "[notify-relay ${project}] exited (code $?), restarting in ${RELAY_RESTART_DELAY_S}s"; ` +
+    `sleep ${RELAY_RESTART_DELAY_S}; done`
+  );
+}
+
 /**
  * Add the notify-relay to a captain workspace as a background tab. The
  * relay tails the daemon's per-project mailbox and forwards each new event to
@@ -202,7 +226,7 @@ async function ensureNotifyRelayTab(
     }
     await runtime.spawnInjector({
       captainWorkspace: workspace,
-      command: `cockpit notify-relay ${project} --as captain`,
+      command: buildRelaySupervisorCommand(project),
       title: NOTIFY_RELAY_TAB_TITLE,
       placement: "background",
     });


### PR DESCRIPTION
## Problem (#186)
The cockpit `notify-relay` only ever spawns via `cockpit launch`. On **any** exit it stays dead, and the captain receives **zero** crew notifications (CREW BLOCKED/DONE) even though the daemon keeps recording every event. The documented failure (2026-05-31): the relay died during a series of daemon restarts and was never restarted on the next session — the captain was silently blind.

The most common death is a **boot race during a daemon/session restart**: `runNotifyRelay` throws `captain workspace 'X' not running` (notify-relay.ts:194) and the CLI does `process.exit(1)` (line 336).

## Why not a hook or the daemon
- **Captain SessionStart hook** — not viable. `buildCommand` passes no settings path for the captain (command.ts), cmux owns the captain's `--settings`, and cockpit hooks injected via `--settings` get overridden by the cmux wrapper.
- **Daemon supervisor** — not viable. cmux refuses any spawner not descended from its app process (the very reason the relay exists).

## Fix
The relay tab is the one cockpit-controlled process living inside the cmux tree, so wrap its command in a self-restarting shell loop:
```
while true; do cockpit notify-relay <project> --as captain; echo "…exited (code \$?), restarting in 3s"; sleep 3; done
```
Any exit respawns the relay, and it rides out the boot race until the captain workspace appears. Lives entirely in the cmux tab — no daemon, no captain-hook.

## Changes
- `src/commands/launch.ts` — new exported `buildRelaySupervisorCommand(project)`; `ensureNotifyRelayTab` uses it.
- `src/commands/__tests__/launch.test.ts` — 3 tests pinning the loop contract.

## Verification
- TDD RED→GREEN
- Full suite **725/725** passing, `tsc --noEmit` clean
- GitNexus `detect_changes`: low risk, 0 affected processes
- Live shell test confirms the loop respawns after each exit and `$?` captures the code

## Deliberately out of scope
A stale-cursor watchdog for mid-session *hangs*. All evidence is died-and-stayed-dead, which this fully covers. Follow-up if mid-session hangs ever appear.

Closes #186