### PR TITLE
feat(control): socket-boundary schema validation (#87)

### DIFF
--- a/src/control/__tests__/daemon.test.ts
+++ b/src/control/__tests__/daemon.test.ts
@@ -689,3 +689,36 @@ describe("sweep: task-timeout (#225)", () => {
     expect(timeoutCalls()).toBe(1);
   });
 });
+
+// ── Issue #87: socket-boundary schema validation ──────────────────────────────
+
+describe("daemon handle() socket-boundary validation (#87)", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "cp-val-")); });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("handle() rejects completely unknown request kind with a clear structured error", async () => {
+    const store = createStore(dir);
+    const d = createDaemon({ store, now: () => 1000 });
+    await expect(
+      d.handle({ kind: "UNKNOWN_KIND_INJECTED_BY_ROGUE_CLIENT" } as any),
+    ).rejects.toThrow(/unknown.*kind|unhandled.*kind/i);
+  });
+
+  it("handle() rejects unknown event type with a clear validation error — NOT a store corruption (#87)", async () => {
+    const store = createStore(dir);
+    const task = rec("t-validate", { state: "working" });
+    store.put(task);
+    const d = createDaemon({ store, now: () => 2000 });
+    await expect(
+      d.handle({
+        kind: "event",
+        project: "p",
+        event: { type: "future.unknown.event.from.wire", id: "t-validate" } as any,
+      }),
+    ).rejects.toThrow(/unknown.*event.*type|event.*type.*unknown/i);
+    // The store record must be UNCHANGED — no corruption from reduce() returning undefined.
+    expect(store.get("p", "t-validate")?.state).toBe("working");
+  });
+});
+

--- a/src/control/__tests__/protocol-socket.test.ts
+++ b/src/control/__tests__/protocol-socket.test.ts
@@ -287,3 +287,63 @@ describe("keepalive framing (#94)", () => {
     expect(cleared).toContain(42);
   });
 });
+
+// ── Issue #87: malformed / newline-less input fast error ─────────────────────
+
+describe("socket input validation (#87)", () => {
+  let cleanup: (() => void) | undefined;
+  afterEach(() => { cleanup?.(); cleanup = undefined; });
+
+  it("server replies with structured error when client sends valid JSON without a trailing newline", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "cp-nonl-"));
+    const sock = join(dir, "nonl.sock");
+    const server = startServer(sock, async () => "should-not-reach");
+    cleanup = () => { server.close(); rmSync(dir, { recursive: true, force: true }); };
+
+    const reply = await new Promise<any>((resolve, reject) => {
+      const conn = createConnection(sock);
+      conn.setEncoding("utf-8");
+      let buf = "";
+      conn.on("connect", () => {
+        // Write valid JSON with NO trailing newline, then half-close the write side.
+        conn.write('{"kind":"status","project":"p","id":"x"}');
+        conn.end();
+      });
+      conn.on("data", (chunk: string) => { buf += chunk; });
+      conn.on("close", () => {
+        try { resolve(JSON.parse(buf.split("\n")[0]!)); } catch { reject(new Error(`no parseable reply: ${buf}`)); }
+      });
+      conn.on("error", reject);
+    });
+
+    expect(reply.ok).toBe(false);
+    expect(reply.error).toMatch(/newline/i);
+    expect(reply._v).toBe(PROTOCOL_VERSION);
+  });
+
+  it("server replies with structured error when client sends invalid JSON (malformed)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "cp-badj-"));
+    const sock = join(dir, "badj.sock");
+    const server = startServer(sock, async () => "should-not-reach");
+    cleanup = () => { server.close(); rmSync(dir, { recursive: true, force: true }); };
+
+    const reply = await new Promise<any>((resolve, reject) => {
+      const conn = createConnection(sock);
+      conn.setEncoding("utf-8");
+      let buf = "";
+      conn.on("connect", () => {
+        conn.write("not-valid-json-at-all\n");
+      });
+      conn.on("data", (chunk: string) => {
+        buf += chunk;
+        if (buf.includes("\n")) { conn.destroy(); resolve(JSON.parse(buf.split("\n")[0]!)); }
+      });
+      setTimeout(() => reject(new Error("timeout — no reply received")), 1000);
+      conn.on("error", reject);
+    });
+
+    expect(reply.ok).toBe(false);
+    expect(reply.error).toMatch(/malformed|invalid.*json/i);
+    expect(reply._v).toBe(PROTOCOL_VERSION);
+  });
+});

