### PR TITLE
fix(relay): parseDraftFromScreen third state — overlay/unknown screen defers (#268)

### DIFF
--- a/docs/reports/268-overlay-fixture.txt
+++ b/docs/reports/268-overlay-fixture.txt
@@ -1,0 +1,20 @@
+ Claude Code — pact-network-captain
+
+  ✻ Thinking for 12s
+
+  Let me check the status of the crew tasks…
+
+ ╔══════════════════════════════════════════════════════════════════════════╗
+ ║  /model                                                                  ║
+ ║                                                                          ║
+ ║  Current model: claude-opus-4-8                                          ║
+ ║                                                                          ║
+ ║  ❯ claude-opus-4-8      Powerful, best for complex tasks                 ║
+ ║    claude-sonnet-4-6    Fast and intelligent                             ║
+ ║    claude-haiku-4-5     Fastest                                          ║
+ ║                                                                          ║
+ ║  [Enter] Select   [Esc] Cancel                                           ║
+ ╚══════════════════════════════════════════════════════════════════════════╝
+
+   Model: Opus 4.8  Ctx Used: 31.2%  Cost: $8.42  Session: 47m
+   ⏵⏵ auto mode on · 0 shells

--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -304,7 +304,10 @@ describe("cmux driver", () => {
   });
 
   it("sendToSurface sanitizes multi-line messages", async () => {
-    execFileMock.mockReturnValue("");
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return makeTestScreen("\u276F \u258C");
+      return "";
+    });
     await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "multi\nline\r\ntext");
     const sendCall = execFileMock.mock.calls.find((c) => argvOf(c)[0] === "send");
     expect(sendCall).toBeDefined();
@@ -344,11 +347,14 @@ describe("cmux driver", () => {
     expect(text).toBe("");
   });
 
-  // #258: when no draft is detected (empty screen / cursor-only), deliver
+  // #258: when no draft is detected (cursor-only input box), deliver
   // message+Enter directly with no key-chord preamble. ctrl-u/ctrl+a/ctrl+k/
   // ctrl+y are all no-ops against Claude Code's input box.
   it("sendToSurface delivers message+Enter directly when no draft detected", async () => {
-    execFileMock.mockReturnValue("");
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return makeTestScreen("\u276F \u258C");
+      return "";
+    });
     await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done");
     const calls = execFileMock.mock.calls.map(argvOf);
 
@@ -367,7 +373,10 @@ describe("cmux driver", () => {
   });
 
   it("sendToSurface delivers shell metacharacters as literal text scoped to surface", async () => {
-    execFileMock.mockReturnValue("");
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return makeTestScreen("\u276F \u258C");
+      return "";
+    });
     const text = 'done: `cmux close-workspace` $(whoami)';
     await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, text);
     const sendCall = execFileMock.mock.calls.find((c) => argvOf(c)[0] === "send");
@@ -564,32 +573,30 @@ describe("sendToSurface draft-preservation", () => {
     expect(cmdsAfterRestore.every((c) => !c.includes("Enter"))).toBe(true);
   });
 
-  it("delivers normally when read-screen throws, without crashing", async () => {
+  // #268: unreadable screen → draft stays null → DeferDelivery (never deliver into unknown state).
+  it("throws DeferDelivery when read-screen throws (surface unreadable — defer, not deliver)", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
       if (args.includes("read-screen")) throw new Error("surface gone");
       return "";
     });
     await expect(
       driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done"),
-    ).resolves.toBeUndefined();
+    ).rejects.toBeInstanceOf(DeferDelivery);
     const cmds = execFileMock.mock.calls.map(cmdOf);
