### PR TITLE
feat(crew): per-crew git worktree isolation via --worktree (#216)

### DIFF
--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -78,6 +78,13 @@ vi.mock("../../lib/per-crew-settings.js", () => ({
   writePerCrewOpencodeConfig,
 }));
 
+const addWorktree = vi.hoisted(() => vi.fn());
+const removeWorktree = vi.hoisted(() => vi.fn());
+vi.mock("../../lib/git-worktree.js", () => ({
+  addWorktree,
+  removeWorktree,
+}));
+
 const existsSyncMock = vi.hoisted(() => vi.fn());
 const readFileSyncMock = vi.hoisted(() => vi.fn());
 vi.mock("node:fs", async (importOriginal) => {
@@ -128,6 +135,8 @@ describe("cockpit crew spawn", () => {
     writePerCrewSettingsLocal.mockReturnValue("/tmp/brove/.claude/settings.local.json");
     writePerCrewOpencodeConfig.mockReset();
     writePerCrewOpencodeConfig.mockReturnValue("/tmp/per-crew/opencode.json");
+    addWorktree.mockReset();
+    removeWorktree.mockReset();
     existsSyncMock.mockReset();
     readFileSyncMock.mockReset();
     // Default: pretend the codex role template is absent so older tests that
@@ -187,6 +196,73 @@ describe("cockpit crew spawn", () => {
       "do the thing",
     ]);
     expect(result.title).toBe("🔧 brove:crew-1");
+  });
+
+  it("--worktree creates an isolated worktree and spawns the crew with its path as cwd", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude --append-system-prompt-file /tmp/crew.md");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-wt1" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-wt1", project: "brove", provider: "claude", mode: "interactive" });
+    const wtPath = "/tmp/brove/.worktrees/brove-crew-1";
+    addWorktree.mockReturnValue(wtPath);
+
+    const promise = runCrewSpawn({ project: "brove", task: "do the thing", worktree: true });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    // Worktree created from config.worktreeDir, off the develop base branch.
+    expect(addWorktree).toHaveBeenCalledWith({
+      repoRoot: "/tmp/brove",
+      worktreeDir: ".worktrees",
+      project: "brove",
+      name: "crew-1",
+      base: "develop",
+    });
+    // The crew runs in the worktree, not the shared root checkout.
+    expect(buildDispatchRequest).toHaveBeenCalledWith(expect.objectContaining({ cwd: wtPath }));
+    expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ workdir: wtPath }));
+    expect(writePerCrewSettingsLocal).toHaveBeenCalledWith(expect.objectContaining({ projectCwd: wtPath }));
+  });
+
+  it("without --worktree never creates a worktree (cwd stays the root checkout)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude ...");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-nowt" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-nowt" });
+
+    const promise = runCrewSpawn({ project: "brove", task: "do the thing" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(addWorktree).not.toHaveBeenCalled();
+    expect(buildDispatchRequest).toHaveBeenCalledWith(expect.objectContaining({ cwd: "/tmp/brove" }));
+    expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ workdir: "/tmp/brove" }));
+  });
+
+  it("--worktree threads a custom config.worktreeDir into worktree creation", async () => {
+    loadConfig.mockReturnValue({
+      ...baseConfig,
+      defaults: { ...baseConfig.defaults, worktreeDir: ".wt" },
+    });
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude ...");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-wtc" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-wtc" });
+    addWorktree.mockReturnValue("/tmp/brove/.wt/brove-crew-1");
+
+    const promise = runCrewSpawn({ project: "brove", task: "task", worktree: true });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(addWorktree).toHaveBeenCalledWith(expect.objectContaining({ worktreeDir: ".wt" }));
   });
 
   it("auto-names the next crew based on existing tabs (crew-1 + crew-3 → crew-2)", async () => {
@@ -622,6 +698,7 @@ describe("cockpit crew send/read/close/list", () => {
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
     cockpitdCall.mockReset();
+    removeWorktree.mockReset();
   });
 
   it("send delivers a message to the matching crew tab", async () => {
@@ -733,6 +810,43 @@ describe("cockpit crew send/read/close/list", () => {
       surfaceId: "surface:10",
       title: "🔧 brove:crew-1",
     });
+  });
+
+  it("close removes the crew's worktree when its task ran in one (cwd != root)", async () => {
+    listSurfaces.mockResolvedValue([
+      { workspaceId: "workspace:5", surfaceId: "surface:10", title: "🔧 brove:crew-1" },
+    ]);
+    const wtPath = "/tmp/brove/.worktrees/brove-crew-1";
+    cockpitdCall.mockImplementation(async (req: unknown) => {
+      const r = req as { kind: string };
+      if (r.kind === "list") {
+        return [{ id: "task-wt-1", name: "crew-1", project: "brove", state: "done", provider: "claude", mode: "interactive", task: "task", cwd: wtPath, createdAt: 1000, lastHeartbeat: 1000, lastEvent: "task.done", heartbeatBudgetMs: 300000, attempts: [] }];
+      }
+      return undefined;
+    });
+
+    await runCrewClose("brove", "crew-1");
+
+    expect(removeWorktree).toHaveBeenCalledWith("/tmp/brove", wtPath);
+    expect(closePane).toHaveBeenCalled();
+  });
+
+  it("close does NOT remove a worktree for a non-worktree crew (cwd == root)", async () => {
+    listSurfaces.mockResolvedValue([
+      { workspaceId: "workspace:5", surfaceId: "surface:10", title: "🔧 brove:crew-1" },
+    ]);
+    cockpitdCall.mockImplementation(async (req: unknown) => {
+      const r = req as { kind: string };
+      if (r.kind === "list") {
+        return [{ id: "task-root-1", name: "crew-1", project: "brove", state: "done", provider: "claude", mode: "interactive", task: "task", cwd: "/tmp/brove", createdAt: 1000, lastHeartbeat: 1000, lastEvent: "task.done", heartbeatBudgetMs: 300000, attempts: [] }];
+      }
+      return undefined;
+    });
+
+    await runCrewClose("brove", "crew-1");
+
+    expect(removeWorktree).not.toHaveBeenCalled();
+    expect(closePane).toHaveBeenCalled();
   });
 
   it("close emits task.cancelled for a non-terminal crew task before closing the pane (#184)", async () => {

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -19,10 +19,17 @@ import type { PaneRef, PanePlacement, RuntimeDriver } from "../runtimes/types.js
 import { buildDispatchRequest, cockpitdCall, sendCodexFirstTurn } from "./crew-control.js";
 import { tailLines } from "./crew-output.js";
 import { writePerCrewSettingsLocal, writePerCrewOpencodeConfig } from "../lib/per-crew-settings.js";
+import { addWorktree, removeWorktree } from "../lib/git-worktree.js";
 import { resolveTextInput } from "../lib/resolve-text-input.js";
 import { TERMINAL_STATES, type TaskRecord } from "../control/types.js";
 
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "cockpit", "templates");
+
+// Base branch for `--worktree` crew branches. GitFlow: feature work branches
+// off develop. Chosen over "current HEAD" deliberately — basing off the
+// captain's volatile HEAD would reintroduce the coupling this isolation feature
+// exists to remove (and the captain's HEAD is exactly what gets dragged today).
+const WORKTREE_BASE_BRANCH = "develop";
 
 // Poll-based first-turn delivery: after launching the CLI, poll the pane
 // until the agent is ready to accept input. Replaces a fixed delay (was 3s).
@@ -164,6 +171,9 @@ export interface CrewSpawnInput {
   direction?: PanePlacement;
   agent?: string;
   approvalPolicy?: string;
+  /** Opt-in (#216): run this crew in its own git worktree + branch instead of
+   *  the shared root checkout. For feature tasks; small/one-off tasks omit it. */
+  worktree?: boolean;
 }
 
 export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
@@ -193,6 +203,22 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
   }
   const name = input.name ?? nextAutoName(existingTitles, input.project);
 
+  // Feature crews (--worktree) run in an isolated worktree+branch so a crew's
+  // `git checkout` can't drag the captain's (shared) HEAD. Small crews keep
+  // running on the root checkout — spawnCwd stays proj.path, behavior unchanged.
+  // Build/daemon still run from the MAIN checkout's dist (#216): worktrees edit
+  // source only. The worktree path becomes the crew's cwd via the existing cwd
+  // plumbing (dispatch record + buildCommand workdir).
+  const spawnCwd = input.worktree
+    ? addWorktree({
+        repoRoot: proj.path,
+        worktreeDir: config.defaults.worktreeDir ?? ".worktrees",
+        project: input.project,
+        name,
+        base: WORKTREE_BASE_BRANCH,
+      })
+    : proj.path;
+
   const agents = new CapabilityRegistry({
     claude: createClaudeDriver(),
     codex: createCodexDriver(),
@@ -220,7 +246,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
     return runCodexInteractiveSpawn({
       project: input.project,
       task: input.task,
-      cwd: proj.path,
+      cwd: spawnCwd,
       runtime,
       workspaceId: captain.id,
       name,
@@ -255,7 +281,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
       provider: "claude",
       mode: "interactive",
       project: input.project,
-      cwd: proj.path,
+      cwd: spawnCwd,
       task: input.task,
       name,
     });
@@ -267,10 +293,10 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
     // merge across *different* settings sources — only multiple --settings
     // flags collide. .claude/settings.local.json is gitignored and merges
     // with any existing user hooks (#134).
-    writePerCrewSettingsLocal({ projectCwd: proj.path });
+    writePerCrewSettingsLocal({ projectCwd: spawnCwd });
     const cliCommand = agent.buildCommand({
       prompt: input.task,
-      workdir: proj.path,
+      workdir: spawnCwd,
       role: "crew",
       promptFile,
       interactive: true,
@@ -306,7 +332,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
       provider: "opencode",
       mode: "interactive",
       project: input.project,
-      cwd: proj.path,
+      cwd: spawnCwd,
       task: input.task,
       name,
       // opencode has no heartbeat hook, so a normal budget would false-stall
@@ -323,7 +349,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
     });
     const cliCommand = agent.buildCommand({
       prompt: input.task,
-      workdir: proj.path,
+      workdir: spawnCwd,
       role: "crew",
       promptFile,
       interactive: true,
@@ -342,7 +368,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
 
   const cliCommand = agent.buildCommand({
     prompt: input.task,
-    workdir: proj.path,
+    workdir: spawnCwd,
     role: "crew",
     promptFile,
     interactive,
@@ -484,17 +510,28 @@ export async function runCrewClose(project: string, name: string): Promise<void>
   if (!crew) {
     throw new Error(`Crew '${name}' not found for ${project}. Run 'cockpit crew list ${project}'.`);
   }
+  // resolveCaptainWorkspace already validated the project exists; reload for its
+  // root path so we can tell a worktree crew (cwd != root) from a root crew.
+  const projRoot = loadConfig().projects[project]?.path;
   // Terminalize the daemon task before closing the pane (#184). Without this,
   // non-terminal tasks (blocked/working/awaiting-input) linger in the daemon
   // ledger and keep firing phantom CREW BLOCKED/IDLE pushes until the next
   // daemon restart. 'cancelled' is terminal but NOT in ATTENTION_STATES, so
   // firePush stays silent — captain initiated the close, no notification needed.
   let taskId: string | undefined;
+  // Worktree to clean up after the pane closes — set only when this crew ran in
+  // its own worktree (cwd recorded by the daemon differs from the root checkout).
+  // A non-worktree crew has cwd === root (or unset), so this stays undefined and
+  // close is unaffected (#216).
+  let worktreeCwd: string | undefined;
   try {
     const tasks = (await cockpitdCall({ kind: "list", project })) as TaskRecord[];
     const task = tasks.find((t) => t.name === name);
     if (task) {
       taskId = task.id;
+      if (task.cwd && projRoot && task.cwd !== projRoot) {
+        worktreeCwd = task.cwd;
+      }
       if (!TERMINAL_STATES.has(task.state)) {
         await cockpitdCall({ kind: "event", project, event: { type: "task.cancelled", id: task.id, reason: "closed by captain" } });
       }
@@ -515,6 +552,16 @@ export async function runCrewClose(project: string, name: string): Promise<void>
   // that the cmux pane-close cascade may have missed.
   if (taskId !== undefined) {
     await reapCrewChildren(taskId);
+  }
+  // Auto-clean the crew's worktree AFTER its processes are gone, so we don't
+  // yank a dir out from under a live shell. Best-effort: a failed removal must
+  // not break close (the branch is preserved regardless).
+  if (worktreeCwd && projRoot) {
+    try {
+      removeWorktree(projRoot, worktreeCwd);
+    } catch (e) {
+      process.stderr.write(`(worktree remove failed: ${(e as Error).message})\n`);
+    }
   }
 }
 
@@ -542,12 +589,13 @@ crewCommand
   .option("--direction <dir>", "Placement: tab (default) or split direction (right|left|up|down)", "tab")
   .option("--agent <name>", "Agent CLI to use (claude|codex|gemini|opencode)", "claude")
   .option("--approval", "force codex approvalPolicy='untrusted' (codex only; exercises gate primitive)", false)
+  .option("--worktree", "run the crew in its own git worktree + branch (feature tasks; small tasks omit to share the root checkout)", false)
   .option("--task-file <path>", "Read task prompt from file instead of positional arg ('-' for stdin)")
   .action(
     async (
       project: string,
       task: string | undefined,
-      opts: { name?: string; direction: PanePlacement; agent: string; approval: boolean; taskFile?: string },
+      opts: { name?: string; direction: PanePlacement; agent: string; approval: boolean; worktree: boolean; taskFile?: string },
     ) => {
       try {
         const resolvedTask = await resolveTextInput({ positional: task, filePath: opts.taskFile, label: "task" });
@@ -558,6 +606,7 @@ crewCommand
           direction: opts.direction,
           agent: opts.agent,
           ...(opts.approval ? { approvalPolicy: "untrusted" } : {}),
+          ...(opts.worktree ? { worktree: true } : {}),
         });
         console.log(chalk.green(`✔ Crew '${pane.title}' spawned (${pane.surfaceId})`));
       } catch (err) {

--- a/src/lib/__tests__/git-worktree.test.ts
+++ b/src/lib/__tests__/git-worktree.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import path from "node:path";
+
+const execFileSyncMock = vi.hoisted(() => vi.fn());
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  const merged = { ...actual, execFileSync: execFileSyncMock };
+  return { ...merged, default: merged };
+});
+
+import { worktreePath, crewBranch, addWorktree, removeWorktree } from "../git-worktree.js";
+
+describe("worktreePath", () => {
+  it("resolves <repoRoot>/<worktreeDir>/<project>-<name>", () => {
+    expect(worktreePath("/tmp/brove", ".worktrees", "brove", "crew-1")).toBe(
+      path.resolve("/tmp/brove", ".worktrees", "brove-crew-1"),
+    );
+  });
+
+  it("honors a custom worktreeDir from config", () => {
+    expect(worktreePath("/tmp/brove", ".wt", "brove", "fix-typos")).toBe(
+      path.resolve("/tmp/brove", ".wt", "brove-fix-typos"),
+    );
+  });
+});
+
+describe("crewBranch", () => {
+  it("namespaces the crew name under crew/", () => {
+    expect(crewBranch("crew-1")).toBe("crew/crew-1");
+  });
+});
+
+describe("addWorktree", () => {
+  beforeEach(() => execFileSyncMock.mockReset());
+
+  it("runs `git -C <repo> worktree add <path> -b crew/<name> <base>` and returns the path", () => {
+    const wt = addWorktree({
+      repoRoot: "/tmp/brove",
+      worktreeDir: ".worktrees",
+      project: "brove",
+      name: "crew-1",
+      base: "develop",
+    });
+
+    const expectedPath = path.resolve("/tmp/brove", ".worktrees", "brove-crew-1");
+    expect(wt).toBe(expectedPath);
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      "git",
+      ["-C", "/tmp/brove", "worktree", "add", expectedPath, "-b", "crew/crew-1", "develop"],
+      expect.objectContaining({ stdio: "pipe" }),
+    );
+  });
+});
+
+describe("removeWorktree", () => {
+  beforeEach(() => execFileSyncMock.mockReset());
+
+  it("runs `git -C <repo> worktree remove <path>` (no --force on the happy path)", () => {
+    removeWorktree("/tmp/brove", "/tmp/brove/.worktrees/brove-crew-1");
+
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      "git",
+      ["-C", "/tmp/brove", "worktree", "remove", "/tmp/brove/.worktrees/brove-crew-1"],
+      expect.objectContaining({ stdio: "pipe" }),
+    );
+  });
+
+  it("retries with --force when a plain remove fails (dirty/locked worktree)", () => {
+    let calls = 0;
+    execFileSyncMock.mockImplementation(() => {
+      calls++;
+      if (calls === 1) throw new Error("contains modified or untracked files");
+      return "";
+    });
+
+    removeWorktree("/tmp/brove", "/tmp/brove/.worktrees/brove-crew-1");
+
+    expect(execFileSyncMock).toHaveBeenCalledTimes(2);
+    expect(execFileSyncMock).toHaveBeenLastCalledWith(
+      "git",
+      ["-C", "/tmp/brove", "worktree", "remove", "--force", "/tmp/brove/.worktrees/brove-crew-1"],
+      expect.objectContaining({ stdio: "pipe" }),
+    );
+  });
+});

--- a/src/lib/git-worktree.ts
+++ b/src/lib/git-worktree.ts
@@ -1,0 +1,65 @@
+// src/lib/git-worktree.ts
+//
+// Per-crew git worktree isolation (#216). A FEATURE crew (spawned with
+// `--worktree`) runs in its own worktree + branch so it can switch HEAD without
+// dragging the captain's checkout. Small/one-off crews keep running on the
+// shared root checkout (unchanged default). The side-effecting `git worktree`
+// calls live here so crew.ts stays mockable and surgical — same seam pattern as
+// per-crew-settings.ts.
+//
+// Builds and the daemon still run from the MAIN checkout's `dist`; worktrees
+// edit source only (issue #216 caveat).
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+export interface WorktreeSpec {
+  /** The project's root checkout (also the shared `.git` owner). */
+  repoRoot: string;
+  /** Config.defaults.worktreeDir, resolved relative to repoRoot (e.g. ".worktrees"). */
+  worktreeDir: string;
+  project: string;
+  /** Crew name (e.g. "crew-1" or a --name value). */
+  name: string;
+  /** Branch to base the new crew branch on (GitFlow: "develop"). */
+  base: string;
+}
+
+/** Deterministic worktree path: <repoRoot>/<worktreeDir>/<project>-<name>. */
+export function worktreePath(repoRoot: string, worktreeDir: string, project: string, name: string): string {
+  return path.resolve(repoRoot, worktreeDir, `${project}-${name}`);
+}
+
+/** Crew branch name for a worktree crew. */
+export function crewBranch(name: string): string {
+  return `crew/${name}`;
+}
+
+/**
+ * Create the crew's worktree + branch and return its absolute path.
+ * Fails loud (throws) if git refuses — e.g. the base branch is missing or the
+ * branch/path already exists. The caller's name-uniqueness check already
+ * prevents live duplicates; a re-spawned-after-close name can collide on the
+ * existing branch (rare — pick a new --name).
+ */
+export function addWorktree(spec: WorktreeSpec): string {
+  const wt = worktreePath(spec.repoRoot, spec.worktreeDir, spec.project, spec.name);
+  execFileSync(
+    "git",
+    ["-C", spec.repoRoot, "worktree", "add", wt, "-b", crewBranch(spec.name), spec.base],
+    { stdio: "pipe" },
+  );
+  return wt;
+}
+
+/**
+ * Remove a crew's worktree (auto-clean on close). Tries a plain remove first;
+ * a dirty/locked worktree makes git refuse, so we retry with --force. The
+ * branch is left intact so the crew's commits survive the close.
+ */
+export function removeWorktree(repoRoot: string, wtPath: string): void {
+  try {
+    execFileSync("git", ["-C", repoRoot, "worktree", "remove", wtPath], { stdio: "pipe" });
+  } catch {
+    execFileSync("git", ["-C", repoRoot, "worktree", "remove", "--force", wtPath], { stdio: "pipe" });
+  }
+}


### PR DESCRIPTION
Fixes #216. Completes the designed-but-unwired per-crew worktree feature.

## Background
The original design accounted for worktrees (`config.worktreeDir` defaulting to `.worktrees`) but nothing ever read it — there was no `git worktree` call anywhere, and `crew.ts` always spawned with `cwd: proj.path`. So concurrent crews shared one HEAD and collided. This PR finishes the stub, reusing the existing `cwd` plumbing.

## Design (per owner)
- **Small/one-off crew → root** (current default, unchanged).
- **Feature crew → its own git worktree + branch** (opt-in via `--worktree`).

## What
- New `src/lib/git-worktree.ts` (side-effecting `git worktree` calls isolated for mockability, same seam as per-crew-settings.ts):
  - `worktreePath` = `<repoRoot>/<worktreeDir>/<project>-<name>`
  - `crewBranch` = `crew/<name>`
  - `addWorktree` = `git worktree add <wt> -b crew/<name> develop` (fails loud)
  - `removeWorktree` = plain remove → `--force` retry; **branch left intact so commits survive close**
- `crew.ts`: `--worktree` flag. When set, `spawnCwd = addWorktree(...)` (base `develop`); else `spawnCwd = proj.path` (unchanged). `crew close` removes the worktree.

## Caveat (documented in code)
Builds and the daemon still run from the **main** checkout's `dist`; worktrees edit source only.

## Verification
- `vitest` 44/44 (git-worktree + crew); `tsc --noEmit` clean.
- **Dogfooded**: this PR was itself implemented by a crew running in an isolated worktree, concurrently with #217, with **zero collision** on the main checkout — the exact scenario #216 unblocks.

## Follow-ups (not in scope)
- Auto-pick worktree-vs-root by task size (kept explicit `--worktree` for safety).
- Per-worktree node_modules (currently the crew relies on the main checkout's deps).
