### PR TITLE
feat(opencode): CP3 permission gate — surface permission.asked to captain (opt-in)

### DIFF
--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -247,6 +247,8 @@ describe("cockpit crew spawn", () => {
       project: "brove",
       taskId: "task-oc1",
     }));
+    // CP3 default unchanged: without --approval, bash is NOT gated.
+    expect(writePerCrewOpencodeConfig.mock.calls[0][0].gateBash).toBeFalsy();
     expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ interactive: true }));
     expect(newPane).toHaveBeenCalledWith(expect.objectContaining({
       workspaceId: "workspace:5",
@@ -263,6 +265,22 @@ describe("cockpit crew spawn", () => {
       { workspaceId: "workspace:5", surfaceId: "surface:9" },
       "do the thing",
     ]);
+  });
+
+  it("--approval gates bash for opencode crews (CP3 opt-in → gateBash:true)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("opencode");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-oc2" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-oc2", project: "brove", provider: "opencode", mode: "interactive" });
+
+    const promise = runCrewSpawn({ project: "brove", task: "do it", agent: "opencode", approval: true });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(writePerCrewOpencodeConfig).toHaveBeenCalledWith(expect.objectContaining({ gateBash: true }));
   });
 
   it("--agent codex routes through the control-plane daemon and opens an attach tab in the captain", async () => {

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -164,6 +164,10 @@ export interface CrewSpawnInput {
   direction?: PanePlacement;
   agent?: string;
   approvalPolicy?: string;
+  /** CP3 opt-in: gate risky tools (bash) so the captain approves them.
+   *  codex maps this to approvalPolicy='untrusted'; opencode maps it to a
+   *  bash:"ask" per-crew config. Default (false) = fully autonomous. */
+  approval?: boolean;
 }
 
 export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
@@ -320,6 +324,9 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
       stateRoot: path.join(os.homedir(), ".config", "cockpit", "state"),
       project: input.project,
       taskId: rec.id,
+      // CP3 opt-in: --approval gates bash so the captain approves shell commands.
+      // Without it, bash stays auto-approved (default behavior unchanged).
+      ...(input.approval ? { gateBash: true } : {}),
     });
     const cliCommand = agent.buildCommand({
       prompt: input.task,
@@ -541,7 +548,7 @@ crewCommand
   .option("--name <name>", "Crew name (default: auto-generated crew-N)")
   .option("--direction <dir>", "Placement: tab (default) or split direction (right|left|up|down)", "tab")
   .option("--agent <name>", "Agent CLI to use (claude|codex|gemini|opencode)", "claude")
-  .option("--approval", "force codex approvalPolicy='untrusted' (codex only; exercises gate primitive)", false)
+  .option("--approval", "gate risky tools so the captain approves them (codex: approvalPolicy='untrusted'; opencode: bash:'ask')", false)
   .option("--task-file <path>", "Read task prompt from file instead of positional arg ('-' for stdin)")
   .action(
     async (
@@ -557,7 +564,9 @@ crewCommand
           name: opts.name,
           direction: opts.direction,
           agent: opts.agent,
-          ...(opts.approval ? { approvalPolicy: "untrusted" } : {}),
+          // --approval is provider-agnostic: codex consumes approvalPolicy,
+          // opencode consumes the `approval` flag (→ bash:"ask" per-crew config).
+          ...(opts.approval ? { approvalPolicy: "untrusted", approval: true } : {}),
         });
         console.log(chalk.green(`✔ Crew '${pane.title}' spawned (${pane.surfaceId})`));
       } catch (err) {

--- a/src/control/__tests__/cockpitd-opencode-approval.test.ts
+++ b/src/control/__tests__/cockpitd-opencode-approval.test.ts
@@ -1,0 +1,93 @@
+// src/control/__tests__/cockpitd-opencode-approval.test.ts
+//
+// CP3 (opencode permission gate): the captain's gate-resolve for an OPENCODE
+// task must route to opencodeBridge.answer (which POSTs the decision to the
+// crew's server), while a codex task still routes to codexDriver.answer.
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startCockpitd } from "../cockpitd.js";
+import { sendRequest } from "../protocol.js";
+import type { TaskRecord } from "../types.js";
+
+function fakeCodexDriver(answer: ReturnType<typeof vi.fn>) {
+  return {
+    dispatch: vi.fn(), reattach: vi.fn(), say: vi.fn(), steer: vi.fn(),
+    interrupt: vi.fn(), answer, close: vi.fn(),
+  } as never;
+}
+
+function seedRecord(o: { id: string; provider: TaskRecord["provider"]; gateKind: "approval" | "input" }): TaskRecord {
+  return {
+    id: o.id, project: "p", provider: o.provider, mode: "interactive",
+    state: "blocked", task: "x", createdAt: 1, lastHeartbeat: 1, lastEvent: "",
+    heartbeatBudgetMs: 1000,
+    attempts: [{ attemptId: "a", startedAt: 1, lastHeartbeatAt: 1 }],
+    gates: [{ gateId: `g-${o.id}`, taskId: o.id, kind: o.gateKind, question: "?", state: "pending", createdAt: 1 }],
+  };
+}
+
+describe("cockpitd opencode approval routing (CP3)", () => {
+  let stop: (() => void) | undefined;
+  let dir: string;
+  afterEach(() => { stop?.(); if (dir) rmSync(dir, { recursive: true, force: true }); });
+
+  it("routes an opencode gate-resolve to opencodeBridge.answer, not codex", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-cp3-"));
+    const sock = join(dir, "c.sock");
+    const ocAnswer = vi.fn().mockResolvedValue(true);
+    const codexAnswer = vi.fn().mockResolvedValue(undefined);
+    const handle = startCockpitd({
+      stateRoot: join(dir, "state"), sockPath: sock, sweepMs: 0,
+      opencodeBridge: { start: vi.fn(), stop: vi.fn(), answer: ocAnswer },
+      codexDriver: fakeCodexDriver(codexAnswer),
+    });
+    stop = handle.stop;
+    await sendRequest(sock, { kind: "seed", record: seedRecord({ id: "o1", provider: "opencode", gateKind: "approval" }) });
+    await sendRequest(sock, {
+      kind: "gate-resolve", project: "p", gateId: "g-o1", resolvedBy: "captain",
+      payload: { text: "approve", decision: "approve" },
+    });
+    expect(ocAnswer).toHaveBeenCalledWith("o1", "approve");
+    expect(codexAnswer).not.toHaveBeenCalled();
+  });
+
+  it("maps a deny decision to opencodeBridge.answer('deny')", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-cp3-"));
+    const sock = join(dir, "c.sock");
+    const ocAnswer = vi.fn().mockResolvedValue(true);
+    const handle = startCockpitd({
+      stateRoot: join(dir, "state"), sockPath: sock, sweepMs: 0,
+      opencodeBridge: { start: vi.fn(), stop: vi.fn(), answer: ocAnswer },
+      codexDriver: fakeCodexDriver(vi.fn()),
+    });
+    stop = handle.stop;
+    await sendRequest(sock, { kind: "seed", record: seedRecord({ id: "o2", provider: "opencode", gateKind: "approval" }) });
+    await sendRequest(sock, {
+      kind: "gate-resolve", project: "p", gateId: "g-o2", resolvedBy: "captain",
+      payload: { text: "deny", decision: "deny" },
+    });
+    expect(ocAnswer).toHaveBeenCalledWith("o2", "deny");
+  });
+
+  it("still routes a codex gate-resolve to codexDriver.answer", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-cp3-"));
+    const sock = join(dir, "c.sock");
+    const ocAnswer = vi.fn().mockResolvedValue(true);
+    const codexAnswer = vi.fn().mockResolvedValue(undefined);
+    const handle = startCockpitd({
+      stateRoot: join(dir, "state"), sockPath: sock, sweepMs: 0,
+      opencodeBridge: { start: vi.fn(), stop: vi.fn(), answer: ocAnswer },
+      codexDriver: fakeCodexDriver(codexAnswer),
+    });
+    stop = handle.stop;
+    await sendRequest(sock, { kind: "seed", record: seedRecord({ id: "c1", provider: "codex", gateKind: "approval" }) });
+    await sendRequest(sock, {
+      kind: "gate-resolve", project: "p", gateId: "g-c1", resolvedBy: "captain",
+      payload: { text: "approve", decision: "approve" },
+    });
+    expect(codexAnswer).toHaveBeenCalledWith("c1", { text: "approve", decision: "approve" });
+    expect(ocAnswer).not.toHaveBeenCalled();
+  });
+});

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -57,6 +57,8 @@ export interface CockpitdOpts {
   opencodeBridge?: {
     start: (o: { taskId: string; port: number }) => void;
     stop: (taskId: string) => void;
+    /** CP3: POST the captain's approve/deny decision to the crew's server. */
+    answer: (taskId: string, decision: "approve" | "deny") => Promise<boolean>;
   };
 }
 
