### PR TITLE
feat(heal): cockpit heal <component> — targeted remediation surface (#234)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`cockpit heal <component>` — targeted remediation surface.** Three subcommands close the detect → notify → remediate loop for remote/unattended operation. `heal status [--project P] [--json]` (dry-run: prints unhealthy components and the exact fix command; `--json` is machine-readable for skill/Telegram bridges; exit 0=healthy, 1=error, 2=unhealthy). `heal relay <project>` (re-establishes the notify-relay via the existing `spawnInjector` primitive; idempotent — no-op on alive/stale relay so it never competes with the captain's `#240`-owned supervisor). `heal daemon` (restarts cockpitd via the idempotent launchd kickstart path). `cockpit heal crew <id>` is explicitly deferred (overlaps #100). Closes #234. (#234)
+
 - **Hard crew task-timeout.** The daemon sweep now detects non-terminal tasks that exceed a per-task wall-clock ceiling (default 8h, configurable via `defaults.taskTimeoutMs`). When the ceiling is crossed the daemon fires a detect-only `CREW TIMEOUT` escalation to the captain via the existing mailbox → notify-relay pipe — the same path `CREW STALLED` / `CREW DONE` ride. No state change or kill (detection-first, per #77). Distinct from the heartbeat/stall budget, which only measures heartbeat freshness; a continuously-heartbeating crew stuck on one task for hours is now caught. Closes #225. (#225)
 
 ### Fixed

--- a/src/commands/__tests__/heal.test.ts
+++ b/src/commands/__tests__/heal.test.ts
@@ -1,0 +1,303 @@
+// src/commands/__tests__/heal.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ComponentHealth } from "../../control/liveness.js";
+
+// ── pure helper (no I/O) ─────────────────────────────────────────────────────
+
+import {
+  buildHealStatus,
+  healCmdFor,
+  type HealStatusResult,
+} from "../heal.js";
+
+// ── fixture helpers ──────────────────────────────────────────────────────────
+
+function makeRelay(state: ComponentHealth["state"], project = "brove"): ComponentHealth {
+  return { kind: "relay", project, ref: "relay", state, lastSeenMs: state === "alive" ? Date.now() : null };
+}
+function makeDaemon(state: ComponentHealth["state"]): ComponentHealth {
+  return { kind: "captain", project: "brove", ref: "brove-captain", state, lastSeenMs: null };
+}
+function makeCrew(state: ComponentHealth["state"]): ComponentHealth {
+  return { kind: "crew", project: "brove", ref: "worker-1", state, lastSeenMs: null };
+}
+
+// ── healCmdFor ───────────────────────────────────────────────────────────────
+
+describe("healCmdFor", () => {
+  it("returns null for alive relay (already healthy)", () => {
+    expect(healCmdFor(makeRelay("alive"))).toBeNull();
+  });
+  it("returns null for stale relay (recent heartbeat — let #240 supervisor handle it)", () => {
+    expect(healCmdFor(makeRelay("stale"))).toBeNull();
+  });
+  it("returns heal relay cmd for gone relay", () => {
+    const cmd = healCmdFor(makeRelay("gone", "brove"));
+    expect(cmd).toBe("cockpit heal relay --project brove");
+  });
+  it("returns heal relay cmd for unknown relay (truly absent)", () => {
+    const cmd = healCmdFor(makeRelay("unknown", "scaffold"));
+    expect(cmd).toBe("cockpit heal relay --project scaffold");
+  });
+  it("returns null for non-relay components (no heal verb for captain/crew/command)", () => {
+    expect(healCmdFor(makeDaemon("gone"))).toBeNull();
+    expect(healCmdFor(makeCrew("gone"))).toBeNull();
+  });
+});
+
+// ── buildHealStatus ──────────────────────────────────────────────────────────
+
+describe("buildHealStatus", () => {
+  it("healthy=true when all components are alive", () => {
+    const components: ComponentHealth[] = [
+      makeRelay("alive", "brove"),
+      makeRelay("alive", "scaffold"),
+    ];
+    const result = buildHealStatus(components);
+    expect(result.healthy).toBe(true);
+    expect(result.components.every((c) => c.healCmd === null)).toBe(true);
+  });
+
+  it("healthy=false when any relay is gone", () => {
+    const components: ComponentHealth[] = [
+      makeRelay("gone", "brove"),
+      makeRelay("alive", "scaffold"),
+    ];
+    const result = buildHealStatus(components);
+    expect(result.healthy).toBe(false);
+    const down = result.components.find((c) => c.project === "brove" && c.kind === "relay");
+    expect(down?.healCmd).toBe("cockpit heal relay --project brove");
+  });
+
+  it("healthy=false when relay is unknown", () => {
+    const result = buildHealStatus([makeRelay("unknown", "brove")]);
+    expect(result.healthy).toBe(false);
+    expect(result.components[0].healCmd).toBe("cockpit heal relay --project brove");
+  });
+
+  it("healthy=true when relay is stale (recent heartbeat — #240 supervisor covers it)", () => {
+    const result = buildHealStatus([makeRelay("stale", "brove")]);
+    expect(result.healthy).toBe(true);
+    expect(result.components[0].healCmd).toBeNull();
+  });
+
+  it("returns all component fields in output", () => {
+    const relay = makeRelay("gone", "brove");
+    const result = buildHealStatus([relay]);
+    const out = result.components[0];
+    expect(out.kind).toBe("relay");
+    expect(out.project).toBe("brove");
+    expect(out.ref).toBe("relay");
+    expect(out.state).toBe("gone");
+    expect(typeof out.healCmd === "string" || out.healCmd === null).toBe(true);
+  });
+
+  it("empty component list → healthy=true", () => {
+    const result = buildHealStatus([]);
+    expect(result.healthy).toBe(true);
+  });
+
+  it("daemon-unreachable (null components) → healthy=false", () => {
+    const result = buildHealStatus(null);
+    expect(result.healthy).toBe(false);
+    expect(result.daemonUnreachable).toBe(true);
+  });
+});
+
+// ── integration: runHealStatus (mocked I/O) ──────────────────────────────────
+
+describe("runHealStatus (integration, mocked I/O)", () => {
+  let queryHealthMock: ReturnType<typeof vi.fn>;
+  let stdoutLines: string[];
+  let stderrLines: string[];
+  let exitCode: number | undefined;
+
+  beforeEach(async () => {
+    stdoutLines = [];
+    stderrLines = [];
+    exitCode = undefined;
+    queryHealthMock = vi.fn();
+
+    vi.doMock("../health-view.js", () => ({ queryHealth: queryHealthMock }));
+  });
+
+  it("exits 0 and prints healthy when all alive", async () => {
+    queryHealthMock.mockResolvedValue([makeRelay("alive", "brove")]);
+    const { runHealStatus } = await import("../heal.js");
+    const code = await runHealStatus({
+      project: undefined,
+      json: false,
+      queryHealth: queryHealthMock,
+      stdout: { write: (s: string) => { stdoutLines.push(s); } } as unknown as NodeJS.WritableStream,
+      stderr: { write: (s: string) => { stderrLines.push(s); } } as unknown as NodeJS.WritableStream,
+    });
+    expect(code).toBe(0);
+    const out = stdoutLines.join("");
+    expect(out).toContain("healthy");
+  });
+
+  it("exits 2 when a relay is gone, shows heal command", async () => {
+    queryHealthMock.mockResolvedValue([makeRelay("gone", "brove")]);
+    const { runHealStatus } = await import("../heal.js");
+    const code = await runHealStatus({
+      project: undefined,
+      json: false,
+      queryHealth: queryHealthMock,
+      stdout: { write: (s: string) => { stdoutLines.push(s); } } as unknown as NodeJS.WritableStream,
+      stderr: { write: (s: string) => { stderrLines.push(s); } } as unknown as NodeJS.WritableStream,
+    });
+    expect(code).toBe(2);
+    const out = stdoutLines.join("");
+    expect(out).toContain("cockpit heal relay --project brove");
+  });
+
+  it("--json outputs valid JSON with healthy=false and healCmd", async () => {
+    queryHealthMock.mockResolvedValue([makeRelay("gone", "brove")]);
+    const { runHealStatus } = await import("../heal.js");
+    await runHealStatus({
+      project: undefined,
+      json: true,
+      queryHealth: queryHealthMock,
+      stdout: { write: (s: string) => { stdoutLines.push(s); } } as unknown as NodeJS.WritableStream,
+      stderr: { write: (s: string) => { stderrLines.push(s); } } as unknown as NodeJS.WritableStream,
+    });
+    const parsed = JSON.parse(stdoutLines.join(""));
+    expect(parsed.healthy).toBe(false);
+    const comp = parsed.components.find((c: { kind: string; project: string }) => c.kind === "relay" && c.project === "brove");
+    expect(comp.healCmd).toBe("cockpit heal relay --project brove");
+  });
+
+  it("exits 1 and prints error when daemon unreachable", async () => {
+    queryHealthMock.mockResolvedValue(null);
+    const { runHealStatus } = await import("../heal.js");
+    const code = await runHealStatus({
+      project: undefined,
+      json: false,
+      queryHealth: queryHealthMock,
+      stdout: { write: (s: string) => { stdoutLines.push(s); } } as unknown as NodeJS.WritableStream,
+      stderr: { write: (s: string) => { stderrLines.push(s); } } as unknown as NodeJS.WritableStream,
+    });
+    expect(code).toBe(1);
+    const err = stderrLines.join("");
+    expect(err).toContain("daemon unreachable");
+  });
+});
+
+// ── integration: runHealRelay (mocked I/O) ────────────────────────────────────
+
+describe("runHealRelay (integration, mocked I/O)", () => {
+  it("exits 0 with 'already healthy' when relay is alive (strict idempotency)", async () => {
+    const queryHealth = vi.fn().mockResolvedValue([makeRelay("alive", "brove")]);
+    const healer = vi.fn().mockResolvedValue(undefined);
+    const lines: string[] = [];
+    const { runHealRelay } = await import("../heal.js");
+    const code = await runHealRelay({
+      project: "brove",
+      queryHealth,
+      relayHealer: healer,
+      stdout: { write: (s: string) => { lines.push(s); } } as unknown as NodeJS.WritableStream,
+      stderr: { write: () => false } as unknown as NodeJS.WritableStream,
+    });
+    expect(code).toBe(0);
+    expect(healer).not.toHaveBeenCalled();
+    expect(lines.join("")).toContain("already healthy");
+  });
+
+  it("exits 0 with 'already healthy' when relay is stale (recent heartbeat — #240 supervisor covers it)", async () => {
+    const queryHealth = vi.fn().mockResolvedValue([makeRelay("stale", "brove")]);
+    const healer = vi.fn().mockResolvedValue(undefined);
+    const lines: string[] = [];
+    const { runHealRelay } = await import("../heal.js");
+    const code = await runHealRelay({
+      project: "brove",
+      queryHealth,
+      relayHealer: healer,
+      stdout: { write: (s: string) => { lines.push(s); } } as unknown as NodeJS.WritableStream,
+      stderr: { write: () => false } as unknown as NodeJS.WritableStream,
+    });
+    expect(code).toBe(0);
+    expect(healer).not.toHaveBeenCalled();
+    expect(lines.join("")).toContain("already healthy");
+  });
+
+  it("calls healer and exits 0 when relay is gone", async () => {
+    const queryHealth = vi.fn().mockResolvedValue([makeRelay("gone", "brove")]);
+    const healer = vi.fn().mockResolvedValue(undefined);
+    const lines: string[] = [];
+    const { runHealRelay } = await import("../heal.js");
+    const code = await runHealRelay({
+      project: "brove",
+      queryHealth,
+      relayHealer: healer,
+      stdout: { write: (s: string) => { lines.push(s); } } as unknown as NodeJS.WritableStream,
+      stderr: { write: () => false } as unknown as NodeJS.WritableStream,
+    });
+    expect(code).toBe(0);
+    expect(healer).toHaveBeenCalledWith("brove");
+    expect(lines.join("")).toContain("relay");
+  });
+
+  it("calls healer and exits 0 when relay is unknown (truly absent)", async () => {
+    const queryHealth = vi.fn().mockResolvedValue([makeRelay("unknown", "brove")]);
+    const healer = vi.fn().mockResolvedValue(undefined);
+    const lines: string[] = [];
+    const { runHealRelay } = await import("../heal.js");
+    const code = await runHealRelay({
+      project: "brove",
+      queryHealth,
+      relayHealer: healer,
+      stdout: { write: (s: string) => { lines.push(s); } } as unknown as NodeJS.WritableStream,
+      stderr: { write: () => false } as unknown as NodeJS.WritableStream,
+    });
+    expect(code).toBe(0);
+    expect(healer).toHaveBeenCalledWith("brove");
+  });
+
+  it("exits 1 when daemon unreachable", async () => {
+    const queryHealth = vi.fn().mockResolvedValue(null);
+    const healer = vi.fn();
+    const errLines: string[] = [];
+    const { runHealRelay } = await import("../heal.js");
+    const code = await runHealRelay({
+      project: "brove",
+      queryHealth,
+      relayHealer: healer,
+      stdout: { write: () => false } as unknown as NodeJS.WritableStream,
+      stderr: { write: (s: string) => { errLines.push(s); } } as unknown as NodeJS.WritableStream,
+    });
+    expect(code).toBe(1);
+    expect(healer).not.toHaveBeenCalled();
+    expect(errLines.join("")).toContain("daemon unreachable");
+  });
+});
+
+// ── integration: runHealDaemon (mocked I/O) ───────────────────────────────────
+
+describe("runHealDaemon (integration, mocked I/O)", () => {
+  it("calls ensureDaemon and exits 0", async () => {
+    const ensure = vi.fn();
+    const lines: string[] = [];
+    const { runHealDaemon } = await import("../heal.js");
+    const code = await runHealDaemon({
+      ensureDaemon: ensure,
+      stdout: { write: (s: string) => { lines.push(s); } } as unknown as NodeJS.WritableStream,
+      stderr: { write: () => false } as unknown as NodeJS.WritableStream,
+    });
+    expect(code).toBe(0);
+    expect(ensure).toHaveBeenCalledOnce();
+    expect(lines.join("")).toContain("daemon");
+  });
+
+  it("exits 1 and prints error when ensureDaemon throws", async () => {
+    const ensure = vi.fn().mockImplementation(() => { throw new Error("launchctl failed"); });
+    const errLines: string[] = [];
+    const { runHealDaemon } = await import("../heal.js");
+    const code = await runHealDaemon({
+      ensureDaemon: ensure,
+      stdout: { write: () => false } as unknown as NodeJS.WritableStream,
+      stderr: { write: (s: string) => { errLines.push(s); } } as unknown as NodeJS.WritableStream,
+    });
+    expect(code).toBe(1);
+    expect(errLines.join("")).toContain("launchctl failed");
+  });
+});

--- a/src/commands/heal.ts
+++ b/src/commands/heal.ts
@@ -1,0 +1,249 @@
+// src/commands/heal.ts
+//
+// cockpit heal <component> — targeted, idempotent, machine-readable remediation
+// surface for the detect → notify → remediate loop (#234).
+//
+// Subcommands:
+//   heal status  — dry-run: print unhealthy components + the exact heal command
+//   heal relay   — re-establish the notify-relay (lineage-safe, idempotent)
+//   heal daemon  — restart cockpitd via the existing launchd kickstart path
+//
+// DEFERRED: heal crew <id> — re-attach a stuck crew task (overlaps #100, more
+// complex; explicitly out of MVP scope).
+import { Command } from "commander";
+import chalk from "chalk";
+import { queryHealth } from "./health-view.js";
+import { createRelayHealer } from "../control/relay-healer.js";
+import { ensureDaemon as _ensureDaemon } from "../control/launchd.js";
+import type { ComponentHealth, HealthState } from "../control/liveness.js";
+
+// ── pure helpers (fully unit-testable, no I/O) ────────────────────────────────
+
+export interface HealComponent {
+  kind: ComponentHealth["kind"];
+  project: string;
+  ref: string;
+  state: HealthState;
+  healCmd: string | null;
+}
+
+export interface HealStatusResult {
+  healthy: boolean;
+  daemonUnreachable?: boolean;
+  components: HealComponent[];
+}
+
+/**
+ * Pure. Return the heal command string for a component that needs remediation,
+ * or null when no action is needed (or when no heal verb exists for this kind).
+ *
+ * Relay idempotency rule (#240): the captain-owned 'relay supervise' process
+ * is the PRIMARY relay lifecycle manager. 'cockpit heal relay' is the MANUAL
+ * fallback for when NO supervised relay is running (captain wedged/dead). To
+ * avoid competing with a partially-degraded but still-supervised relay, we
+ * only spawn on 'gone' or 'unknown' — never on 'alive' or 'stale'.
+ */
+export function healCmdFor(c: ComponentHealth): string | null {
+  if (c.kind === "relay" && (c.state === "gone" || c.state === "unknown")) {
+    return `cockpit heal relay --project ${c.project}`;
+  }
+  return null;
+}
+
+/**
+ * Pure. Assemble the HealStatusResult from a raw liveness snapshot.
+ * null input = daemon unreachable.
+ */
+export function buildHealStatus(components: ComponentHealth[] | null): HealStatusResult {
+  if (components === null) {
+    return { healthy: false, daemonUnreachable: true, components: [] };
+  }
+  const out: HealComponent[] = components.map((c) => ({
+    kind: c.kind,
+    project: c.project,
+    ref: c.ref,
+    state: c.state,
+    healCmd: healCmdFor(c),
+  }));
+  const healthy = out.every((c) => c.healCmd === null);
+  return { healthy, components: out };
+}
+
+// ── injectable runners (used by Commander actions + tests) ────────────────────
+
+export interface HealStatusOpts {
+  project: string | undefined;
+  json: boolean;
+  queryHealth: typeof queryHealth;
+  stdout: NodeJS.WritableStream;
+  stderr: NodeJS.WritableStream;
+}
+
+/** Returns exit code: 0=all healthy, 1=error/daemon-unreachable, 2=unhealthy */
+export async function runHealStatus(opts: HealStatusOpts): Promise<number> {
+  const { project, json, stdout, stderr } = opts;
+  let rows: ComponentHealth[] | null;
+  try {
+    rows = await opts.queryHealth(project);
+  } catch (e) {
+    stderr.write(`heal status: ${(e as Error).message}\n`);
+    return 1;
+  }
+
+  const result = buildHealStatus(rows);
+
+  if (result.daemonUnreachable) {
+    if (json) {
+      stdout.write(JSON.stringify({ healthy: false, daemonUnreachable: true, components: [] }) + "\n");
+    } else {
+      stderr.write("daemon unreachable — start the daemon first (cockpit heal daemon)\n");
+    }
+    return 1;
+  }
+
+  if (json) {
+    stdout.write(JSON.stringify(result) + "\n");
+    return result.healthy ? 0 : 2;
+  }
+
+  if (result.healthy) {
+    stdout.write(chalk.green("✔ all components healthy\n"));
+    return 0;
+  }
+
+  stdout.write(chalk.bold("Unhealthy components:\n\n"));
+  for (const c of result.components) {
+    if (c.healCmd) {
+      stdout.write(`  ${chalk.red("✘")} ${c.kind.padEnd(8)} ${c.ref.padEnd(16)} ${chalk.red(c.state.padEnd(8))} ${c.project}\n`);
+      stdout.write(`      heal: ${chalk.cyan(c.healCmd)}\n`);
+    }
+  }
+  return 2;
+}
+
+export interface HealRelayOpts {
+  project: string;
+  queryHealth: typeof queryHealth;
+  relayHealer: (project: string) => Promise<void>;
+  stdout: NodeJS.WritableStream;
+  stderr: NodeJS.WritableStream;
+}
+
+/** Returns exit code: 0=success/already-healthy, 1=error */
+export async function runHealRelay(opts: HealRelayOpts): Promise<number> {
+  const { project, stdout, stderr } = opts;
+  let rows: ComponentHealth[] | null;
+  try {
+    rows = await opts.queryHealth(project);
+  } catch (e) {
+    stderr.write(`heal relay: ${(e as Error).message}\n`);
+    return 1;
+  }
+
+  if (rows === null) {
+    stderr.write("daemon unreachable — start the daemon first (cockpit heal daemon)\n");
+    return 1;
+  }
+
+  const relay = rows.find((c) => c.kind === "relay" && c.project === project);
+  const state = relay?.state ?? "unknown";
+
+  // Strict idempotency: 'alive' or 'stale' means a heartbeat was recently
+  // received, so the #240-supervised relay is functioning or recovering.
+  // Do not compete with the captain's supervisor in that window.
+  if (state === "alive" || state === "stale") {
+    stdout.write(chalk.green(`✔ relay for '${project}' already healthy (${state}) — no action taken\n`));
+    return 0;
+  }
+
+  // 'gone' or 'unknown': no supervised relay is running; spawn manually.
+  stdout.write(`relay for '${project}' is ${state} — re-establishing...\n`);
+  try {
+    await opts.relayHealer(project);
+    stdout.write(chalk.green(`✔ relay re-establish attempted for '${project}'\n`));
+    // TODO(#240): if the captain's harness-wake fires in this same window, a
+    // second relay could briefly start (two relays draining the mailbox →
+    // duplicate deliveries). Acceptable in MVP; revisit when #240 adds a relay
+    // presence check before waking.
+    return 0;
+  } catch (e) {
+    stderr.write(`heal relay failed: ${(e as Error).message}\n`);
+    return 1;
+  }
+}
+
+export interface HealDaemonOpts {
+  ensureDaemon: () => void;
+  stdout: NodeJS.WritableStream;
+  stderr: NodeJS.WritableStream;
+}
+
+/** Returns exit code: 0=success, 1=error */
+export async function runHealDaemon(opts: HealDaemonOpts): Promise<number> {
+  const { stdout, stderr } = opts;
+  stdout.write("restarting cockpitd via launchd kickstart...\n");
+  try {
+    opts.ensureDaemon();
+    stdout.write(chalk.green("✔ daemon kickstart complete\n"));
+    return 0;
+  } catch (e) {
+    stderr.write(`heal daemon failed: ${(e as Error).message}\n`);
+    return 1;
+  }
+}
+
+// ── Commander command tree ────────────────────────────────────────────────────
+
+export const healCommand = new Command("heal")
+  .description("Targeted, idempotent remediation for cockpit components (relay, daemon)")
+  .addHelpText("after", "\nDeferred: 'cockpit heal crew <id>' (re-attach) — see issue #100.")
+  .addCommand(
+    new Command("status")
+      .description("Dry-run: print unhealthy components and the exact heal command for each")
+      .option("-p, --project <project>", "scope to one project")
+      .option("--json", "output machine-readable JSON (exit 0=healthy, 1=error, 2=unhealthy)")
+      .action(async (opts: { project?: string; json?: boolean }) => {
+        const code = await runHealStatus({
+          project: opts.project,
+          json: opts.json ?? false,
+          queryHealth,
+          stdout: process.stdout,
+          stderr: process.stderr,
+        });
+        process.exit(code);
+      }),
+  )
+  .addCommand(
+    new Command("relay")
+      .description(
+        "Re-establish the notify-relay for a project (lineage-safe, idempotent).\n" +
+        "No-op when relay is alive or stale — the #240 captain-owned supervisor is the primary path;\n" +
+        "this is the manual fallback for when no supervised relay is running.",
+      )
+      .argument("<project>", "project to re-establish the relay for")
+      .option("-p, --project <project>", "alias for the positional project argument")
+      .action(async (positional: string, opts: { project?: string }) => {
+        const project = opts.project ?? positional;
+        const healer = createRelayHealer((m) => process.stdout.write(m + "\n"));
+        const code = await runHealRelay({
+          project,
+          queryHealth,
+          relayHealer: healer,
+          stdout: process.stdout,
+          stderr: process.stderr,
+        });
+        process.exit(code);
+      }),
+  )
+  .addCommand(
+    new Command("daemon")
+      .description("Restart cockpitd via the idempotent launchd kickstart path")
+      .action(async () => {
+        const code = await runHealDaemon({
+          ensureDaemon: _ensureDaemon,
+          stdout: process.stdout,
+          stderr: process.stderr,
+        });
+        process.exit(code);
+      }),
+  );

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { relayCommand } from "./commands/relay.js";
 import { projectionCommand } from "./commands/projection.js";
 import { codexChatSmokeCommand } from "./commands/codex-chat-smoke.js";
 import { configCommand } from "./commands/config.js";
+import { healCommand } from "./commands/heal.js";
 import { detectDrift } from "./lib/config-drift.js";
 import { needsCheck, withStamp } from "./lib/config-version.js";
 import { getDefaultConfig } from "./config.js";
@@ -106,6 +107,7 @@ program.addCommand(relayCommand);
 program.addCommand(projectionCommand);
 program.addCommand(codexChatSmokeCommand);
 program.addCommand(configCommand);
+program.addCommand(healCommand);
 
 program.parseAsync().catch((e) => {
   process.stderr.write(`error: ${e instanceof Error ? e.message : String(e)}\n`);


### PR DESCRIPTION
Closes #234.

Adds `cockpit heal <component>` — a targeted, idempotent, machine-readable remediation surface that closes the detect → notify → **remediate** loop (the liveness layer from #239 Phase A / #207 detects; this acts).

## Subcommands
- **`heal status`** — dry-run. Prints unhealthy components and the *exact* heal command for each. `--json` emits machine-readable output (exit `0`=healthy, `1`=error/daemon-unreachable, `2`=unhealthy) so skills and remote callers can branch on it.
- **`heal relay [<project>]`** — re-establishes the notify-relay via the lineage-safe `spawnInjector` path. **Idempotent**: no-ops when the relay is `alive` or `stale`, so it never competes with the #240 captain-owned relay supervisor. Only spawns on `gone`/`unknown` (no supervised relay running — captain wedged/dead).
- **`heal daemon`** — restarts `cockpitd` via the existing idempotent `ensureDaemon` launchd kickstart.

`heal crew <id>` is intentionally **deferred** (overlaps #100, more complex) — TODO left in code and in `heal --help`.

## Design notes
- Pure helpers (`healCmdFor`, `buildHealStatus`) are I/O-free and fully unit-tested; the runners take injected deps for the same reason.
- Relay idempotency is strict by design — see the inline rationale referencing #240. One known MVP race (captain harness-wake spawning a second relay in the same window) is documented with a TODO, acceptable for MVP.

## Tests
23 new tests in `heal.test.ts`, all green. Full `tsc` build clean.