### PR TITLE
ci: migrate release workflow to Node 24 runtime (deprecation 2026-06-16)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,14 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Determine version
@@ -90,7 +90,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.check.outputs.should_release == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.ver.outputs.tag }}
           name: ${{ steps.ver.outputs.tag }}


### PR DESCRIPTION
## Summary

Bump `node-version` from `"20"` to `"24"` **and** upgrade three actions to their Node-24-native major tags in `.github/workflows/release.yml`, ahead of GitHub Actions' Node 20 runtime removal after 2026-06-16.

## Changes

| File | Change |
|------|--------|
| `node-version` | `"20"` → `"24"` (line 26) |
| `actions/checkout` | `@v4` → `@v6` (line 19) |
| `actions/setup-node` | `@v4` → `@v6` (line 24) |
| `softprops/action-gh-release` | `@v2` → `@v3` (line 93) |

## Action runtime verification (via each tag's `action.yml` `using:` field)

| Action tag | Runtime | Status |
|------------|---------|--------|
| `actions/checkout@v4` | `node20` | ❌ deprecated |
| `actions/checkout@v6` | `node24` | ✅ target |
| `actions/setup-node@v4` | `node20` | ❌ deprecated |
| `actions/setup-node@v6` | `node24` | ✅ target |
| `softprops/action-gh-release@v2` | `node20` | ❌ deprecated |
| `softprops/action-gh-release@v3` | `node24` | ✅ target |

All three actions' v4→v6 / v2→v3 major bumps were reviewed for breaking changes on our specific inputs (`fetch-depth`, `node-version`, `registry-url`, `tag_name`, `name`, `body_path`). **No breaking changes** for our usage patterns.

## Verification

- `git diff` shows **only** `.github/workflows/release.yml` changed (4 insertions, 4 deletions)
- YAML validates successfully
- `npm run build` (tsc) passes
- `package.json` engines field (`>=18`) left untouched — it describes minimum requirement, not CI runtime