@@ -182,6 +184,13 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       const found = store.listAll().find((r) => r.id === ev.id);
       if (!found) return;
       void d.handle({ kind: "event", project: found.project, event: ev });
+      // CP3: a gated permission must become a resolvable gate so the captain can
+      // approve/deny via `crew reply --gate`. Opencode crews never attach a
+      // renderer (no `crew attach`), so schedulePromotion always fires after the
+      // grace window — mirroring the codex emit hook below.
+      if (ev.type === "task.approval.requested") {
+        schedulePromotion(ev.id, ev.requestId, "approval", ev.question);
+      }
     },
     log,
   });
@@ -253,8 +262,20 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       );
     },
     resolveInteractiveGate: async (taskId, payload) => {
-      try { await codexDriver.answer(taskId, payload); }
-      catch (e) { log(`gate-resolve answer failed: ${(e as Error).message}`); }
+      // Route the captain's decision to the owning provider's driver. Opencode
+      // crews resolve via the SSE bridge (POST to the crew's server); codex via
+      // its app-server respondToServerRequest. Provider comes from the record.
+      const rec = store.listAll().find((r) => r.id === taskId);
+      try {
+        if (rec?.provider === "opencode") {
+          // Only an explicit "approve" approves; any other reply (incl. an
+          // ambiguous one) denies — never auto-approve a permission gate.
+          const decision = (payload as { decision?: string })?.decision === "approve" ? "approve" : "deny";
+          await opencodeBridge.answer(taskId, decision);
+        } else {
+          await codexDriver.answer(taskId, payload);
+        }
+      } catch (e) { log(`gate-resolve answer failed: ${(e as Error).message}`); }
     },
   });
 

