### PR TITLE
feat(skills): cockpit-register-project and cockpit-new-project (#262)

### DIFF
--- a/plugin/skills/cockpit-new-project/SKILL.md
+++ b/plugin/skills/cockpit-new-project/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: cockpit-new-project
+description: Create a brand-new GitHub repo, clone it, and register it in cockpit. Handles both new workspace (new group) and existing workspace (join existing group).
+---
+
+# Create and Register a New Project
+
+Use when the project does not exist yet — you need to create the GitHub repo, clone it locally, and wire it into cockpit.
+
+## Step 1 — Collect inputs
+
+You need:
+- **Repo name** (kebab-case, e.g. `my-project`)
+- **GitHub org or user** (e.g. `Quantum3-Labs` or your GitHub username)
+- **Visibility** — `public` or `private`
+- **Local parent directory** — where to clone into (e.g. `/Users/you/Q3/MyGroup/`)
+
+## Step 2 — Determine workspace placement
+
+**New workspace** (no existing group):
+- Pick a group name (kebab-case). This project will be `primary` automatically.
+- No `--group-role` needed.
+
+**Existing workspace** (joining an existing group):
+- Run `cockpit projects list` to see current groups.
+- Pick the group to join and specify a role for this project (e.g. `"landing page"`, `"mobile client"`, `"CLI tool"`).
+- The role must NOT be `"primary"` — that slot is already taken.
+
+## Step 3 — Create the GitHub repo and clone
+
+```bash
+gh repo create <org>/<repo-name> --[public|private] --clone --clone-dir <parent-dir>
+```
+
+This creates the repo on GitHub and clones it into `<parent-dir>/<repo-name>`.
+
+## Step 4 — Optional: initial scaffold
+
+If the repo should start with a README and first commit:
+```bash
+cd <parent-dir>/<repo-name>
+echo "# <repo-name>" > README.md
+git add README.md
+git commit -m "chore: initial commit"
+git push
+```
+
+Skip if the repo already has content or the user wants to scaffold separately.
+
+## Step 5 — Register in cockpit
+
+```bash
+cockpit projects add <repo-name> <parent-dir>/<repo-name> \
+  --captain "⚓ <repo-name>-captain" \
+  [--group <group-name>] \
+  [--group-role "<role description>"]
+```
+
+Omit `--group` and `--group-role` for a standalone project with no group.
+
+## Step 6 — Verify
+
+```bash
+cockpit projects list
+```
+
+Confirm the new entry appears with the correct path, group, and role.

--- a/plugin/skills/cockpit-register-project/SKILL.md
+++ b/plugin/skills/cockpit-register-project/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: cockpit-register-project
+description: Register an existing local repo (or GitHub URL) into cockpit config. Use when a project already exists and just needs to be wired into cockpit.
+---
+
+# Register an Existing Project
+
+Use when the repo already exists locally or on GitHub and you just need to register it in cockpit.
+
+## Step 1 — Resolve the local path
+
+**Local path given:** use it directly.
+
+**GitHub URL given:** clone first, then use the destination:
+```bash
+gh repo clone <org>/<repo> <dest-path>
+```
+
+## Step 2 — Determine the project name
+
+Default to the directory name:
+```bash
+basename <path>
+```
+
+Override if the directory name is ambiguous (e.g. `src`, `app`).
+
+## Step 3 — Determine group placement
+
+List existing projects and their groups:
+```bash
+cockpit projects list
+```
+
+Then decide:
+
+**New group** — pick a group name (kebab-case). This project will be `primary` automatically (first in group). No `--group-role` needed.
+
+**Existing group** — pick the group name and specify a role that describes this project's purpose (e.g. `"documentation site"`, `"agent task queue"`, `"shared skills library"`). The role must NOT be `"primary"` — that slot is already taken by the first project in the group.
+
+> Note: `--group-role` only auto-sets to `"primary"` when it is the first project registered in a group. All subsequent projects in the same group require an explicit `--group-role`.
+
+## Step 4 — Register
+
+```bash
+cockpit projects add <name> <path> \
+  --captain "⚓ <name>-captain" \
+  [--group <group-name>] \
+  [--group-role "<role description>"]
+```
+
+Omit `--group` and `--group-role` entirely if this is a standalone project with no group.
+
+## Step 5 — Verify
+
+```bash
+cockpit projects list
+```
+
+Confirm the new entry appears with the correct path, group, and role.


### PR DESCRIPTION
## Summary

Closes #262 — adds two agent-usable skills for project management so captains and operators don't need to manually edit `config.json` or know about `cockpit projects add` from memory.

- **`cockpit-register-project`** — wire an existing local repo (or GitHub URL) into cockpit config: resolve path, derive name, pick group placement, run `cockpit projects add`, verify.
- **`cockpit-new-project`** — create a brand-new GitHub repo via `gh repo create`, clone it, then register in cockpit. Handles two paths: new workspace (new group, auto-primary) and existing workspace (join group with explicit non-primary role).

Both skills explicitly call out the `--group-role` auto-primary gotcha: the flag only auto-sets to `"primary"` for the first project in a group — all subsequent projects require an explicit role. This was the silent trap that triggered the issue.

## Test plan

- [ ] Invoke `/cockpit-register-project` in a captain session — steps are clear and commands are copy-pasteable
- [ ] Invoke `/cockpit-new-project` for new workspace path — group auto-primary, no `--group-role` needed
- [ ] Invoke `/cockpit-new-project` for existing workspace path — explicit role required, `cockpit projects list` shown first
- [ ] Verify skills appear in `cockpit projection` output for non-Claude agents