### PR TITLE
fix(daemon): gate SessionEnd terminalization behind surface-liveness; stop false-cancel of live crews (closes #227)

### DIFF
--- a/src/control/__tests__/daemon.test.ts
+++ b/src/control/__tests__/daemon.test.ts
@@ -189,6 +189,48 @@ describe("daemon handler", () => {
     expect(store.get("p", "g6")?.state).toBe("working");
   });
 
+  // ── Issue #227: SessionEnd surface-liveness gate ─────────────────────────
+  // A task.session.ended event must ONLY terminalize the record when the
+  // crew's surface is PROVABLY gone. If the surface is alive or liveness is
+  // unknown, the event is a no-op — prevents a nested/spurious SessionEnd
+  // from false-cancelling a live working crew (#227 regression). The
+  // 'gone'-only / 'unknown'-never-reaps semantics are identical to the sweep.
+  it("event: task.session.ended on a LIVE interactive surface → no-op, NOT cancelled (#227)", async () => {
+    const store = createStore(dir);
+    store.put(rec("s227a", { mode: "interactive", name: "crew-1", state: "working" }));
+    const d = createDaemon({ store, now: () => 1000, isSurfaceAlive: async () => "alive" });
+    const r = await d.handle({ kind: "event", project: "p", event: { type: "task.session.ended", id: "s227a" } });
+    expect((r as TaskRecord).state).toBe("working");
+    expect(store.get("p", "s227a")?.state).toBe("working");
+  });
+
+  it("event: task.session.ended on UNKNOWN surface liveness → no-op, NOT cancelled (#227)", async () => {
+    const store = createStore(dir);
+    store.put(rec("s227b", { mode: "interactive", name: "crew-1", state: "awaiting-input" }));
+    // No isSurfaceAlive passed → defaults to always-unknown
+    const d = createDaemon({ store, now: () => 1000 });
+    const r = await d.handle({ kind: "event", project: "p", event: { type: "task.session.ended", id: "s227b" } });
+    expect((r as TaskRecord).state).toBe("awaiting-input");
+    expect(store.get("p", "s227b")?.state).toBe("awaiting-input");
+  });
+
+  it("event: task.session.ended on a GONE surface → cancelled (#139 regression preserved) (#227)", async () => {
+    const store = createStore(dir);
+    store.put(rec("s227c", { mode: "interactive", name: "crew-1", state: "blocked", question: "?" }));
+    const d = createDaemon({ store, now: () => 1000, isSurfaceAlive: async () => "gone" });
+    const r = await d.handle({ kind: "event", project: "p", event: { type: "task.session.ended", id: "s227c" } });
+    expect((r as TaskRecord).state).toBe("cancelled");
+    expect(store.get("p", "s227c")?.state).toBe("cancelled");
+  });
+
+  it("event: task.session.ended on an already-terminal task is a no-op regardless of liveness (#227)", async () => {
+    const store = createStore(dir);
+    store.put(rec("s227d", { state: "done", resultRef: "/r" }));
+    const d = createDaemon({ store, now: () => 1000, isSurfaceAlive: async () => "alive" });
+    const r = await d.handle({ kind: "event", project: "p", event: { type: "task.session.ended", id: "s227d" } });
+    expect((r as TaskRecord).state).toBe("done"); // terminal state is absorbing — no state change
+  });
+
   it("dispatch persists submitted then (headless) triggers launch hook", async () => {
     const store = createStore(dir);
     const launched: string[] = [];

--- a/src/control/daemon.ts
+++ b/src/control/daemon.ts
@@ -1,6 +1,7 @@
 // src/control/daemon.ts
 import type { Store } from "./store.js";
 import type { ControlEvent, TaskRecord, TaskState } from "./types.js";
+import { TERMINAL_STATES } from "./types.js";
 import { reduce } from "./state-machine.js";
 import { evaluateStall, recoverStall } from "./watchdog.js";
 import { classifyHealth, RELAY_STALE_MS, RELAY_GONE_MS, type RelayHealth } from "./liveness.js";
@@ -229,6 +230,15 @@ export function createDaemon(deps: DaemonDeps) {
           // A captain turn (crew send/reply) arrives as task.started → record it
           // so a quick trailing turn-end is debounced (#210).
           if (req.event.type === "task.started") lastCaptainTurnAt.set(req.event.id, now());
+          // #227: gate SessionEnd behind surface-liveness — only terminalize
+          // when the surface is provably GONE. Prevents a nested/spurious
+          // SessionEnd from false-cancelling a live crew while preserving the
+          // #139 dead-crew behavior. "unknown" never cancels (transient cmux
+          // outage), identical to the sweep reaper's semantics.
+          if (req.event.type === "task.session.ended" && !TERMINAL_STATES.has(cur.state)) {
+            const liveness = deps.isSurfaceAlive ? await deps.isSurfaceAlive(cur) : "unknown";
+            if (liveness !== "gone") return cur; // alive/unknown: no-op, keep current state
+          }
           const next = reduce(cur, req.event, now());
           if (next !== cur) {
             store.put(next); // skip redundant write on terminal no-ops


### PR DESCRIPTION
## Summary

The #139 fix (shipped in v0.5.2) mapped the claude `SessionEnd` hook to `task.session.ended` → `cancelled` **unconditionally** in the reducer, with **no liveness gate**. A `SessionEnd` that fires while the crew's *primary* session is still alive (e.g. a nested/subprocess claude that inherited `COCKPIT_CREW_TASK_ID`, or any spurious SessionEnd) **false-cancels a live working crew**.

## Fix (Option A)

Gate the `task.session.ended` event in the daemon event handler (the orchestration layer with access to `isSurfaceAlive`) — not in the pure reducer. On `task.session.ended`, run the existing `isSurfaceAlive` probe (from #139/#226). Terminalize → `cancelled` **ONLY** when the surface is provably `gone`. `alive`/`unknown` is a **no-op** — the event is dropped without touching the reducer.

This reuses the exact `gone`-only / `unknown`-never-cancels semantics of the sweep reaper (#139). The pure reducer is **unchanged** (still maps `task.session.ended` → `cancelled`), so the contract between event type and state remains explicit — only the daemon gates which events reach the reducer.

## TDD Verification (all 4 new tests + existing 850 pass)

- **LIVE surface + SessionEnd** → NOT cancelled (the #227 regression)
- **UNKNOWN surface + SessionEnd** → NOT cancelled (safe no-op; transient cmux outage never false-cancels)
- **GONE surface + SessionEnd** → cancelled (the #139 behavior preserved — dead crew still terminalizes)
- **Terminal state + SessionEnd** → no-op (absorbing guard, regardless of liveness)

## Files Changed

- `src/control/daemon.ts` — import `TERMINAL_STATES`; add liveness gate before `reduce()` for `task.session.ended` events
- `src/control/__tests__/daemon.test.ts` — 4 new regression tests for #227