### PR TITLE
fix(daemon): RAM-flood root-causes — crash-loop, test-isolation, orphan cleanup (#259, #260, #261)

### DIFF
--- a/src/control/__tests__/cockpitd-headless.test.ts
+++ b/src/control/__tests__/cockpitd-headless.test.ts
@@ -31,4 +31,24 @@ describe("cockpitd headless wiring", () => {
     const st: any = await sendRequest(sock, { kind: "status", project: "p", id: "h1" });
     expect(st.state).toBe("done");
   });
+
+  it("stop() kills in-flight headless children", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-h-"));
+    const sock = join(dir, "c.sock");
+    const child: any = new EventEmitter();
+    child.stdout = new EventEmitter(); child.stderr = new EventEmitter(); child.pid = 5678;
+    child.kill = vi.fn();
+    const spawn = vi.fn(() => child);
+    const h = startCockpitd({ stateRoot: join(dir, "state"), sockPath: sock, sweepMs: 0, spawn: spawn as any });
+    stop = h.stop;
+    await sendRequest(sock, { kind: "dispatch", record: {
+      id: "h2", project: "p", provider: "claude", mode: "headless",
+      state: "submitted", task: "go", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "dispatch", heartbeatBudgetMs: 10000,
+      attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }] } });
+    await new Promise((r) => setTimeout(r, 20));
+    h.stop();
+    stop = undefined;
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
 });

--- a/src/control/__tests__/daemon.test.ts
+++ b/src/control/__tests__/daemon.test.ts
@@ -94,6 +94,20 @@ describe("daemon handler", () => {
     expect(store.get("p", "h2")?.state).toBe("working");
   });
 
