### PR TITLE
fix(codex): gate first-turn say() on in-flight dispatch (#212)

### DIFF
--- a/src/control/codex/__tests__/driver.test.ts
+++ b/src/control/codex/__tests__/driver.test.ts
@@ -314,6 +314,52 @@ describe("CodexInteractiveDriver.dispatch", () => {
     });
   });
 
+  it("first-turn say() awaits an in-flight dispatch instead of dropping the turn (race #212)", async () => {
+    resolveCodexModelMock.mockResolvedValue(undefined);
+    const client = fakeClient();
+    // startThread parks on a deferred promise to simulate the JSON-RPC
+    // round-trip window during which the first-turn say() arrives — the exact
+    // window where threadByTask is still empty.
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    client.startThread = vi.fn().mockImplementation(async () => {
+      await gate;
+      return { threadId: "TH-1" };
+    });
+    const drv = new CodexInteractiveDriver({ makeClient: () => client, emit: () => {} });
+    const task = {
+      id: "t1", project: "p", provider: "codex", mode: "interactive",
+      state: "submitted", task: "x", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000,
+      attempts: [{ attemptId: "a1", startedAt: 1, lastHeartbeatAt: 1 }],
+      cwd: "/tmp/work",
+    } as any;
+
+    const dispatchP = drv.dispatch(task);   // parks inside startThread
+    const sayP = drv.say("t1", "hello");     // first turn arrives DURING the await window
+    await Promise.resolve();                 // let say() reach its thread lookup
+    release();                               // startThread resolves → thread mapped
+
+    await expect(Promise.all([dispatchP, sayP])).resolves.toBeDefined();
+    expect(client.sendTurn).toHaveBeenCalledWith("TH-1", "hello");
+  });
+
+  it("say() still rejects with 'no thread' when its dispatch failed (no thread ever mapped)", async () => {
+    const client = fakeClient();
+    client.startThread = vi.fn().mockRejectedValue(new Error("startThread boom"));
+    const drv = new CodexInteractiveDriver({ makeClient: () => client, emit: () => {} });
+    const task = {
+      id: "t1", project: "p", provider: "codex", mode: "interactive",
+      state: "submitted", task: "x", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000,
+      attempts: [{ attemptId: "a1", startedAt: 1, lastHeartbeatAt: 1 }],
+      cwd: "/tmp/work",
+    } as any;
+    const dispatchP = drv.dispatch(task).catch(() => {});
+    await expect(drv.say("t1", "hello")).rejects.toThrow(/no thread/);
+    await dispatchP;
+  });
+
   it("if initialize rejects, emits task.failed with a clear handshake error", async () => {
     const client = fakeClient();
     client.initialize = vi.fn().mockRejectedValue(new Error("Not initialized"));

--- a/src/control/codex/driver.ts
+++ b/src/control/codex/driver.ts
@@ -45,6 +45,13 @@ export class CodexInteractiveDriver {
   private handshakeP?: Promise<void>;
   private threadByTask = new Map<string, string>();
   private taskByThread = new Map<string, string>();
+  /**
+   * taskId → in-flight dispatch promise. The first-turn say() can arrive while
+   * dispatch() is still awaiting startThread (threadByTask not yet set); say()
+   * awaits this gate before reading threadByTask so the first turn isn't lost
+   * with "no thread for task" (issue #212).
+   */
+  private dispatchByTask = new Map<string, Promise<void>>();
   /** taskId → last pending server-request {id, method} (for answer()) */
   private serverRequestByTask = new Map<string, { id: number; method: string }>();
   private deps: DriverDeps;
@@ -69,6 +76,19 @@ export class CodexInteractiveDriver {
   }
 
   async dispatch(rec: TaskRecord & { cwd?: string; model?: string }): Promise<void> {
+    // Register the in-flight dispatch synchronously so a concurrent first-turn
+    // say() can await it (see dispatchByTask / issue #212). Cleared once the
+    // thread is mapped (or dispatch failed), after which say() reads the map.
+    const p = this.runDispatch(rec);
+    this.dispatchByTask.set(rec.id, p.then(() => {}, () => {}));
+    try {
+      await p;
+    } finally {
+      this.dispatchByTask.delete(rec.id);
+    }
+  }
+
+  private async runDispatch(rec: TaskRecord & { cwd?: string; model?: string }): Promise<void> {
     try {
       const c = await this.ensureClient();
       await withTimeout(this.ensureHandshake(), 10_000, "handshake timed out");
@@ -105,6 +125,10 @@ export class CodexInteractiveDriver {
   }
 
   async say(taskId: string, text: string): Promise<void> {
+    // Wait out any in-flight dispatch so the first turn isn't dropped during
+    // the startThread window (#212). The gate never rejects; a failed dispatch
+    // simply leaves threadByTask empty → the existing "no thread" throw stands.
+    await this.dispatchByTask.get(taskId);
     const c = this.client!;
     const tid = this.threadByTask.get(taskId);
     if (!tid) throw new Error(`no thread for task ${taskId}`);


### PR DESCRIPTION
Fixes #212.

## Problem
A codex-only race between `CodexInteractiveDriver.dispatch()` and the first-turn `say()` dropped the initial turn with `say err: Error: no thread for task <id>`. `dispatch()` awaits `startThread` before setting `threadByTask`; if the first-turn `say()` lands during that await window, the map is empty → it throws and the turn is lost. The codex crew then sits idle at `working/task.started`. Seen 5× across 4 days; **not** restart-induced (stable daemon). claude/opencode never use this path.

## Fix (Option 2 from the issue)
A per-task in-flight dispatch gate:
- `dispatchByTask: Map<string, Promise<void>>` registered **synchronously** at the start of `dispatch()` (before the first await), cleared in `finally`.
- `say()` awaits `dispatchByTask.get(taskId)` before reading `threadByTask`.
- The gate promise swallows resolve **and** reject (`.then(()=>{}, ()=>{})`), so it never throws — a genuinely failed dispatch still leaves `threadByTask` empty and the existing `no thread for task` throw stands (behavior preserved).

Surgical: only `dispatch()` is wrapped (original body moved verbatim to `runDispatch()`), plus the gate await in `say()`. No claude/opencode code touched.

## Tests (TDD, RED→GREEN)
- **race #212**: `startThread` parks on a deferred promise; first-turn `say()` arrives during the window; on release asserts `sendTurn("TH-1","hello")` was called (turn not dropped).
- **failure preserved**: `startThread` rejects; `say()` still rejects with `/no thread/`.

## Verification
- `vitest run src/control/codex/__tests__/driver.test.ts` → 23/23 pass
- `tsc --noEmit` → clean
- Scope: only `src/control/codex/driver.ts` (+24) and its test (+46)
- `gitnexus_impact` run on `dispatch`/`say` before editing (codex-isolated; reached only via the launchInteractive hook and the socket onAttachInbound router)

## Reviewer notes
- Closes the dispatch↔say window only; does not change the post-restart reattach path (that recovers separately via `shouldReattachCodex`).
