### PR TITLE
feat(routing): leveled crew routing (#275)

### DIFF
--- a/plugin/skills/add-pick-crew-rule/SKILL.md
+++ b/plugin/skills/add-pick-crew-rule/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: add-pick-crew-rule
+description: Add, edit, or remove a leveled crew routing rule in config.json without hand-editing JSON. Routing rules map task-text keywords to a tier → {agent, model}.
+---
+
+# Manage Crew Routing Rules
+
+Crew routing rules live in `defaults.crewRouting.rules` inside `~/.config/cockpit/config.json`.
+Each rule has the shape:
+
+```jsonc
+{
+  "tier":  "<label>",      // human label, e.g. "extreme" / "hard" / "daily"
+  "match": "<regex>",      // case-insensitive regex tested against the task text
+  "agent": "claude|codex|gemini|opencode",
+  "model": "opus|sonnet"   // omit for codex/opencode (they use their own defaults)
+}
+```
+
+Rules are evaluated in order; the **first match wins**.
+
+## Adding a rule
+
+1. Read the current config:
+   ```bash
+   cat ~/.config/cockpit/config.json
+   ```
+
+2. Identify the `defaults.crewRouting.rules` array. If it is absent, add it.
+
+3. Build the new rule object. Validate:
+   - `tier` is a non-empty string
+   - `match` is a valid regex (test it mentally against a sample task string)
+   - `agent` is one of `claude`, `codex`, `gemini`, `opencode`
+   - `model` is only set for claude rules (`opus` or `sonnet`); omit for other agents
+
+4. Insert the rule at the correct position — **rules are evaluated in order**.
+   Higher-priority / more specific tiers (e.g. "extreme") belong before broader ones
+   (e.g. "hard"). Append low-priority catch-alls last.
+
+5. Write the updated config back via the existing save path:
+   ```typescript
+   // The saveConfig helper in src/config.ts handles atomic write + newline.
+   // If editing the live file directly, use JSON.stringify(config, null, 2) + "\n".
+   ```
+
+6. Verify the rule fires as expected:
+   ```bash
+   # Quick smoke-test (no live crew spawned):
+   node -e "
+     const {loadConfig} = require(process.env.HOME + '/.config/cockpit/node_modules/...');
+     // or just log the matching rule manually
+     const rules = require(process.env.HOME + '/.config/cockpit/config.json')
+       .defaults?.crewRouting?.rules ?? [];
+     const task = 'YOUR TEST TASK HERE';
+     const hit = rules.find(r => new RegExp(r.match,'i').test(task));
+     console.log(hit ?? 'no match');
+   "
+   ```
+
+## Editing an existing rule
+
+Read → locate the rule by `tier` or `match` → update the field(s) → write back.
+
+## Removing a rule
+
+Read → filter out the rule by `tier` or `match` → write back.
+
+## Precedence reminder
+
+- Explicit `--agent` / `--model` on `cockpit crew spawn` **always** override routing.
+- If no rule matches, the spawn falls through to `defaults.roles.crew` behavior (unchanged from pre-routing behavior).
+
+## Example rules
+
+```jsonc
+// Route deep-reasoning work to the strongest model
+{ "tier": "extreme", "match": "redesign|architect|rewrite|from scratch|deep reasoning", "agent": "claude", "model": "opus" }
+
+// Route standard feature/refactor work to a faster model
+{ "tier": "hard",    "match": "refactor|migrate|implement|feature|daemon|control-plane", "agent": "claude", "model": "sonnet" }
+
+// Route mobile tasks to codex (no model — uses codex default)
+{ "tier": "mobile",  "match": "mobile|ios|swift|android|kotlin|react native", "agent": "codex" }
+
+// Route trivial edits to opencode (cheapest path)
+{ "tier": "daily",   "match": "typo|rename|bump|docs|comment|lint|format", "agent": "opencode" }
+```

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -147,6 +147,32 @@ Open as a side-by-side pane when you want live preview:
 cockpit crew spawn brove "Fix typo in README" --direction right
 ```
 
+### Leveled crew routing
+
+When you spawn a crew without an explicit `--agent` or `--model`, cockpit automatically
+consults the routing rules in `defaults.crewRouting.rules` (config.json) and picks the
+right tier for the task:
+
+| Tier | Matches | Routes to |
+|------|---------|-----------|
+| extreme | redesign, architect, rewrite, from scratch | claude/opus |
+| hard | refactor, migrate, implement, feature | claude/sonnet |
+| mobile | mobile, ios, swift, android, kotlin | codex |
+| daily | typo, rename, bump, docs, lint | opencode |
+
+The chosen route is printed as a dim one-liner before the spawn completes, e.g.:
+```
+routed: tier=hard → claude/sonnet (rule: "refactor|migrate|implement|feature|daemon|control-plane")
+```
+
+**Override at any time** — explicit flags always win over routing:
+```bash
+cockpit crew spawn brove "refactor auth" --agent codex     # forces codex despite "hard" tier
+cockpit crew spawn brove "fix typo" --model opus           # forces opus despite "daily" tier
+```
+
+To add, edit, or remove routing rules: use the `cockpit:add-pick-crew-rule` skill.
+
 ### Rules
 
 - **Reuse with `send` before spawning a new one.** Same task track, same crew. New track = new crew.

--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -93,6 +93,9 @@ vi.mock("node:fs", async (importOriginal) => {
   return { ...merged, default: merged };
 });
 
+const resolveCrewRoute = vi.hoisted(() => vi.fn());
+vi.mock("../../control/crew-routing.js", () => ({ resolveCrewRoute }));
+
 import { runCrewSpawn, runCrewSend, runCrewRead, runCrewClose, runCrewList, sendFirstTurnWhenReady, reapCrewChildren, isTurnAccepted } from "../crew.js";
 
 const baseConfig = {
@@ -142,6 +145,9 @@ describe("cockpit crew spawn", () => {
     // Default: pretend the codex role template is absent so older tests that
     // don't care about role injection still pass unchanged.
     existsSyncMock.mockReturnValue(false);
+    resolveCrewRoute.mockReset();
+    // Default: no routing match (fall through to existing defaults).
+    resolveCrewRoute.mockReturnValue(null);
   });
 
   afterEach(() => {
@@ -568,6 +574,83 @@ describe("cockpit crew spawn", () => {
     status.mockResolvedValue(null);
     await expect(runCrewSpawn({ project: "brove", task: "x" }))
       .rejects.toThrow(/captain workspace 'brove-captain' is not running/i);
+  });
+
+  describe("leveled crew routing (#275)", () => {
+    it("uses routed agent+model when no explicit agent/model provided and routing matches", async () => {
+      loadConfig.mockReturnValue(baseConfig);
+      status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+      listSurfaces.mockResolvedValue([]);
+      newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+      buildCommand.mockReturnValue("claude --model sonnet ...");
+      buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-route1" } }));
+      cockpitdCall.mockResolvedValue({ id: "task-route1" });
+      resolveCrewRoute.mockReturnValue({ agent: "claude", model: "sonnet", tier: "hard", matchedRule: "refactor|implement" });
+
+      const promise = runCrewSpawn({ project: "brove", task: "refactor the daemon" });
+      await vi.advanceTimersByTimeAsync(3000);
+      await promise;
+
+      expect(resolveCrewRoute).toHaveBeenCalledWith("refactor the daemon", baseConfig);
+      expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ model: "sonnet" }));
+    });
+
+    it("explicit --agent overrides routing when agentExplicit=true", async () => {
+      loadConfig.mockReturnValue(baseConfig);
+      status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+      listSurfaces.mockResolvedValue([]);
+      newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+      buildCommand.mockReturnValue("gemini ...");
+      // routing would suggest claude/sonnet but agentExplicit=true suppresses it
+      resolveCrewRoute.mockReturnValue({ agent: "claude", model: "sonnet", tier: "hard", matchedRule: "refactor" });
+
+      await runCrewSpawn({ project: "brove", task: "refactor the daemon", agent: "gemini", agentExplicit: true });
+
+      // routing should NOT have been consulted
+      expect(resolveCrewRoute).not.toHaveBeenCalled();
+      expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ model: undefined }));
+    });
+
+    it("explicit --model overrides routing model even when agentExplicit is false", async () => {
+      loadConfig.mockReturnValue(baseConfig);
+      status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+      listSurfaces.mockResolvedValue([]);
+      newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+      buildCommand.mockReturnValue("claude --model opus ...");
+      buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-modelx" } }));
+      cockpitdCall.mockResolvedValue({ id: "task-modelx" });
+
+      const promise = runCrewSpawn({ project: "brove", task: "refactor the daemon", model: "opus" });
+      await vi.advanceTimersByTimeAsync(3000);
+      await promise;
+
+      // model passed explicitly → routing skipped entirely
+      expect(resolveCrewRoute).not.toHaveBeenCalled();
+      expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ model: "opus" }));
+    });
+
+    it("falls through to defaults.roles.crew when routing returns null", async () => {
+      loadConfig.mockReturnValue({
+        ...baseConfig,
+        defaults: {
+          ...baseConfig.defaults,
+          roles: { crew: { agent: "claude", model: "opus" } },
+        },
+      });
+      status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+      listSurfaces.mockResolvedValue([]);
+      newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+      buildCommand.mockReturnValue("claude --model opus ...");
+      buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-fallthrough" } }));
+      cockpitdCall.mockResolvedValue({ id: "task-fallthrough" });
+      resolveCrewRoute.mockReturnValue(null);
+
+      const promise = runCrewSpawn({ project: "brove", task: "some unmatched task" });
+      await vi.advanceTimersByTimeAsync(3000);
+      await promise;
+
+      expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ model: "opus" }));
+    });
   });
 });
 

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import os from "node:os";
 import chalk from "chalk";
 import { loadConfig } from "../config.js";
+import { resolveCrewRoute } from "../control/crew-routing.js";
 import { createCmuxDriver, RuntimeRegistry } from "../runtimes/index.js";
 import {
   createClaudeDriver,
@@ -224,6 +225,8 @@ export interface CrewSpawnInput {
   /** Per-spawn model override — takes precedence over defaults.roles.crew.model.
    *  Agent-specific alias (e.g. "sonnet", "opus" for claude; "gpt-5.5" for codex). */
   model?: string;
+  /** True when --agent was explicitly passed by the caller; suppresses crew routing. */
+  agentExplicit?: boolean;
 }
 
 export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
@@ -269,13 +272,22 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
       })
     : proj.path;
 
+  // #275 leveled crew routing: consult routing rules when agent/model were not
+  // explicitly provided by the caller. Explicit --agent or --model always win.
+  const route = !input.agentExplicit && !input.model
+    ? resolveCrewRoute(input.task, config)
+    : null;
+  if (route) {
+    console.log(chalk.dim(`routed: tier=${route.tier} → ${route.agent}${route.model ? `/${route.model}` : ""} (rule: "${route.matchedRule}")`));
+  }
+
   const agents = new CapabilityRegistry({
     claude: createClaudeDriver(),
     codex: createCodexDriver(),
     gemini: createGeminiDriver(),
     opencode: createOpencodeDriver(),
   });
-  const agentName = input.agent ?? "claude";
+  const agentName = route?.agent ?? input.agent ?? "claude";
   const agent = agents.get(agentName);
   if (!agent) {
     throw new Error(`Unknown agent '${agentName}'. Known: claude, codex, gemini, opencode.`);
@@ -318,7 +330,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
   // fall back to the agent's own default to avoid passing an invalid model arg.
   const crewRole = config.defaults.roles?.crew;
   const configModel = crewRole && crewRole.agent === agent.name ? crewRole.model : undefined;
-  const crewModel = input.model ?? configModel;
+  const crewModel = input.model ?? route?.model ?? configModel;
 
   // Claude crews route through the control-plane daemon (PR #85 + this spec)
   // so the captain learns terminal state via `cockpit crew status` instead
@@ -674,15 +686,18 @@ crewCommand
       project: string,
       task: string | undefined,
       opts: { name?: string; direction: PanePlacement; agent: string; approval: boolean; worktree: boolean; taskFile?: string; model?: string },
+      cmd: Command,
     ) => {
       try {
         const resolvedTask = await resolveTextInput({ positional: task, filePath: opts.taskFile, label: "task" });
+        const agentExplicit = cmd.getOptionValueSource("agent") === "cli";
         const pane = await runCrewSpawn({
           project,
           task: resolvedTask,
           name: opts.name,
           direction: opts.direction,
           agent: opts.agent,
+          agentExplicit,
           // --approval is provider-agnostic: codex consumes approvalPolicy,
           // opencode consumes the `approval` flag (→ bash:"ask" per-crew config).
           ...(opts.approval ? { approvalPolicy: "untrusted", approval: true } : {}),

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,17 @@ export interface PermissionConfig {
 
 export type ModelAlias = "opus" | "sonnet" | "haiku";
 
+export interface CrewRoutingRule {
+  tier: string;
+  match: string;
+  agent: string;
+  model?: string;
+}
+
+export interface CrewRoutingConfig {
+  rules: CrewRoutingRule[];
+}
+
 export interface ModelRoutingConfig {
   command: ModelAlias;
   captain: ModelAlias;
@@ -73,6 +84,8 @@ export interface CockpitConfig {
     roles?: RoleConfig;
     /** #225 hard crew task-timeout ceiling (ms). Default: 8h. */
     taskTimeoutMs?: number;
+    /** #275 rule-based crew routing: keyword rules map task text to {agent, model}. Optional — absent = fall through to defaults.roles.crew. */
+    crewRouting?: CrewRoutingConfig;
   };
   metrics: {
     enabled: boolean;
@@ -114,6 +127,14 @@ export function getDefaultConfig(): CockpitConfig {
         exploration: { agent: "claude", model: "haiku" },
       },
       taskTimeoutMs: 8 * 60 * 60 * 1000,
+      crewRouting: {
+        rules: [
+          { tier: "extreme", match: "redesign|architect|rewrite|from scratch|deep reasoning", agent: "claude", model: "opus" },
+          { tier: "hard", match: "refactor|migrate|implement|feature|daemon|control-plane", agent: "claude", model: "sonnet" },
+          { tier: "mobile", match: "mobile|ios|swift|android|kotlin|react native", agent: "codex" },
+          { tier: "daily", match: "typo|rename|bump|docs|comment|lint|format", agent: "opencode" },
+        ],
+      },
     },
     metrics: {
       enabled: true,

--- a/src/control/__tests__/crew-routing.test.ts
+++ b/src/control/__tests__/crew-routing.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { resolveCrewRoute } from "../crew-routing.js";
+import type { CockpitConfig } from "../../config.js";
+
+function makeConfig(overrides?: Partial<CockpitConfig["defaults"]>): CockpitConfig {
+  return {
+    commandName: "command",
+    hubVault: "~/hub",
+    projects: {},
+    defaults: {
+      maxCrew: 5,
+      worktreeDir: ".worktrees",
+      teammateMode: "in-process",
+      permissions: { command: "auto", captain: "auto" },
+      crewRouting: {
+        rules: [
+          { tier: "extreme", match: "redesign|architect|rewrite", agent: "claude", model: "opus" },
+          { tier: "hard", match: "refactor|implement|feature", agent: "claude", model: "sonnet" },
+          { tier: "mobile", match: "mobile|ios|swift", agent: "codex" },
+          { tier: "daily", match: "typo|docs|lint", agent: "opencode" },
+        ],
+      },
+      ...overrides,
+    },
+    metrics: { enabled: false, path: "" },
+  };
+}
+
+describe("resolveCrewRoute", () => {
+  it("returns null when crewRouting is absent", () => {
+    const config = makeConfig({ crewRouting: undefined });
+    expect(resolveCrewRoute("refactor the auth module", config)).toBeNull();
+  });
+
+  it("returns null when rules array is empty", () => {
+    const config = makeConfig({ crewRouting: { rules: [] } });
+    expect(resolveCrewRoute("refactor the auth module", config)).toBeNull();
+  });
+
+  it("returns null when no rule matches", () => {
+    const config = makeConfig();
+    expect(resolveCrewRoute("update the README with examples", config)).toBeNull();
+  });
+
+  it("matches the extreme tier on 'redesign'", () => {
+    const config = makeConfig();
+    const result = resolveCrewRoute("redesign the auth system", config);
+    expect(result).toMatchObject({ tier: "extreme", agent: "claude", model: "opus" });
+  });
+
+  it("matches the hard tier on 'refactor'", () => {
+    const config = makeConfig();
+    const result = resolveCrewRoute("refactor the daemon module", config);
+    expect(result).toMatchObject({ tier: "hard", agent: "claude", model: "sonnet" });
+  });
+
+  it("first-match-wins: extreme rule fires before hard when both could match", () => {
+    const config = makeConfig();
+    // "rewrite" matches extreme; "implement" matches hard — extreme rule comes first
+    const result = resolveCrewRoute("rewrite and implement the new api", config);
+    expect(result?.tier).toBe("extreme");
+  });
+
+  it("matches are case-insensitive", () => {
+    const config = makeConfig();
+    expect(resolveCrewRoute("REFACTOR the auth module", config)).toMatchObject({ tier: "hard" });
+    expect(resolveCrewRoute("Fix a TYPO in the readme", config)).toMatchObject({ tier: "daily" });
+  });
+
+  it("returns a rule without model when the rule omits model (mobile tier)", () => {
+    const config = makeConfig();
+    const result = resolveCrewRoute("mobile ios layout fixes", config);
+    expect(result?.tier).toBe("mobile");
+    expect(result?.agent).toBe("codex");
+    expect(result?.model).toBeUndefined();
+  });
+
+  it("returns matchedRule with the original regex string", () => {
+    const config = makeConfig();
+    const result = resolveCrewRoute("implement a new login flow", config);
+    expect(result?.matchedRule).toBe("refactor|implement|feature");
+  });
+
+  it("falls through to later rules when earlier rules don't match", () => {
+    const config = makeConfig();
+    const result = resolveCrewRoute("fix a typo in the readme", config);
+    expect(result?.tier).toBe("daily");
+    expect(result?.agent).toBe("opencode");
+  });
+});

--- a/src/control/crew-routing.ts
+++ b/src/control/crew-routing.ts
@@ -1,0 +1,30 @@
+import type { CockpitConfig } from "../config.js";
+
+export interface CrewRouteResult {
+  agent: string;
+  model?: string;
+  tier: string;
+  matchedRule: string;
+}
+
+/**
+ * Resolve a crew route from task text against config.defaults.crewRouting.rules.
+ * Returns the first matching rule's agent/model, or null if no rule matches or
+ * crewRouting is absent. Pure — no side effects.
+ */
+export function resolveCrewRoute(taskText: string, config: CockpitConfig): CrewRouteResult | null {
+  const rules = config.defaults.crewRouting?.rules;
+  if (!rules || rules.length === 0) return null;
+  for (const rule of rules) {
+    const re = new RegExp(rule.match, "i");
+    if (re.test(taskText)) {
+      return {
+        agent: rule.agent,
+        ...(rule.model !== undefined ? { model: rule.model } : {}),
+        tier: rule.tier,
+        matchedRule: rule.match,
+      };
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

- Adds `defaults.crewRouting.rules` to `config.json` (optional, ships with a default extreme/hard/mobile/daily ruleset)
- New pure resolver `src/control/crew-routing.ts` — first regex match wins, null on no match or absent config
- `crew spawn` consults routing automatically when `--agent` and `--model` are both absent; explicit flags always override
- New skill `cockpit:add-pick-crew-rule` for managing rules without hand-editing JSON
- `captain-ops` SKILL.md updated with a "Leveled crew routing" subsection

## Test plan

- [ ] `npm test` — 1018 tests passing (9 new: resolver unit tests + spawn routing integration)
- [ ] `resolveCrewRoute`: first-match-wins ordering, case-insensitivity, null on no match, null when crewRouting absent
- [ ] Explicit `--agent`/`--model` flags suppress routing (checked via `cmd.getOptionValueSource('agent')`)
- [ ] No-match falls through to existing `defaults.roles.crew` behavior unchanged
- [ ] Existing spawn tests (claude/codex/opencode/worktree) all unaffected