### PR TITLE
release: v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-06-05
+
+A daemon-reliability and crew-safety patch release. The headline fix
+terminalizes dead interactive crews so they stop re-emitting false
+`CREW STALLED` alerts, plus per-crew worktree isolation and shell-injection-safe
+crew dispatch.
+
+### Added
+
+- **Per-crew git worktree isolation.** Crews can now run in their own git
+  worktree via `--worktree`, so concurrent crews no longer collide on a shared
+  working tree / HEAD. (#216, #218)
+- **opencode CP3 permission gate.** Interactive opencode crews can surface
+  `permission.asked` to the captain (opt-in), closing the last notify-and-answer
+  gap for opencode. (#215)
+- **Injection-safe crew dispatch.** `cockpit crew spawn`/`send` accept
+  `--task-file` / `--message-file` to pass briefs and messages by file,
+  bypassing shell metacharacter substitution and inline-brief truncation.
+  (#177, #205)
+
+### Fixed
+
+- **Dead interactive crews are now terminalized.** A three-part fix stops
+  orphaned interactive crews (no live pane, no heartbeat) from oscillating
+  `working ↔ stalled` and firing false `CREW STALLED` alerts forever:
+  `SessionEnd` now terminalizes a claude crew instead of resuming it to
+  `working`; `crew close` terminalizes the daemon task even when the pane is
+  already gone; and a surface-liveness backstop in the daemon's sweep/reconcile
+  reaps crews whose surface is provably gone. Liveness-based, so the 24h
+  interactive heartbeat budget (#131/#133) is preserved. (#139, #219)
+- **notify-relay no longer silently drops events.** The daemon↔relay formatter
+  is unified so the daemon is the single source of truth; `CREW IDLE` and
+  `task.approval.requested` events reach the captain instead of being discarded
+  on formatter drift. (#210, #214, #217)
+- **codex first-turn race.** The initial codex turn is no longer dropped
+  ("no thread for task") — first-turn `say()` is gated on the in-flight
+  dispatch. (#212, #213)
+- **Bounded crew read/tasks output.** `cockpit crew read`/`tasks` output is
+  bounded to prevent truncated results and `/compact` churn. (#206)
+
+### Docs
+
+- Corrected the crew-lifecycle checklist methodology (two signal mechanisms,
+  CP4 gap #210, 2026-06-03 findings). (#211)
+
 ## [0.5.0] - 2026-06-01
 
 This release closes the cross-agent **crew-lifecycle parity** goal: all three

--- a/docs/testing/crew-lifecycle-checklist.md
+++ b/docs/testing/crew-lifecycle-checklist.md
@@ -22,6 +22,24 @@ silently stuck. Every pause (question / permission / idle) and the finish must r
 
 ---
 
+## Two Signal Mechanisms
+
+The daemon receives crew state changes via **two distinct mechanisms**. Do not conflate them:
+
+**TYPE 1 — Automatic turn-end / idle / liveness** (daemon *observes* the agent; no model action required):
+| Agent | Mechanism | File ref | Reliability |
+|-------|-----------|----------|-------------|
+| claude | Stop hook → `cockpit crew _hook` → `task.turn.completed` | `src/control/interactive/claude.ts:198` | FLAKY — Stop hook may not fire (#187) |
+| opencode | Embedded HTTP server SSE `session.idle` → daemon `OpencodeSseBridge` → `task.turn.completed` | `src/control/opencode/sse-bridge.ts` | Reliable |
+| codex | app-server JSON-RPC `turn/completed` notification → `normalizeAppServerNotification` → `task.turn.completed` | `src/control/codex/normalize.ts:40-44` | Reliable, direct |
+
+**TYPE 2 — Explicit terminal DONE / BLOCKED / FAILED** (the crew *decides*; the model runs `cockpit crew signal …`):
+- **HARD INVARIANT** across all agents: NO automatic event maps to `task.done`. A turn ending ≠ the task being done (anti-#2576). "Done" is always explicit.
+- **claude / opencode:** `cockpit crew signal done|blocked|failed` reads `COCKPIT_CREW_TASK_ID` from the shell env (set on their cmux shell launch).
+- **codex:** the command needs `--task-id <id> --project <project>` (codex shares ONE app-server across threads; `startThread` has no env param, so no per-thread `COCKPIT_CREW_TASK_ID`). The codex crew template already injects these flags into its `developerInstructions` (PR #173). When driving a codex crew manually, pass `--task-id` / `--project` explicitly — do NOT use the bare claude-style command (it errors `COCKPIT_CREW_TASK_ID unset`).
+
+---
+
 ## Checkpoints
 
 Drive each from the **captain** side. "Captain signal" is what you must actually observe — a
@@ -42,6 +60,7 @@ notification reaching the captain session, not just the crew screen.
 - **Resolve:** `cockpit crew send cockpit lifecycle-test "<answer>"` — crew unblocks and proceeds
   using the answer.
 - [ ] PASS — blocked notification received **and** answer unblocked it
+> **Codex note:** Signals via the crew's own `developerInstructions` (PR #173) which inject `--task-id <id> --project cockpit`. When driving codex manually, pass those flags explicitly — the bare `cockpit crew signal...` errors `COCKPIT_CREW_TASK_ID unset`. See §"Two Signal Mechanisms" above.
 
 ### 3. Permission gate → captain approves
 - **Action:** Tell the crew to perform a **real privileged action** that the allowlist does NOT
@@ -59,18 +78,21 @@ notification reaching the captain session, not just the crew screen.
 > Note: #2 and #3 both surface as CREW BLOCKED but via **different feeders** — #2 is an explicit
 > `signal blocked`, #3 is the live Notification hook on a real prompt. Verify both paths.
 
-### 4. Idle — pings captain, NOT finished
+### 4. Idle — daemon transitions to awaiting-input (Type 1); captain ping is GAP (#210)
 - **Action:** Tell the crew to finish the current turn's work and **wait for the next turn
   without signaling done**.
-- **Expect:** crew completes the turn and goes idle/awaiting. The Stop hook fires a
-  `task.progress` **liveness** event (anti-#2576: bare turn-end ≠ done).
-- **Captain signal:** captain is pinged that the crew is **idle/awaiting** — and the daemon task
-  state is **non-terminal** (still `working`/awaiting, NOT `done`).
-- **Verify state:** `cockpit crew list cockpit` shows the crew alive and non-terminal.
-- [ ] PASS — idle ping received **and** state is not terminal
+- **Expect (daemon side):** The crew completes the turn. The Type 1 mechanism fires per agent:
+  - claude: Stop hook (flaky, #187) → `task.turn.completed` → daemon transitions `working → awaiting-input`.
+  - opencode: SSE `session.idle` → `OpencodeSseBridge` → `task.turn.completed` → awaiting-input. Reliable.
+  - codex: app-server JSON-RPC `turn/completed` → `task.turn.completed` → awaiting-input. Reliable.
+  The daemon task state is **non-terminal** (`awaiting-input`, NOT `done`).
+- **Captain signal:** **GAP (#210).** The relay's `formatEntry` drops `task.turn.completed` / `task.idle` events before they reach the captain mailbox. The captain currently receives NO idle/awaiting ping. Until #210 is fixed, expect this to FAIL for ALL agents.
+- **Verify state (workaround):** `cockpit crew list cockpit` shows the crew alive and non-terminal (`awaiting-input`). This confirms the daemon transitioned correctly even without the captain notification.
+- [ ] STATE VERIFIED — daemon state is non-terminal (`awaiting-input`); captain ping is **GAP (#210)** across all agents until the relay is fixed
 
 ### 5. Finish — pings captain (done)
 - **Action:** Tell the crew to run `cockpit crew signal done --message "<one-line summary>"`.
+  > **Codex note:** same `--task-id <id> --project cockpit` requirement as CP2; prefer the crew's self-signal via `developerInstructions`.
 - **Expect:** crew transitions to terminal `done`.
 - **Captain signal:** **CREW DONE** reaches the captain; daemon task state is terminal `done`.
 - [ ] PASS — done notification received **and** state is terminal
@@ -78,6 +100,7 @@ notification reaching the captain session, not just the crew screen.
 ### 6. Reopen after done — redo → done again
 - **Action:** With the crew already terminal `done` (checkpoint 5), the captain reviews, finds a gap, and sends a new turn with redo instructions: `cockpit crew send cockpit <name> "<redo>"`.
 - **Expect:** `cockpit crew send` detects the terminal task and fires `task.reopened` (#148) — the task returns to non-terminal `working`. The crew does the redo, then runs `cockpit crew signal done` again.
+  > **Codex note:** same `--task-id` / `--project` requirement; the second `signal done` needs the same flags.
 - **Captain signal:** crew responds to the new turn despite having been done; the second `signal done` fires **CREW DONE** again and the daemon ledger returns to terminal `done` (`lastEvent: task.done`).
 - **Note:** a turn-end `Stop` hook may transiently set `lastEvent: task.progress`; the explicit `signal done` is what settles the ledger back to terminal `done`.
 - [ ] PASS — done crew reopened on the new turn AND reported done a second time
@@ -99,6 +122,9 @@ notification reaching the captain session, not just the crew screen.
 | 2026-05-30 | claude | b0b8753 | PASS | PASS | PASS | GAP | PASS | PASS | checkpoint 4 = state OK but no captain idle ping (Stop hook liveness-only) |
 | 2026-06-01 | codex  | fix/codex-sandbox-full-access | PASS | PASS | PASS | PASS | PASS | PASS | All pass after switching codex crews to `danger-full-access` (parity with unsandboxed claude/opencode). `signal` now reaches the daemon; reducer guard keeps `blocked` through the trailing app-server turn-end. CP3 via `--approval`. |
 | 2026-06-01 | opencode | feat/opencode-idle-sse-bridge | PASS | PASS | DEFER | PASS | PASS | PASS | CP4 closed via SSE `session.idle` bridge (daemon auto-→awaiting-input, no signal). CP3 deferred (per-crew config auto-approves all tools). |
+| 2026-06-03 | claude | ffc97f6 | PASS | PASS | DEFERRED (auto mode) | GAP (#210) | PASS | PASS | CP3 no longer gates — crews default to `--permission-mode auto` (#199). CP4 idle ping = #210. |
+| 2026-06-03 | codex | ffc97f6 | PASS | PASS | DEFERRED (--approval) | GAP (#210) | PASS | PASS | Signals via `--task-id` (PR #173) self-injected in `developerInstructions`; verified live. Earlier 'fail' was a test error (bare signal w/o `--task-id`). |
+| 2026-06-03 | opencode | ffc97f6 | PASS | PASS | DEFERRED (config) | GAP (#210) | PASS | PASS | All explicit signals + SSE turn-end work; CP4 ping blocked by #210. |
 
 ---
 
@@ -122,3 +148,16 @@ notification reaching the captain session, not just the crew screen.
 - **Fix shipped: `sandbox: "danger-full-access"` for codex crews.** This is **parity, not regression** — claude and opencode crews already run with NO Seatbelt sandbox (real CLI in a cmux pane); codex was the only sandboxed agent. Full-access removes the FS jail so `cockpit crew signal` reaches the daemon. `approvalPolicy` is an independent axis, so CP3 still gates when `--approval` sets it to `untrusted`.
 - **Reducer guard (also required).** Codex runs `signal blocked` mid-turn; the app-server then fires `TurnCompleted`. Without the guard (`task.turn.completed` from `blocked` = no-op, shared with the opencode SSE work) that trailing turn-end would flip `blocked → awaiting-input` and drop the question. Verified live: `blocked` + question survived; `signal done` stayed terminal.
 - **Verified live (all 6 PASS).** CP2 `signal blocked` → CREW BLOCKED (mailbox) → answer unblocked; CP5 `signal done` → terminal `done` + CREW DONE; CP6 reopen → 2nd CREW DONE. CP1/CP3/CP4 unchanged (app-server). Codex reaches full parity.
+
+## Findings — 2026-06-03 (all agents — methodology correction)
+
+This run corrected the checklist methodology after the captain identified that the checklist conflated **two distinct signal mechanisms** (see §"Two Signal Mechanisms" above).
+
+- **Deliverable checkpoints (1, 2, 5, 6) all PASS for all three agents.** Interactive boot, blocked→answer→unblock, explicit `signal done`, and reopen→re-done are fully functional on claude, codex, and opencode.
+- **CP3 (permission) = DEFERRED-by-design for all agents.**
+  - claude/codex: `--permission-mode auto` is now the default (#199); crews auto-approve all tools.
+  - opencode: per-crew config auto-approves everything (no permission prompts surface).
+  - *No regression.* If gated permission testing is needed, run with `--permission-mode default` (claude/codex) or reconfigure opencode's tool approval settings.
+- **CP4 (idle) = GAP (#210) for ALL agents.** The daemon correctly transitions `working → awaiting-input` via each agent's Type 1 mechanism (opencode SSE reliable, codex reliable, claude Stop hook flaky). But the captain receives **zero** idle/awaiting notification because the relay's `formatEntry` drops `task.turn.completed` / `task.idle` events before they reach the captain mailbox. This is a single infrastructure fix tracked as #210. Do NOT mark CP4 PASS until the relay delivers the idle ping.
+- **codex signal path verified intact.** PR #173's `--task-id` / `--project` injection in `developerInstructions` is working. The earlier apparent codex "failure" was a test error — a bare `cockpit crew signal done` (no `--task-id`) inside a codex crew, which correctly errors `COCKPIT_CREW_TASK_ID unset`. The crew's self-signal via its own instructions works.
+- **Cross-reference issues:** #207 (relay as SPOF), #208 (captain polling defeats notification), #209 (cmux execFileSync hang), #210 (relay formatEntry drops idle events).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-cockpit",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Multi-project agent orchestration for Claude Code",
   "type": "module",
   "bin": {

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -107,7 +107,11 @@ cockpit crew send <project> <name> "<message>"
 
 ```bash
 cockpit crew list <project>                 # see all live crews for the project
-cockpit crew read <project> <name>          # read the crew's current screen
+cockpit crew tasks <project>                # compact task listing (use --json for verbose)
+cockpit crew tasks <project> --state-only <id>  # fast state check (prints one word)
+cockpit crew read <project> <name>          # read tail of a crew's screen (~40 lines)
+cockpit crew read <project> <name> --full   # entire scrollback (may be large)
+cockpit crew read <project> <name> --lines 100  # custom tail length
 cockpit crew close <project> <name>         # shutdown the crew (closes its tab)
 ```
 
@@ -148,10 +152,11 @@ cockpit crew spawn brove "Fix typo in README" --direction right
 ## Task Coordination
 
 You don't have an Agent Team or `TaskCreate`/`TaskUpdate` tools — those were Claude-specific. Track crew progress by:
-1. `cockpit crew read <project> <name>` — read the crew's screen directly from CLI.
-2. `cockpit crew list <project>` — see all live crews and pick the right one.
-3. Inspecting the crew tab visually in cmux when you want richer context (you have its surface ref from the spawn output).
-4. Asking the user to check the dashboard if you need a cross-project view (see issue #44).
+1. `cockpit crew read <project> <name>` — read tail of a crew's screen (default ~40 lines; `--full` for entire scrollback).
+2. `cockpit crew tasks <project>` — compact task listing (one line per task); `--id <prefix>` to filter; `--state-only <id>` for single-word state.
+3. `cockpit crew list <project>` — see all live crews and pick the right one.
+4. Inspecting the crew tab visually in cmux when you want richer context (you have its surface ref from the spawn output).
+5. Asking the user to check the dashboard if you need a cross-project view (see issue #44).
 
 When a crew sends you a status message via `cockpit runtime send <project> "<message>"`, it lands in your captain pane. Acknowledge, then update your handoff if a meaningful decision was made.
 

--- a/src/commands/__tests__/crew-output.test.ts
+++ b/src/commands/__tests__/crew-output.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from "vitest";
+import { tailLines, formatTaskLine, filterTasks, formatCompactTasks } from "../crew-output.js";
+import type { TaskRecord, TaskState } from "../../control/types.js";
+
+// ─── tailLines ───────────────────────────────────────────────────
+
+describe("tailLines", () => {
+  it("returns input unchanged when fewer lines than max", () => {
+    const text = "line1\nline2\nline3";
+    expect(tailLines(text, 10, 4096)).toBe(text);
+  });
+
+  it("returns last N lines when more lines than max", () => {
+    const text = "line1\nline2\nline3\nline4\nline5";
+    expect(tailLines(text, 3, 4096)).toBe("line3\nline4\nline5");
+  });
+
+  it("returns last N lines when equal to max", () => {
+    const text = "line1\nline2\nline3";
+    expect(tailLines(text, 3, 4096)).toBe(text);
+  });
+
+  it("respects byte cap (truncates at boundary)", () => {
+    const text = "a\nb\nc\nd\ne";
+    // Cap 5 bytes: last 5 bytes of the tail is "d\ne" (3 bytes) but
+    // we need to ensure the full last lines fit.
+    const result = tailLines(text, 100, 5);
+    expect(result.length).toBeLessThanOrEqual(5);
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(tailLines("", 40, 4096)).toBe("");
+  });
+
+  it("handles single line text", () => {
+    expect(tailLines("hello", 40, 4096)).toBe("hello");
+  });
+
+  it("handles trailing newline gracefully", () => {
+    const text = "a\nb\nc\n";
+    expect(tailLines(text, 2, 4096)).toBe("b\nc");
+  });
+
+  it("defaults to 40 lines and 4096 bytes", () => {
+    const lines: string[] = [];
+    for (let i = 0; i < 50; i++) lines.push(`line-${i}`);
+    const text = lines.join("\n");
+    const result = tailLines(text);
+    expect(result.split("\n").length).toBe(40);
+    expect(result).toBe(lines.slice(10).join("\n"));
+  });
+});
+
+// ─── formatTaskLine ──────────────────────────────────────────────
+
+describe("formatTaskLine", () => {
+  const base = {
+    id: "abc12345-def6-7890-abcd-ef1234567890",
+    name: "my-crew",
+    project: "testproj",
+    provider: "claude" as const,
+    mode: "interactive" as const,
+    state: "working" as TaskState,
+    task: "Implement the feature",
+    createdAt: 1000,
+    lastHeartbeat: 2000,
+    lastEvent: "task.started",
+    heartbeatBudgetMs: 300000,
+    attempts: [{ attemptId: "att1", startedAt: 1000, lastHeartbeatAt: 1500 }],
+  } satisfies TaskRecord;
+
+  it("includes short id, provider, state, lastEvent and truncated title", () => {
+    const line = formatTaskLine(base);
+    expect(line).toContain("abc12345");
+    expect(line).toContain("claude");
+    expect(line).toContain("working");
+    expect(line).toContain("Implem");
+  });
+
+  it("truncates task title to ~60 chars", () => {
+    const long = "A".repeat(200);
+    const record = { ...base, task: long };
+    const line = formatTaskLine(record);
+    // Should contain the truncated title (first line, ~60 chars)
+    expect(line.length).toBeLessThan(200);
+    expect(line).toContain("A".repeat(60));
+  });
+
+  it("collapses multi-line task to first line only", () => {
+    const record = { ...base, task: "first line\nsecond line\nthird line" };
+    const line = formatTaskLine(record);
+    expect(line).toContain("first line");
+    expect(line).not.toContain("second line");
+    expect(line).not.toContain("third line");
+  });
+
+  it("produces a single-line output", () => {
+    const line = formatTaskLine(base);
+    expect(line).not.toContain("\n");
+  });
+
+  it("handles missing name gracefully", () => {
+    const record = { ...base, task: "task" };
+    delete (record as { name?: string }).name;
+    const line = formatTaskLine(record);
+    expect(line).toContain("abc12345");
+  });
+
+  it("includes empty state indicator for empty lastEvent", () => {
+    const record = { ...base, lastEvent: "", state: "submitted" as TaskState };
+    const line = formatTaskLine(record);
+    expect(line).toContain("submitted");
+  });
+});
+
+// ─── filterTasks ─────────────────────────────────────────────────
+
+describe("filterTasks", () => {
+  const records: TaskRecord[] = [
+    {
+      id: "aaa-111", name: "crew-a", project: "p", provider: "claude",
+      mode: "interactive", state: "working" as TaskState, task: "task a",
+      createdAt: 1, lastHeartbeat: 1, lastEvent: "task.started",
+      heartbeatBudgetMs: 300000, attempts: [],
+    },
+    {
+      id: "bbb-222", name: "crew-b", project: "p", provider: "codex",
+      mode: "interactive", state: "done" as TaskState, task: "task b",
+      createdAt: 2, lastHeartbeat: 2, lastEvent: "task.done",
+      heartbeatBudgetMs: 300000, attempts: [],
+    },
+    {
+      id: "ccc-333", name: "crew-c", project: "p", provider: "opencode",
+      mode: "interactive", state: "blocked" as TaskState, task: "task c",
+      createdAt: 3, lastHeartbeat: 3, lastEvent: "task.blocked",
+      heartbeatBudgetMs: 300000, attempts: [],
+    },
+  ];
+
+  it("returns all records when no filters", () => {
+    expect(filterTasks(records, {}).length).toBe(3);
+  });
+
+  it("filters by id (prefix match)", () => {
+    const r = filterTasks(records, { id: "aaa" });
+    expect(r.length).toBe(1);
+    expect(r[0].id).toBe("aaa-111");
+  });
+
+  it("filters by state", () => {
+    const r = filterTasks(records, { state: "done" });
+    expect(r.length).toBe(1);
+    expect(r[0].state).toBe("done");
+  });
+
+  it("filters by id and state combined", () => {
+    const r = filterTasks(records, { id: "bbb", state: "working" });
+    expect(r.length).toBe(0);
+  });
+
+  it("returns empty array when no match", () => {
+    expect(filterTasks(records, { id: "zzz" })).toEqual([]);
+  });
+
+  it("finds stateOnly record by id (includes full state string)", () => {
+    const r = filterTasks(records, { id: "ccc", stateOnly: true });
+    expect(r.length).toBe(1);
+    expect(r[0].state).toBe("blocked");
+  });
+});
+
+// ─── formatCompactTasks ──────────────────────────────────────────
+
+describe("formatCompactTasks", () => {
+  const records: TaskRecord[] = [
+    {
+      id: "aaa-111", name: "crew-a", project: "p", provider: "claude",
+      mode: "interactive", state: "working" as TaskState, task: "task a",
+      createdAt: 1, lastHeartbeat: 1, lastEvent: "task.started",
+      heartbeatBudgetMs: 300000, attempts: [],
+    },
+  ];
+
+  it("formats compact list by default", () => {
+    const out = formatCompactTasks(records, {});
+    expect(out).toContain("aaa-111");
+    expect(out).not.toContain("\"id\"");
+  });
+
+  it("formats JSON when compact is false", () => {
+    const out = formatCompactTasks(records, { compact: false });
+    expect(out).toContain("\"id\"");
+    expect(out).toContain("\"aaa-111\"");
+  });
+
+  it("shows single state line when stateOnly is true", () => {
+    const out = formatCompactTasks(records, { stateOnly: true });
+    expect(out).toBe("working");
+  });
+
+  it("prints clear message for empty list", () => {
+    const out = formatCompactTasks([], {});
+    expect(out).toContain("no tasks");
+  });
+
+  it("prints clear message for empty list even with JSON", () => {
+    const out = formatCompactTasks([], { compact: false });
+    expect(out).toContain("no tasks");
+  });
+});

--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -247,6 +247,8 @@ describe("cockpit crew spawn", () => {
       project: "brove",
       taskId: "task-oc1",
     }));
+    // CP3 default unchanged: without --approval, bash is NOT gated.
+    expect(writePerCrewOpencodeConfig.mock.calls[0][0].gateBash).toBeFalsy();
     expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ interactive: true }));
     expect(newPane).toHaveBeenCalledWith(expect.objectContaining({
       workspaceId: "workspace:5",
@@ -263,6 +265,22 @@ describe("cockpit crew spawn", () => {
       { workspaceId: "workspace:5", surfaceId: "surface:9" },
       "do the thing",
     ]);
+  });
+
+  it("--approval gates bash for opencode crews (CP3 opt-in → gateBash:true)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("opencode");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-oc2" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-oc2", project: "brove", provider: "opencode", mode: "interactive" });
+
+    const promise = runCrewSpawn({ project: "brove", task: "do it", agent: "opencode", approval: true });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(writePerCrewOpencodeConfig).toHaveBeenCalledWith(expect.objectContaining({ gateBash: true }));
   });
 
   it("--agent codex routes through the control-plane daemon and opens an attach tab in the captain", async () => {

--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -78,6 +78,13 @@ vi.mock("../../lib/per-crew-settings.js", () => ({
   writePerCrewOpencodeConfig,
 }));
 
+const addWorktree = vi.hoisted(() => vi.fn());
+const removeWorktree = vi.hoisted(() => vi.fn());
+vi.mock("../../lib/git-worktree.js", () => ({
+  addWorktree,
+  removeWorktree,
+}));
+
 const existsSyncMock = vi.hoisted(() => vi.fn());
 const readFileSyncMock = vi.hoisted(() => vi.fn());
 vi.mock("node:fs", async (importOriginal) => {
@@ -128,6 +135,8 @@ describe("cockpit crew spawn", () => {
     writePerCrewSettingsLocal.mockReturnValue("/tmp/brove/.claude/settings.local.json");
     writePerCrewOpencodeConfig.mockReset();
     writePerCrewOpencodeConfig.mockReturnValue("/tmp/per-crew/opencode.json");
+    addWorktree.mockReset();
+    removeWorktree.mockReset();
     existsSyncMock.mockReset();
     readFileSyncMock.mockReset();
     // Default: pretend the codex role template is absent so older tests that
@@ -187,6 +196,73 @@ describe("cockpit crew spawn", () => {
       "do the thing",
     ]);
     expect(result.title).toBe("🔧 brove:crew-1");
+  });
+
+  it("--worktree creates an isolated worktree and spawns the crew with its path as cwd", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude --append-system-prompt-file /tmp/crew.md");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-wt1" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-wt1", project: "brove", provider: "claude", mode: "interactive" });
+    const wtPath = "/tmp/brove/.worktrees/brove-crew-1";
+    addWorktree.mockReturnValue(wtPath);
+
+    const promise = runCrewSpawn({ project: "brove", task: "do the thing", worktree: true });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    // Worktree created from config.worktreeDir, off the develop base branch.
+    expect(addWorktree).toHaveBeenCalledWith({
+      repoRoot: "/tmp/brove",
+      worktreeDir: ".worktrees",
+      project: "brove",
+      name: "crew-1",
+      base: "develop",
+    });
+    // The crew runs in the worktree, not the shared root checkout.
+    expect(buildDispatchRequest).toHaveBeenCalledWith(expect.objectContaining({ cwd: wtPath }));
+    expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ workdir: wtPath }));
+    expect(writePerCrewSettingsLocal).toHaveBeenCalledWith(expect.objectContaining({ projectCwd: wtPath }));
+  });
+
+  it("without --worktree never creates a worktree (cwd stays the root checkout)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude ...");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-nowt" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-nowt" });
+
+    const promise = runCrewSpawn({ project: "brove", task: "do the thing" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(addWorktree).not.toHaveBeenCalled();
+    expect(buildDispatchRequest).toHaveBeenCalledWith(expect.objectContaining({ cwd: "/tmp/brove" }));
+    expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ workdir: "/tmp/brove" }));
+  });
+
+  it("--worktree threads a custom config.worktreeDir into worktree creation", async () => {
+    loadConfig.mockReturnValue({
+      ...baseConfig,
+      defaults: { ...baseConfig.defaults, worktreeDir: ".wt" },
+    });
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude ...");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-wtc" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-wtc" });
+    addWorktree.mockReturnValue("/tmp/brove/.wt/brove-crew-1");
+
+    const promise = runCrewSpawn({ project: "brove", task: "task", worktree: true });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(addWorktree).toHaveBeenCalledWith(expect.objectContaining({ worktreeDir: ".wt" }));
   });
 
   it("auto-names the next crew based on existing tabs (crew-1 + crew-3 → crew-2)", async () => {
@@ -640,6 +716,7 @@ describe("cockpit crew send/read/close/list", () => {
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
     cockpitdCall.mockReset();
+    removeWorktree.mockReset();
   });
 
   it("send delivers a message to the matching crew tab", async () => {
@@ -751,6 +828,43 @@ describe("cockpit crew send/read/close/list", () => {
       surfaceId: "surface:10",
       title: "🔧 brove:crew-1",
     });
+  });
+
+  it("close removes the crew's worktree when its task ran in one (cwd != root)", async () => {
+    listSurfaces.mockResolvedValue([
+      { workspaceId: "workspace:5", surfaceId: "surface:10", title: "🔧 brove:crew-1" },
+    ]);
+    const wtPath = "/tmp/brove/.worktrees/brove-crew-1";
+    cockpitdCall.mockImplementation(async (req: unknown) => {
+      const r = req as { kind: string };
+      if (r.kind === "list") {
+        return [{ id: "task-wt-1", name: "crew-1", project: "brove", state: "done", provider: "claude", mode: "interactive", task: "task", cwd: wtPath, createdAt: 1000, lastHeartbeat: 1000, lastEvent: "task.done", heartbeatBudgetMs: 300000, attempts: [] }];
+      }
+      return undefined;
+    });
+
+    await runCrewClose("brove", "crew-1");
+
+    expect(removeWorktree).toHaveBeenCalledWith("/tmp/brove", wtPath);
+    expect(closePane).toHaveBeenCalled();
+  });
+
+  it("close does NOT remove a worktree for a non-worktree crew (cwd == root)", async () => {
+    listSurfaces.mockResolvedValue([
+      { workspaceId: "workspace:5", surfaceId: "surface:10", title: "🔧 brove:crew-1" },
+    ]);
+    cockpitdCall.mockImplementation(async (req: unknown) => {
+      const r = req as { kind: string };
+      if (r.kind === "list") {
+        return [{ id: "task-root-1", name: "crew-1", project: "brove", state: "done", provider: "claude", mode: "interactive", task: "task", cwd: "/tmp/brove", createdAt: 1000, lastHeartbeat: 1000, lastEvent: "task.done", heartbeatBudgetMs: 300000, attempts: [] }];
+      }
+      return undefined;
+    });
+
+    await runCrewClose("brove", "crew-1");
+
+    expect(removeWorktree).not.toHaveBeenCalled();
+    expect(closePane).toHaveBeenCalled();
   });
 
   it("close emits task.cancelled for a non-terminal crew task before closing the pane (#184)", async () => {

--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -920,6 +920,41 @@ describe("cockpit crew send/read/close/list", () => {
     expect(closePane).toHaveBeenCalled();
   });
 
+  // #139: a dead crew's pane is already gone, but its daemon task record still
+  // dangles in a non-terminal state. close must terminalize that record even
+  // when there is no pane to close — gating terminalization on findCrew left
+  // the zombie record to re-emit false CREW STALLED forever.
+  it("close terminalizes the daemon task when the crew pane is already gone (#139)", async () => {
+    listSurfaces.mockResolvedValue([]); // pane gone — crew session died
+    cockpitdCall.mockImplementation(async (req: unknown) => {
+      const r = req as { kind: string };
+      if (r.kind === "list") {
+        return [{ id: "task-dead-1", name: "crew-1", project: "brove", state: "working", provider: "claude", mode: "interactive", task: "task", createdAt: 1000, lastHeartbeat: 1000, lastEvent: "task.started", heartbeatBudgetMs: 86400000, attempts: [] }];
+      }
+      return undefined;
+    });
+
+    await runCrewClose("brove", "crew-1"); // must NOT throw
+
+    expect(cockpitdCall).toHaveBeenCalledWith(expect.objectContaining({
+      kind: "event",
+      project: "brove",
+      event: { type: "task.cancelled", id: "task-dead-1", reason: "closed by captain" },
+    }));
+    expect(closePane).not.toHaveBeenCalled(); // no pane to close
+  });
+
+  it("close throws when neither a pane nor a daemon task exists (typo guard) (#139)", async () => {
+    listSurfaces.mockResolvedValue([]); // no pane
+    cockpitdCall.mockImplementation(async (req: unknown) => {
+      const r = req as { kind: string };
+      if (r.kind === "list") return []; // no daemon task either
+      return undefined;
+    });
+
+    await expect(runCrewClose("brove", "ghost")).rejects.toThrow(/not found/i);
+  });
+
   it("list returns all crews for the project, ignoring non-crew tabs", async () => {
     listSurfaces.mockResolvedValue([
       { workspaceId: "workspace:5", surfaceId: "surface:9", title: "captain shell" },

--- a/src/commands/__tests__/notify-relay.test.ts
+++ b/src/commands/__tests__/notify-relay.test.ts
@@ -52,10 +52,19 @@ describe("notify-relay default stateRoot", () => {
   });
 });
 
+// Unified-formatter contract (#214/#210): the daemon renders the captain-facing
+// message and stores it on the mailbox entry; the relay is a dumb pipe that
+// delivers entry.message VERBATIM and skips entries with a null/empty message.
+// These tests therefore append entries WITH a message (what defaultNotify now
+// writes), not bare events.
+async function append(stateRoot: string, message: string | null, event: ControlEvent = doneEvent): Promise<number> {
+  return appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event, message });
+}
+
 describe("notify-relay file-tailer", () => {
   it("starts from seq 1 when cursor missing — delivers first event", async () => {
     const stateRoot = freshState();
-    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneEvent });
+    await append(stateRoot, "CREW DONE [claude/deadbeef]: shipped");
     const sendSpy = vi.fn().mockResolvedValue(undefined);
     const stop = await runNotifyRelay({
       project: "demo",
@@ -75,8 +84,8 @@ describe("notify-relay file-tailer", () => {
 
   it("starts from seq+1 when cursor exists — delivers only newer events", async () => {
     const stateRoot = freshState();
-    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneEvent });
-    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneEvent });
+    await append(stateRoot, "CREW DONE [claude/deadbeef]: one");
+    await append(stateRoot, "CREW DONE [claude/deadbeef]: two");
     await writeCursor({ stateRoot, project: "demo", subscriber: "captain", lastAckedSeq: 1 });
     const sendSpy = vi.fn().mockResolvedValue(undefined);
     const stop = await runNotifyRelay({
@@ -97,7 +106,7 @@ describe("notify-relay file-tailer", () => {
 
   it("does NOT advance cursor when sendToSurface throws", async () => {
     const stateRoot = freshState();
-    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneEvent });
+    await append(stateRoot, "CREW DONE [claude/deadbeef]: x");
     const sendSpy = vi.fn().mockRejectedValue(new Error("send failed"));
     const stop = await runNotifyRelay({
       project: "demo",
@@ -114,21 +123,13 @@ describe("notify-relay file-tailer", () => {
     expect(sendSpy.mock.calls.length).toBeGreaterThan(0); // attempted
   });
 
-  it("formats task.done/blocked/failed with provider + short id + payload", async () => {
+  it("delivers entry.message VERBATIM (relay does not re-derive)", async () => {
     const stateRoot = freshState();
-    const blockedEvent: ControlEvent = {
-      type: "task.blocked",
-      id: rec.id,
-      question: "what now?",
-    } as ControlEvent;
-    const failedEvent: ControlEvent = {
-      type: "task.failed",
-      id: rec.id,
-      error: "boom",
-    } as ControlEvent;
-    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneEvent });
-    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: blockedEvent });
-    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: failedEvent });
+    const blockedEvent: ControlEvent = { type: "task.blocked", id: rec.id, question: "what now?" } as ControlEvent;
+    const failedEvent: ControlEvent = { type: "task.failed", id: rec.id, error: "boom" } as ControlEvent;
+    await append(stateRoot, "CREW DONE [claude/deadbeef]: finished", doneEvent);
+    await append(stateRoot, "CREW BLOCKED [claude/deadbeef]: what now?", blockedEvent);
+    await append(stateRoot, "CREW FAILED [claude/deadbeef]: boom", failedEvent);
     const sendSpy = vi.fn().mockResolvedValue(undefined);
     const stop = await runNotifyRelay({
       project: "demo",
@@ -142,14 +143,37 @@ describe("notify-relay file-tailer", () => {
     stop();
     expect(sendSpy).toHaveBeenCalledTimes(3);
     const msgs = sendSpy.mock.calls.map((c) => c[1] as string);
-    expect(msgs[0]).toMatch(/^CREW DONE \[claude\/deadbeef\]:/);
-    expect(msgs[1]).toMatch(/^CREW BLOCKED \[claude\/deadbeef\]: what now\?/);
-    expect(msgs[2]).toMatch(/^CREW FAILED \[claude\/deadbeef\]: boom/);
+    expect(msgs[0]).toBe("CREW DONE [claude/deadbeef]: finished");
+    expect(msgs[1]).toBe("CREW BLOCKED [claude/deadbeef]: what now?");
+    expect(msgs[2]).toBe("CREW FAILED [claude/deadbeef]: boom");
+  });
+
+  it("skips entries with a null/empty message but still advances the cursor", async () => {
+    const stateRoot = freshState();
+    await append(stateRoot, null); // daemon chose not to surface (e.g. debounced idle)
+    await append(stateRoot, "   "); // whitespace-only → also skipped
+    await append(stateRoot, "CREW DONE [claude/deadbeef]: real");
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    const stop = await runNotifyRelay({
+      project: "demo",
+      subscriber: "captain",
+      stateRoot,
+      runtime: fakeRuntime(sendSpy) as never,
+      captainName: "captain",
+      pollMs: 50,
+    });
+    await new Promise((r) => setTimeout(r, 200));
+    stop();
+    // Only the real message is delivered; the two empty entries are acked silently.
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(sendSpy.mock.calls[0][1]).toBe("CREW DONE [claude/deadbeef]: real");
+    const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    expect(cursor?.lastAckedSeq).toBe(3);
   });
 
   it("silently acks entries older than STALE_THRESHOLD_MS without forwarding to captain", async () => {
     const stateRoot = freshState();
-    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneEvent });
+    await append(stateRoot, "CREW DONE [claude/deadbeef]: stale");
     const sendSpy = vi.fn().mockResolvedValue(undefined);
     // Pretend relay is booting far in the future — makes the just-written entry stale.
     const futureNow = () => Date.now() + STALE_THRESHOLD_MS + 60_000;
@@ -168,31 +192,5 @@ describe("notify-relay file-tailer", () => {
     expect(sendSpy).not.toHaveBeenCalled();
     const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
     expect(cursor?.lastAckedSeq).toBe(1);
-  });
-
-  it("task.done with payload.message prefers message over resultRef in display", async () => {
-    const stateRoot = freshState();
-    const doneWithMessage: ControlEvent = {
-      type: "task.done",
-      id: rec.id,
-      resultRef: "/some/result/file.txt",
-      message: "hello world",
-    };
-    await appendToMailbox({ stateRoot, project: "demo", taskRecord: rec, event: doneWithMessage });
-    const sendSpy = vi.fn().mockResolvedValue(undefined);
-    const stop = await runNotifyRelay({
-      project: "demo",
-      subscriber: "captain",
-      stateRoot,
-      runtime: fakeRuntime(sendSpy) as never,
-      captainName: "captain",
-      pollMs: 50,
-    });
-    await new Promise((r) => setTimeout(r, 200));
-    stop();
-    expect(sendSpy).toHaveBeenCalledTimes(1);
-    const out = sendSpy.mock.calls[0][1] as string;
-    expect(out).toBe("CREW DONE [claude/deadbeef]: hello world");
-    expect(out).not.toContain("/some/result/file.txt");
   });
 });

--- a/src/commands/crew-control.ts
+++ b/src/commands/crew-control.ts
@@ -9,6 +9,7 @@ import { sendRequest } from "../control/protocol.js";
 import { ensureDaemon } from "../control/launchd.js";
 import type { ControlEvent, Mode, Provider, TaskRecord } from "../control/types.js";
 import { mapClaudeHookToEvent } from "../control/interactive/claude.js";
+import { filterTasks, formatCompactTasks } from "./crew-output.js";
 import { crewAttachCommand } from "./crew-attach.js";
 import { crewChatCommand } from "./crew-chat.js";
 
@@ -203,9 +204,21 @@ export function addControlPlaneCrewCommands(crew: Command): void {
   crew
     .command("tasks <project>")
     .description("List control-plane tasks for a project (control-plane analogue of legacy `list`)")
-    .action(async (project: string) => {
-      const r = await cockpitdCall({ kind: "list", project });
-      process.stdout.write(JSON.stringify(r) + "\n");
+    .option("--json", "Full JSON output (one or more records)")
+    .option("--id <taskId>", "Show only tasks matching this id prefix")
+    .option("--state <state>", "Filter by task state")
+    .option("--state-only <taskId>", "Print just the state string for a single task")
+    .action(async (project: string, opts: { json?: boolean; id?: string; state?: string; stateOnly?: string }) => {
+      const raw = (await cockpitdCall({ kind: "list", project })) as TaskRecord[];
+      let records = raw;
+      if (opts.stateOnly) {
+        records = filterTasks(records, { id: opts.stateOnly, stateOnly: true });
+        process.stdout.write(formatCompactTasks(records, { stateOnly: true }) + "\n");
+        return;
+      }
+      records = filterTasks(records, { id: opts.id, state: opts.state });
+      const compact = opts.json !== true;
+      process.stdout.write(formatCompactTasks(records, { compact }) + "\n");
     });
 
   // TODO(downstream interactive-wiring spec): deliverReply is not yet wired in

--- a/src/commands/crew-output.ts
+++ b/src/commands/crew-output.ts
@@ -1,0 +1,67 @@
+import type { TaskRecord } from "../control/types.js";
+
+export function tailLines(
+  text: string,
+  maxLines = 40,
+  maxBytes = 4096,
+): string {
+  if (!text) return "";
+  const lines = text.split("\n");
+  if (lines.at(-1) === "") lines.pop();
+  const kept = lines.slice(-maxLines);
+  let result = kept.join("\n");
+  if (Buffer.byteLength(result, "utf-8") > maxBytes) {
+    const truncated: string[] = [];
+    let bytes = 0;
+    for (const line of kept) {
+      const lineBytes = Buffer.byteLength(line, "utf-8") + 1;
+      if (bytes + lineBytes > maxBytes) break;
+      truncated.push(line);
+      bytes += lineBytes;
+    }
+    result = truncated.join("\n");
+  }
+  return result;
+}
+
+function shortId(id: string): string {
+  return id.slice(0, 8);
+}
+
+export function formatTaskLine(record: TaskRecord): string {
+  const sid = shortId(record.id);
+  const title = record.task
+    .split("\n")[0]
+    .slice(0, 60);
+  return `${sid}  ${record.provider}  ${record.state}  ${record.lastEvent}  ${title}`;
+}
+
+export function filterTasks(
+  records: TaskRecord[],
+  opts: { id?: string; state?: string; stateOnly?: boolean },
+): TaskRecord[] {
+  let filtered = records;
+  if (opts.id) {
+    filtered = filtered.filter((r) => r.id.startsWith(opts.id!));
+  }
+  if (opts.state) {
+    filtered = filtered.filter((r) => r.state === opts.state);
+  }
+  return filtered;
+}
+
+export function formatCompactTasks(
+  records: TaskRecord[],
+  opts: { compact?: boolean; stateOnly?: boolean },
+): string {
+  if (records.length === 0) {
+    return "(no tasks match filter)";
+  }
+  if (opts.stateOnly) {
+    return records[0].state;
+  }
+  if (opts.compact === false) {
+    return JSON.stringify(records, null, 2);
+  }
+  return records.map(formatTaskLine).join("\n");
+}

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -492,7 +492,14 @@ export async function reapCrewChildren(taskId: string, graceMs = 2000): Promise<
   const marker = `COCKPIT_CREW_TASK_ID=${taskId}`;
   try {
     const stdout = await new Promise<string>((resolve, reject) => {
-      nodeExec("ps auxE", (err, out) => (err ? reject(err) : resolve(out)));
+      // `ps auxE` dumps every process's full env, which on a busy machine far
+      // exceeds exec's default 1 MB maxBuffer (~2.7 MB with ~1k procs). Without
+      // a raised cap the call errors with "maxBuffer length exceeded", the outer
+      // catch swallows it, and the reap silently no-ops — leaving crew children
+      // alive. 64 MB comfortably covers thousands of processes.
+      nodeExec("ps auxE", { maxBuffer: 64 * 1024 * 1024 }, (err, out) =>
+        err ? reject(err) : resolve(out),
+      );
     });
     const pids: number[] = [];
     for (const line of stdout.split("\n").slice(1)) {

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -164,6 +164,10 @@ export interface CrewSpawnInput {
   direction?: PanePlacement;
   agent?: string;
   approvalPolicy?: string;
+  /** CP3 opt-in: gate risky tools (bash) so the captain approves them.
+   *  codex maps this to approvalPolicy='untrusted'; opencode maps it to a
+   *  bash:"ask" per-crew config. Default (false) = fully autonomous. */
+  approval?: boolean;
 }
 
 export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
@@ -320,6 +324,9 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
       stateRoot: path.join(os.homedir(), ".config", "cockpit", "state"),
       project: input.project,
       taskId: rec.id,
+      // CP3 opt-in: --approval gates bash so the captain approves shell commands.
+      // Without it, bash stays auto-approved (default behavior unchanged).
+      ...(input.approval ? { gateBash: true } : {}),
     });
     const cliCommand = agent.buildCommand({
       prompt: input.task,
@@ -541,7 +548,7 @@ crewCommand
   .option("--name <name>", "Crew name (default: auto-generated crew-N)")
   .option("--direction <dir>", "Placement: tab (default) or split direction (right|left|up|down)", "tab")
   .option("--agent <name>", "Agent CLI to use (claude|codex|gemini|opencode)", "claude")
-  .option("--approval", "force codex approvalPolicy='untrusted' (codex only; exercises gate primitive)", false)
+  .option("--approval", "gate risky tools so the captain approves them (codex: approvalPolicy='untrusted'; opencode: bash:'ask')", false)
   .option("--task-file <path>", "Read task prompt from file instead of positional arg ('-' for stdin)")
   .action(
     async (
@@ -557,7 +564,9 @@ crewCommand
           name: opts.name,
           direction: opts.direction,
           agent: opts.agent,
-          ...(opts.approval ? { approvalPolicy: "untrusted" } : {}),
+          // --approval is provider-agnostic: codex consumes approvalPolicy,
+          // opencode consumes the `approval` flag (→ bash:"ask" per-crew config).
+          ...(opts.approval ? { approvalPolicy: "untrusted", approval: true } : {}),
         });
         console.log(chalk.green(`✔ Crew '${pane.title}' spawned (${pane.surfaceId})`));
       } catch (err) {

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -19,10 +19,17 @@ import type { PaneRef, PanePlacement, RuntimeDriver } from "../runtimes/types.js
 import { buildDispatchRequest, cockpitdCall, sendCodexFirstTurn } from "./crew-control.js";
 import { tailLines } from "./crew-output.js";
 import { writePerCrewSettingsLocal, writePerCrewOpencodeConfig } from "../lib/per-crew-settings.js";
+import { addWorktree, removeWorktree } from "../lib/git-worktree.js";
 import { resolveTextInput } from "../lib/resolve-text-input.js";
 import { TERMINAL_STATES, type TaskRecord } from "../control/types.js";
 
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "cockpit", "templates");
+
+// Base branch for `--worktree` crew branches. GitFlow: feature work branches
+// off develop. Chosen over "current HEAD" deliberately — basing off the
+// captain's volatile HEAD would reintroduce the coupling this isolation feature
+// exists to remove (and the captain's HEAD is exactly what gets dragged today).
+const WORKTREE_BASE_BRANCH = "develop";
 
 // Poll-based first-turn delivery: after launching the CLI, poll the pane
 // until the agent is ready to accept input. Replaces a fixed delay (was 3s).
@@ -164,6 +171,9 @@ export interface CrewSpawnInput {
   direction?: PanePlacement;
   agent?: string;
   approvalPolicy?: string;
+  /** Opt-in (#216): run this crew in its own git worktree + branch instead of
+   *  the shared root checkout. For feature tasks; small/one-off tasks omit it. */
+  worktree?: boolean;
   /** CP3 opt-in: gate risky tools (bash) so the captain approves them.
    *  codex maps this to approvalPolicy='untrusted'; opencode maps it to a
    *  bash:"ask" per-crew config. Default (false) = fully autonomous. */
@@ -197,6 +207,22 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
   }
   const name = input.name ?? nextAutoName(existingTitles, input.project);
 
+  // Feature crews (--worktree) run in an isolated worktree+branch so a crew's
+  // `git checkout` can't drag the captain's (shared) HEAD. Small crews keep
+  // running on the root checkout — spawnCwd stays proj.path, behavior unchanged.
+  // Build/daemon still run from the MAIN checkout's dist (#216): worktrees edit
+  // source only. The worktree path becomes the crew's cwd via the existing cwd
+  // plumbing (dispatch record + buildCommand workdir).
+  const spawnCwd = input.worktree
+    ? addWorktree({
+        repoRoot: proj.path,
+        worktreeDir: config.defaults.worktreeDir ?? ".worktrees",
+        project: input.project,
+        name,
+        base: WORKTREE_BASE_BRANCH,
+      })
+    : proj.path;
+
   const agents = new CapabilityRegistry({
     claude: createClaudeDriver(),
     codex: createCodexDriver(),
@@ -224,7 +250,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
     return runCodexInteractiveSpawn({
       project: input.project,
       task: input.task,
-      cwd: proj.path,
+      cwd: spawnCwd,
       runtime,
       workspaceId: captain.id,
       name,
@@ -259,7 +285,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
       provider: "claude",
       mode: "interactive",
       project: input.project,
-      cwd: proj.path,
+      cwd: spawnCwd,
       task: input.task,
       name,
     });
@@ -271,10 +297,10 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
     // merge across *different* settings sources — only multiple --settings
     // flags collide. .claude/settings.local.json is gitignored and merges
     // with any existing user hooks (#134).
-    writePerCrewSettingsLocal({ projectCwd: proj.path });
+    writePerCrewSettingsLocal({ projectCwd: spawnCwd });
     const cliCommand = agent.buildCommand({
       prompt: input.task,
-      workdir: proj.path,
+      workdir: spawnCwd,
       role: "crew",
       promptFile,
       interactive: true,
@@ -310,7 +336,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
       provider: "opencode",
       mode: "interactive",
       project: input.project,
-      cwd: proj.path,
+      cwd: spawnCwd,
       task: input.task,
       name,
       // opencode has no heartbeat hook, so a normal budget would false-stall
@@ -330,7 +356,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
     });
     const cliCommand = agent.buildCommand({
       prompt: input.task,
-      workdir: proj.path,
+      workdir: spawnCwd,
       role: "crew",
       promptFile,
       interactive: true,
@@ -349,7 +375,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
 
   const cliCommand = agent.buildCommand({
     prompt: input.task,
-    workdir: proj.path,
+    workdir: spawnCwd,
     role: "crew",
     promptFile,
     interactive,
@@ -491,17 +517,28 @@ export async function runCrewClose(project: string, name: string): Promise<void>
   if (!crew) {
     throw new Error(`Crew '${name}' not found for ${project}. Run 'cockpit crew list ${project}'.`);
   }
+  // resolveCaptainWorkspace already validated the project exists; reload for its
+  // root path so we can tell a worktree crew (cwd != root) from a root crew.
+  const projRoot = loadConfig().projects[project]?.path;
   // Terminalize the daemon task before closing the pane (#184). Without this,
   // non-terminal tasks (blocked/working/awaiting-input) linger in the daemon
   // ledger and keep firing phantom CREW BLOCKED/IDLE pushes until the next
   // daemon restart. 'cancelled' is terminal but NOT in ATTENTION_STATES, so
   // firePush stays silent — captain initiated the close, no notification needed.
   let taskId: string | undefined;
+  // Worktree to clean up after the pane closes — set only when this crew ran in
+  // its own worktree (cwd recorded by the daemon differs from the root checkout).
+  // A non-worktree crew has cwd === root (or unset), so this stays undefined and
+  // close is unaffected (#216).
+  let worktreeCwd: string | undefined;
   try {
     const tasks = (await cockpitdCall({ kind: "list", project })) as TaskRecord[];
     const task = tasks.find((t) => t.name === name);
     if (task) {
       taskId = task.id;
+      if (task.cwd && projRoot && task.cwd !== projRoot) {
+        worktreeCwd = task.cwd;
+      }
       if (!TERMINAL_STATES.has(task.state)) {
         await cockpitdCall({ kind: "event", project, event: { type: "task.cancelled", id: task.id, reason: "closed by captain" } });
       }
@@ -522,6 +559,16 @@ export async function runCrewClose(project: string, name: string): Promise<void>
   // that the cmux pane-close cascade may have missed.
   if (taskId !== undefined) {
     await reapCrewChildren(taskId);
+  }
+  // Auto-clean the crew's worktree AFTER its processes are gone, so we don't
+  // yank a dir out from under a live shell. Best-effort: a failed removal must
+  // not break close (the branch is preserved regardless).
+  if (worktreeCwd && projRoot) {
+    try {
+      removeWorktree(projRoot, worktreeCwd);
+    } catch (e) {
+      process.stderr.write(`(worktree remove failed: ${(e as Error).message})\n`);
+    }
   }
 }
 
@@ -549,12 +596,13 @@ crewCommand
   .option("--direction <dir>", "Placement: tab (default) or split direction (right|left|up|down)", "tab")
   .option("--agent <name>", "Agent CLI to use (claude|codex|gemini|opencode)", "claude")
   .option("--approval", "gate risky tools so the captain approves them (codex: approvalPolicy='untrusted'; opencode: bash:'ask')", false)
+  .option("--worktree", "run the crew in its own git worktree + branch (feature tasks; small tasks omit to share the root checkout)", false)
   .option("--task-file <path>", "Read task prompt from file instead of positional arg ('-' for stdin)")
   .action(
     async (
       project: string,
       task: string | undefined,
-      opts: { name?: string; direction: PanePlacement; agent: string; approval: boolean; taskFile?: string },
+      opts: { name?: string; direction: PanePlacement; agent: string; approval: boolean; worktree: boolean; taskFile?: string },
     ) => {
       try {
         const resolvedTask = await resolveTextInput({ positional: task, filePath: opts.taskFile, label: "task" });
@@ -567,6 +615,7 @@ crewCommand
           // --approval is provider-agnostic: codex consumes approvalPolicy,
           // opencode consumes the `approval` flag (→ bash:"ask" per-crew config).
           ...(opts.approval ? { approvalPolicy: "untrusted", approval: true } : {}),
+          ...(opts.worktree ? { worktree: true } : {}),
         });
         console.log(chalk.green(`✔ Crew '${pane.title}' spawned (${pane.surfaceId})`));
       } catch (err) {

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -18,6 +18,7 @@ import {
 import type { PaneRef, PanePlacement, RuntimeDriver } from "../runtimes/types.js";
 import { buildDispatchRequest, cockpitdCall, sendCodexFirstTurn } from "./crew-control.js";
 import { writePerCrewSettingsLocal, writePerCrewOpencodeConfig } from "../lib/per-crew-settings.js";
+import { resolveTextInput } from "../lib/resolve-text-input.js";
 import { TERMINAL_STATES, type TaskRecord } from "../control/types.js";
 
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "cockpit", "templates");
@@ -535,21 +536,23 @@ crewCommand
     "Spawn an interactive crew session as a tab in the captain's workspace (use --direction to split into a pane instead)",
   )
   .argument("<project>", "Project name (must be registered)")
-  .argument("<task>", "Initial task prompt for the crew session")
+  .argument("[task]", "Initial task prompt for the crew session (omit with --task-file)")
   .option("--name <name>", "Crew name (default: auto-generated crew-N)")
   .option("--direction <dir>", "Placement: tab (default) or split direction (right|left|up|down)", "tab")
   .option("--agent <name>", "Agent CLI to use (claude|codex|gemini|opencode)", "claude")
   .option("--approval", "force codex approvalPolicy='untrusted' (codex only; exercises gate primitive)", false)
+  .option("--task-file <path>", "Read task prompt from file instead of positional arg ('-' for stdin)")
   .action(
     async (
       project: string,
-      task: string,
-      opts: { name?: string; direction: PanePlacement; agent: string; approval: boolean },
+      task: string | undefined,
+      opts: { name?: string; direction: PanePlacement; agent: string; approval: boolean; taskFile?: string },
     ) => {
       try {
+        const resolvedTask = await resolveTextInput({ positional: task, filePath: opts.taskFile, label: "task" });
         const pane = await runCrewSpawn({
           project,
-          task,
+          task: resolvedTask,
           name: opts.name,
           direction: opts.direction,
           agent: opts.agent,
@@ -588,10 +591,12 @@ crewCommand
   .description("Send a follow-up message to an existing crew session")
   .argument("<project>", "Project name")
   .argument("<name>", "Crew name (e.g. crew-1)")
-  .argument("<message>", "Message to send")
-  .action(async (project: string, name: string, message: string) => {
+  .argument("[message]", "Message to send (omit with --message-file)")
+  .option("--message-file <path>", "Read message from file instead of positional arg ('-' for stdin)")
+  .action(async (project: string, name: string, message: string | undefined, opts: { messageFile?: string }) => {
     try {
-      await runCrewSend(project, name, message);
+      const resolvedMessage = await resolveTextInput({ positional: message, filePath: opts.messageFile, label: "message" });
+      await runCrewSend(project, name, resolvedMessage);
       console.log(chalk.green(`✔ Sent to ${project}:${name}`));
     } catch (err) {
       console.error(chalk.red((err as Error).message));

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -17,6 +17,7 @@ import {
 } from "../drivers/index.js";
 import type { PaneRef, PanePlacement, RuntimeDriver } from "../runtimes/types.js";
 import { buildDispatchRequest, cockpitdCall, sendCodexFirstTurn } from "./crew-control.js";
+import { tailLines } from "./crew-output.js";
 import { writePerCrewSettingsLocal, writePerCrewOpencodeConfig } from "../lib/per-crew-settings.js";
 import { resolveTextInput } from "../lib/resolve-text-input.js";
 import { TERMINAL_STATES, type TaskRecord } from "../control/types.js";
@@ -606,13 +607,16 @@ crewCommand
 
 crewCommand
   .command("read")
-  .description("Read the current screen of a crew session")
+  .description("Read the current screen of a crew session (tail by default; use --full for the entire scrollback)")
   .argument("<project>", "Project name")
   .argument("<name>", "Crew name")
-  .action(async (project: string, name: string) => {
+  .option("--lines <N>", "Number of trailing lines to show", "40")
+  .option("--full", "Show the entire scrollback (overrides --lines)")
+  .action(async (project: string, name: string, opts: { lines?: string; full?: boolean }) => {
     try {
       const screen = await runCrewRead(project, name);
-      console.log(screen);
+      const out = opts.full ? screen : tailLines(screen, Number(opts.lines ?? 40));
+      console.log(out);
     } catch (err) {
       console.error(chalk.red((err as Error).message));
       process.exit(1);

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -513,18 +513,16 @@ export async function reapCrewChildren(taskId: string, graceMs = 2000): Promise<
 
 export async function runCrewClose(project: string, name: string): Promise<void> {
   const { runtime, workspaceId } = await resolveCaptainWorkspace(project);
-  const crew = await findCrew(runtime, workspaceId, project, name);
-  if (!crew) {
-    throw new Error(`Crew '${name}' not found for ${project}. Run 'cockpit crew list ${project}'.`);
-  }
   // resolveCaptainWorkspace already validated the project exists; reload for its
   // root path so we can tell a worktree crew (cwd != root) from a root crew.
   const projRoot = loadConfig().projects[project]?.path;
-  // Terminalize the daemon task before closing the pane (#184). Without this,
-  // non-terminal tasks (blocked/working/awaiting-input) linger in the daemon
-  // ledger and keep firing phantom CREW BLOCKED/IDLE pushes until the next
-  // daemon restart. 'cancelled' is terminal but NOT in ATTENTION_STATES, so
-  // firePush stays silent — captain initiated the close, no notification needed.
+  // Terminalize the daemon task FIRST — before (and independent of) finding the
+  // cmux pane (#184, hardened for #139). Without this, non-terminal tasks
+  // (blocked/working/awaiting-input) linger in the daemon ledger and keep firing
+  // phantom CREW BLOCKED/IDLE/STALLED pushes. Crucially, a DEAD crew's pane is
+  // already gone, so gating terminalization on findCrew (the old order) left that
+  // zombie record dangling forever. 'cancelled' is terminal but NOT in
+  // ATTENTION_STATES, so firePush stays silent — captain initiated the close.
   let taskId: string | undefined;
   // Worktree to clean up after the pane closes — set only when this crew ran in
   // its own worktree (cwd recorded by the daemon differs from the root checkout).
@@ -554,7 +552,16 @@ export async function runCrewClose(project: string, name: string): Promise<void>
   } catch {
     // Swallow daemon errors — a crew without a daemon must still close.
   }
-  await runtime.closePane(crew);
+  // Close the cmux pane if it still exists. A dead crew's pane is already gone —
+  // that is not an error (the record is terminalized above); proceed to reap
+  // children / clean the worktree. Only a genuine miss (no pane AND no daemon
+  // task) is a typo → surface the not-found error.
+  const crew = await findCrew(runtime, workspaceId, project, name);
+  if (crew) {
+    await runtime.closePane(crew);
+  } else if (taskId === undefined) {
+    throw new Error(`Crew '${name}' not found for ${project}. Run 'cockpit crew list ${project}'.`);
+  }
   // Reap any surviving child processes (vitest workers, node subprocs, etc.)
   // that the cmux pane-close cascade may have missed.
   if (taskId !== undefined) {

--- a/src/commands/notify-relay.ts
+++ b/src/commands/notify-relay.ts
@@ -38,32 +38,18 @@ export const STALE_THRESHOLD_MS = 5 * 60 * 1000;
 // genuinely-blocked crew goes quiet well before the multi-minute stall budget.
 export const PROBE_QUIET_MS = 20_000;
 
-function shortId(id: string): string {
-  return id.slice(0, 8);
-}
-
-export function formatEntry(entry: MailboxEntry): string | null {
-  const tag = `[${entry.provider}/${entry.name != null ? entry.name : shortId(entry.taskId)}]`;
-  switch (entry.kind) {
-    case "task.started":
-    case "task.progress":
-      return null; // suppress liveness/start
-    case "task.done": {
-      const msg =
-        (entry.payload.message as string | undefined) ??
-        (entry.payload.resultRef as string | undefined) ??
-        "(no message)";
-      return `CREW DONE ${tag}: ${msg.toString().split(/\r?\n/)[0].slice(0, 200)}`;
-    }
-    case "task.blocked":
-      return `CREW BLOCKED ${tag}: ${(entry.payload.question as string | undefined) ?? "(no question)"}`;
-    case "task.failed":
-      return `CREW FAILED ${tag}: ${(entry.payload.error as string | undefined) ?? "(no error)"}`;
-    case "task.stalled":
-      return `CREW STALLED ${tag}: no heartbeat`;
-    default:
-      return null;
-  }
+// Unified-formatter (#214/#210): the daemon's formatMessage is the single
+// source of truth for the captain-facing message and stores it on the mailbox
+// entry. The relay is a dumb pipe — it delivers entry.message verbatim and
+// skips entries the daemon chose not to surface (null/empty). The old
+// formatEntry switch re-derived the message from the raw event kind and had
+// drifted (no case for task.approval.requested / task.idle), silently dropping
+// those events. It is retired; deliverable() is the whole policy now.
+export function deliverable(entry: MailboxEntry): string | null {
+  const msg = entry.message;
+  if (msg == null) return null;
+  const trimmed = msg.trim();
+  return trimmed.length > 0 ? msg : null;
 }
 
 // ── Phase 2b: in-cmux interactive-block probe ───────────────────────────────
@@ -239,7 +225,7 @@ export async function runNotifyRelay(opts: RunOpts): Promise<() => void> {
           lastAcked = entry.seq;
           continue;
         }
-        const msg = formatEntry(entry);
+        const msg = deliverable(entry);
         if (msg) {
           try {
             await (opts.runtime as RuntimeDriver & {

--- a/src/control/__tests__/cockpitd-notify-default.test.ts
+++ b/src/control/__tests__/cockpitd-notify-default.test.ts
@@ -6,12 +6,13 @@
 // cockpitd-push.test.ts; this file covers what defaultNotify writes once it
 // fires.
 
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { startCockpitd } from "../cockpitd.js";
 import { sendRequest } from "../protocol.js";
+import { runNotifyRelay } from "../../commands/notify-relay.js";
 import type { TaskRecord } from "../types.js";
 
 function seedRec(id: string): TaskRecord {
@@ -55,6 +56,60 @@ describe("cockpitd defaultNotify writes to mailbox", () => {
     expect(lines[0].payload.resultRef).toBe("/tmp/result");
     expect(lines[0].seq).toBe(1);
     expect(typeof lines[0].ts).toBe("string");
+  });
+
+  it("#214: task.approval.requested → CREW BLOCKED message persisted AND delivered by the relay", async () => {
+    // Regression for #214 (approval dropped) via the unified formatter. The
+    // daemon reduces task.approval.requested → blocked and renders CREW BLOCKED;
+    // defaultNotify must persist that message; the relay must deliver it
+    // verbatim. The OLD relay re-derived from event.kind (no approval case) and
+    // silently dropped it, leaving the captain blind to permission gates.
+    dir = mkdtempSync(join(tmpdir(), "cp-notify-"));
+    const sock = join(dir, "c.sock");
+    const stateRoot = join(dir, "state");
+    const handle = startCockpitd({ stateRoot, sockPath: sock, sweepMs: 0 });
+    stop = handle.stop;
+
+    await sendRequest(sock, { kind: "seed", record: seedRec("task-appr-1") });
+    await sendRequest(sock, {
+      kind: "event",
+      project: "p",
+      event: {
+        type: "task.approval.requested",
+        id: "task-appr-1",
+        requestId: 1,
+        question: "Allow edit to src/foo.ts?",
+        kind: "edit",
+      },
+    });
+    await new Promise((r) => setTimeout(r, 100));
+
+    // 1) The daemon-rendered CREW BLOCKED message is persisted on the entry.
+    const inboxPath = join(stateRoot, "inbox", "p.log");
+    const entry = JSON.parse(readFileSync(inboxPath, "utf-8").trim());
+    expect(entry.kind).toBe("task.approval.requested");
+    expect(entry.message).toMatch(/^CREW BLOCKED \[claude\//);
+    expect(entry.message).toContain("Allow edit to src/foo.ts?");
+
+    // 2) The relay delivers that message verbatim to the captain surface.
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    const runtime = {
+      sendToSurface: sendSpy,
+      status: vi.fn().mockResolvedValue({ id: "ws1", name: "captain", status: "running" }),
+      listSurfaces: vi.fn().mockResolvedValue([{ workspaceId: "ws1", surfaceId: "s1", title: "captain" }]),
+    };
+    const stopRelay = await runNotifyRelay({
+      project: "p",
+      subscriber: "captain",
+      stateRoot,
+      runtime: runtime as never,
+      captainName: "captain",
+      pollMs: 50,
+    });
+    await new Promise((r) => setTimeout(r, 200));
+    stopRelay();
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(sendSpy.mock.calls[0][1]).toBe(entry.message);
   });
 
   it("assigns monotonic seq across multiple notifies in the same project", async () => {

--- a/src/control/__tests__/cockpitd-opencode-approval.test.ts
+++ b/src/control/__tests__/cockpitd-opencode-approval.test.ts
@@ -1,0 +1,93 @@
+// src/control/__tests__/cockpitd-opencode-approval.test.ts
+//
+// CP3 (opencode permission gate): the captain's gate-resolve for an OPENCODE
+// task must route to opencodeBridge.answer (which POSTs the decision to the
+// crew's server), while a codex task still routes to codexDriver.answer.
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startCockpitd } from "../cockpitd.js";
+import { sendRequest } from "../protocol.js";
+import type { TaskRecord } from "../types.js";
+
+function fakeCodexDriver(answer: ReturnType<typeof vi.fn>) {
+  return {
+    dispatch: vi.fn(), reattach: vi.fn(), say: vi.fn(), steer: vi.fn(),
+    interrupt: vi.fn(), answer, close: vi.fn(),
+  } as never;
+}
+
+function seedRecord(o: { id: string; provider: TaskRecord["provider"]; gateKind: "approval" | "input" }): TaskRecord {
+  return {
+    id: o.id, project: "p", provider: o.provider, mode: "interactive",
+    state: "blocked", task: "x", createdAt: 1, lastHeartbeat: 1, lastEvent: "",
+    heartbeatBudgetMs: 1000,
+    attempts: [{ attemptId: "a", startedAt: 1, lastHeartbeatAt: 1 }],
+    gates: [{ gateId: `g-${o.id}`, taskId: o.id, kind: o.gateKind, question: "?", state: "pending", createdAt: 1 }],
+  };
+}
+
+describe("cockpitd opencode approval routing (CP3)", () => {
+  let stop: (() => void) | undefined;
+  let dir: string;
+  afterEach(() => { stop?.(); if (dir) rmSync(dir, { recursive: true, force: true }); });
+
+  it("routes an opencode gate-resolve to opencodeBridge.answer, not codex", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-cp3-"));
+    const sock = join(dir, "c.sock");
+    const ocAnswer = vi.fn().mockResolvedValue(true);
+    const codexAnswer = vi.fn().mockResolvedValue(undefined);
+    const handle = startCockpitd({
+      stateRoot: join(dir, "state"), sockPath: sock, sweepMs: 0,
+      opencodeBridge: { start: vi.fn(), stop: vi.fn(), answer: ocAnswer },
+      codexDriver: fakeCodexDriver(codexAnswer),
+    });
+    stop = handle.stop;
+    await sendRequest(sock, { kind: "seed", record: seedRecord({ id: "o1", provider: "opencode", gateKind: "approval" }) });
+    await sendRequest(sock, {
+      kind: "gate-resolve", project: "p", gateId: "g-o1", resolvedBy: "captain",
+      payload: { text: "approve", decision: "approve" },
+    });
+    expect(ocAnswer).toHaveBeenCalledWith("o1", "approve");
+    expect(codexAnswer).not.toHaveBeenCalled();
+  });
+
+  it("maps a deny decision to opencodeBridge.answer('deny')", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-cp3-"));
+    const sock = join(dir, "c.sock");
+    const ocAnswer = vi.fn().mockResolvedValue(true);
+    const handle = startCockpitd({
+      stateRoot: join(dir, "state"), sockPath: sock, sweepMs: 0,
+      opencodeBridge: { start: vi.fn(), stop: vi.fn(), answer: ocAnswer },
+      codexDriver: fakeCodexDriver(vi.fn()),
+    });
+    stop = handle.stop;
+    await sendRequest(sock, { kind: "seed", record: seedRecord({ id: "o2", provider: "opencode", gateKind: "approval" }) });
+    await sendRequest(sock, {
+      kind: "gate-resolve", project: "p", gateId: "g-o2", resolvedBy: "captain",
+      payload: { text: "deny", decision: "deny" },
+    });
+    expect(ocAnswer).toHaveBeenCalledWith("o2", "deny");
+  });
+
+  it("still routes a codex gate-resolve to codexDriver.answer", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-cp3-"));
+    const sock = join(dir, "c.sock");
+    const ocAnswer = vi.fn().mockResolvedValue(true);
+    const codexAnswer = vi.fn().mockResolvedValue(undefined);
+    const handle = startCockpitd({
+      stateRoot: join(dir, "state"), sockPath: sock, sweepMs: 0,
+      opencodeBridge: { start: vi.fn(), stop: vi.fn(), answer: ocAnswer },
+      codexDriver: fakeCodexDriver(codexAnswer),
+    });
+    stop = handle.stop;
+    await sendRequest(sock, { kind: "seed", record: seedRecord({ id: "c1", provider: "codex", gateKind: "approval" }) });
+    await sendRequest(sock, {
+      kind: "gate-resolve", project: "p", gateId: "g-c1", resolvedBy: "captain",
+      payload: { text: "approve", decision: "approve" },
+    });
+    expect(codexAnswer).toHaveBeenCalledWith("c1", { text: "approve", decision: "approve" });
+    expect(ocAnswer).not.toHaveBeenCalled();
+  });
+});

--- a/src/control/__tests__/cockpitd-push.test.ts
+++ b/src/control/__tests__/cockpitd-push.test.ts
@@ -92,7 +92,7 @@ describe("cockpitd push notifications (#109)", () => {
     store.put(rec("task-stall-1", { mode: "headless", state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250 }));
     const n = fakeNotify();
     const d = createDaemon({ store, now: () => 5000, notify: n.notify });
-    d.sweep();
+    await d.sweep();
     expect(store.get("p", "task-stall-1")?.state).toBe("stalled");
     expect(n.calls).toHaveLength(1);
     expect(n.calls[0]?.message).toMatch(/^CREW STALLED \[claude\/task-sta/);
@@ -105,7 +105,7 @@ describe("cockpitd push notifications (#109)", () => {
     store.put(rec("task-idle-1", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250 }));
     const n = fakeNotify();
     const d = createDaemon({ store, now: () => 5000, notify: n.notify });
-    d.sweep();
+    await d.sweep();
     expect(store.get("p", "task-idle-1")?.state).toBe("awaiting-input");
     expect(n.calls).toHaveLength(1);
     expect(n.calls[0]?.message).toMatch(/^CREW IDLE \[claude\/task-idl/);
@@ -118,9 +118,9 @@ describe("cockpitd push notifications (#109)", () => {
     store.put(rec("task-idle-2", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250 }));
     const n = fakeNotify();
     const d = createDaemon({ store, now: () => 5000, notify: n.notify });
-    d.sweep(); // working → awaiting-input, one push
-    d.sweep(); // awaiting-input is not 'working' → no re-stall, no re-notify
-    d.sweep();
+    await d.sweep(); // working → awaiting-input, one push
+    await d.sweep(); // awaiting-input is not 'working' → no re-stall, no re-notify
+    await d.sweep();
     expect(store.get("p", "task-idle-2")?.state).toBe("awaiting-input");
     expect(n.calls).toHaveLength(1);
   });
@@ -130,7 +130,7 @@ describe("cockpitd push notifications (#109)", () => {
     store.put(rec("task-idle-3", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250 }));
     const n = fakeNotify();
     const d = createDaemon({ store, now: () => 5000, notify: n.notify });
-    d.sweep(); // → awaiting-input, push #1 (CREW IDLE)
+    await d.sweep(); // → awaiting-input, push #1 (CREW IDLE)
     await d.handle({ kind: "event", project: "p", event: { type: "task.started", id: "task-idle-3" } });
     expect(store.get("p", "task-idle-3")?.state).toBe("working");
     expect(n.calls).toHaveLength(1); // working is not an attention state → no extra push

--- a/src/control/__tests__/daemon.test.ts
+++ b/src/control/__tests__/daemon.test.ts
@@ -316,6 +316,80 @@ describe("daemon – blocked crew resume path (#183)", () => {
     expect(calls[0].message).toContain("second prompt");
   });
 
+  // ── #214: DONE message preservation (unified formatter) ───────────────────
+  it("CREW DONE prefers the crew's signal-done message over the task snippet", async () => {
+    const store = createStore(dir);
+    store.put(rec("t-dm", { state: "working", task: "the original assigned task" }));
+    const calls: any[] = [];
+    const d = createDaemon({ store, now: () => 2000, notify: async (a) => { calls.push(a); } });
+    await d.handle({ kind: "event", project: "p", event: { type: "task.done", id: "t-dm", resultRef: "/r", message: "fixed the formatter, all tests pass" } });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].message).toBe("CREW DONE [claude/t-dm]: fixed the formatter, all tests pass");
+  });
+
+  it("CREW DONE falls back to the task snippet when no message is provided", async () => {
+    const store = createStore(dir);
+    store.put(rec("t-ds", { state: "working", task: "implement the thing" }));
+    const calls: any[] = [];
+    const d = createDaemon({ store, now: () => 2000, notify: async (a) => { calls.push(a); } });
+    await d.handle({ kind: "event", project: "p", event: { type: "task.done", id: "t-ds", resultRef: "/r" } });
+    expect(calls[0].message).toBe("CREW DONE [claude/t-ds]: implement the thing");
+  });
+
+  // ── #210: CREW IDLE debounce ──────────────────────────────────────────────
+  // awaiting-input fires CREW IDLE, but must NOT spam during an active
+  // captain-driven back-and-forth: a turn-end shortly after the captain's own
+  // task.started (crew send/reply) is suppressed; a genuine self-idle delivers.
+  describe("CREW IDLE debounce (#210)", () => {
+    it("suppresses CREW IDLE when the turn ends within the debounce window of a captain turn", async () => {
+      const store = createStore(dir);
+      store.put(rec("t-deb", { state: "working" }));
+      const calls: any[] = [];
+      let nowMs = 10_000;
+      const d = createDaemon({ store, now: () => nowMs, notify: async (a) => { calls.push(a); } });
+      // Captain sends → task.started (working → working, records lastCaptainTurnAt)
+      await d.handle({ kind: "event", project: "p", event: { type: "task.started", id: "t-deb" } });
+      // Crew finishes the turn 3s later (well within the window)
+      nowMs = 13_000;
+      await d.handle({ kind: "event", project: "p", event: { type: "task.turn.completed", id: "t-deb", turnId: "turn-1" } });
+      expect(store.get("p", "t-deb")?.state).toBe("awaiting-input");
+      expect(calls.filter((c) => c.message.includes("CREW IDLE"))).toHaveLength(0);
+    });
+
+    it("delivers CREW IDLE for a self-idle turn-end long after the captain's last turn", async () => {
+      const store = createStore(dir);
+      store.put(rec("t-self", { state: "working" }));
+      const calls: any[] = [];
+      let nowMs = 10_000;
+      const d = createDaemon({ store, now: () => nowMs, notify: async (a) => { calls.push(a); } });
+      await d.handle({ kind: "event", project: "p", event: { type: "task.started", id: "t-self" } });
+      // Turn ends far outside the debounce window → genuine idle, must deliver
+      nowMs = 10_000 + 5 * 60_000;
+      await d.handle({ kind: "event", project: "p", event: { type: "task.turn.completed", id: "t-self", turnId: "turn-1" } });
+      const idle = calls.filter((c) => c.message.includes("CREW IDLE"));
+      expect(idle).toHaveLength(1);
+    });
+
+    it("delivers CREW IDLE for a turn-end with no prior captain turn at all", async () => {
+      const store = createStore(dir);
+      store.put(rec("t-none", { state: "working" }));
+      const calls: any[] = [];
+      const d = createDaemon({ store, now: () => 50_000, notify: async (a) => { calls.push(a); } });
+      await d.handle({ kind: "event", project: "p", event: { type: "task.turn.completed", id: "t-none", turnId: "turn-1" } });
+      expect(calls.filter((c) => c.message.includes("CREW IDLE"))).toHaveLength(1);
+    });
+
+    it("does NOT debounce CREW BLOCKED even right after a captain turn", async () => {
+      const store = createStore(dir);
+      store.put(rec("t-blk", { state: "working" }));
+      const calls: any[] = [];
+      const d = createDaemon({ store, now: () => 2000, notify: async (a) => { calls.push(a); } });
+      await d.handle({ kind: "event", project: "p", event: { type: "task.started", id: "t-blk" } });
+      await d.handle({ kind: "event", project: "p", event: { type: "task.blocked", id: "t-blk", reason: "r", question: "q" } });
+      expect(calls.filter((c) => c.message.includes("CREW BLOCKED"))).toHaveLength(1);
+    });
+  });
+
   it("awaiting-input + task.started → working + subsequent task.blocked fires CREW BLOCKED (#183)", async () => {
     // Same fix path for crews that went idle (awaiting-input) before captain replied.
     const store = createStore(dir);

--- a/src/control/__tests__/daemon.test.ts
+++ b/src/control/__tests__/daemon.test.ts
@@ -52,24 +52,45 @@ describe("daemon handler", () => {
     const store = createStore(dir);
     store.put(rec("h1", { state: "working", mode: "headless", pid: 999999 }));
     const d = createDaemon({ store, now: () => 5000, isPidAlive: () => false });
-    d.reconcile();
+    await d.reconcile();
     expect(store.get("p", "h1")?.state).toBe("failed");
     expect(store.get("p", "h1")?.error).toMatch(/orphan|daemon restart/i);
   });
 
-  it("reconcile: working interactive task → stalled (hook source gone)", async () => {
+  // #139: on daemon restart a LIVE interactive crew's cmux pane survives the
+  // bounce, so it must NOT be moved to 'stalled' (the old behavior false-stalled
+  // it AND fired CREW STALLED). Only a PROVABLY-gone surface is terminalized.
+  it("reconcile: interactive orphan with a GONE surface → cancelled (silent) (#139)", async () => {
     const store = createStore(dir);
     store.put(rec("i1", { state: "working", mode: "interactive" }));
-    const d = createDaemon({ store, now: () => 5000, isPidAlive: () => false });
-    d.reconcile();
-    expect(store.get("p", "i1")?.state).toBe("stalled");
+    const calls: any[] = [];
+    const d = createDaemon({ store, now: () => 5000, isSurfaceAlive: async () => "gone", notify: async (a) => { calls.push(a); } });
+    await d.reconcile();
+    expect(store.get("p", "i1")?.state).toBe("cancelled");
+    expect(calls.length).toBe(0); // silent — no CREW STALLED re-emitted
+  });
+
+  it("reconcile: interactive orphan with a LIVE surface stays working (reattachable) (#139)", async () => {
+    const store = createStore(dir);
+    store.put(rec("i2", { state: "working", mode: "interactive" }));
+    const d = createDaemon({ store, now: () => 5000, isSurfaceAlive: async () => "alive" });
+    await d.reconcile();
+    expect(store.get("p", "i2")?.state).toBe("working");
+  });
+
+  it("reconcile: interactive orphan with UNKNOWN surface liveness stays working (never false-cancel) (#139)", async () => {
+    const store = createStore(dir);
+    store.put(rec("i3", { state: "working", mode: "interactive" }));
+    const d = createDaemon({ store, now: () => 5000, isSurfaceAlive: async () => "unknown" });
+    await d.reconcile();
+    expect(store.get("p", "i3")?.state).toBe("working");
   });
 
   it("reconcile: working headless task with live pid → stays working", async () => {
     const store = createStore(dir);
     store.put(rec("h2", { state: "working", mode: "headless", pid: 4242 }));
     const d = createDaemon({ store, now: () => 5000, isPidAlive: () => true });
-    d.reconcile();
+    await d.reconcile();
     expect(store.get("p", "h2")?.state).toBe("working");
   });
 
@@ -77,7 +98,7 @@ describe("daemon handler", () => {
     const store = createStore(dir);
     store.put(rec("s1", { mode: "headless", state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 100 }));
     const d = createDaemon({ store, now: () => 1000 });
-    d.sweep();
+    await d.sweep();
     expect(store.get("p", "s1")?.state).toBe("stalled");
   });
 
@@ -85,7 +106,7 @@ describe("daemon handler", () => {
     const store = createStore(dir);
     store.put(rec("s1i", { mode: "interactive", state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 100 }));
     const d = createDaemon({ store, now: () => 1000 });
-    d.sweep();
+    await d.sweep();
     expect(store.get("p", "s1i")?.state).toBe("awaiting-input");
   });
 
@@ -93,7 +114,7 @@ describe("daemon handler", () => {
     const store = createStore(dir);
     store.put(rec("s2", { state: "stalled", lastHeartbeat: 990, heartbeatBudgetMs: 100 }));
     const d = createDaemon({ store, now: () => 1000 });
-    d.sweep();
+    await d.sweep();
     expect(store.get("p", "s2")?.state).toBe("working");
   });
 
@@ -102,8 +123,70 @@ describe("daemon handler", () => {
     // lastHeartbeat=0, budget=100, now=1000 → 1000-0=1000 > 100 → guard blocks recovery
     store.put(rec("s3", { state: "stalled", lastHeartbeat: 0, heartbeatBudgetMs: 100 }));
     const d = createDaemon({ store, now: () => 1000 });
-    d.sweep();
+    await d.sweep();
     expect(store.get("p", "s3")?.state).toBe("stalled");
+  });
+
+  // ── #139 backstop: sweep reaps interactive records whose surface is gone ─────
+  // Covers opencode crews (no SessionEnd hook) and any missed claude SessionEnd.
+  // A provably-gone surface means the crew can never make progress → cancelled,
+  // silently (NOT oscillated working↔stalled, NOT a re-fired CREW STALLED).
+  it("sweep: interactive WORKING record with a gone surface → cancelled (silent), within 24h budget (#139)", async () => {
+    const store = createStore(dir);
+    // Heartbeat is FRESH (well within the 24h budget) — proves the reap is
+    // liveness-based, not a shorter timeout. The legitimate-idle false-stall fix
+    // (#131/#133) keeps the 86400000ms budget; only a dead surface reaps.
+    store.put(rec("g1", { mode: "interactive", state: "working", lastHeartbeat: 990, heartbeatBudgetMs: 86_400_000 }));
+    const calls: any[] = [];
+    const d = createDaemon({ store, now: () => 1000, isSurfaceAlive: async () => "gone", notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    expect(store.get("p", "g1")?.state).toBe("cancelled");
+    expect(calls.length).toBe(0); // silent reap
+  });
+
+  it("sweep: interactive AWAITING-INPUT record with a gone surface → cancelled (#139)", async () => {
+    const store = createStore(dir);
+    store.put(rec("g2", { mode: "interactive", state: "awaiting-input", lastHeartbeat: 990, heartbeatBudgetMs: 86_400_000 }));
+    const d = createDaemon({ store, now: () => 1000, isSurfaceAlive: async () => "gone" });
+    await d.sweep();
+    expect(store.get("p", "g2")?.state).toBe("cancelled");
+  });
+
+  it("sweep: interactive STALLED record with a gone surface → cancelled (not left oscillating) (#139)", async () => {
+    const store = createStore(dir);
+    store.put(rec("g3", { mode: "interactive", state: "stalled", lastHeartbeat: 990, heartbeatBudgetMs: 86_400_000 }));
+    const d = createDaemon({ store, now: () => 1000, isSurfaceAlive: async () => "gone" });
+    await d.sweep();
+    expect(store.get("p", "g3")?.state).toBe("cancelled");
+  });
+
+  // The critical non-regression: a LEGITIMATELY-IDLE live crew (surface alive)
+  // that is over its heartbeat budget must still become awaiting-input (CREW
+  // IDLE), NEVER reaped. This preserves the #131/#133 24h-budget false-stall fix.
+  it("sweep: interactive over-budget record with a LIVE surface → awaiting-input, not reaped (#139)", async () => {
+    const store = createStore(dir);
+    store.put(rec("g4", { mode: "interactive", state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 100 }));
+    const d = createDaemon({ store, now: () => 1000, isSurfaceAlive: async () => "alive" });
+    await d.sweep();
+    expect(store.get("p", "g4")?.state).toBe("awaiting-input");
+  });
+
+  it("sweep: interactive over-budget record with UNKNOWN surface → awaiting-input, never false-reaped (#139)", async () => {
+    const store = createStore(dir);
+    store.put(rec("g5", { mode: "interactive", state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 100 }));
+    const d = createDaemon({ store, now: () => 1000, isSurfaceAlive: async () => "unknown" });
+    await d.sweep();
+    expect(store.get("p", "g5")?.state).toBe("awaiting-input");
+  });
+
+  it("sweep: headless records are never surface-reaped (pid is their liveness) (#139)", async () => {
+    const store = createStore(dir);
+    // A headless working record with a fresh heartbeat: even if isSurfaceAlive
+    // says 'gone', headless mode must ignore it (it has no cmux surface).
+    store.put(rec("g6", { mode: "headless", state: "working", lastHeartbeat: 990, heartbeatBudgetMs: 1000 }));
+    const d = createDaemon({ store, now: () => 1000, isSurfaceAlive: async () => "gone" });
+    await d.sweep();
+    expect(store.get("p", "g6")?.state).toBe("working");
   });
 
   it("dispatch persists submitted then (headless) triggers launch hook", async () => {

--- a/src/control/__tests__/integration-restart.test.ts
+++ b/src/control/__tests__/integration-restart.test.ts
@@ -10,17 +10,18 @@ describe("integration: daemon restart mid-task (success criterion)", () => {
   let stop: (() => void) | undefined; let dir: string;
   afterEach(() => { stop?.(); if (dir) rmSync(dir, { recursive: true, force: true }); });
 
-  it("a working interactive task survives a daemon restart as 'stalled' (no false done)", async () => {
+  // #139: an interactive crew whose cmux pane is PROVABLY gone is terminalized
+  // (cancelled) on daemon restart — never oscillated to 'stalled' (which fired
+  // false CREW STALLED on every restart) and never fabricated to 'done'.
+  it("interactive orphan with a GONE surface → cancelled on daemon restart (no false done/stalled)", async () => {
     dir = mkdtempSync(join(tmpdir(), "cp-int-"));
     const sock = join(dir, "c.sock");
     const stateRoot = join(dir, "state");
 
     let h = startCockpitd({ stateRoot, sockPath: sock, sweepMs: 0 });
     // Construct the precondition (a WORKING interactive task) via `seed`, not
-    // `dispatch`: red-team #4 fix makes interactive dispatch fail-loud until
-    // the deferred interactive launcher exists. The success criterion under
-    // test is reconcile behavior (working interactive → stalled across a
-    // restart, never fabricated `done`), which is unchanged and still proven.
+    // `dispatch`: red-team #4 fix makes interactive dispatch fail-loud until the
+    // deferred interactive launcher exists.
     await sendRequest(sock, { kind: "seed", record: {
       id: "t1", project: "p", provider: "claude", mode: "interactive",
       state: "working", task: "x", createdAt: 1, lastHeartbeat: 1,
@@ -30,15 +31,59 @@ describe("integration: daemon restart mid-task (success criterion)", () => {
     // crash the daemon mid-task
     h.stop();
 
-    // restart — reconcile() must run on boot
-    h = startCockpitd({ stateRoot, sockPath: sock, sweepMs: 0 });
+    // restart — reconcile() runs on boot; the crew's pane is gone (session died)
+    h = startCockpitd({ stateRoot, sockPath: sock, sweepMs: 0, isSurfaceAlive: async () => "gone" });
+    stop = h.stop;
+
+    const st: any = await pollStatus(sock, "t1", (s) => s.state === "cancelled");
+    expect(st.state).toBe("cancelled");        // terminalized, not oscillated
+    expect(st.state).not.toBe("stalled");      // never re-emits CREW STALLED
+    expect(st.state).not.toBe("done");         // never fabricated success
+  });
+
+  // The non-regression companion: when liveness is INDETERMINATE (cmux down at
+  // boot — the common test/headless case), the crew stays 'working' (the
+  // reattach loop + a later sweep re-check own it). Never false-cancelled, never
+  // false-stalled, never falsely 'done'.
+  it("interactive orphan with UNKNOWN surface liveness stays 'working' on restart (no false terminal)", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-int-unk-"));
+    const sock = join(dir, "c.sock");
+    const stateRoot = join(dir, "state");
+
+    let h = startCockpitd({ stateRoot, sockPath: sock, sweepMs: 0 });
+    await sendRequest(sock, { kind: "seed", record: {
+      id: "t1", project: "p", provider: "claude", mode: "interactive",
+      state: "working", task: "x", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "task.started", heartbeatBudgetMs: 999999,
+      attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }] } });
+    h.stop();
+
+    h = startCockpitd({ stateRoot, sockPath: sock, sweepMs: 0, isSurfaceAlive: async () => "unknown" });
     stop = h.stop;
 
     const st: any = await sendRequest(sock, { kind: "status", project: "p", id: "t1" });
-    expect(st.state).toBe("stalled");          // surfaced deterministically
-    expect(st.state).not.toBe("done");          // never fabricated success
+    expect(st.state).toBe("working");
+    expect(st.state).not.toBe("done");
+    expect(st.state).not.toBe("cancelled");
   });
 });
+
+// Boot reconcile runs in an async IIFE, so a status query can race it; poll
+// briefly until the predicate holds (or time out and return the last status).
+async function pollStatus(
+  sock: string,
+  id: string,
+  done: (s: any) => boolean,
+  tries = 40,
+): Promise<any> {
+  let last: any;
+  for (let i = 0; i < tries; i++) {
+    last = await sendRequest(sock, { kind: "status", project: "p", id });
+    if (done(last)) return last;
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  return last;
+}
 
 describe("integration: headless dead-pid conservative crash recovery", () => {
   it("dead headless pid reconciles to 'failed' on daemon restart", async () => {

--- a/src/control/__tests__/interactive-claude-hook.test.ts
+++ b/src/control/__tests__/interactive-claude-hook.test.ts
@@ -17,9 +17,14 @@ describe("mapClaudeHookToEvent", () => {
     expect(ev).toEqual({ type: "task.progress", id: TID, note: "subagentstop" });
   });
 
-  it("maps SessionEnd → task.progress with note 'sessionend' (NOT terminal)", () => {
+  // #139: SessionEnd means the crew session is GONE. It must NOT be liveness —
+  // mapping it to task.progress resumed a dead crew to 'working', which the
+  // watchdog then false-stalled ~budget later. It maps to task.session.ended,
+  // which the reducer terminalizes (→ cancelled). Only PostToolUse and
+  // SubagentStop count as resume-liveness.
+  it("maps SessionEnd → task.session.ended (terminal, NOT liveness) (#139)", () => {
     const ev = mapClaudeHookToEvent("SessionEnd", { reason: "exit" }, TID);
-    expect(ev).toEqual({ type: "task.progress", id: TID, note: "sessionend" });
+    expect(ev).toEqual({ type: "task.session.ended", id: TID });
   });
 
   // PostToolUse fires after every tool call MID-turn, so it keeps the

--- a/src/control/__tests__/mailbox.test.ts
+++ b/src/control/__tests__/mailbox.test.ts
@@ -57,6 +57,28 @@ describe("appendToMailbox", () => {
     expect(typeof entry.ts).toBe("string");
   });
 
+  it("persists the daemon-rendered message verbatim on the entry (unified-formatter)", async () => {
+    const stateRoot = freshState();
+    await appendToMailbox({
+      stateRoot,
+      project: "demo",
+      taskRecord: sampleRecord,
+      event: doneEvent,
+      message: "CREW DONE [claude/abc]: shipped it",
+    });
+    const logPath = join(stateRoot, "inbox", "demo.log");
+    const entry = JSON.parse(readFileSync(logPath, "utf-8").trim());
+    expect(entry.message).toBe("CREW DONE [claude/abc]: shipped it");
+  });
+
+  it("stores message:null when the daemon passes no message", async () => {
+    const stateRoot = freshState();
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    const logPath = join(stateRoot, "inbox", "demo.log");
+    const entry = JSON.parse(readFileSync(logPath, "utf-8").trim());
+    expect(entry.message).toBeNull();
+  });
+
   it("assigns monotonically increasing seq on subsequent appends", async () => {
     const stateRoot = freshState();
     const s1 = await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });

--- a/src/control/__tests__/state-machine.test.ts
+++ b/src/control/__tests__/state-machine.test.ts
@@ -218,6 +218,33 @@ describe("state-machine reduce", () => {
     const next = reduce(done, { type: "task.cancelled", id: "t1", reason: "closed" }, 7000);
     expect(next).toBe(done);
   });
+
+  // ── Issue #139: a dead claude session terminalizes, never resumes 'working' ──
+  // SessionEnd maps to task.session.ended (NOT task.progress). The crew process
+  // is gone, so the record must reach a terminal state instead of being revived
+  // to 'working' (where nothing heartbeats and the watchdog later false-stalls).
+  it("task.session.ended on awaiting-input → cancelled (NOT working) (#139)", () => {
+    const next = reduce(rec({ state: "awaiting-input" }), { type: "task.session.ended", id: "t1" }, 8000);
+    expect(next.state).toBe("cancelled");
+    expect(next.lastHeartbeat).toBe(8000);
+    expect(next.lastEvent).toBe("task.session.ended");
+  });
+
+  it("task.session.ended on working → cancelled (#139)", () => {
+    const next = reduce(rec({ state: "working" }), { type: "task.session.ended", id: "t1" }, 8001);
+    expect(next.state).toBe("cancelled");
+  });
+
+  it("task.session.ended on blocked → cancelled (dead session can't be answered) (#139)", () => {
+    const next = reduce(rec({ state: "blocked", question: "q?" }), { type: "task.session.ended", id: "t1" }, 8002);
+    expect(next.state).toBe("cancelled");
+  });
+
+  it("done task absorbs task.session.ended — already terminal, no state change (#139)", () => {
+    const done = rec({ state: "done", resultRef: "/r" });
+    const next = reduce(done, { type: "task.session.ended", id: "t1" }, 8003);
+    expect(next).toBe(done);
+  });
 });
 
 describe("DispatchAttempt schema", () => {

--- a/src/control/__tests__/surface-liveness.test.ts
+++ b/src/control/__tests__/surface-liveness.test.ts
@@ -1,0 +1,31 @@
+// src/control/__tests__/surface-liveness.test.ts
+import { describe, it, expect } from "vitest";
+import { surfaceVerdict } from "../crew-pane-reader.js";
+
+// #139: the pure decision behind the daemon's interactive surface-liveness
+// backstop. "gone" must mean PROVABLY absent (cmux answered, the crew's pane is
+// not among the surfaces) — never an "I couldn't tell" — so a transient cmux
+// outage can never false-reap a live crew.
+describe("surfaceVerdict (#139)", () => {
+  const WANT = "🔧 brove:crew-1";
+
+  it("present surface list containing the crew's title → alive", () => {
+    expect(surfaceVerdict(["🔧 brove:crew-1", "some-other-tab"], WANT)).toBe("alive");
+  });
+
+  it("present surface list NOT containing the crew's title → gone (provably absent)", () => {
+    expect(surfaceVerdict(["some-other-tab"], WANT)).toBe("gone");
+  });
+
+  it("empty surface list (cmux up, captain found, no crew pane) → gone", () => {
+    expect(surfaceVerdict([], WANT)).toBe("gone");
+  });
+
+  it("null surfaces (could not enumerate — cmux down / no captain) → unknown, never reaps", () => {
+    expect(surfaceVerdict(null, WANT)).toBe("unknown");
+  });
+
+  it("null want-title (crew has no name) → unknown", () => {
+    expect(surfaceVerdict(["anything"], null)).toBe("unknown");
+  });
+});

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -207,6 +207,9 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
         project: args.project,
         taskRecord: args.record,
         event: args.event,
+        // Persist the daemon-rendered message (#214/#210): the relay delivers it
+        // verbatim instead of re-deriving from the raw event (which drifted).
+        message: args.message,
       });
     } catch (e) {
       log(`mailbox append failed project=${args.project}: ${(e as Error).message}`);

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -12,6 +12,7 @@ import { CodexInteractiveDriver, shouldReattachCodex } from "./codex/driver.js";
 import { OpencodeSseBridge } from "./opencode/sse-bridge.js";
 import { makeGate } from "./codex/gate.js";
 import { appendToMailbox, rotateIfNeeded } from "./mailbox.js";
+import { createSurfaceLivenessProbe } from "./crew-pane-reader.js";
 import { readdir } from "node:fs/promises";
 import type { Gate, TaskRecord, ControlEvent } from "./types.js";
 import { TERMINAL_STATES } from "./types.js";
@@ -22,6 +23,9 @@ export interface CockpitdOpts {
   sockPath?: string;
   sweepMs?: number; // 0 disables the interval (tests)
   isPidAlive?: (pid: number) => boolean; // injectable for the headless reconcile path (tests)
+  // injectable for the #139 interactive surface-liveness reaper (tests); defaults
+  // to the real cmux probe. Returns "alive" | "gone" | "unknown".
+  isSurfaceAlive?: (rec: TaskRecord) => Promise<"alive" | "gone" | "unknown">;
   spawn?: typeof realSpawn;
   /**
    * Push-notification hook (#109). Defaults to appending a structured event
@@ -228,6 +232,9 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
 
   const d = createDaemon({
     store, now: () => Date.now(), isPidAlive, notify,
+    // #139 backstop: terminalize interactive crews whose cmux pane is provably
+    // gone (sweep/reconcile reaper). Three-valued; "unknown" never reaps.
+    isSurfaceAlive: opts.isSurfaceAlive ?? createSurfaceLivenessProbe(),
     launchHeadless: async (rec) => {
       await runHeadless({
         provider: rec.provider, task: rec.task, id: rec.id, sessionId: rec.sessionId,
@@ -282,37 +289,49 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
     },
   });
 
-  d.reconcile(); // crash recovery on boot
+  // Crash recovery on boot. reconcile() is async (#139: it consults the
+  // interactive surface-liveness probe to reap dead crews instead of stalling
+  // them), so run it — and the reattach loops that depend on its terminalizing a
+  // dead crew before we re-subscribe it — inside an async IIFE. startCockpitd
+  // stays synchronous (returns the handle immediately); boot recovery settles
+  // shortly after. Errors are swallowed: a flaky probe must not crash boot.
+  void (async () => {
+    try {
+      await d.reconcile();
+    } catch (e) {
+      log(`reconcile on boot failed: ${(e as Error).message}`);
+    }
 
-  // Restart-reattach (spec §5; closes interactive slice of #86):
-  // For each LIVE interactive-codex task that has a resumeRef, fire reattach()
-  // against the driver. Fire-and-forget; failures are logged only.
-  //
-  // Guard against the reattach storm: resuming a thread re-spawns its per-thread
-  // MCP servers (gitnexus/pay), so blindly reattaching every non-terminal codex
-  // task means each daemon restart re-spawns one MCP set per HISTORICAL crew —
-  // which exhausted RAM (22 zombie tasks → 22 gitnexus servers on one boot).
-  // Skip terminal tasks (done/failed/cancelled — incl. crews closed via the new
-  // codex-close archive) AND stale tasks whose crew pane is long gone (no
-  // heartbeat within the staleness window — the watchdog would stall them too).
-  const bootNow = Date.now();
-  const REATTACH_STALE_MS = 10 * 60_000;
-  for (const rec of store.listAll()) {
-    if (!shouldReattachCodex(rec, bootNow, REATTACH_STALE_MS)) continue;
-    codexDriver.reattach(rec).catch((e: unknown) => {
-      log(`reattach failed for ${rec.id}: ${(e as Error).message}`);
-    });
-  }
+    // Restart-reattach (spec §5; closes interactive slice of #86):
+    // For each LIVE interactive-codex task that has a resumeRef, fire reattach()
+    // against the driver. Fire-and-forget; failures are logged only.
+    //
+    // Guard against the reattach storm: resuming a thread re-spawns its per-thread
+    // MCP servers (gitnexus/pay), so blindly reattaching every non-terminal codex
+    // task means each daemon restart re-spawns one MCP set per HISTORICAL crew —
+    // which exhausted RAM (22 zombie tasks → 22 gitnexus servers on one boot).
+    // Skip terminal tasks (done/failed/cancelled — incl. crews closed via the new
+    // codex-close archive AND #139's surface-reaped crews) AND stale tasks whose
+    // crew pane is long gone (no heartbeat within the staleness window).
+    const bootNow = Date.now();
+    const REATTACH_STALE_MS = 10 * 60_000;
+    for (const rec of store.listAll()) {
+      if (!shouldReattachCodex(rec, bootNow, REATTACH_STALE_MS)) continue;
+      codexDriver.reattach(rec).catch((e: unknown) => {
+        log(`reattach failed for ${rec.id}: ${(e as Error).message}`);
+      });
+    }
 
-  // Re-subscribe the opencode SSE bridge after a daemon bounce: the crew's
-  // cmux pane (and its `opencode --port <N>` server) survives a daemon restart,
-  // so a non-terminal opencode crew with a known serverPort can be re-attached.
-  for (const rec of store.listAll()) {
-    if (rec.provider !== "opencode" || rec.mode !== "interactive") continue;
-    if (TERMINAL_STATES.has(rec.state)) continue;
-    if (!rec.serverPort) continue;
-    opencodeBridge.start({ taskId: rec.id, port: rec.serverPort });
-  }
+    // Re-subscribe the opencode SSE bridge after a daemon bounce: the crew's
+    // cmux pane (and its `opencode --port <N>` server) survives a daemon restart,
+    // so a non-terminal opencode crew with a known serverPort can be re-attached.
+    for (const rec of store.listAll()) {
+      if (rec.provider !== "opencode" || rec.mode !== "interactive") continue;
+      if (TERMINAL_STATES.has(rec.state)) continue;
+      if (!rec.serverPort) continue;
+      opencodeBridge.start({ taskId: rec.id, port: rec.serverPort });
+    }
+  })();
 
   const server = startServer(sockPath, {
     handler: async (msg: any) => {
@@ -360,7 +379,17 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
 
   let timer: NodeJS.Timeout | undefined;
   if (opts.sweepMs && opts.sweepMs > 0) {
-    timer = setInterval(() => d.sweep(), opts.sweepMs);
+    // sweep() is async (#139: it probes cmux surface liveness). Guard against an
+    // overlapping run if a probe is slow — skip this tick rather than stacking
+    // sweeps. Errors are swallowed so a flaky probe never crashes the daemon.
+    let sweeping = false;
+    timer = setInterval(() => {
+      if (sweeping) return;
+      sweeping = true;
+      void d.sweep()
+        .catch((e: unknown) => log(`sweep failed: ${(e as Error).message}`))
+        .finally(() => { sweeping = false; });
+    }, opts.sweepMs);
     timer.unref?.();
   }
 

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -57,6 +57,8 @@ export interface CockpitdOpts {
   opencodeBridge?: {
     start: (o: { taskId: string; port: number }) => void;
     stop: (taskId: string) => void;
+    /** CP3: POST the captain's approve/deny decision to the crew's server. */
+    answer: (taskId: string, decision: "approve" | "deny") => Promise<boolean>;
   };
 }
 
@@ -182,6 +184,13 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       const found = store.listAll().find((r) => r.id === ev.id);
       if (!found) return;
       void d.handle({ kind: "event", project: found.project, event: ev });
+      // CP3: a gated permission must become a resolvable gate so the captain can
+      // approve/deny via `crew reply --gate`. Opencode crews never attach a
+      // renderer (no `crew attach`), so schedulePromotion always fires after the
+      // grace window — mirroring the codex emit hook below.
+      if (ev.type === "task.approval.requested") {
+        schedulePromotion(ev.id, ev.requestId, "approval", ev.question);
+      }
     },
     log,
   });
@@ -256,8 +265,20 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       );
     },
     resolveInteractiveGate: async (taskId, payload) => {
-      try { await codexDriver.answer(taskId, payload); }
-      catch (e) { log(`gate-resolve answer failed: ${(e as Error).message}`); }
+      // Route the captain's decision to the owning provider's driver. Opencode
+      // crews resolve via the SSE bridge (POST to the crew's server); codex via
+      // its app-server respondToServerRequest. Provider comes from the record.
+      const rec = store.listAll().find((r) => r.id === taskId);
+      try {
+        if (rec?.provider === "opencode") {
+          // Only an explicit "approve" approves; any other reply (incl. an
+          // ambiguous one) denies — never auto-approve a permission gate.
+          const decision = (payload as { decision?: string })?.decision === "approve" ? "approve" : "deny";
+          await opencodeBridge.answer(taskId, decision);
+        } else {
+          await codexDriver.answer(taskId, payload);
+        }
+      } catch (e) { log(`gate-resolve answer failed: ${(e as Error).message}`); }
     },
   });
 

--- a/src/control/codex/__tests__/driver.test.ts
+++ b/src/control/codex/__tests__/driver.test.ts
@@ -314,6 +314,52 @@ describe("CodexInteractiveDriver.dispatch", () => {
     });
   });
 
+  it("first-turn say() awaits an in-flight dispatch instead of dropping the turn (race #212)", async () => {
+    resolveCodexModelMock.mockResolvedValue(undefined);
+    const client = fakeClient();
+    // startThread parks on a deferred promise to simulate the JSON-RPC
+    // round-trip window during which the first-turn say() arrives — the exact
+    // window where threadByTask is still empty.
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    client.startThread = vi.fn().mockImplementation(async () => {
+      await gate;
+      return { threadId: "TH-1" };
+    });
+    const drv = new CodexInteractiveDriver({ makeClient: () => client, emit: () => {} });
+    const task = {
+      id: "t1", project: "p", provider: "codex", mode: "interactive",
+      state: "submitted", task: "x", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000,
+      attempts: [{ attemptId: "a1", startedAt: 1, lastHeartbeatAt: 1 }],
+      cwd: "/tmp/work",
+    } as any;
+
+    const dispatchP = drv.dispatch(task);   // parks inside startThread
+    const sayP = drv.say("t1", "hello");     // first turn arrives DURING the await window
+    await Promise.resolve();                 // let say() reach its thread lookup
+    release();                               // startThread resolves → thread mapped
+
+    await expect(Promise.all([dispatchP, sayP])).resolves.toBeDefined();
+    expect(client.sendTurn).toHaveBeenCalledWith("TH-1", "hello");
+  });
+
+  it("say() still rejects with 'no thread' when its dispatch failed (no thread ever mapped)", async () => {
+    const client = fakeClient();
+    client.startThread = vi.fn().mockRejectedValue(new Error("startThread boom"));
+    const drv = new CodexInteractiveDriver({ makeClient: () => client, emit: () => {} });
+    const task = {
+      id: "t1", project: "p", provider: "codex", mode: "interactive",
+      state: "submitted", task: "x", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000,
+      attempts: [{ attemptId: "a1", startedAt: 1, lastHeartbeatAt: 1 }],
+      cwd: "/tmp/work",
+    } as any;
+    const dispatchP = drv.dispatch(task).catch(() => {});
+    await expect(drv.say("t1", "hello")).rejects.toThrow(/no thread/);
+    await dispatchP;
+  });
+
   it("if initialize rejects, emits task.failed with a clear handshake error", async () => {
     const client = fakeClient();
     client.initialize = vi.fn().mockRejectedValue(new Error("Not initialized"));

--- a/src/control/codex/driver.ts
+++ b/src/control/codex/driver.ts
@@ -45,6 +45,13 @@ export class CodexInteractiveDriver {
   private handshakeP?: Promise<void>;
   private threadByTask = new Map<string, string>();
   private taskByThread = new Map<string, string>();
+  /**
+   * taskId → in-flight dispatch promise. The first-turn say() can arrive while
+   * dispatch() is still awaiting startThread (threadByTask not yet set); say()
+   * awaits this gate before reading threadByTask so the first turn isn't lost
+   * with "no thread for task" (issue #212).
+   */
+  private dispatchByTask = new Map<string, Promise<void>>();
   /** taskId → last pending server-request {id, method} (for answer()) */
   private serverRequestByTask = new Map<string, { id: number; method: string }>();
   private deps: DriverDeps;
@@ -69,6 +76,19 @@ export class CodexInteractiveDriver {
   }
 
   async dispatch(rec: TaskRecord & { cwd?: string; model?: string }): Promise<void> {
+    // Register the in-flight dispatch synchronously so a concurrent first-turn
+    // say() can await it (see dispatchByTask / issue #212). Cleared once the
+    // thread is mapped (or dispatch failed), after which say() reads the map.
+    const p = this.runDispatch(rec);
+    this.dispatchByTask.set(rec.id, p.then(() => {}, () => {}));
+    try {
+      await p;
+    } finally {
+      this.dispatchByTask.delete(rec.id);
+    }
+  }
+
+  private async runDispatch(rec: TaskRecord & { cwd?: string; model?: string }): Promise<void> {
     try {
       const c = await this.ensureClient();
       await withTimeout(this.ensureHandshake(), 10_000, "handshake timed out");
@@ -105,6 +125,10 @@ export class CodexInteractiveDriver {
   }
 
   async say(taskId: string, text: string): Promise<void> {
+    // Wait out any in-flight dispatch so the first turn isn't dropped during
+    // the startThread window (#212). The gate never rejects; a failed dispatch
+    // simply leaves threadByTask empty → the existing "no thread" throw stands.
+    await this.dispatchByTask.get(taskId);
     const c = this.client!;
     const tid = this.threadByTask.get(taskId);
     if (!tid) throw new Error(`no thread for task ${taskId}`);

--- a/src/control/crew-pane-reader.ts
+++ b/src/control/crew-pane-reader.ts
@@ -10,6 +10,58 @@ function crewPaneTitle(project: string, name: string): string {
   return `🔧 ${project}:${name}`;
 }
 
+export type SurfaceLiveness = "alive" | "gone" | "unknown";
+
+/**
+ * Pure: decide an interactive crew's surface liveness from a resolved surface
+ * list (#139). Three-valued so a transient cmux outage never false-reaps a live
+ * crew — "gone" means PROVABLY absent, not "couldn't tell":
+ *   - wantTitle null (crew has no name)            → "unknown"
+ *   - surfaceTitles null (could not enumerate)     → "unknown"
+ *   - title present in the list                    → "alive"
+ *   - title absent from an enumerated list         → "gone"
+ */
+export function surfaceVerdict(surfaceTitles: string[] | null, wantTitle: string | null): SurfaceLiveness {
+  if (!wantTitle) return "unknown";
+  if (surfaceTitles == null) return "unknown";
+  return surfaceTitles.includes(wantTitle) ? "alive" : "gone";
+}
+
+/**
+ * I/O: enumerate the captain workspace's surface titles for a crew's project,
+ * the same way the pane reader does. Returns null on ANY failure (cmux down, no
+ * captain, no project) — surfaceVerdict maps null → "unknown" so we never reap
+ * on an inconclusive probe. Never throws (the daemon sweep must not trip).
+ */
+async function listCaptainSurfaceTitles(rec: TaskRecord): Promise<string[] | null> {
+  try {
+    const config = loadConfig();
+    const proj = config.projects[rec.project];
+    if (!proj) return null;
+    const runtime = new RuntimeRegistry({ cmux: createCmuxDriver() }).forProject(rec.project, config);
+    const captain = await runtime.status(proj.captainName);
+    if (!captain) return null;
+    const surfaces = await runtime.listSurfaces(captain.id);
+    return surfaces.map((s) => s.title ?? "");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build the daemon's interactive surface-liveness probe (#139 backstop). Wired
+ * into createDaemon as `isSurfaceAlive`: the sweep/reconcile reaper terminalizes
+ * a non-terminal interactive record whose pane is provably gone. Non-interactive
+ * or unnamed records short-circuit to "unknown" (never reaped).
+ */
+export function createSurfaceLivenessProbe(): (rec: TaskRecord) => Promise<SurfaceLiveness> {
+  return async (rec) => {
+    if (rec.mode !== "interactive" || !rec.name) return "unknown";
+    const titles = await listCaptainSurfaceTitles(rec);
+    return surfaceVerdict(titles, crewPaneTitle(rec.project, rec.name));
+  };
+}
+
 /**
  * Build the daemon's best-effort crew-pane reader (Phase 2b). Resolves the
  * crew's cmux pane the same way `cockpit crew read` does — captain workspace →

--- a/src/control/daemon.ts
+++ b/src/control/daemon.ts
@@ -11,6 +11,17 @@ export interface DaemonDeps {
   deliverReply?: (rec: TaskRecord, message: string) => Promise<void>;
   /** Defaults to a real process.kill(pid,0) check at the call site (Task 17). */
   isPidAlive?: (pid: number) => boolean;
+  /**
+   * #139 backstop: the interactive analogue of isPidAlive. Resolves whether an
+   * interactive crew's backing cmux surface (pane/tab) still exists. Three-valued
+   * so a transient cmux outage never false-reaps a live crew:
+   *   - "alive"   → the crew's pane is present; keep watching.
+   *   - "gone"    → cmux answered AND the pane is provably absent → terminalize.
+   *   - "unknown" → could not determine (cmux down, no captain, error) → do nothing.
+   * Defaults to always-"unknown" (never reaps) when not wired — pure unit tests
+   * and any non-cmux deployment are unaffected.
+   */
+  isSurfaceAlive?: (rec: TaskRecord) => Promise<"alive" | "gone" | "unknown">;
   /** Wired in cockpitd to runHeadless; absent in pure unit tests. */
   launchHeadless?: (rec: TaskRecord) => Promise<void>;
   /**
@@ -42,6 +53,12 @@ export interface DaemonDeps {
 // Stop-hook turn boundary) fires exactly one accurate CREW IDLE push. The
 // firePush prev===next guard keeps it from re-firing while the task sits idle.
 const ATTENTION_STATES: ReadonlySet<TaskState> = new Set(["done", "blocked", "failed", "stalled", "awaiting-input"]);
+
+// #139: non-terminal, post-launch states an interactive crew can be sitting in
+// while its session has actually died. Any of these with a provably-gone surface
+// is a zombie → reap to 'cancelled'. 'submitted' is excluded: it is pre-launch
+// (no surface yet), so reaping it would race the spawn.
+const REAPABLE_SURFACE_STATES: ReadonlySet<TaskState> = new Set(["working", "stalled", "awaiting-input", "blocked"]);
 
 // #210: CREW IDLE (awaiting-input) is debounced — suppressed when the turn-end
 // lands within this window of the captain's own last turn to the crew (a
@@ -216,9 +233,25 @@ export function createDaemon(deps: DaemonDeps) {
         default: { const _exhaustive: never = req; throw new Error(`unhandled request kind`); }
       }
     },
-    sweep(): void {
+    async sweep(): Promise<void> {
       const t = now();
+      const surfaceAlive = deps.isSurfaceAlive ?? (async () => "unknown" as const);
       for (const r of store.listAll()) {
+        // #139 backstop: reap interactive records whose backing surface is
+        // PROVABLY gone (crew session died with no terminal signal — opencode has
+        // no SessionEnd hook, and a hard kill can drop claude's). This is
+        // liveness-based reaping, NOT a shorter timeout: the 24h heartbeat budget
+        // is untouched, so a legitimately-idle LIVE crew is never reaped (its
+        // surface answers "alive" and falls through to evaluateStall → CREW IDLE).
+        // "unknown" (cmux down) never reaps. cancelled is silent (not in
+        // ATTENTION_STATES) — no false CREW STALLED re-emitted.
+        if (r.mode === "interactive" && REAPABLE_SURFACE_STATES.has(r.state)) {
+          const liveness = await surfaceAlive(r);
+          if (liveness === "gone") {
+            store.put({ ...r, state: "cancelled", lastEvent: "sweep.surface-gone" });
+            continue;
+          }
+        }
         const idle = evaluateStall(r, t);
         if (idle) {
           store.put(idle);
@@ -237,8 +270,9 @@ export function createDaemon(deps: DaemonDeps) {
         if (recovered && t - r.lastHeartbeat <= r.heartbeatBudgetMs) store.put(recovered);
       }
     },
-    reconcile(): void {
+    async reconcile(): Promise<void> {
       const alive = deps.isPidAlive ?? (() => true);
+      const surfaceAlive = deps.isSurfaceAlive ?? (async () => "unknown" as const);
       for (const r of store.listAll()) {
         if (r.state !== "working" && r.state !== "submitted") continue;
         if (r.mode === "headless") {
@@ -255,14 +289,16 @@ export function createDaemon(deps: DaemonDeps) {
           };
           firePush(deps, r.project, r.state, failed, synthEvent, lastCaptainTurnAt.get(r.id));
         } else {
-          const stalled: TaskRecord = { ...r, state: "stalled", lastEvent: "reconcile" };
-          store.put(stalled);
-          const synthEvent: ControlEvent = {
-            type: "task.reconcile-failed",
-            id: r.id,
-            reason: "interactive task lost on daemon restart",
-          };
-          firePush(deps, r.project, r.state, stalled, synthEvent, lastCaptainTurnAt.get(r.id));
+          // #139: an interactive crew's cmux pane SURVIVES a daemon bounce, so a
+          // live crew must stay 'working' for the reattach loop to re-subscribe
+          // it. The old unconditional → 'stalled' both false-stalled live crews
+          // AND fired CREW STALLED on every restart. Reap ONLY when the surface
+          // is provably gone; alive/unknown stay working (sweep re-checks later).
+          const liveness = await surfaceAlive(r);
+          if (liveness === "gone") {
+            store.put({ ...r, state: "cancelled", lastEvent: "reconcile.surface-gone" });
+            // silent — the crew is gone; no alarming push (consistent with close).
+          }
         }
       }
     },

--- a/src/control/daemon.ts
+++ b/src/control/daemon.ts
@@ -43,20 +43,33 @@ export interface DaemonDeps {
 // firePush prev===next guard keeps it from re-firing while the task sits idle.
 const ATTENTION_STATES: ReadonlySet<TaskState> = new Set(["done", "blocked", "failed", "stalled", "awaiting-input"]);
 
+// #210: CREW IDLE (awaiting-input) is debounced — suppressed when the turn-end
+// lands within this window of the captain's own last turn to the crew (a
+// `crew send`/reply emits task.started). This silences the rapid
+// send→respond→turn-end churn of an active back-and-forth while still
+// delivering a genuine self-idle (turn-end / idle-watchdog long after the
+// captain last engaged). Only awaiting-input is debounced; every other
+// attention state always delivers.
+export const IDLE_DEBOUNCE_MS = 12_000;
+
 function shortId(id: string): string {
   return id.slice(0, 8);
 }
 
-function formatMessage(rec: TaskRecord): string | null {
+function formatMessage(rec: TaskRecord, event?: ControlEvent): string | null {
   const tag = `[${rec.provider}/${rec.name != null ? rec.name : shortId(rec.id)}]`;
   switch (rec.state) {
     case "done": {
-      // Spec: "<resultRef-content-first-line-or-the-task-snippet>".
-      // resultRef content lives on disk; for daemon-purity we don't read it
-      // here. The task snippet is the documented fallback and gives the
-      // captain enough context to know which crew finished.
-      const snippet = (rec.task ?? "").split(/\r?\n/)[0]?.trim().slice(0, 120) ?? "";
-      return `CREW DONE ${tag}: ${snippet}`;
+      // Prefer the crew's own done message (`signal done --message`), carried on
+      // the task.done event — this is what captains relied on under the old
+      // relay formatter and must not regress (#214 unification). The task
+      // snippet is the documented fallback when no message was provided.
+      const doneMsg = event?.type === "task.done" ? event.message : undefined;
+      const body =
+        doneMsg != null && doneMsg.trim().length > 0
+          ? doneMsg.split(/\r?\n/)[0].trim().slice(0, 200)
+          : ((rec.task ?? "").split(/\r?\n/)[0]?.trim().slice(0, 120) ?? "");
+      return `CREW DONE ${tag}: ${body}`;
     }
     case "blocked":
       return `CREW BLOCKED ${tag}: ${(rec.question ?? "(no question)").trim()}`;
@@ -77,11 +90,22 @@ function firePush(
   prev: TaskState,
   next: TaskRecord,
   event: ControlEvent,
+  lastCaptainTurnAt?: number,
 ): void {
   if (!deps.notify) return;
   if (prev === next.state) return;
   if (!ATTENTION_STATES.has(next.state)) return;
-  const message = formatMessage(next);
+  // #210 idle debounce: a turn-end (awaiting-input) within IDLE_DEBOUNCE_MS of
+  // the captain's last turn is part of an active back-and-forth — suppress the
+  // CREW IDLE. All other attention states are never debounced.
+  if (
+    next.state === "awaiting-input" &&
+    lastCaptainTurnAt != null &&
+    deps.now() - lastCaptainTurnAt <= IDLE_DEBOUNCE_MS
+  ) {
+    return;
+  }
+  const message = formatMessage(next, event);
   if (!message) return;
   // Fire-and-forget; swallow errors so the daemon never trips on a flaky
   // notifier. Sync throws and async rejections both land here.
@@ -105,6 +129,11 @@ type Req =
 
 export function createDaemon(deps: DaemonDeps) {
   const { store, now } = deps;
+  // #210: per-task timestamp of the captain's most recent turn (a `crew send`/
+  // reply/answer emits task.started). Used to debounce CREW IDLE during an
+  // active back-and-forth. Bounded by the live task set; never read after a
+  // task terminates (terminal states don't transition to awaiting-input).
+  const lastCaptainTurnAt = new Map<string, number>();
   return {
     async handle(req: Req): Promise<TaskRecord | TaskRecord[]> {
       switch (req.kind) {
@@ -142,10 +171,13 @@ export function createDaemon(deps: DaemonDeps) {
         case "event": {
           const cur = store.get(req.project, req.event.id);
           if (!cur) throw new Error(`unknown task ${req.event.id}`);
+          // A captain turn (crew send/reply) arrives as task.started → record it
+          // so a quick trailing turn-end is debounced (#210).
+          if (req.event.type === "task.started") lastCaptainTurnAt.set(req.event.id, now());
           const next = reduce(cur, req.event, now());
           if (next !== cur) {
             store.put(next); // skip redundant write on terminal no-ops
-            firePush(deps, req.project, cur.state, next, req.event);
+            firePush(deps, req.project, cur.state, next, req.event, lastCaptainTurnAt.get(next.id));
           }
           return next;
         }
@@ -160,6 +192,8 @@ export function createDaemon(deps: DaemonDeps) {
           const r = store.get(req.project, req.id);
           if (!r) throw new Error(`unknown task ${req.id}`);
           if (r.state !== "blocked") throw new Error(`task ${req.id} is not blocked (state=${r.state})`);
+          // The captain's answer is a turn to the crew (#210 debounce key).
+          lastCaptainTurnAt.set(r.id, now());
           const next = reduce(r, { type: "task.started", id: r.id }, now());
           store.put(next); // persist the transition before delivering (durable first)
           if (deps.deliverReply) await deps.deliverReply(r, req.message);
@@ -195,7 +229,7 @@ export function createDaemon(deps: DaemonDeps) {
             idle.state === "awaiting-input"
               ? { type: "task.idle", id: r.id, heartbeatBudgetMs: r.heartbeatBudgetMs }
               : { type: "task.stalled", id: r.id, heartbeatBudgetMs: r.heartbeatBudgetMs };
-          firePush(deps, r.project, r.state, idle, synthEvent);
+          firePush(deps, r.project, r.state, idle, synthEvent, lastCaptainTurnAt.get(r.id));
           continue;
         }
         const recovered = recoverStall(r, t);
@@ -219,7 +253,7 @@ export function createDaemon(deps: DaemonDeps) {
             id: r.id,
             error: failed.error ?? "reconcile",
           };
-          firePush(deps, r.project, r.state, failed, synthEvent);
+          firePush(deps, r.project, r.state, failed, synthEvent, lastCaptainTurnAt.get(r.id));
         } else {
           const stalled: TaskRecord = { ...r, state: "stalled", lastEvent: "reconcile" };
           store.put(stalled);
@@ -228,7 +262,7 @@ export function createDaemon(deps: DaemonDeps) {
             id: r.id,
             reason: "interactive task lost on daemon restart",
           };
-          firePush(deps, r.project, r.state, stalled, synthEvent);
+          firePush(deps, r.project, r.state, stalled, synthEvent, lastCaptainTurnAt.get(r.id));
         }
       }
     },

--- a/src/control/interactive/claude.ts
+++ b/src/control/interactive/claude.ts
@@ -10,9 +10,10 @@ import type { ControlEvent } from "../types.js";
 // Stop fires at turn completion and maps to task.turn.completed so the task
 // transitions to awaiting-input (immune to stall detection) — without this,
 // a captain AFK for >heartbeatBudgetMs would get a false CREW STALLED.
-// SubagentStop/SessionEnd fire only at turn boundaries but are liveness-only:
-// SubagentStop fires while the parent agent still owns the turn, and SessionEnd
-// is an unreliable signal (crash / Ctrl-C / /exit).
+// SubagentStop fires only at a turn boundary but is liveness-only — it fires
+// while the parent agent still owns the turn. SessionEnd is NOT liveness: it
+// signals the session is gone (crash / Ctrl-C / /exit), so it terminalizes the
+// record (→ task.session.ended) rather than resuming 'working' (#139).
 const EVENTS = ["Stop", "SubagentStop", "SessionEnd", "PostToolUse", "Notification"] as const;
 
 /**
@@ -162,7 +163,9 @@ function resolveLastAssistantText(payload: unknown): string | null {
 /**
  * Map a Claude hook event name to a cockpit ControlEvent. Codifies the anti-#2576
  * invariant: NO Claude hook ever maps to `task.done`/`task.failed`.
- * PostToolUse/SubagentStop/SessionEnd = liveness only (task.progress).
+ * PostToolUse/SubagentStop = resume-liveness only (task.progress). SessionEnd is
+ * the lone terminalizing hook: the session is gone, so it maps to
+ * task.session.ended → cancelled (#139) — silent, never done/failed.
  * Terminal `done`/`failed` come exclusively from explicit `cockpit crew signal`.
  *
  * Stop = turn boundary. It normally maps to task.turn.completed → awaiting-input
@@ -204,9 +207,16 @@ export function mapClaudeHookToEvent(
       }
       return { type: "task.progress", id: taskId, note: "notification" };
     }
-    case "SubagentStop":
     case "SessionEnd":
+      // #139: the session is GONE. NOT liveness — mapping this to task.progress
+      // resumed a dead crew to 'working' (awaiting-input → working), where
+      // nothing heartbeats and the watchdog false-stalled it ~budget later.
+      // Terminalize the record instead (reducer: task.session.ended → cancelled).
+      return { type: "task.session.ended", id: taskId };
+    case "SubagentStop":
     case "PostToolUse":
+      // The only resume-liveness hooks: PostToolUse fires after every tool call
+      // mid-turn; SubagentStop fires while the parent still owns the turn.
       return { type: "task.progress", id: taskId, note: event.toLowerCase() };
     default:
       return null;

--- a/src/control/mailbox.ts
+++ b/src/control/mailbox.ts
@@ -12,6 +12,11 @@ export interface MailboxEntry {
   kind: ControlEvent["type"];
   provider: TaskRecord["provider"];
   payload: Record<string, unknown>;
+  /** Daemon-rendered captain-facing message (unified-formatter, #214/#210).
+   *  The daemon's formatMessage is the single source of truth; the relay
+   *  delivers this verbatim and skips entries where it is null/empty.
+   *  `null` on entries the daemon chose not to surface (and legacy records). */
+  message?: string | null;
 }
 
 interface AppendOpts {
@@ -19,6 +24,8 @@ interface AppendOpts {
   project: string;
   taskRecord: TaskRecord;
   event: ControlEvent;
+  /** Captain-facing message rendered by the daemon (daemon.ts formatMessage). */
+  message?: string | null;
 }
 
 function inboxDir(stateRoot: string): string {
@@ -112,6 +119,7 @@ export async function appendToMailbox(opts: AppendOpts): Promise<number> {
       kind: opts.event.type,
       provider: opts.taskRecord.provider,
       payload: extractPayload(opts.event),
+      message: opts.message ?? null,
     };
     await fs.appendFile(file, JSON.stringify(entry) + "\n", { encoding: "utf-8" });
     return seq;

--- a/src/control/opencode/__tests__/sse-bridge.test.ts
+++ b/src/control/opencode/__tests__/sse-bridge.test.ts
@@ -125,4 +125,89 @@ describe("OpencodeSseBridge", () => {
     await flush();
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
+
+  // ── CP3: permission gate (live-verified opencode 1.15.13 shapes) ──────────
+  // permission.asked carries properties = PermissionRequest:
+  //   { id:"per_…", sessionID:"ses_…", permission:"bash", patterns:[…], … }
+  // Reply endpoint (live-verified): POST /session/{sessionID}/permissions/{permissionID}
+  //   body { response: "once"|"always"|"reject" } → 200, fires permission.replied.
+
+  /** fetchImpl that streams the given SSE on GET /event and 200s any POST. */
+  function permFetch(sse: string[]) {
+    return vi.fn().mockImplementation((url: unknown) => {
+      if (String(url).endsWith("/event")) return Promise.resolve(sseResponse(sse));
+      return Promise.resolve({ ok: true, status: 200, body: null } as unknown as Response);
+    });
+  }
+
+  it("maps permission.asked → task.approval.requested", async () => {
+    const events: ControlEvent[] = [];
+    const fetchImpl = permFetch([
+      'data: {"id":"e1","type":"permission.asked","properties":{"id":"per_1","sessionID":"ses_1","permission":"bash","patterns":["echo hi"]}}\n',
+    ]);
+    const bridge = new OpencodeSseBridge({ emit: (e) => events.push(e), fetchImpl });
+    bridge.start({ taskId: "t1", port: 7777 });
+    await flush();
+    await flush();
+    const ev = events.find((e) => e.type === "task.approval.requested");
+    expect(ev).toBeDefined();
+    expect(ev).toMatchObject({ type: "task.approval.requested", id: "t1", kind: "bash" });
+    // requestId is a synthetic number (opencode has no numeric request id on the
+    // bus); it keys the daemon's gate promotion just like codex's JSON-RPC id.
+    expect(typeof (ev as { requestId: number }).requestId).toBe("number");
+    expect((ev as { question: string }).question).toContain("bash");
+  });
+
+  it("answer(approve) POSTs response 'once' to /session/{id}/permissions/{id}", async () => {
+    const events: ControlEvent[] = [];
+    const fetchImpl = permFetch([
+      'data: {"type":"permission.asked","properties":{"id":"per_9","sessionID":"ses_9","permission":"bash","patterns":[]}}\n',
+    ]);
+    const bridge = new OpencodeSseBridge({ emit: (e) => events.push(e), fetchImpl });
+    bridge.start({ taskId: "t1", port: 7777 });
+    await flush();
+    await flush();
+    const resolved = await bridge.answer("t1", "approve");
+    expect(resolved).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "http://127.0.0.1:7777/session/ses_9/permissions/per_9",
+      expect.objectContaining({ method: "POST", body: JSON.stringify({ response: "once" }) }),
+    );
+  });
+
+  it("answer(deny) POSTs response 'reject'", async () => {
+    const fetchImpl = permFetch([
+      'data: {"type":"permission.asked","properties":{"id":"per_7","sessionID":"ses_7","permission":"bash","patterns":[]}}\n',
+    ]);
+    const bridge = new OpencodeSseBridge({ emit: () => {}, fetchImpl });
+    bridge.start({ taskId: "t1", port: 7777 });
+    await flush();
+    await flush();
+    await bridge.answer("t1", "deny");
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "http://127.0.0.1:7777/session/ses_7/permissions/per_7",
+      expect.objectContaining({ method: "POST", body: JSON.stringify({ response: "reject" }) }),
+    );
+  });
+
+  it("answer() returns false when no permission is pending", async () => {
+    const fetchImpl = permFetch([]);
+    const bridge = new OpencodeSseBridge({ emit: () => {}, fetchImpl });
+    bridge.start({ taskId: "t1", port: 7777 });
+    await flush();
+    expect(await bridge.answer("t1", "approve")).toBe(false);
+  });
+
+  it("permission.replied clears the pending permission", async () => {
+    const fetchImpl = permFetch([
+      'data: {"type":"permission.asked","properties":{"id":"per_5","sessionID":"ses_5","permission":"bash","patterns":[]}}\n',
+      'data: {"type":"permission.replied","properties":{"sessionID":"ses_5","requestID":"per_5","reply":"once"}}\n',
+    ]);
+    const bridge = new OpencodeSseBridge({ emit: () => {}, fetchImpl });
+    bridge.start({ taskId: "t1", port: 7777 });
+    await flush();
+    await flush();
+    // Already resolved on the bus → captain's later answer is a no-op.
+    expect(await bridge.answer("t1", "approve")).toBe(false);
+  });
 });

--- a/src/control/opencode/sse-bridge.ts
+++ b/src/control/opencode/sse-bridge.ts
@@ -36,6 +36,13 @@ export interface OpencodeSseBridgeDeps {
  */
 export class OpencodeSseBridge {
   private controllers = new Map<string, AbortController>();
+  /** taskId → the crew's opencode server port (for permission-reply POSTs). */
+  private portByTask = new Map<string, number>();
+  /** taskId → the last unresolved permission on the bus (for answer()). */
+  private pendingPermByTask = new Map<string, { permID: string; sessionID: string }>();
+  /** Synthetic monotonic request id. opencode has no numeric id on the bus, but
+   *  task.approval.requested carries one (codex parity) to key gate promotion. */
+  private nextRequestId = 1;
   private deps: OpencodeSseBridgeDeps;
 
   constructor(deps: OpencodeSseBridgeDeps) {
@@ -45,6 +52,7 @@ export class OpencodeSseBridge {
   /** Begin subscribing to the crew's /event stream. Idempotent per task. */
   start(o: { taskId: string; port: number }): void {
     if (this.controllers.has(o.taskId)) return;
+    this.portByTask.set(o.taskId, o.port);
     const ac = new AbortController();
     this.controllers.set(o.taskId, ac);
     void this.run(o.taskId, o.port, ac);
@@ -53,9 +61,41 @@ export class OpencodeSseBridge {
   /** Stop subscribing for a task (crew closed / terminal). */
   stop(taskId: string): void {
     const ac = this.controllers.get(taskId);
-    if (!ac) return;
-    ac.abort();
-    this.controllers.delete(taskId);
+    if (ac) { ac.abort(); this.controllers.delete(taskId); }
+    this.portByTask.delete(taskId);
+    this.pendingPermByTask.delete(taskId);
+  }
+
+  /**
+   * Resolve a pending opencode permission by POSTing the captain's decision to
+   * the crew's server (live-verified, opencode 1.15.13: POST
+   * /session/{sessionID}/permissions/{permissionID} with
+   * { response: "once" | "reject" } → 200, fires permission.replied). Mirrors
+   * codex's driver.answer(). Returns true if there WAS a pending permission (so
+   * the caller knows the answer was an approval, not a reply to a plain `signal
+   * blocked` question); false if nothing was pending (already resolved on the
+   * bus, or no gate).
+   */
+  async answer(taskId: string, decision: "approve" | "deny"): Promise<boolean> {
+    const pend = this.pendingPermByTask.get(taskId);
+    const port = this.portByTask.get(taskId);
+    if (!pend || port == null) return false;
+    this.pendingPermByTask.delete(taskId);
+    const fetchImpl = this.deps.fetchImpl ?? fetch;
+    const response = decision === "approve" ? "once" : "reject";
+    try {
+      await fetchImpl(`http://127.0.0.1:${port}/session/${pend.sessionID}/permissions/${pend.permID}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ response }),
+      });
+    } catch (e) {
+      this.deps.log?.(`opencode permission reply failed for ${taskId}: ${(e as Error).message}`);
+    }
+    // Clear blocked → working; the crew continues (or aborts) the turn, and a
+    // later session.idle settles it back to awaiting-input.
+    this.deps.emit({ type: "task.started", id: taskId });
+    return true;
   }
 
   private async run(taskId: string, port: number, ac: AbortController): Promise<void> {
@@ -128,7 +168,18 @@ export class OpencodeSseBridge {
     // SSE field form `data: {json}`; opencode also emits bare JSON lines.
     if (line.startsWith("data:")) line = line.slice(5).trim();
     if (!line.startsWith("{")) return;
-    let json: { type?: string; properties?: { sessionID?: string } } | undefined;
+    let json:
+      | {
+          type?: string;
+          properties?: {
+            id?: string;
+            sessionID?: string;
+            requestID?: string;
+            permission?: string;
+            patterns?: string[];
+          };
+        }
+      | undefined;
     try {
       json = JSON.parse(line);
     } catch {
@@ -142,6 +193,30 @@ export class OpencodeSseBridge {
         id: taskId,
         turnId: json.properties?.sessionID ?? "opencode",
       });
+    } else if (json?.type === "permission.asked") {
+      // A gated tool (e.g. bash, when --approval set bash:"ask") needs approval.
+      // Live-verified payload (opencode 1.15.13): properties = PermissionRequest
+      // { id:"per_…", sessionID:"ses_…", permission:"bash", patterns:[cmd], … }.
+      // Record the pending request so answer() can POST the decision, and surface
+      // it as task.approval.requested (codex parity) — the reducer turns it into
+      // blocked and the relay renders CREW BLOCKED with the tool + command.
+      const p = json.properties;
+      if (p?.id && p?.sessionID) {
+        this.pendingPermByTask.set(taskId, { permID: p.id, sessionID: p.sessionID });
+        const tool = p.permission ?? "a tool";
+        const cmd = Array.isArray(p.patterns) && p.patterns.length ? `: ${p.patterns.join(" ")}` : "";
+        this.deps.emit({
+          type: "task.approval.requested",
+          id: taskId,
+          requestId: this.nextRequestId++,
+          question: `opencode requests permission to run ${tool}${cmd}`,
+          kind: tool,
+        });
+      }
+    } else if (json?.type === "permission.replied") {
+      // The permission was resolved on the bus (by us or another client) — clear
+      // pending state so a later captain answer is a no-op rather than a stale POST.
+      this.pendingPermByTask.delete(taskId);
     }
   }
 }

--- a/src/control/state-machine.ts
+++ b/src/control/state-machine.ts
@@ -74,6 +74,11 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
       return { ...base, state: "failed", error: ev.error, exitCode: ev.exitCode };
     case "task.cancelled":
       return { ...base, state: "cancelled" };
+    case "task.session.ended":
+      // #139: the claude crew session ended (SessionEnd hook). The process is
+      // gone, so terminalize instead of resuming 'working'. Reuses the silent
+      // 'cancelled' state — no alarming push, just a clean terminal record.
+      return { ...base, state: "cancelled" };
     case "task.session":
       return stampAttempt(base, { resumeRef: ev.resumeRef }, now);
     case "task.turn.started":

--- a/src/control/types.ts
+++ b/src/control/types.ts
@@ -105,7 +105,13 @@ export type ControlEvent =
   // Emitted by runCrewClose before closing the pane; transitions a non-terminal
   // task to the absorbing 'cancelled' state. Silent: captain initiated the close
   // so no CREW CANCELLED push is fired (not in ATTENTION_STATES).
-  | { type: "task.cancelled"; id: string; reason?: string };
+  | { type: "task.cancelled"; id: string; reason?: string }
+  // #139: a claude crew's SessionEnd hook fired — the session is GONE. Unlike
+  // the other turn-boundary hooks (PostToolUse/SubagentStop = liveness), a dead
+  // session must NOT resume 'working' (nothing heartbeats → false CREW STALLED
+  // ~budget later). Terminalizes the record to the absorbing 'cancelled' state.
+  // Silent (not in ATTENTION_STATES), like task.cancelled.
+  | { type: "task.session.ended"; id: string };
 
 // 'stalled' is intentionally excluded — recoverable by the watchdog.
 // 'cancelled' is terminal and silent (captain-initiated close).

--- a/src/lib/__tests__/git-worktree.test.ts
+++ b/src/lib/__tests__/git-worktree.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import path from "node:path";
+
+const execFileSyncMock = vi.hoisted(() => vi.fn());
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  const merged = { ...actual, execFileSync: execFileSyncMock };
+  return { ...merged, default: merged };
+});
+
+import { worktreePath, crewBranch, addWorktree, removeWorktree } from "../git-worktree.js";
+
+describe("worktreePath", () => {
+  it("resolves <repoRoot>/<worktreeDir>/<project>-<name>", () => {
+    expect(worktreePath("/tmp/brove", ".worktrees", "brove", "crew-1")).toBe(
+      path.resolve("/tmp/brove", ".worktrees", "brove-crew-1"),
+    );
+  });
+
+  it("honors a custom worktreeDir from config", () => {
+    expect(worktreePath("/tmp/brove", ".wt", "brove", "fix-typos")).toBe(
+      path.resolve("/tmp/brove", ".wt", "brove-fix-typos"),
+    );
+  });
+});
+
+describe("crewBranch", () => {
+  it("namespaces the crew name under crew/", () => {
+    expect(crewBranch("crew-1")).toBe("crew/crew-1");
+  });
+});
+
+describe("addWorktree", () => {
+  beforeEach(() => execFileSyncMock.mockReset());
+
+  it("runs `git -C <repo> worktree add <path> -b crew/<name> <base>` and returns the path", () => {
+    const wt = addWorktree({
+      repoRoot: "/tmp/brove",
+      worktreeDir: ".worktrees",
+      project: "brove",
+      name: "crew-1",
+      base: "develop",
+    });
+
+    const expectedPath = path.resolve("/tmp/brove", ".worktrees", "brove-crew-1");
+    expect(wt).toBe(expectedPath);
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      "git",
+      ["-C", "/tmp/brove", "worktree", "add", expectedPath, "-b", "crew/crew-1", "develop"],
+      expect.objectContaining({ stdio: "pipe" }),
+    );
+  });
+});
+
+describe("removeWorktree", () => {
+  beforeEach(() => execFileSyncMock.mockReset());
+
+  it("runs `git -C <repo> worktree remove <path>` (no --force on the happy path)", () => {
+    removeWorktree("/tmp/brove", "/tmp/brove/.worktrees/brove-crew-1");
+
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      "git",
+      ["-C", "/tmp/brove", "worktree", "remove", "/tmp/brove/.worktrees/brove-crew-1"],
+      expect.objectContaining({ stdio: "pipe" }),
+    );
+  });
+
+  it("retries with --force when a plain remove fails (dirty/locked worktree)", () => {
+    let calls = 0;
+    execFileSyncMock.mockImplementation(() => {
+      calls++;
+      if (calls === 1) throw new Error("contains modified or untracked files");
+      return "";
+    });
+
+    removeWorktree("/tmp/brove", "/tmp/brove/.worktrees/brove-crew-1");
+
+    expect(execFileSyncMock).toHaveBeenCalledTimes(2);
+    expect(execFileSyncMock).toHaveBeenLastCalledWith(
+      "git",
+      ["-C", "/tmp/brove", "worktree", "remove", "--force", "/tmp/brove/.worktrees/brove-crew-1"],
+      expect.objectContaining({ stdio: "pipe" }),
+    );
+  });
+});

--- a/src/lib/__tests__/per-crew-settings.test.ts
+++ b/src/lib/__tests__/per-crew-settings.test.ts
@@ -301,4 +301,20 @@ describe("writePerCrewOpencodeConfig", () => {
     expect(fs.existsSync(out)).toBe(true);
     expect(fs.statSync(path.dirname(out)).isDirectory()).toBe(true);
   });
+
+  it("defaults bash to 'allow' (CP3 opt-in: default behavior unchanged)", () => {
+    const out = writePerCrewOpencodeConfig({ stateRoot: tmp, project: "alpha", taskId: "tid-1" });
+    const json = JSON.parse(fs.readFileSync(out, "utf-8"));
+    expect(json.permission.bash).toBe("allow");
+  });
+
+  it("gateBash:true sets bash to 'ask' so the captain approves shell commands", () => {
+    const out = writePerCrewOpencodeConfig({ stateRoot: tmp, project: "alpha", taskId: "tid-1", gateBash: true });
+    const json = JSON.parse(fs.readFileSync(out, "utf-8"));
+    expect(json.permission.bash).toBe("ask");
+    // Only bash flips — every other tool stays auto-approved (surgical gate).
+    expect(json.permission.edit).toBe("allow");
+    expect(json.permission.read).toBe("allow");
+    expect(json.permission.external_directory).toEqual({ "**": "allow" });
+  });
 });

--- a/src/lib/__tests__/resolve-text-input.test.ts
+++ b/src/lib/__tests__/resolve-text-input.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { resolveTextInput } from "../resolve-text-input.js";
+
+describe("resolveTextInput", () => {
+  describe("file precedence over positional", () => {
+    it("reads from file when --task-file is provided, ignoring positional", async () => {
+      const content = await resolveTextInput(
+        { positional: "positional task", filePath: "/tmp/task.txt", label: "task" },
+        { readFile: () => "file content" },
+      );
+      expect(content).toBe("file content");
+    });
+
+    it("reads from file when --message-file is provided, ignoring positional", async () => {
+      const content = await resolveTextInput(
+        { positional: "positional msg", filePath: "/tmp/msg.txt", label: "message" },
+        { readFile: () => "message from file" },
+      );
+      expect(content).toBe("message from file");
+    });
+  });
+
+  describe("stdin via '-'", () => {
+    it("reads stdin when --task-file - is provided", async () => {
+      const content = await resolveTextInput(
+        { filePath: "-", label: "task" },
+        { readStdin: async () => "stdin content with `backticks`" },
+      );
+      expect(content).toBe("stdin content with `backticks`");
+    });
+
+    it("reads stdin when --message-file - is provided", async () => {
+      const content = await resolveTextInput(
+        { filePath: "-", label: "message" },
+        { readStdin: async () => "stdin `message`" },
+      );
+      expect(content).toBe("stdin `message`");
+    });
+  });
+
+  describe("falls back to positional", () => {
+    it("returns positional when no file option is provided", async () => {
+      const content = await resolveTextInput(
+        { positional: "positional task", label: "task" },
+      );
+      expect(content).toBe("positional task");
+    });
+
+    it("returns empty string positional when provided as positional", async () => {
+      const content = await resolveTextInput(
+        { positional: "", label: "task" },
+      );
+      expect(content).toBe("");
+    });
+  });
+
+  describe("error cases", () => {
+    it("throws with clear error when --task-file path does not exist", async () => {
+      const err = new Error("ENOENT") as NodeJS.ErrnoException;
+      err.code = "ENOENT";
+      const readFile = () => { throw err; };
+
+      await expect(
+        resolveTextInput({ filePath: "/nonexistent/task.txt", label: "task" }, { readFile }),
+      ).rejects.toThrow(/--task-file.*file not found/);
+    });
+
+    it("throws with clear error when --message-file path does not exist", async () => {
+      const err = new Error("ENOENT") as NodeJS.ErrnoException;
+      err.code = "ENOENT";
+      const readFile = () => { throw err; };
+
+      await expect(
+        resolveTextInput({ filePath: "/nonexistent/msg.txt", label: "message" }, { readFile }),
+      ).rejects.toThrow(/--message-file.*file not found/);
+    });
+
+    it("throws clear error when neither positional nor --task-file is provided", async () => {
+      await expect(
+        resolveTextInput({ label: "task" }),
+      ).rejects.toThrow(/No task/);
+    });
+
+    it("throws clear error when neither positional nor --message-file is provided", async () => {
+      await expect(
+        resolveTextInput({ label: "message" }),
+      ).rejects.toThrow(/No message/);
+    });
+  });
+
+  describe("content preservation", () => {
+    it("preserves backticks, quotes, and newlines verbatim from files", async () => {
+      const content = await resolveTextInput(
+        { filePath: "/tmp/special.txt", label: "task" },
+        { readFile: () => "line one\nline two with `backticks`\nline three with \"quotes\"" },
+      );
+      expect(content).toBe("line one\nline two with `backticks`\nline three with \"quotes\"");
+    });
+
+    it("preserves backticks, quotes, and newlines verbatim from stdin", async () => {
+      const content = await resolveTextInput(
+        { filePath: "-", label: "message" },
+        { readStdin: async () => "line one\nline two with `backticks`\nline three with \"quotes\"" },
+      );
+      expect(content).toBe("line one\nline two with `backticks`\nline three with \"quotes\"");
+    });
+
+    it("preserves multi-line shell-injection payload verbatim from files", async () => {
+      const payload = "echo `id`\necho $(whoami)\necho \"nested '$HOME'\"";
+      const content = await resolveTextInput(
+        { filePath: "/tmp/payload.txt", label: "task" },
+        { readFile: () => payload },
+      );
+      expect(content).toBe(payload);
+    });
+  });
+
+  describe("real fs readFile (integration)", () => {
+    it("reads an actual file from disk via default readFile", async () => {
+      const { readFileSync } = await import("node:fs");
+      const { mkdtempSync } = await import("node:fs");
+      const { writeFileSync } = await import("node:fs");
+      const { rmSync } = await import("node:fs");
+      const { join } = await import("node:path");
+      const { tmpdir } = await import("node:os");
+
+      const tmp = mkdtempSync(join(tmpdir(), "resolve-test-"));
+      try {
+        const filePath = join(tmp, "input.txt");
+        writeFileSync(filePath, "real file content with `backticks`");
+        const content = await resolveTextInput(
+          { filePath, label: "task" },
+          { readFile: (p: string) => readFileSync(p, "utf8") },
+        );
+        expect(content).toBe("real file content with `backticks`");
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/src/lib/git-worktree.ts
+++ b/src/lib/git-worktree.ts
@@ -1,0 +1,65 @@
+// src/lib/git-worktree.ts
+//
+// Per-crew git worktree isolation (#216). A FEATURE crew (spawned with
+// `--worktree`) runs in its own worktree + branch so it can switch HEAD without
+// dragging the captain's checkout. Small/one-off crews keep running on the
+// shared root checkout (unchanged default). The side-effecting `git worktree`
+// calls live here so crew.ts stays mockable and surgical — same seam pattern as
+// per-crew-settings.ts.
+//
+// Builds and the daemon still run from the MAIN checkout's `dist`; worktrees
+// edit source only (issue #216 caveat).
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+export interface WorktreeSpec {
+  /** The project's root checkout (also the shared `.git` owner). */
+  repoRoot: string;
+  /** Config.defaults.worktreeDir, resolved relative to repoRoot (e.g. ".worktrees"). */
+  worktreeDir: string;
+  project: string;
+  /** Crew name (e.g. "crew-1" or a --name value). */
+  name: string;
+  /** Branch to base the new crew branch on (GitFlow: "develop"). */
+  base: string;
+}
+
+/** Deterministic worktree path: <repoRoot>/<worktreeDir>/<project>-<name>. */
+export function worktreePath(repoRoot: string, worktreeDir: string, project: string, name: string): string {
+  return path.resolve(repoRoot, worktreeDir, `${project}-${name}`);
+}
+
+/** Crew branch name for a worktree crew. */
+export function crewBranch(name: string): string {
+  return `crew/${name}`;
+}
+
+/**
+ * Create the crew's worktree + branch and return its absolute path.
+ * Fails loud (throws) if git refuses — e.g. the base branch is missing or the
+ * branch/path already exists. The caller's name-uniqueness check already
+ * prevents live duplicates; a re-spawned-after-close name can collide on the
+ * existing branch (rare — pick a new --name).
+ */
+export function addWorktree(spec: WorktreeSpec): string {
+  const wt = worktreePath(spec.repoRoot, spec.worktreeDir, spec.project, spec.name);
+  execFileSync(
+    "git",
+    ["-C", spec.repoRoot, "worktree", "add", wt, "-b", crewBranch(spec.name), spec.base],
+    { stdio: "pipe" },
+  );
+  return wt;
+}
+
+/**
+ * Remove a crew's worktree (auto-clean on close). Tries a plain remove first;
+ * a dirty/locked worktree makes git refuse, so we retry with --force. The
+ * branch is left intact so the crew's commits survive the close.
+ */
+export function removeWorktree(repoRoot: string, wtPath: string): void {
+  try {
+    execFileSync("git", ["-C", repoRoot, "worktree", "remove", wtPath], { stdio: "pipe" });
+  } catch {
+    execFileSync("git", ["-C", repoRoot, "worktree", "remove", "--force", wtPath], { stdio: "pipe" });
+  }
+}

--- a/src/lib/per-crew-settings.ts
+++ b/src/lib/per-crew-settings.ts
@@ -176,11 +176,17 @@ export function writePerCrewSettingsLocal(o: {
  * ~/.config/opencode/opencode.json automatically.
  *
  * Returns the absolute path to the written file.
+ *
+ * CP3 opt-in: with `gateBash`, bash flips to "ask" so the captain approves
+ * shell commands (opencode emits `permission.asked` → daemon surfaces CREW
+ * BLOCKED → captain's decision is POSTed back). Default (no flag) keeps bash
+ * "allow" — opencode crews stay fully autonomous unless `--approval` is passed.
  */
 export function writePerCrewOpencodeConfig(o: {
   stateRoot: string;
   project: string;
   taskId: string;
+  gateBash?: boolean;
 }): string {
   const dir = join(o.stateRoot, o.project, o.taskId);
   mkdirSync(dir, { recursive: true });
@@ -191,7 +197,7 @@ export function writePerCrewOpencodeConfig(o: {
       edit: "allow",
       glob: "allow",
       grep: "allow",
-      bash: "allow",
+      bash: o.gateBash ? "ask" : "allow",
       webfetch: "allow",
       websearch: "allow",
       task: "allow",

--- a/src/lib/resolve-text-input.ts
+++ b/src/lib/resolve-text-input.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs";
+
+async function readAllStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+function flagName(label: string): string {
+  return label === "task" ? "--task-file" : "--message-file";
+}
+
+export interface ResolveTextInputOpts {
+  positional?: string;
+  filePath?: string;
+  label: string;
+}
+
+export interface ResolveTextInputDeps {
+  readFile?: (path: string) => string;
+  readStdin?: () => Promise<string>;
+}
+
+export async function resolveTextInput(
+  opts: ResolveTextInputOpts,
+  deps?: ResolveTextInputDeps,
+): Promise<string> {
+  const readFile = deps?.readFile ?? ((p: string) => fs.readFileSync(p, "utf8"));
+  const readStdin = deps?.readStdin ?? readAllStdin;
+
+  if (opts.filePath) {
+    if (opts.filePath === "-") {
+      return readStdin();
+    }
+    try {
+      return readFile(opts.filePath);
+    } catch (e) {
+      const err = e as NodeJS.ErrnoException;
+      const flag = flagName(opts.label);
+      if (err.code === "ENOENT") {
+        throw new Error(`${flag} '${opts.filePath}': file not found`);
+      }
+      throw new Error(`${flag} '${opts.filePath}': ${err.message}`);
+    }
+  }
+
+  if (opts.positional === undefined) {
+    throw new Error(
+      `No ${opts.label} provided. Provide a positional argument or use ${flagName(opts.label)}.`,
+    );
+  }
+
+  return opts.positional;
+}


### PR DESCRIPTION
## Release v0.5.2

Daemon-reliability + crew-safety patch. Merging to `main` triggers the release workflow (tag `v0.5.2` → GitHub release → guarded npm publish).

### Highlights
- **#139** — terminalize dead interactive crews (SessionEnd terminalize + close-when-pane-gone + surface-liveness sweep/reconcile backstop); stops false `CREW STALLED` spam. 24h heartbeat budget preserved (#131/#133 not regressed). (#219)
- **#216/#218** — per-crew git worktree isolation (`--worktree`).
- **#215** — opencode CP3 permission gate.
- **#214/#210/#217** — unified daemon↔relay notification formatter (CREW IDLE delivery + idle debounce).
- **#177/#205** — injection-safe crew dispatch (`--task-file`/`--message-file`).
- maxBuffer fix so `reapCrewChildren` works on busy machines (#222 content; not in CHANGELOG — add on back-merge).

### Verification
- 817 tests green; `tsc --noEmit` clean; CHANGELOG 0.5.2 entry present.

### Post-merge
- Back-merge `main` → `develop` (carries version bump + maxBuffer).
- Close #222 (its content ships here).