### PR TITLE
test: guard macOS-only reapCrewChildren test to darwin (#203)

### DIFF
--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -805,7 +805,7 @@ describe("cockpit crew send/read/close/list", () => {
 });
 
 describe("reapCrewChildren", () => {
-  it("kills node processes tagged with the crew task ID and leaves sibling processes alive", async () => {
+  it.skipIf(process.platform !== "darwin")("kills node processes tagged with the crew task ID and leaves sibling processes alive", async () => {
     const taskId = `reap-crew-test-${process.pid}-${Date.now()}`;
     const siblingId = `reap-sibling-test-${process.pid}-${Date.now()}`;
 


### PR DESCRIPTION
Unblocks the v0.5.1 release CI. The reapCrewChildren test uses `ps auxE` (macOS-only) and fails on Linux CI; guard it with `it.skipIf(process.platform !== 'darwin')`. One-line change. Fixes the Test-step failure on main so the release workflow can tag + publish v0.5.1. See #203.