### PR TITLE
feat(246): cross-project intra-group delegation (Phase 1)

### DIFF
--- a/docs/superpowers/specs/2026-06-12-cross-project-delegation-design.md
+++ b/docs/superpowers/specs/2026-06-12-cross-project-delegation-design.md
@@ -1,0 +1,95 @@
+# Cross-project (intra-group) delegation — design
+
+**Issue:** #246 — Clearer cross-project communication flow
+**Date:** 2026-06-12
+**Status:** Approved design, pending implementation
+
+## Problem
+
+Sibling projects in a group (e.g. `scaffold-stylus` ↔ `scaffold-stylus-docs`, `brove` ↔ `brove-docs`) have no first-class way for one captain to ask another to do work. Group awareness today is passive (config `group`/`groupRole` + claude-mem context). There is no defined channel for a stylus captain to say "stylus-docs, please document this change" and have it land as actionable, tracked work in the sibling.
+
+## Decisions (from brainstorm)
+
+| Decision | Choice |
+|----------|--------|
+| What happens on B's side | **Auto-accept + work** — B's captain automatically takes the task and spawns a crew. |
+| Trigger surface | **`cockpit group dispatch`** (Phase 1), later extended by **`runtime send --to-captain`** (Phase 2). |
+| Boot semantics | If B (captain workspace + relay) is **not up**, dispatch boots it and waits for warmup before delivering. |
+| Report-back | **Auto relay-back + wake A** — B's done/blocked signal routes back and wakes A's captain. A dispatches-and-yields, never polls (consistent with #241). |
+| Reach | **Same-group only** for now. Cross-group is out of scope (captains can read config to stay *aware* of other groups; no dispatch channel to them). |
+| Safety toggle | B's config gets `acceptDelegations` (**default true**); a project can opt out. |
+
+## Architecture — one new field, reuse the per-project relay
+
+The key insight: cockpit already routes per-project. `TaskRecord` has a `project` field (`src/control/types.ts:43`); the mailbox is per-project (`${project}.log`); each captain runs a per-project notify-relay that watches its own project and wakes its captain. **A cross-project task is just a normal task that remembers where it came from.**
+
+### Data model
+
+Add one optional field to `TaskRecord`:
+
+```ts
+originProject?: string;  // set when this task was delegated from a sibling captain
+```
+
+A delegated task is recorded with `project: B, originProject: A`. No new bus, no new transport:
+- **Delivery to B:** B's existing relay already watches project B → it wakes B's captain with the request.
+- **Report-back to A:** when the task settles, the daemon sees `originProject: A` and fans the signal back to **A's** mailbox → A's relay wakes A's captain.
+
+### `cockpit group dispatch <to-project> "<task>"` — flow
+
+1. **Resolve & gate.** A = current project (from cwd/config), B = `<to-project>`. Reject if B is not in A's `group`. Reject if B has `acceptDelegations: false` (clear message, no silent drop).
+2. **Ensure B is up.** If B's captain workspace / relay are not running, `cockpit launch B` and start B's relay, then **wait for warmup** — bounded poll on relay heartbeat / captain-pane readiness with a hard timeout (no unbounded loop). If warmup times out, fail the dispatch with a clear error (task not recorded).
+3. **Record.** Write the task to the daemon: `{ project: B, originProject: A, status: submitted, task: "<task>" }`.
+4. **Deliver.** B's relay wakes B's captain: `📨 Cross-project task from <A>: <task>`. If `acceptDelegations` is true, B's captain auto-accepts and spawns a crew (opencode default) to do the work.
+5. **Yield.** A's `group dispatch` returns immediately; A's captain dispatches-and-yields. No polling.
+
+### Report-back round-trip
+
+When B's crew signals `done` / `blocked` / `failed`:
+1. Daemon updates the task record.
+2. Daemon sees `originProject: A` and writes a report event to A's mailbox.
+3. A's relay wakes A's captain: `✅ Delegated task → B: done` (or `⛔ Delegated task → B: blocked — <reason>`).
+
+Both sides are event-driven; neither polls.
+
+### Safety
+
+- **Same-group check** is the hard boundary — enforced in `group dispatch` before anything is recorded or booted.
+- **`acceptDelegations`** (per-project config, default `true`) lets a project opt out of being driven. When `false`, dispatch is rejected (Phase 1 keeps it simple — no notify-only downgrade).
+
+### captain-ops skill
+
+Add a "Cross-project delegation" section to the captain-ops skill:
+- When to use `group dispatch` (a task genuinely belongs to a sibling).
+- The same-group rule and `acceptDelegations` behavior.
+- That report-back auto-wakes the captain — **dispatch and yield, do not poll** the sibling.
+
+## Components & boundaries
+
+| Unit | Responsibility | Depends on |
+|------|----------------|------------|
+| `group` command (`src/commands/group.ts`, new) | Parse `group dispatch`, resolve A/B, same-group gate, boot-if-down + warmup wait, record task, return | config, launch, daemon client, relay status |
+| `TaskRecord.originProject` (`src/control/types.ts`) | Carry origin so report-back can route | — |
+| Daemon report-back (`src/control/…`) | On settle, if `originProject` set, write report event to origin's mailbox | mailbox, state-machine |
+| `acceptDelegations` (config) | Per-project opt-out | config schema |
+| captain-ops skill section | Teach captains the flow | — |
+
+## Phasing
+
+- **Phase 1 (this issue, #246):** `group dispatch` + `originProject` + report-back + same-group gate + `acceptDelegations` + captain-ops section. Tests for: same-group gate, boot-if-down warmup timeout, record shape, report-back fan-out to origin.
+- **Phase 2 (later, separate issue):** `cockpit runtime send --to-captain <project> "<msg>"` for free-form peer captain↔captain comms, riding the same `originProject` rail. Not built now.
+
+## Out of scope
+
+- Cross-group delegation.
+- Notify-only downgrade when `acceptDelegations: false`.
+- Multi-hop delegation chains (A→B→C tracking).
+- Phase 2 peer comms.
+
+## Success criteria
+
+1. `cockpit group dispatch <sibling> "<task>"` from project A records a task on B with `originProject: A`, booting B if it was down.
+2. B's captain is woken with the request and (when `acceptDelegations` is true) auto-spawns a crew.
+3. On completion/block, A's captain is auto-woken with the outcome — without A polling.
+4. Dispatch to a non-same-group project, or to a project with `acceptDelegations: false`, is rejected with a clear message.
+5. captain-ops documents the flow and the dispatch-and-yield discipline.

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -220,6 +220,40 @@ If your config has `group` / `groupRole`:
 - Use **claude-mem** to search for context from sibling projects
 - `primary` role: your changes may need propagation to forks/dependents
 
+## Cross-Project Delegation
+
+When a task genuinely belongs to a sibling project in the same group, use **`cockpit group dispatch <to-project> '<task>'`** instead of hand-writing a message. This records a tracked task on the sibling's project and auto-wakes its captain via the existing mailbox/relay.
+
+### Rules
+
+1. **Same-group only.** `group dispatch` rejects any target whose `group` field differs from yours. Cross-group dispatch is out of scope — use claude-mem / wiki queries for awareness.
+2. **`acceptDelegations`.** If the sibling's project config has `acceptDelegations: false`, the command rejects with a clear error. The default is `true`.
+3. **Boot-if-down.** If the sibling's captain workspace / notify-relay are not running, `group dispatch` boots them (`cockpit launch <project>`) and waits for warmup with a bounded poll (30s hard timeout). If warmup fails, the dispatch is rejected (task not recorded).
+
+### Dispatch-and-yield (do NOT poll)
+
+Once the task is recorded to the daemon, `group dispatch` **returns immediately**. The sibling's captain auto-accepts (because `acceptDelegations` is true) and spawns a crew. When the task settles — done, blocked, or failed — the daemon fans the outcome back to **your** mailbox automatically. Your relay wakes you up. **You never poll the sibling.**
+
+HARD RULE: Do NOT add a polling loop after `group dispatch`. The report-back is event-driven; trust it.
+
+### Report-back format
+
+| Settlement | Message |
+|------------|---------|
+| done | `✅ Cross-project task → B: done — <task snippet>` |
+| blocked | `⛔ Cross-project task → B: blocked — <question>` |
+| failed | `⛔ Cross-project task → B: failed — <error>` |
+| stalled | `⚠️ Cross-project task → B: stalled (no heartbeat)` |
+
+### Example
+
+```bash
+# You are captain of "scaffold-stylus". Ask the docs sibling to update docs.
+cockpit group dispatch scaffold-stylus-docs "Document the new --format flag added in PR #42"
+# → "✔ Dispatched to 'scaffold-stylus-docs' (task abc12345)"
+# → (returns immediately; you are notified when settled)
+```
+
 ## Recording Learnings
 
 Recording learnings is **opt-in**. Record when something genuinely surprised you or a useful pattern emerged — not on a schedule.

--- a/src/commands/__tests__/group.test.ts
+++ b/src/commands/__tests__/group.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const sendRequestMock = vi.hoisted(() => vi.fn());
+const execSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../control/protocol.js", () => ({
+  sendRequest: sendRequestMock,
+}));
+
+vi.mock("node:child_process", () => ({
+  execSync: execSyncMock,
+}));
+
+const loadConfig = vi.hoisted(() => vi.fn());
+vi.mock("../../config.js", () => ({
+  loadConfig,
+  resolveHome: (p: string) => p,
+}));
+
+import { runGroupDispatch } from "../group.js";
+
+const makeConfig = (overrides: Record<string, any> = {}) => {
+  const projects: Record<string, any> = {
+    projA: {
+      path: "/projects/a",
+      captainName: "⚓ A-captain",
+      spokeVault: "/spokes/a",
+      host: "local",
+      group: "mygroup",
+      groupRole: "primary",
+      ...(overrides.acceptDelegationsA !== undefined ? { acceptDelegations: overrides.acceptDelegationsA } : {}),
+    },
+    projB: {
+      path: "/projects/b",
+      captainName: "⚓ B-captain",
+      spokeVault: "/spokes/b",
+      host: "local",
+      group: "mygroup",
+      groupRole: "fork",
+      ...(overrides.acceptDelegationsB !== undefined ? { acceptDelegations: overrides.acceptDelegationsB } : {}),
+    },
+    projC: {
+      path: "/projects/c",
+      captainName: "⚓ C-captain",
+      spokeVault: "/spokes/c",
+      host: "local",
+      group: "othergroup",
+      groupRole: "primary",
+    },
+  };
+  return {
+    commandName: "command",
+    hubVault: "~/hub",
+    projects,
+    defaults: {
+      maxCrew: 5,
+      worktreeDir: ".worktrees",
+      teammateMode: "in-process",
+      permissions: { command: "auto", captain: "auto", crew: "auto" },
+    },
+    metrics: { enabled: false, path: "/tmp/metrics.json" },
+  };
+};
+
+describe("runGroupDispatch", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    loadConfig.mockReturnValue(makeConfig());
+    sendRequestMock.mockResolvedValue([]);
+    execSyncMock.mockReturnValue("");
+  });
+
+  // ── same-group gate ──────────────────────────────────────────────────────
+
+  it("rejects dispatch to a project NOT in the same group", async () => {
+    await expect(
+      runGroupDispatch({
+        fromProject: "projA",
+        toProject: "projC",
+        task: "do something",
+      }),
+    ).rejects.toThrow(/not in the same group/i);
+
+    expect(sendRequestMock).not.toHaveBeenCalled();
+    expect(execSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects dispatch when toProject has acceptDelegations: false", async () => {
+    loadConfig.mockReturnValue(makeConfig({ acceptDelegationsB: false }));
+
+    await expect(
+      runGroupDispatch({
+        fromProject: "projA",
+        toProject: "projB",
+        task: "do something",
+      }),
+    ).rejects.toThrow(/acceptDelegations.*false/i);
+
+    expect(sendRequestMock).not.toHaveBeenCalled();
+    expect(execSyncMock).not.toHaveBeenCalled();
+  });
+
+  // ── warmup timeout ───────────────────────────────────────────────────────
+
+  it("fails clearly when warmup times out", async () => {
+    // sendRequest for health returns empty → captain not alive → launch + poll
+    sendRequestMock.mockResolvedValue([]);
+
+    loadConfig.mockReturnValue(makeConfig({}));
+
+    await expect(
+      runGroupDispatch({
+        fromProject: "projA",
+        toProject: "projB",
+        task: "do something",
+        warmupTimeoutMs: 100,
+        warmupPollMs: 20,
+      }),
+    ).rejects.toThrow(/timed out waiting for captain warmup/i);
+  });
+
+  // ── task record shape ────────────────────────────────────────────────────
+
+  it("records a task with originProject set when dispatch succeeds", async () => {
+    // sendRequest signature is (sockPath, msg, timeoutMs). The second arg is the msg.
+    sendRequestMock.mockImplementation((_sock: string, msg: any, _timeout?: number) => {
+      if (msg?.kind === "health") {
+        return [
+          { kind: "captain", project: "projB", state: "alive", lastSeenMs: Date.now() },
+        ];
+      }
+      if (msg?.kind === "dispatch") {
+        return msg.record;
+      }
+      return undefined;
+    });
+
+    loadConfig.mockReturnValue(makeConfig({}));
+
+    const result = await runGroupDispatch({
+      fromProject: "projA",
+      toProject: "projB",
+      task: "update the docs",
+    });
+
+    expect(result).toBeDefined();
+    expect((result as any).originProject).toBe("projA");
+    expect((result as any).project).toBe("projB");
+    expect((result as any).state).toBe("submitted");
+    expect((result as any).task).toBe("update the docs");
+  });
+});