+  // #259: crash-restart re-ran reconcile() → launchHeadless → real spawn, multiplying
+  // orphans. An in-flight launch (no pid yet) must not be failed by reconcile.
+  it("reconcile: headless task with in-flight launch is not marked failed (#259)", async () => {
+    const store = createStore(dir);
+    store.put(rec("hif", { state: "submitted", mode: "headless" }));
+    const d = createDaemon({
+      store, now: () => 5000,
+      isPidAlive: () => false,
+      isHeadlessInFlight: (id) => id === "hif",
+    });
+    await d.reconcile();
+    expect(store.get("p", "hif")?.state).toBe("submitted");
+  });
+
   it("sweep: marks an over-budget working HEADLESS task stalled", async () => {
     const store = createStore(dir);
     store.put(rec("s1", { mode: "headless", state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 100 }));

--- a/src/control/__tests__/ensure-daemon-callsite.test.ts
+++ b/src/control/__tests__/ensure-daemon-callsite.test.ts
@@ -31,8 +31,9 @@ it("no call site recomputes the daemon entry path", () => {
   }
 });
 
-it("daemonEntryPath resolves to a sibling control/cockpitd.js, never ~/.config/cockpit/dist", () => {
-  const p = daemonEntryPath();
-  expect(p.endsWith(`${join("control", "cockpitd.js")}`)).toBe(true);
-  expect(p).not.toContain(join(".config", "cockpit", "dist"));
+// #259: in vitest context import.meta.url resolves to the src/ tree, so
+// daemonEntryPath() resolves to src/control/cockpitd.js which doesn't exist.
+// The guard must throw so ensureDaemon() catches it and never writes a bad plist.
+it("daemonEntryPath throws when compiled entry not found (src-tree guard, #259)", () => {
+  expect(() => daemonEntryPath()).toThrow(/compiled entry not found|run.*build/i);
 });

--- a/src/control/__tests__/headless-launcher.test.ts
+++ b/src/control/__tests__/headless-launcher.test.ts
@@ -8,6 +8,7 @@ function fakeChild() {
   ee.stdout = new EventEmitter();
   ee.stderr = new EventEmitter();
   ee.pid = 7777;
+  ee.kill = vi.fn();
   return ee;
 }
 
@@ -17,7 +18,7 @@ describe("runHeadless", () => {
     const spawn = vi.fn(() => child);
     const events: any[] = [];
     const writeResult = vi.fn(() => "/tmp/result/t1.txt");
-    const p = runHeadless({
+    const { result } = runHeadless({
       provider: "claude", task: "x", id: "t1",
       spawn: spawn as any, emit: (e) => events.push(e),
       writeResult,
@@ -25,7 +26,7 @@ describe("runHeadless", () => {
     expect(events[0]).toMatchObject({ type: "task.started", id: "t1", pid: 7777 });
     child.stdout.emit("data", '{"result":"ok","session_id":"s1"}');
     child.emit("close", 0);
-    await p;
+    await result;
     const done = events.find((e) => e.type === "task.done");
     expect(done).toBeTruthy();
     expect(events.some((e) => e.type === "task.progress")).toBe(true);
@@ -36,12 +37,12 @@ describe("runHeadless", () => {
   it("spawns the child in opts.cwd (so codex/claude work in the project, not /)", async () => {
     const child = fakeChild();
     const spawn = vi.fn(() => child);
-    const p = runHeadless({
+    const { result } = runHeadless({
       provider: "codex", task: "x", id: "t9", cwd: "/work/proj",
       spawn: spawn as any, emit: () => {},
     });
     child.emit("close", 0);
-    await p;
+    await result;
     expect(spawn).toHaveBeenCalledWith(
       "codex", expect.any(Array),
       expect.objectContaining({ cwd: "/work/proj" }),
@@ -51,36 +52,49 @@ describe("runHeadless", () => {
   it("cwd unset → spawn cwd is undefined (inherit, back-compat)", async () => {
     const child = fakeChild();
     const spawn = vi.fn(() => child);
-    const p = runHeadless({
+    const { result } = runHeadless({
       provider: "claude", task: "x", id: "t10",
       spawn: spawn as any, emit: () => {},
     });
     child.emit("close", 0);
-    await p;
+    await result;
     expect((spawn.mock.calls[0] as unknown[])[2]).toMatchObject({ cwd: undefined });
   });
 
   it("emits task.failed on non-zero exit", async () => {
     const child = fakeChild();
     const events: any[] = [];
-    const p = runHeadless({
+    const { result } = runHeadless({
       provider: "claude", task: "x", id: "t2",
       spawn: (() => child) as any, emit: (e) => events.push(e),
     });
     child.stderr.emit("data", "explode");
     child.emit("close", 2);
-    await p;
+    await result;
     expect(events.find((e) => e.type === "task.failed")).toMatchObject({ exitCode: 2 });
   });
 
   it("emits task.failed and resolves when spawn emits error (ENOENT)", async () => {
     const child = fakeChild();
     const events: any[] = [];
-    const p = runHeadless({ provider: "claude", task: "x", id: "t3",
+    const { result } = runHeadless({ provider: "claude", task: "x", id: "t3",
       spawn: (() => child) as any, emit: (e) => events.push(e) });
     child.emit("error", Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }));
-    await p; // must not hang
+    await result; // must not hang
     expect(events.find((e) => e.type === "task.failed")).toMatchObject({ id: "t3" });
     expect(events.find((e) => e.type === "task.failed")?.error).toMatch(/spawn error/);
+  });
+
+  it("returns kill() that sends SIGTERM to child", async () => {
+    const child = fakeChild();
+    const spawn = vi.fn(() => child);
+    const { result, kill } = runHeadless({
+      provider: "claude", task: "x", id: "t-kill",
+      spawn: spawn as any, emit: () => {},
+    });
+    kill();
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    child.emit("close", 0);
+    await result;
   });
 });

--- a/src/control/__tests__/protocol-socket.test.ts
+++ b/src/control/__tests__/protocol-socket.test.ts
@@ -288,6 +288,53 @@ describe("keepalive framing (#94)", () => {
   });
 });
 
+// ── Issue #259: write to dead client must not crash the server ────────────────
+
+describe("non-fatal socket write (#259)", () => {
+  let cleanup: (() => void) | undefined;
+  afterEach(() => { cleanup?.(); cleanup = undefined; });
+
+  it("server survives write-after-disconnect when handler reply races a dropped client", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "cp-wad-"));
+    const sock = join(dir, "wad.sock");
+
+    let resolveHandler!: () => void;
+    const handlerLatch = new Promise<void>((r) => { resolveHandler = r; });
+    let handlerStarted = false;
+
+    const server = startServer(sock, async (msg: any) => {
+      if (msg.slow) {
+        handlerStarted = true;
+        await handlerLatch;
+        return { slow: true };
+      }
+      return { echo: msg.ping };
+    });
+    cleanup = () => { server.close(); rmSync(dir, { recursive: true, force: true }); };
+
+    // Client sends a slow request then disconnects before the handler returns.
+    await new Promise<void>((resolve, reject) => {
+      const conn = createConnection(sock);
+      conn.setEncoding("utf-8");
+      conn.on("connect", () => {
+        conn.write(encodeMsg({ slow: true }));
+        setTimeout(() => { conn.destroy(); resolve(); }, 10);
+      });
+      conn.on("error", reject);
+    });
+
+    // Wait for handler to start, then release it — it will try to write to the dead conn.
+    await new Promise((r) => setTimeout(r, 40));
+    expect(handlerStarted).toBe(true);
+    resolveHandler();
+    await new Promise((r) => setTimeout(r, 60));
+
+    // Server must still be alive — if conn.write threw out of the process it would be dead.
+    const res = await sendRequest(sock, { ping: "still-alive" });
+    expect(res).toEqual({ echo: "still-alive" });
+  });
+});
+
 // ── Issue #87: malformed / newline-less input fast error ─────────────────────
 
 describe("socket input validation (#87)", () => {

--- a/src/control/__tests__/relay-proxy.test.ts
+++ b/src/control/__tests__/relay-proxy.test.ts
@@ -59,6 +59,7 @@ describe("relay-proxy protocol round-trip (#239 Phase B)", () => {
       stateRoot: join(dir, "state"),
       sockPath: sock,
       sweepMs: 5,
+      launchHeadless: async () => {},
       ...overrides,
     });
     stop = handle.stop;

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -115,6 +115,7 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   // would cause the second relay-proxy-poll to return non-empty despite the queue
   // being cleared on the first poll.
   const inFlightProbes = new Set<string>();
+  const inFlightHeadlessIds = new Set<string>(); // #259: tasks being launched (no pid yet)
   const activeHeadlessKills = new Set<() => void>();
 
   // Replaces createSurfaceLivenessProbe(): enqueues a probe for the relay to
@@ -282,9 +283,14 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
         provider: rec.provider, task: rec.task, id: rec.id, sessionId: rec.sessionId,
         cwd: rec.cwd, spawn, emit: ingest(rec.project), writeResult,
       });
+      inFlightHeadlessIds.add(rec.id); // #259: mark in-flight before pid is set
       activeHeadlessKills.add(handle.kill);
-      try { await handle.result; } finally { activeHeadlessKills.delete(handle.kill); }
+      try { await handle.result; } finally {
+        inFlightHeadlessIds.delete(rec.id);
+        activeHeadlessKills.delete(handle.kill);
+      }
     }),
+    isHeadlessInFlight: (id) => inFlightHeadlessIds.has(id),
     launchInteractive: async (rec) => {
       if (rec.provider === "codex") {
         await codexDriver.dispatch(rec as any);

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -62,6 +62,8 @@ export interface CockpitdOpts {
   /** #207 best-effort relay healer. Defaults to a real cmux spawnInjector
    *  re-spawn (mostly inert under launchd). Tests inject a fake/spy. */
   healRelay?: (project: string) => Promise<void> | void;
+  /** Inject a fake headless launcher for tests to avoid real process spawns. */
+  launchHeadless?: (rec: TaskRecord) => Promise<void>;
   /** Inject a fake opencode SSE bridge for tests. Defaults to a real one. */
   opencodeBridge?: {
     start: (o: { taskId: string; port: number }) => void;
@@ -113,6 +115,7 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   // would cause the second relay-proxy-poll to return non-empty despite the queue
   // being cleared on the first poll.
   const inFlightProbes = new Set<string>();
+  const activeHeadlessKills = new Set<() => void>();
 
   // Replaces createSurfaceLivenessProbe(): enqueues a probe for the relay to
   // execute, then returns the most-recent cached result ("unknown" when nothing
@@ -274,12 +277,14 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
     isSurfaceAlive: opts.isSurfaceAlive ?? proxiedSurfaceAlive,
     // #207 best-effort relay heal on the sweep (secondary — surface is primary).
     healRelay: opts.healRelay ?? createRelayHealer(log),
-    launchHeadless: async (rec) => {
-      await runHeadless({
+    launchHeadless: opts.launchHeadless ?? (async (rec) => {
+      const handle = runHeadless({
         provider: rec.provider, task: rec.task, id: rec.id, sessionId: rec.sessionId,
         cwd: rec.cwd, spawn, emit: ingest(rec.project), writeResult,
       });
-    },
+      activeHeadlessKills.add(handle.kill);
+      try { await handle.result; } finally { activeHeadlessKills.delete(handle.kill); }
+    }),
     launchInteractive: async (rec) => {
       if (rec.provider === "codex") {
         await codexDriver.dispatch(rec as any);
@@ -545,6 +550,7 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
     stop() {
       if (timer) clearInterval(timer);
       if (rotationTimer) clearInterval(rotationTimer);
+      for (const kill of activeHeadlessKills) kill();
       server.close();
       log("stopped");
     },

--- a/src/control/daemon.ts
+++ b/src/control/daemon.ts
@@ -27,6 +27,14 @@ export interface DaemonDeps {
   /** Wired in cockpitd to runHeadless; absent in pure unit tests. */
   launchHeadless?: (rec: TaskRecord) => Promise<void>;
   /**
+   * #259: true when a launchHeadless call for this task ID is currently in
+   * flight (process spawned but no pid yet). reconcile() skips these so a
+   * crash-restart re-run does NOT mark an actively-launching task as failed
+   * and re-dispatch it, multiplying orphaned headless processes.
+   * Defaults to () => false when not wired (pure unit tests, non-headless modes).
+   */
+  isHeadlessInFlight?: (id: string) => boolean;
+  /**
    * Forward hook for the deferred interactive-wiring spec. While absent,
    * interactive dispatch fails LOUD (red-team #4) instead of silently
    * black-holing in `submitted` forever.
@@ -401,6 +409,7 @@ export function createDaemon(deps: DaemonDeps) {
         if (r.state !== "working" && r.state !== "submitted") continue;
         if (r.mode === "headless") {
           if (r.pid != null && alive(r.pid)) continue; // still running, keep watching
+          if (deps.isHeadlessInFlight?.(r.id)) continue; // #259: launch in-flight, pid not yet set
           const failed: TaskRecord = {
             ...r, state: "failed", lastEvent: "reconcile",
             error: "orphaned by daemon restart; exit unobserved (conservative fail)",

--- a/src/control/headless-launcher.ts
+++ b/src/control/headless-launcher.ts
@@ -20,7 +20,12 @@ export interface RunHeadlessOpts {
   writeResult?: (id: string, payload: string) => string;
 }
 
-export function runHeadless(opts: RunHeadlessOpts): Promise<void> {
+export interface HeadlessHandle {
+  result: Promise<void>;
+  kill: () => void;
+}
+
+export function runHeadless(opts: RunHeadlessOpts): HeadlessHandle {
   const adapter = getHeadlessAdapter(opts.provider);
   const argv = adapter.buildCommand(opts.task, opts.sessionId);
   const child = opts.spawn(argv[0], argv.slice(1), {
@@ -37,7 +42,7 @@ export function runHeadless(opts: RunHeadlessOpts): Promise<void> {
   });
   child.stderr?.on("data", (d) => { err += String(d); });
 
-  return new Promise<void>((resolve) => {
+  const result = new Promise<void>((resolve) => {
     child.once("error", (e: Error) => {
       opts.emit({ type: "task.failed", id: opts.id, error: `spawn error: ${e.message}`, exitCode: undefined });
       resolve(); // never hang the daemon; resolve() is idempotent
@@ -54,4 +59,6 @@ export function runHeadless(opts: RunHeadlessOpts): Promise<void> {
       resolve();
     });
   });
+
+  return { result, kill: () => child.kill("SIGTERM") };
 }

--- a/src/control/launchd.ts
+++ b/src/control/launchd.ts
@@ -19,7 +19,14 @@ export function plistPath(): string {
  * because runtime-sync never mirrors compiled output there).
  */
 export function daemonEntryPath(): string {
-  return join(dirname(fileURLToPath(import.meta.url)), "cockpitd.js");
+  const p = join(dirname(fileURLToPath(import.meta.url)), "cockpitd.js");
+  if (!existsSync(p)) {
+    throw new Error(
+      `daemonEntryPath: compiled entry not found at '${p}'; ` +
+      `run 'npm run build' — a src-tree or missing path in the launchd plist causes a MODULE_NOT_FOUND crash-loop (#259)`,
+    );
+  }
+  return p;
 }
 
 function xmlEscape(s: string): string {

--- a/src/control/protocol.ts
+++ b/src/control/protocol.ts
@@ -141,12 +141,16 @@ export function startServer(
           continue;
         }
         // Normal request/response path.
+        // #259: both writes are wrapped — a destroyed socket can throw synchronously
+        // (write-after-end); that throw would escape the async data handler and become
+        // an unhandled rejection, killing the daemon. Client-gone writes are silently
+        // swallowed; the conn.on("error") handler above covers the emitted error event.
         try {
           const reply = await handler(msg);
-          conn.write(encodeMsg({ ok: true, reply, _v: PROTOCOL_VERSION }));
+          try { conn.write(encodeMsg({ ok: true, reply, _v: PROTOCOL_VERSION })); } catch { /* client gone */ }
         } catch (e) {
           const errMsg = e instanceof Error ? e.message : String(e);
-          conn.write(encodeMsg({ ok: false, error: errMsg, _v: PROTOCOL_VERSION }));
+          try { conn.write(encodeMsg({ ok: false, error: errMsg, _v: PROTOCOL_VERSION })); } catch { /* client gone */ }
         }
       }
     });


### PR DESCRIPTION
## Summary
Fixes the recurring RAM flood that froze the machine (13.5 GB swap, load avg 82, forced restarts). Root cause: orphaned `claude -p` CLI sessions accumulating from two triggers, amplified by detached children surviving daemon restarts.

## Fixes
- **#259 — daemon crash-loop:** `cockpitd` was tight-respawned by launchd (`KeepAlive`+`ThrottleInterval=10`) every 10–30s, and each boot's `reconcile()` re-dispatched headless tasks → real `claude -p` spawns. Three root-causes fixed: (1) the stray `src/control/cockpitd.js` launch path (MODULE_NOT_FOUND) is guarded so a bad path can't corrupt the plist; (2) socket-write failures are wrapped so a write to a dead client no longer escapes as an unhandled rejection and kills the process; (3) reconcile skips tasks whose `launchHeadless` is still in-flight (`inFlightHeadlessIds`), so a restart can't multiply spawns.
- **#260 — test isolation:** daemon tests no longer shell out to the real `claude` CLI. Added a `launchHeadless` injection point to `CockpitdOpts`; the affected tests inject fakes. Running the suite previously spawned real `claude -p "do something"` processes that leaked.
- **#261 — orphan cleanup:** `runHeadless` now returns `{result, kill}`; `cockpitd` tracks `activeHeadlessKills` and SIGTERMs every live headless child in `stop()`, so detached children no longer orphan to PPID 1 and survive restarts.

## Verification
- 95 targeted tests pass (incl. new `protocol-socket` and reconcile-guard tests); `npm run build` clean; **0 leaked `claude -p`** after test runs.
- **End-to-end:** live daemon kickstarted on this code and watched 75s — single boot, **0 crash signatures**, **0 leaks** (vs. the old crash-loop).

Closes #259, #260, #261.