### PR TITLE
fix(daemon): root-fix #225 timeout flood — terminalize on timeout + shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`cockpit shutdown` now terminalizes crew task records before closing workspaces.** Previously, closing a captain workspace left all its crew task records non-terminal in the daemon store (ghost records). On daemon restart the `#225` timeout sweep fired against every ghost simultaneously, flooding the captain with `CREW TIMEOUT` notifications. `cockpit shutdown [project]` now sends `task.cancelled` (reason: `captain shutdown`) for every non-terminal crew task before closing the workspace — the same terminalization `cockpit crew close` already performed. Daemon errors during terminalization are swallowed so a down daemon never blocks the workspace close. Closes ghost-source root cause of the `#225` timeout flood. (#225)
+
+- **Crew task-timeout now terminalizes the record (persistent dedup, flood-proof across restarts).** The prior `#225` implementation used an in-memory `firedTimeout` Set that reset on daemon restart, re-firing every `CREW TIMEOUT` notification for all still-non-terminal tasks on every restart. The Set is removed; when a task exceeds the wall-clock ceiling the sweep now transitions it to `cancelled` (`lastEvent: "sweep.task-timeout"`) via `store.put` **before** firing the notification. The terminal state is the persistent dedup: `TERMINAL_STATES.has(r.state)` at the top of the sweep loop gates every future pass, including passes from a freshly-restarted daemon instance. The timeout message continues to report the task's **original** state (e.g. `state: awaiting-input`), not `cancelled`. Reverses the detect-only decision from `#77`; detect-only + volatile dedup was the flood bug. (#225)
+
 - **Running captains no longer show 'gone'.** Captain liveness now derives from the relay heartbeat the daemon can see over the socket, instead of a cmux read the launchd daemon is always denied. Relay beating → captain alive; heartbeat gone → captain gone; no relay registered → unknown (no false alarm). (#239 Phase A)
 
 ## [0.5.3] - 2026-06-06

--- a/src/commands/__tests__/shutdown.test.ts
+++ b/src/commands/__tests__/shutdown.test.ts
@@ -1,0 +1,80 @@
+// src/commands/__tests__/shutdown.test.ts
+// #225 root-fix Fix A: shutdown terminalization of non-terminal crew tasks.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const cockpitdCall = vi.hoisted(() => vi.fn());
+vi.mock("../crew-control.js", () => ({ cockpitdCall }));
+
+const loadConfig = vi.hoisted(() => vi.fn());
+vi.mock("../../config.js", () => ({ loadConfig, resolveHome: (p: string) => p }));
+
+const stopMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const listMock = vi.hoisted(() => vi.fn());
+vi.mock("../../runtimes/index.js", () => ({
+  createCmuxDriver: () => ({}),
+  RuntimeRegistry: class {
+    forProject() { return { list: listMock, stop: stopMock }; }
+    global() { return { list: listMock, stop: stopMock }; }
+  },
+}));
+
+import { shutdownCommand } from "../shutdown.js";
+
+describe("shutdown: crew task terminalization on captain close (#225 Fix A)", () => {
+  beforeEach(() => {
+    cockpitdCall.mockReset();
+    listMock.mockReset();
+    stopMock.mockReset();
+    stopMock.mockResolvedValue(undefined);
+  });
+
+  it("sends task.cancelled for each non-terminal crew task, skips already-terminal", async () => {
+    loadConfig.mockReturnValue({
+      projects: {
+        brove: { captainName: "⚓ brove", path: "/p/brove" },
+      },
+      commandName: "command",
+    });
+    // Captain workspace exists
+    listMock.mockResolvedValue([{ id: "ws1", name: "⚓ brove" }]);
+    // Daemon returns one working + one already-cancelled task
+    cockpitdCall
+      .mockResolvedValueOnce([
+        { id: "t1", state: "working" },
+        { id: "t2", state: "cancelled" },
+      ])
+      .mockResolvedValue({});
+
+    await shutdownCommand.parseAsync(["node", "shutdown", "brove"]);
+
+    expect(cockpitdCall).toHaveBeenCalledWith({ kind: "list", project: "brove" });
+    expect(cockpitdCall).toHaveBeenCalledWith({
+      kind: "event", project: "brove",
+      event: { type: "task.cancelled", id: "t1", reason: "captain shutdown" },
+    });
+    // t2 is already cancelled — must NOT send a second task.cancelled
+    const cancelEvents = cockpitdCall.mock.calls.filter(
+      (args) => args[0]?.kind === "event" && args[0]?.event?.type === "task.cancelled",
+    );
+    expect(cancelEvents).toHaveLength(1);
+  });
+
+  it("daemon errors during terminalization do not prevent workspace close (try/catch)", async () => {
+    loadConfig.mockReturnValue({
+      projects: {
+        brove: { captainName: "⚓ brove", path: "/p/brove" },
+      },
+      commandName: "command",
+    });
+    listMock.mockResolvedValue([{ id: "ws1", name: "⚓ brove" }]);
+    // Daemon is unreachable
+    cockpitdCall.mockRejectedValue(new Error("daemon down"));
+
+    // Must not throw — cmux close still proceeds
+    await expect(
+      shutdownCommand.parseAsync(["node", "shutdown", "brove"]),
+    ).resolves.not.toThrow();
+    // Workspace was still closed despite daemon error
+    expect(stopMock).toHaveBeenCalledWith("ws1");
+  });
+});

--- a/src/commands/shutdown.ts
+++ b/src/commands/shutdown.ts
@@ -3,6 +3,9 @@ import chalk from "chalk";
 import { loadConfig } from "../config.js";
 import { createCmuxDriver, RuntimeRegistry } from "../runtimes/index.js";
 import type { RuntimeDriver } from "../runtimes/index.js";
+import { cockpitdCall } from "./crew-control.js";
+import type { TaskRecord } from "../control/types.js";
+import { TERMINAL_STATES } from "../control/types.js";
 
 // Captain workspaces gained the leading "⚓ " prefix partway through cockpit's
 // life. Workspaces created before that convention persist with the un-prefixed
@@ -70,6 +73,18 @@ export const shutdownCommand = new Command("shutdown")
           `\nShutting down ${cockpitWorkspaces.length} workspace(s)...\n`,
         ),
       );