--- a/src/commands/group.ts
+++ b/src/commands/group.ts
@@ -1,0 +1,169 @@
+// src/commands/group.ts
+//
+// #246: cross-project intra-group delegation. `cockpit group dispatch`
+// sends a task to a sibling project in the same group. The target's captain
+// is woken via the existing mailbox/relay path. A dispatches-and-yields;
+// the origin captain is auto-woken when the task settles (report-back).
+
+import { Command } from "commander";
+import { execSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import chalk from "chalk";
+import { loadConfig, resolveHome, type CockpitConfig } from "../config.js";
+import { sendRequest } from "../control/protocol.js";
+import type { TaskRecord, Provider, Mode } from "../control/types.js";
+
+const SOCK = join(homedir(), ".config", "cockpit", "cockpit.sock");
+const WARMUP_TIMEOUT_MS = 30_000;
+const WARMUP_POLL_MS = 1_000;
+
+/** Resolve the current project name by matching cwd against config paths. */
+export function resolveCurrentProject(config: CockpitConfig): string | null {
+  const cwd = process.cwd();
+  for (const [name, proj] of Object.entries(config.projects)) {
+    const resolvedPath = resolveHome(proj.path);
+    if (cwd.startsWith(resolvedPath)) return name;
+  }
+  return null;
+}
+
+/** Check via the daemon health endpoint whether a project's captain is up. */
+async function isCaptainAlive(project: string): Promise<boolean> {
+  try {
+    const health = (await sendRequest(SOCK, { kind: "health", project }, 5000)) as Array<{
+      kind: string; project: string; state: string;
+    }>;
+    const captain = health?.find((h) => h.kind === "captain" && h.project === project);
+    return captain != null && captain.state !== "gone" && captain.state !== "unknown";
+  } catch {
+    return false;
+  }
+}
+
+/** Poll the daemon health endpoint until the target project's relay is up,
+ *  or the hard timeout expires. Returns true if warmup succeeded. */
+export async function waitForWarmup(
+  project: string,
+  timeoutMs = WARMUP_TIMEOUT_MS,
+  pollMs = WARMUP_POLL_MS,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await isCaptainAlive(project)) return true;
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+  return false;
+}
+
+export interface GroupDispatchOpts {
+  fromProject: string;
+  toProject: string;
+  task: string;
+  provider?: Provider;
+  mode?: Mode;
+  warmupTimeoutMs?: number;
+  warmupPollMs?: number;
+}
+
+/** Pure-ish dispatch function (extracted for testability). */
+export async function runGroupDispatch(opts: GroupDispatchOpts): Promise<TaskRecord> {
+  const config = loadConfig();
+  const fromCfg = config.projects[opts.fromProject];
+  const toCfg = config.projects[opts.toProject];
+
+  if (!toCfg) {
+    throw new Error(`target project '${opts.toProject}' not found in config`);
+  }
+
+  // #246: same-group gate — hard boundary
+  if (!fromCfg.group || !toCfg.group || fromCfg.group !== toCfg.group) {
+    throw new Error(
+      `cannot dispatch: '${opts.toProject}' (group: ${toCfg.group ?? "none"}) ` +
+      `is not in the same group as '${opts.fromProject}' (group: ${fromCfg.group ?? "none"})`,
+    );
+  }
+
+  // #246: acceptDelegations check
+  if (toCfg.acceptDelegations === false) {
+    throw new Error(
+      `cannot dispatch to '${opts.toProject}': project has acceptDelegations set to false`,
+    );
+  }
+
+  // Ensure B's captain/relay is up
+  const alive = await isCaptainAlive(opts.toProject);
+  if (!alive) {
+    try {
+      execSync(`cockpit launch ${opts.toProject}`, { stdio: "ignore", timeout: 15_000 });
+    } catch {
+      throw new Error(`failed to launch captain for '${opts.toProject}' — is cockpit installed?`);
+    }
+
+    const warmed = await waitForWarmup(opts.toProject, opts.warmupTimeoutMs, opts.warmupPollMs);
+    if (!warmed) {
+      throw new Error(
+        `dispatch to '${opts.toProject}' timed out waiting for captain warmup ` +
+        `(>${(opts.warmupTimeoutMs ?? WARMUP_TIMEOUT_MS) / 1000}s)`,
+      );
+    }
+  }
+
+  // Record the task via the daemon
+  const now = Date.now();
+  const attemptId = randomUUID();
+  const record: TaskRecord = {
+    id: randomUUID(),
+    project: opts.toProject,
+    originProject: opts.fromProject,
+    provider: opts.provider ?? "claude",
+    mode: opts.mode ?? "headless",
+    state: "submitted",
+    task: opts.task,
+    createdAt: now,
+    lastHeartbeat: now,
+    lastEvent: "dispatch",
+    heartbeatBudgetMs: 300000,
+    attempts: [{ attemptId, startedAt: now, lastHeartbeatAt: now }],
+  };
+
+  const result = await sendRequest(SOCK, { kind: "dispatch", record }) as TaskRecord;
+  return result;
+}
+
+// ── CLI command ──────────────────────────────────────────────────────────────
+
+export const groupCommand = new Command("group")
+  .description("Cross-project intra-group operations (Phase 1: dispatch)")
+  .addCommand(
+    new Command("dispatch")
+      .description("Dispatch a task to a sibling project in the same group")
+      .argument("<to-project>", "Target project name (must be in the same group)")
+      .argument("<task>", "Task description to dispatch")
+      .option("--provider <p>", "claude|opencode|codex", "claude")
+      .option("--mode <m>", "headless|interactive", "headless")
+      .action(async (toProject: string, task: string, opts: { provider?: Provider; mode?: Mode }) => {
+        const fromProject = resolveCurrentProject(loadConfig());
+        if (!fromProject) {
+          console.error(chalk.red("Could not determine current project from cwd. Run from inside a registered project directory."));
+          process.exit(1);
+        }
+
+        try {
+          const result = await runGroupDispatch({
+            fromProject,
+            toProject,
+            task,
+            provider: opts.provider,
+            mode: opts.mode,
+          });
+          console.log(chalk.green(`✔ Dispatched to '${toProject}' (task ${result.id.slice(0, 8)})`));
+          console.log(chalk.dim(`  originProject: ${result.originProject ?? "none"}`));
+          console.log(chalk.dim("  You will be notified when the task settles (done/blocked/failed)."));
+        } catch (e) {
+          console.error(chalk.red(`✘ ${(e as Error).message}`));
+          process.exit(1);
+        }
+      }),
+  );

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,9 @@ export interface ProjectConfig {
   groupRole?: string;
   runtime?: string;
   workspace?: string;
+  /** #246: when false, `cockpit group dispatch` rejects delegations to this
+   *  project. Defaults to true when absent. */
+  acceptDelegations?: boolean;
 }
 
 export interface PermissionConfig {

--- a/src/control/__tests__/daemon.test.ts
+++ b/src/control/__tests__/daemon.test.ts
@@ -736,3 +736,122 @@ describe("daemon handle() socket-boundary validation (#87)", () => {
   });
 });
 
