### PR TITLE
docs: fix crew lifecycle checklist methodology — two signal mechanisms, CP4 GAP #210, 2026-06-03 findings

### DIFF
--- a/docs/testing/crew-lifecycle-checklist.md
+++ b/docs/testing/crew-lifecycle-checklist.md
@@ -22,6 +22,24 @@ silently stuck. Every pause (question / permission / idle) and the finish must r
 
 ---
 
+## Two Signal Mechanisms
+
+The daemon receives crew state changes via **two distinct mechanisms**. Do not conflate them:
+
+**TYPE 1 — Automatic turn-end / idle / liveness** (daemon *observes* the agent; no model action required):
+| Agent | Mechanism | File ref | Reliability |
+|-------|-----------|----------|-------------|
+| claude | Stop hook → `cockpit crew _hook` → `task.turn.completed` | `src/control/interactive/claude.ts:198` | FLAKY — Stop hook may not fire (#187) |
+| opencode | Embedded HTTP server SSE `session.idle` → daemon `OpencodeSseBridge` → `task.turn.completed` | `src/control/opencode/sse-bridge.ts` | Reliable |
+| codex | app-server JSON-RPC `turn/completed` notification → `normalizeAppServerNotification` → `task.turn.completed` | `src/control/codex/normalize.ts:40-44` | Reliable, direct |
+
+**TYPE 2 — Explicit terminal DONE / BLOCKED / FAILED** (the crew *decides*; the model runs `cockpit crew signal …`):
+- **HARD INVARIANT** across all agents: NO automatic event maps to `task.done`. A turn ending ≠ the task being done (anti-#2576). "Done" is always explicit.
+- **claude / opencode:** `cockpit crew signal done|blocked|failed` reads `COCKPIT_CREW_TASK_ID` from the shell env (set on their cmux shell launch).
+- **codex:** the command needs `--task-id <id> --project <project>` (codex shares ONE app-server across threads; `startThread` has no env param, so no per-thread `COCKPIT_CREW_TASK_ID`). The codex crew template already injects these flags into its `developerInstructions` (PR #173). When driving a codex crew manually, pass `--task-id` / `--project` explicitly — do NOT use the bare claude-style command (it errors `COCKPIT_CREW_TASK_ID unset`).
+
+---
+
 ## Checkpoints
 
 Drive each from the **captain** side. "Captain signal" is what you must actually observe — a
@@ -42,6 +60,7 @@ notification reaching the captain session, not just the crew screen.
 - **Resolve:** `cockpit crew send cockpit lifecycle-test "<answer>"` — crew unblocks and proceeds
   using the answer.
 - [ ] PASS — blocked notification received **and** answer unblocked it
+> **Codex note:** Signals via the crew's own `developerInstructions` (PR #173) which inject `--task-id <id> --project cockpit`. When driving codex manually, pass those flags explicitly — the bare `cockpit crew signal...` errors `COCKPIT_CREW_TASK_ID unset`. See §"Two Signal Mechanisms" above.
 
 ### 3. Permission gate → captain approves
 - **Action:** Tell the crew to perform a **real privileged action** that the allowlist does NOT
@@ -59,18 +78,21 @@ notification reaching the captain session, not just the crew screen.
 > Note: #2 and #3 both surface as CREW BLOCKED but via **different feeders** — #2 is an explicit
 > `signal blocked`, #3 is the live Notification hook on a real prompt. Verify both paths.
 
-### 4. Idle — pings captain, NOT finished
+### 4. Idle — daemon transitions to awaiting-input (Type 1); captain ping is GAP (#210)
 - **Action:** Tell the crew to finish the current turn's work and **wait for the next turn
   without signaling done**.
-- **Expect:** crew completes the turn and goes idle/awaiting. The Stop hook fires a
-  `task.progress` **liveness** event (anti-#2576: bare turn-end ≠ done).
-- **Captain signal:** captain is pinged that the crew is **idle/awaiting** — and the daemon task
-  state is **non-terminal** (still `working`/awaiting, NOT `done`).
-- **Verify state:** `cockpit crew list cockpit` shows the crew alive and non-terminal.
-- [ ] PASS — idle ping received **and** state is not terminal
+- **Expect (daemon side):** The crew completes the turn. The Type 1 mechanism fires per agent:
+  - claude: Stop hook (flaky, #187) → `task.turn.completed` → daemon transitions `working → awaiting-input`.
+  - opencode: SSE `session.idle` → `OpencodeSseBridge` → `task.turn.completed` → awaiting-input. Reliable.
+  - codex: app-server JSON-RPC `turn/completed` → `task.turn.completed` → awaiting-input. Reliable.
+  The daemon task state is **non-terminal** (`awaiting-input`, NOT `done`).
+- **Captain signal:** **GAP (#210).** The relay's `formatEntry` drops `task.turn.completed` / `task.idle` events before they reach the captain mailbox. The captain currently receives NO idle/awaiting ping. Until #210 is fixed, expect this to FAIL for ALL agents.
+- **Verify state (workaround):** `cockpit crew list cockpit` shows the crew alive and non-terminal (`awaiting-input`). This confirms the daemon transitioned correctly even without the captain notification.
+- [ ] STATE VERIFIED — daemon state is non-terminal (`awaiting-input`); captain ping is **GAP (#210)** across all agents until the relay is fixed
 
 ### 5. Finish — pings captain (done)
 - **Action:** Tell the crew to run `cockpit crew signal done --message "<one-line summary>"`.
+  > **Codex note:** same `--task-id <id> --project cockpit` requirement as CP2; prefer the crew's self-signal via `developerInstructions`.
 - **Expect:** crew transitions to terminal `done`.
 - **Captain signal:** **CREW DONE** reaches the captain; daemon task state is terminal `done`.
 - [ ] PASS — done notification received **and** state is terminal
@@ -78,6 +100,7 @@ notification reaching the captain session, not just the crew screen.
 ### 6. Reopen after done — redo → done again
 - **Action:** With the crew already terminal `done` (checkpoint 5), the captain reviews, finds a gap, and sends a new turn with redo instructions: `cockpit crew send cockpit <name> "<redo>"`.
 - **Expect:** `cockpit crew send` detects the terminal task and fires `task.reopened` (#148) — the task returns to non-terminal `working`. The crew does the redo, then runs `cockpit crew signal done` again.
+  > **Codex note:** same `--task-id` / `--project` requirement; the second `signal done` needs the same flags.
 - **Captain signal:** crew responds to the new turn despite having been done; the second `signal done` fires **CREW DONE** again and the daemon ledger returns to terminal `done` (`lastEvent: task.done`).
 - **Note:** a turn-end `Stop` hook may transiently set `lastEvent: task.progress`; the explicit `signal done` is what settles the ledger back to terminal `done`.
 - [ ] PASS — done crew reopened on the new turn AND reported done a second time
@@ -99,6 +122,9 @@ notification reaching the captain session, not just the crew screen.
 | 2026-05-30 | claude | b0b8753 | PASS | PASS | PASS | GAP | PASS | PASS | checkpoint 4 = state OK but no captain idle ping (Stop hook liveness-only) |
 | 2026-06-01 | codex  | fix/codex-sandbox-full-access | PASS | PASS | PASS | PASS | PASS | PASS | All pass after switching codex crews to `danger-full-access` (parity with unsandboxed claude/opencode). `signal` now reaches the daemon; reducer guard keeps `blocked` through the trailing app-server turn-end. CP3 via `--approval`. |
 | 2026-06-01 | opencode | feat/opencode-idle-sse-bridge | PASS | PASS | DEFER | PASS | PASS | PASS | CP4 closed via SSE `session.idle` bridge (daemon auto-→awaiting-input, no signal). CP3 deferred (per-crew config auto-approves all tools). |
+| 2026-06-03 | claude | ffc97f6 | PASS | PASS | DEFERRED (auto mode) | GAP (#210) | PASS | PASS | CP3 no longer gates — crews default to `--permission-mode auto` (#199). CP4 idle ping = #210. |
+| 2026-06-03 | codex | ffc97f6 | PASS | PASS | DEFERRED (--approval) | GAP (#210) | PASS | PASS | Signals via `--task-id` (PR #173) self-injected in `developerInstructions`; verified live. Earlier 'fail' was a test error (bare signal w/o `--task-id`). |
+| 2026-06-03 | opencode | ffc97f6 | PASS | PASS | DEFERRED (config) | GAP (#210) | PASS | PASS | All explicit signals + SSE turn-end work; CP4 ping blocked by #210. |
 
 ---
 
@@ -122,3 +148,16 @@ notification reaching the captain session, not just the crew screen.
 - **Fix shipped: `sandbox: "danger-full-access"` for codex crews.** This is **parity, not regression** — claude and opencode crews already run with NO Seatbelt sandbox (real CLI in a cmux pane); codex was the only sandboxed agent. Full-access removes the FS jail so `cockpit crew signal` reaches the daemon. `approvalPolicy` is an independent axis, so CP3 still gates when `--approval` sets it to `untrusted`.
 - **Reducer guard (also required).** Codex runs `signal blocked` mid-turn; the app-server then fires `TurnCompleted`. Without the guard (`task.turn.completed` from `blocked` = no-op, shared with the opencode SSE work) that trailing turn-end would flip `blocked → awaiting-input` and drop the question. Verified live: `blocked` + question survived; `signal done` stayed terminal.
 - **Verified live (all 6 PASS).** CP2 `signal blocked` → CREW BLOCKED (mailbox) → answer unblocked; CP5 `signal done` → terminal `done` + CREW DONE; CP6 reopen → 2nd CREW DONE. CP1/CP3/CP4 unchanged (app-server). Codex reaches full parity.
+
+## Findings — 2026-06-03 (all agents — methodology correction)
+
+This run corrected the checklist methodology after the captain identified that the checklist conflated **two distinct signal mechanisms** (see §"Two Signal Mechanisms" above).
+
+- **Deliverable checkpoints (1, 2, 5, 6) all PASS for all three agents.** Interactive boot, blocked→answer→unblock, explicit `signal done`, and reopen→re-done are fully functional on claude, codex, and opencode.
+- **CP3 (permission) = DEFERRED-by-design for all agents.**
+  - claude/codex: `--permission-mode auto` is now the default (#199); crews auto-approve all tools.
+  - opencode: per-crew config auto-approves everything (no permission prompts surface).
+  - *No regression.* If gated permission testing is needed, run with `--permission-mode default` (claude/codex) or reconfigure opencode's tool approval settings.
+- **CP4 (idle) = GAP (#210) for ALL agents.** The daemon correctly transitions `working → awaiting-input` via each agent's Type 1 mechanism (opencode SSE reliable, codex reliable, claude Stop hook flaky). But the captain receives **zero** idle/awaiting notification because the relay's `formatEntry` drops `task.turn.completed` / `task.idle` events before they reach the captain mailbox. This is a single infrastructure fix tracked as #210. Do NOT mark CP4 PASS until the relay delivers the idle ping.
+- **codex signal path verified intact.** PR #173's `--task-id` / `--project` injection in `developerInstructions` is working. The earlier apparent codex "failure" was a test error — a bare `cockpit crew signal done` (no `--task-id`) inside a codex crew, which correctly errors `COCKPIT_CREW_TASK_ID unset`. The crew's self-signal via its own instructions works.
+- **Cross-reference issues:** #207 (relay as SPOF), #208 (captain polling defeats notification), #209 (cmux execFileSync hang), #210 (relay formatEntry drops idle events).


### PR DESCRIPTION
## Summary

Corrects the crew lifecycle checklist to properly distinguish the two signal mechanisms (Type 1 automatic turn-end vs Type 2 explicit DONE/BLOCKED/FAILED), fixes CP4 expectations to reflect the known GAP (#210), and records the 2026-06-03 live correction run.

## Changes

1. **New §Two Signal Mechanisms** — Type 1 (per-agent turn-end/idle detection) vs Type 2 (explicit `cockpit crew signal`) table with per-agent reliability and codex `--task-id` requirement
2. **CP4 (Idle) corrected** — daemon transition is per-agent Type 1; captain ping is a universal GAP (#210) because relay `formatEntry` drops `task.turn.completed`/`task.idle` events
3. **Codex notes on CP2/CP5/CP6** — signal must use `--task-id` / `--project` (self-injected via PR #173 in template); bare command errors `COCKPIT_CREW_TASK_ID unset`
4. **Result log: 3 new rows** (claude/codex/opencode 2026-06-03) with corrected methodology
5. **New Findings — 2026-06-03** summarizing: deliverable checkpoints PASS, CP3 deferred-by-design (`--permission-mode auto`), CP4 universal GAP (#210), codex signal path verified intact
