### PR TITLE
feat(relay): cockpit relay logs — live terminal output via unix-socket broadcaster (#244)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (3602 symbols, 5968 relationships, 88 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (3945 symbols, 6454 relationships, 107 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/src/commands/__tests__/relay.test.ts
+++ b/src/commands/__tests__/relay.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi } from "vitest";
-import { buildRelaySuperviseArgs } from "../relay.js";
+import { createServer } from "node:net";
+import { existsSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildRelaySuperviseArgs, readRelayLogs } from "../relay.js";
+
+function cleanSock(path: string) {
+  if (existsSync(path)) try { unlinkSync(path); } catch { /* ignore */ }
+}
 
 describe("relay supervise", () => {
   it("buildRelaySuperviseArgs returns correct runNotifyRelay opts for a project", () => {
@@ -54,5 +62,104 @@ describe("relay supervise", () => {
         stateRoot: "/tmp/state",
       }),
     ).toThrow(/unknown project/);
+  });
+});
+
+describe("readRelayLogs", () => {
+  it("streams lines from live socket to stdout", async () => {
+    const sockPath = join(tmpdir(), "test-rl-stream.sock");
+    cleanSock(sockPath);
+    const received: string[] = [];
+    const fakeStdout = { write: (s: string) => { received.push(s); return true; } };
+    const fakeStderr = { write: (_s: string) => true };
+
+    const server = createServer((conn) => {
+      conn.write("line1\nline2\n");
+      conn.end();
+    });
+    await new Promise<void>((res) => server.listen(sockPath, res));
+
+    await readRelayLogs({
+      sockPath,
+      follow: false,
+      stdout: fakeStdout as any,
+      stderr: fakeStderr as any,
+      sleep: () => Promise.resolve(),
+    });
+
+    expect(received.join("")).toContain("line1");
+    expect(received.join("")).toContain("line2");
+    await new Promise<void>((res, rej) => server.close((e) => (e ? rej(e) : res())));
+  });
+
+  it("ENOENT: writes friendly 'no live relay' error, does not throw", async () => {
+    const sockPath = join(tmpdir(), "test-rl-noent.sock");
+    const errors: string[] = [];
+    const fakeStdout = { write: (_s: string) => true };
+    const fakeStderr = { write: (s: string) => { errors.push(s); return true; } };
+
+    await readRelayLogs({
+      sockPath,
+      follow: false,
+      stdout: fakeStdout as any,
+      stderr: fakeStderr as any,
+      sleep: () => Promise.resolve(),
+    });
+
+    expect(errors.join("")).toMatch(/no live relay/i);
+    expect(errors.join("")).not.toContain("ENOENT");
+  });
+
+  it("ECONNREFUSED: same friendly error as ENOENT", async () => {
+    const sockPath = join(tmpdir(), "test-rl-econnrefused.sock");
+    cleanSock(sockPath);
+    const server = createServer(() => {});
+    await new Promise<void>((res) => server.listen(sockPath, res));
+    await new Promise<void>((res, rej) => server.close((e) => (e ? rej(e) : res())));
+
+    const errors: string[] = [];
+    const fakeStdout = { write: (_s: string) => true };
+    const fakeStderr = { write: (s: string) => { errors.push(s); return true; } };
+
+    await readRelayLogs({
+      sockPath,
+      follow: false,
+      stdout: fakeStdout as any,
+      stderr: fakeStderr as any,
+      sleep: () => Promise.resolve(),
+    });
+
+    expect(errors.join("")).toMatch(/no live relay/i);
+  });
+
+  it("follow: retries until socket appears, then streams", async () => {
+    const sockPath = join(tmpdir(), "test-rl-follow.sock");
+    cleanSock(sockPath);
+    const received: string[] = [];
+    const fakeStdout = { write: (s: string) => { received.push(s); return true; } };
+    const fakeStderr = { write: (_s: string) => true };
+
+    let attempt = 0;
+    let server: ReturnType<typeof createServer> | undefined;
+
+    const sleep = async (_ms: number) => {
+      attempt++;
+      if (attempt === 2) {
+        server = createServer((conn) => { conn.write("appeared\n"); conn.end(); });
+        await new Promise<void>((res) => server!.listen(sockPath, res));
+      }
+    };
+
+    await readRelayLogs({
+      sockPath,
+      follow: true,
+      stdout: fakeStdout as any,
+      stderr: fakeStderr as any,
+      sleep,
+      shouldContinue: () => attempt < 4,
+    });
+
+    expect(received.join("")).toContain("appeared");
+    if (server) await new Promise<void>((res, rej) => server!.close((e) => (e ? rej(e) : res())));
   });
 });

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -1,9 +1,14 @@
 import { Command } from "commander";