+// ── Issue #246: cross-project delegation report-back ──────────────────────────
+
+describe("daemon report-back on settle with originProject (#246)", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "cp-246-")); });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  function rec246(id: string, overrides: Partial<TaskRecord> = {}): TaskRecord {
+    return {
+      id, project: "projB", provider: "claude", mode: "interactive",
+      state: "working", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000,
+      attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }],
+      originProject: "projA",
+      ...overrides,
+    };
+  }
+
+  it("fires notify to origin project when task transitions to done", async () => {
+    const store = createStore(dir);
+    const calls: Array<{ project: string; message: string }> = [];
+    const notify = vi.fn(async (a: { project: string; message: string }) => { calls.push(a); });
+    store.put(rec246("t-done"));
+    const d = createDaemon({ store, now: () => 2000, notify });
+
+    await d.handle({ kind: "event", project: "projB", event: { type: "task.done", id: "t-done", resultRef: "/tmp/r" } });
+
+    const originCalls = calls.filter((c) => c.project === "projA");
+    expect(originCalls.length).toBe(1);
+    expect(originCalls[0].message).toMatch(/projB.*done|delegat/i);
+  });
+
+  it("fires notify to origin project when task transitions to blocked", async () => {
+    const store = createStore(dir);
+    const calls: Array<{ project: string; message: string }> = [];
+    const notify = vi.fn(async (a: { project: string; message: string }) => { calls.push(a); });
+    store.put(rec246("t-blocked"));
+    const d = createDaemon({ store, now: () => 2000, notify });
+
+    await d.handle({ kind: "event", project: "projB", event: { type: "task.blocked", id: "t-blocked", reason: "stuck", question: "help" } });
+
+    const originCalls = calls.filter((c) => c.project === "projA");
+    expect(originCalls.length).toBe(1);
+    expect(originCalls[0].message).toMatch(/blocked|stuck/i);
+  });
+
+  it("fires notify to origin project when task transitions to failed", async () => {
+    const store = createStore(dir);
+    const calls: Array<{ project: string; message: string }> = [];
+    const notify = vi.fn(async (a: { project: string; message: string }) => { calls.push(a); });
+    store.put(rec246("t-failed"));
+    const d = createDaemon({ store, now: () => 2000, notify });
+
+    await d.handle({ kind: "event", project: "projB", event: { type: "task.failed", id: "t-failed", error: "oops" } });
+
+    const originCalls = calls.filter((c) => c.project === "projA");
+    expect(originCalls.length).toBe(1);
+    expect(originCalls[0].message).toMatch(/failed|oops/i);
+  });
+
+  it("does NOT fire report-back when task has no originProject", async () => {
+    const store = createStore(dir);
+    const calls: Array<{ project: string; message: string }> = [];
+    const notify = vi.fn(async (a: { project: string; message: string }) => { calls.push(a); });
+    store.put(rec246("t-no-origin", { originProject: undefined }));
+    const d = createDaemon({ store, now: () => 2000, notify });
+
+    await d.handle({ kind: "event", project: "projB", event: { type: "task.done", id: "t-no-origin", resultRef: "/tmp/r" } });
+
+    const originCalls = calls.filter((c) => c.project === "projA");
+    expect(originCalls.length).toBe(0);
+  });
+
+  it("does NOT fire report-back when task settles but originProject equals project (self-delegation no-op)", async () => {
+    const store = createStore(dir);
+    const calls: Array<{ project: string; message: string }> = [];
+    const notify = vi.fn(async (a: { project: string; message: string }) => { calls.push(a); });
+    store.put(rec246("t-self", { originProject: "projB" })); // same as project
+    const d = createDaemon({ store, now: () => 2000, notify });
+
+    await d.handle({ kind: "event", project: "projB", event: { type: "task.done", id: "t-self", resultRef: "/tmp/r" } });
+
+    // Exactly 1 notify call: the normal CREW DONE (no extra report-back since
+    // originProject === project).
+    expect(calls.length).toBe(1);
+    expect(calls[0].project).toBe("projB");
+  });
+
+  it("fires notify to origin project on stall (sweep-synthetic)", async () => {
+    const store = createStore(dir);
+    const calls: Array<{ project: string; message: string }> = [];
+    const notify = vi.fn(async (a: { project: string; message: string }) => { calls.push(a); });
+    store.put(rec246("t-stall", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 100, mode: "headless" }));
+    const d = createDaemon({ store, now: () => 2000, notify });
+
+    await d.sweep();
+
+    const originCalls = calls.filter((c) => c.project === "projA");
+    expect(originCalls.length).toBe(1);
+    expect(originCalls[0].message).toMatch(/stall|no heartbeat/i);
+  });
+
+  it("dispatched task with originProject notifies B (target) mailbox with delegation message", async () => {
+    const store = createStore(dir);
+    const calls: Array<{ project: string; message: string }> = [];
+    const notify = vi.fn(async (a: { project: string; message: string }) => { calls.push(a); });
+    const d = createDaemon({ store, now: () => 2000, notify });
+
+    await d.handle({
+      kind: "dispatch",
+      record: rec246("t-deleg", { state: "submitted", project: "projB", originProject: "projA" }),
+    });
+
+    const bCalls = calls.filter((c) => c.project === "projB");
+    expect(bCalls.length).toBe(1);
+    expect(bCalls[0].message).toMatch(/cross.project|projA/i);
+  });
+});
+

