### PR TITLE
fix(crew): bound crew read/tasks output (fix #135)

### DIFF
--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -107,7 +107,11 @@ cockpit crew send <project> <name> "<message>"
 
 ```bash
 cockpit crew list <project>                 # see all live crews for the project
-cockpit crew read <project> <name>          # read the crew's current screen
+cockpit crew tasks <project>                # compact task listing (use --json for verbose)
+cockpit crew tasks <project> --state-only <id>  # fast state check (prints one word)
+cockpit crew read <project> <name>          # read tail of a crew's screen (~40 lines)
+cockpit crew read <project> <name> --full   # entire scrollback (may be large)
+cockpit crew read <project> <name> --lines 100  # custom tail length
 cockpit crew close <project> <name>         # shutdown the crew (closes its tab)
 ```
 
@@ -148,10 +152,11 @@ cockpit crew spawn brove "Fix typo in README" --direction right
 ## Task Coordination
 
 You don't have an Agent Team or `TaskCreate`/`TaskUpdate` tools — those were Claude-specific. Track crew progress by:
-1. `cockpit crew read <project> <name>` — read the crew's screen directly from CLI.
-2. `cockpit crew list <project>` — see all live crews and pick the right one.
-3. Inspecting the crew tab visually in cmux when you want richer context (you have its surface ref from the spawn output).
-4. Asking the user to check the dashboard if you need a cross-project view (see issue #44).
+1. `cockpit crew read <project> <name>` — read tail of a crew's screen (default ~40 lines; `--full` for entire scrollback).
+2. `cockpit crew tasks <project>` — compact task listing (one line per task); `--id <prefix>` to filter; `--state-only <id>` for single-word state.
+3. `cockpit crew list <project>` — see all live crews and pick the right one.
+4. Inspecting the crew tab visually in cmux when you want richer context (you have its surface ref from the spawn output).
+5. Asking the user to check the dashboard if you need a cross-project view (see issue #44).
 
 When a crew sends you a status message via `cockpit runtime send <project> "<message>"`, it lands in your captain pane. Acknowledge, then update your handoff if a meaningful decision was made.
 

--- a/src/commands/__tests__/crew-output.test.ts
+++ b/src/commands/__tests__/crew-output.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from "vitest";
+import { tailLines, formatTaskLine, filterTasks, formatCompactTasks } from "../crew-output.js";
+import type { TaskRecord, TaskState } from "../../control/types.js";
+
+// ─── tailLines ───────────────────────────────────────────────────
+
+describe("tailLines", () => {
+  it("returns input unchanged when fewer lines than max", () => {
+    const text = "line1\nline2\nline3";
+    expect(tailLines(text, 10, 4096)).toBe(text);
+  });
+
+  it("returns last N lines when more lines than max", () => {
+    const text = "line1\nline2\nline3\nline4\nline5";
+    expect(tailLines(text, 3, 4096)).toBe("line3\nline4\nline5");
+  });
+
+  it("returns last N lines when equal to max", () => {
+    const text = "line1\nline2\nline3";
+    expect(tailLines(text, 3, 4096)).toBe(text);
+  });
+
+  it("respects byte cap (truncates at boundary)", () => {
+    const text = "a\nb\nc\nd\ne";
+    // Cap 5 bytes: last 5 bytes of the tail is "d\ne" (3 bytes) but
+    // we need to ensure the full last lines fit.
+    const result = tailLines(text, 100, 5);
+    expect(result.length).toBeLessThanOrEqual(5);
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(tailLines("", 40, 4096)).toBe("");
+  });
+
+  it("handles single line text", () => {
+    expect(tailLines("hello", 40, 4096)).toBe("hello");
+  });
+
+  it("handles trailing newline gracefully", () => {
+    const text = "a\nb\nc\n";
+    expect(tailLines(text, 2, 4096)).toBe("b\nc");
+  });
+
+  it("defaults to 40 lines and 4096 bytes", () => {
+    const lines: string[] = [];
+    for (let i = 0; i < 50; i++) lines.push(`line-${i}`);
+    const text = lines.join("\n");
+    const result = tailLines(text);
+    expect(result.split("\n").length).toBe(40);
+    expect(result).toBe(lines.slice(10).join("\n"));
+  });
+});
+
+// ─── formatTaskLine ──────────────────────────────────────────────
+
+describe("formatTaskLine", () => {
+  const base = {
+    id: "abc12345-def6-7890-abcd-ef1234567890",
+    name: "my-crew",
+    project: "testproj",
+    provider: "claude" as const,
+    mode: "interactive" as const,
+    state: "working" as TaskState,
+    task: "Implement the feature",
+    createdAt: 1000,
+    lastHeartbeat: 2000,
+    lastEvent: "task.started",
+    heartbeatBudgetMs: 300000,
+    attempts: [{ attemptId: "att1", startedAt: 1000, lastHeartbeatAt: 1500 }],
+  } satisfies TaskRecord;
+
+  it("includes short id, provider, state, lastEvent and truncated title", () => {
+    const line = formatTaskLine(base);
+    expect(line).toContain("abc12345");
+    expect(line).toContain("claude");
+    expect(line).toContain("working");
+    expect(line).toContain("Implem");
+  });
+
+  it("truncates task title to ~60 chars", () => {
+    const long = "A".repeat(200);
+    const record = { ...base, task: long };
+    const line = formatTaskLine(record);
+    // Should contain the truncated title (first line, ~60 chars)
+    expect(line.length).toBeLessThan(200);
+    expect(line).toContain("A".repeat(60));
+  });
+
+  it("collapses multi-line task to first line only", () => {
+    const record = { ...base, task: "first line\nsecond line\nthird line" };
+    const line = formatTaskLine(record);
+    expect(line).toContain("first line");
+    expect(line).not.toContain("second line");
+    expect(line).not.toContain("third line");
+  });
+
+  it("produces a single-line output", () => {
+    const line = formatTaskLine(base);
+    expect(line).not.toContain("\n");
+  });
+
+  it("handles missing name gracefully", () => {
+    const record = { ...base, task: "task" };
+    delete (record as { name?: string }).name;
+    const line = formatTaskLine(record);
+    expect(line).toContain("abc12345");
+  });
+
+  it("includes empty state indicator for empty lastEvent", () => {
+    const record = { ...base, lastEvent: "", state: "submitted" as TaskState };
+    const line = formatTaskLine(record);
+    expect(line).toContain("submitted");
+  });
+});
+
+// ─── filterTasks ─────────────────────────────────────────────────
+
+describe("filterTasks", () => {
+  const records: TaskRecord[] = [
+    {
+      id: "aaa-111", name: "crew-a", project: "p", provider: "claude",
+      mode: "interactive", state: "working" as TaskState, task: "task a",
+      createdAt: 1, lastHeartbeat: 1, lastEvent: "task.started",
+      heartbeatBudgetMs: 300000, attempts: [],
+    },
+    {
+      id: "bbb-222", name: "crew-b", project: "p", provider: "codex",
+      mode: "interactive", state: "done" as TaskState, task: "task b",
+      createdAt: 2, lastHeartbeat: 2, lastEvent: "task.done",
+      heartbeatBudgetMs: 300000, attempts: [],
+    },
+    {
+      id: "ccc-333", name: "crew-c", project: "p", provider: "opencode",
+      mode: "interactive", state: "blocked" as TaskState, task: "task c",
+      createdAt: 3, lastHeartbeat: 3, lastEvent: "task.blocked",
+      heartbeatBudgetMs: 300000, attempts: [],
+    },
+  ];
+
+  it("returns all records when no filters", () => {
+    expect(filterTasks(records, {}).length).toBe(3);
+  });
+
+  it("filters by id (prefix match)", () => {
+    const r = filterTasks(records, { id: "aaa" });
+    expect(r.length).toBe(1);
+    expect(r[0].id).toBe("aaa-111");
+  });
+
+  it("filters by state", () => {
+    const r = filterTasks(records, { state: "done" });
+    expect(r.length).toBe(1);
+    expect(r[0].state).toBe("done");
+  });
+
+  it("filters by id and state combined", () => {
+    const r = filterTasks(records, { id: "bbb", state: "working" });
+    expect(r.length).toBe(0);
+  });
+
+  it("returns empty array when no match", () => {
+    expect(filterTasks(records, { id: "zzz" })).toEqual([]);
+  });
+
+  it("finds stateOnly record by id (includes full state string)", () => {
+    const r = filterTasks(records, { id: "ccc", stateOnly: true });
+    expect(r.length).toBe(1);
+    expect(r[0].state).toBe("blocked");
+  });
+});
+
+// ─── formatCompactTasks ──────────────────────────────────────────
+
+describe("formatCompactTasks", () => {
+  const records: TaskRecord[] = [
+    {
+      id: "aaa-111", name: "crew-a", project: "p", provider: "claude",
+      mode: "interactive", state: "working" as TaskState, task: "task a",
+      createdAt: 1, lastHeartbeat: 1, lastEvent: "task.started",
+      heartbeatBudgetMs: 300000, attempts: [],
+    },
+  ];
+
+  it("formats compact list by default", () => {
+    const out = formatCompactTasks(records, {});
+    expect(out).toContain("aaa-111");
+    expect(out).not.toContain("\"id\"");
+  });
+
+  it("formats JSON when compact is false", () => {
+    const out = formatCompactTasks(records, { compact: false });
+    expect(out).toContain("\"id\"");
+    expect(out).toContain("\"aaa-111\"");
+  });
+
+  it("shows single state line when stateOnly is true", () => {
+    const out = formatCompactTasks(records, { stateOnly: true });
+    expect(out).toBe("working");
+  });
+
+  it("prints clear message for empty list", () => {
+    const out = formatCompactTasks([], {});
+    expect(out).toContain("no tasks");
+  });
+
+  it("prints clear message for empty list even with JSON", () => {
+    const out = formatCompactTasks([], { compact: false });
+    expect(out).toContain("no tasks");
+  });
+});

--- a/src/commands/crew-control.ts
+++ b/src/commands/crew-control.ts
@@ -9,6 +9,7 @@ import { sendRequest } from "../control/protocol.js";
 import { ensureDaemon } from "../control/launchd.js";
 import type { ControlEvent, Mode, Provider, TaskRecord } from "../control/types.js";
 import { mapClaudeHookToEvent } from "../control/interactive/claude.js";
+import { filterTasks, formatCompactTasks } from "./crew-output.js";
 import { crewAttachCommand } from "./crew-attach.js";
 import { crewChatCommand } from "./crew-chat.js";
 
@@ -203,9 +204,21 @@ export function addControlPlaneCrewCommands(crew: Command): void {
   crew
     .command("tasks <project>")
     .description("List control-plane tasks for a project (control-plane analogue of legacy `list`)")
-    .action(async (project: string) => {
-      const r = await cockpitdCall({ kind: "list", project });
-      process.stdout.write(JSON.stringify(r) + "\n");
+    .option("--json", "Full JSON output (one or more records)")
+    .option("--id <taskId>", "Show only tasks matching this id prefix")
+    .option("--state <state>", "Filter by task state")
+    .option("--state-only <taskId>", "Print just the state string for a single task")
+    .action(async (project: string, opts: { json?: boolean; id?: string; state?: string; stateOnly?: string }) => {
+      const raw = (await cockpitdCall({ kind: "list", project })) as TaskRecord[];
+      let records = raw;
+      if (opts.stateOnly) {
+        records = filterTasks(records, { id: opts.stateOnly, stateOnly: true });
+        process.stdout.write(formatCompactTasks(records, { stateOnly: true }) + "\n");
+        return;
+      }
+      records = filterTasks(records, { id: opts.id, state: opts.state });
+      const compact = opts.json !== true;
+      process.stdout.write(formatCompactTasks(records, { compact }) + "\n");
     });
 
   // TODO(downstream interactive-wiring spec): deliverReply is not yet wired in

--- a/src/commands/crew-output.ts
+++ b/src/commands/crew-output.ts
@@ -1,0 +1,67 @@
+import type { TaskRecord } from "../control/types.js";
+
+export function tailLines(
+  text: string,
+  maxLines = 40,
+  maxBytes = 4096,
+): string {
+  if (!text) return "";
+  const lines = text.split("\n");
+  if (lines.at(-1) === "") lines.pop();
+  const kept = lines.slice(-maxLines);
+  let result = kept.join("\n");
+  if (Buffer.byteLength(result, "utf-8") > maxBytes) {
+    const truncated: string[] = [];
+    let bytes = 0;
+    for (const line of kept) {
+      const lineBytes = Buffer.byteLength(line, "utf-8") + 1;
+      if (bytes + lineBytes > maxBytes) break;
+      truncated.push(line);
+      bytes += lineBytes;
+    }
+    result = truncated.join("\n");
+  }
+  return result;
+}
+
+function shortId(id: string): string {
+  return id.slice(0, 8);
+}
+
+export function formatTaskLine(record: TaskRecord): string {
+  const sid = shortId(record.id);
+  const title = record.task
+    .split("\n")[0]
+    .slice(0, 60);
+  return `${sid}  ${record.provider}  ${record.state}  ${record.lastEvent}  ${title}`;
+}
+
+export function filterTasks(
+  records: TaskRecord[],
+  opts: { id?: string; state?: string; stateOnly?: boolean },
+): TaskRecord[] {
+  let filtered = records;
+  if (opts.id) {
+    filtered = filtered.filter((r) => r.id.startsWith(opts.id!));
+  }
+  if (opts.state) {
+    filtered = filtered.filter((r) => r.state === opts.state);
+  }
+  return filtered;
+}
+
+export function formatCompactTasks(
+  records: TaskRecord[],
+  opts: { compact?: boolean; stateOnly?: boolean },
+): string {
+  if (records.length === 0) {
+    return "(no tasks match filter)";
+  }
+  if (opts.stateOnly) {
+    return records[0].state;
+  }
+  if (opts.compact === false) {
+    return JSON.stringify(records, null, 2);
+  }
+  return records.map(formatTaskLine).join("\n");
+}

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -17,6 +17,7 @@ import {
 } from "../drivers/index.js";
 import type { PaneRef, PanePlacement, RuntimeDriver } from "../runtimes/types.js";
 import { buildDispatchRequest, cockpitdCall, sendCodexFirstTurn } from "./crew-control.js";
+import { tailLines } from "./crew-output.js";
 import { writePerCrewSettingsLocal, writePerCrewOpencodeConfig } from "../lib/per-crew-settings.js";
 import { resolveTextInput } from "../lib/resolve-text-input.js";
 import { TERMINAL_STATES, type TaskRecord } from "../control/types.js";
@@ -606,13 +607,16 @@ crewCommand
 
 crewCommand
   .command("read")
-  .description("Read the current screen of a crew session")
+  .description("Read the current screen of a crew session (tail by default; use --full for the entire scrollback)")
   .argument("<project>", "Project name")
   .argument("<name>", "Crew name")
-  .action(async (project: string, name: string) => {
+  .option("--lines <N>", "Number of trailing lines to show", "40")
+  .option("--full", "Show the entire scrollback (overrides --lines)")
+  .action(async (project: string, name: string, opts: { lines?: string; full?: boolean }) => {
     try {
       const screen = await runCrewRead(project, name);
-      console.log(screen);
+      const out = opts.full ? screen : tailLines(screen, Number(opts.lines ?? 40));
+      console.log(out);
     } catch (err) {
       console.error(chalk.red((err as Error).message));
       process.exit(1);


### PR DESCRIPTION
## Summary

Fix #135: unbounded output from `cockpit crew read` and `cockpit crew tasks` was truncating tool results and forcing captains to `/compact`.

## Changes

### New file: `src/commands/crew-output.ts`
Pure helper functions with unit tests:
- **`tailLines(text, maxLines, maxBytes)`** — returns last N lines, respecting a byte cap. Defaults to 40 lines / 4KB.
- **`formatTaskLine(record)`** — single-line compact task display: short id (8 chars) + provider + state + lastEvent + truncated title (~60 chars).
- **`filterTasks(records, opts)`** — filter by id prefix, state, or stateOnly.
- **`formatCompactTasks(records, opts)`** — render as compact list, JSON, or state-only.

### `cockpit crew read` (src/commands/crew.ts)
- **Default**: bounded tail of ~40 lines (~4KB)
- `--lines <N>`: custom tail length
- `--full`: entire scrollback (preserves current behavior opt-in)

### `cockpit crew tasks` (src/commands/crew-control.ts)
- **Default**: compact one-line-per-task output
- `--json`: verbose full-record form (preserves current behavior opt-in)
- `--id <prefix>`: filter by task id prefix
- `--state <state>`: filter by state
- `--state-only <taskId>`: fast path — prints single state word
- Empty filters print a clear message (not empty dump)

### SKILL.md
Updated captain-ops guidance to recommend the compact forms.

## Verification
- 764 tests pass (74 files), including 25 new unit tests
- TypeScript `tsc --noEmit` clean
- GitNexus: LOW risk, 0 affected processes
- TDD: all new helpers were test-first