+import { createConnection } from "node:net";
 import chalk from "chalk";
 import { loadConfig, type CockpitConfig } from "../config.js";
 import { createCmuxDriver, RuntimeRegistry } from "../runtimes/index.js";
 import { runNotifyRelay, DEFAULT_STATE_ROOT } from "./notify-relay.js";
 import { runRelaySupervisor } from "../control/relay-supervisor-loop.js";
+import {
+  createRelayLogBroadcaster,
+  relayLogSockPath,
+} from "../control/relay-log-broadcaster.js";
 import type { RuntimeDriver } from "../runtimes/types.js";
 
 export interface RelaySuperviseArgs {
@@ -30,6 +35,67 @@ export function buildRelaySuperviseArgs(opts: RelaySuperviseArgs): {
   };
 }
 
+const NO_RELAY_CODES = new Set(["ENOENT", "ECONNREFUSED", "ENOTSOCK"]);
+
+async function connectAndStream(
+  sockPath: string,
+  stdout: NodeJS.WritableStream,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const conn = createConnection(sockPath);
+    let settled = false;
+    conn.on("error", (e) => {
+      if (!settled) {
+        settled = true;
+        reject(e);
+      }
+    });
+    conn.on("data", (chunk: Buffer | string) => {
+      stdout.write(chunk as string);
+    });
+    // Ensure full close after server half-closes (conn.end() on server side).
+    conn.on("end", () => { conn.destroy(); });
+    conn.on("close", () => {
+      if (!settled) {
+        settled = true;
+        resolve();
+      }
+    });
+  });
+}
+
+export async function readRelayLogs(opts: {
+  sockPath: string;
+  follow: boolean;
+  stdout: NodeJS.WritableStream;
+  stderr: NodeJS.WritableStream;
+  sleep: (ms: number) => Promise<void>;
+  shouldContinue?: () => boolean;
+}): Promise<void> {
+  const { sockPath, follow, stdout, stderr, sleep } = opts;
+  const shouldContinue = opts.shouldContinue ?? (() => true);
+  const project = sockPath.match(/relay-(.+)\.sock$/)?.[1] ?? sockPath;
+
+  while (shouldContinue()) {
+    try {
+      await connectAndStream(sockPath, stdout);
+      if (!follow) return;
+    } catch (e: unknown) {
+      const code = (e as NodeJS.ErrnoException)?.code;
+      if (code && NO_RELAY_CODES.has(code)) {
+        if (!follow) {
+          stderr.write(`no live relay for '${project}' — start the captain first\n`);
+          return;
+        }
+        // follow: fall through to sleep + retry
+      } else {
+        throw e;
+      }
+    }
+    await sleep(2000);
+  }
+}
+
 export const relayCommand = new Command("relay")
   .description("Manage the notify-relay supervisor for a project captain")
   .addCommand(
@@ -54,6 +120,14 @@ export const relayCommand = new Command("relay")
           const registry = new RuntimeRegistry({ cmux: createCmuxDriver() });
           const runtime = registry.forProject(project, config);
 
+          const broadcaster = await createRelayLogBroadcaster(project);
+
+          const teeLog = (prefix: string) => (m: string) => {
+            const line = `${prefix} ${m}`;
+            process.stdout.write(line + "\n");
+            broadcaster.log(line);
+          };
+
           const stop = await runRelaySupervisor({
             delayMs: 3000,
             bootRelay: async () => {
@@ -64,17 +138,17 @@ export const relayCommand = new Command("relay")
                 runtime: runtime as unknown as RuntimeDriver,
                 captainName: relayArgs.captainName,
                 pollMs: 1000,
+                log: teeLog(`[notify-relay ${project}]`),
               });
               return innerStop;
             },
             sleep: (ms: number) => new Promise((r) => setTimeout(r, ms)),
-            log: (m: string) =>
-              process.stdout.write(`[relay supervise ${project}] ${m}\n`),
+            log: teeLog(`[relay supervise ${project}]`),
           });
 
           process.on("SIGTERM", () => {
             if (stop) stop();
-            process.exit(0);
+            broadcaster.close().finally(() => process.exit(0));
           });
 
           // Process stays alive on the relay's setInterval handles.
