### PR TITLE
fix(relay): configurable force-defer timeout (5min) + scope draft parse to live input box (#258)

### DIFF
--- a/src/commands/__tests__/notify-relay.test.ts
+++ b/src/commands/__tests__/notify-relay.test.ts
@@ -9,7 +9,7 @@ import { mkdtempSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { appendToMailbox, writeCursor, readCursor } from "../../control/mailbox.js";
-import { runNotifyRelay, DEFAULT_STATE_ROOT, STALE_THRESHOLD_MS, MAX_DEFERS } from "../notify-relay.js";
+import { runNotifyRelay, DEFAULT_STATE_ROOT, STALE_THRESHOLD_MS, DEFAULT_MAX_DEFERS } from "../notify-relay.js";
 import { DeferDelivery } from "../../runtimes/cmux.js";
 import type { TaskRecord, ControlEvent } from "../../control/types.js";
 
@@ -220,6 +220,10 @@ describe("notify-relay file-tailer", () => {
 
 // #258 idle-defer: relay-level defer tracking.
 describe("notify-relay idle-defer (#258 phase 2)", () => {
+  it("DEFAULT_MAX_DEFERS is 300 (~5min at 1s poll cadence)", () => {
+    expect(DEFAULT_MAX_DEFERS).toBe(300);
+  });
+
   it("does NOT advance cursor when sendToSurface throws DeferDelivery", async () => {
     const stateRoot = freshState();
     await append(stateRoot, "CREW DONE [claude/deadbeef]: x");
@@ -232,7 +236,7 @@ describe("notify-relay idle-defer (#258 phase 2)", () => {
       captainName: "captain",
       pollMs: 50,
     });
-    // 4 polls at 50ms — deferCount=4, well below MAX_DEFERS=30; cursor stays null
+    // 4 polls at 50ms — deferCount=4, well below DEFAULT_MAX_DEFERS=300; cursor stays null
     await new Promise((r) => setTimeout(r, 250));
     stop();
     const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
@@ -264,9 +268,10 @@ describe("notify-relay idle-defer (#258 phase 2)", () => {
     expect(sendSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 
-  it("force-delivers after MAX_DEFERS consecutive defers so message is never stuck", async () => {
+  it("force-delivers after maxDeferDeliveries consecutive defers so message is never stuck", async () => {
     const stateRoot = freshState();
     await append(stateRoot, "CREW DONE [claude/deadbeef]: x");
+    const TEST_MAX_DEFERS = 3; // inject small value so test runs fast
     // Always defer unless force=true
     const sendSpy = vi.fn().mockImplementation(
       (_surface: unknown, _msg: string, opts?: { force?: boolean }) => {
@@ -281,9 +286,10 @@ describe("notify-relay idle-defer (#258 phase 2)", () => {
       runtime: fakeRuntime(sendSpy) as never,
       captainName: "captain",
       pollMs: 50,
+      maxDeferDeliveries: TEST_MAX_DEFERS,
     });
-    // MAX_DEFERS=30 polls + 1 force-deliver; at 50ms each = ~1550ms; allow 2500ms margin
-    await new Promise((r) => setTimeout(r, 2500));
+    // TEST_MAX_DEFERS polls + 1 force-deliver; at 50ms each = ~200ms; allow 500ms margin
+    await new Promise((r) => setTimeout(r, 500));
     stop();
     const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
     expect(cursor?.lastAckedSeq).toBe(1);
@@ -292,7 +298,38 @@ describe("notify-relay idle-defer (#258 phase 2)", () => {
       (c) => (c[2] as { force?: boolean } | undefined)?.force === true,
     );
     expect(forcedCall).toBeDefined();
-    // Total calls = MAX_DEFERS defers + 1 force-deliver
-    expect(sendSpy.mock.calls.length).toBeGreaterThanOrEqual(MAX_DEFERS + 1);
+    // Total calls = TEST_MAX_DEFERS defers + 1 force-deliver
+    expect(sendSpy.mock.calls.length).toBeGreaterThanOrEqual(TEST_MAX_DEFERS + 1);
+  });
+
+  it("honors config-injected maxDeferDeliveries override", async () => {
+    const stateRoot = freshState();
+    await append(stateRoot, "CREW DONE [claude/deadbeef]: x");
+    // With maxDeferDeliveries=1, force-deliver should trigger after a single defer
+    const sendSpy = vi.fn().mockImplementation(
+      (_surface: unknown, _msg: string, opts?: { force?: boolean }) => {
+        if (opts?.force) return Promise.resolve();
+        return Promise.reject(new DeferDelivery());
+      },
+    );
+    const stop = await runNotifyRelay({
+      project: "demo",
+      subscriber: "captain",
+      stateRoot,
+      runtime: fakeRuntime(sendSpy) as never,
+      captainName: "captain",
+      pollMs: 50,
+      maxDeferDeliveries: 1,
+    });
+    await new Promise((r) => setTimeout(r, 300));
+    stop();
+    const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    expect(cursor?.lastAckedSeq).toBe(1);
+    // First call defers, second call force-delivers
+    expect(sendSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+    const forcedCall = sendSpy.mock.calls.find(
+      (c) => (c[2] as { force?: boolean } | undefined)?.force === true,
+    );
+    expect(forcedCall).toBeDefined();
   });
 });

--- a/src/commands/notify-relay.ts
+++ b/src/commands/notify-relay.ts
@@ -29,9 +29,10 @@ import type { TaskRecord, ControlEvent } from "../control/types.js";
 
 export const DEFAULT_STATE_ROOT = join(homedir(), ".config", "cockpit", "state");
 
-// #258 idle-defer: max consecutive defers before force-delivering so a message
-// can never be stuck forever (~30s at the default 1s poll cadence).
-export const MAX_DEFERS = 30;
+// #258 idle-defer: default max consecutive defers before force-delivering so a
+// message can never be stuck forever (~5min/300s at the default 1s poll cadence).
+// Override via config key relay.maxDeferDeliveries.
+export const DEFAULT_MAX_DEFERS = 300;
 
 // How often the in-cmux probe scrapes interactive crew panes for a block. The
 // daemon can't do this (launchd can't connect to cmux), so it lives here.
@@ -178,6 +179,8 @@ interface RunOpts {
   /** Override Date.now() — useful in tests to simulate a future session start time. */
   now?: () => number;
   log?: (m: string) => void;
+  /** Max consecutive defers before force-deliver. Default: DEFAULT_MAX_DEFERS. */
+  maxDeferDeliveries?: number;
 }
 
 export async function runNotifyRelay(opts: RunOpts): Promise<() => void> {
@@ -200,6 +203,7 @@ export async function runNotifyRelay(opts: RunOpts): Promise<() => void> {
   if (!captainSurface) throw new Error("no surfaces in captain workspace");
 
   const sessionStartMs = (opts.now ?? (() => Date.now()))();
+  const maxDefers = opts.maxDeferDeliveries ?? DEFAULT_MAX_DEFERS;
 
   // #258 idle-defer: consecutive defer counts per mailbox seq.
   // Keyed by entry.seq; deleted on successful delivery.
@@ -258,7 +262,7 @@ export async function runNotifyRelay(opts: RunOpts): Promise<() => void> {
         if (msg) {
           try {
             const deferCount = deferCounts.get(entry.seq) ?? 0;
-            const force = deferCount >= MAX_DEFERS;
+            const force = deferCount >= maxDefers;
             await (opts.runtime as RuntimeDriver & {
               sendToSurface: (s: unknown, m: string, o?: { force?: boolean }) => Promise<void>;
             }).sendToSurface(captainSurface, msg, force ? { force: true } : undefined);
@@ -400,6 +404,7 @@ export const notifyRelayCommand = new Command("notify-relay")
         runtime,
         captainName: projCfg.captainName,
         pollMs: 1000,
+        maxDeferDeliveries: config.relay?.maxDeferDeliveries ?? DEFAULT_MAX_DEFERS,
       });
       process.on("SIGTERM", () => process.exit(0));
     } catch (err) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,6 +57,10 @@ export interface CockpitConfig {
   projection?: {
     targets?: string[];
   };
+  relay?: {
+    /** Max consecutive defers before force-delivering a message (~1s poll cadence). Default: 300 (~5min). */
+    maxDeferDeliveries?: number;
+  };
   defaults: {
     maxCrew: number;
     worktreeDir: string;

--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createCmuxDriver, sanitizeForCmuxSend, parseDraftFromScreen, DeferDelivery } from "../cmux.js";
 
@@ -12,6 +14,21 @@ vi.mock("node:child_process", () => ({
 // irrelevant to behavior.
 const argvOf = (call: unknown[]): string[] => call[1] as string[];
 const cmdOf = (call: unknown[]): string => (call[1] as string[]).join(" ");
+
+// Build a minimal screen in the real Claude Code format for parseDraftFromScreen tests.
+// Layout: optional transcript lines, then top-HR, then inputLine, then bottom-HR, then
+// a two-line status block. The HR lines use U+2500 ─ (110 chars) matching a real screen.
+const HR = "─".repeat(110);
+function makeTestScreen(inputLine: string, ...transcriptLines: string[]): string {
+  return [
+    ...transcriptLines,
+    HR,
+    inputLine,
+    HR,
+    "   Model: Opus 4.8  Ctx Used: 52.0%",
+    "  ⏵⏵ auto mode on",
+  ].join("\n");
+}
 
 describe("cmux driver", () => {
   const driver = createCmuxDriver();
@@ -498,7 +515,7 @@ describe("sendToSurface draft-preservation", () => {
 
   it("delivers directly when captain surface has no in-progress draft", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      if (args.includes("read-screen")) return "  Claude Code  \n  Tools: ...  \n  > ▌  ";
+      if (args.includes("read-screen")) return makeTestScreen("❯ ▌");
       return "";
     });
     await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew is done");
@@ -516,10 +533,7 @@ describe("sendToSurface draft-preservation", () => {
     const DRAFT = "hello this is my draft";
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
       if (args.includes("read-screen")) {
-        return [
-          "│ Some conversation history │",
-          `│ > ${DRAFT}  │`,
-        ].join("\n");
+        return makeTestScreen(`│ > ${DRAFT}  │`, "│ Some conversation history │");
       }
       return "";
     });
@@ -572,62 +586,80 @@ describe("parseDraftFromScreen", () => {
     expect(parseDraftFromScreen("")).toBe("");
   });
 
-  it("returns empty string when input shows only cursor indicator", () => {
-    const screen = ["│ > ▌  │", "╰────────╯"].join("\n");
+  it("returns empty string when screen has no HR boundaries (cannot locate input box)", () => {
+    // No long ─ HR lines → cannot locate input box → safe fallback is ""
+    const screen = "Claude Code\nsome transcript\n> looks like input but no HR box";
     expect(parseDraftFromScreen(screen)).toBe("");
   });
 
-  it("extracts draft from plain '> text' input line", () => {
-    const screen = ["Some history", "> hello this is my draft"].join("\n");
+  it("returns empty string when input box is empty (cursor only)", () => {
+    const screen = makeTestScreen("❯ ▌");
+    expect(parseDraftFromScreen(screen)).toBe("");
+  });
+
+  // (i) Happy path: real draft between HR rules above the status bar
+  it("extracts draft from plain ‘❯ text’ input line between HR boundaries", () => {
+    const screen = makeTestScreen("❯ my draft here", "Some history");
+    expect(parseDraftFromScreen(screen)).toBe("my draft here");
+  });
+
+  it("extracts draft from plain ‘> text’ input line between HR boundaries", () => {
+    const screen = makeTestScreen("> hello this is my draft", "Some history");
     expect(parseDraftFromScreen(screen)).toBe("hello this is my draft");
   });
 
-  it("extracts draft from box-drawing input line", () => {
-    const screen = [
-      "╭─────────────────────╮",
-      "│ > my draft message  │",
-      "╰─────────────────────╯",
-    ].join("\n");
+  // (ii) Box-drawing content variant: │ ❯ text │ line inside the HR-bounded input box
+  it("extracts draft from box-drawing input line between HR boundaries", () => {
+    const screen = makeTestScreen("│ > my draft message  │");
     expect(parseDraftFromScreen(screen)).toBe("my draft message");
   });
 
-  it("ignores top-of-screen content and returns the bottom input line", () => {
-    // Simulate a line containing "> " far above the input (e.g. in conversation history)
-    const screen = [
+  it("extracts draft from real Claude Code box-drawing prompt between HR boundaries", () => {
+    const screen = makeTestScreen("│ ❯ my real draft message │");
+    expect(parseDraftFromScreen(screen)).toBe("my real draft message");
+  });
+
+  // (iii) Regression: transcript above the top HR has ‘> sent message’ lines — must be ignored
+  it("returns '' when input box is empty but transcript above contains sent '> ' lines", () => {
+    const screen = makeTestScreen("❯ ", "> this is a sent message in the transcript");
+    expect(parseDraftFromScreen(screen)).toBe("");
+  });
+
+  it("ignores transcript '> ' lines above the top HR, returns actual draft from input box", () => {
+    const screen = makeTestScreen(
+      "│ > actual draft       │",
       "> old prompt from history",
       "response text",
       "more history",
-      "─────────────────────────────────────────────────────────",
-      "│ > actual draft       │",
-    ].join("\n");
-    // Should pick the last matching line (the actual draft area)
+    );
     expect(parseDraftFromScreen(screen)).toBe("actual draft");
   });
 
-  it("returns empty string when there is no '>' input line", () => {
-    const screen = ["   Claude Code   ", "   Thinking...  "].join("\n");
+  it("returns empty string when no prompt glyph inside the input box", () => {
+    const screen = makeTestScreen("   thinking...   ", "   Claude Code   ");
     expect(parseDraftFromScreen(screen)).toBe("");
   });
 
   // Real Claude Code prompt uses ❯ (U+276F) + non-breaking space (U+00A0)
-  // confirmed via hexdump: bytes e2 9d af c2 a0 <draft text>
   it("extracts draft from real Claude Code prompt (❯ + non-breaking space)", () => {
-    const screen = ["Some history", "❯ hello draft text"].join("\n");
+    const screen = makeTestScreen("❯ hello draft text", "Some history");
     expect(parseDraftFromScreen(screen)).toBe("hello draft text");
   });
 
-  it("extracts draft from real Claude Code box-drawing prompt (❯ + non-breaking space)", () => {
-    const screen = [
-      "╭──────────────────────────╮",
-      "│ ❯ my real draft message │",
-      "╰──────────────────────────╯",
-    ].join("\n");
-    expect(parseDraftFromScreen(screen)).toBe("my real draft message");
+  it("returns empty string when real prompt has only cursor indicator (❯ ▌)", () => {
+    const screen = makeTestScreen("│ ❯ ▌  │");
+    expect(parseDraftFromScreen(screen)).toBe("");
   });
 
-  it("returns empty string when real prompt has only cursor indicator (❯ + NBSP + ▌)", () => {
-    const screen = ["│ ❯ ▌  │", "╰────────╯"].join("\n");
-    expect(parseDraftFromScreen(screen)).toBe("");
+  // Regression fixture: real captain screen captured during the #258 bug.
+  // Input box was empty (❯ with no text) but the transcript contained a sent
+  // ❯ message — parseDraftFromScreen must return "" not the sent message.
+  it("returns '' for real fixture: empty input box with sent ❯ lines in transcript (regression #258)", () => {
+    const fixture = readFileSync(
+      join(process.cwd(), "docs/reports/258-parse-bug-fixture.txt"),
+      "utf-8",
+    );
+    expect(parseDraftFromScreen(fixture)).toBe("");
   });
 });
 
@@ -690,7 +722,7 @@ describe("sendToSurface Approach B (#258 deliver-when-empty)", () => {
 
   it("non-empty draft, not forced → throws DeferDelivery immediately without sending", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      if (args.includes("read-screen")) return "❯ hello draft text";
+      if (args.includes("read-screen")) return makeTestScreen("❯ hello draft text");
       return "";
     });
     await expect(
@@ -721,7 +753,7 @@ describe("sendToSurface Approach B (#258 deliver-when-empty)", () => {
   it("non-empty draft + force=true → backspace clear, deliver, restore without Enter", async () => {
     const DRAFT = "my walk-away draft";
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      if (args.includes("read-screen")) return `❯ ${DRAFT}`;
+      if (args.includes("read-screen")) return makeTestScreen(`❯ ${DRAFT}`);
       return "";
     });
     await driver.sendToSurface(

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -92,25 +92,50 @@ export function sanitizeForCmuxSend(text: string): string {
 export function parseDraftFromScreen(screen: string): string {
   if (!screen) return "";
   const lines = screen.split(/\r?\n/);
+
+  // Locate the last two HR lines (runs of U+2500 ─) — they are the bottom and top
+  // boundaries of the live input box. Everything above the top HR is transcript
+  // content and is never scanned, preventing sent user messages with a ❯/> prefix
+  // from being mistaken for the live draft (#258).
+  const HR_RE = /^\s*─{10,}\s*$/;
+  let bottomHR = -1;
+  let topHR = -1;
   for (let i = lines.length - 1; i >= 0; i--) {
-    const line = lines[i];
+    if (HR_RE.test(lines[i])) {
+      if (bottomHR === -1) {
+        bottomHR = i;
+      } else {
+        topHR = i;
+        break;
+      }
+    }
+  }
+
+  // Can't locate both boundaries — return "" so delivery proceeds rather than
+  // restoring garbage into the captain's input box.
+  if (topHR === -1) return "";
+
+  // Extract content lines strictly between the two HRs (the live input box only).
+  const inputLines = lines.slice(topHR + 1, bottomHR);
+
+  for (const line of inputLines) {
     let extracted: string | undefined;
-    // Box-drawing input line: │ [>❯] text │  (❯ is the real Claude Code prompt)
+    // Box-drawing input line: │ [>❯] text │
     const boxMatch = line.match(/│\s*[>❯]\s+(.*?)\s*│/);
     if (boxMatch) {
       extracted = boxMatch[1].trim();
     } else {
-      // Plain input line: optionally-indented [>❯] text
-      const plainMatch = line.match(/^\s*[>❯]\s+(.+)$/);
+      // Plain input line — allow empty content after the prompt glyph
+      const plainMatch = line.match(/^\s*[>❯]\s*(.*)$/);
       if (plainMatch) extracted = plainMatch[1].trim();
     }
     if (extracted !== undefined) {
-      // Strip terminal cursor characters (▌, █, etc.) that trail the caret position
-      const draft = extracted.replace(/\s*[▌█▍▎▏▌█]+\s*$/, "").trim();
+      // Strip terminal cursor glyphs (▌, █, etc.) that trail the caret position
+      const draft = extracted.replace(/\s*[▌█▔▎▏▌█]+\s*$/, "").trim();
       if (draft) return draft;
-      // cursor-only line — continue scanning upward
     }
   }
+
   return "";
 }
 


### PR DESCRIPTION
## Summary
Follow-up hardening for #258 (deliver-when-empty draft preservation, merged in #267). Two fixes, both found via live testing:

1. **Configurable force-defer timeout.** The walk-away force-deliver fallback is now read from config (`relay.maxDeferDeliveries`), default **300 (~5 min)** instead of a hardcoded 30. After the timeout a held draft is force-delivered via best-effort backspace clear+restore. Tune it in `config.json` with no code change.

2. **Scope `parseDraftFromScreen` to the live input box.** It previously scanned the whole screen and, when the input was empty, walked up into the transcript and grabbed a **sent message** — causing spurious defers and re-pasting an already-sent message. It now reads only the input line inside the box bounded by the two `───` rules just above the status bar. Empty box → `""`.

## Verification
- `npm run build` clean; targeted cmux + notify-relay tests pass
- **Live:** relay logged **32 consecutive `deferred: captain typing`** while a real draft was held, then delivered when the input cleared
- Parse confirmed against real screen captures: held draft extracted correctly; empty input / transcript-with-sent-message → `""`

## Known follow-up
#268 — when the captain surface isn't showing the input box (overlay open / scrolled), the relay can mis-read it as empty and deliver into nowhere (lost signal). Tracked separately; not addressed here.

Refs #258.