### PR TITLE
fix(cli): suppress drift banner during config subcommand (avoids double-print)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,29 +42,30 @@ ensureRuntimeSynced({
   runtimeRoot: join(homedir(), ".config", "cockpit"),
 });
 
-// Non-blocking config-drift banner. Fires only when the running package
-// version differs from the version stamped in config.json (i.e. just after
-// an update or on a legacy unstamped config). Detect + print only — never
-// mutates config and never throws; the CLI must stay usable regardless.
-try {
-  const cfgPath = join(homedir(), ".config", "cockpit", "config.json");
-  if (existsSync(cfgPath)) {
-    const cfg = JSON.parse(readFileSync(cfgPath, "utf-8"));
-    if (needsCheck(cfg, pkg.version)) {
-      const items = detectDrift(cfg, getDefaultConfig());
-      if (items.length === 0) {
-        writeFileSync(cfgPath, JSON.stringify(withStamp(cfg, pkg.version), null, 2) + "\n");
-      } else {
-        const from = cfg._cockpitVersion ?? "an earlier version";
-        process.stderr.write(
-          `\n\u26A1 cockpit updated ${from} \u2192 ${pkg.version} \u2014 ${items.length} config change(s) detected.\n` +
-          `   Run \`cockpit config check\` (or use the config-doctor skill) to reconcile.\n\n`,
-        );
+// Non-blocking config-drift banner. Suppressed during "cockpit config" —
+// the config command already surfaces drift, making the banner redundant.
+// Detect + print only — never mutates config and never throws.
+if (process.argv[2] !== "config") {
+  try {
+    const cfgPath = join(homedir(), ".config", "cockpit", "config.json");
+    if (existsSync(cfgPath)) {
+      const cfg = JSON.parse(readFileSync(cfgPath, "utf-8"));
+      if (needsCheck(cfg, pkg.version)) {
+        const items = detectDrift(cfg, getDefaultConfig());
+        if (items.length === 0) {
+          writeFileSync(cfgPath, JSON.stringify(withStamp(cfg, pkg.version), null, 2) + "\n");
+        } else {
+          const from = cfg._cockpitVersion ?? "an earlier version";
+          process.stderr.write(
+            `\n\u26A1 cockpit updated ${from} \u2192 ${pkg.version} \u2014 ${items.length} config change(s) detected.\n` +
+            `   Run \`cockpit config check\` (or use the config-doctor skill) to reconcile.\n\n`,
+          );
+        }
       }
     }
+  } catch {
+    // Drift banner is best-effort; never block the CLI.
   }
-} catch {
-  // Drift banner is best-effort; never block the CLI.
 }
 
 // Self-heal the control-plane daemon the same way we self-heal the runtime:


### PR DESCRIPTION
## Problem

The config-drift ⚡ banner prints on **every** CLI invocation, including `cockpit config check` itself. When drift exists the user sees the banner AND the report (double-print). The banner also says "Run \`cockpit config check\`" — confusing when that is already running.

## Root Cause

`src/index.ts:49-68` — the drift-banner try-block runs before commander parses argv, so every subcommand triggers it.

## Fix

Wrap the banner block in `if (process.argv[2] !== "config")`. Surgical — one guard condition, only `src/index.ts` changed.

## Guard behaviour

| Command | Drift banner fires? | Reason |
|---|---|---|
| `cockpit config check` | ❌ Suppressed | Config command already surfaces drift |
| `cockpit config fix` | ❌ Suppressed | Config command already surfaces drift |
| `cockpit doctor` | ✅ Yes | No other drift surface |
| `cockpit crew spawn ...` | ✅ Yes | No other drift surface |
| `cockpit` (no args) | ✅ Yes | `undefined !== "config"` → true |

## Verification

- [x] Build passes (`npm run build`)
- [x] All 868 tests green (`npm test`)
- [x] Only `src/index.ts` changed per `git diff`