--- a/src/control/opencode/__tests__/sse-bridge.test.ts
+++ b/src/control/opencode/__tests__/sse-bridge.test.ts
@@ -125,4 +125,89 @@ describe("OpencodeSseBridge", () => {
     await flush();
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
+
+  // ── CP3: permission gate (live-verified opencode 1.15.13 shapes) ──────────
+  // permission.asked carries properties = PermissionRequest:
+  //   { id:"per_…", sessionID:"ses_…", permission:"bash", patterns:[…], … }
+  // Reply endpoint (live-verified): POST /session/{sessionID}/permissions/{permissionID}
+  //   body { response: "once"|"always"|"reject" } → 200, fires permission.replied.
+
+  /** fetchImpl that streams the given SSE on GET /event and 200s any POST. */
+  function permFetch(sse: string[]) {
+    return vi.fn().mockImplementation((url: unknown) => {
+      if (String(url).endsWith("/event")) return Promise.resolve(sseResponse(sse));
+      return Promise.resolve({ ok: true, status: 200, body: null } as unknown as Response);
+    });
+  }
+
+  it("maps permission.asked → task.approval.requested", async () => {
+    const events: ControlEvent[] = [];
+    const fetchImpl = permFetch([
+      'data: {"id":"e1","type":"permission.asked","properties":{"id":"per_1","sessionID":"ses_1","permission":"bash","patterns":["echo hi"]}}\n',
+    ]);
+    const bridge = new OpencodeSseBridge({ emit: (e) => events.push(e), fetchImpl });
+    bridge.start({ taskId: "t1", port: 7777 });
+    await flush();
+    await flush();
+    const ev = events.find((e) => e.type === "task.approval.requested");
+    expect(ev).toBeDefined();
+    expect(ev).toMatchObject({ type: "task.approval.requested", id: "t1", kind: "bash" });
+    // requestId is a synthetic number (opencode has no numeric request id on the
+    // bus); it keys the daemon's gate promotion just like codex's JSON-RPC id.
+    expect(typeof (ev as { requestId: number }).requestId).toBe("number");
+    expect((ev as { question: string }).question).toContain("bash");
+  });
+
+  it("answer(approve) POSTs response 'once' to /session/{id}/permissions/{id}", async () => {
+    const events: ControlEvent[] = [];
+    const fetchImpl = permFetch([
+      'data: {"type":"permission.asked","properties":{"id":"per_9","sessionID":"ses_9","permission":"bash","patterns":[]}}\n',
+    ]);
+    const bridge = new OpencodeSseBridge({ emit: (e) => events.push(e), fetchImpl });
+    bridge.start({ taskId: "t1", port: 7777 });
+    await flush();
+    await flush();
+    const resolved = await bridge.answer("t1", "approve");
+    expect(resolved).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "http://127.0.0.1:7777/session/ses_9/permissions/per_9",
+      expect.objectContaining({ method: "POST", body: JSON.stringify({ response: "once" }) }),
+    );
+  });
+
+  it("answer(deny) POSTs response 'reject'", async () => {
+    const fetchImpl = permFetch([
+      'data: {"type":"permission.asked","properties":{"id":"per_7","sessionID":"ses_7","permission":"bash","patterns":[]}}\n',
+    ]);
+    const bridge = new OpencodeSseBridge({ emit: () => {}, fetchImpl });
+    bridge.start({ taskId: "t1", port: 7777 });
+    await flush();
+    await flush();
+    await bridge.answer("t1", "deny");
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "http://127.0.0.1:7777/session/ses_7/permissions/per_7",
+      expect.objectContaining({ method: "POST", body: JSON.stringify({ response: "reject" }) }),
+    );
+  });
+
+  it("answer() returns false when no permission is pending", async () => {
+    const fetchImpl = permFetch([]);
+    const bridge = new OpencodeSseBridge({ emit: () => {}, fetchImpl });
+    bridge.start({ taskId: "t1", port: 7777 });
+    await flush();
+    expect(await bridge.answer("t1", "approve")).toBe(false);
+  });
+
+  it("permission.replied clears the pending permission", async () => {
+    const fetchImpl = permFetch([
+      'data: {"type":"permission.asked","properties":{"id":"per_5","sessionID":"ses_5","permission":"bash","patterns":[]}}\n',
+      'data: {"type":"permission.replied","properties":{"sessionID":"ses_5","requestID":"per_5","reply":"once"}}\n',
+    ]);
+    const bridge = new OpencodeSseBridge({ emit: () => {}, fetchImpl });
+    bridge.start({ taskId: "t1", port: 7777 });
+    await flush();
+    await flush();
+    // Already resolved on the bus → captain's later answer is a no-op.
+    expect(await bridge.answer("t1", "approve")).toBe(false);
+  });
 });