+      // Terminalize all non-terminal crew tasks across every project before
+      // closing workspaces — prevents ghost records from flooding on restart.
+      for (const proj of Object.keys(config.projects)) {
+        try {
+          const tasks = (await cockpitdCall({ kind: "list", project: proj })) as TaskRecord[];
+          for (const task of tasks) {
+            if (!TERMINAL_STATES.has(task.state)) {
+              await cockpitdCall({ kind: "event", project: proj, event: { type: "task.cancelled", id: task.id, reason: "captain shutdown" } });
+            }
+          }
+        } catch { /* best-effort — daemon miss must not block workspace close */ }
+      }
       for (const ws of cockpitWorkspaces) {
         try {
           await globalRuntime.stop(ws.id);
@@ -96,6 +111,17 @@ export const shutdownCommand = new Command("shutdown")
     console.log(
       chalk.bold(`\nShutting down captain workspace for '${project}'...\n`),
     );
+
+    // Terminalize non-terminal crew tasks for this project before closing the
+    // captain workspace — prevents ghost records from flooding on restart (#225).
+    try {
+      const tasks = (await cockpitdCall({ kind: "list", project })) as TaskRecord[];
+      for (const task of tasks) {
+        if (!TERMINAL_STATES.has(task.state)) {
+          await cockpitdCall({ kind: "event", project, event: { type: "task.cancelled", id: task.id, reason: "captain shutdown" } });
+        }
+      }
+    } catch { /* best-effort — daemon miss must not block workspace close */ }
 
     const { failed } = await closeMatching(
       runtime,

--- a/src/control/__tests__/daemon.test.ts
+++ b/src/control/__tests__/daemon.test.ts
@@ -632,4 +632,60 @@ describe("sweep: task-timeout (#225)", () => {
     const d = createDaemon({ store, now: () => 2000, taskTimeoutMs: 1_000 });
     await expect(d.sweep()).resolves.toBeUndefined();
   });
+
+  // ── #225 root-fix: terminate-on-timeout (Fix C) ──────────────────────────────
+
+  it("timeout terminates task record (state=cancelled, lastEvent=sweep.task-timeout)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    store.put(rec("t225h", {
+      state: "working", createdAt: 0,
+      lastHeartbeat: 1990, heartbeatBudgetMs: 86_400_000,
+    }));
+    const d = createDaemon({ store, now: () => 2000, taskTimeoutMs: 1_000, notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].message).toMatch(/CREW TIMEOUT/);
+    const r = store.get("p", "t225h");
+    expect(r?.state).toBe("cancelled");
+    expect(r?.lastEvent).toBe("sweep.task-timeout");
+  });
+
+  it("timeout message shows original state, not 'cancelled' (Fix C note 1)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    store.put(rec("t225i", {
+      state: "awaiting-input", createdAt: 0,
+      lastHeartbeat: 1990, heartbeatBudgetMs: 86_400_000,
+    }));
+    const d = createDaemon({ store, now: () => 2000, taskTimeoutMs: 1_000, notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    expect(calls[0].message).toContain("awaiting-input");
+    expect(calls[0].message).not.toContain("state: cancelled");
+  });
+
+  it("flood proof: fresh daemon over same store never re-fires (Fix C persistent dedup)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    const notify = async (a: any) => { calls.push(a); };
+    store.put(rec("t225j", {
+      state: "working", createdAt: 0,
+      lastHeartbeat: 1990, heartbeatBudgetMs: 86_400_000,
+    }));
+
+    const d1 = createDaemon({ store, now: () => 2000, taskTimeoutMs: 1_000, notify });
+    await d1.sweep();
+    const timeoutCalls = () => calls.filter((c) => c.message.includes("CREW TIMEOUT")).length;
+    expect(timeoutCalls()).toBe(1);
+
+    // Second sweep on same daemon: task is terminal, no re-fire
+    await d1.sweep();
+    expect(timeoutCalls()).toBe(1);
+
+    // Fresh daemon, same store, empty in-memory state — this is the flood scenario.
+    // Terminal state in the store is the persistent dedup: must still be exactly 1.
+    const d2 = createDaemon({ store, now: () => 2000, taskTimeoutMs: 1_000, notify });
+    await d2.sweep();
+    expect(timeoutCalls()).toBe(1);
+  });
 });

