### PR TITLE
fix(cmux): preserve captain draft on relay delivery — deliver-when-empty (#258)

### DIFF
--- a/src/commands/__tests__/notify-relay.test.ts
+++ b/src/commands/__tests__/notify-relay.test.ts
@@ -9,7 +9,8 @@ import { mkdtempSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { appendToMailbox, writeCursor, readCursor } from "../../control/mailbox.js";
-import { runNotifyRelay, DEFAULT_STATE_ROOT, STALE_THRESHOLD_MS } from "../notify-relay.js";
+import { runNotifyRelay, DEFAULT_STATE_ROOT, STALE_THRESHOLD_MS, MAX_DEFERS } from "../notify-relay.js";
+import { DeferDelivery } from "../../runtimes/cmux.js";
 import type { TaskRecord, ControlEvent } from "../../control/types.js";
 
 function freshState(): string {
@@ -214,5 +215,84 @@ describe("notify-relay file-tailer", () => {
     expect(sendSpy).not.toHaveBeenCalled();
     const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
     expect(cursor?.lastAckedSeq).toBe(1);
+  });
+});
+
+// #258 idle-defer: relay-level defer tracking.
+describe("notify-relay idle-defer (#258 phase 2)", () => {
+  it("does NOT advance cursor when sendToSurface throws DeferDelivery", async () => {
+    const stateRoot = freshState();
+    await append(stateRoot, "CREW DONE [claude/deadbeef]: x");
+    const sendSpy = vi.fn().mockRejectedValue(new DeferDelivery());
+    const stop = await runNotifyRelay({
+      project: "demo",
+      subscriber: "captain",
+      stateRoot,
+      runtime: fakeRuntime(sendSpy) as never,
+      captainName: "captain",
+      pollMs: 50,
+    });
+    // 4 polls at 50ms — deferCount=4, well below MAX_DEFERS=30; cursor stays null
+    await new Promise((r) => setTimeout(r, 250));
+    stop();
+    const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    expect(cursor).toBeNull();
+    expect(sendSpy.mock.calls.length).toBeGreaterThan(0);
+  });
+
+  it("delivers and advances cursor once DeferDelivery resolves", async () => {
+    const stateRoot = freshState();
+    await append(stateRoot, "CREW DONE [claude/deadbeef]: x");
+    // Defer once, then resolve
+    let attempts = 0;
+    const sendSpy = vi.fn().mockImplementation(() => {
+      if (++attempts <= 1) return Promise.reject(new DeferDelivery());
+      return Promise.resolve();
+    });
+    const stop = await runNotifyRelay({
+      project: "demo",
+      subscriber: "captain",
+      stateRoot,
+      runtime: fakeRuntime(sendSpy) as never,
+      captainName: "captain",
+      pollMs: 50,
+    });
+    await new Promise((r) => setTimeout(r, 300));
+    stop();
+    const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    expect(cursor?.lastAckedSeq).toBe(1);
+    expect(sendSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("force-delivers after MAX_DEFERS consecutive defers so message is never stuck", async () => {
+    const stateRoot = freshState();
+    await append(stateRoot, "CREW DONE [claude/deadbeef]: x");
+    // Always defer unless force=true
+    const sendSpy = vi.fn().mockImplementation(
+      (_surface: unknown, _msg: string, opts?: { force?: boolean }) => {
+        if (opts?.force) return Promise.resolve();
+        return Promise.reject(new DeferDelivery());
+      },
+    );
+    const stop = await runNotifyRelay({
+      project: "demo",
+      subscriber: "captain",
+      stateRoot,
+      runtime: fakeRuntime(sendSpy) as never,
+      captainName: "captain",
+      pollMs: 50,
+    });
+    // MAX_DEFERS=30 polls + 1 force-deliver; at 50ms each = ~1550ms; allow 2500ms margin
+    await new Promise((r) => setTimeout(r, 2500));
+    stop();
+    const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    expect(cursor?.lastAckedSeq).toBe(1);
+    // The call that succeeded must have had force=true
+    const forcedCall = sendSpy.mock.calls.find(
+      (c) => (c[2] as { force?: boolean } | undefined)?.force === true,
+    );
+    expect(forcedCall).toBeDefined();
+    // Total calls = MAX_DEFERS defers + 1 force-deliver
+    expect(sendSpy.mock.calls.length).toBeGreaterThanOrEqual(MAX_DEFERS + 1);
   });
 });

--- a/src/commands/notify-relay.ts
+++ b/src/commands/notify-relay.ts
@@ -13,6 +13,7 @@ import { join } from "node:path";
 import chalk from "chalk";
 import { loadConfig } from "../config.js";
 import { RuntimeRegistry, createCmuxDriver } from "../runtimes/index.js";
+import { DeferDelivery } from "../runtimes/cmux.js";
 import type { RuntimeDriver } from "../runtimes/types.js";
 import {
   readCursor,
@@ -27,6 +28,10 @@ import { cockpitdCall } from "./crew-control.js";
 import type { TaskRecord, ControlEvent } from "../control/types.js";
 
 export const DEFAULT_STATE_ROOT = join(homedir(), ".config", "cockpit", "state");
+
+// #258 idle-defer: max consecutive defers before force-delivering so a message
+// can never be stuck forever (~30s at the default 1s poll cadence).
+export const MAX_DEFERS = 30;
 
 // How often the in-cmux probe scrapes interactive crew panes for a block. The
 // daemon can't do this (launchd can't connect to cmux), so it lives here.
@@ -196,6 +201,10 @@ export async function runNotifyRelay(opts: RunOpts): Promise<() => void> {
 
   const sessionStartMs = (opts.now ?? (() => Date.now()))();
 
+  // #258 idle-defer: consecutive defer counts per mailbox seq.
+  // Keyed by entry.seq; deleted on successful delivery.
+  const deferCounts = new Map<number, number>();
+
   const cursor = await readCursor({
     stateRoot: opts.stateRoot,
     project: opts.project,
@@ -248,10 +257,19 @@ export async function runNotifyRelay(opts: RunOpts): Promise<() => void> {
         const msg = deliverable(entry);
         if (msg) {
           try {
+            const deferCount = deferCounts.get(entry.seq) ?? 0;
+            const force = deferCount >= MAX_DEFERS;
             await (opts.runtime as RuntimeDriver & {
-              sendToSurface: (s: unknown, m: string) => Promise<void>;
-            }).sendToSurface(captainSurface, msg);
+              sendToSurface: (s: unknown, m: string, o?: { force?: boolean }) => Promise<void>;
+            }).sendToSurface(captainSurface, msg, force ? { force: true } : undefined);
+            deferCounts.delete(entry.seq);
           } catch (e) {
+            if (e instanceof DeferDelivery) {
+              deferCounts.set(entry.seq, (deferCounts.get(entry.seq) ?? 0) + 1);
+              log(`deferred: captain typing (seq=${entry.seq})`);
+              // Don't advance cursor; the next poll will retry from the same seq.
+              return;
+            }
             log(`sendToSurface failed seq=${entry.seq}: ${(e as Error).message}`);
             // Don't advance cursor; the next poll will retry from the same seq.
             return;

--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { createCmuxDriver, sanitizeForCmuxSend, parseDraftFromScreen } from "../cmux.js";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createCmuxDriver, sanitizeForCmuxSend, parseDraftFromScreen, DeferDelivery } from "../cmux.js";
 
 const execFileMock = vi.hoisted(() => vi.fn());
 vi.mock("node:child_process", () => ({
@@ -327,29 +327,26 @@ describe("cmux driver", () => {
     expect(text).toBe("");
   });
 
-  // #258: relay delivery must not clobber a captain's in-progress draft.
-  // Before injecting the crew message, kill the current input into the readline
-  // kill ring (ctrl+a → ctrl+k); after Enter, yank it back (ctrl+y).
-  // Empty drafts are safe: ctrl+k on empty line leaves an empty kill-ring entry
-  // and ctrl+y restores nothing.
-  it("sendToSurface wraps delivery in kill/yank sandwich to preserve captain draft", async () => {
+  // #258: when no draft is detected (empty screen / cursor-only), deliver
+  // message+Enter directly with no key-chord preamble. ctrl-u/ctrl+a/ctrl+k/
+  // ctrl+y are all no-ops against Claude Code's input box.
+  it("sendToSurface delivers message+Enter directly when no draft detected", async () => {
     execFileMock.mockReturnValue("");
     await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done");
     const calls = execFileMock.mock.calls.map(argvOf);
-    const idx = (pred: (a: string[]) => boolean, after = -1) =>
-      calls.findIndex((a, i) => i > after && pred(a));
 
-    const ctrlAIdx = idx(a => a.includes("send-key") && a.includes("ctrl+a") && a.includes("surface:8"));
-    const ctrlKIdx = idx(a => a.includes("send-key") && a.includes("ctrl+k") && a.includes("surface:8"), ctrlAIdx);
-    const msgIdx   = idx(a => a[0] === "send" && a.includes("crew done"), ctrlKIdx);
-    const enterIdx = idx(a => a.includes("send-key") && a.includes("Enter") && a.includes("surface:8"), msgIdx);
-    const ctrlYIdx = idx(a => a.includes("send-key") && a.includes("ctrl+y") && a.includes("surface:8"), enterIdx);
+    // No kill-ring or ctrl-u keys
+    expect(calls.every((a) => !a.includes("ctrl+a"))).toBe(true);
+    expect(calls.every((a) => !a.includes("ctrl+k"))).toBe(true);
+    expect(calls.every((a) => !a.includes("ctrl+y"))).toBe(true);
+    expect(calls.every((a) => !a.includes("ctrl-u"))).toBe(true);
+    // No backspaces either — nothing to clear
+    expect(calls.every((a) => !a.includes("backspace"))).toBe(true);
 
-    expect(ctrlAIdx, "ctrl+a before message").toBeGreaterThanOrEqual(0);
-    expect(ctrlKIdx, "ctrl+k after ctrl+a").toBeGreaterThan(ctrlAIdx);
-    expect(msgIdx,   "message after ctrl+k").toBeGreaterThan(ctrlKIdx);
+    const msgIdx   = calls.findIndex((a) => a[0] === "send" && a.includes("crew done"));
+    const enterIdx = calls.findIndex((a, i) => i > msgIdx && a.includes("send-key") && a.includes("Enter") && a.includes("surface:8"));
+    expect(msgIdx, "message send exists").toBeGreaterThanOrEqual(0);
     expect(enterIdx, "Enter after message").toBeGreaterThan(msgIdx);
-    expect(ctrlYIdx, "ctrl+y after Enter").toBeGreaterThan(enterIdx);
   });
 
   it("sendToSurface delivers shell metacharacters as literal text scoped to surface", async () => {
@@ -514,33 +511,40 @@ describe("sendToSurface draft-preservation", () => {
     expect(sends[0]).toContain("crew is done");
   });
 
-  it("saves draft, clears input, delivers, then restores draft without submitting", async () => {
+  it("saves draft, clears input via backspaces, delivers, then restores draft without submitting (force=true)", async () => {
+    // "hello this is my draft" = 22 chars → 24 backspaces (draft.length + 2 margin)
+    const DRAFT = "hello this is my draft";
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
       if (args.includes("read-screen")) {
         return [
           "│ Some conversation history │",
-          "│ > hello this is my draft  │",
+          `│ > ${DRAFT}  │`,
         ].join("\n");
       }
       return "";
     });
-    await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done");
+    await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done", { force: true });
     const calls = execFileMock.mock.calls.map(argvOf);
-    // ctrl-u must come before the message send
-    const ctrlUIdx = calls.findIndex((a) => a.includes("send-key") && a.includes("ctrl-u"));
+
+    // No ctrl-u: that key is a no-op against Claude Code's input box
+    expect(calls.every((a) => !a.includes("ctrl-u"))).toBe(true);
+
+    // Backspaces must precede the message send
     const msgSendIdx = calls.findIndex((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")));
-    const enterIdx = calls.findIndex((a) => a.includes("send-key") && a.includes("Enter"));
+    const backspacesBefore = calls.slice(0, msgSendIdx).filter((a) => a.includes("send-key") && a.includes("backspace")).length;
+    expect(backspacesBefore, "backspace count = draft.length + 2").toBe(DRAFT.length + 2);
+
+    const enterIdx = calls.findIndex((a, i) => i > msgSendIdx && a.includes("send-key") && a.includes("Enter"));
     // findLastIndex is ES2023; reverse-scan manually to stay within repo's tsconfig target
     let restoreIdx = -1;
     for (let i = calls.length - 1; i >= 0; i--) {
       const a: string[] = calls[i];
-      if (a[0] === "send" && a.some((s: string) => s.includes("hello this is my draft"))) { restoreIdx = i; break; }
+      if (a[0] === "send" && a.some((s: string) => s.includes(DRAFT))) { restoreIdx = i; break; }
     }
-    expect(ctrlUIdx).toBeGreaterThanOrEqual(0);
-    expect(msgSendIdx).toBeGreaterThan(ctrlUIdx);
-    expect(enterIdx).toBeGreaterThan(msgSendIdx);
+    expect(msgSendIdx).toBeGreaterThanOrEqual(0);
+    expect(enterIdx, "Enter after message").toBeGreaterThan(msgSendIdx);
     // Restore send comes after Enter (draft goes back without submitting)
-    expect(restoreIdx).toBeGreaterThan(enterIdx);
+    expect(restoreIdx, "restore after Enter").toBeGreaterThan(enterIdx);
     // Restore must NOT be followed by another Enter
     const cmdsAfterRestore = execFileMock.mock.calls.slice(restoreIdx + 1).map(cmdOf);
     expect(cmdsAfterRestore.every((c) => !c.includes("Enter"))).toBe(true);
@@ -670,5 +674,75 @@ describe("sanitizeForCmuxSend", () => {
 
   it("handles empty string", () => {
     expect(sanitizeForCmuxSend("")).toBe("");
+  });
+});
+
+// #258 Approach B: deliver-only-when-empty. No 250ms stability double-read.
+// Draft present → DeferDelivery (caller retries next poll until input is empty).
+// Draft absent → deliver directly (nothing to protect, no backspaces).
+// Draft + force → backspace clear, deliver, restore (walk-away last-resort).
+describe("sendToSurface Approach B (#258 deliver-when-empty)", () => {
+  const driver = createCmuxDriver();
+
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  it("non-empty draft, not forced → throws DeferDelivery immediately without sending", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return "❯ hello draft text";
+      return "";
+    });
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done"),
+    ).rejects.toBeInstanceOf(DeferDelivery);
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    // Must not have attempted any send after the defer decision
+    expect(cmds.filter((c) => c.startsWith("send ") && !c.startsWith("send-key"))).toHaveLength(0);
+    expect(cmds.filter((c) => c.includes("Enter"))).toHaveLength(0);
+  });
+
+  it("empty input → delivers directly (no backspace, no restore)", async () => {
+    execFileMock.mockReturnValue("");
+    await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done");
+    const calls = execFileMock.mock.calls.map(argvOf);
+    // No backspaces — nothing to clear
+    expect(calls.every((a) => !a.includes("backspace"))).toBe(true);
+    // Message delivered then Enter
+    const msgIdx = calls.findIndex((a) => a[0] === "send" && a.includes("crew done"));
+    const enterIdx = calls.findIndex((a, i) => i > msgIdx && a.includes("send-key") && a.includes("Enter"));
+    expect(msgIdx, "message send").toBeGreaterThanOrEqual(0);
+    expect(enterIdx, "Enter after message").toBeGreaterThan(msgIdx);
+    // No restore send after Enter
+    const afterEnter = calls.slice(enterIdx + 1);
+    expect(afterEnter.filter((a) => a[0] === "send")).toHaveLength(0);
+  });
+
+  it("non-empty draft + force=true → backspace clear, deliver, restore without Enter", async () => {
+    const DRAFT = "my walk-away draft";
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return `❯ ${DRAFT}`;
+      return "";
+    });
+    await driver.sendToSurface(
+      { workspaceId: "workspace:3", surfaceId: "surface:8" },
+      "crew done",
+      { force: true },
+    );
+    const calls = execFileMock.mock.calls.map(argvOf);
+    const msgIdx = calls.findIndex((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")));
+    const backspacesBefore = calls.slice(0, msgIdx).filter((a) => a.includes("send-key") && a.includes("backspace")).length;
+    expect(backspacesBefore, "backspace count = draft.length + 2").toBe(DRAFT.length + 2);
+    const enterIdx = calls.findIndex((a, i) => i > msgIdx && a.includes("send-key") && a.includes("Enter"));
+    let restoreIdx = -1;
+    for (let i = calls.length - 1; i >= 0; i--) {
+      const a: string[] = calls[i];
+      if (a[0] === "send" && a.some((s: string) => s.includes(DRAFT))) { restoreIdx = i; break; }
+    }
+    expect(enterIdx, "Enter after message").toBeGreaterThan(msgIdx);
+    expect(restoreIdx, "restore after Enter").toBeGreaterThan(enterIdx);
+    // Restore must NOT be followed by another Enter
+    const afterRestore = execFileMock.mock.calls.slice(restoreIdx + 1).map(cmdOf);
+    expect(afterRestore.every((c) => !c.includes("Enter"))).toBe(true);
   });
 });

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -14,6 +14,15 @@ export class CmuxTimeoutError extends Error {
   }
 }
 
+// #258 Approach B: thrown by sendToSurface when the captain has any draft in
+// the input box. The relay defers delivery until the input is empty.
+export class DeferDelivery extends Error {
+  constructor() {
+    super("deferred: captain composing");
+    this.name = "DeferDelivery";
+  }
+}
+
 // Invoke cmux with an argv array and NO shell. Every element (especially crew
 // prompt text passed through send/send-to-surface) reaches cmux as a single
 // literal argument — backticks, $(), quotes are never parsed. See #118.
@@ -286,32 +295,33 @@ export function createCmuxDriver(): RuntimeDriver {
       return { workspaceId: wsId, surfaceId, title: opts.title };
     },
 
-    async sendToSurface(surface: PaneRef, text: string): Promise<void> {
-      // #258: preserve any in-progress captain draft around relay delivery.
-      // First try to read the screen and detect a real draft:
-      //   - If found: ctrl-u clears the line, message is delivered, then the
-      //     draft text is re-typed (no Enter) so the captain can keep editing.
-      // Fall back to the readline kill-ring approach when the screen is
-      // unreadable or no draft is detected (empty input / cursor only):
-      //   - ctrl+a→ctrl+k saves the (empty) line into the kill ring, message
-      //     delivered, ctrl+y restores — always a no-op on an empty line.
+    async sendToSurface(surface: PaneRef, text: string, opts?: { force?: boolean }): Promise<void> {
+      // #258 Approach B: deliver only when the captain's input is empty.
+      // Read screen once; treat unreadable as empty so delivery always proceeds.
       let draft = "";
       try {
         const screen = cmux(["read-screen", "--workspace", surface.workspaceId, "--surface", surface.surfaceId]);
         draft = parseDraftFromScreen(screen);
-      } catch { /* screen unreadable — fall through to kill-ring path */ }
+      } catch { /* screen unreadable — treat as empty, deliver directly */ }
 
-      if (draft) {
-        cmux(["send-key", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, "ctrl-u"]);
+      if (draft && !opts?.force) {
+        // Captain is composing — defer until input clears (relay retries next poll).
+        throw new DeferDelivery();
+      }
+
+      if (draft && opts?.force) {
+        // Walk-away last-resort: backspace×(N+2) clears, deliver, restore draft.
+        const backspaceCount = draft.length + 2;
+        for (let i = 0; i < backspaceCount; i++) {
+          cmux(["send-key", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, "backspace"]);
+        }
         cmux(["send", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, sanitizeForCmuxSend(text)]);
         cmux(["send-key", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, "Enter"]);
         cmux(["send", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, sanitizeForCmuxSend(draft)]);
       } else {
-        cmux(["send-key", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, "ctrl+a"]);
-        cmux(["send-key", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, "ctrl+k"]);
+        // Input is empty — deliver directly, nothing to protect.
         cmux(["send", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, sanitizeForCmuxSend(text)]);
         cmux(["send-key", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, "Enter"]);
-        cmux(["send-key", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, "ctrl+y"]);
       }
     },
 

--- a/src/runtimes/types.ts
+++ b/src/runtimes/types.ts
@@ -73,5 +73,6 @@ export interface RuntimeDriver {
   // targets one surface directly. Used by the notify-relay injector to
   // deliver messages to the captain's primary surface. Throws if the surface
   // no longer exists.
-  sendToSurface(surface: PaneRef, text: string): Promise<void>;
+  // opts.force=true skips the idle-defer stability check (#258 phase 2).
+  sendToSurface(surface: PaneRef, text: string, opts?: { force?: boolean }): Promise<void>;
 }


### PR DESCRIPTION
## Summary
The merged #258 fix (#266) didn't work against the real Claude Code TUI — verified by a live round-trip where a captain draft + a relay-delivered crew message got concatenated and submitted together. This reworks it to a robust, race-free approach.

## Why the previous attempts failed (all caught by live testing, not unit tests)
- `ctrl-u` / `ctrl+a`+`ctrl+k` are **no-ops** in Claude Code's input (proven via live `cmux send-key`) — only `backspace` deletes
- `parseDraftFromScreen` matched only synthetic `>`, but the real prompt is `❯` + non-breaking space
- backspace×N clear is **slow** (~600ms for a long draft) so it races live keystrokes
- a fixed idle-stability window mis-fires for **slow typists** (between-keystroke gaps exceed the window)

## Approach B — deliver only when the input is empty
`sendToSurface` reads the input: if **any draft** is present it throws `DeferDelivery` and the relay retries on its next poll (**never touches the user's keystrokes**); when the input is **empty** it delivers directly. A per-seq defer counter force-delivers after `MAX_DEFERS` (~30s) as a walk-away fallback (best-effort backspace clear+restore). `parseDraftFromScreen` now recognizes `❯`+NBSP, plain `>`, and box-drawing input lines.

This eliminates the whole clear-and-restore race: in normal use the inbox is empty most of the time so messages land promptly; they only wait while you're actively composing, then drop in the instant you submit/clear.

## Verification
- `npm run build` clean; 90 targeted tests pass (cmux + notify-relay + relay-proxy)
- **Live round-trip:** relay logged **24 consecutive `deferred: captain typing`** while a draft was held, then `deliver seq=917` the moment the input went empty — **no clobber, no keystroke interference**

Closes #258.