### PR TITLE
feat(daemon): service-health layer — relay register/health-check/heal + component liveness (closes #207, #77, #208)

### DIFF
--- a/docs/decisions/2026-06-05-issue-208-verdict.md
+++ b/docs/decisions/2026-06-05-issue-208-verdict.md
@@ -1,0 +1,56 @@
+# Verdict: close #208 (watchdog idle backstop for interactive crews)
+
+**Date:** 2026-06-05 · **Decided as part of:** the service-health layer (#207/#77).
+**Outcome:** **CLOSE #208.** No new code required; the residual is already covered.
+
+## What #208 was
+
+The stall/idle watchdog never provided a working idle backstop for interactive
+crews. Two root causes:
+
+- **B1** — interactive crews carry a 24h `heartbeatBudgetMs`, so
+  `evaluateStall` never fires the idle→`awaiting-input` transition within a real
+  session.
+- **B2** — even if it fired, the synthetic `task.idle` was dropped by the relay's
+  old `formatEntry` (no case for `task.idle`), so the captain never saw it.
+
+## Why it is now resolved
+
+- **B2 — RESOLVED by #217.** The relay no longer formats; the daemon's
+  `formatMessage` is the single source of truth and handles
+  `awaiting-input → CREW IDLE` (`src/control/daemon.ts:97-98`). The relay's
+  `deliverable()` delivers the daemon message verbatim. So a fired idle event is
+  now delivered, not discarded.
+- **B1 — superseded by #139 liveness reaping.** A *dead* interactive crew
+  (surface/pane provably gone) is terminalized by the daemon sweep/reconcile
+  surface-liveness reaper, not by a heartbeat timeout. The 24h budget stays
+  untouched, so the #131/#133 false-stall fix for *legitimately-idle live* crews
+  does not regress.
+
+## The only residual, and why it needs no new surface
+
+A *live* crew whose turn-end signal was missed (so it sits at `working` without a
+prompt nudge). This is covered today by two independent, reliable mechanisms:
+
+1. **Reliable per-agent turn-end signals** → `awaiting-input` → `CREW IDLE`:
+   claude Stop hook (#133) and opencode SSE `session.idle` (#188). The watchdog
+   was only ever meant to *backstop* these; they are now dependable.
+2. **The in-cmux relay pane-probe** (`createInteractiveProbe`,
+   `src/commands/notify-relay.ts`): scrapes quiet `working` panes and fires
+   `CREW BLOCKED` for a crew parked at a permission prompt / trailing question —
+   exactly the "turn ended but no signal" shape.
+
+The new service-health layer additionally surfaces every non-terminal crew's
+liveness (`cockpit status --detailed` / `doctor`), giving the captain a passive
+view of any crew that has gone quiet.
+
+## Why NOT add a daemon-side live-idle nudge
+
+A second, shorter heartbeat budget gated on `surface=alive` would re-introduce
+the exact false-stall the 24h budget was set to prevent (#131/#133): a
+legitimately-idle live crew awaiting the captain would be nudged/false-stalled.
+One threshold cannot serve both "don't false-stall" and "timely idle backstop,"
+and the two mechanisms above already cover the residual. Not worth the regression
+risk.
+
+**Action on merge:** close #208 with a link to this verdict.

--- a/docs/plans/2026-06-05-service-health-liveness-layer.md
+++ b/docs/plans/2026-06-05-service-health-liveness-layer.md
@@ -136,6 +136,17 @@ Per the issue's own 2026-06-05 comment and the code:
 ## Explicitly deferred (follow-up issues, not gold-plated here)
 
 1. **cmux-tree-resident relay-keeper** — the genuine in-prod auto-heal (this PR's
-   daemon heal is best-effort + surfaced).
-2. #77's reactions.json escalation rules + hard crew task-timeout escalation.
-3. #64 hook/socket event ingestion into the liveness layer (event-ready, not event-blocked).
+   daemon heal is best-effort + surfaced). → filed as **#224**.
+2. #77's reactions.json escalation + hard crew task-timeout + #64 event
+   ingestion. → filed as **#225**.
+
+---
+
+## Status: APPROVED (2026-06-05) — built
+
+Captain approved all three scope decisions, priority refinement: **the
+non-negotiable core is "captain is never SILENTLY blind" (detect + surface).
+Best-effort heal is SECONDARY** and intentionally minimal — mostly inert under
+launchd (cmux lineage), so the liveness surface + the actionable
+"relay DOWN — run: cockpit launch &lt;project&gt;" message is the guarantee, not
+the heal. #208 verdict: `docs/decisions/2026-06-05-issue-208-verdict.md` → CLOSE.

--- a/docs/plans/2026-06-05-service-health-liveness-layer.md
+++ b/docs/plans/2026-06-05-service-health-liveness-layer.md
@@ -1,0 +1,141 @@
+# Service-Health / Liveness Layer — First-Cut Plan
+
+**Closes:** #207 (relay register/health-check/heal) + #77 (component liveness layer).
+**Resolves:** #208 residual (verdict + close).
+**Branch target:** `develop`. **Blast radius:** LOW (all changes additive — no existing signature breaks).
+
+---
+
+## The one theme
+
+Cockpit has no liveness tracking for its **own** services, so when one dies the
+failure is silent and cascades. The daemon already sweeps every 30s and owns the
+task ledger + mailbox surfaces — it is the natural home for a health layer.
+
+## The decisive architectural constraint (researched, not assumed)
+
+cmux enforces a **process-lineage check on writers**: only a process inside
+cmux's process tree may `send` / `new-surface` into a captain pane. The cockpitd
+daemon runs under **launchd — NOT in cmux's tree**. Therefore:
+
+| Daemon → cmux | Allowed? | Evidence |
+|---|---|---|
+| **Read** (`list-workspaces`, `tree`, `read-screen`) | ✅ yes | the #139 surface-liveness probe is wired into the daemon and relies on it |
+| **Write / spawn** (`send`, `new-surface`) | ❌ refused | `Error: Failed to write to socket`; research note `2026-05-27-multi-session-orchestrator-notification-patterns.md` (4× confirmations); cmux notifier `notify()` also shells the lineage-bound `cockpit runtime send` |
+
+**Consequence:** the daemon **cannot itself re-spawn a relay tab in production.**
+The genuine in-prod heal must be performed by a cmux-tree-resident process. The
+daemon's honest role is: **register + detect + drive heal best-effort + expose a
+queryable liveness surface** so the captain is *never silently blind* (the
+out-of-band safety net is `cockpit doctor` / `status --detailed`, run from inside
+cmux). This shapes the heal design below and is **the key scope decision for the
+captain to approve.**
+
+---
+
+## Part A — Component liveness layer (#77 foundation)
+
+New pure module `src/control/liveness.ts` (runtime-agnostic):
+
+- `ComponentKind = "relay" | "captain" | "crew" | "command"`
+- `ComponentHealth = { kind, project, ref, state: "alive"|"stale"|"gone"|"unknown", lastSeenMs, detail }`
+- Pure `classifyHealth(lastSeenMs | null, now, staleMs, goneMs) → state`.
+
+The daemon holds an in-memory `Map<project, RelayHealth>` (fed by Part B) and
+**derives** the other components on demand from sources it already has:
+
+- **crew** → `store.listAll()` task records (`lastHeartbeat`, `state`). Already tracked; just project it.
+- **captain** → daemon reads cmux `runtime.status(captainName)` (read = allowed). Alive iff workspace present.
+- **command** → command is optional/on-demand now; workspace-presence if configured, else `"unknown"`. Minimal.
+- **relay** → the registration-heartbeat map (Part B).
+
+Surface:
+- New additive socket verb `{ kind: "health", project? } → ComponentHealth[]`.
+- `cockpit doctor` gains a **Service Health** section.
+- `cockpit status --detailed` renders per-component last-seen + state.
+
+**Deferred to follow-up (documented, NOT this PR):** reactions.json escalate
+rules, hard crew task-timeout escalation, #64 hook/socket event ingestion.
+(#77 itself scopes auto-recovery OUT except relay heal.)
+
+## Part B — Relay register + health-check + heal (#207 core)
+
+1. **Registration** (additive socket kinds, routed in `cockpitd` server handler):
+   - boot: `{ kind:"relay-register", project, pid, startedAt }`
+   - every ~10s: `{ kind:"relay-heartbeat", project, pid }`
+   - daemon stores `RelayHealth{ project, pid, startedAt, lastSeenMs }`.
+   - Wired into `runNotifyRelay` (notify-relay.ts) via the already-imported
+     `cockpitdCall` — additive interval alongside the existing drain/probe loops.
+
+2. **Health-check** (additive pass in `daemon.sweep`, runs on the existing 30s tick):
+   - For each project that should have a relay (registered, or live captain
+     workspace), flag dark when `now - lastSeenMs > RELAY_STALE_MS` (≈2× heartbeat).
+   - (Stretch, may defer to stay surgical) cursor-progress signal: mailbox has
+     `seq > subscriber cursor` while captain is live ⇒ relay alive-but-not-draining.
+
+3. **Heal** — bounded by the constraint above:
+   - Daemon calls an injected `healRelay(project)` dep, **debounced** (one attempt
+     per "gone" episode via `lastHealAttemptMs`, not every sweep).
+   - Default impl attempts re-spawn via the runtime's `spawnInjector`
+     (best-effort). If cmux refuses (lineage) → log + leave liveness `"gone"` so
+     `cockpit doctor` shows it. Tests inject a fake and assert it fires once per
+     detected-dead relay (killed-relay fixture).
+   - **KEY DECISION (captain to approve):** because daemon→cmux injection is
+     lineage-blocked in prod, daemon-side heal is best-effort + always-surfaced.
+     The robust in-prod heal — a small **cmux-tree-resident "relay-keeper"** that
+     polls daemon relay-health and re-spawns the relay tab — is the recommended
+     **follow-up**, not this PR. This PR guarantees the captain is never
+     *silently* blind; full auto-heal-in-prod lands next.
+
+## Part C — #208 verdict (document + close)
+
+Per the issue's own 2026-06-05 comment and the code:
+
+- **B2** (dropped `task.idle`) — **RESOLVED by #217**: daemon `formatMessage`
+  handles `awaiting-input → CREW IDLE` (daemon.ts:97-98); relay `deliverable()`
+  delivers the daemon message verbatim.
+- **B1** (24h budget disables backstop) — addressed by **#139 liveness reaping**:
+  dead interactive crews are terminalized by surface-liveness in sweep/reconcile,
+  not by heartbeat timeout. The 24h budget stays (no #131/#133 false-stall regression).
+- **Residual** (timely idle nudge for a *live* crew whose turn-end was missed) is
+  **COVERED** by: (a) reliable per-agent turn-end signals (claude Stop #133,
+  opencode SSE session.idle #188) → `awaiting-input` → CREW IDLE, and (b) the
+  in-cmux relay pane-probe (`createInteractiveProbe`) that scrapes quiet working
+  panes → CREW BLOCKED.
+
+**Verdict: CLOSE #208.** No new code required beyond documentation. A daemon-side
+"live-idle nudge" would mean a second short heartbeat budget gated on
+`surface=alive` — it risks re-introducing the #131/#133 false-stall, so it is
+**not recommended.** If the captain wants it anyway, it is a tightly-scoped follow-up.
+
+---
+
+## TDD test list
+
+- `liveness.test.ts` — `classifyHealth` thresholds (alive/stale/gone/unknown).
+- daemon `relay-register` / `relay-heartbeat` → `RelayHealth` map populated.
+- daemon sweep: stale relay → marked `gone` + `healRelay` invoked **once** (debounced).
+- killed-relay fixture: register → advance clock past stale → sweep → heal fires.
+- `health` verb returns projected component health (relay/captain/crew/command).
+- doctor / `status --detailed` renders the Service Health section.
+- Full `npm test` green + `tsc --noEmit` clean.
+
+## Files (all additive, LOW blast radius)
+
+| File | Change |
+|---|---|
+| `src/control/liveness.ts` *(new)* + test | pure health classification + projection |
+| `src/control/types.ts` | `RelayHealth`, `ComponentHealth` types |
+| `src/control/daemon.ts` | `DaemonDeps` += relay-health map + `healRelay`; sweep relay pass; handle `relay-register`/`relay-heartbeat`/`health` |
+| `src/control/cockpitd.ts` | wire default `healRelay` + relay-health; route new socket kinds |
+| `src/commands/notify-relay.ts` | register + heartbeat in `runNotifyRelay` |
+| `src/commands/doctor.ts` | Service Health section |
+| `src/commands/status.ts` | `--detailed` flag + liveness |
+| docs | #208 verdict note; #77 deferred-scope follow-ups |
+
+## Explicitly deferred (follow-up issues, not gold-plated here)
+
+1. **cmux-tree-resident relay-keeper** — the genuine in-prod auto-heal (this PR's
+   daemon heal is best-effort + surfaced).
+2. #77's reactions.json escalation rules + hard crew task-timeout escalation.
+3. #64 hook/socket event ingestion into the liveness layer (event-ready, not event-blocked).

--- a/src/commands/__tests__/health-view.test.ts
+++ b/src/commands/__tests__/health-view.test.ts
@@ -1,0 +1,39 @@
+// src/commands/__tests__/health-view.test.ts
+import { describe, it, expect } from "vitest";
+import { healthIcon, ageText, healthRow } from "../health-view.js";
+import type { ComponentHealth } from "../../control/liveness.js";
+
+describe("health-view (pure rendering)", () => {
+  it("healthIcon maps every state", () => {
+    expect(healthIcon("alive")).toBeTruthy();
+    expect(healthIcon("gone")).toBeTruthy();
+    expect(healthIcon("alive")).not.toBe(healthIcon("gone"));
+  });
+
+  it("ageText: null → em-dash; seconds/minutes/hours buckets", () => {
+    expect(ageText(null, 100_000)).toBe("—");
+    expect(ageText(95_000, 100_000)).toBe("5s ago");
+    expect(ageText(40_000, 100_000)).toBe("1m ago");
+    expect(ageText(100_000 - 2 * 3_600_000, 100_000)).toBe("2h ago");
+  });
+
+  it("healthRow surfaces a down relay's actionable detail (never silently blind)", () => {
+    const c: ComponentHealth = {
+      kind: "relay", project: "brove", ref: "relay", state: "gone",
+      lastSeenMs: null, detail: "relay DOWN — run: cockpit launch brove (re-establishes the notify-relay tab)",
+    };
+    const row = healthRow(c, 1_000);
+    expect(row).toContain("relay");
+    expect(row).toContain("gone");
+    expect(row).toContain("cockpit launch brove");
+  });
+
+  it("healthRow includes ref + state for an alive crew", () => {
+    const c: ComponentHealth = {
+      kind: "crew", project: "p", ref: "alpha", state: "alive", lastSeenMs: 900, detail: "working",
+    };
+    const row = healthRow(c, 900);
+    expect(row).toContain("alpha");
+    expect(row).toContain("alive");
+  });
+});

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -8,6 +8,7 @@ import { loadConfig } from "../config.js";
 import { createCmuxDriver, RuntimeRegistry } from "../runtimes/index.js";
 import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
 import { createCmuxNotifier, NotifierRegistry } from "../notifiers/index.js";
+import { queryHealth, printServiceHealth } from "./health-view.js";
 import {
   createCursorEmitter,
   createCodexEmitter,
@@ -202,6 +203,10 @@ export const doctorCommand = new Command("doctor")
     console.log(
       `\n${passed === total ? chalk.green("All checks passed") : chalk.yellow(`${passed}/${total} checks passed`)}\n`,
     );
+
+    // #77 service-health: live per-component liveness from the daemon. Printed
+    // before the prereq-fail exit so a degraded install still shows what is up.
+    printServiceHealth(await queryHealth());
 
     if (results.some((r) => !r)) {
       process.exit(1);

--- a/src/commands/health-view.ts
+++ b/src/commands/health-view.ts
@@ -1,0 +1,91 @@
+// src/commands/health-view.ts
+//
+// Client + pure renderer for the daemon's #77 service-health surface. Shared by
+// `cockpit doctor` and `cockpit status --detailed`. The query is a RAW socket
+// call (never kickstarts the daemon); rendering is pure and unit-tested.
+import { homedir } from "node:os";
+import { join } from "node:path";
+import chalk from "chalk";
+import { sendRequest } from "../control/protocol.js";
+import type { ComponentHealth, HealthState } from "../control/liveness.js";
+
+const SOCK = join(homedir(), ".config", "cockpit", "cockpit.sock");
+
+/**
+ * Query the daemon for component liveness. Returns null when the daemon is
+ * unreachable (the surface shows "daemon unreachable" rather than kickstarting
+ * it). Optionally scoped to one project.
+ */
+export async function queryHealth(project?: string): Promise<ComponentHealth[] | null> {
+  try {
+    const reply = await sendRequest(SOCK, { kind: "health", project });
+    return Array.isArray(reply) ? (reply as ComponentHealth[]) : [];
+  } catch {
+    return null;
+  }
+}
+
+export function healthIcon(state: HealthState): string {
+  switch (state) {
+    case "alive": return "✔";
+    case "stale": return "•";
+    case "gone": return "✘";
+    case "unknown": return "○";
+  }
+}
+
+/** Color the state token without affecting the plain-text rendering used in tests. */
+export function colorState(state: HealthState): string {
+  switch (state) {
+    case "alive": return chalk.green(state);
+    case "stale": return chalk.yellow(state);
+    case "gone": return chalk.red(state);
+    case "unknown": return chalk.dim(state);
+  }
+}
+
+/** Human-friendly age of the last-seen timestamp, or em-dash when there is none. */
+export function ageText(lastSeenMs: number | null, now: number): string {
+  if (lastSeenMs == null) return "—";
+  const s = Math.max(0, Math.round((now - lastSeenMs) / 1000));
+  if (s < 60) return `${s}s ago`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m ago`;
+  return `${Math.round(m / 60)}h ago`;
+}
+
+/** Pure plain-text row (no color) — kept colorless so it is trivially testable. */
+export function healthRow(c: ComponentHealth, now: number): string {
+  const head = `${healthIcon(c.state)} ${c.kind.padEnd(8)} ${c.ref.padEnd(16)} ${c.state.padEnd(8)} ${ageText(c.lastSeenMs, now)}`;
+  return c.detail ? `${head}  ${c.detail}` : head;
+}
+
+/**
+ * Print the Service Health section to stdout (used by doctor + status --detailed).
+ * Groups rows by project; flags the daemon being unreachable.
+ */
+export function printServiceHealth(rows: ComponentHealth[] | null, now: number = Date.now()): void {
+  console.log(chalk.bold("\nService Health\n"));
+  if (rows == null) {
+    console.log(`  ${chalk.red("✘")} daemon unreachable — cockpit liveness is unknown (start the daemon)`);
+    return;
+  }
+  if (rows.length === 0) {
+    console.log(chalk.dim("  no registered projects"));
+    return;
+  }
+  const byProject = new Map<string, ComponentHealth[]>();
+  for (const c of rows) {
+    const list = byProject.get(c.project) ?? [];
+    list.push(c);
+    byProject.set(c.project, list);
+  }
+  for (const [project, comps] of byProject) {
+    console.log(`  ${chalk.cyan(project)}`);
+    for (const c of comps) {
+      // Reuse the pure row for layout; recolor the state token in place.
+      const plain = healthRow(c, now);
+      console.log(`    ${plain.replace(c.state, colorState(c.state))}`);
+    }
+  }
+}

--- a/src/commands/launch.ts
+++ b/src/commands/launch.ts
@@ -13,6 +13,7 @@ import type { RuntimeDriver, WorkspaceRef } from "../runtimes/index.js";
 import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
 import { ensureSpokeLayout } from "../lib/vault-layout.js";
 import { resolveCmuxBin } from "../lib/cmux-bin.js";
+import { buildRelaySupervisorCommand, NOTIFY_RELAY_TAB_TITLE } from "../control/relay-supervisor.js";
 
 const CMUX_APP = "/Applications/cmux.app";
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "cockpit", "templates");
@@ -178,31 +179,10 @@ function buildAgentCmd(
   });
 }
 
-const NOTIFY_RELAY_TAB_TITLE = "✉ notify-relay";
-
-const RELAY_RESTART_DELAY_S = 3;
-
-/**
- * Build the command for the relay tab as a self-restarting shell supervisor
- * loop (#186). The relay process can exit on its own — most commonly a boot
- * race during a daemon/session restart, where `runNotifyRelay` throws "captain
- * workspace 'X' not running" and the CLI does `process.exit(1)`. With a bare
- * `cockpit notify-relay …` invocation it then stays dead, and the captain is
- * silently blind to every CREW BLOCKED/DONE event (the documented 2026-05-31
- * failure). Wrapping it in `while true; do …; sleep N; done` makes any exit
- * respawn the relay — and rides out the boot race until the captain workspace
- * appears. The loop is typed into the tab's shell by spawnInjector, so the cmux
- * tab is the supervisor; this needs no daemon (which can't spawn into cmux) and
- * no captain-side hook (cmux owns the captain's settings).
- */
-export function buildRelaySupervisorCommand(project: string): string {
-  const relay = `cockpit notify-relay ${project} --as captain`;
-  return (
-    `while true; do ${relay}; ` +
-    `echo "[notify-relay ${project}] exited (code $?), restarting in ${RELAY_RESTART_DELAY_S}s"; ` +
-    `sleep ${RELAY_RESTART_DELAY_S}; done`
-  );
-}
+// Relay-tab builders moved to src/control/relay-supervisor.ts (shared with the
+// daemon's #207 healer). Re-exported for back-compat (launch.test.ts imports
+// them from "../launch").
+export { buildRelaySupervisorCommand, NOTIFY_RELAY_TAB_TITLE };
 
 /**
  * Add the notify-relay to a captain workspace as a background tab. The

--- a/src/commands/notify-relay.ts
+++ b/src/commands/notify-relay.ts
@@ -20,6 +20,7 @@ import {
   readFromCursor,
   type MailboxEntry,
 } from "../control/mailbox.js";
+import { sendRequest } from "../control/protocol.js";
 import { classifyPaneTail } from "../control/interactive/pane-classifier.js";
 import { createCrewPaneReader } from "../control/crew-pane-reader.js";
 import { cockpitdCall } from "./crew-control.js";
@@ -37,6 +38,9 @@ export const STALE_THRESHOLD_MS = 5 * 60 * 1000;
 // candidate: PostToolUse never fires while a permission prompt is up, so a
 // genuinely-blocked crew goes quiet well before the multi-minute stall budget.
 export const PROBE_QUIET_MS = 20_000;
+// #207: how often the relay heartbeats its liveness to the daemon. The daemon's
+// RELAY_STALE_MS/RELAY_GONE_MS windows are sized as multiples of this.
+export const RELAY_REGISTER_HEARTBEAT_MS = 10_000;
 
 // Unified-formatter (#214/#210): the daemon's formatMessage is the single
 // source of truth for the captain-facing message and stores it on the mailbox
@@ -201,6 +205,22 @@ export async function runNotifyRelay(opts: RunOpts): Promise<() => void> {
   let stopped = false;
   let draining = false;
 
+  // #207: register with the daemon so it knows this project SHOULD have a live
+  // relay, and heartbeat every ~10s so the sweep can health-check (and, if this
+  // relay dies entirely, surface it as down). Best-effort via a RAW socket call
+  // (not cockpitdCall) so a registration attempt never KICKSTARTS the daemon —
+  // a relay registering should not resurrect a down daemon, and the drain loop
+  // is what actually matters. Errors are swallowed.
+  const relayPid = process.pid;
+  const sockPath = join(homedir(), ".config", "cockpit", "cockpit.sock");
+  const announceRelay = (req: unknown) => void sendRequest(sockPath, req).catch(() => {});
+  announceRelay({ kind: "relay-register", project: opts.project, pid: relayPid, startedAt: sessionStartMs });
+  const heartbeatInterval = setInterval(() => {
+    if (stopped) return;
+    announceRelay({ kind: "relay-heartbeat", project: opts.project, pid: relayPid });
+  }, RELAY_REGISTER_HEARTBEAT_MS);
+  heartbeatInterval.unref?.();
+
   async function drain(): Promise<void> {
     if (draining) return;
     draining = true;
@@ -282,6 +302,7 @@ export async function runNotifyRelay(opts: RunOpts): Promise<() => void> {
   return () => {
     stopped = true;
     clearInterval(interval);
+    clearInterval(heartbeatInterval);
     if (probeInterval) clearInterval(probeInterval);
   };
 }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 import matter from "gray-matter";
 import { loadConfig } from "../config.js";
 import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
+import { queryHealth, printServiceHealth } from "./health-view.js";
 
 interface StatusFrontmatter {
   project?: string;
@@ -41,7 +42,8 @@ function progressBar(completed: number, total: number): string {
 
 export const statusCommand = new Command("status")
   .description("Show status of all projects from spoke vault status files")
-  .action(async () => {
+  .option("--detailed", "also show live per-component service health from the daemon (#77)")
+  .action(async (opts: { detailed?: boolean }) => {
     const config = loadConfig();
     const projects = Object.entries(config.projects);
     const registry = new WorkspaceRegistry({ obsidian: createObsidianDriver });
@@ -94,4 +96,10 @@ export const statusCommand = new Command("status")
     }
 
     console.log("");
+
+    // #77: --detailed adds the live service-health view (relay/captain/crew/
+    // command per-component last-seen + state) queried from the daemon.
+    if (opts.detailed) {
+      printServiceHealth(await queryHealth());
+    }
   });

--- a/src/control/__tests__/cockpitd-relay-health.test.ts
+++ b/src/control/__tests__/cockpitd-relay-health.test.ts
@@ -1,0 +1,63 @@
+// src/control/__tests__/cockpitd-relay-health.test.ts
+//
+// End-to-end through the real socket: relay-register/heartbeat routing and the
+// #77 health verb assembly (with an injected captainProbe — no cmux). Covers the
+// #207 "captain SILENTLY blind" case: a live captain with NO relay → relay gone
+// + actionable.
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startCockpitd } from "../cockpitd.js";
+import { sendRequest } from "../protocol.js";
+import type { ComponentHealth } from "../liveness.js";
+
+const find = (cs: ComponentHealth[], kind: ComponentHealth["kind"]) =>
+  cs.find((c) => c.kind === kind);
+
+describe("cockpitd relay-health socket (#207/#77)", () => {
+  let stop: (() => void) | undefined;
+  let dir: string;
+  afterEach(() => { stop?.(); if (dir) rmSync(dir, { recursive: true, force: true }); });
+
+  function boot(captainPresent: boolean | null) {
+    dir = mkdtempSync(join(tmpdir(), "cp-crh-"));
+    const sock = join(dir, "c.sock");
+    const handle = startCockpitd({
+      stateRoot: join(dir, "state"),
+      sockPath: sock,
+      sweepMs: 0,
+      captainProbe: async () => captainPresent,
+    });
+    stop = handle.stop;
+    return sock;
+  }
+
+  it("relay-register → health shows the relay alive with its pid", async () => {
+    const sock = boot(true);
+    const ok: any = await sendRequest(sock, { kind: "relay-register", project: "p", pid: 4242, startedAt: 1 });
+    expect(ok).toEqual({ ok: true });
+    const cs: ComponentHealth[] = await sendRequest(sock, { kind: "health", project: "p" }) as any;
+    const relay = find(cs, "relay")!;
+    expect(relay.state).toBe("alive");
+    expect(relay.detail).toContain("4242");
+    expect(find(cs, "captain")!.state).toBe("alive");
+  });
+
+  it("live captain but NO relay registered → relay GONE with actionable (never silently blind)", async () => {
+    const sock = boot(true);
+    const cs: ComponentHealth[] = await sendRequest(sock, { kind: "health", project: "p" }) as any;
+    const relay = find(cs, "relay")!;
+    expect(relay.state).toBe("gone");
+    expect(relay.detail).toContain("cockpit launch p");
+  });
+
+  it("relay-heartbeat keeps the relay registered/alive", async () => {
+    const sock = boot(null);
+    await sendRequest(sock, { kind: "relay-register", project: "p", pid: 7, startedAt: 1 });
+    const ok: any = await sendRequest(sock, { kind: "relay-heartbeat", project: "p", pid: 7 });
+    expect(ok).toEqual({ ok: true });
+    const cs: ComponentHealth[] = await sendRequest(sock, { kind: "health", project: "p" }) as any;
+    expect(find(cs, "relay")!.state).toBe("alive");
+  });
+});

--- a/src/control/__tests__/daemon-relay-health.test.ts
+++ b/src/control/__tests__/daemon-relay-health.test.ts
@@ -1,0 +1,104 @@
+// src/control/__tests__/daemon-relay-health.test.ts
+//
+// #207: the daemon REGISTERS each project's relay, HEALTH-CHECKS it on the sweep,
+// and best-effort HEALs a dark one. The non-negotiable core is detection +
+// surface (getRelayHealth) so the captain is never SILENTLY blind; heal is
+// secondary (mostly inert under launchd — cmux lineage).
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDaemon } from "../daemon.js";
+import { createStore } from "../store.js";
+import { RELAY_GONE_MS } from "../liveness.js";
+
+describe("daemon relay health (#207)", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "cp-rh-")); });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("registerRelay → getRelayHealth records pid + lastSeen=now", () => {
+    const store = createStore(dir);
+    const d = createDaemon({ store, now: () => 1000 });
+    d.registerRelay({ project: "p", pid: 42, startedAt: 900 });
+    const [rh] = d.getRelayHealth();
+    expect(rh).toMatchObject({ project: "p", pid: 42, startedAt: 900, lastSeenMs: 1000 });
+  });
+
+  it("relayHeartbeat advances lastSeen", () => {
+    let t = 1000;
+    const store = createStore(dir);
+    const d = createDaemon({ store, now: () => t });
+    d.registerRelay({ project: "p", pid: 42, startedAt: 900 });
+    t = 5000;
+    d.relayHeartbeat({ project: "p", pid: 42 });
+    expect(d.getRelayHealth()[0].lastSeenMs).toBe(5000);
+  });
+
+  it("sweep heals a relay gone silent past the gone window — exactly once (debounced)", async () => {
+    let t = 1000;
+    const healed: string[] = [];
+    const store = createStore(dir);
+    const d = createDaemon({ store, now: () => t, healRelay: (p) => { healed.push(p); } });
+    d.registerRelay({ project: "p", pid: 42, startedAt: 900 });
+
+    // Fresh: no heal.
+    t = 1000 + RELAY_GONE_MS; // boundary = still stale, not gone
+    await d.sweep();
+    expect(healed).toEqual([]);
+
+    // Gone: heal fires once.
+    t = 1000 + RELAY_GONE_MS + 1;
+    await d.sweep();
+    expect(healed).toEqual(["p"]);
+
+    // Still gone on the very next sweep: debounced, no repeat hammering.
+    t += 1000;
+    await d.sweep();
+    expect(healed).toEqual(["p"]);
+  });
+
+  it("a relay that comes back (fresh heartbeat) re-arms heal for a future death", async () => {
+    let t = 1000;
+    const healed: string[] = [];
+    const store = createStore(dir);
+    const d = createDaemon({ store, now: () => t, healRelay: (p) => { healed.push(p); } });
+    d.registerRelay({ project: "p", pid: 42, startedAt: 900 });
+
+    t = 1000 + RELAY_GONE_MS + 1;
+    await d.sweep();
+    expect(healed).toEqual(["p"]);
+
+    // Relay recovers and beats again.
+    t += 1000;
+    d.relayHeartbeat({ project: "p", pid: 42 });
+
+    // Dies again later → heals again (debounce was re-armed by the heartbeat).
+    t += RELAY_GONE_MS + 1;
+    await d.sweep();
+    expect(healed).toEqual(["p", "p"]);
+  });
+
+  it("a healthy relay is never healed", async () => {
+    let t = 1000;
+    const healed: string[] = [];
+    const store = createStore(dir);
+    const d = createDaemon({ store, now: () => t, healRelay: (p) => { healed.push(p); } });
+    d.registerRelay({ project: "p", pid: 42, startedAt: 900 });
+    for (let i = 0; i < 5; i++) {
+      t += 10_000;
+      d.relayHeartbeat({ project: "p", pid: 42 });
+      await d.sweep();
+    }
+    expect(healed).toEqual([]);
+  });
+
+  it("a throwing healRelay never breaks the sweep", async () => {
+    let t = 1000;
+    const store = createStore(dir);
+    const d = createDaemon({ store, now: () => t, healRelay: () => { throw new Error("cmux refused (lineage)"); } });
+    d.registerRelay({ project: "p", pid: 42, startedAt: 900 });
+    t = 1000 + RELAY_GONE_MS + 1;
+    await expect(d.sweep()).resolves.toBeUndefined();
+  });
+});

--- a/src/control/__tests__/liveness.test.ts
+++ b/src/control/__tests__/liveness.test.ts
@@ -1,0 +1,113 @@
+// src/control/__tests__/liveness.test.ts
+import { describe, it, expect } from "vitest";
+import {
+  classifyHealth,
+  projectHealth,
+  relayActionable,
+  RELAY_STALE_MS,
+  RELAY_GONE_MS,
+  type RelayHealth,
+  type ComponentHealth,
+} from "../liveness.js";
+
+const relay = (o: Partial<RelayHealth> = {}): RelayHealth => ({
+  project: "p",
+  pid: 123,
+  startedAt: 0,
+  lastSeenMs: 1_000,
+  ...o,
+});
+
+const find = (cs: ComponentHealth[], kind: ComponentHealth["kind"]) =>
+  cs.find((c) => c.kind === kind);
+
+describe("classifyHealth (pure)", () => {
+  it("null last-seen → unknown", () => {
+    expect(classifyHealth(null, 10_000, 1_000, 2_000)).toBe("unknown");
+  });
+  it("within stale window → alive", () => {
+    expect(classifyHealth(1_000, 1_500, 1_000, 2_000)).toBe("alive");
+  });
+  it("exactly at stale boundary → alive (inclusive)", () => {
+    expect(classifyHealth(1_000, 2_000, 1_000, 2_000)).toBe("alive");
+  });
+  it("past stale but within gone window → stale", () => {
+    expect(classifyHealth(1_000, 2_500, 1_000, 2_000)).toBe("stale");
+  });
+  it("exactly at gone boundary → stale (inclusive)", () => {
+    expect(classifyHealth(1_000, 3_000, 1_000, 2_000)).toBe("stale");
+  });
+  it("past gone window → gone", () => {
+    expect(classifyHealth(1_000, 3_001, 1_000, 2_000)).toBe("gone");
+  });
+});
+
+describe("relayActionable", () => {
+  it("names the project and the recovery command", () => {
+    const msg = relayActionable("brove");
+    expect(msg).toContain("brove");
+    expect(msg).toContain("cockpit launch brove");
+  });
+});
+
+describe("projectHealth (pure projection)", () => {
+  const base = {
+    project: "p",
+    captainName: "p-captain",
+    captainPresent: true as boolean | null,
+    commandPresent: null as boolean | null,
+    crews: [],
+  };
+
+  it("registered relay seen recently → relay alive", () => {
+    const now = 1_000 + RELAY_STALE_MS; // exactly at stale boundary = alive
+    const cs = projectHealth({ ...base, now, relay: relay({ lastSeenMs: 1_000 }) });
+    const r = find(cs, "relay")!;
+    expect(r.state).toBe("alive");
+    expect(r.lastSeenMs).toBe(1_000);
+  });
+
+  it("registered relay gone silent → relay gone WITH actionable detail (never silently blind)", () => {
+    const now = 1_000 + RELAY_GONE_MS + 1;
+    const cs = projectHealth({ ...base, now, relay: relay({ lastSeenMs: 1_000 }) });
+    const r = find(cs, "relay")!;
+    expect(r.state).toBe("gone");
+    expect(r.detail).toContain("cockpit launch p");
+  });
+
+  it("no relay registered but captain live → relay gone (a live captain SHOULD have a relay)", () => {
+    const cs = projectHealth({ ...base, now: 10_000, relay: null, captainPresent: true });
+    expect(find(cs, "relay")!.state).toBe("gone");
+  });
+
+  it("no relay registered and captain absent → relay unknown (nothing should be running)", () => {
+    const cs = projectHealth({ ...base, now: 10_000, relay: null, captainPresent: false });
+    expect(find(cs, "relay")!.state).toBe("unknown");
+  });
+
+  it("captain presence maps directly (no timestamp): true→alive, false→gone, null→unknown", () => {
+    expect(find(projectHealth({ ...base, now: 1, relay: null, captainPresent: true }), "captain")!.state).toBe("alive");
+    expect(find(projectHealth({ ...base, now: 1, relay: null, captainPresent: false }), "captain")!.state).toBe("gone");
+    expect(find(projectHealth({ ...base, now: 1, relay: null, captainPresent: null }), "captain")!.state).toBe("unknown");
+  });
+
+  it("command omitted (commandPresent null) → no command row (command is on-demand)", () => {
+    const cs = projectHealth({ ...base, now: 1, relay: null, commandPresent: null });
+    expect(find(cs, "command")).toBeUndefined();
+  });
+
+  it("emits one crew row per non-terminal crew, skipping terminal ones", () => {
+    const cs = projectHealth({
+      ...base,
+      now: 1_000,
+      relay: relay(),
+      crews: [
+        { id: "a1", name: "alpha", state: "working", lastHeartbeat: 900, mode: "interactive" },
+        { id: "b2", name: "beta", state: "done", lastHeartbeat: 900, mode: "interactive" },
+        { id: "c3", name: "gamma", state: "awaiting-input", lastHeartbeat: 900, mode: "interactive" },
+      ],
+    });
+    const crews = cs.filter((c) => c.kind === "crew");
+    expect(crews.map((c) => c.ref).sort()).toEqual(["alpha", "gamma"]);
+  });
+});

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -307,19 +307,26 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   const captainProbe = opts.captainProbe ?? createCaptainProbe();
   async function buildHealth(only?: string): Promise<ComponentHealth[]> {
     const config = loadConfig();
-    const names = only ? [only] : Object.keys(config.projects);
-    const now = Date.now();
     const relays = d.getRelayHealth();
+    const now = Date.now();
+    // Projects known from config ∪ relay registrations ∪ active tasks, so a
+    // registered-but-unconfigured relay (or a crew) still surfaces.
+    const known = new Set<string>([
+      ...Object.keys(config.projects),
+      ...relays.map((r) => r.project),
+      ...store.listAll().map((t) => t.project),
+    ]);
+    const names = only ? [only] : [...known];
     const out: ComponentHealth[] = [];
     for (const project of names) {
       const proj = config.projects[project];
-      if (!proj) continue;
-      const captainPresent = await captainProbe(project, proj.captainName);
+      const captainName = proj?.captainName ?? `${project}-captain`;
+      const captainPresent = await captainProbe(project, captainName);
       out.push(
         ...projectHealth({
           project,
           now,
-          captainName: proj.captainName,
+          captainName,
           relay: relays.find((r) => r.project === project) ?? null,
           captainPresent,
           commandPresent: null, // command is on-demand; not tracked in this cut

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -13,6 +13,9 @@ import { OpencodeSseBridge } from "./opencode/sse-bridge.js";
 import { makeGate } from "./codex/gate.js";
 import { appendToMailbox, rotateIfNeeded } from "./mailbox.js";
 import { createSurfaceLivenessProbe } from "./crew-pane-reader.js";
+import { createRelayHealer, createCaptainProbe } from "./relay-healer.js";
+import { projectHealth, type ComponentHealth } from "./liveness.js";
+import { loadConfig } from "../config.js";
 import { readdir } from "node:fs/promises";
 import type { Gate, TaskRecord, ControlEvent } from "./types.js";
 import { TERMINAL_STATES } from "./types.js";
@@ -57,6 +60,12 @@ export interface CockpitdOpts {
     answer: (taskId: string, payload: unknown) => Promise<void>;
     close: (taskId: string) => Promise<void>;
   };
+  /** #207 best-effort relay healer. Defaults to a real cmux spawnInjector
+   *  re-spawn (mostly inert under launchd). Tests inject a fake/spy. */
+  healRelay?: (project: string) => Promise<void> | void;
+  /** #77 captain-presence probe for the health verb. Defaults to a real cmux
+   *  read. Returns true/false/null (null = couldn't determine). Tests inject. */
+  captainProbe?: (project: string, captainName: string) => Promise<boolean | null>;
   /** Inject a fake opencode SSE bridge for tests. Defaults to a real one. */
   opencodeBridge?: {
     start: (o: { taskId: string; port: number }) => void;
@@ -235,6 +244,8 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
     // #139 backstop: terminalize interactive crews whose cmux pane is provably
     // gone (sweep/reconcile reaper). Three-valued; "unknown" never reaps.
     isSurfaceAlive: opts.isSurfaceAlive ?? createSurfaceLivenessProbe(),
+    // #207 best-effort relay heal on the sweep (secondary — surface is primary).
+    healRelay: opts.healRelay ?? createRelayHealer(log),
     launchHeadless: async (rec) => {
       await runHeadless({
         provider: rec.provider, task: rec.task, id: rec.id, sessionId: rec.sessionId,
@@ -288,6 +299,36 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       } catch (e) { log(`gate-resolve answer failed: ${(e as Error).message}`); }
     },
   });
+
+  // #77 service-health surface. Assembles per-component liveness for the health
+  // socket verb: the relay map comes from the daemon, captain presence from a
+  // cmux read (allowed from launchd), crews from the store — all fed into the
+  // pure projectHealth(). Never throws (a flaky cmux read maps to "unknown").
+  const captainProbe = opts.captainProbe ?? createCaptainProbe();
+  async function buildHealth(only?: string): Promise<ComponentHealth[]> {
+    const config = loadConfig();
+    const names = only ? [only] : Object.keys(config.projects);
+    const now = Date.now();
+    const relays = d.getRelayHealth();
+    const out: ComponentHealth[] = [];
+    for (const project of names) {
+      const proj = config.projects[project];
+      if (!proj) continue;
+      const captainPresent = await captainProbe(project, proj.captainName);
+      out.push(
+        ...projectHealth({
+          project,
+          now,
+          captainName: proj.captainName,
+          relay: relays.find((r) => r.project === project) ?? null,
+          captainPresent,
+          commandPresent: null, // command is on-demand; not tracked in this cut
+          crews: store.list(project),
+        }),
+      );
+    }
+    return out;
+  }
 
   // Crash recovery on boot. reconcile() is async (#139: it consults the
   // interactive surface-liveness probe to reap dead crews instead of stalling
@@ -344,6 +385,22 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       if (msg.kind === "codex-close") {
         await codexDriver.close(msg.taskId).catch((e: unknown) => log(`codex close err: ${e}`));
         return { ok: true };
+      }
+      // #207 relay registration: the notify-relay announces itself on boot and
+      // heartbeats every ~10s so the daemon can health-check it on the sweep.
+      if (msg.kind === "relay-register") {
+        d.registerRelay({ project: msg.project, pid: msg.pid, startedAt: msg.startedAt ?? Date.now() });
+        return { ok: true };
+      }
+      if (msg.kind === "relay-heartbeat") {
+        d.relayHeartbeat({ project: msg.project, pid: msg.pid });
+        return { ok: true };
+      }
+      // #77 service-health surface: per-component liveness for the queried
+      // project (or all). The captain probe (cmux read) is allowed from the
+      // daemon; the heavy lifting is the pure projectHealth().
+      if (msg.kind === "health") {
+        return await buildHealth(msg.project as string | undefined);
       }
       return d.handle(msg);
     },

--- a/src/control/daemon.ts
+++ b/src/control/daemon.ts
@@ -3,6 +3,7 @@ import type { Store } from "./store.js";
 import type { ControlEvent, TaskRecord, TaskState } from "./types.js";
 import { reduce } from "./state-machine.js";
 import { evaluateStall, recoverStall } from "./watchdog.js";
+import { classifyHealth, RELAY_STALE_MS, RELAY_GONE_MS, type RelayHealth } from "./liveness.js";
 
 export interface DaemonDeps {
   store: Store;
@@ -47,6 +48,16 @@ export interface DaemonDeps {
     record: TaskRecord;
     event: ControlEvent;
   }) => Promise<void> | void;
+  /**
+   * #207 relay heal (SECONDARY — best-effort). Called once per "down" episode
+   * when the sweep finds a registered relay gone dark. The default impl
+   * (cockpitd) attempts a `spawnInjector` re-spawn, but is mostly inert in prod:
+   * the launchd daemon is outside cmux's process-lineage and cannot inject. The
+   * non-negotiable guarantee — "captain never SILENTLY blind" — is delivered by
+   * getRelayHealth() + the liveness surface, not by this hook. Errors are
+   * swallowed by the sweep so a refused cmux write never trips the daemon.
+   */
+  healRelay?: (project: string) => Promise<void> | void;
 }
 
 // 'awaiting-input' is an attention state: entering it (idle watchdog OR a
@@ -151,7 +162,34 @@ export function createDaemon(deps: DaemonDeps) {
   // active back-and-forth. Bounded by the live task set; never read after a
   // task terminates (terminal states don't transition to awaiting-input).
   const lastCaptainTurnAt = new Map<string, number>();
+  // #207: per-project relay registration + last heartbeat. The relay registers
+  // over the socket on boot and beats every ~10s; the sweep health-checks these.
+  const relayHealth = new Map<string, RelayHealth>();
+  // Per-project last heal attempt, so a persistently-dark relay is healed once
+  // per episode, not every 30s sweep. Re-armed (deleted) when a fresh heartbeat
+  // proves the relay recovered.
+  const lastHealAttempt = new Map<string, number>();
   return {
+    /** #207: a notify-relay announced itself (boot). */
+    registerRelay(r: { project: string; pid: number; startedAt: number }): void {
+      relayHealth.set(r.project, { ...r, lastSeenMs: now() });
+      lastHealAttempt.delete(r.project);
+    },
+    /** #207: a notify-relay heartbeat (every ~10s). Re-arms heal. */
+    relayHeartbeat(r: { project: string; pid: number }): void {
+      const prev = relayHealth.get(r.project);
+      relayHealth.set(r.project, {
+        project: r.project,
+        pid: r.pid,
+        startedAt: prev?.startedAt ?? now(),
+        lastSeenMs: now(),
+      });
+      lastHealAttempt.delete(r.project);
+    },
+    /** #207/#77: snapshot of every registered relay's health (for the surface). */
+    getRelayHealth(): RelayHealth[] {
+      return [...relayHealth.values()];
+    },
     async handle(req: Req): Promise<TaskRecord | TaskRecord[]> {
       switch (req.kind) {
         case "dispatch": {
@@ -268,6 +306,26 @@ export function createDaemon(deps: DaemonDeps) {
         const recovered = recoverStall(r, t);
         // recoverStall does NOT check heartbeat freshness — guard per its contract
         if (recovered && t - r.lastHeartbeat <= r.heartbeatBudgetMs) store.put(recovered);
+      }
+      // #207 relay health-check: a registered relay gone dark past the gone
+      // window is down. Best-effort heal, debounced to once per episode. The
+      // surface (getRelayHealth) already exposes the "gone" state regardless —
+      // that is the never-silently-blind guarantee; heal is the secondary try.
+      if (deps.healRelay) {
+        for (const rh of relayHealth.values()) {
+          if (classifyHealth(rh.lastSeenMs, t, RELAY_STALE_MS, RELAY_GONE_MS) !== "gone") continue;
+          const last = lastHealAttempt.get(rh.project);
+          if (last != null && t - last <= RELAY_GONE_MS) continue; // debounce
+          lastHealAttempt.set(rh.project, t);
+          try {
+            const r = deps.healRelay(rh.project);
+            if (r && typeof (r as Promise<void>).catch === "function") {
+              (r as Promise<void>).catch(() => {});
+            }
+          } catch {
+            // best-effort — a refused cmux write (lineage) must not trip the sweep
+          }
+        }
       }
     },
     async reconcile(): Promise<void> {

--- a/src/control/liveness.ts
+++ b/src/control/liveness.ts
@@ -1,0 +1,178 @@
+// src/control/liveness.ts
+//
+// PURE service-health layer (no I/O, no clock) — the #77 foundation. Mirrors
+// watchdog.ts: every function derives a verdict from records + an explicit `now`
+// so it is fully unit-testable. All runtime probing (cmux reads for captain
+// presence, the relay-heartbeat map) is gathered by the caller (cockpitd) and
+// passed in already-resolved; this module never touches cmux.
+import type { TaskState, Mode } from "./types.js";
+
+export type ComponentKind = "relay" | "captain" | "crew" | "command";
+
+// alive  = seen within the stale window (healthy)
+// stale  = quiet past stale but not yet gone (degrading)
+// gone   = dark past the gone window (treat as down)
+// unknown = no signal / not applicable (never alarms)
+export type HealthState = "alive" | "stale" | "gone" | "unknown";
+
+export interface ComponentHealth {
+  kind: ComponentKind;
+  project: string;
+  /** crew name / captain name / "relay" / "command". */
+  ref: string;
+  state: HealthState;
+  /** epoch ms of last evidence of life, or null when there is no timestamp
+   *  source (captain/command presence is a boolean, not a heartbeat). */
+  lastSeenMs: number | null;
+  /** human-facing context — for a down relay, the actionable recovery command. */
+  detail?: string;
+}
+
+/** A notify-relay's registration + last heartbeat, tracked by the daemon. */
+export interface RelayHealth {
+  project: string;
+  pid: number;
+  startedAt: number;
+  lastSeenMs: number;
+}
+
+// Relay heartbeats every ~10s (notify-relay). Stale at ~2.5×, gone at ~6×, so a
+// single missed beat never flaps to "down" but a truly dead relay is caught
+// within one or two daemon sweeps (30s each).
+export const RELAY_STALE_MS = 25_000;
+export const RELAY_GONE_MS = 60_000;
+
+// Crews legitimately idle for long (24h interactive budget), so the surface uses
+// generous windows — these only flag a genuinely dark crew, and #139 already
+// reaps provably-dead ones. Display-only; does not drive any state transition.
+export const CREW_STALE_MS = 5 * 60_000;
+export const CREW_GONE_MS = 30 * 60_000;
+
+/**
+ * Pure. Classify a last-seen timestamp into a health state.
+ *   null            → "unknown"
+ *   age <= staleMs  → "alive"   (boundary inclusive)
+ *   age <= goneMs   → "stale"   (boundary inclusive)
+ *   else            → "gone"
+ */
+export function classifyHealth(
+  lastSeenMs: number | null,
+  now: number,
+  staleMs: number,
+  goneMs: number,
+): HealthState {
+  if (lastSeenMs == null) return "unknown";
+  const age = now - lastSeenMs;
+  if (age <= staleMs) return "alive";
+  if (age <= goneMs) return "stale";
+  return "gone";
+}
+
+/**
+ * The actionable recovery instruction surfaced when a relay is down. The daemon
+ * cannot re-establish a cmux relay tab itself (launchd is outside cmux's
+ * process-lineage), so the honest remedy is a captain-run command. Keeping this
+ * in the surface is the "never silently blind" guarantee.
+ */
+export function relayActionable(project: string): string {
+  return `relay DOWN — run: cockpit launch ${project} (re-establishes the notify-relay tab)`;
+}
+
+const TERMINAL: ReadonlySet<TaskState> = new Set(["done", "failed", "cancelled"]);
+
+/** Minimal crew shape the projection needs (subset of TaskRecord). */
+export interface CrewLiveness {
+  id: string;
+  name?: string;
+  state: TaskState;
+  lastHeartbeat: number;
+  mode: Mode;
+}
+
+/**
+ * Pure. Project one project's component health from already-gathered inputs.
+ * Emits: a relay row, a captain row, a command row (only when applicable), and
+ * one row per non-terminal crew. cmux presence booleans are resolved by the
+ * caller (cockpitd reads cmux); null means "could not determine" → unknown.
+ */
+export function projectHealth(input: {
+  project: string;
+  now: number;
+  captainName: string;
+  relay: RelayHealth | null;
+  /** true = captain workspace present, false = absent, null = cmux unreadable. */
+  captainPresent: boolean | null;
+  /** true/false when a command workspace is expected; null = not applicable. */
+  commandPresent: boolean | null;
+  crews: CrewLiveness[];
+}): ComponentHealth[] {
+  const { project, now, captainName, relay, captainPresent, commandPresent, crews } = input;
+  const out: ComponentHealth[] = [];
+
+  // ── relay ──────────────────────────────────────────────────────────────
+  if (relay) {
+    const state = classifyHealth(relay.lastSeenMs, now, RELAY_STALE_MS, RELAY_GONE_MS);
+    out.push({
+      kind: "relay",
+      project,
+      ref: "relay",
+      state,
+      lastSeenMs: relay.lastSeenMs,
+      detail: state === "alive" ? `pid ${relay.pid}` : relayActionable(project),
+    });
+  } else {
+    // No registration. A LIVE captain should have a relay → its absence is a
+    // down relay (the #207 silent-blind case). No captain → nothing should be
+    // running, so it is genuinely unknown, not an alarm.
+    const state: HealthState = captainPresent ? "gone" : "unknown";
+    out.push({
+      kind: "relay",
+      project,
+      ref: "relay",
+      state,
+      lastSeenMs: null,
+      detail: state === "gone" ? relayActionable(project) : undefined,
+    });
+  }
+
+  // ── captain ────────────────────────────────────────────────────────────
+  out.push({
+    kind: "captain",
+    project,
+    ref: captainName,
+    state: presence(captainPresent),
+    lastSeenMs: null,
+    detail: captainPresent === false ? "captain workspace not running" : undefined,
+  });
+
+  // ── command (on-demand; only surfaced when applicable) ───────────────────
+  if (commandPresent !== null) {
+    out.push({
+      kind: "command",
+      project,
+      ref: "command",
+      state: presence(commandPresent),
+      lastSeenMs: null,
+    });
+  }
+
+  // ── crews (one row per non-terminal crew) ────────────────────────────────
+  for (const c of crews) {
+    if (TERMINAL.has(c.state)) continue;
+    out.push({
+      kind: "crew",
+      project,
+      ref: c.name ?? c.id.slice(0, 8),
+      state: classifyHealth(c.lastHeartbeat, now, CREW_STALE_MS, CREW_GONE_MS),
+      lastSeenMs: c.lastHeartbeat,
+      detail: c.state,
+    });
+  }
+
+  return out;
+}
+
+function presence(p: boolean | null): HealthState {
+  if (p === null) return "unknown";
+  return p ? "alive" : "gone";
+}

--- a/src/control/relay-healer.ts
+++ b/src/control/relay-healer.ts
@@ -1,0 +1,78 @@
+// src/control/relay-healer.ts
+//
+// cmux-facing helpers for the #207 relay-health layer, isolated behind the
+// runtime driver (same pattern as crew-pane-reader.ts). Both functions resolve
+// the captain workspace via the runtime and NEVER throw — a flaky cmux probe
+// must not trip the daemon sweep / health verb.
+import { loadConfig } from "../config.js";
+import { createCmuxDriver, RuntimeRegistry } from "../runtimes/index.js";
+import { buildRelaySupervisorCommand, NOTIFY_RELAY_TAB_TITLE } from "./relay-supervisor.js";
+
+/**
+ * Resolve whether a project's captain workspace is currently present.
+ *   true  → workspace running
+ *   false → enumerated, absent
+ *   null  → could not determine (cmux down, no project) — never alarms
+ * cmux READS are allowed from the launchd daemon (unlike writes), so this works
+ * in prod; the #139 surface probe relies on the same primitive.
+ */
+export function createCaptainProbe(): (project: string, captainName: string) => Promise<boolean | null> {
+  return async (project, captainName) => {
+    try {
+      const config = loadConfig();
+      if (!config.projects[project]) return null;
+      const runtime = new RuntimeRegistry({ cmux: createCmuxDriver() }).forProject(project, config);
+      const ws = await runtime.status(captainName);
+      return ws != null;
+    } catch {
+      return null;
+    }
+  };
+}
+
+/**
+ * Best-effort relay heal (#207, SECONDARY). Re-spawns the notify-relay tab in
+ * the captain workspace via the runtime's spawnInjector. This is mostly INERT in
+ * production: cmux refuses writes from the launchd daemon (outside its
+ * process-lineage), so the spawn is rejected and we just log. The genuine
+ * in-prod recovery is the cmux-tree-resident relay-keeper (#224); the
+ * never-silently-blind guarantee comes from the liveness SURFACE, not this hook.
+ * Never throws.
+ */
+export function createRelayHealer(
+  log: (m: string) => void = () => {},
+): (project: string) => Promise<void> {
+  return async (project) => {
+    try {
+      const config = loadConfig();
+      const proj = config.projects[project];
+      if (!proj) return;
+      const runtime = new RuntimeRegistry({ cmux: createCmuxDriver() }).forProject(project, config);
+      const ws = await runtime.status(proj.captainName);
+      if (!ws) {
+        log(`relay heal ${project}: captain workspace not present; nothing to heal into`);
+        return;
+      }
+      // Dedup: close any pre-existing relay tab before respawning fresh.
+      try {
+        const surfaces = await runtime.listSurfaces(ws.id);
+        for (const s of surfaces) {
+          if (s.title === NOTIFY_RELAY_TAB_TITLE) {
+            try { await runtime.closePane(s); } catch { /* best effort */ }
+          }
+        }
+      } catch { /* best effort */ }
+      await runtime.spawnInjector({
+        captainWorkspace: ws,
+        command: buildRelaySupervisorCommand(project),
+        title: NOTIFY_RELAY_TAB_TITLE,
+        placement: "background",
+      });
+      log(`relay heal ${project}: re-spawned notify-relay tab`);
+    } catch (e) {
+      // Expected under launchd (cmux lineage refusal). The surface still shows
+      // the relay down with its actionable; this is the secondary path.
+      log(`relay heal ${project} failed (expected under launchd lineage): ${(e as Error).message}`);
+    }
+  };
+}

--- a/src/control/relay-supervisor.ts
+++ b/src/control/relay-supervisor.ts
@@ -1,0 +1,31 @@
+// src/control/relay-supervisor.ts
+//
+// Pure builders for the notify-relay tab — extracted from launch.ts so both the
+// launcher (in-cmux) and the daemon's best-effort relay healer (#207) can share
+// them without the daemon importing launch.ts's heavy driver/workspace graph.
+
+export const NOTIFY_RELAY_TAB_TITLE = "✉ notify-relay";
+
+const RELAY_RESTART_DELAY_S = 3;
+
+/**
+ * Build the command for the relay tab as a self-restarting shell supervisor
+ * loop (#186). The relay process can exit on its own — most commonly a boot
+ * race during a daemon/session restart, where `runNotifyRelay` throws "captain
+ * workspace 'X' not running" and the CLI does `process.exit(1)`. With a bare
+ * `cockpit notify-relay …` invocation it then stays dead, and the captain is
+ * silently blind to every CREW BLOCKED/DONE event (the documented 2026-05-31
+ * failure). Wrapping it in `while true; do …; sleep N; done` makes any exit
+ * respawn the relay — and rides out the boot race until the captain workspace
+ * appears. The loop is typed into the tab's shell by spawnInjector, so the cmux
+ * tab is the supervisor; this needs no daemon (which can't spawn into cmux) and
+ * no captain-side hook (cmux owns the captain's settings).
+ */
+export function buildRelaySupervisorCommand(project: string): string {
+  const relay = `cockpit notify-relay ${project} --as captain`;
+  return (
+    `while true; do ${relay}; ` +
+    `echo "[notify-relay ${project}] exited (code $?), restarting in ${RELAY_RESTART_DELAY_S}s"; ` +
+    `sleep ${RELAY_RESTART_DELAY_S}; done`
+  );
+}


### PR DESCRIPTION
## Summary

Service-health / liveness layer for cockpit's **own** infrastructure. One theme: cockpit had no liveness tracking for its own services, so when one died the failure was silent and cascaded. The daemon (which already sweeps every 30s and owns the task ledger + mailbox) is now the health authority.

Closes #207, #77, #208.

## The decisive constraint (shapes the heal design)

cmux enforces a **process-lineage check on writers**: only a process inside cmux's process tree may inject/spawn into a captain pane. The cockpitd daemon runs under **launchd — outside that tree**. So:

- Daemon **CAN read** cmux (`list-workspaces`/`tree`/`read-screen`) — the captain-presence probe relies on this.
- Daemon **CANNOT inject/spawn** into a captain pane — writes are refused (`Failed to write to socket`). There is no daemon→captain channel that bypasses the relay.

**Consequence + priority (per captain):** the non-negotiable core is **"the captain is never SILENTLY blind" = detect + surface**. Best-effort heal is **secondary** and intentionally minimal (mostly inert under launchd); the liveness surface + the actionable `relay DOWN — run: cockpit launch <project>` message is what delivers the guarantee. The genuine in-prod auto-heal (a cmux-tree-resident relay-keeper) is deferred → **#224**.

## What's in this PR

**#207 — relay register + health-check + heal**
- The notify-relay registers + heartbeats (every 10s) with the daemon over the existing socket (raw call — never kickstarts a down daemon).
- The daemon health-checks each registered relay on the sweep; a relay gone dark past `RELAY_GONE_MS` triggers a **debounced** best-effort heal (once per down episode) via the injected `healRelay` (default: cmux `spawnInjector` re-spawn, isolated in `relay-healer.ts`).

**#77 — component liveness layer + surface**
- New **pure** `src/control/liveness.ts` (mirrors `watchdog.ts`: records + a clock arg, no I/O) — `classifyHealth` + `projectHealth` for relay/captain/crew/command. All cmux probing stays behind the runtime driver.
- New `health` socket verb; surfaced in **`cockpit doctor`** (always) and **`cockpit status --detailed`**. A live captain with no relay surfaces as relay **GONE + actionable** — the #207 silent-blind case made loud.
- Deferred (reactions.json escalation, hard crew task-timeout, #64 ingestion) → **#225**.

**#208 — verdict: CLOSE** (`docs/decisions/2026-06-05-issue-208-verdict.md`)
- B2 resolved by #217, B1 superseded by #139 liveness reaping. The only residual (live crew with a missed turn-end) is covered by reliable turn-end signals (#133/#188) + the in-cmux relay pane-probe. A new daemon-side live-idle nudge would re-introduce the #131/#133 false-stall — not worth it.

## Tests (TDD)
- `liveness.test.ts` (14) — pure classification + projection.
- `daemon-relay-health.test.ts` (6) — register/heartbeat/getRelayHealth + debounced heal + killed-relay fixture + throwing-healer safety.
- `cockpitd-relay-health.test.ts` (3) — relay-register/heartbeat/health verbs end-to-end through the real socket; "live captain, no relay → GONE + actionable".
- `health-view.test.ts` (4) — pure renderer.
- **Full suite: 844 passed (81 files). `tsc --noEmit` clean.**

## Blast radius
LOW — additive throughout (new optional `DaemonDeps`/`CockpitdOpts` fields, new socket verbs, new modules). `buildRelaySupervisorCommand`/`NOTIFY_RELAY_TAB_TITLE` extracted from `launch.ts` to `src/control/relay-supervisor.ts` (re-exported for back-compat) so the daemon can share them without importing launch.ts's heavy graph.

> Note: GitNexus impact analysis was run pre-edit (createDaemon/sweep = LOW, 0 breaking callers). `detect_changes` not re-run — the index pre-dates this branch; verification rests on the full green suite + tsc.

Plan: `docs/plans/2026-06-05-service-health-liveness-layer.md`. Follow-ups: #224, #225.