### PR TITLE
feat(relay): log deliver line on successful relay delivery (#244)

### DIFF
--- a/src/commands/__tests__/notify-relay.test.ts
+++ b/src/commands/__tests__/notify-relay.test.ts
@@ -171,6 +171,28 @@ describe("notify-relay file-tailer", () => {
     expect(cursor?.lastAckedSeq).toBe(3);
   });
 
+  it("logs a deliver line on successful delivery", async () => {
+    const stateRoot = freshState();
+    await append(stateRoot, "CREW DONE [claude/deadbeef]: shipped");
+    const sendSpy = vi.fn().mockResolvedValue(undefined);
+    const logSpy = vi.fn();
+    const stop = await runNotifyRelay({
+      project: "demo",
+      subscriber: "captain",
+      stateRoot,
+      runtime: fakeRuntime(sendSpy) as never,
+      captainName: "captain",
+      pollMs: 50,
+      log: logSpy,
+    });
+    await new Promise((r) => setTimeout(r, 200));
+    stop();
+    const lines = logSpy.mock.calls.map((c) => c[0] as string);
+    expect(lines).toContainEqual(
+      expect.stringMatching(/deliver seq=1 -> captain: CREW DONE \[claude\/deadbeef\]: shipped/),
+    );
+  });
+
   it("silently acks entries older than STALE_THRESHOLD_MS without forwarding to captain", async () => {
     const stateRoot = freshState();
     await append(stateRoot, "CREW DONE [claude/deadbeef]: stale");

--- a/src/commands/notify-relay.ts
+++ b/src/commands/notify-relay.ts
@@ -256,6 +256,7 @@ export async function runNotifyRelay(opts: RunOpts): Promise<() => void> {
             // Don't advance cursor; the next poll will retry from the same seq.
             return;
           }
+          log(`deliver seq=${entry.seq} -> ${opts.subscriber}: ${msg}`);
         }
         await writeCursor({
           stateRoot: opts.stateRoot,


### PR DESCRIPTION
## What

Adds a one-line **success** log on the relay's `drain()` happy path so that `cockpit relay logs` (shipped in #244) shows crew signals *flowing through* — not just failures.

Before this, `drain()` only logged on failure (`sendToSurface failed seq=...`). A healthy relay delivering events was silent in the relay log, making it look idle even while working.

## Change (surgical)

`src/commands/notify-relay.ts` — one line added inside the existing `if (msg)` success branch, after `sendToSurface` succeeds:

```ts
log(`deliver seq=${entry.seq} -> ${opts.subscriber}: ${msg}`);
```

Mirrors the style/vars of the adjacent failure log. The failure log is unchanged. The line only fires for actually-delivered messages — null/empty entries (debounced idle, etc.) still skip it, since the log lives inside `if (msg)`.

No sensitive data added: `msg` is the exact text already delivered to the captain pane.

## Test (TDD)

`src/commands/__tests__/notify-relay.test.ts` — new test `logs a deliver line on successful delivery` written **first** (watched it fail with `received []`), then implemented. Asserts the injected `log` spy receives `deliver seq=1 -> captain: CREW DONE [...]` on a successful send.

## Evidence

- New test: RED (`expected [] to deep equally contain`) → GREEN after the one-line change.
- Full notify-relay file: **8/8 passing**, deliver lines confirmed in output for done/blocked/failed/real messages; null/whitespace entries correctly NOT logged.
- Full suite: **894 passed (87 files)**.
- `tsc --noEmit`: clean (exit 0).
- `gitnexus impact` on `runNotifyRelay`: **LOW** (1 caller, same file).
- `gitnexus detect_changes`: only `runNotifyRelay`/`drain` touched — no scope creep.

## Scope

Touches **only** the two files: `src/commands/notify-relay.ts` and its test. Branched off `develop`. Not merged.

Follow-up to #244.