@@ -84,5 +158,31 @@ export const relayCommand = new Command("relay")
           console.error(chalk.red(`relay supervise: ${(err as Error).message}`));
           process.exit(1);
         }
+      }),
+  )
+  .addCommand(
+    new Command("logs")
+      .description(
+        "Stream live relay log output to this terminal. " +
+          "Connects to the running relay's log socket; exit with Ctrl+C.",
+      )
+      .argument("<project>", "Project to stream relay logs for")
+      .option("-f, --follow", "auto-reconnect if the relay restarts")
+      .action(async (project: string, opts: { follow?: boolean }) => {
+        const sockPath = relayLogSockPath(project);
+        let hadError = false;
+        await readRelayLogs({
+          sockPath,
+          follow: opts.follow ?? false,
+          stdout: process.stdout,
+          stderr: {
+            write: (s: string) => {
+              hadError = true;
+              return process.stderr.write(s);
+            },
+          } as unknown as NodeJS.WritableStream,
+          sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+        });
+        if (hadError) process.exit(1);
       }),
   );

--- a/src/control/__tests__/relay-log-broadcaster.test.ts
+++ b/src/control/__tests__/relay-log-broadcaster.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { createConnection } from "node:net";
+import { existsSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { createRelayLogBroadcaster, relayLogSockPath } from "../relay-log-broadcaster.js";
+
+const DIR = tmpdir();
+
+describe("relayLogSockPath", () => {
+  it("returns <dir>/relay-<project>.sock", () => {
+    expect(relayLogSockPath("myproj", "/d")).toBe("/d/relay-myproj.sock");
+  });
+});
+
+describe("createRelayLogBroadcaster", () => {
+  it("log() with no clients does not throw", async () => {
+    const b = await createRelayLogBroadcaster("rlb-t1", DIR);
+    expect(() => b.log("hello")).not.toThrow();
+    await b.close();
+  });
+
+  it("log() delivers line to connected client", async () => {
+    const b = await createRelayLogBroadcaster("rlb-t2", DIR);
+    const received: string[] = [];
+    const client = createConnection(b.sockPath);
+    await new Promise<void>((res) => client.on("connect", res));
+    client.setEncoding("utf-8");
+    client.on("data", (d: string) => received.push(d));
+
+    b.log("hello relay");
+    await new Promise((r) => setTimeout(r, 40));
+
+    expect(received.join("")).toContain("hello relay\n");
+    client.destroy();
+    await b.close();
+  });
+
+  it("log() after client disconnects does not throw", async () => {
+    const b = await createRelayLogBroadcaster("rlb-t3", DIR);
+    const client = createConnection(b.sockPath);
+    await new Promise<void>((res) => client.on("connect", res));
+    client.destroy();
+    await new Promise((r) => setTimeout(r, 40));
+
+    expect(() => b.log("after gone")).not.toThrow();
+    await b.close();
+  });
+
+  it("close() removes the socket file", async () => {
+    const b = await createRelayLogBroadcaster("rlb-t4", DIR);
+    expect(existsSync(b.sockPath)).toBe(true);
+    await b.close();
+    expect(existsSync(b.sockPath)).toBe(false);
+  });
+
+  it("boot succeeds when stale socket file exists (simulates prior kill -9)", async () => {
+    const path = relayLogSockPath("rlb-t5", DIR);
+    writeFileSync(path, "stale-data");
+
+    const b = await createRelayLogBroadcaster("rlb-t5", DIR);
+    expect(existsSync(b.sockPath)).toBe(true);
+    await b.close();
+  });
+});

--- a/src/control/relay-log-broadcaster.ts
+++ b/src/control/relay-log-broadcaster.ts
@@ -1,0 +1,79 @@
+import { createServer, type Socket, type Server } from "node:net";
+import { existsSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const DEFAULT_SOCK_DIR = join(homedir(), ".config", "cockpit");
+
+export function relayLogSockPath(project: string, sockDir?: string): string {
+  return join(sockDir ?? DEFAULT_SOCK_DIR, `relay-${project}.sock`);
+}
+
+export async function createRelayLogBroadcaster(
+  project: string,
+  sockDir?: string,
+): Promise<{
+  log(m: string): void;
+  close(): Promise<void>;
+  sockPath: string;
+}> {
+  const sockPath = relayLogSockPath(project, sockDir);
+  const clients = new Set<Socket>();
+
+  // Remove stale socket file before listening (handles prior kill -9 leaving behind a dead socket).
+  if (existsSync(sockPath)) {
+    try {
+      unlinkSync(sockPath);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  const server: Server = createServer((conn) => {
+    clients.add(conn);
+    conn.on("error", () => clients.delete(conn));
+    conn.on("close", () => clients.delete(conn));
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(sockPath, () => {
+      server.removeListener("error", reject);
+      resolve();
+    });
+  });
+
+  function log(m: string): void {
+    const line = m.endsWith("\n") ? m : m + "\n";
+    for (const client of clients) {
+      try {
+        client.write(line);
+      } catch {
+        clients.delete(client);
+      }
+    }
+  }
+
+  function close(): Promise<void> {
+    for (const client of clients) {
+      try {
+        client.destroy();
+      } catch {
+        /* ignore */
+      }
+    }
+    clients.clear();
+    return new Promise<void>((resolve) => {
+      server.close(() => {
+        try {
+          if (existsSync(sockPath)) unlinkSync(sockPath);
+        } catch {
+          /* ignore */
+        }
+        resolve();
+      });
+    });
+  }
+
+  return { log, close, sockPath };
+}


### PR DESCRIPTION
## Summary

- Closes #244 — adds `cockpit relay logs <project> [--follow]` for on-demand live visibility into the captain-owned relay process (follow-up to #240).
- **No persistent logfile** — lines are broadcast to connected socket readers only; dropped when nobody is watching.
- **Zero change to relay core** — `notify-relay.ts` is untouched; the broadcaster is wired in via the existing `opts.log` injection point in `relay supervise`.

## Mechanism

The relay supervisor creates a `net.Server` at `~/.config/cockpit/relay-<project>.sock` on boot (stale file from prior `kill -9` is unlinked first). The relay's `log` function tees each line to `process.stdout` (harness file, unchanged) **and** all connected socket clients. When the relay stops, `close()` destroys clients, closes the server, and unlinks the socket file.

`cockpit relay logs <project>` connects to the socket and streams to the terminal.  
`cockpit relay logs <project> --follow` auto-reconnects (2s backoff) after relay restarts.

## Files changed

| File | Change |
|------|--------|
| `src/control/relay-log-broadcaster.ts` | New — `createRelayLogBroadcaster()` + `relayLogSockPath()` |
| `src/commands/relay.ts` | `readRelayLogs()` exported fn, broadcaster wired into `supervise`, `logs` subcommand added |
| `src/control/__tests__/relay-log-broadcaster.test.ts` | New — 6 tests (boot, deliver, disconnect, close, stale-socket) |
| `src/commands/__tests__/relay.test.ts` | 4 new `readRelayLogs` tests (stream, ENOENT, ECONNREFUSED, follow-reconnect) |

## Test plan

- [x] `createRelayLogBroadcaster`: log with no clients, log to client, log after disconnect, close removes file, stale socket → boot still succeeds
- [x] `readRelayLogs`: streams live output, ENOENT → friendly message, ECONNREFUSED → same message, `--follow` retries until socket appears
- [x] 893/893 tests passing, `tsc --noEmit` clean