--- a/src/control/daemon.ts
+++ b/src/control/daemon.ts
@@ -133,6 +133,25 @@ function formatMessage(rec: TaskRecord, event?: ControlEvent): string | null {
   }
 }
 
+/** #246: cross-project delegation report-back message. Called when a task
+ *  with originProject settles to a terminal state. Returns a captain-facing
+ *  one-liner that the origin's relay delivers verbatim. */
+function formatDelegationReport(rec: TaskRecord, originProject: string, targetProject: string): string | null {
+  const shortTask = (rec.task ?? "").split(/\r?\n/)[0]?.trim().slice(0, 120) ?? "";
+  switch (rec.state) {
+    case "done":
+      return `✅ Cross-project task → ${targetProject}: done — ${shortTask}`;
+    case "blocked":
+      return `⛔ Cross-project task → ${targetProject}: blocked — ${(rec.question ?? "(no question)").trim()}`;
+    case "failed":
+      return `⛔ Cross-project task → ${targetProject}: failed — ${(rec.error ?? "(no error)").trim()}`;
+    case "stalled":
+      return `⚠️ Cross-project task → ${targetProject}: stalled (no heartbeat in ${rec.heartbeatBudgetMs}ms)`;
+    default:
+      return null;
+  }
+}
+
 function firePush(
   deps: DaemonDeps,
   project: string,
@@ -165,6 +184,21 @@ function firePush(
     }
   } catch {
     // intentionally swallowed
+  }
+  // #246: cross-project delegation report-back. When a delegated task settles
+  // (done/blocked/failed/stalled/cancelled), fan the outcome back to the origin
+  // project's mailbox so A's relay wakes A's captain (dispatch-and-yield, never
+  // poll). 'awaiting-input' is excluded — the origin doesn't need a noise push
+  // every time the target crew ends a turn.
+  const reportState = next.state === "done" || next.state === "blocked" || next.state === "failed" || next.state === "stalled" || next.state === "cancelled";
+  if (next.originProject && next.originProject !== project && reportState) {
+    const originMsg = formatDelegationReport(next, next.originProject, project);
+    if (originMsg && deps.notify) {
+      try {
+        const r = deps.notify({ project: next.originProject, message: originMsg, record: next, event });
+        if (r && typeof (r as Promise<void>).catch === "function") (r as Promise<void>).catch(() => {});
+      } catch { /* swallowed */ }
+    }
   }
 }
 