--- a/src/control/daemon.ts
+++ b/src/control/daemon.ts
@@ -182,9 +182,6 @@ export function createDaemon(deps: DaemonDeps) {
   // per episode, not every 30s sweep. Re-armed (deleted) when a fresh heartbeat
   // proves the relay recovered.
   const lastHealAttempt = new Map<string, number>();
-  // #225: task IDs that have already received a CREW TIMEOUT escalation.
-  // Deduplicates across sweeps — a task gets at most one timeout push.
-  const firedTimeout = new Set<string>();
   return {
     /** #207: a notify-relay announced itself (boot). */
     registerRelay(r: { project: string; pid: number; startedAt: number }): void {
@@ -300,24 +297,30 @@ export function createDaemon(deps: DaemonDeps) {
       const t = now();
       const surfaceAlive = deps.isSurfaceAlive ?? (async () => "unknown" as const);
       for (const r of store.listAll()) {
-        // #225 task timeout: detect non-terminal tasks that have exceeded the
-        // wall-clock ceiling. Fires at most once per task (firedTimeout dedup).
-        // Does NOT change state (detect-first, per #77).
-        if (!TERMINAL_STATES.has(r.state) && !firedTimeout.has(r.id) && deps.notify) {
+        // #225 root-fix: terminate non-terminal tasks that exceeded the wall-clock
+        // ceiling. Terminalization is the persistent dedup — a daemon restart sees
+        // the cancelled record and the TERMINAL_STATES gate above blocks re-fire.
+        // The volatile firedTimeout Set is removed; terminal state replaces it.
+        if (!TERMINAL_STATES.has(r.state)) {
           const ceiling = deps.taskTimeoutMs ?? DEFAULT_TASK_TIMEOUT_MS;
           if (t - r.createdAt > ceiling) {
-            firedTimeout.add(r.id);
+            const prevState = r.state; // capture BEFORE terminalization (shown in message)
             const tag = `[${r.provider}/${r.name != null ? r.name : shortId(r.id)}]`;
             const hrs = Math.round(ceiling / 3_600_000);
-            const msg = `CREW TIMEOUT ${tag}: wall-clock exceeded ${hrs}h (id: ${r.id}, state: ${r.state})`;
+            const msg = `CREW TIMEOUT ${tag}: wall-clock exceeded ${hrs}h (id: ${r.id}, state: ${prevState})`;
             const synthEvent: ControlEvent = { type: "task.timeout", id: r.id, taskTimeoutMs: ceiling };
-            try {
-              const p = deps.notify({ project: r.project, message: msg, record: r, event: synthEvent });
-              if (p && typeof (p as Promise<void>).catch === "function") {
-                (p as Promise<void>).catch(() => {});
+            // Terminalize first — persisted to store so any future daemon instance
+            // sees a terminal record and skips it (flood-proof across restarts).
+            store.put({ ...r, state: "cancelled", lastEvent: "sweep.task-timeout" });
+            if (deps.notify) {
+              try {
+                const p = deps.notify({ project: r.project, message: msg, record: r, event: synthEvent });
+                if (p && typeof (p as Promise<void>).catch === "function") {
+                  (p as Promise<void>).catch(() => {});
+                }
+              } catch {
+                // swallowed — a flaky notifier must never trip the sweep
               }
-            } catch {
-              // swallowed — a flaky notifier must never trip the sweep
             }
           }
         }


### PR DESCRIPTION
Root-fixes the #225 timeout flood. **A**: shutdown/close terminalizes crew task records (stops ghost creation). **C**: timeout terminalizes the task on fire (persisted as cancelled+lastEvent=sweep.task-timeout), replacing the volatile in-memory dedup — each ghost fires exactly once and a daemon restart can never re-flood. Reuses 'cancelled' (silent), preserves original state in the message, record-only (no tab kill). Flood-proof test: fresh daemon over same store never re-fires. 52 tests.