### PR TITLE
fix(notify): unify daemon↔relay formatter — single source of truth (#214, #210)

### DIFF
--- a/src/commands/__tests__/notify-relay.test.ts
+++ b/src/commands/__tests__/notify-relay.test.ts
@@ -52,10 +52,19 @@ describe("notify-relay default stateRoot", () => {
   });
 });
 
+// Unified-formatter contract (#214/#210): the daemon renders the captain-facing
+// message and stores it on the mailbox entry; the relay is a dumb pipe that
+// delivers entry.message VERBATIM and skips entries with a null/empty message.
+// These tests therefore append entries WITH a message (what defaultNotify now
+// writes), not bare events.
+async function append(stateRoot: string, message: string | null, event: ControlEvent = doneEvent): Promise<number> {
+  return appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event, message });
+}
+
 describe("notify-relay file-tailer", () => {
   it("starts from seq 1 when cursor missing — delivers first event", async () => {
     const stateRoot = freshState();
-    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneEvent });
+    await append(stateRoot, "CREW DONE [claude/deadbeef]: shipped");
     const sendSpy = vi.fn().mockResolvedValue(undefined);
     const stop = await runNotifyRelay({
       project: "demo",
@@ -75,8 +84,8 @@ describe("notify-relay file-tailer", () => {
 
   it("starts from seq+1 when cursor exists — delivers only newer events", async () => {
     const stateRoot = freshState();
-    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneEvent });
-    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneEvent });
+    await append(stateRoot, "CREW DONE [claude/deadbeef]: one");
+    await append(stateRoot, "CREW DONE [claude/deadbeef]: two");
     await writeCursor({ stateRoot, project: "demo", subscriber: "captain", lastAckedSeq: 1 });
     const sendSpy = vi.fn().mockResolvedValue(undefined);
     const stop = await runNotifyRelay({
@@ -97,7 +106,7 @@ describe("notify-relay file-tailer", () => {
 
   it("does NOT advance cursor when sendToSurface throws", async () => {
     const stateRoot = freshState();
-    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneEvent });
+    await append(stateRoot, "CREW DONE [claude/deadbeef]: x");
     const sendSpy = vi.fn().mockRejectedValue(new Error("send failed"));
     const stop = await runNotifyRelay({
       project: "demo",
@@ -114,21 +123,13 @@ describe("notify-relay file-tailer", () => {
     expect(sendSpy.mock.calls.length).toBeGreaterThan(0); // attempted
   });
 
-  it("formats task.done/blocked/failed with provider + short id + payload", async () => {
+  it("delivers entry.message VERBATIM (relay does not re-derive)", async () => {
     const stateRoot = freshState();
-    const blockedEvent: ControlEvent = {
-      type: "task.blocked",
-      id: rec.id,
-      question: "what now?",
-    } as ControlEvent;
-    const failedEvent: ControlEvent = {
-      type: "task.failed",
-      id: rec.id,
-      error: "boom",
-    } as ControlEvent;
-    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneEvent });
-    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: blockedEvent });
-    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: failedEvent });
+    const blockedEvent: ControlEvent = { type: "task.blocked", id: rec.id, question: "what now?" } as ControlEvent;
+    const failedEvent: ControlEvent = { type: "task.failed", id: rec.id, error: "boom" } as ControlEvent;
+    await append(stateRoot, "CREW DONE [claude/deadbeef]: finished", doneEvent);
+    await append(stateRoot, "CREW BLOCKED [claude/deadbeef]: what now?", blockedEvent);
+    await append(stateRoot, "CREW FAILED [claude/deadbeef]: boom", failedEvent);
     const sendSpy = vi.fn().mockResolvedValue(undefined);
     const stop = await runNotifyRelay({
       project: "demo",
@@ -142,14 +143,37 @@ describe("notify-relay file-tailer", () => {
     stop();
     expect(sendSpy).toHaveBeenCalledTimes(3);
     const msgs = sendSpy.mock.calls.map((c) => c[1] as string);
-    expect(msgs[0]).toMatch(/^CREW DONE \[claude\/deadbeef\]:/);
-    expect(msgs[1]).toMatch(/^CREW BLOCKED \[claude\/deadbeef\]: what now\?/);
-    expect(msgs[2]).toMatch(/^CREW FAILED \[claude\/deadbeef\]: boom/);
+    expect(msgs[0]).toBe("CREW DONE [claude/deadbeef]: finished");
+    expect(msgs[1]).toBe("CREW BLOCKED [claude/deadbeef]: what now?");
+    expect(msgs[2]).toBe("CREW FAILED [claude/deadbeef]: boom");
+  });
+
+  it("skips entries with a null/empty message but still advances the cursor", async () => {
+    const stateRoot = freshState();
+    await append(stateRoot, null); // daemon chose not to surface (e.g. debounced idle)
+    await append(stateRoot, "   "); // whitespace-only → also skipped
+    await append(stateRoot, "CREW DONE [claude/deadbeef]: real");
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    const stop = await runNotifyRelay({
+      project: "demo",
+      subscriber: "captain",
+      stateRoot,
+      runtime: fakeRuntime(sendSpy) as never,
+      captainName: "captain",
+      pollMs: 50,
+    });
+    await new Promise((r) => setTimeout(r, 200));
+    stop();
+    // Only the real message is delivered; the two empty entries are acked silently.
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(sendSpy.mock.calls[0][1]).toBe("CREW DONE [claude/deadbeef]: real");
+    const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    expect(cursor?.lastAckedSeq).toBe(3);
   });
 
   it("silently acks entries older than STALE_THRESHOLD_MS without forwarding to captain", async () => {
     const stateRoot = freshState();
-    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneEvent });
+    await append(stateRoot, "CREW DONE [claude/deadbeef]: stale");
     const sendSpy = vi.fn().mockResolvedValue(undefined);
     // Pretend relay is booting far in the future — makes the just-written entry stale.
     const futureNow = () => Date.now() + STALE_THRESHOLD_MS + 60_000;
@@ -168,31 +192,5 @@ describe("notify-relay file-tailer", () => {
     expect(sendSpy).not.toHaveBeenCalled();
     const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
     expect(cursor?.lastAckedSeq).toBe(1);
-  });
-
-  it("task.done with payload.message prefers message over resultRef in display", async () => {
-    const stateRoot = freshState();
-    const doneWithMessage: ControlEvent = {
-      type: "task.done",
-      id: rec.id,
-      resultRef: "/some/result/file.txt",
-      message: "hello world",
-    };
-    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneWithMessage });
-    const sendSpy = vi.fn().mockResolvedValue(undefined);
-    const stop = await runNotifyRelay({
-      project: "demo",
-      subscriber: "captain",
-      stateRoot,
-      runtime: fakeRuntime(sendSpy) as never,
-      captainName: "captain",
-      pollMs: 50,
-    });
-    await new Promise((r) => setTimeout(r, 200));
-    stop();
-    expect(sendSpy).toHaveBeenCalledTimes(1);
-    const out = sendSpy.mock.calls[0][1] as string;
-    expect(out).toBe("CREW DONE [claude/deadbeef]: hello world");
-    expect(out).not.toContain("/some/result/file.txt");
   });
 });

--- a/src/commands/notify-relay.ts
+++ b/src/commands/notify-relay.ts
@@ -38,32 +38,18 @@ export const STALE_THRESHOLD_MS = 5 * 60 * 1000;
 // genuinely-blocked crew goes quiet well before the multi-minute stall budget.
 export const PROBE_QUIET_MS = 20_000;
 
-function shortId(id: string): string {
-  return id.slice(0, 8);
-}
-
-export function formatEntry(entry: MailboxEntry): string | null {
-  const tag = `[${entry.provider}/${entry.name != null ? entry.name : shortId(entry.taskId)}]`;
-  switch (entry.kind) {
-    case "task.started":
-    case "task.progress":
-      return null; // suppress liveness/start
-    case "task.done": {
-      const msg =
-        (entry.payload.message as string | undefined) ??
-        (entry.payload.resultRef as string | undefined) ??
-        "(no message)";
-      return `CREW DONE ${tag}: ${msg.toString().split(/\r?\n/)[0].slice(0, 200)}`;
-    }
-    case "task.blocked":
-      return `CREW BLOCKED ${tag}: ${(entry.payload.question as string | undefined) ?? "(no question)"}`;
-    case "task.failed":
-      return `CREW FAILED ${tag}: ${(entry.payload.error as string | undefined) ?? "(no error)"}`;
-    case "task.stalled":
-      return `CREW STALLED ${tag}: no heartbeat`;
-    default:
-      return null;
-  }
+// Unified-formatter (#214/#210): the daemon's formatMessage is the single
+// source of truth for the captain-facing message and stores it on the mailbox
+// entry. The relay is a dumb pipe — it delivers entry.message verbatim and
+// skips entries the daemon chose not to surface (null/empty). The old
+// formatEntry switch re-derived the message from the raw event kind and had
+// drifted (no case for task.approval.requested / task.idle), silently dropping
+// those events. It is retired; deliverable() is the whole policy now.
+export function deliverable(entry: MailboxEntry): string | null {
+  const msg = entry.message;
+  if (msg == null) return null;
+  const trimmed = msg.trim();
+  return trimmed.length > 0 ? msg : null;
 }
 
 // ── Phase 2b: in-cmux interactive-block probe ───────────────────────────────
@@ -239,7 +225,7 @@ export async function runNotifyRelay(opts: RunOpts): Promise<() => void> {
           lastAcked = entry.seq;
           continue;
         }
-        const msg = formatEntry(entry);
+        const msg = deliverable(entry);
         if (msg) {
           try {
             await (opts.runtime as RuntimeDriver & {

--- a/src/control/__tests__/cockpitd-notify-default.test.ts
+++ b/src/control/__tests__/cockpitd-notify-default.test.ts
@@ -6,12 +6,13 @@
 // cockpitd-push.test.ts; this file covers what defaultNotify writes once it
 // fires.
 
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { startCockpitd } from "../cockpitd.js";
 import { sendRequest } from "../protocol.js";
+import { runNotifyRelay } from "../../commands/notify-relay.js";
 import type { TaskRecord } from "../types.js";
 
 function seedRec(id: string): TaskRecord {
@@ -55,6 +56,60 @@ describe("cockpitd defaultNotify writes to mailbox", () => {
     expect(lines[0].payload.resultRef).toBe("/tmp/result");
     expect(lines[0].seq).toBe(1);
     expect(typeof lines[0].ts).toBe("string");
+  });
+
+  it("#214: task.approval.requested → CREW BLOCKED message persisted AND delivered by the relay", async () => {
+    // Regression for #214 (approval dropped) via the unified formatter. The
+    // daemon reduces task.approval.requested → blocked and renders CREW BLOCKED;
+    // defaultNotify must persist that message; the relay must deliver it
+    // verbatim. The OLD relay re-derived from event.kind (no approval case) and
+    // silently dropped it, leaving the captain blind to permission gates.
+    dir = mkdtempSync(join(tmpdir(), "cp-notify-"));
+    const sock = join(dir, "c.sock");
+    const stateRoot = join(dir, "state");
+    const handle = startCockpitd({ stateRoot, sockPath: sock, sweepMs: 0 });
+    stop = handle.stop;
+
+    await sendRequest(sock, { kind: "seed", record: seedRec("task-appr-1") });
+    await sendRequest(sock, {
+      kind: "event",
+      project: "p",
+      event: {
+        type: "task.approval.requested",
+        id: "task-appr-1",
+        requestId: 1,
+        question: "Allow edit to src/foo.ts?",
+        kind: "edit",
+      },
+    });
+    await new Promise((r) => setTimeout(r, 100));
+
+    // 1) The daemon-rendered CREW BLOCKED message is persisted on the entry.
+    const inboxPath = join(stateRoot, "inbox", "p.log");
+    const entry = JSON.parse(readFileSync(inboxPath, "utf-8").trim());
+    expect(entry.kind).toBe("task.approval.requested");
+    expect(entry.message).toMatch(/^CREW BLOCKED \[claude\//);
+    expect(entry.message).toContain("Allow edit to src/foo.ts?");
+
+    // 2) The relay delivers that message verbatim to the captain surface.
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    const runtime = {
+      sendToSurface: sendSpy,
+      status: vi.fn().mockResolvedValue({ id: "ws1", name: "captain", status: "running" }),
+      listSurfaces: vi.fn().mockResolvedValue([{ workspaceId: "ws1", surfaceId: "s1", title: "captain" }]),
+    };
+    const stopRelay = await runNotifyRelay({
+      project: "p",
+      subscriber: "captain",
+      stateRoot,
+      runtime: runtime as never,
+      captainName: "captain",
+      pollMs: 50,
+    });
+    await new Promise((r) => setTimeout(r, 200));
+    stopRelay();
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(sendSpy.mock.calls[0][1]).toBe(entry.message);
   });
 
   it("assigns monotonic seq across multiple notifies in the same project", async () => {

--- a/src/control/__tests__/daemon.test.ts
+++ b/src/control/__tests__/daemon.test.ts
@@ -316,6 +316,80 @@ describe("daemon – blocked crew resume path (#183)", () => {
     expect(calls[0].message).toContain("second prompt");
   });
 
+  // ── #214: DONE message preservation (unified formatter) ───────────────────
+  it("CREW DONE prefers the crew's signal-done message over the task snippet", async () => {
+    const store = createStore(dir);
+    store.put(rec("t-dm", { state: "working", task: "the original assigned task" }));
+    const calls: any[] = [];
+    const d = createDaemon({ store, now: () => 2000, notify: async (a) => { calls.push(a); } });
+    await d.handle({ kind: "event", project: "p", event: { type: "task.done", id: "t-dm", resultRef: "/r", message: "fixed the formatter, all tests pass" } });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].message).toBe("CREW DONE [claude/t-dm]: fixed the formatter, all tests pass");
+  });
+
+  it("CREW DONE falls back to the task snippet when no message is provided", async () => {
+    const store = createStore(dir);
+    store.put(rec("t-ds", { state: "working", task: "implement the thing" }));
+    const calls: any[] = [];
+    const d = createDaemon({ store, now: () => 2000, notify: async (a) => { calls.push(a); } });
+    await d.handle({ kind: "event", project: "p", event: { type: "task.done", id: "t-ds", resultRef: "/r" } });
+    expect(calls[0].message).toBe("CREW DONE [claude/t-ds]: implement the thing");
+  });
+
+  // ── #210: CREW IDLE debounce ──────────────────────────────────────────────
+  // awaiting-input fires CREW IDLE, but must NOT spam during an active
+  // captain-driven back-and-forth: a turn-end shortly after the captain's own
+  // task.started (crew send/reply) is suppressed; a genuine self-idle delivers.
+  describe("CREW IDLE debounce (#210)", () => {
+    it("suppresses CREW IDLE when the turn ends within the debounce window of a captain turn", async () => {
+      const store = createStore(dir);
+      store.put(rec("t-deb", { state: "working" }));
+      const calls: any[] = [];
+      let nowMs = 10_000;
+      const d = createDaemon({ store, now: () => nowMs, notify: async (a) => { calls.push(a); } });
+      // Captain sends → task.started (working → working, records lastCaptainTurnAt)
+      await d.handle({ kind: "event", project: "p", event: { type: "task.started", id: "t-deb" } });
+      // Crew finishes the turn 3s later (well within the window)
+      nowMs = 13_000;
+      await d.handle({ kind: "event", project: "p", event: { type: "task.turn.completed", id: "t-deb", turnId: "turn-1" } });
+      expect(store.get("p", "t-deb")?.state).toBe("awaiting-input");
+      expect(calls.filter((c) => c.message.includes("CREW IDLE"))).toHaveLength(0);
+    });
+
+    it("delivers CREW IDLE for a self-idle turn-end long after the captain's last turn", async () => {
+      const store = createStore(dir);
+      store.put(rec("t-self", { state: "working" }));
+      const calls: any[] = [];
+      let nowMs = 10_000;
+      const d = createDaemon({ store, now: () => nowMs, notify: async (a) => { calls.push(a); } });
+      await d.handle({ kind: "event", project: "p", event: { type: "task.started", id: "t-self" } });
+      // Turn ends far outside the debounce window → genuine idle, must deliver
+      nowMs = 10_000 + 5 * 60_000;
+      await d.handle({ kind: "event", project: "p", event: { type: "task.turn.completed", id: "t-self", turnId: "turn-1" } });
+      const idle = calls.filter((c) => c.message.includes("CREW IDLE"));
+      expect(idle).toHaveLength(1);
+    });
+
+    it("delivers CREW IDLE for a turn-end with no prior captain turn at all", async () => {
+      const store = createStore(dir);
+      store.put(rec("t-none", { state: "working" }));
+      const calls: any[] = [];
+      const d = createDaemon({ store, now: () => 50_000, notify: async (a) => { calls.push(a); } });
+      await d.handle({ kind: "event", project: "p", event: { type: "task.turn.completed", id: "t-none", turnId: "turn-1" } });
+      expect(calls.filter((c) => c.message.includes("CREW IDLE"))).toHaveLength(1);
+    });
+
+    it("does NOT debounce CREW BLOCKED even right after a captain turn", async () => {
+      const store = createStore(dir);
+      store.put(rec("t-blk", { state: "working" }));
+      const calls: any[] = [];
+      const d = createDaemon({ store, now: () => 2000, notify: async (a) => { calls.push(a); } });
+      await d.handle({ kind: "event", project: "p", event: { type: "task.started", id: "t-blk" } });
+      await d.handle({ kind: "event", project: "p", event: { type: "task.blocked", id: "t-blk", reason: "r", question: "q" } });
+      expect(calls.filter((c) => c.message.includes("CREW BLOCKED"))).toHaveLength(1);
+    });
+  });
+
   it("awaiting-input + task.started → working + subsequent task.blocked fires CREW BLOCKED (#183)", async () => {
     // Same fix path for crews that went idle (awaiting-input) before captain replied.
     const store = createStore(dir);

--- a/src/control/__tests__/mailbox.test.ts
+++ b/src/control/__tests__/mailbox.test.ts
@@ -57,6 +57,28 @@ describe("appendToMailbox", () => {
     expect(typeof entry.ts).toBe("string");
   });
 
+  it("persists the daemon-rendered message verbatim on the entry (unified-formatter)", async () => {
+    const stateRoot = freshState();
+    await appendToMailbox({
+      stateRoot,
+      project: "demo",
+      taskRecord: sampleRecord,
+      event: doneEvent,
+      message: "CREW DONE [claude/abc]: shipped it",
+    });
+    const logPath = join(stateRoot, "inbox", "demo.log");
+    const entry = JSON.parse(readFileSync(logPath, "utf-8").trim());
+    expect(entry.message).toBe("CREW DONE [claude/abc]: shipped it");
+  });
+
+  it("stores message:null when the daemon passes no message", async () => {
+    const stateRoot = freshState();
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    const logPath = join(stateRoot, "inbox", "demo.log");
+    const entry = JSON.parse(readFileSync(logPath, "utf-8").trim());
+    expect(entry.message).toBeNull();
+  });
+
   it("assigns monotonically increasing seq on subsequent appends", async () => {
     const stateRoot = freshState();
     const s1 = await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -207,6 +207,9 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
         project: args.project,
         taskRecord: args.record,
         event: args.event,
+        // Persist the daemon-rendered message (#214/#210): the relay delivers it
+        // verbatim instead of re-deriving from the raw event (which drifted).
+        message: args.message,
       });
     } catch (e) {
       log(`mailbox append failed project=${args.project}: ${(e as Error).message}`);

--- a/src/control/daemon.ts
+++ b/src/control/daemon.ts
@@ -43,20 +43,33 @@ export interface DaemonDeps {
 // firePush prev===next guard keeps it from re-firing while the task sits idle.
 const ATTENTION_STATES: ReadonlySet<TaskState> = new Set(["done", "blocked", "failed", "stalled", "awaiting-input"]);
 
+// #210: CREW IDLE (awaiting-input) is debounced — suppressed when the turn-end
+// lands within this window of the captain's own last turn to the crew (a
+// `crew send`/reply emits task.started). This silences the rapid
+// send→respond→turn-end churn of an active back-and-forth while still
+// delivering a genuine self-idle (turn-end / idle-watchdog long after the
+// captain last engaged). Only awaiting-input is debounced; every other
+// attention state always delivers.
+export const IDLE_DEBOUNCE_MS = 12_000;
+
 function shortId(id: string): string {
   return id.slice(0, 8);
 }
 
-function formatMessage(rec: TaskRecord): string | null {
+function formatMessage(rec: TaskRecord, event?: ControlEvent): string | null {
   const tag = `[${rec.provider}/${rec.name != null ? rec.name : shortId(rec.id)}]`;
   switch (rec.state) {
     case "done": {
-      // Spec: "<resultRef-content-first-line-or-the-task-snippet>".
-      // resultRef content lives on disk; for daemon-purity we don't read it
-      // here. The task snippet is the documented fallback and gives the
-      // captain enough context to know which crew finished.
-      const snippet = (rec.task ?? "").split(/\r?\n/)[0]?.trim().slice(0, 120) ?? "";
-      return `CREW DONE ${tag}: ${snippet}`;
+      // Prefer the crew's own done message (`signal done --message`), carried on
+      // the task.done event — this is what captains relied on under the old
+      // relay formatter and must not regress (#214 unification). The task
+      // snippet is the documented fallback when no message was provided.
+      const doneMsg = event?.type === "task.done" ? event.message : undefined;
+      const body =
+        doneMsg != null && doneMsg.trim().length > 0
+          ? doneMsg.split(/\r?\n/)[0].trim().slice(0, 200)
+          : ((rec.task ?? "").split(/\r?\n/)[0]?.trim().slice(0, 120) ?? "");
+      return `CREW DONE ${tag}: ${body}`;
     }
     case "blocked":
       return `CREW BLOCKED ${tag}: ${(rec.question ?? "(no question)").trim()}`;
@@ -77,11 +90,22 @@ function firePush(
   prev: TaskState,
   next: TaskRecord,
   event: ControlEvent,
+  lastCaptainTurnAt?: number,
 ): void {
   if (!deps.notify) return;
   if (prev === next.state) return;
   if (!ATTENTION_STATES.has(next.state)) return;
-  const message = formatMessage(next);
+  // #210 idle debounce: a turn-end (awaiting-input) within IDLE_DEBOUNCE_MS of
+  // the captain's last turn is part of an active back-and-forth — suppress the
+  // CREW IDLE. All other attention states are never debounced.
+  if (
+    next.state === "awaiting-input" &&
+    lastCaptainTurnAt != null &&
+    deps.now() - lastCaptainTurnAt <= IDLE_DEBOUNCE_MS
+  ) {
+    return;
+  }
+  const message = formatMessage(next, event);
   if (!message) return;
   // Fire-and-forget; swallow errors so the daemon never trips on a flaky
   // notifier. Sync throws and async rejections both land here.
@@ -105,6 +129,11 @@ type Req =
 
 export function createDaemon(deps: DaemonDeps) {
   const { store, now } = deps;
+  // #210: per-task timestamp of the captain's most recent turn (a `crew send`/
+  // reply/answer emits task.started). Used to debounce CREW IDLE during an
+  // active back-and-forth. Bounded by the live task set; never read after a
+  // task terminates (terminal states don't transition to awaiting-input).
+  const lastCaptainTurnAt = new Map<string, number>();
   return {
     async handle(req: Req): Promise<TaskRecord | TaskRecord[]> {
       switch (req.kind) {
@@ -142,10 +171,13 @@ export function createDaemon(deps: DaemonDeps) {
         case "event": {
           const cur = store.get(req.project, req.event.id);
           if (!cur) throw new Error(`unknown task ${req.event.id}`);
+          // A captain turn (crew send/reply) arrives as task.started → record it
+          // so a quick trailing turn-end is debounced (#210).
+          if (req.event.type === "task.started") lastCaptainTurnAt.set(req.event.id, now());
           const next = reduce(cur, req.event, now());
           if (next !== cur) {
             store.put(next); // skip redundant write on terminal no-ops
-            firePush(deps, req.project, cur.state, next, req.event);
+            firePush(deps, req.project, cur.state, next, req.event, lastCaptainTurnAt.get(next.id));
           }
           return next;
         }
@@ -160,6 +192,8 @@ export function createDaemon(deps: DaemonDeps) {
           const r = store.get(req.project, req.id);
           if (!r) throw new Error(`unknown task ${req.id}`);
           if (r.state !== "blocked") throw new Error(`task ${req.id} is not blocked (state=${r.state})`);
+          // The captain's answer is a turn to the crew (#210 debounce key).
+          lastCaptainTurnAt.set(r.id, now());
           const next = reduce(r, { type: "task.started", id: r.id }, now());
           store.put(next); // persist the transition before delivering (durable first)
           if (deps.deliverReply) await deps.deliverReply(r, req.message);
@@ -195,7 +229,7 @@ export function createDaemon(deps: DaemonDeps) {
             idle.state === "awaiting-input"
               ? { type: "task.idle", id: r.id, heartbeatBudgetMs: r.heartbeatBudgetMs }
               : { type: "task.stalled", id: r.id, heartbeatBudgetMs: r.heartbeatBudgetMs };
-          firePush(deps, r.project, r.state, idle, synthEvent);
+          firePush(deps, r.project, r.state, idle, synthEvent, lastCaptainTurnAt.get(r.id));
           continue;
         }
         const recovered = recoverStall(r, t);
@@ -219,7 +253,7 @@ export function createDaemon(deps: DaemonDeps) {
             id: r.id,
             error: failed.error ?? "reconcile",
           };
-          firePush(deps, r.project, r.state, failed, synthEvent);
+          firePush(deps, r.project, r.state, failed, synthEvent, lastCaptainTurnAt.get(r.id));
         } else {
           const stalled: TaskRecord = { ...r, state: "stalled", lastEvent: "reconcile" };
           store.put(stalled);
@@ -228,7 +262,7 @@ export function createDaemon(deps: DaemonDeps) {
             id: r.id,
             reason: "interactive task lost on daemon restart",
           };
-          firePush(deps, r.project, r.state, stalled, synthEvent);
+          firePush(deps, r.project, r.state, stalled, synthEvent, lastCaptainTurnAt.get(r.id));
         }
       }
     },

--- a/src/control/mailbox.ts
+++ b/src/control/mailbox.ts
@@ -12,6 +12,11 @@ export interface MailboxEntry {
   kind: ControlEvent["type"];
   provider: TaskRecord["provider"];
   payload: Record<string, unknown>;
+  /** Daemon-rendered captain-facing message (unified-formatter, #214/#210).
+   *  The daemon's formatMessage is the single source of truth; the relay
+   *  delivers this verbatim and skips entries where it is null/empty.
+   *  `null` on entries the daemon chose not to surface (and legacy records). */
+  message?: string | null;
 }
 
 interface AppendOpts {
@@ -19,6 +24,8 @@ interface AppendOpts {
   project: string;
   taskRecord: TaskRecord;
   event: ControlEvent;
+  /** Captain-facing message rendered by the daemon (daemon.ts formatMessage). */
+  message?: string | null;
 }
 
 function inboxDir(stateRoot: string): string {
@@ -112,6 +119,7 @@ export async function appendToMailbox(opts: AppendOpts): Promise<number> {
       kind: opts.event.type,
       provider: opts.taskRecord.provider,
       payload: extractPayload(opts.event),
+      message: opts.message ?? null,
     };
     await fs.appendFile(file, JSON.stringify(entry) + "\n", { encoding: "utf-8" });
     return seq;


### PR DESCRIPTION
Fixes #214. Addresses #210. Implements the §7.3 "one shared formatter" redesign — eliminates daemon↔relay formatter drift.

## Root cause
The daemon already rendered the correct captain message (`daemon.ts formatMessage`, state-based, complete) and passed it to `notify({message,…})`. But `cockpitd.ts defaultNotify` **discarded `args.message`** and the mailbox stored only the raw event kind. The relay (`notify-relay.ts formatEntry`) then **re-derived** the message from the event kind via its own switch — which had drifted: no case for `task.approval.requested` (→ codex/opencode permission gates were captain-blind, #214) or `task.turn.completed`/idle (#210).

## Fix — daemon is the single source of truth
- **mailbox.ts**: `MailboxEntry` gains `message?: string | null`; `appendToMailbox` persists the daemon-rendered message.
- **cockpitd.ts**: `defaultNotify` passes `args.message` into the mailbox (stops discarding it).
- **notify-relay.ts**: relay is now a dumb pipe — delivers `entry.message` verbatim, skips null. The divergent `formatEntry` switch is removed.
- **Result**: `task.approval.requested` (state-machine reduces it to `blocked`) now renders **CREW BLOCKED** via the one formatter and reaches the captain — fixing #214 for **both codex and opencode** at once. (Regression test: `#214: task.approval.requested → CREW BLOCKED persisted AND delivered by the relay`.)

## Two subtleties handled
1. **DONE `--message` preserved (no regression)**: `formatMessage` now prefers the crew's `signal done --message` (carried on the `task.done` event) over the task snippet — matching the old relay behavior.
2. **Idle debounce (#210)**: `awaiting-input` → CREW IDLE is delivered, but **suppressed when the turn-end lands within `IDLE_DEBOUNCE_MS` (12s) of the captain's last turn** (`crew send`/reply emits `task.started`, tracked per task). This silences rapid send→respond→turn-end churn while still delivering a genuine self-idle. All other attention states always deliver. **`IDLE_DEBOUNCE_MS` is the reviewable knob.**

## Verification
- `vitest` 60/60 across the 4 touched test files (daemon, mailbox, cockpitd-notify, notify-relay); `tsc --noEmit` clean; no orphans.

## Pairs with
#215 (opencode CP3) — that PR emits `task.approval.requested` for opencode; this PR makes it reach the captain. Merge this to unblock #215's captain visibility.