--- a/src/control/__tests__/protocol.test.ts
+++ b/src/control/__tests__/protocol.test.ts
@@ -22,4 +22,22 @@ describe("framing", () => {
     const dec = createDecoder();
     expect(dec.push('{"type":"_keepalive"}\n{"ok":true}\n')).toEqual([{ ok: true }]);
   });
+
+  // ── Issue #87: remainder() exposes unprocessed buffer content ────────────
+  it("decoder remainder() returns buffered bytes not yet terminated with a newline (#87)", () => {
+    const dec = createDecoder();
+    dec.push('{"partial":true}'); // no newline — stays buffered
+    expect(dec.remainder()).toBe('{"partial":true}');
+  });
+
+  it("decoder remainder() returns empty string when buffer is empty", () => {
+    const dec = createDecoder();
+    expect(dec.remainder()).toBe("");
+  });
+
+  it("decoder remainder() returns empty string after a complete newline-terminated message is consumed", () => {
+    const dec = createDecoder();
+    dec.push('{"ok":true}\n');
+    expect(dec.remainder()).toBe("");
+  });
 });

--- a/src/control/__tests__/state-machine.test.ts
+++ b/src/control/__tests__/state-machine.test.ts
@@ -245,6 +245,14 @@ describe("state-machine reduce", () => {
     const next = reduce(done, { type: "task.session.ended", id: "t1" }, 8003);
     expect(next).toBe(done);
   });