@@ -228,6 +262,20 @@ export function createDaemon(deps: DaemonDeps) {
       switch (req.kind) {
         case "dispatch": {
           store.put(req.record);
+          // #246: cross-project delegation — notify B's mailbox so B's relay
+          // wakes B's captain with the request. Skip auto-launch; B's captain
+          // decides how to execute (typically spawns a crew).
+          if (req.record.originProject) {
+            const origin = req.record.originProject;
+            const msg = `📨 Cross-project task from ${origin}: ${req.record.task}`;
+            if (deps.notify) {
+              try {
+                const r = deps.notify({ project: req.record.project, message: msg, record: req.record, event: { type: "task.started", id: req.record.id } });
+                if (r && typeof (r as Promise<void>).catch === "function") (r as Promise<void>).catch(() => {});
+              } catch { /* swallowed — flaky notifier must not break dispatch */ }
+            }
+            return req.record;
+          }
           if (req.record.mode === "headless" && deps.launchHeadless) {
             deps.launchHeadless(req.record).catch((e: unknown) => {
               const error = e instanceof Error ? e.message : String(e);

--- a/src/control/types.ts
+++ b/src/control/types.ts
@@ -73,6 +73,10 @@ export interface TaskRecord {
    *  (`opencode --port <N>`). The daemon's SSE bridge subscribes to
    *  http://127.0.0.1:<serverPort>/event for reliable turn-end detection. */
   serverPort?: number;
+  /** #246: cross-project intra-group delegation — set to the origin project's
+   *  name when this task was dispatched by a sibling captain. When the task
+   *  settles, the daemon fans the outcome back to originProject's mailbox. */
+  originProject?: string;
 }
 
 export type ControlEvent =

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import { projectionCommand } from "./commands/projection.js";
 import { codexChatSmokeCommand } from "./commands/codex-chat-smoke.js";
 import { configCommand } from "./commands/config.js";
 import { healCommand } from "./commands/heal.js";
+import { groupCommand } from "./commands/group.js";
 import { detectDrift } from "./lib/config-drift.js";
 import { needsCheck, withStamp } from "./lib/config-version.js";
 import { getDefaultConfig } from "./config.js";
@@ -108,6 +109,7 @@ program.addCommand(projectionCommand);
 program.addCommand(codexChatSmokeCommand);
 program.addCommand(configCommand);
 program.addCommand(healCommand);
+program.addCommand(groupCommand);
 
 program.parseAsync().catch((e) => {
   process.stderr.write(`error: ${e instanceof Error ? e.message : String(e)}\n`);


### PR DESCRIPTION
## Summary
Phase 1 of cross-project (intra-group) delegation — `cockpit group dispatch`. Closes #246 (Phase 1; Phase 2 peer comms tracked separately).

Design spec: `docs/superpowers/specs/2026-06-12-cross-project-delegation-design.md`

## What it does
`cockpit group dispatch <to-project> '<task>'` lets a captain hand work to a same-group sibling:
- **Same-group gate** — rejects dispatch outside the caller's `group`.
- **`acceptDelegations`** (per-project config, default true) — a project can opt out of being driven.
- **Boot-if-down + bounded warmup** — launches the sibling captain if it's not up and waits (30s hard timeout) for its relay heartbeat before recording the task; fails clearly on timeout.
- **One new field** — `TaskRecord.originProject`. A delegated task is a normal task that remembers where it came from; no separate cross-project bus.
- **Delivery** — daemon notifies B's mailbox (`📨 Cross-project task from A`); B's captain auto-accepts and spawns a crew. Dispatch early-returns (skips `launchHeadless`) so B's captain owns execution.
- **Report-back** — on settle (done/blocked/failed/stalled), the daemon fans the outcome back to the origin's mailbox so A's captain is auto-woken. Dispatch-and-yield, never poll (#241).
- **captain-ops** — new 'Cross-project delegation' section.

## Verification
- `npm run build` clean (tsc)
- Full suite **1004/1004 green** (91 files; +11 new tests)
- New tests: same-group gate, acceptDelegations rejection, warmup timeout, record shape (`originProject`), report-back fan-out on done/blocked/failed/stalled, no-op for missing origin.

## Notes
- `cancelled` is in the report-state set but not formatted → no report on cancel (harmless).
- Scope is Phase 1 only; `runtime send --to-captain` peer comms deferred to a follow-up.

🤖 Spawned crew (opencode) implementation, captain-reviewed before PR.