### PR TITLE
fix(crew): cd into spawnCwd before launching claude/opencode (#279)

### DIFF
--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -271,6 +271,64 @@ describe("cockpit crew spawn", () => {
     expect(addWorktree).toHaveBeenCalledWith(expect.objectContaining({ worktreeDir: ".wt" }));
   });
 
+  it("--worktree claude crew: launch command starts with cd into worktree path", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude --append-system-prompt-file /tmp/crew.md");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-wtcd" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-wtcd", project: "brove", provider: "claude", mode: "interactive" });
+    const wtPath = "/tmp/brove/.worktrees/brove-crew-1";
+    addWorktree.mockReturnValue(wtPath);
+
+    const promise = runCrewSpawn({ project: "brove", task: "feature work", worktree: true });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    const launchCmd: string = sendToPane.mock.calls[0]?.[1];
+    // Shell must cd into the worktree before launching the agent (#279).
+    expect(launchCmd).toMatch(/^cd '\/tmp\/brove\/\.worktrees\/brove-crew-1' && /);
+  });
+
+  it("non-worktree claude crew: launch command starts with cd into main checkout (no-op harmless)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude ...");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-nowt2" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-nowt2", project: "brove", provider: "claude", mode: "interactive" });
+
+    const promise = runCrewSpawn({ project: "brove", task: "small fix" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    const launchCmd: string = sendToPane.mock.calls[0]?.[1];
+    // Non-worktree: cwd is proj.path — cd is a no-op but still issued for uniformity.
+    expect(launchCmd).toMatch(/^cd '\/tmp\/brove' && /);
+  });
+
+  it("--worktree opencode crew: launch command starts with cd into worktree path", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("opencode");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-ocwt" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-ocwt", project: "brove", provider: "opencode", mode: "interactive" });
+    const wtPath = "/tmp/brove/.worktrees/brove-crew-1";
+    addWorktree.mockReturnValue(wtPath);
+
+    const promise = runCrewSpawn({ project: "brove", task: "feature work", worktree: true, agent: "opencode", agentExplicit: true });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    const launchCmd: string = sendToPane.mock.calls[0]?.[1];
+    // Shell must cd into the worktree before launching opencode (#279).
+    expect(launchCmd).toMatch(/^cd '\/tmp\/brove\/\.worktrees\/brove-crew-1' && /);
+  });
+
   it("auto-names the next crew based on existing tabs (crew-1 + crew-3 → crew-2)", async () => {
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -221,6 +221,12 @@ export function buildCompletionProtocol(taskId: string, project: string): string
   ].join("\n");
 }
 
+// POSIX single-quote a path so it is safe to embed in a shell command even
+// when the path contains spaces or special characters.
+function shellQuote(p: string): string {
+  return "'" + p.replace(/'/g, "'\\''") + "'";
+}
+
 export interface CrewSpawnInput {
   project: string;
   task: string;
@@ -389,7 +395,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
     // Prefix the CLI command with env so the hook bridge + signal verb
     // running inside the crew's cmux tab can identify their task.
     const envPrefix = `COCKPIT_CREW_TASK_ID=${rec.id} COCKPIT_CREW_PROJECT=${input.project}`;
-    await runtime.sendToPane(pane, `${envPrefix} ${cliCommand}`);
+    await runtime.sendToPane(pane, `cd ${shellQuote(spawnCwd)} && ${envPrefix} ${cliCommand}`);
     const preLaunchScreen = (await runtime.readPaneScreen(pane)) ?? "";
     await sendFirstTurnWhenReady(runtime, pane, `${input.task}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen);
     return { ...pane, title };
@@ -439,7 +445,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
     const title = titleFor(input.project, name);
     const pane = await runtime.newPane({ workspaceId: captain.id, direction, title });
     const envPrefix = `COCKPIT_CREW_TASK_ID=${rec.id} COCKPIT_CREW_PROJECT=${input.project}`;
-    await runtime.sendToPane(pane, `${envPrefix} OPENCODE_CONFIG=${opencodeConfigPath} ${cliCommand}`);
+    await runtime.sendToPane(pane, `cd ${shellQuote(spawnCwd)} && ${envPrefix} OPENCODE_CONFIG=${opencodeConfigPath} ${cliCommand}`);
     const preLaunchScreen = (await runtime.readPaneScreen(pane)) ?? "";
     await sendFirstTurnWhenReady(runtime, pane, `${input.task}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen, {
       // #235: opencode's idle splash ("Ask anything…") keeps mutating (cursor


### PR DESCRIPTION
## Problem

`cockpit crew spawn --worktree` creates an isolated worktree and sets `spawnCwd` to it, but the crew's cmux pane is created in the captain's workspace cwd (main checkout). `cmux new-surface`/`new-pane` have no `--cwd` flag, so the shell never enters the worktree — the agent's git ops run against the main checkout, dragging the captain's HEAD onto the crew branch.

Proof: a `--worktree` crew's status line shows `⎇ develop` (main checkout branch), not `crew/<name>`.

## Fix

Prepend `cd '<spawnCwd>' && ` (POSIX single-quoted) to the `sendToPane` launch command for both **claude** and **opencode**. For non-worktree crews `spawnCwd === proj.path`, so the `cd` is a harmless no-op — behavior is unchanged.

**Codex** is unaffected — it dispatches through the daemon with `cwd: spawnCwd` and launches `cockpit crew attach` in the pane (not the agent CLI directly). Confirmed by reading `runCodexInteractiveSpawn`.

## Changes

- `src/commands/crew.ts` — add `shellQuote()` helper; prepend `cd` on both the claude (L398) and opencode (L448) `sendToPane` lines
- `src/commands/__tests__/crew.test.ts` — 3 new tests:
  - `--worktree` claude crew: launch starts with `cd '<worktree>'`
  - non-worktree claude crew: launch starts with `cd '<proj.path>'` (no-op)
  - `--worktree` opencode crew: launch starts with `cd '<worktree>'`

## Tests

```
npm test → 1028/1028 passed
```

## Manual verification

To verify after merge: spawn a `--worktree` crew and check its status line shows `crew/<name>` (not `develop`), and that the captain's main checkout `git status` does not show a branch switch. This requires a live cmux environment — the unit tests cover the mechanism and are the primary regression guard.

Closes #279