-    // Still delivers the message
-    expect(cmds.some((c) => c.includes("send ") && c.includes("crew done"))).toBe(true);
-    expect(cmds.some((c) => c.includes("send-key") && c.includes("Enter"))).toBe(true);
-    // No ctrl-u on failure path
-    expect(cmds.every((c) => !c.includes("ctrl-u"))).toBe(true);
+    // Must not have sent anything — deferred
+    expect(cmds.filter((c) => c.startsWith("send ") && !c.startsWith("send-key"))).toHaveLength(0);
   });
 });
 
 describe("parseDraftFromScreen", () => {
-  it("returns empty string for empty screen", () => {
-    expect(parseDraftFromScreen("")).toBe("");
+  it("returns null for empty screen (input box not confirmed visible — defer)", () => {
+    expect(parseDraftFromScreen("")).toBeNull();
   });
 
-  it("returns empty string when screen has no HR boundaries (cannot locate input box)", () => {
-    // No long ─ HR lines → cannot locate input box → safe fallback is ""
+  it("returns null when screen has no HR boundaries (overlay/unknown — must defer, not deliver)", () => {
+    // No long ─ HR lines → cannot confirm input box → null signals DEFER (#268)
     const screen = "Claude Code\nsome transcript\n> looks like input but no HR box";
-    expect(parseDraftFromScreen(screen)).toBe("");
+    expect(parseDraftFromScreen(screen)).toBeNull();
   });
 
   it("returns empty string when input box is empty (cursor only)", () => {
@@ -660,6 +667,35 @@ describe("parseDraftFromScreen", () => {
       "utf-8",
     );
     expect(parseDraftFromScreen(fixture)).toBe("");
+  });
+
+  // #268: overlay/menu/scrolled screen — HR boundaries absent → input box NOT confirmed.
+  // Must return null (not "") so the delivery gate knows to defer, never keystroke into unknown UI.
+  it("returns null when screen has no HR boundaries (overlay / menu / scrolled-away input box)", () => {
+    // No ─{10,} HR lines → topHR stays -1 → box not confirmed visible
+    const overlayScreen = [
+      " ╔══════════════════════════════════════╗",
+      " ║  /model                              ║",
+      " ║  ❯ claude-opus-4-8   (Powerful)      ║",
+      " ║    claude-sonnet-4-6 (Fast)          ║",
+      " ║  [Enter] Select  [Esc] Cancel        ║",
+      " ╚══════════════════════════════════════╝",
+      "   Model: Opus 4.8  Ctx Used: 31%",
+    ].join("\n");
+    expect(parseDraftFromScreen(overlayScreen)).toBeNull();
+  });
+
+  it("returns null for empty screen (input box not confirmed visible)", () => {
+    expect(parseDraftFromScreen("")).toBeNull();
+  });
+
+  // Regression fixture: real overlay screen captured for #268.
+  it("returns null for real overlay fixture (regression #268)", () => {
+    const fixture = readFileSync(
+      join(process.cwd(), "docs/reports/268-overlay-fixture.txt"),
+      "utf-8",
+    );
+    expect(parseDraftFromScreen(fixture)).toBeNull();
   });
 });
 
@@ -735,7 +771,10 @@ describe("sendToSurface Approach B (#258 deliver-when-empty)", () => {
   });
 
   it("empty input → delivers directly (no backspace, no restore)", async () => {
-    execFileMock.mockReturnValue("");
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return makeTestScreen("\u276F \u258C");
+      return "";
+    });
     await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done");
     const calls = execFileMock.mock.calls.map(argvOf);
     // No backspaces — nothing to clear
@@ -748,6 +787,31 @@ describe("sendToSurface Approach B (#258 deliver-when-empty)", () => {
     // No restore send after Enter
     const afterEnter = calls.slice(enterIdx + 1);
     expect(afterEnter.filter((a) => a[0] === "send")).toHaveLength(0);
+  });
+
+  // #268: overlay / unknown screen → input box NOT positively confirmed → must defer,
+  // never keystroke into an overlay or scrolled-away surface.
+  it("throws DeferDelivery when read-screen returns a screen with no input-box boundaries (overlay/menu)", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) {
+        // No ─{10,} HR lines → parseDraftFromScreen returns null → must defer
+        return [
+          " ╔══════════════════════════════════════╗",
+          " ║  /model                              ║",
+          " ║  ❯ claude-opus-4-8   (Powerful)      ║",
+          " ║    claude-sonnet-4-6 (Fast)          ║",
+          " ║  [Enter] Select  [Esc] Cancel        ║",
+          " ╚══════════════════════════════════════╝",
+        ].join("\n");
+      }
+      return "";
+    });
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done"),
+    ).rejects.toBeInstanceOf(DeferDelivery);
+    // Must not have sent anything into the overlay
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.filter((c) => c.startsWith("send ") && !c.startsWith("send-key"))).toHaveLength(0);
   });
 
   it("non-empty draft + force=true → backspace clear, deliver, restore without Enter", async () => {

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -79,18 +79,22 @@ export function sanitizeForCmuxSend(text: string): string {
 }
 
 /**
- * Extract the in-progress draft from a cmux read-screen capture (#258).
+ * Extract the in-progress draft from a cmux read-screen capture (#258 / #268).
  * Scans from the bottom of the screen so history lines that contain `> ` are
  * ignored; only the actual input area (the last matching line) is returned.
  * Handles both `>` (synthetic/test) and `❯` (U+276F, the real Claude Code
  * prompt character) as the input caret. The real prompt is followed by a
  * non-breaking space (U+00A0); JS `\s` covers it, so `\s+` matches either.
  * Also handles box-drawing `│ ❯ text │` variants.
- * Returns the trimmed draft text, or "" when the line holds only a cursor
- * indicator (▌ / █) or no input line is present.
+ *
+ * Three-state return (#268):
+ *   "draft text" — input box found with content  → caller must DEFER
+ *   ""           — input box positively confirmed empty → caller may DELIVER
+ *   null         — HR boundaries not found (overlay/menu/scrolled) → caller must DEFER
  */
-export function parseDraftFromScreen(screen: string): string {
-  if (!screen) return "";
+export function parseDraftFromScreen(screen: string): string | null {
+  // Empty screen means the input box is definitely not visible — defer (#268).
+  if (!screen) return null;
   const lines = screen.split(/\r?\n/);
 
   // Locate the last two HR lines (runs of U+2500 ─) — they are the bottom and top
@@ -111,9 +115,9 @@ export function parseDraftFromScreen(screen: string): string {
     }
   }
 
-  // Can't locate both boundaries — return "" so delivery proceeds rather than
-  // restoring garbage into the captain's input box.
-  if (topHR === -1) return "";
+  // Can't locate both boundaries — input box not visible (overlay/menu/scrolled
+  // transcript). Defer so keystrokes never land in an unknown UI state (#268).
+  if (topHR === -1) return null;
 
   // Extract content lines strictly between the two HRs (the live input box only).
   const inputLines = lines.slice(topHR + 1, bottomHR);
@@ -321,13 +325,18 @@ export function createCmuxDriver(): RuntimeDriver {
     },
 
     async sendToSurface(surface: PaneRef, text: string, opts?: { force?: boolean }): Promise<void> {
-      // #258 Approach B: deliver only when the captain's input is empty.
-      // Read screen once; treat unreadable as empty so delivery always proceeds.
-      let draft = "";
+      // #258/#268 Approach B: deliver only when the captain's input is positively
+      // confirmed empty. null = box not visible (overlay/menu/scroll) → always defer.
+      let draft: string | null = null;
       try {
         const screen = cmux(["read-screen", "--workspace", surface.workspaceId, "--surface", surface.surfaceId]);
         draft = parseDraftFromScreen(screen);
-      } catch { /* screen unreadable — treat as empty, deliver directly */ }
+      } catch { /* screen unreadable — draft stays null, will defer below */ }
+
+      // null = box not confirmed visible → never keystroke into an overlay (#268).
+      if (draft === null) {
+        throw new DeferDelivery();
+      }
 
       if (draft && !opts?.force) {
         // Captain is composing — defer until input clears (relay retries next poll).


### PR DESCRIPTION
## Problem

`parseDraftFromScreen` collapsed two distinct states into the same `""` return:

| State | Old return | Correct action |
|-------|-----------|---------------|
| Input box present and empty | `""` | DELIVER ✓ |
| Input box **not visible** (overlay, menu, scrolled transcript) | `""` | **DEFER** ✗ |

`sendToSurface` received `""` and delivered in both cases — keystroking into a model-picker overlay or a scrolled-away surface.

## Fix

Changed `parseDraftFromScreen` return type from `string` to `string | null`:

- `"text"` — draft present → DEFER (unchanged)
- `""`     — input box **positively confirmed** empty → DELIVER (unchanged)
- `null`   — HR boundaries absent or screen unreadable → DEFER (new)

`sendToSurface` now throws `DeferDelivery` immediately on `null`, before the existing non-empty-draft check. The relay retries on its next poll — same as any other defer path.

**Blast radius:** LOW — `parseDraftFromScreen` has exactly 1 caller (`sendToSurface`), Runtimes module only.

## Tests

- 3 new `parseDraftFromScreen` cases: empty screen → `null`, overlay screen → `null`, real overlay fixture → `null`
- 1 new `sendToSurface` integration: overlay screen → throws `DeferDelivery` without sending
- 7 existing tests updated to reflect the new contract (mock screens that previously returned `""` now use `makeTestScreen("❯ ▌")` to provide a positively-confirmed empty box)
- Fixture added: `docs/reports/268-overlay-fixture.txt`

## Verification

```
npm test  →  993 passed (993), 90 test files
```