+
+  // ── Issue #87: exhaustive reduce — never return undefined ──────────────────
+  it("unknown/future event type is a no-op — returns the original record, never undefined (#87)", () => {
+    const r = rec({ state: "working" });
+    const next = reduce(r, { type: "future.unknown.event.type" } as any, 5000);
+    expect(next).toBe(r);          // same reference — unchanged record
+    expect(next).not.toBeUndefined(); // the accidental store.put(undefined) path must be closed
+  });
 });
 
 describe("DispatchAttempt schema", () => {

--- a/src/control/daemon.ts
+++ b/src/control/daemon.ts
@@ -168,6 +168,19 @@ type Req =
   | { kind: "reply"; project: string; id: string; message: string }
   | { kind: "gate-resolve"; project: string; gateId: string; resolvedBy: string; payload: unknown };
 
+// #87: exhaustive set of known ControlEvent types for socket-boundary validation.
+// Any event.type arriving from the wire that is not in this set is rejected with
+// a clean structured error before it can reach reduce() or the store.
+const KNOWN_EVENT_TYPES: ReadonlySet<string> = new Set([
+  "task.started", "task.progress", "heartbeat",
+  "task.blocked", "task.done", "task.failed",
+  "task.session", "task.turn.started", "task.turn.completed",
+  "task.delta", "task.input.requested", "task.approval.requested",
+  "task.reattached", "task.reopened",
+  "task.stalled", "task.idle", "task.timeout", "task.reconcile-failed",
+  "task.cancelled", "task.session.ended",
+]);
+
 export function createDaemon(deps: DaemonDeps) {
   const { store, now } = deps;
   // #210: per-task timestamp of the captain's most recent turn (a `crew send`/
@@ -237,6 +250,10 @@ export function createDaemon(deps: DaemonDeps) {
           return failed;
         }
         case "event": {
+          // #87: validate event.type at the socket boundary before touching state.
+          if (!KNOWN_EVENT_TYPES.has((req.event as any).type)) {
+            throw new Error(`unknown event type '${(req.event as any).type}' — not a valid ControlEvent`);
+          }
           const cur = store.get(req.project, req.event.id);
           if (!cur) throw new Error(`unknown task ${req.event.id}`);
           // A captain turn (crew send/reply) arrives as task.started → record it

--- a/src/control/protocol.ts
+++ b/src/control/protocol.ts
@@ -11,7 +11,7 @@ export function encodeMsg(obj: unknown): string {
   return JSON.stringify(obj) + "\n";
 }
 
-export function createDecoder() {
+export function createDecoder(onParseError?: (line: string) => void) {
   let buf = "";
   return {
     push(chunk: string): unknown[] {
@@ -27,9 +27,19 @@ export function createDecoder() {
           // Silently discard keepalive frames (#94) — never surface to any consumer.
           if (typeof parsed === "object" && parsed !== null && (parsed as any).type === "_keepalive") continue;
           out.push(parsed);
-        } catch { /* skip malformed */ }
+        } catch {
+          // #87: notify caller of malformed lines so the server can reply with a
+          // structured error instead of silently dropping the frame.
+          onParseError?.(line);
+        }
       }
       return out;
+    },
+    // #87: exposes the unprocessed buffer content — bytes received but not yet
+    // terminated with a newline. The server checks this on connection end to
+    // detect newline-less input and reply with a fast structured error.
+    remainder(): string {
+      return buf;
     },
   };
 }
@@ -93,10 +103,19 @@ export function startServer(
     try { unlinkSync(sockPath); } catch { /* stale socket */ }
   }
   const server = createServer((conn) => {
-    const dec = createDecoder();
     conn.setEncoding("utf-8");
     let claimType: "none" | "attach" = "none";
     let keepaliveId: ReturnType<typeof setInterval> | undefined;
+
+    // #87: reply with a structured error when a newline-terminated line fails to
+    // parse as JSON, so the client gets a fast error instead of a silent drop.
+    const dec = createDecoder((badLine) => {
+      if (claimType !== "attach") {
+        try {
+          conn.write(encodeMsg({ ok: false, error: `malformed request: invalid JSON`, _v: PROTOCOL_VERSION }));
+        } catch { /* conn already closed */ }
+      }
+    });
 
     conn.on("data", async (chunk: string) => {
       for (const msg of dec.push(chunk)) {
@@ -132,6 +151,16 @@ export function startServer(
       }
     });
     conn.on("error", () => { /* client vanished; ignore */ });
+    // #87: when the client half-closes (done sending) with bytes still in the
+    // decoder buffer, the message had no newline terminator — send a fast error
+    // instead of silently leaving the client to hit the 5s sendRequest timeout.
+    conn.on("end", () => {
+      if (claimType !== "attach" && dec.remainder().trim()) {
+        try {
+          conn.write(encodeMsg({ ok: false, error: `malformed request: missing newline terminator`, _v: PROTOCOL_VERSION }));
+        } catch { /* conn already closed */ }
+      }
+    });
     conn.on("close", () => {
       if (keepaliveId !== undefined) clearIntervalFn(keepaliveId);
       if (claimType === "attach") onAttachClose?.(conn);

--- a/src/control/state-machine.ts
+++ b/src/control/state-machine.ts
@@ -105,5 +105,11 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
       // Synthetic notify-only events; the daemon has already updated state
       // directly via the watchdog/reconcile paths. Reducer is a no-op.
       return rec;
+    default:
+      // #87: unknown/future event type from the wire — safe no-op.
+      // The socket boundary (handle()) validates known types before calling
+      // reduce; this default is a deep-defense fallback so reduce() can
+      // never return undefined regardless of how it is called.
+      return rec;
   }
 }


### PR DESCRIPTION
Closes #87 — the last TG-path prerequisite before #65, built on the #92/#94 envelope+keepalive framing.

## Three problems fixed (all at the socket boundary)

1. **Exhaustive `reduce()`** — added a `default: return rec` case so the reducer can never return `undefined` for an unknown/future event type (was silently falling through; only an accidental `store.put(undefined)` throw prevented state corruption). Deep-defense fallback behind the boundary check.
2. **Schema validation in `daemon.handle()`** — `event.type` is now validated against `KNOWN_EVENT_TYPES` (the full 20-member `ControlEvent` union) before touching state; unknown types throw a clean structured error.
3. **Fast error on malformed input** — `createDecoder` now reports parse failures (`onParseError`) and exposes `remainder()`; the server replies with a structured error on bad JSON **and** on newline-less/half-closed input, instead of letting the client hang the full 5s `sendRequest` timeout. Both paths gated to non-attach connections.

## Verification
- 7 new tests across `protocol.test.ts`, `protocol-socket.test.ts`, `state-machine.test.ts`, `daemon.test.ts`
- `KNOWN_EVENT_TYPES` confirmed exhaustive vs. the `ControlEvent` union in `types.ts` (20/20)
- `tsc --noEmit` clean; full suite 947/947; control subset 112/112 green on the authoritative checkout
- Preserves #92/#94 handshake + keepalive behavior (`_v` envelope retained on error replies)

Surgical: only `protocol.ts` / `daemon.ts` / `state-machine.ts` + their tests touched.
