### PR TITLE
feat: add --task-file/--message-file to bypass shell injection (#177)

### DIFF
--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -18,6 +18,7 @@ import {
 import type { PaneRef, PanePlacement, RuntimeDriver } from "../runtimes/types.js";
 import { buildDispatchRequest, cockpitdCall, sendCodexFirstTurn } from "./crew-control.js";
 import { writePerCrewSettingsLocal, writePerCrewOpencodeConfig } from "../lib/per-crew-settings.js";
+import { resolveTextInput } from "../lib/resolve-text-input.js";
 import { TERMINAL_STATES, type TaskRecord } from "../control/types.js";
 
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "cockpit", "templates");
@@ -535,21 +536,23 @@ crewCommand
     "Spawn an interactive crew session as a tab in the captain's workspace (use --direction to split into a pane instead)",
   )
   .argument("<project>", "Project name (must be registered)")
-  .argument("<task>", "Initial task prompt for the crew session")
+  .argument("[task]", "Initial task prompt for the crew session (omit with --task-file)")
   .option("--name <name>", "Crew name (default: auto-generated crew-N)")
   .option("--direction <dir>", "Placement: tab (default) or split direction (right|left|up|down)", "tab")
   .option("--agent <name>", "Agent CLI to use (claude|codex|gemini|opencode)", "claude")
   .option("--approval", "force codex approvalPolicy='untrusted' (codex only; exercises gate primitive)", false)
