### PR TITLE
fix: eliminate ENOTEMPTY teardown flake (#146) and add crew anti-poll guard (#241)

### DIFF
--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -161,12 +161,17 @@ cockpit crew spawn brove "Fix typo in README" --direction right
 
 ## Task Coordination
 
-You don't have an Agent Team or `TaskCreate`/`TaskUpdate` tools — those were Claude-specific. Track crew progress by:
-1. `cockpit crew read <project> <name>` — read tail of a crew's screen (default ~40 lines; `--full` for entire scrollback).
-2. `cockpit crew tasks <project>` — compact task listing (one line per task); `--id <prefix>` to filter; `--state-only <id>` for single-word state.
-3. `cockpit crew list <project>` — see all live crews and pick the right one.
-4. Inspecting the crew tab visually in cmux when you want richer context (you have its surface ref from the spawn output).
-5. Asking the user to check the dashboard if you need a cross-project view (see issue #44).
+**HARD RULE: Do NOT poll crew screens in a loop.** Crew lifecycle events (idle / done / blocked) arrive via the **notify-relay** automatically — trust the relay signal. Polling loops hang indefinitely, exhaust context, and mask real blockers.
+
+You don't have an Agent Team or `TaskCreate`/`TaskUpdate` tools — those were Claude-specific. When you need crew status:
+1. **Wait for the relay to notify you.** When a crew finishes, signals blocked, or goes idle, the notify-relay delivers the event to your captain pane. This is the primary mechanism — do not replace it with polling.
+2. `cockpit crew read <project> <name>` — **on-demand spot-check only** (a single read when you have a specific reason, e.g. reviewing a finished diff). Never in a loop, never with `until`.
+3. `cockpit crew tasks <project>` — **on-demand** compact task listing; `--id <prefix>` to filter; `--state-only <id>` for a single-word state check.
+4. `cockpit crew list <project>` — see all live crews and pick the right one.
+5. Inspecting the crew tab visually in cmux when you want richer context (you have its surface ref from the spawn output).
+6. Asking the user to check the dashboard if you need a cross-project view (see issue #44).
+
+If you ever need a bounded check (not a loop), use a fixed counter (≤ 3 attempts with a sleep between), or watch the mailbox seq — never an unbounded `until` loop.
 
 When a crew sends you a status message via `cockpit runtime send <project> "<message>"`, it lands in your captain pane. Acknowledge, then update your handoff if a meaningful decision was made.
 

--- a/src/control/__tests__/cockpitd-claude-interactive.test.ts
+++ b/src/control/__tests__/cockpitd-claude-interactive.test.ts
@@ -7,10 +7,10 @@ import { startCockpitd } from "../cockpitd.js";
 import { sendRequest } from "../protocol.js";
 
 describe("cockpitd claude interactive wiring", () => {
-  let stop: (() => void) | undefined;
+  let stop: (() => Promise<void>) | undefined;
   let dir: string;
-  afterEach(() => {
-    stop?.();
+  afterEach(async () => {
+    await stop?.();
     if (dir) rmSync(dir, { recursive: true, force: true });
   });
 

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -553,12 +553,11 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   }
 
   return {
-    stop() {
+    stop(): Promise<void> {
       if (timer) clearInterval(timer);
       if (rotationTimer) clearInterval(rotationTimer);
       for (const kill of activeHeadlessKills) kill();
-      server.close();
-      log("stopped");
+      return new Promise<void>((resolve) => server.close(() => { log("stopped"); resolve(); }));
     },
   };
 }


### PR DESCRIPTION
## Summary

- **#146** — `stop()` in `cockpitd.ts` now returns `Promise<void>` (wrapping `server.close()` in a promise). The affected test's `afterEach` awaits it before `rmSync`, closing the race where a floating `void d.handle(task.started)` notify/mailbox write could create files after `rmSync` started traversing the temp dir.
- **#241** — Added an explicit **HARD RULE: Do NOT poll crew screens in a loop** to the Task Coordination section of `captain-ops/SKILL.md`. Establishes the notify-relay as the primary event delivery mechanism; reframes `crew read`/`crew tasks` as on-demand spot-checks only. Mirrors the existing dispatch-and-yield rule for cross-project group dispatch.

## Verification

- **#146**: confirmed the teardown race via the ENOENT log visible in a test run (floating mailbox write after rmSync on a fast machine); ran the test file ×5 before and after — passes clean with awaited stop.
- **#241**: confirmed the Task Coordination section still framed `crew read` as the primary tracking mechanism with no anti-poll guard for regular crews before the fix.
- `npm test` — **92 files, 1018 tests, all green**.

## Test plan

- [ ] Run `npx vitest run src/control/__tests__/cockpitd-claude-interactive.test.ts` ×5 — confirm no ENOTEMPTY / ENOENT errors in test output
- [ ] Read the Task Coordination section in `plugin/skills/captain-ops/SKILL.md` — confirm HARD RULE is present and relay-first framing is clear
- [ ] `npm test` green