### PR TITLE
ci: add PR-time CI workflow (build + test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test


### PR DESCRIPTION
## Problem

There is no CI on PRs or pushes to `develop`. `npm test` only runs in `release.yml` on push to `main`, so broken tests reach `develop` silently (this bit the v0.5.4 release twice).

## Solution

Add `.github/workflows/ci.yml` that runs on:
- `pull_request` targeting `develop` or `main`
- `push` to `develop`

Mirrors `release.yml` conventions:
- Node 24 via `actions/setup-node@v6`
- `npm ci` → `npm run build` → `npm test`
- `ubuntu-latest` runner

Includes a `concurrency` block with `cancel-in-progress: true` to cancel duplicate runs on the same ref.

## Verification

- [x] YAML parses as valid
- [x] `npm run build` passes
- [x] `npm test` — 993 tests pass