### PR TITLE
fix(crew): bake completion-protocol into claude + opencode first turns (#278)

### DIFF
--- a/docs/superpowers/specs/2026-06-13-crew-done-lifecycle-fix-design.md
+++ b/docs/superpowers/specs/2026-06-13-crew-done-lifecycle-fix-design.md
@@ -1,0 +1,66 @@
+# Crew DONE Lifecycle Fix — Design Spec
+
+**Date:** 2026-06-13
+**Issue:** #278 (lifecycle); relates to #279 (worktree), #148/#64 (done plumbing — healthy).
+**Status:** Design approved (scope B, captain-side backstop). Awaiting implementation.
+
+## Problem (proven live 2026-06-13)
+
+Crew completion does not reliably emit `task.done` → no **CREW DONE**. Cross-agent lifecycle test:
+
+| Agent | Emitted `done` unprompted |
+|-------|:--:|
+| claude | ❌ (finished + opened PR, never ran signal → watchdog IDLE) |
+| opencode | ❌ (finished + committed, never ran signal → watchdog IDLE) |
+| codex | ✅ (ran signal — concrete per-turn imperative with ids baked in) |
+
+Two failure modes:
+- **Mode 1 (mechanism):** `COCKPIT_CREW_TASK_ID` is injected only as a racy keystroke-inline env prefix; when it drops, the crew literally can't signal.
+- **Mode 2 (discretion):** even with env present, emitting `done` depends on the model choosing to run a CLI command, which claude/opencode skip after reporting via text.
+
+Codex avoids both because its developerInstructions are a concrete imperative — *"run EXACTLY `cockpit crew signal done --task-id <id> --project <proj> …`"* — ids baked in, at the point of action.
+
+## Fix (scope B = crew-side win + captain-side backstop)
+
+### Part 1 — Crew-side: concrete per-turn imperative (codex parity) for claude + opencode
+
+Append a standard **completion-protocol** suffix to the first-turn text sent to claude and opencode crews (in `src/commands/crew.ts`, where the first turn is composed — claude ~L369, opencode ~L419). Built from the dispatched `rec.id` and project:
+
+```
+---
+COMPLETION PROTOCOL (required): When this task is fully complete, your FINAL action
+MUST be to run exactly:
+  cockpit crew signal done --task-id <rec.id> --project <project> --message "<one-line summary>"
+Run it as a discrete final step AFTER you report results. If you are blocked or need a
+decision, instead run: cockpit crew signal blocked --task-id <rec.id> --project <project> --question "<q>"
+```
+
+- **Baking in `--task-id`/`--project`** makes the signal robust to the env race (kills Mode 1) AND puts a concrete imperative at the point of action (kills most of Mode 2).
+- Keep the existing env injection and template wording (unchanged); this suffix is additive and is the load-bearing reliability lever.
+- Mirror the same suffix for the `blocked` path so a waiting crew also terminalizes its intent explicitly.
+- Codex already does this — no change to codex.
+
+### Part 2 — Captain-side: IDLE reconciliation (behavioral, in `plugin/skills/captain-ops/SKILL.md`)
+
+CREW IDLE is **ambiguous** — it can mean "finished but didn't signal" OR "genuinely waiting for the captain." Add a **"Handling CREW IDLE"** subsection instructing the captain to **classify** with a single on-demand spot-check (allowed — not polling), then act:
+
+| What the spot-check shows | Captain action |
+|---------------------------|----------------|
+| Completed work (PR/commit opened + reported done) but no CREW DONE | Treat as the #278 case: review the work; if good, terminalize (merge + `crew close`). If not actually done, **re-task** it (the #148 reopen flow): tell it what's next. |
+| Genuinely waiting for the captain (asked a question / needs a decision) | Respond — send the next instruction via `crew send`. Do NOT terminalize. |
+| Still mid-task / transient idle | Leave it; wait for the next relay event. |
+
+This is the backstop: even if Part 1's imperative is skipped, the lifecycle still terminalizes (or correctly continues) because the captain reconciles intent instead of letting the task silently strand at IDLE.
+
+## Out of scope
+- Daemon/hook-driven auto-done (Approach C) — rejected: risks conflating `done`≠`blocked`≠`awaiting-input` (anti-#2576).
+- The #279 worktree-cwd fix — separate issue (pairs with this but not bundled).
+
+## Testing
+- Unit (`src/commands/__tests__/crew.test.ts`): assert the claude and opencode first-turn text includes the completion-protocol suffix with the correct `--task-id`/`--project` substituted; assert codex path unchanged.
+- Manual lifecycle re-check: spawn a normal claude crew and an opencode crew (no explicit signal instruction beyond the new built-in suffix) → confirm CREW DONE now fires unprompted for both. Re-run the same 3-agent check from #278.
+
+## Success criteria
+- A normal claude/opencode crew that completes a task emits `task.done` → CREW DONE **without** the captain telling it to.
+- The signal works even if the keystroke env injection dropped (ids are in the command).
+- captain-ops documents how to classify and handle CREW IDLE (done vs waiting vs working).

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -199,6 +199,25 @@ You don't have an Agent Team or `TaskCreate`/`TaskUpdate` tools — those were C
 
 If you ever need a bounded check (not a loop), use a fixed counter (≤ 3 attempts with a sleep between), or watch the mailbox seq — never an unbounded `until` loop.
 
+### Handling CREW IDLE
+
+CREW IDLE is **ambiguous** — the watchdog did not detect a heartbeat, which can happen when:
+- **(a)** The crew finished but never ran `cockpit crew signal done` (issue #278 — common for claude/opencode before the completion-protocol fix).
+- **(b)** The crew is genuinely waiting for the captain (asked a question or needs a decision).
+- **(c)** The crew is still mid-task and the idle pulse was transient.
+
+On CREW IDLE, do a **single on-demand spot-check** (allowed — not a polling loop), then classify:
+
+| Spot-check shows | Captain action |
+|-----------------|----------------|
+| Completed work (PR opened, commits pushed, results reported) but no CREW DONE | Treat as the #278 case — review; if good, terminalize (`merge` + `crew close`). If not actually done, **re-task**: send the next instruction via `crew send` (the #148 re-open flow). |
+| Crew asked a question or is waiting for a decision | Respond via `crew send`. Do NOT terminalize — it will signal done after the next turn. |
+| Still mid-task / transient idle | Leave it; wait for the next relay event. |
+
+**Do not re-send the original task** if the crew appears to have completed it — that triggers a duplicate run. Read the crew screen or diff first, then decide: terminalize vs re-task vs leave.
+
+This is the captain-side backstop: even if the completion-protocol imperative is skipped, the lifecycle still terminalizes because the captain classifies intent instead of letting the task strand at IDLE.
+
 When a crew sends you a status message via `cockpit runtime send <project> "<message>"`, it lands in your captain pane. Acknowledge, then update your handoff if a meaningful decision was made.
 
 ## When Crew Finishes

--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -96,7 +96,7 @@ vi.mock("node:fs", async (importOriginal) => {
 const resolveCrewRoute = vi.hoisted(() => vi.fn());
 vi.mock("../../control/crew-routing.js", () => ({ resolveCrewRoute }));
 
-import { runCrewSpawn, runCrewSend, runCrewRead, runCrewClose, runCrewList, sendFirstTurnWhenReady, reapCrewChildren, isTurnAccepted } from "../crew.js";
+import { runCrewSpawn, runCrewSend, runCrewRead, runCrewClose, runCrewList, sendFirstTurnWhenReady, reapCrewChildren, isTurnAccepted, buildCompletionProtocol } from "../crew.js";
 
 const baseConfig = {
   commandName: "command",
@@ -196,11 +196,11 @@ describe("cockpit crew spawn", () => {
     expect(sendToPane.mock.calls[0]?.[1]).toContain("COCKPIT_CREW_TASK_ID=task-cl1");
     expect(sendToPane.mock.calls[0]?.[1]).toContain("COCKPIT_CREW_PROJECT=brove");
     expect(sendToPane.mock.calls[0]?.[1]).toContain("claude --append-system-prompt-file /tmp/crew.md");
-    // Second sendToPane delivers the task as the first prompt.
-    expect(sendToPane.mock.calls[1]).toEqual([
-      { workspaceId: "workspace:5", surfaceId: "surface:9" },
-      "do the thing",
-    ]);
+    // Second sendToPane delivers the task + completion-protocol suffix as the first prompt.
+    expect(sendToPane.mock.calls[1]?.[0]).toEqual({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    expect(sendToPane.mock.calls[1]?.[1]).toContain("do the thing");
+    expect(sendToPane.mock.calls[1]?.[1]).toContain("--task-id task-cl1");
+    expect(sendToPane.mock.calls[1]?.[1]).toContain("--project brove");
     expect(result.title).toBe("🔧 brove:crew-1");
   });
 
@@ -342,11 +342,11 @@ describe("cockpit crew spawn", () => {
     expect(sendToPane.mock.calls[0]?.[1]).toContain("COCKPIT_CREW_PROJECT=brove");
     expect(sendToPane.mock.calls[0]?.[1]).toContain("OPENCODE_CONFIG=/tmp/per-crew/opencode.json");
     expect(sendToPane.mock.calls[0]?.[1]).toContain("opencode");
-    // Second sendToPane delivers the task as the first prompt.
-    expect(sendToPane.mock.calls[1]).toEqual([
-      { workspaceId: "workspace:5", surfaceId: "surface:9" },
-      "do the thing",
-    ]);
+    // Second sendToPane delivers the task + completion-protocol suffix as the first prompt.
+    expect(sendToPane.mock.calls[1]?.[0]).toEqual({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    expect(sendToPane.mock.calls[1]?.[1]).toContain("do the thing");
+    expect(sendToPane.mock.calls[1]?.[1]).toContain("--task-id task-oc1");
+    expect(sendToPane.mock.calls[1]?.[1]).toContain("--project brove");
   });
 
   it("--approval gates bash for opencode crews (CP3 opt-in → gateBash:true)", async () => {
@@ -1151,6 +1151,132 @@ describe("cockpit crew send/read/close/list", () => {
       { name: "crew-1", surfaceId: "surface:10" },
       { name: "fix-typos", surfaceId: "surface:11" },
     ]);
+  });
+});
+
+describe("buildCompletionProtocol (#278)", () => {
+  it("includes the task-id and project in the done signal command", () => {
+    const result = buildCompletionProtocol("task-abc123", "my-project");
+    expect(result).toContain("--task-id task-abc123");
+    expect(result).toContain("--project my-project");
+    expect(result).toContain("crew signal done");
+  });
+
+  it("includes the blocked signal form with the same ids", () => {
+    const result = buildCompletionProtocol("task-abc123", "my-project");
+    expect(result).toContain("crew signal blocked");
+    expect(result).toContain("--task-id task-abc123");
+    expect(result).toContain("--project my-project");
+  });
+
+  it("substitutes both task-id and project independently", () => {
+    const a = buildCompletionProtocol("id-A", "proj-A");
+    const b = buildCompletionProtocol("id-B", "proj-B");
+    expect(a).toContain("--task-id id-A");
+    expect(a).toContain("--project proj-A");
+    expect(b).toContain("--task-id id-B");
+    expect(b).toContain("--project proj-B");
+    expect(a).not.toContain("id-B");
+    expect(b).not.toContain("id-A");
+  });
+});
+
+describe("completion-protocol suffix in first turns (#278)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    newPane.mockReset();
+    sendToPane.mockReset();
+    readPaneScreen.mockReset();
+    listSurfaces.mockReset();
+    status.mockReset();
+    buildCommand.mockReset();
+    loadConfig.mockReset();
+    cockpitdCall.mockReset();
+    buildDispatchRequest.mockReset();
+    sendCodexFirstTurn.mockReset();
+    sendCodexFirstTurn.mockResolvedValue(undefined);
+    writePerCrewSettingsLocal.mockReset();
+    writePerCrewSettingsLocal.mockReturnValue("/tmp/brove/.claude/settings.local.json");
+    writePerCrewOpencodeConfig.mockReset();
+    writePerCrewOpencodeConfig.mockReturnValue("/tmp/per-crew/opencode.json");
+    addWorktree.mockReset();
+    existsSyncMock.mockReset();
+    existsSyncMock.mockReturnValue(false);
+    resolveCrewRoute.mockReset();
+    resolveCrewRoute.mockReturnValue(null);
+    let reads = 0;
+    readPaneScreen.mockImplementation(async () => {
+      reads++;
+      if (reads === 1) return "booting…";
+      if (reads <= 4) return "> ready";
+      return "> ready\nworking…";
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("claude first turn includes completion-protocol suffix with baked-in task-id and project", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude ...");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-proto-cl" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-proto-cl", project: "brove", provider: "claude", mode: "interactive" });
+
+    const promise = runCrewSpawn({ project: "brove", task: "fix the bug" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    const firstTurn = sendToPane.mock.calls[1]?.[1] as string;
+    expect(firstTurn).toContain("fix the bug");
+    expect(firstTurn).toContain("COMPLETION PROTOCOL");
+    expect(firstTurn).toContain("--task-id task-proto-cl");
+    expect(firstTurn).toContain("--project brove");
+    expect(firstTurn).toContain("crew signal done");
+    expect(firstTurn).toContain("crew signal blocked");
+  });
+
+  it("opencode first turn includes completion-protocol suffix with baked-in task-id and project", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("opencode");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-proto-oc" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-proto-oc", project: "brove", provider: "opencode", mode: "interactive" });
+
+    const promise = runCrewSpawn({ project: "brove", task: "fix the bug", agent: "opencode" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    const firstTurn = sendToPane.mock.calls[1]?.[1] as string;
+    expect(firstTurn).toContain("fix the bug");
+    expect(firstTurn).toContain("COMPLETION PROTOCOL");
+    expect(firstTurn).toContain("--task-id task-proto-oc");
+    expect(firstTurn).toContain("--project brove");
+    expect(firstTurn).toContain("crew signal done");
+    expect(firstTurn).toContain("crew signal blocked");
+  });
+
+  it("codex first turn is sent via sendCodexFirstTurn unchanged — no completion-protocol suffix", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-proto-cx" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-proto-cx", project: "brove", provider: "codex", mode: "interactive" });
+
+    await runCrewSpawn({ project: "brove", task: "fix the bug", agent: "codex" });
+
+    // sendCodexFirstTurn receives the bare task text — no protocol suffix
+    expect(sendCodexFirstTurn).toHaveBeenCalledWith("task-proto-cx", "fix the bug");
+    // sendToPane only fires once (the crew attach command) — no second first-turn send
+    expect(sendToPane).toHaveBeenCalledTimes(1);
+    expect(sendToPane.mock.calls[0]?.[1]).toContain("crew attach");
+    expect(sendToPane.mock.calls[0]?.[1]).not.toContain("COMPLETION PROTOCOL");
   });
 });
 

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -208,6 +208,19 @@ export async function sendFirstTurnWhenReady(
   }
 }
 
+/** Builds the completion-protocol suffix baked into claude + opencode first turns (#278).
+ *  Substituting --task-id and --project at source makes the signal robust to env-var
+ *  races (Mode 1) and gives the model a concrete imperative at the point of action (Mode 2). */
+export function buildCompletionProtocol(taskId: string, project: string): string {
+  return [
+    "---",
+    "COMPLETION PROTOCOL (required): When this task is fully complete, your FINAL action MUST be to run exactly:",
+    `  cockpit crew signal done --task-id ${taskId} --project ${project} --message "<one-line summary>"`,
+    "Run it as a discrete final step AFTER you report your results. If you are blocked or need a decision, instead run:",
+    `  cockpit crew signal blocked --task-id ${taskId} --project ${project} --question "<your question>"`,
+  ].join("\n");
+}
+
 export interface CrewSpawnInput {
   project: string;
   task: string;
@@ -378,7 +391,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
     const envPrefix = `COCKPIT_CREW_TASK_ID=${rec.id} COCKPIT_CREW_PROJECT=${input.project}`;
     await runtime.sendToPane(pane, `${envPrefix} ${cliCommand}`);
     const preLaunchScreen = (await runtime.readPaneScreen(pane)) ?? "";
-    await sendFirstTurnWhenReady(runtime, pane, input.task, preLaunchScreen);
+    await sendFirstTurnWhenReady(runtime, pane, `${input.task}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen);
     return { ...pane, title };
   }
 
@@ -428,7 +441,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
     const envPrefix = `COCKPIT_CREW_TASK_ID=${rec.id} COCKPIT_CREW_PROJECT=${input.project}`;
     await runtime.sendToPane(pane, `${envPrefix} OPENCODE_CONFIG=${opencodeConfigPath} ${cliCommand}`);
     const preLaunchScreen = (await runtime.readPaneScreen(pane)) ?? "";
-    await sendFirstTurnWhenReady(runtime, pane, input.task, preLaunchScreen, {
+    await sendFirstTurnWhenReady(runtime, pane, `${input.task}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen, {
       // #235: opencode's idle splash ("Ask anything…") keeps mutating (cursor
       // blink, status line toggle), so the old screen-changed check would always
       // see a *different* screen and never re-send a dropped turn. The splashMarker


### PR DESCRIPTION
## Summary

Fixes #278 — crew DONE lifecycle not reliably emitting `task.done` for claude and opencode crews.

**Two failure modes diagnosed (live 2026-06-13):**
- **Mode 1 (mechanism):** `COCKPIT_CREW_TASK_ID` is injected as a racy keystroke-inline env prefix; if it drops, the crew can't signal at all
- **Mode 2 (discretion):** even with env present, claude/opencode rely on model judgment to run a CLI command — they skip it in favour of text reporting

Codex already works because its `developerInstructions` contains a concrete per-turn imperative with `--task-id` and `--project` baked in.

## Changes

### Part 1 — Code (`src/commands/crew.ts`)

- **`buildCompletionProtocol(taskId, project)`** — new exported pure helper that builds the completion-protocol suffix with `--task-id` and `--project` substituted at source
- **Claude first turn** — suffix appended before `sendFirstTurnWhenReady`; `rec.id` + `input.project` baked in
- **Opencode first turn** — same suffix, same approach
- **Codex path unchanged** — already has parity; no modification

### Part 2 — Docs (`plugin/skills/captain-ops/SKILL.md`)

Added **"Handling CREW IDLE"** subsection to the Task Coordination section. Teaches the captain to classify ambiguous IDLE states with a single spot-check (consistent with the existing anti-poll rule) rather than letting tasks strand silently.

### Design spec

`docs/superpowers/specs/2026-06-13-crew-done-lifecycle-fix-design.md` added to the branch.

## Test plan

- [ ] `buildCompletionProtocol` unit tests — correct `--task-id`/`--project` substitution, includes both `done` and `blocked` forms
- [ ] Claude first-turn assertion updated to `toContain` (suffix present with baked ids)
- [ ] Opencode first-turn assertion updated to `toContain` (suffix present with baked ids)
- [ ] Codex `sendCodexFirstTurn` still receives bare task text; `sendToPane` fires exactly once (attach command only)
- [ ] `npm test` — 1025/1025 green