### PR TITLE
fix(liveness): derive captain liveness from relay heartbeat (#239 Phase A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Hard crew task-timeout.** The daemon sweep now detects non-terminal tasks that exceed a per-task wall-clock ceiling (default 8h, configurable via `defaults.taskTimeoutMs`). When the ceiling is crossed the daemon fires a detect-only `CREW TIMEOUT` escalation to the captain via the existing mailbox → notify-relay pipe — the same path `CREW STALLED` / `CREW DONE` ride. No state change or kill (detection-first, per #77). Distinct from the heartbeat/stall budget, which only measures heartbeat freshness; a continuously-heartbeating crew stuck on one task for hours is now caught. Closes #225. (#225)
 
+### Fixed
+
+- **Running captains no longer show 'gone'.** Captain liveness now derives from the relay heartbeat the daemon can see over the socket, instead of a cmux read the launchd daemon is always denied. Relay beating → captain alive; heartbeat gone → captain gone; no relay registered → unknown (no false alarm). (#239 Phase A)
+
 ## [0.5.3] - 2026-06-06
 
 A reliability and config-hygiene release. Adds a service-health layer and config-drift detection, and hardens the daemon against false crew-cancellation and hung cmux subprocesses.

--- a/src/control/__tests__/cockpitd-relay-health.test.ts
+++ b/src/control/__tests__/cockpitd-relay-health.test.ts
@@ -1,9 +1,8 @@
 // src/control/__tests__/cockpitd-relay-health.test.ts
 //
 // End-to-end through the real socket: relay-register/heartbeat routing and the
-// #77 health verb assembly (with an injected captainProbe — no cmux). Covers the
-// #207 "captain SILENTLY blind" case: a live captain with NO relay → relay gone
-// + actionable.
+// #77 health verb assembly. Captain liveness is derived from relay heartbeat
+// (#239 Phase A) — no cmux probe injection needed.
 import { describe, it, expect, afterEach } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -20,40 +19,41 @@ describe("cockpitd relay-health socket (#207/#77)", () => {
   let dir: string;
   afterEach(() => { stop?.(); if (dir) rmSync(dir, { recursive: true, force: true }); });
 
-  function boot(captainPresent: boolean | null) {
+  function boot() {
     dir = mkdtempSync(join(tmpdir(), "cp-crh-"));
     const sock = join(dir, "c.sock");
     const handle = startCockpitd({
       stateRoot: join(dir, "state"),
       sockPath: sock,
       sweepMs: 0,
-      captainProbe: async () => captainPresent,
     });
     stop = handle.stop;
     return sock;
   }
 
-  it("relay-register → health shows the relay alive with its pid", async () => {
-    const sock = boot(true);
+  it("relay-register → health shows the relay alive with its pid, captain alive", async () => {
+    const sock = boot();
     const ok: any = await sendRequest(sock, { kind: "relay-register", project: "p", pid: 4242, startedAt: 1 });
     expect(ok).toEqual({ ok: true });
     const cs: ComponentHealth[] = await sendRequest(sock, { kind: "health", project: "p" }) as any;
     const relay = find(cs, "relay")!;
     expect(relay.state).toBe("alive");
     expect(relay.detail).toContain("4242");
+    // captain liveness from relay heartbeat (#239): relay alive → captain alive
     expect(find(cs, "captain")!.state).toBe("alive");
   });
 
-  it("live captain but NO relay registered → relay GONE with actionable (never silently blind)", async () => {
-    const sock = boot(true);
+  it("no relay registered → relay unknown, captain unknown (#239 Phase A: no cmux probe)", async () => {
+    // Without captainPresent signal (cmux-denied from launchd), relay-null is
+    // "unknown" — we cannot distinguish "relay dead" from "nothing running".
+    const sock = boot();
     const cs: ComponentHealth[] = await sendRequest(sock, { kind: "health", project: "p" }) as any;
-    const relay = find(cs, "relay")!;
-    expect(relay.state).toBe("gone");
-    expect(relay.detail).toContain("cockpit launch p");
+    expect(find(cs, "relay")!.state).toBe("unknown");
+    expect(find(cs, "captain")!.state).toBe("unknown");
   });
 
   it("relay-heartbeat keeps the relay registered/alive", async () => {
-    const sock = boot(null);
+    const sock = boot();
     await sendRequest(sock, { kind: "relay-register", project: "p", pid: 7, startedAt: 1 });
     const ok: any = await sendRequest(sock, { kind: "relay-heartbeat", project: "p", pid: 7 });
     expect(ok).toEqual({ ok: true });

--- a/src/control/__tests__/liveness.test.ts
+++ b/src/control/__tests__/liveness.test.ts
@@ -54,7 +54,6 @@ describe("projectHealth (pure projection)", () => {
   const base = {
     project: "p",
     captainName: "p-captain",
-    captainPresent: true as boolean | null,
     commandPresent: null as boolean | null,
     crews: [],
   };
@@ -75,25 +74,37 @@ describe("projectHealth (pure projection)", () => {
     expect(r.detail).toContain("cockpit launch p");
   });
 
-  it("no relay registered but captain live → relay gone (a live captain SHOULD have a relay)", () => {
-    const cs = projectHealth({ ...base, now: 10_000, relay: null, captainPresent: true });
-    expect(find(cs, "relay")!.state).toBe("gone");
-  });
-
-  it("no relay registered and captain absent → relay unknown (nothing should be running)", () => {
-    const cs = projectHealth({ ...base, now: 10_000, relay: null, captainPresent: false });
+  it("no relay registered → relay unknown (no cmux probe available from daemon; #239)", () => {
+    // Without captainPresent (cmux-denied from launchd), we can't distinguish
+    // "captain alive but relay dead" from "nothing running" → unknown, not gone.
+    const cs = projectHealth({ ...base, now: 10_000, relay: null });
     expect(find(cs, "relay")!.state).toBe("unknown");
-  });
-
-  it("captain presence maps directly (no timestamp): true→alive, false→gone, null→unknown", () => {
-    expect(find(projectHealth({ ...base, now: 1, relay: null, captainPresent: true }), "captain")!.state).toBe("alive");
-    expect(find(projectHealth({ ...base, now: 1, relay: null, captainPresent: false }), "captain")!.state).toBe("gone");
-    expect(find(projectHealth({ ...base, now: 1, relay: null, captainPresent: null }), "captain")!.state).toBe("unknown");
   });
 
   it("command omitted (commandPresent null) → no command row (command is on-demand)", () => {
     const cs = projectHealth({ ...base, now: 1, relay: null, commandPresent: null });
     expect(find(cs, "command")).toBeUndefined();
+  });
+
+  // ── captain liveness from relay heartbeat (Phase A / #239) ────────────────
+
+  it("relay heartbeat fresh → captain alive", () => {
+    const now = 1_000 + RELAY_STALE_MS; // exactly at stale boundary = alive
+    const cs = projectHealth({ ...base, now, relay: relay({ lastSeenMs: 1_000 }) });
+    const c = find(cs, "captain")!;
+    expect(c.state).toBe("alive");
+    expect(c.lastSeenMs).toBe(1_000); // relay timestamp surfaces as captain's last-seen
+  });
+
+  it("relay heartbeat gone → captain gone (relay-presence IS the captain signal)", () => {
+    const now = 1_000 + RELAY_GONE_MS + 1; // relay past gone window
+    const cs = projectHealth({ ...base, now, relay: relay({ lastSeenMs: 1_000 }) });
+    expect(find(cs, "captain")!.state).toBe("gone");
+  });
+
+  it("no relay registered → captain unknown (no signal, no alarm)", () => {
+    const cs = projectHealth({ ...base, now: 10_000, relay: null });
+    expect(find(cs, "captain")!.state).toBe("unknown");
   });
 
   it("emits one crew row per non-terminal crew, skipping terminal ones", () => {

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -13,7 +13,7 @@ import { OpencodeSseBridge } from "./opencode/sse-bridge.js";
 import { makeGate } from "./codex/gate.js";
 import { appendToMailbox, rotateIfNeeded } from "./mailbox.js";
 import { createSurfaceLivenessProbe } from "./crew-pane-reader.js";
-import { createRelayHealer, createCaptainProbe } from "./relay-healer.js";
+import { createRelayHealer } from "./relay-healer.js";
 import { projectHealth, type ComponentHealth } from "./liveness.js";
 import { loadConfig } from "../config.js";
 import { readdir } from "node:fs/promises";
@@ -63,9 +63,6 @@ export interface CockpitdOpts {
   /** #207 best-effort relay healer. Defaults to a real cmux spawnInjector
    *  re-spawn (mostly inert under launchd). Tests inject a fake/spy. */
   healRelay?: (project: string) => Promise<void> | void;
-  /** #77 captain-presence probe for the health verb. Defaults to a real cmux
-   *  read. Returns true/false/null (null = couldn't determine). Tests inject. */
-  captainProbe?: (project: string, captainName: string) => Promise<boolean | null>;
   /** Inject a fake opencode SSE bridge for tests. Defaults to a real one. */
   opencodeBridge?: {
     start: (o: { taskId: string; port: number }) => void;
@@ -304,11 +301,10 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   });
 
   // #77 service-health surface. Assembles per-component liveness for the health
-  // socket verb: the relay map comes from the daemon, captain presence from a
-  // cmux read (allowed from launchd), crews from the store — all fed into the
-  // pure projectHealth(). Never throws (a flaky cmux read maps to "unknown").
-  const captainProbe = opts.captainProbe ?? createCaptainProbe();
-  async function buildHealth(only?: string): Promise<ComponentHealth[]> {
+  // socket verb: relay map from the daemon, captain liveness from relay heartbeat
+  // (#239 Phase A — cmux probe removed; launchd lineage denies it), crews from
+  // the store — all fed into the pure projectHealth().
+  function buildHealth(only?: string): ComponentHealth[] {
     const config = loadConfig();
     const relays = d.getRelayHealth();
     const now = Date.now();
@@ -324,14 +320,12 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
     for (const project of names) {
       const proj = config.projects[project];
       const captainName = proj?.captainName ?? `${project}-captain`;
-      const captainPresent = await captainProbe(project, captainName);
       out.push(
         ...projectHealth({
           project,
           now,
           captainName,
           relay: relays.find((r) => r.project === project) ?? null,
-          captainPresent,
           commandPresent: null, // command is on-demand; not tracked in this cut
           crews: store.list(project),
         }),
@@ -407,10 +401,9 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
         return { ok: true };
       }
       // #77 service-health surface: per-component liveness for the queried
-      // project (or all). The captain probe (cmux read) is allowed from the
-      // daemon; the heavy lifting is the pure projectHealth().
+      // project (or all). Captain liveness derived from relay heartbeat (#239).
       if (msg.kind === "health") {
-        return await buildHealth(msg.project as string | undefined);
+        return buildHealth(msg.project as string | undefined);
       }
       return d.handle(msg);
     },

--- a/src/control/liveness.ts
+++ b/src/control/liveness.ts
@@ -92,21 +92,25 @@ export interface CrewLiveness {
 /**
  * Pure. Project one project's component health from already-gathered inputs.
  * Emits: a relay row, a captain row, a command row (only when applicable), and
- * one row per non-terminal crew. cmux presence booleans are resolved by the
- * caller (cockpitd reads cmux); null means "could not determine" → unknown.
+ * one row per non-terminal crew.
+ *
+ * Captain liveness (#239 Phase A): derived from relay heartbeat presence, not a
+ * cmux probe. The relay runs inside the captain's process tree (#240) and beats
+ * the daemon every ~10s — relay presence IS captain presence.
+ *   relay alive/stale → captain ALIVE
+ *   relay gone        → captain GONE
+ *   no relay          → captain UNKNOWN (no signal; do not alarm)
  */
 export function projectHealth(input: {
   project: string;
   now: number;
   captainName: string;
   relay: RelayHealth | null;
-  /** true = captain workspace present, false = absent, null = cmux unreadable. */
-  captainPresent: boolean | null;
   /** true/false when a command workspace is expected; null = not applicable. */
   commandPresent: boolean | null;
   crews: CrewLiveness[];
 }): ComponentHealth[] {
-  const { project, now, captainName, relay, captainPresent, commandPresent, crews } = input;
+  const { project, now, captainName, relay, commandPresent, crews } = input;
   const out: ComponentHealth[] = [];
 
   // ── relay ──────────────────────────────────────────────────────────────
@@ -121,28 +125,33 @@ export function projectHealth(input: {
       detail: state === "alive" ? `pid ${relay.pid}` : relayActionable(project),
     });
   } else {
-    // No registration. A LIVE captain should have a relay → its absence is a
-    // down relay (the #207 silent-blind case). No captain → nothing should be
-    // running, so it is genuinely unknown, not an alarm.
-    const state: HealthState = captainPresent ? "gone" : "unknown";
+    // No relay registered. Without the cmux probe (denied from launchd, #239)
+    // we cannot distinguish "captain alive but relay dead" from "nothing
+    // running" — report unknown rather than falsely alarm.
     out.push({
       kind: "relay",
       project,
       ref: "relay",
-      state,
+      state: "unknown",
       lastSeenMs: null,
-      detail: state === "gone" ? relayActionable(project) : undefined,
     });
   }
 
   // ── captain ────────────────────────────────────────────────────────────
+  // Relay heartbeat is the liveness signal (#239 Phase A). relay.lastSeenMs
+  // surfaces as the captain's last-seen timestamp so consumers can show age.
+  const captainState: HealthState = !relay
+    ? "unknown"
+    : classifyHealth(relay.lastSeenMs, now, RELAY_STALE_MS, RELAY_GONE_MS) === "gone"
+      ? "gone"
+      : "alive";
   out.push({
     kind: "captain",
     project,
     ref: captainName,
-    state: presence(captainPresent),
-    lastSeenMs: null,
-    detail: captainPresent === false ? "captain workspace not running" : undefined,
+    state: captainState,
+    lastSeenMs: relay?.lastSeenMs ?? null,
+    detail: captainState === "gone" ? "captain presumed gone — relay heartbeat dark" : undefined,
   });
 
   // ── command (on-demand; only surfaced when applicable) ───────────────────

--- a/src/control/relay-healer.ts
+++ b/src/control/relay-healer.ts
@@ -1,38 +1,12 @@
 // src/control/relay-healer.ts
 //
-// cmux-facing helpers for the #207 relay-health layer, isolated behind the
-// runtime driver (same pattern as crew-pane-reader.ts). Both functions resolve
-// the captain workspace via the runtime and NEVER throw — a flaky cmux probe
-// must not trip the daemon sweep / health verb.
+// cmux-facing helper for the #207 relay-health layer, isolated behind the
+// runtime driver (same pattern as crew-pane-reader.ts). Resolves the captain
+// workspace via the runtime and NEVER throws — a flaky cmux probe must not
+// trip the daemon sweep / health verb.
 import { loadConfig } from "../config.js";
 import { createCmuxDriver, RuntimeRegistry } from "../runtimes/index.js";
 import { buildRelaySupervisorCommand, NOTIFY_RELAY_TAB_TITLE } from "./relay-supervisor.js";
-
-/**
- * Resolve whether a project's captain workspace is currently present.
- *   true  → workspace running
- *   false → enumerated, absent
- *   null  → could not determine (cmux down, no project) — never alarms
- *
- * NOTE: NOT used from the daemon health path. (#239 Phase A) Captain liveness
- * is now derived from relay heartbeat presence in liveness.projectHealth() —
- * the daemon (launchd) is outside cmux's process-lineage and would always get
- * null here anyway. This function is still valid for cmux-resident callers
- * (e.g. the #139 surface-liveness probe).
- */
-export function createCaptainProbe(): (project: string, captainName: string) => Promise<boolean | null> {
-  return async (project, captainName) => {
-    try {
-      const config = loadConfig();
-      if (!config.projects[project]) return null;
-      const runtime = new RuntimeRegistry({ cmux: createCmuxDriver() }).forProject(project, config);
-      const ws = await runtime.status(captainName);
-      return ws != null;
-    } catch {
-      return null;
-    }
-  };
-}
 
 /**
  * Best-effort relay heal (#207, SECONDARY). Re-spawns the notify-relay tab in

--- a/src/control/relay-healer.ts
+++ b/src/control/relay-healer.ts
@@ -13,10 +13,12 @@ import { buildRelaySupervisorCommand, NOTIFY_RELAY_TAB_TITLE } from "./relay-sup
  *   true  → workspace running
  *   false → enumerated, absent
  *   null  → could not determine (cmux down, no project) — never alarms
- * NOTE: cmux lineage enforcement blocks ALL daemon-originated cmux calls
- * (reads included — see #224 revert), so from the launchd daemon this resolves
- * null in prod. It still works from a cmux-resident caller; the #139 surface
- * probe relies on the same primitive.
+ *
+ * NOTE: NOT used from the daemon health path. (#239 Phase A) Captain liveness
+ * is now derived from relay heartbeat presence in liveness.projectHealth() —
+ * the daemon (launchd) is outside cmux's process-lineage and would always get
+ * null here anyway. This function is still valid for cmux-resident callers
+ * (e.g. the #139 surface-liveness probe).
  */
 export function createCaptainProbe(): (project: string, captainName: string) => Promise<boolean | null> {
   return async (project, captainName) => {


### PR DESCRIPTION
## What

Phase A of #239: swap the captain-liveness source from a dead cmux probe to the relay heartbeat the daemon already receives.

## Why

`cockpitd` runs outside the cmux process tree (launchd LaunchAgent), so cmux's lineage check denies **all** daemon-originated cmux calls — reads included (#224 revert). The old `createCaptainProbe()` cmux read therefore always resolved `null` in prod, making running captains show as `gone`/`unknown` in the health verb.

The relay already runs inside the captain's process tree (#240) and heartbeats the daemon every ~10s. **Relay presence is captain presence** — no cmux probe needed.

## How

- Remove `createCaptainProbe()` and its wiring from `cockpitd.ts`; `buildHealth` is now synchronous (no async cmux read).
- `projectHealth()` derives captain state from `relay.lastSeenMs` via the existing `RELAY_STALE_MS`/`RELAY_GONE_MS` thresholds:
  - relay alive/stale → captain **ALIVE**
  - relay gone → captain **GONE**
  - no relay → captain **UNKNOWN** (no signal; don't false-alarm)
- No-relay branch now reports `unknown` instead of inferring `gone` from the (now-absent) captain probe.

## Test

- `liveness.test.ts` (15) + `cockpitd-relay-health.test.ts` (3) updated and green.
- Full suite unaffected (pure projection + removed async path).

## Follow-up

Phase B (relay-as-cmux-proxy for the daemon's other cmux ops) tracked separately in #239; #249 reframed as the driver-agnostic generalization for non-cmux drivers.