+  .option("--task-file <path>", "Read task prompt from file instead of positional arg ('-' for stdin)")
   .action(
     async (
       project: string,
-      task: string,
-      opts: { name?: string; direction: PanePlacement; agent: string; approval: boolean },
+      task: string | undefined,
+      opts: { name?: string; direction: PanePlacement; agent: string; approval: boolean; taskFile?: string },
     ) => {
       try {
+        const resolvedTask = await resolveTextInput({ positional: task, filePath: opts.taskFile, label: "task" });
         const pane = await runCrewSpawn({
           project,
-          task,
+          task: resolvedTask,
           name: opts.name,
           direction: opts.direction,
           agent: opts.agent,
@@ -588,10 +591,12 @@ crewCommand
   .description("Send a follow-up message to an existing crew session")
   .argument("<project>", "Project name")
   .argument("<name>", "Crew name (e.g. crew-1)")
-  .argument("<message>", "Message to send")
-  .action(async (project: string, name: string, message: string) => {
+  .argument("[message]", "Message to send (omit with --message-file)")
+  .option("--message-file <path>", "Read message from file instead of positional arg ('-' for stdin)")
+  .action(async (project: string, name: string, message: string | undefined, opts: { messageFile?: string }) => {
     try {
-      await runCrewSend(project, name, message);
+      const resolvedMessage = await resolveTextInput({ positional: message, filePath: opts.messageFile, label: "message" });
+      await runCrewSend(project, name, resolvedMessage);
       console.log(chalk.green(`✔ Sent to ${project}:${name}`));
     } catch (err) {
       console.error(chalk.red((err as Error).message));

--- a/src/lib/__tests__/resolve-text-input.test.ts
+++ b/src/lib/__tests__/resolve-text-input.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { resolveTextInput } from "../resolve-text-input.js";
+
+describe("resolveTextInput", () => {
+  describe("file precedence over positional", () => {
+    it("reads from file when --task-file is provided, ignoring positional", async () => {
+      const content = await resolveTextInput(
+        { positional: "positional task", filePath: "/tmp/task.txt", label: "task" },
+        { readFile: () => "file content" },
+      );
+      expect(content).toBe("file content");
+    });
+
+    it("reads from file when --message-file is provided, ignoring positional", async () => {
+      const content = await resolveTextInput(
+        { positional: "positional msg", filePath: "/tmp/msg.txt", label: "message" },
+        { readFile: () => "message from file" },
+      );
+      expect(content).toBe("message from file");
+    });
+  });
+
+  describe("stdin via '-'", () => {
+    it("reads stdin when --task-file - is provided", async () => {
+      const content = await resolveTextInput(
+        { filePath: "-", label: "task" },
+        { readStdin: async () => "stdin content with `backticks`" },
+      );
+      expect(content).toBe("stdin content with `backticks`");
+    });
+
+    it("reads stdin when --message-file - is provided", async () => {
+      const content = await resolveTextInput(
+        { filePath: "-", label: "message" },
+        { readStdin: async () => "stdin `message`" },
+      );
+      expect(content).toBe("stdin `message`");
+    });
+  });
+
+  describe("falls back to positional", () => {
+    it("returns positional when no file option is provided", async () => {
+      const content = await resolveTextInput(
+        { positional: "positional task", label: "task" },
+      );
+      expect(content).toBe("positional task");
+    });
+
+    it("returns empty string positional when provided as positional", async () => {
+      const content = await resolveTextInput(
+        { positional: "", label: "task" },
+      );
+      expect(content).toBe("");
+    });
+  });
+
+  describe("error cases", () => {
+    it("throws with clear error when --task-file path does not exist", async () => {
+      const err = new Error("ENOENT") as NodeJS.ErrnoException;
+      err.code = "ENOENT";
+      const readFile = () => { throw err; };
+
+      await expect(
+        resolveTextInput({ filePath: "/nonexistent/task.txt", label: "task" }, { readFile }),
+      ).rejects.toThrow(/--task-file.*file not found/);
+    });
+
+    it("throws with clear error when --message-file path does not exist", async () => {
+      const err = new Error("ENOENT") as NodeJS.ErrnoException;
+      err.code = "ENOENT";
+      const readFile = () => { throw err; };
+
+      await expect(
+        resolveTextInput({ filePath: "/nonexistent/msg.txt", label: "message" }, { readFile }),
+      ).rejects.toThrow(/--message-file.*file not found/);
+    });
+
+    it("throws clear error when neither positional nor --task-file is provided", async () => {
+      await expect(
+        resolveTextInput({ label: "task" }),
+      ).rejects.toThrow(/No task/);
+    });
+
+    it("throws clear error when neither positional nor --message-file is provided", async () => {
+      await expect(
+        resolveTextInput({ label: "message" }),
+      ).rejects.toThrow(/No message/);
+    });
+  });
+
+  describe("content preservation", () => {
+    it("preserves backticks, quotes, and newlines verbatim from files", async () => {
+      const content = await resolveTextInput(
+        { filePath: "/tmp/special.txt", label: "task" },
+        { readFile: () => "line one\nline two with `backticks`\nline three with \"quotes\"" },
+      );
+      expect(content).toBe("line one\nline two with `backticks`\nline three with \"quotes\"");
+    });
+
+    it("preserves backticks, quotes, and newlines verbatim from stdin", async () => {
+      const content = await resolveTextInput(
+        { filePath: "-", label: "message" },
+        { readStdin: async () => "line one\nline two with `backticks`\nline three with \"quotes\"" },
+      );
+      expect(content).toBe("line one\nline two with `backticks`\nline three with \"quotes\"");
+    });
+
+    it("preserves multi-line shell-injection payload verbatim from files", async () => {
+      const payload = "echo `id`\necho $(whoami)\necho \"nested '$HOME'\"";
+      const content = await resolveTextInput(
+        { filePath: "/tmp/payload.txt", label: "task" },
+        { readFile: () => payload },
+      );
+      expect(content).toBe(payload);
+    });
+  });
+
+  describe("real fs readFile (integration)", () => {
+    it("reads an actual file from disk via default readFile", async () => {
+      const { readFileSync } = await import("node:fs");
+      const { mkdtempSync } = await import("node:fs");
+      const { writeFileSync } = await import("node:fs");
+      const { rmSync } = await import("node:fs");
+      const { join } = await import("node:path");
+      const { tmpdir } = await import("node:os");
+
+      const tmp = mkdtempSync(join(tmpdir(), "resolve-test-"));
+      try {
+        const filePath = join(tmp, "input.txt");
+        writeFileSync(filePath, "real file content with `backticks`");
+        const content = await resolveTextInput(
+          { filePath, label: "task" },
+          { readFile: (p: string) => readFileSync(p, "utf8") },
+        );
+        expect(content).toBe("real file content with `backticks`");
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/src/lib/resolve-text-input.ts
+++ b/src/lib/resolve-text-input.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs";
+
+async function readAllStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+function flagName(label: string): string {
+  return label === "task" ? "--task-file" : "--message-file";
+}
+
+export interface ResolveTextInputOpts {
+  positional?: string;
+  filePath?: string;
+  label: string;
+}
+
+export interface ResolveTextInputDeps {
+  readFile?: (path: string) => string;
+  readStdin?: () => Promise<string>;
+}
+
+export async function resolveTextInput(
+  opts: ResolveTextInputOpts,
+  deps?: ResolveTextInputDeps,
+): Promise<string> {
+  const readFile = deps?.readFile ?? ((p: string) => fs.readFileSync(p, "utf8"));
+  const readStdin = deps?.readStdin ?? readAllStdin;
+
+  if (opts.filePath) {
+    if (opts.filePath === "-") {
+      return readStdin();
+    }
+    try {
+      return readFile(opts.filePath);
+    } catch (e) {
+      const err = e as NodeJS.ErrnoException;
+      const flag = flagName(opts.label);
+      if (err.code === "ENOENT") {
+        throw new Error(`${flag} '${opts.filePath}': file not found`);
+      }
+      throw new Error(`${flag} '${opts.filePath}': ${err.message}`);
+    }
+  }
+
+  if (opts.positional === undefined) {
+    throw new Error(
+      `No ${opts.label} provided. Provide a positional argument or use ${flagName(opts.label)}.`,
+    );
+  }
+
+  return opts.positional;
+}


### PR DESCRIPTION
## Summary

Fixes #177 — crew spawn/send task text is shell-injected when callers use double quotes containing backticks.

## Changes

### New: resolveTextInput helper (`src/lib/resolve-text-input.ts`)
Small async function with injectable deps that resolves text from either:
- A positional argument (back-compat)
- A file path (`--task-file <path>` / `--message-file <path>`)
- stdin (`--task-file -` / `--message-file -`)

### Changed: `src/commands/crew.ts`
- `cockpit crew spawn`: `<task>` → `[task]` (optional when `--task-file` used), added `--task-file <path>` option
- `cockpit crew send`: `<message>` → `[message]` (optional when `--message-file` used), added `--message-file <path>` option
- Both action handlers call `resolveTextInput` before dispatching

### Tests
- 14 unit tests for resolveTextInput (file precedence, stdin, errors, content preservation)
- All 739 existing tests pass (zero regressions)

## Design

The resolver takes `{positional, filePath, label}` plus optional `{readFile, readStdin}` deps for testability. File/flag takes precedence over positional. The positional arg is optional (Commander `[arg]`) when the flag is provided. Clear errors for missing input or missing files.

Backticks/quotes/newlines survive verbatim since they bypass shell parsing entirely.