### PR TITLE
fix: terminalize dead interactive crews — close #139

### DIFF
--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -920,6 +920,41 @@ describe("cockpit crew send/read/close/list", () => {
     expect(closePane).toHaveBeenCalled();
   });
 
+  // #139: a dead crew's pane is already gone, but its daemon task record still
+  // dangles in a non-terminal state. close must terminalize that record even
+  // when there is no pane to close — gating terminalization on findCrew left
+  // the zombie record to re-emit false CREW STALLED forever.
+  it("close terminalizes the daemon task when the crew pane is already gone (#139)", async () => {
+    listSurfaces.mockResolvedValue([]); // pane gone — crew session died
+    cockpitdCall.mockImplementation(async (req: unknown) => {
+      const r = req as { kind: string };
+      if (r.kind === "list") {
+        return [{ id: "task-dead-1", name: "crew-1", project: "brove", state: "working", provider: "claude", mode: "interactive", task: "task", createdAt: 1000, lastHeartbeat: 1000, lastEvent: "task.started", heartbeatBudgetMs: 86400000, attempts: [] }];
+      }
+      return undefined;
+    });
+
+    await runCrewClose("brove", "crew-1"); // must NOT throw
+
+    expect(cockpitdCall).toHaveBeenCalledWith(expect.objectContaining({
+      kind: "event",
+      project: "brove",
+      event: { type: "task.cancelled", id: "task-dead-1", reason: "closed by captain" },
+    }));
+    expect(closePane).not.toHaveBeenCalled(); // no pane to close
+  });
+
+  it("close throws when neither a pane nor a daemon task exists (typo guard) (#139)", async () => {
+    listSurfaces.mockResolvedValue([]); // no pane
+    cockpitdCall.mockImplementation(async (req: unknown) => {
+      const r = req as { kind: string };
+      if (r.kind === "list") return []; // no daemon task either
+      return undefined;
+    });
+
+    await expect(runCrewClose("brove", "ghost")).rejects.toThrow(/not found/i);
+  });
+
   it("list returns all crews for the project, ignoring non-crew tabs", async () => {
     listSurfaces.mockResolvedValue([
       { workspaceId: "workspace:5", surfaceId: "surface:9", title: "captain shell" },

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -513,18 +513,16 @@ export async function reapCrewChildren(taskId: string, graceMs = 2000): Promise<
 
 export async function runCrewClose(project: string, name: string): Promise<void> {
   const { runtime, workspaceId } = await resolveCaptainWorkspace(project);
-  const crew = await findCrew(runtime, workspaceId, project, name);
-  if (!crew) {
-    throw new Error(`Crew '${name}' not found for ${project}. Run 'cockpit crew list ${project}'.`);
-  }
   // resolveCaptainWorkspace already validated the project exists; reload for its
   // root path so we can tell a worktree crew (cwd != root) from a root crew.
   const projRoot = loadConfig().projects[project]?.path;
-  // Terminalize the daemon task before closing the pane (#184). Without this,
-  // non-terminal tasks (blocked/working/awaiting-input) linger in the daemon
-  // ledger and keep firing phantom CREW BLOCKED/IDLE pushes until the next
-  // daemon restart. 'cancelled' is terminal but NOT in ATTENTION_STATES, so
-  // firePush stays silent — captain initiated the close, no notification needed.
+  // Terminalize the daemon task FIRST — before (and independent of) finding the
+  // cmux pane (#184, hardened for #139). Without this, non-terminal tasks
+  // (blocked/working/awaiting-input) linger in the daemon ledger and keep firing
+  // phantom CREW BLOCKED/IDLE/STALLED pushes. Crucially, a DEAD crew's pane is
+  // already gone, so gating terminalization on findCrew (the old order) left that
+  // zombie record dangling forever. 'cancelled' is terminal but NOT in
+  // ATTENTION_STATES, so firePush stays silent — captain initiated the close.
   let taskId: string | undefined;
   // Worktree to clean up after the pane closes — set only when this crew ran in
   // its own worktree (cwd recorded by the daemon differs from the root checkout).
@@ -554,7 +552,16 @@ export async function runCrewClose(project: string, name: string): Promise<void>
   } catch {
     // Swallow daemon errors — a crew without a daemon must still close.
   }
-  await runtime.closePane(crew);
+  // Close the cmux pane if it still exists. A dead crew's pane is already gone —
+  // that is not an error (the record is terminalized above); proceed to reap
+  // children / clean the worktree. Only a genuine miss (no pane AND no daemon
+  // task) is a typo → surface the not-found error.
+  const crew = await findCrew(runtime, workspaceId, project, name);
+  if (crew) {
+    await runtime.closePane(crew);
+  } else if (taskId === undefined) {
+    throw new Error(`Crew '${name}' not found for ${project}. Run 'cockpit crew list ${project}'.`);
+  }
   // Reap any surviving child processes (vitest workers, node subprocs, etc.)
   // that the cmux pane-close cascade may have missed.
   if (taskId !== undefined) {

--- a/src/control/__tests__/cockpitd-push.test.ts
+++ b/src/control/__tests__/cockpitd-push.test.ts
@@ -92,7 +92,7 @@ describe("cockpitd push notifications (#109)", () => {
     store.put(rec("task-stall-1", { mode: "headless", state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250 }));
     const n = fakeNotify();
     const d = createDaemon({ store, now: () => 5000, notify: n.notify });
-    d.sweep();
+    await d.sweep();
     expect(store.get("p", "task-stall-1")?.state).toBe("stalled");
     expect(n.calls).toHaveLength(1);
     expect(n.calls[0]?.message).toMatch(/^CREW STALLED \[claude\/task-sta/);
@@ -105,7 +105,7 @@ describe("cockpitd push notifications (#109)", () => {
     store.put(rec("task-idle-1", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250 }));
     const n = fakeNotify();
     const d = createDaemon({ store, now: () => 5000, notify: n.notify });
-    d.sweep();
+    await d.sweep();
     expect(store.get("p", "task-idle-1")?.state).toBe("awaiting-input");
     expect(n.calls).toHaveLength(1);
     expect(n.calls[0]?.message).toMatch(/^CREW IDLE \[claude\/task-idl/);
@@ -118,9 +118,9 @@ describe("cockpitd push notifications (#109)", () => {
     store.put(rec("task-idle-2", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250 }));
     const n = fakeNotify();
     const d = createDaemon({ store, now: () => 5000, notify: n.notify });
-    d.sweep(); // working → awaiting-input, one push
-    d.sweep(); // awaiting-input is not 'working' → no re-stall, no re-notify
-    d.sweep();
+    await d.sweep(); // working → awaiting-input, one push
+    await d.sweep(); // awaiting-input is not 'working' → no re-stall, no re-notify
+    await d.sweep();
     expect(store.get("p", "task-idle-2")?.state).toBe("awaiting-input");
     expect(n.calls).toHaveLength(1);
   });
@@ -130,7 +130,7 @@ describe("cockpitd push notifications (#109)", () => {
     store.put(rec("task-idle-3", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250 }));
     const n = fakeNotify();
     const d = createDaemon({ store, now: () => 5000, notify: n.notify });
-    d.sweep(); // → awaiting-input, push #1 (CREW IDLE)
+    await d.sweep(); // → awaiting-input, push #1 (CREW IDLE)
     await d.handle({ kind: "event", project: "p", event: { type: "task.started", id: "task-idle-3" } });
     expect(store.get("p", "task-idle-3")?.state).toBe("working");
     expect(n.calls).toHaveLength(1); // working is not an attention state → no extra push

--- a/src/control/__tests__/daemon.test.ts
+++ b/src/control/__tests__/daemon.test.ts
@@ -52,24 +52,45 @@ describe("daemon handler", () => {
     const store = createStore(dir);
     store.put(rec("h1", { state: "working", mode: "headless", pid: 999999 }));
     const d = createDaemon({ store, now: () => 5000, isPidAlive: () => false });
-    d.reconcile();
+    await d.reconcile();
     expect(store.get("p", "h1")?.state).toBe("failed");
     expect(store.get("p", "h1")?.error).toMatch(/orphan|daemon restart/i);
   });
 
-  it("reconcile: working interactive task → stalled (hook source gone)", async () => {
+  // #139: on daemon restart a LIVE interactive crew's cmux pane survives the
+  // bounce, so it must NOT be moved to 'stalled' (the old behavior false-stalled
+  // it AND fired CREW STALLED). Only a PROVABLY-gone surface is terminalized.
+  it("reconcile: interactive orphan with a GONE surface → cancelled (silent) (#139)", async () => {
     const store = createStore(dir);
     store.put(rec("i1", { state: "working", mode: "interactive" }));
-    const d = createDaemon({ store, now: () => 5000, isPidAlive: () => false });
-    d.reconcile();
-    expect(store.get("p", "i1")?.state).toBe("stalled");
+    const calls: any[] = [];
+    const d = createDaemon({ store, now: () => 5000, isSurfaceAlive: async () => "gone", notify: async (a) => { calls.push(a); } });
+    await d.reconcile();
+    expect(store.get("p", "i1")?.state).toBe("cancelled");
+    expect(calls.length).toBe(0); // silent — no CREW STALLED re-emitted
+  });
+
+  it("reconcile: interactive orphan with a LIVE surface stays working (reattachable) (#139)", async () => {
+    const store = createStore(dir);
+    store.put(rec("i2", { state: "working", mode: "interactive" }));
+    const d = createDaemon({ store, now: () => 5000, isSurfaceAlive: async () => "alive" });
+    await d.reconcile();
+    expect(store.get("p", "i2")?.state).toBe("working");
+  });
+
+  it("reconcile: interactive orphan with UNKNOWN surface liveness stays working (never false-cancel) (#139)", async () => {
+    const store = createStore(dir);
+    store.put(rec("i3", { state: "working", mode: "interactive" }));
+    const d = createDaemon({ store, now: () => 5000, isSurfaceAlive: async () => "unknown" });
+    await d.reconcile();
+    expect(store.get("p", "i3")?.state).toBe("working");
   });
 
   it("reconcile: working headless task with live pid → stays working", async () => {
     const store = createStore(dir);
     store.put(rec("h2", { state: "working", mode: "headless", pid: 4242 }));
     const d = createDaemon({ store, now: () => 5000, isPidAlive: () => true });
-    d.reconcile();
+    await d.reconcile();
     expect(store.get("p", "h2")?.state).toBe("working");
   });
 
@@ -77,7 +98,7 @@ describe("daemon handler", () => {
     const store = createStore(dir);
     store.put(rec("s1", { mode: "headless", state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 100 }));
     const d = createDaemon({ store, now: () => 1000 });
-    d.sweep();
+    await d.sweep();
     expect(store.get("p", "s1")?.state).toBe("stalled");
   });
 
@@ -85,7 +106,7 @@ describe("daemon handler", () => {
     const store = createStore(dir);
     store.put(rec("s1i", { mode: "interactive", state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 100 }));
     const d = createDaemon({ store, now: () => 1000 });
-    d.sweep();
+    await d.sweep();
     expect(store.get("p", "s1i")?.state).toBe("awaiting-input");
   });
 
@@ -93,7 +114,7 @@ describe("daemon handler", () => {
     const store = createStore(dir);
     store.put(rec("s2", { state: "stalled", lastHeartbeat: 990, heartbeatBudgetMs: 100 }));
     const d = createDaemon({ store, now: () => 1000 });
-    d.sweep();
+    await d.sweep();
     expect(store.get("p", "s2")?.state).toBe("working");
   });
 
@@ -102,8 +123,70 @@ describe("daemon handler", () => {
     // lastHeartbeat=0, budget=100, now=1000 → 1000-0=1000 > 100 → guard blocks recovery
     store.put(rec("s3", { state: "stalled", lastHeartbeat: 0, heartbeatBudgetMs: 100 }));
     const d = createDaemon({ store, now: () => 1000 });
-    d.sweep();
+    await d.sweep();
     expect(store.get("p", "s3")?.state).toBe("stalled");
+  });
+
+  // ── #139 backstop: sweep reaps interactive records whose surface is gone ─────
+  // Covers opencode crews (no SessionEnd hook) and any missed claude SessionEnd.
+  // A provably-gone surface means the crew can never make progress → cancelled,
+  // silently (NOT oscillated working↔stalled, NOT a re-fired CREW STALLED).
+  it("sweep: interactive WORKING record with a gone surface → cancelled (silent), within 24h budget (#139)", async () => {
+    const store = createStore(dir);
+    // Heartbeat is FRESH (well within the 24h budget) — proves the reap is
+    // liveness-based, not a shorter timeout. The legitimate-idle false-stall fix
+    // (#131/#133) keeps the 86400000ms budget; only a dead surface reaps.
+    store.put(rec("g1", { mode: "interactive", state: "working", lastHeartbeat: 990, heartbeatBudgetMs: 86_400_000 }));
+    const calls: any[] = [];
+    const d = createDaemon({ store, now: () => 1000, isSurfaceAlive: async () => "gone", notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    expect(store.get("p", "g1")?.state).toBe("cancelled");
+    expect(calls.length).toBe(0); // silent reap
+  });
+
+  it("sweep: interactive AWAITING-INPUT record with a gone surface → cancelled (#139)", async () => {
+    const store = createStore(dir);
+    store.put(rec("g2", { mode: "interactive", state: "awaiting-input", lastHeartbeat: 990, heartbeatBudgetMs: 86_400_000 }));
+    const d = createDaemon({ store, now: () => 1000, isSurfaceAlive: async () => "gone" });
+    await d.sweep();
+    expect(store.get("p", "g2")?.state).toBe("cancelled");
+  });
+
+  it("sweep: interactive STALLED record with a gone surface → cancelled (not left oscillating) (#139)", async () => {
+    const store = createStore(dir);
+    store.put(rec("g3", { mode: "interactive", state: "stalled", lastHeartbeat: 990, heartbeatBudgetMs: 86_400_000 }));
+    const d = createDaemon({ store, now: () => 1000, isSurfaceAlive: async () => "gone" });
+    await d.sweep();
+    expect(store.get("p", "g3")?.state).toBe("cancelled");
+  });
+
+  // The critical non-regression: a LEGITIMATELY-IDLE live crew (surface alive)
+  // that is over its heartbeat budget must still become awaiting-input (CREW
+  // IDLE), NEVER reaped. This preserves the #131/#133 24h-budget false-stall fix.
+  it("sweep: interactive over-budget record with a LIVE surface → awaiting-input, not reaped (#139)", async () => {
+    const store = createStore(dir);
+    store.put(rec("g4", { mode: "interactive", state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 100 }));
+    const d = createDaemon({ store, now: () => 1000, isSurfaceAlive: async () => "alive" });
+    await d.sweep();
+    expect(store.get("p", "g4")?.state).toBe("awaiting-input");
+  });
+
+  it("sweep: interactive over-budget record with UNKNOWN surface → awaiting-input, never false-reaped (#139)", async () => {
+    const store = createStore(dir);
+    store.put(rec("g5", { mode: "interactive", state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 100 }));
+    const d = createDaemon({ store, now: () => 1000, isSurfaceAlive: async () => "unknown" });
+    await d.sweep();
+    expect(store.get("p", "g5")?.state).toBe("awaiting-input");
+  });
+
+  it("sweep: headless records are never surface-reaped (pid is their liveness) (#139)", async () => {
+    const store = createStore(dir);
+    // A headless working record with a fresh heartbeat: even if isSurfaceAlive
+    // says 'gone', headless mode must ignore it (it has no cmux surface).
+    store.put(rec("g6", { mode: "headless", state: "working", lastHeartbeat: 990, heartbeatBudgetMs: 1000 }));
+    const d = createDaemon({ store, now: () => 1000, isSurfaceAlive: async () => "gone" });
+    await d.sweep();
+    expect(store.get("p", "g6")?.state).toBe("working");
   });
 
   it("dispatch persists submitted then (headless) triggers launch hook", async () => {

--- a/src/control/__tests__/integration-restart.test.ts
+++ b/src/control/__tests__/integration-restart.test.ts
@@ -10,17 +10,18 @@ describe("integration: daemon restart mid-task (success criterion)", () => {
   let stop: (() => void) | undefined; let dir: string;
   afterEach(() => { stop?.(); if (dir) rmSync(dir, { recursive: true, force: true }); });
 
-  it("a working interactive task survives a daemon restart as 'stalled' (no false done)", async () => {
+  // #139: an interactive crew whose cmux pane is PROVABLY gone is terminalized
+  // (cancelled) on daemon restart — never oscillated to 'stalled' (which fired
+  // false CREW STALLED on every restart) and never fabricated to 'done'.
+  it("interactive orphan with a GONE surface → cancelled on daemon restart (no false done/stalled)", async () => {
     dir = mkdtempSync(join(tmpdir(), "cp-int-"));
     const sock = join(dir, "c.sock");
     const stateRoot = join(dir, "state");
 
     let h = startCockpitd({ stateRoot, sockPath: sock, sweepMs: 0 });
     // Construct the precondition (a WORKING interactive task) via `seed`, not
-    // `dispatch`: red-team #4 fix makes interactive dispatch fail-loud until
-    // the deferred interactive launcher exists. The success criterion under
-    // test is reconcile behavior (working interactive → stalled across a
-    // restart, never fabricated `done`), which is unchanged and still proven.
+    // `dispatch`: red-team #4 fix makes interactive dispatch fail-loud until the
+    // deferred interactive launcher exists.
     await sendRequest(sock, { kind: "seed", record: {
       id: "t1", project: "p", provider: "claude", mode: "interactive",
       state: "working", task: "x", createdAt: 1, lastHeartbeat: 1,
@@ -30,15 +31,59 @@ describe("integration: daemon restart mid-task (success criterion)", () => {
     // crash the daemon mid-task
     h.stop();
 
-    // restart — reconcile() must run on boot
-    h = startCockpitd({ stateRoot, sockPath: sock, sweepMs: 0 });
+    // restart — reconcile() runs on boot; the crew's pane is gone (session died)
+    h = startCockpitd({ stateRoot, sockPath: sock, sweepMs: 0, isSurfaceAlive: async () => "gone" });
+    stop = h.stop;
+
+    const st: any = await pollStatus(sock, "t1", (s) => s.state === "cancelled");
+    expect(st.state).toBe("cancelled");        // terminalized, not oscillated
+    expect(st.state).not.toBe("stalled");      // never re-emits CREW STALLED
+    expect(st.state).not.toBe("done");         // never fabricated success
+  });
+
+  // The non-regression companion: when liveness is INDETERMINATE (cmux down at
+  // boot — the common test/headless case), the crew stays 'working' (the
+  // reattach loop + a later sweep re-check own it). Never false-cancelled, never
+  // false-stalled, never falsely 'done'.
+  it("interactive orphan with UNKNOWN surface liveness stays 'working' on restart (no false terminal)", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-int-unk-"));
+    const sock = join(dir, "c.sock");
+    const stateRoot = join(dir, "state");
+
+    let h = startCockpitd({ stateRoot, sockPath: sock, sweepMs: 0 });
+    await sendRequest(sock, { kind: "seed", record: {
+      id: "t1", project: "p", provider: "claude", mode: "interactive",
+      state: "working", task: "x", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "task.started", heartbeatBudgetMs: 999999,
+      attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }] } });
+    h.stop();
+
+    h = startCockpitd({ stateRoot, sockPath: sock, sweepMs: 0, isSurfaceAlive: async () => "unknown" });
     stop = h.stop;
 
     const st: any = await sendRequest(sock, { kind: "status", project: "p", id: "t1" });
-    expect(st.state).toBe("stalled");          // surfaced deterministically
-    expect(st.state).not.toBe("done");          // never fabricated success
+    expect(st.state).toBe("working");
+    expect(st.state).not.toBe("done");
+    expect(st.state).not.toBe("cancelled");
   });
 });
+
+// Boot reconcile runs in an async IIFE, so a status query can race it; poll
+// briefly until the predicate holds (or time out and return the last status).
+async function pollStatus(
+  sock: string,
+  id: string,
+  done: (s: any) => boolean,
+  tries = 40,
+): Promise<any> {
+  let last: any;
+  for (let i = 0; i < tries; i++) {
+    last = await sendRequest(sock, { kind: "status", project: "p", id });
+    if (done(last)) return last;
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  return last;
+}
 
 describe("integration: headless dead-pid conservative crash recovery", () => {
   it("dead headless pid reconciles to 'failed' on daemon restart", async () => {

--- a/src/control/__tests__/interactive-claude-hook.test.ts
+++ b/src/control/__tests__/interactive-claude-hook.test.ts
@@ -17,9 +17,14 @@ describe("mapClaudeHookToEvent", () => {
     expect(ev).toEqual({ type: "task.progress", id: TID, note: "subagentstop" });
   });
 
-  it("maps SessionEnd → task.progress with note 'sessionend' (NOT terminal)", () => {
+  // #139: SessionEnd means the crew session is GONE. It must NOT be liveness —
+  // mapping it to task.progress resumed a dead crew to 'working', which the
+  // watchdog then false-stalled ~budget later. It maps to task.session.ended,
+  // which the reducer terminalizes (→ cancelled). Only PostToolUse and
+  // SubagentStop count as resume-liveness.
+  it("maps SessionEnd → task.session.ended (terminal, NOT liveness) (#139)", () => {
     const ev = mapClaudeHookToEvent("SessionEnd", { reason: "exit" }, TID);
-    expect(ev).toEqual({ type: "task.progress", id: TID, note: "sessionend" });
+    expect(ev).toEqual({ type: "task.session.ended", id: TID });
   });
 
   // PostToolUse fires after every tool call MID-turn, so it keeps the

--- a/src/control/__tests__/state-machine.test.ts
+++ b/src/control/__tests__/state-machine.test.ts
@@ -218,6 +218,33 @@ describe("state-machine reduce", () => {
     const next = reduce(done, { type: "task.cancelled", id: "t1", reason: "closed" }, 7000);
     expect(next).toBe(done);
   });
+
+  // ── Issue #139: a dead claude session terminalizes, never resumes 'working' ──
+  // SessionEnd maps to task.session.ended (NOT task.progress). The crew process
+  // is gone, so the record must reach a terminal state instead of being revived
+  // to 'working' (where nothing heartbeats and the watchdog later false-stalls).
+  it("task.session.ended on awaiting-input → cancelled (NOT working) (#139)", () => {
+    const next = reduce(rec({ state: "awaiting-input" }), { type: "task.session.ended", id: "t1" }, 8000);
+    expect(next.state).toBe("cancelled");
+    expect(next.lastHeartbeat).toBe(8000);
+    expect(next.lastEvent).toBe("task.session.ended");
+  });
+
+  it("task.session.ended on working → cancelled (#139)", () => {
+    const next = reduce(rec({ state: "working" }), { type: "task.session.ended", id: "t1" }, 8001);
+    expect(next.state).toBe("cancelled");
+  });
+
+  it("task.session.ended on blocked → cancelled (dead session can't be answered) (#139)", () => {
+    const next = reduce(rec({ state: "blocked", question: "q?" }), { type: "task.session.ended", id: "t1" }, 8002);
+    expect(next.state).toBe("cancelled");
+  });
+
+  it("done task absorbs task.session.ended — already terminal, no state change (#139)", () => {
+    const done = rec({ state: "done", resultRef: "/r" });
+    const next = reduce(done, { type: "task.session.ended", id: "t1" }, 8003);
+    expect(next).toBe(done);
+  });
 });
 
 describe("DispatchAttempt schema", () => {

--- a/src/control/__tests__/surface-liveness.test.ts
+++ b/src/control/__tests__/surface-liveness.test.ts
@@ -1,0 +1,31 @@
+// src/control/__tests__/surface-liveness.test.ts
+import { describe, it, expect } from "vitest";
+import { surfaceVerdict } from "../crew-pane-reader.js";
+
+// #139: the pure decision behind the daemon's interactive surface-liveness
+// backstop. "gone" must mean PROVABLY absent (cmux answered, the crew's pane is
+// not among the surfaces) — never an "I couldn't tell" — so a transient cmux
+// outage can never false-reap a live crew.
+describe("surfaceVerdict (#139)", () => {
+  const WANT = "🔧 brove:crew-1";
+
+  it("present surface list containing the crew's title → alive", () => {
+    expect(surfaceVerdict(["🔧 brove:crew-1", "some-other-tab"], WANT)).toBe("alive");
+  });
+
+  it("present surface list NOT containing the crew's title → gone (provably absent)", () => {
+    expect(surfaceVerdict(["some-other-tab"], WANT)).toBe("gone");
+  });
+
+  it("empty surface list (cmux up, captain found, no crew pane) → gone", () => {
+    expect(surfaceVerdict([], WANT)).toBe("gone");
+  });
+
+  it("null surfaces (could not enumerate — cmux down / no captain) → unknown, never reaps", () => {
+    expect(surfaceVerdict(null, WANT)).toBe("unknown");
+  });
+
+  it("null want-title (crew has no name) → unknown", () => {
+    expect(surfaceVerdict(["anything"], null)).toBe("unknown");
+  });
+});

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -12,6 +12,7 @@ import { CodexInteractiveDriver, shouldReattachCodex } from "./codex/driver.js";
 import { OpencodeSseBridge } from "./opencode/sse-bridge.js";
 import { makeGate } from "./codex/gate.js";
 import { appendToMailbox, rotateIfNeeded } from "./mailbox.js";
+import { createSurfaceLivenessProbe } from "./crew-pane-reader.js";
 import { readdir } from "node:fs/promises";
 import type { Gate, TaskRecord, ControlEvent } from "./types.js";
 import { TERMINAL_STATES } from "./types.js";
@@ -22,6 +23,9 @@ export interface CockpitdOpts {
   sockPath?: string;
   sweepMs?: number; // 0 disables the interval (tests)
   isPidAlive?: (pid: number) => boolean; // injectable for the headless reconcile path (tests)
+  // injectable for the #139 interactive surface-liveness reaper (tests); defaults
+  // to the real cmux probe. Returns "alive" | "gone" | "unknown".
+  isSurfaceAlive?: (rec: TaskRecord) => Promise<"alive" | "gone" | "unknown">;
   spawn?: typeof realSpawn;
   /**
    * Push-notification hook (#109). Defaults to appending a structured event
@@ -228,6 +232,9 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
 
   const d = createDaemon({
     store, now: () => Date.now(), isPidAlive, notify,
+    // #139 backstop: terminalize interactive crews whose cmux pane is provably
+    // gone (sweep/reconcile reaper). Three-valued; "unknown" never reaps.
+    isSurfaceAlive: opts.isSurfaceAlive ?? createSurfaceLivenessProbe(),
     launchHeadless: async (rec) => {
       await runHeadless({
         provider: rec.provider, task: rec.task, id: rec.id, sessionId: rec.sessionId,
@@ -282,37 +289,49 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
     },
   });
 
-  d.reconcile(); // crash recovery on boot
+  // Crash recovery on boot. reconcile() is async (#139: it consults the
+  // interactive surface-liveness probe to reap dead crews instead of stalling
+  // them), so run it — and the reattach loops that depend on its terminalizing a
+  // dead crew before we re-subscribe it — inside an async IIFE. startCockpitd
+  // stays synchronous (returns the handle immediately); boot recovery settles
+  // shortly after. Errors are swallowed: a flaky probe must not crash boot.
+  void (async () => {
+    try {
+      await d.reconcile();
+    } catch (e) {
+      log(`reconcile on boot failed: ${(e as Error).message}`);
+    }
 
-  // Restart-reattach (spec §5; closes interactive slice of #86):
-  // For each LIVE interactive-codex task that has a resumeRef, fire reattach()
-  // against the driver. Fire-and-forget; failures are logged only.
-  //
-  // Guard against the reattach storm: resuming a thread re-spawns its per-thread
-  // MCP servers (gitnexus/pay), so blindly reattaching every non-terminal codex
-  // task means each daemon restart re-spawns one MCP set per HISTORICAL crew —
-  // which exhausted RAM (22 zombie tasks → 22 gitnexus servers on one boot).
-  // Skip terminal tasks (done/failed/cancelled — incl. crews closed via the new
-  // codex-close archive) AND stale tasks whose crew pane is long gone (no
-  // heartbeat within the staleness window — the watchdog would stall them too).
-  const bootNow = Date.now();
-  const REATTACH_STALE_MS = 10 * 60_000;
-  for (const rec of store.listAll()) {
-    if (!shouldReattachCodex(rec, bootNow, REATTACH_STALE_MS)) continue;
-    codexDriver.reattach(rec).catch((e: unknown) => {
-      log(`reattach failed for ${rec.id}: ${(e as Error).message}`);
-    });
-  }
+    // Restart-reattach (spec §5; closes interactive slice of #86):
+    // For each LIVE interactive-codex task that has a resumeRef, fire reattach()
+    // against the driver. Fire-and-forget; failures are logged only.
+    //
+    // Guard against the reattach storm: resuming a thread re-spawns its per-thread
+    // MCP servers (gitnexus/pay), so blindly reattaching every non-terminal codex
+    // task means each daemon restart re-spawns one MCP set per HISTORICAL crew —
+    // which exhausted RAM (22 zombie tasks → 22 gitnexus servers on one boot).
+    // Skip terminal tasks (done/failed/cancelled — incl. crews closed via the new
+    // codex-close archive AND #139's surface-reaped crews) AND stale tasks whose
+    // crew pane is long gone (no heartbeat within the staleness window).
+    const bootNow = Date.now();
+    const REATTACH_STALE_MS = 10 * 60_000;
+    for (const rec of store.listAll()) {
+      if (!shouldReattachCodex(rec, bootNow, REATTACH_STALE_MS)) continue;
+      codexDriver.reattach(rec).catch((e: unknown) => {
+        log(`reattach failed for ${rec.id}: ${(e as Error).message}`);
+      });
+    }
 
-  // Re-subscribe the opencode SSE bridge after a daemon bounce: the crew's
-  // cmux pane (and its `opencode --port <N>` server) survives a daemon restart,
-  // so a non-terminal opencode crew with a known serverPort can be re-attached.
-  for (const rec of store.listAll()) {
-    if (rec.provider !== "opencode" || rec.mode !== "interactive") continue;
-    if (TERMINAL_STATES.has(rec.state)) continue;
-    if (!rec.serverPort) continue;
-    opencodeBridge.start({ taskId: rec.id, port: rec.serverPort });
-  }
+    // Re-subscribe the opencode SSE bridge after a daemon bounce: the crew's
+    // cmux pane (and its `opencode --port <N>` server) survives a daemon restart,
+    // so a non-terminal opencode crew with a known serverPort can be re-attached.
+    for (const rec of store.listAll()) {
+      if (rec.provider !== "opencode" || rec.mode !== "interactive") continue;
+      if (TERMINAL_STATES.has(rec.state)) continue;
+      if (!rec.serverPort) continue;
+      opencodeBridge.start({ taskId: rec.id, port: rec.serverPort });
+    }
+  })();
 
   const server = startServer(sockPath, {
     handler: async (msg: any) => {
@@ -360,7 +379,17 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
 
   let timer: NodeJS.Timeout | undefined;
   if (opts.sweepMs && opts.sweepMs > 0) {
-    timer = setInterval(() => d.sweep(), opts.sweepMs);
+    // sweep() is async (#139: it probes cmux surface liveness). Guard against an
+    // overlapping run if a probe is slow — skip this tick rather than stacking
+    // sweeps. Errors are swallowed so a flaky probe never crashes the daemon.
+    let sweeping = false;
+    timer = setInterval(() => {
+      if (sweeping) return;
+      sweeping = true;
+      void d.sweep()
+        .catch((e: unknown) => log(`sweep failed: ${(e as Error).message}`))
+        .finally(() => { sweeping = false; });
+    }, opts.sweepMs);
     timer.unref?.();
   }
 

--- a/src/control/crew-pane-reader.ts
+++ b/src/control/crew-pane-reader.ts
@@ -10,6 +10,58 @@ function crewPaneTitle(project: string, name: string): string {
   return `🔧 ${project}:${name}`;
 }
 
+export type SurfaceLiveness = "alive" | "gone" | "unknown";
+
+/**
+ * Pure: decide an interactive crew's surface liveness from a resolved surface
+ * list (#139). Three-valued so a transient cmux outage never false-reaps a live
+ * crew — "gone" means PROVABLY absent, not "couldn't tell":
+ *   - wantTitle null (crew has no name)            → "unknown"
+ *   - surfaceTitles null (could not enumerate)     → "unknown"
+ *   - title present in the list                    → "alive"
+ *   - title absent from an enumerated list         → "gone"
+ */
+export function surfaceVerdict(surfaceTitles: string[] | null, wantTitle: string | null): SurfaceLiveness {
+  if (!wantTitle) return "unknown";
+  if (surfaceTitles == null) return "unknown";
+  return surfaceTitles.includes(wantTitle) ? "alive" : "gone";
+}
+
+/**
+ * I/O: enumerate the captain workspace's surface titles for a crew's project,
+ * the same way the pane reader does. Returns null on ANY failure (cmux down, no
+ * captain, no project) — surfaceVerdict maps null → "unknown" so we never reap
+ * on an inconclusive probe. Never throws (the daemon sweep must not trip).
+ */
+async function listCaptainSurfaceTitles(rec: TaskRecord): Promise<string[] | null> {
+  try {
+    const config = loadConfig();
+    const proj = config.projects[rec.project];
+    if (!proj) return null;
+    const runtime = new RuntimeRegistry({ cmux: createCmuxDriver() }).forProject(rec.project, config);
+    const captain = await runtime.status(proj.captainName);
+    if (!captain) return null;
+    const surfaces = await runtime.listSurfaces(captain.id);
+    return surfaces.map((s) => s.title ?? "");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build the daemon's interactive surface-liveness probe (#139 backstop). Wired
+ * into createDaemon as `isSurfaceAlive`: the sweep/reconcile reaper terminalizes
+ * a non-terminal interactive record whose pane is provably gone. Non-interactive
+ * or unnamed records short-circuit to "unknown" (never reaped).
+ */
+export function createSurfaceLivenessProbe(): (rec: TaskRecord) => Promise<SurfaceLiveness> {
+  return async (rec) => {
+    if (rec.mode !== "interactive" || !rec.name) return "unknown";
+    const titles = await listCaptainSurfaceTitles(rec);
+    return surfaceVerdict(titles, crewPaneTitle(rec.project, rec.name));
+  };
+}
+
 /**
  * Build the daemon's best-effort crew-pane reader (Phase 2b). Resolves the
  * crew's cmux pane the same way `cockpit crew read` does — captain workspace →

--- a/src/control/daemon.ts
+++ b/src/control/daemon.ts
@@ -11,6 +11,17 @@ export interface DaemonDeps {
   deliverReply?: (rec: TaskRecord, message: string) => Promise<void>;
   /** Defaults to a real process.kill(pid,0) check at the call site (Task 17). */
   isPidAlive?: (pid: number) => boolean;
+  /**
+   * #139 backstop: the interactive analogue of isPidAlive. Resolves whether an
+   * interactive crew's backing cmux surface (pane/tab) still exists. Three-valued
+   * so a transient cmux outage never false-reaps a live crew:
+   *   - "alive"   → the crew's pane is present; keep watching.
+   *   - "gone"    → cmux answered AND the pane is provably absent → terminalize.
+   *   - "unknown" → could not determine (cmux down, no captain, error) → do nothing.
+   * Defaults to always-"unknown" (never reaps) when not wired — pure unit tests
+   * and any non-cmux deployment are unaffected.
+   */
+  isSurfaceAlive?: (rec: TaskRecord) => Promise<"alive" | "gone" | "unknown">;
   /** Wired in cockpitd to runHeadless; absent in pure unit tests. */
   launchHeadless?: (rec: TaskRecord) => Promise<void>;
   /**
@@ -42,6 +53,12 @@ export interface DaemonDeps {
 // Stop-hook turn boundary) fires exactly one accurate CREW IDLE push. The
 // firePush prev===next guard keeps it from re-firing while the task sits idle.
 const ATTENTION_STATES: ReadonlySet<TaskState> = new Set(["done", "blocked", "failed", "stalled", "awaiting-input"]);
+
+// #139: non-terminal, post-launch states an interactive crew can be sitting in
+// while its session has actually died. Any of these with a provably-gone surface
+// is a zombie → reap to 'cancelled'. 'submitted' is excluded: it is pre-launch
+// (no surface yet), so reaping it would race the spawn.
+const REAPABLE_SURFACE_STATES: ReadonlySet<TaskState> = new Set(["working", "stalled", "awaiting-input", "blocked"]);
 
 // #210: CREW IDLE (awaiting-input) is debounced — suppressed when the turn-end
 // lands within this window of the captain's own last turn to the crew (a
@@ -216,9 +233,25 @@ export function createDaemon(deps: DaemonDeps) {
         default: { const _exhaustive: never = req; throw new Error(`unhandled request kind`); }
       }
     },
-    sweep(): void {
+    async sweep(): Promise<void> {
       const t = now();
+      const surfaceAlive = deps.isSurfaceAlive ?? (async () => "unknown" as const);
       for (const r of store.listAll()) {
+        // #139 backstop: reap interactive records whose backing surface is
+        // PROVABLY gone (crew session died with no terminal signal — opencode has
+        // no SessionEnd hook, and a hard kill can drop claude's). This is
+        // liveness-based reaping, NOT a shorter timeout: the 24h heartbeat budget
+        // is untouched, so a legitimately-idle LIVE crew is never reaped (its
+        // surface answers "alive" and falls through to evaluateStall → CREW IDLE).
+        // "unknown" (cmux down) never reaps. cancelled is silent (not in
+        // ATTENTION_STATES) — no false CREW STALLED re-emitted.
+        if (r.mode === "interactive" && REAPABLE_SURFACE_STATES.has(r.state)) {
+          const liveness = await surfaceAlive(r);
+          if (liveness === "gone") {
+            store.put({ ...r, state: "cancelled", lastEvent: "sweep.surface-gone" });
+            continue;
+          }
+        }
         const idle = evaluateStall(r, t);
         if (idle) {
           store.put(idle);
@@ -237,8 +270,9 @@ export function createDaemon(deps: DaemonDeps) {
         if (recovered && t - r.lastHeartbeat <= r.heartbeatBudgetMs) store.put(recovered);
       }
     },
-    reconcile(): void {
+    async reconcile(): Promise<void> {
       const alive = deps.isPidAlive ?? (() => true);
+      const surfaceAlive = deps.isSurfaceAlive ?? (async () => "unknown" as const);
       for (const r of store.listAll()) {
         if (r.state !== "working" && r.state !== "submitted") continue;
         if (r.mode === "headless") {
@@ -255,14 +289,16 @@ export function createDaemon(deps: DaemonDeps) {
           };
           firePush(deps, r.project, r.state, failed, synthEvent, lastCaptainTurnAt.get(r.id));
         } else {
-          const stalled: TaskRecord = { ...r, state: "stalled", lastEvent: "reconcile" };
-          store.put(stalled);
-          const synthEvent: ControlEvent = {
-            type: "task.reconcile-failed",
-            id: r.id,
-            reason: "interactive task lost on daemon restart",
-          };
-          firePush(deps, r.project, r.state, stalled, synthEvent, lastCaptainTurnAt.get(r.id));
+          // #139: an interactive crew's cmux pane SURVIVES a daemon bounce, so a
+          // live crew must stay 'working' for the reattach loop to re-subscribe
+          // it. The old unconditional → 'stalled' both false-stalled live crews
+          // AND fired CREW STALLED on every restart. Reap ONLY when the surface
+          // is provably gone; alive/unknown stay working (sweep re-checks later).
+          const liveness = await surfaceAlive(r);
+          if (liveness === "gone") {
+            store.put({ ...r, state: "cancelled", lastEvent: "reconcile.surface-gone" });
+            // silent — the crew is gone; no alarming push (consistent with close).
+          }
         }
       }
     },

--- a/src/control/interactive/claude.ts
+++ b/src/control/interactive/claude.ts
@@ -10,9 +10,10 @@ import type { ControlEvent } from "../types.js";
 // Stop fires at turn completion and maps to task.turn.completed so the task
 // transitions to awaiting-input (immune to stall detection) — without this,
 // a captain AFK for >heartbeatBudgetMs would get a false CREW STALLED.
-// SubagentStop/SessionEnd fire only at turn boundaries but are liveness-only:
-// SubagentStop fires while the parent agent still owns the turn, and SessionEnd
-// is an unreliable signal (crash / Ctrl-C / /exit).
+// SubagentStop fires only at a turn boundary but is liveness-only — it fires
+// while the parent agent still owns the turn. SessionEnd is NOT liveness: it
+// signals the session is gone (crash / Ctrl-C / /exit), so it terminalizes the
+// record (→ task.session.ended) rather than resuming 'working' (#139).
 const EVENTS = ["Stop", "SubagentStop", "SessionEnd", "PostToolUse", "Notification"] as const;
 
 /**
@@ -162,7 +163,9 @@ function resolveLastAssistantText(payload: unknown): string | null {
 /**
  * Map a Claude hook event name to a cockpit ControlEvent. Codifies the anti-#2576
  * invariant: NO Claude hook ever maps to `task.done`/`task.failed`.
- * PostToolUse/SubagentStop/SessionEnd = liveness only (task.progress).
+ * PostToolUse/SubagentStop = resume-liveness only (task.progress). SessionEnd is
+ * the lone terminalizing hook: the session is gone, so it maps to
+ * task.session.ended → cancelled (#139) — silent, never done/failed.
  * Terminal `done`/`failed` come exclusively from explicit `cockpit crew signal`.
  *
  * Stop = turn boundary. It normally maps to task.turn.completed → awaiting-input
@@ -204,9 +207,16 @@ export function mapClaudeHookToEvent(
       }
       return { type: "task.progress", id: taskId, note: "notification" };
     }
-    case "SubagentStop":
     case "SessionEnd":
+      // #139: the session is GONE. NOT liveness — mapping this to task.progress
+      // resumed a dead crew to 'working' (awaiting-input → working), where
+      // nothing heartbeats and the watchdog false-stalled it ~budget later.
+      // Terminalize the record instead (reducer: task.session.ended → cancelled).
+      return { type: "task.session.ended", id: taskId };
+    case "SubagentStop":
     case "PostToolUse":
+      // The only resume-liveness hooks: PostToolUse fires after every tool call
+      // mid-turn; SubagentStop fires while the parent still owns the turn.
       return { type: "task.progress", id: taskId, note: event.toLowerCase() };
     default:
       return null;

--- a/src/control/state-machine.ts
+++ b/src/control/state-machine.ts
@@ -74,6 +74,11 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
       return { ...base, state: "failed", error: ev.error, exitCode: ev.exitCode };
     case "task.cancelled":
       return { ...base, state: "cancelled" };
+    case "task.session.ended":
+      // #139: the claude crew session ended (SessionEnd hook). The process is
+      // gone, so terminalize instead of resuming 'working'. Reuses the silent
+      // 'cancelled' state — no alarming push, just a clean terminal record.
+      return { ...base, state: "cancelled" };
     case "task.session":
       return stampAttempt(base, { resumeRef: ev.resumeRef }, now);
     case "task.turn.started":

--- a/src/control/types.ts
+++ b/src/control/types.ts
@@ -105,7 +105,13 @@ export type ControlEvent =
   // Emitted by runCrewClose before closing the pane; transitions a non-terminal
   // task to the absorbing 'cancelled' state. Silent: captain initiated the close
   // so no CREW CANCELLED push is fired (not in ATTENTION_STATES).
-  | { type: "task.cancelled"; id: string; reason?: string };
+  | { type: "task.cancelled"; id: string; reason?: string }
+  // #139: a claude crew's SessionEnd hook fired — the session is GONE. Unlike
+  // the other turn-boundary hooks (PostToolUse/SubagentStop = liveness), a dead
+  // session must NOT resume 'working' (nothing heartbeats → false CREW STALLED
+  // ~budget later). Terminalizes the record to the absorbing 'cancelled' state.
+  // Silent (not in ATTENTION_STATES), like task.cancelled.
+  | { type: "task.session.ended"; id: string };
 
 // 'stalled' is intentionally excluded — recoverable by the watchdog.
 // 'cancelled' is terminal and silent (captain-initiated close).


### PR DESCRIPTION
## Summary

Fixes #139. A dead/closed interactive crew could leave its daemon task in a non-terminal state, producing a false `CREW STALLED` ~5min later. This lands three independent backstops so a crew that goes away is always terminalized.

## Root causes & fixes

1. **SessionEnd resumed `working`** (`67ee017`) — the Claude SessionEnd hook mapped to `task.progress`, reviving a dead session. Added a `task.session.ended` ControlEvent + state-machine reducer case that terminalizes instead. Claude hook adapter now maps SessionEnd → `task.session.ended`.

2. **`crew close` gated terminalization on pane existence** (`6697d9b`) — if the pane was already gone, close skipped terminalizing the daemon task. Now close terminalizes the daemon task independently of pane existence.

3. **No liveness backstop in the daemon** (`130f605`) — added a surface-liveness probe (`isSurfaceAlive` / `surfaceVerdict`) wired into both `sweep` and `reconcile`, so an interactive task whose surface is dead gets reaped automatically even if neither hook nor close fired.

## Testing

- New/updated tests across `state-machine`, `daemon` (sweep + reconcile), `crew` close, `surface-liveness`, `interactive-claude-hook`, and `integration-restart`.
- Full suite green for all #139 logic. The only failures under parallel run are pre-existing flaky temp-dir cleanup / PID races (vary run-to-run, pass in isolation) — unrelated to these changes.

## Anti-regression

Preserves the #2576 constraint: Claude hooks never map to `task.done`/`failed` — SessionEnd maps to the new dedicated terminal `task.session.ended`, not `progress`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)