--- a/src/control/opencode/sse-bridge.ts
+++ b/src/control/opencode/sse-bridge.ts
@@ -36,6 +36,13 @@ export interface OpencodeSseBridgeDeps {
  */
 export class OpencodeSseBridge {
   private controllers = new Map<string, AbortController>();
+  /** taskId → the crew's opencode server port (for permission-reply POSTs). */
+  private portByTask = new Map<string, number>();
+  /** taskId → the last unresolved permission on the bus (for answer()). */
+  private pendingPermByTask = new Map<string, { permID: string; sessionID: string }>();
+  /** Synthetic monotonic request id. opencode has no numeric id on the bus, but
+   *  task.approval.requested carries one (codex parity) to key gate promotion. */
+  private nextRequestId = 1;
   private deps: OpencodeSseBridgeDeps;
 
   constructor(deps: OpencodeSseBridgeDeps) {
@@ -45,6 +52,7 @@ export class OpencodeSseBridge {
   /** Begin subscribing to the crew's /event stream. Idempotent per task. */
   start(o: { taskId: string; port: number }): void {
     if (this.controllers.has(o.taskId)) return;
+    this.portByTask.set(o.taskId, o.port);
     const ac = new AbortController();
     this.controllers.set(o.taskId, ac);
     void this.run(o.taskId, o.port, ac);
@@ -53,9 +61,41 @@ export class OpencodeSseBridge {
   /** Stop subscribing for a task (crew closed / terminal). */
   stop(taskId: string): void {
     const ac = this.controllers.get(taskId);
-    if (!ac) return;
-    ac.abort();
-    this.controllers.delete(taskId);
+    if (ac) { ac.abort(); this.controllers.delete(taskId); }
+    this.portByTask.delete(taskId);
+    this.pendingPermByTask.delete(taskId);
+  }
+
+  /**
+   * Resolve a pending opencode permission by POSTing the captain's decision to
+   * the crew's server (live-verified, opencode 1.15.13: POST
+   * /session/{sessionID}/permissions/{permissionID} with
+   * { response: "once" | "reject" } → 200, fires permission.replied). Mirrors
+   * codex's driver.answer(). Returns true if there WAS a pending permission (so
+   * the caller knows the answer was an approval, not a reply to a plain `signal
+   * blocked` question); false if nothing was pending (already resolved on the
+   * bus, or no gate).
+   */
+  async answer(taskId: string, decision: "approve" | "deny"): Promise<boolean> {
+    const pend = this.pendingPermByTask.get(taskId);
+    const port = this.portByTask.get(taskId);
+    if (!pend || port == null) return false;
+    this.pendingPermByTask.delete(taskId);
+    const fetchImpl = this.deps.fetchImpl ?? fetch;
+    const response = decision === "approve" ? "once" : "reject";
+    try {
+      await fetchImpl(`http://127.0.0.1:${port}/session/${pend.sessionID}/permissions/${pend.permID}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ response }),
+      });
+    } catch (e) {
+      this.deps.log?.(`opencode permission reply failed for ${taskId}: ${(e as Error).message}`);
+    }
+    // Clear blocked → working; the crew continues (or aborts) the turn, and a
+    // later session.idle settles it back to awaiting-input.
+    this.deps.emit({ type: "task.started", id: taskId });
+    return true;
   }
 
   private async run(taskId: string, port: number, ac: AbortController): Promise<void> {
@@ -128,7 +168,18 @@ export class OpencodeSseBridge {
     // SSE field form `data: {json}`; opencode also emits bare JSON lines.
     if (line.startsWith("data:")) line = line.slice(5).trim();
     if (!line.startsWith("{")) return;
-    let json: { type?: string; properties?: { sessionID?: string } } | undefined;
+    let json:
+      | {
+          type?: string;
+          properties?: {
+            id?: string;
+            sessionID?: string;
+            requestID?: string;
+            permission?: string;
+            patterns?: string[];
+          };
+        }
+      | undefined;
     try {
       json = JSON.parse(line);
     } catch {
@@ -142,6 +193,30 @@ export class OpencodeSseBridge {
         id: taskId,
         turnId: json.properties?.sessionID ?? "opencode",
       });
+    } else if (json?.type === "permission.asked") {
+      // A gated tool (e.g. bash, when --approval set bash:"ask") needs approval.
+      // Live-verified payload (opencode 1.15.13): properties = PermissionRequest
+      // { id:"per_…", sessionID:"ses_…", permission:"bash", patterns:[cmd], … }.
+      // Record the pending request so answer() can POST the decision, and surface
+      // it as task.approval.requested (codex parity) — the reducer turns it into
+      // blocked and the relay renders CREW BLOCKED with the tool + command.
+      const p = json.properties;
+      if (p?.id && p?.sessionID) {
+        this.pendingPermByTask.set(taskId, { permID: p.id, sessionID: p.sessionID });
+        const tool = p.permission ?? "a tool";
+        const cmd = Array.isArray(p.patterns) && p.patterns.length ? `: ${p.patterns.join(" ")}` : "";
+        this.deps.emit({
+          type: "task.approval.requested",
+          id: taskId,
+          requestId: this.nextRequestId++,
+          question: `opencode requests permission to run ${tool}${cmd}`,
+          kind: tool,
+        });
+      }
+    } else if (json?.type === "permission.replied") {
+      // The permission was resolved on the bus (by us or another client) — clear
+      // pending state so a later captain answer is a no-op rather than a stale POST.
+      this.pendingPermByTask.delete(taskId);
     }
   }
 }

--- a/src/lib/__tests__/per-crew-settings.test.ts
+++ b/src/lib/__tests__/per-crew-settings.test.ts
@@ -301,4 +301,20 @@ describe("writePerCrewOpencodeConfig", () => {
     expect(fs.existsSync(out)).toBe(true);
     expect(fs.statSync(path.dirname(out)).isDirectory()).toBe(true);
   });
+
+  it("defaults bash to 'allow' (CP3 opt-in: default behavior unchanged)", () => {
+    const out = writePerCrewOpencodeConfig({ stateRoot: tmp, project: "alpha", taskId: "tid-1" });
+    const json = JSON.parse(fs.readFileSync(out, "utf-8"));
+    expect(json.permission.bash).toBe("allow");
+  });
+
+  it("gateBash:true sets bash to 'ask' so the captain approves shell commands", () => {
+    const out = writePerCrewOpencodeConfig({ stateRoot: tmp, project: "alpha", taskId: "tid-1", gateBash: true });
+    const json = JSON.parse(fs.readFileSync(out, "utf-8"));
+    expect(json.permission.bash).toBe("ask");
+    // Only bash flips — every other tool stays auto-approved (surgical gate).
+    expect(json.permission.edit).toBe("allow");
+    expect(json.permission.read).toBe("allow");
+    expect(json.permission.external_directory).toEqual({ "**": "allow" });
+  });
 });

--- a/src/lib/per-crew-settings.ts
+++ b/src/lib/per-crew-settings.ts
@@ -176,11 +176,17 @@ export function writePerCrewSettingsLocal(o: {
  * ~/.config/opencode/opencode.json automatically.
  *
  * Returns the absolute path to the written file.
+ *
+ * CP3 opt-in: with `gateBash`, bash flips to "ask" so the captain approves
+ * shell commands (opencode emits `permission.asked` → daemon surfaces CREW
+ * BLOCKED → captain's decision is POSTed back). Default (no flag) keeps bash
+ * "allow" — opencode crews stay fully autonomous unless `--approval` is passed.
  */
 export function writePerCrewOpencodeConfig(o: {
   stateRoot: string;
   project: string;
   taskId: string;
+  gateBash?: boolean;
 }): string {
   const dir = join(o.stateRoot, o.project, o.taskId);
   mkdirSync(dir, { recursive: true });
@@ -191,7 +197,7 @@ export function writePerCrewOpencodeConfig(o: {
       edit: "allow",
       glob: "allow",
       grep: "allow",
-      bash: "allow",
+      bash: o.gateBash ? "ask" : "allow",
       webfetch: "allow",
       websearch: "allow",
       task: "allow",


### PR DESCRIPTION
Closes the opencode half of CP3 (permission gate → captain approves). Pairs with the daemon↔relay drift fix (#214) which surfaces `task.approval.requested` to the captain; together they make opencode permission gates fully captain-visible.

## What
- **sse-bridge.ts**: handle `permission.asked` on the /event SSE bus → emit `task.approval.requested` (with tool/command context in the question), clear on `permission.replied`.
- **Answer route**: captain approve/deny → `POST /session/{sessionID}/permissions/{permissionID}` with `{ response: "once" | "reject" }` (live-verified against opencode 1.15.13 → 200, fires `permission.replied`). Mirrors codex `driver.answer()`. Distinguishes an approval-reply from a plain `signal blocked` question reply.
- **Opt-in gating**: `--approval` for opencode crews gates `bash` (writePerCrewOpencodeConfig `gateBash`). **Default unchanged** — without the flag, opencode still auto-approves all tools (no nag).

## Scope
opencode-only: `sse-bridge.ts`, `cockpitd.ts` (answer route), `crew.ts` (--approval), `per-crew-settings.ts` (gateBash). Does NOT touch `notify-relay.ts` (relay surfacing handled by the separate drift fix / #214).

## Verification
- `vitest` 74/74 across the 4 touched test files; `tsc --noEmit` clean; no orphans.
- Permission reply endpoint + payload shape live-verified against opencode 1.15.13.

## Dependency
Captain visibility of the emitted `task.approval.requested` requires the relay/formatter drift fix (#214). Until that lands, the event is emitted + answerable but not yet rendered as CREW BLOCKED.
