### PR TITLE
test(routing): lock default ruleset ordering regression

### DIFF
--- a/src/control/__tests__/crew-routing.test.ts
+++ b/src/control/__tests__/crew-routing.test.ts
@@ -88,3 +88,14 @@ describe("resolveCrewRoute", () => {
     expect(result?.agent).toBe("opencode");
   });
 });
+
+// Regression: shipped default ruleset ordering (extreme → hard → mobile → daily)
+import { getDefaultConfig } from "../../config.js";
+
+describe("resolveCrewRoute — shipped default config ordering", () => {
+  it("'implement mobile feature' resolves to hard/claude/sonnet, not mobile/codex (hard rule precedes mobile in default ruleset)", () => {
+    const config = getDefaultConfig();
+    const result = resolveCrewRoute("implement mobile feature", config);
+    expect(result).toMatchObject({ tier: "hard", agent: "claude", model: "sonnet" });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds one regression test to `src/control/__tests__/crew-routing.test.ts` using the **shipped** `getDefaultConfig()` (not the local `makeConfig()` fixture)
- Documents and locks that `"implement mobile feature"` resolves to `tier=hard, agent=claude, model=sonnet` — **not** `mobile/codex` — because the `hard` rule precedes `mobile` in the default rules array (first-match-wins)

## Why

The default ruleset ordering (`extreme → hard → mobile → daily`) is a deliberate design decision. Without this test, a future reorder of the rules array would silently change routing for cross-keyword tasks. This test makes that change loud.

## Test plan

- [ ] `npx vitest run src/control/__tests__/crew-routing.test.ts` — 11 tests pass
- [ ] No other files changed