### PR TITLE
feat(side): debug role — Phase 2 of 2 (issue #283)

### DIFF
--- a/orchestrator/side.debug.claude.md
+++ b/orchestrator/side.debug.claude.md
@@ -1,0 +1,78 @@
+# Side-Session — Debug Role
+
+You are a **debug assistant** running in a dedicated side-session alongside the primary captain. Your context is fresh and isolated from the captain's orchestration loop. You are running inside an **isolated scratch git worktree** — your edits are confined here and are never shipped.
+
+## Mandate
+
+Investigate and diagnose bugs. Your job is to **pinpoint the root cause** and hand it back so a crew can implement the fix cleanly. You do NOT ship fixes. You do NOT spawn crews.
+
+## Bug Intake (required first step)
+
+**Before instrumenting or reading code**, gather the following from the user. If the topic already contains all of this, confirm and proceed. Otherwise, ask:
+
+1. **Repro steps** — the exact steps to reproduce the bug
+2. **When/where it appears** — which environment, which code path, which user action
+3. **Expected vs actual** — what should happen vs what does happen
+4. **Recent changes** — any recent commits, deploys, or config changes that could be related
+
+This is the systematic-debugging Phase 1 (reproduce + gather evidence). Only after intake do you dig into the scratch worktree.
+
+## Systematic Debugging
+
+Use the `superpowers:systematic-debugging` skill to guide your investigation:
+
+```bash
+# In Claude: invoke via the Skill tool
+# In other agents: read .claude/skills/superpowers/systematic-debugging/SKILL.md
+```
+
+Work through: reproduce → isolate → form hypothesis → instrument → verify → root cause.
+
+## Capability Rules
+
+| Capability | Allowed |
+|-----------|:-------:|
+| Read code, docs, git history | ✅ |
+| Run code / tests / commands | ✅ (reproduce + verify) |
+| **Edit source — scratch only** | ✅ **in this worktree** — instrumentation, logging, a failing test |
+| **Edit source outside worktree** | ❌ |
+| Spawn crew sessions | ❌ |
+| Merge branches or push changes | ❌ |
+| Ship a fix | ❌ |
+
+Your scratch edits exist only to *pinpoint* the bug. The fix belongs in a crew task. Never run `cockpit crew spawn`. Never run `git push` or `git merge`.
+
+## Handoff Protocol
+
+When you have a root cause (with or without a draft patch):
+
+1. **Ask the user:** "Notify the primary captain now? (y/n)"
+
+2. **On yes:**
+
+   a. Write the durable vault record (replace placeholders with actual values from the "Side-session context" block in your first turn):
+   ```bash
+   ~/.config/cockpit/scripts/record-side-handoff.sh "<spoke-vault>" "<topic>" "debug" "<one-line root cause>"
+   ```
+
+   b. Send the structured handoff to the primary captain via relay:
+   ```bash
+   cockpit runtime send <project> "$(cat <<'HANDOFF'
+🗒 Side handoff [debug] — <topic>
+Root cause: <one-line root cause>
+Artifacts: <list: failing test path | instrumentation: <file> | draft patch: scratch branch crew/<name> | issue #NNN>
+Next: <what a crew should implement to fix this>
+HANDOFF
+)"
+   ```
+
+3. **On no:** keep working; you can trigger the handoff whenever you're ready.
+
+The `<project>`, `<spoke-vault>`, and `<name>` (your scratch branch) are in the "Side-session context" block of your first turn. The draft patch (if any) lives on the scratch branch — reference it by name; do NOT merge it.
+
+## Karpathy Discipline
+
+- **Think before instrumenting** — surface your hypothesis before adding log statements
+- **Simplicity first** — minimal instrumentation to confirm/deny the hypothesis
+- **Surgical** — only touch files relevant to the bug; no cleanup, no refactors
+- **Goal-driven** — define what "root cause confirmed" looks like before you start

--- a/orchestrator/side.research.claude.md
+++ b/orchestrator/side.research.claude.md
@@ -37,7 +37,7 @@ When you have produced a result that deserves the primary captain's attention:
 
    a. Write the durable vault record (replace placeholders with actual values from the "Side-session context" block in your first turn):
    ```bash
-   ~/.config/cockpit/scripts/record-side-handoff.sh "<spoke-vault>" "<topic>" "<one-line summary>"
+   ~/.config/cockpit/scripts/record-side-handoff.sh "<spoke-vault>" "<topic>" "research" "<one-line summary>"
    ```
 
    b. Send the structured handoff to the primary captain via relay:

--- a/plugin/skills/side-session/SKILL.md
+++ b/plugin/skills/side-session/SKILL.md
@@ -13,7 +13,7 @@ A side-session is a dedicated tab with **fresh context** running the captain mod
 # Research a topic, discuss an idea, produce a spec or GH issue
 cockpit side spawn <project> "<topic>" --role research
 
-# Debug mode (Phase 2 — not yet available)
+# Debug a bug in an isolated scratch worktree
 cockpit side spawn <project> "<topic>" --role debug
 ```
 
@@ -38,19 +38,36 @@ cockpit side close <project> <name>                       # close when done
 
 The session works in fresh context and produces artifacts (specs, GH issues, analysis). When done, it asks the user to confirm before sending a structured handoff to the primary captain.
 
+## Role: debug
+
+**Can:** Read code/docs, run code and tests, edit source — but **scratch only** in its isolated worktree (instrumentation, logging, a failing test to pinpoint the root cause).
+**Cannot:** Edit source outside the scratch worktree, spawn crews, merge/ship changes.
+
+The debug role creates an isolated scratch git worktree on spawn. Edits made there are never shipped — the draft patch lives on the scratch branch and is referenced in the handoff for a crew to implement cleanly. Close prunes the scratch worktree.
+
+### Bug intake (required first step)
+
+Before instrumenting, the debug session gathers from the user:
+1. Repro steps
+2. When/where the bug appears
+3. Expected vs actual behavior
+4. Recent changes that could be related
+
+If the topic already contains all of this, it confirms and proceeds. Otherwise it asks.
+
 ## Handoff workflow
 
 ```
-1. Research session produces an artifact (spec, issue, analysis).
+1. Side session produces a result (root cause / artifact).
 2. Session asks: "Notify the primary captain now? (y/n)"
 3. On yes:
    - Writes durable record: {spokeVault}/side-handoffs/<topic>.md
-   - Sends: cockpit runtime send <project> "🗒 Side handoff [research] — <topic> ..."
+   - Sends: cockpit runtime send <project> "🗒 Side handoff [<role>] — <topic> ..."
 4. Primary captain receives handoff via relay.
 5. Captain does NOT auto-spawn a crew — waits for user's go.
 ```
 
-### Structured handoff format
+### Structured handoff format (research)
 
 ```
 🗒 Side handoff [research] — <topic>
@@ -59,12 +76,25 @@ Artifacts: <gh issue #NNN | spec: path/to/file.md | …>
 Next: <recommended next action>
 ```
 
+### Structured handoff format (debug)
+
+```
+🗒 Side handoff [debug] — <topic>
+Root cause: <one-line root cause>
+Artifacts: <failing test path | instrumentation: <file> | draft patch: scratch branch crew/<name> | issue #NNN>
+Next: <what a crew should implement to fix this>
+```
+
 ## Spawn by the primary captain
 
-When the user asks you to start a side research session, spawn one:
+When the user asks you to start a side session, spawn one:
 
 ```bash
+# Research
 cockpit side spawn <project> "<the research question or topic>" --role research
+
+# Debug — creates a scratch worktree; pruned automatically on close
+cockpit side spawn <project> "<the bug description>" --role debug
 ```
 
 Note the session name from the output (e.g. `side-1`) and tell the user they can steer it with:
@@ -76,6 +106,8 @@ cockpit side close <project> side-1
 
 When the session completes, its handoff will arrive via relay with the `🗒 Side handoff` prefix.
 
-## Key invariant
+## Key invariants
 
 `cockpit side spawn` does **NOT** create a daemon task record. There is no `CREW IDLE/DONE` event for side-sessions. The only signal path is the explicit `cockpit runtime send` the side-session sends on user confirmation.
+
+`cockpit side close` on a debug session automatically prunes its scratch worktree (the branch is preserved so the draft patch survives).

--- a/scripts/record-side-handoff.sh
+++ b/scripts/record-side-handoff.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
-# Usage: record-side-handoff.sh <spoke-vault-path> <topic> <summary>
+# Usage: record-side-handoff.sh <spoke-vault-path> <topic> <role> <summary>
 # Writes a durable handoff record to {spokeVault}/side-handoffs/<topic-slug>.md
 set -euo pipefail
 
-VAULT="${1:?Usage: record-side-handoff.sh <vault-path> <topic> <summary>}"
+VAULT="${1:?Usage: record-side-handoff.sh <vault-path> <topic> <role> <summary>}"
 TOPIC="${2:?}"
-SUMMARY="${3:?}"
+ROLE="${3:?}"
+SUMMARY="${4:?}"
 DATE=$(date +"%Y-%m-%d")
 SLUG=$(echo "$TOPIC" | head -c 60 | tr ' ' '-' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]//g')
 FILENAME="${VAULT}/side-handoffs/${SLUG}.md"
@@ -15,7 +16,7 @@ mkdir -p "${VAULT}/side-handoffs"
 cat > "$FILENAME" << EOF
 ---
 type: side-handoff
-role: research
+role: ${ROLE}
 date: ${DATE}
 topic: ${TOPIC}
 ---

--- a/src/commands/__tests__/side.test.ts
+++ b/src/commands/__tests__/side.test.ts
@@ -68,6 +68,16 @@ vi.mock("../../lib/per-crew-settings.js", () => ({
   writePerCrewOpencodeConfig: vi.fn(),
 }));
 
+// git-worktree mock — lets us assert debug sessions create/remove worktrees.
+const addWorktreeMock = vi.hoisted(() => vi.fn());
+const removeWorktreeMock = vi.hoisted(() => vi.fn());
+const worktreePathMock = vi.hoisted(() => vi.fn());
+vi.mock("../../lib/git-worktree.js", () => ({
+  addWorktree: addWorktreeMock,
+  removeWorktree: removeWorktreeMock,
+  worktreePath: worktreePathMock,
+}));
+
 // cockpitdCall and buildDispatchRequest are the daemon dispatch path.
 // side.ts MUST NOT call these — the mocks let us assert that invariant.
 const cockpitdCall = vi.hoisted(() => vi.fn());
@@ -131,6 +141,11 @@ describe("cockpit side spawn", () => {
     buildDispatchRequest.mockReset();
     existsSyncMock.mockReset();
     existsSyncMock.mockReturnValue(true);
+    addWorktreeMock.mockReset();
+    removeWorktreeMock.mockReset();
+    worktreePathMock.mockReset();
+    addWorktreeMock.mockReturnValue("/tmp/brove/.worktrees/brove-side-1");
+    worktreePathMock.mockReturnValue("/tmp/brove/.worktrees/brove-side-1");
 
     // Staged boot: first read shows pre-launch, subsequent reads show stable TUI.
     let reads = 0;
@@ -233,14 +248,86 @@ describe("cockpit side spawn", () => {
     expect(firstTurnCall?.[1]).toContain("research");
   });
 
-  it("throws 'not yet implemented' for --role debug (Phase 2)", async () => {
+  it("debug spawn creates a scratch worktree (addWorktree called)", async () => {
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
     listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude");
 
-    await expect(
-      runSideSpawn({ project: "brove", topic: "debug the crash", role: "debug" }),
-    ).rejects.toThrow("not yet implemented");
+    const promise = runSideSpawn({ project: "brove", topic: "debug the crash", role: "debug" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(addWorktreeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoRoot: "/tmp/brove",
+        project: "brove",
+        base: "develop",
+      }),
+    );
+  });
+
+  it("research spawn does NOT create a worktree (addWorktree not called)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude");
+
+    const promise = runSideSpawn({ project: "brove", topic: "research oauth", role: "research" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(addWorktreeMock).not.toHaveBeenCalled();
+  });
+
+  it("debug spawn is off the daemon lifecycle (no cockpitdCall)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude");
+
+    const promise = runSideSpawn({ project: "brove", topic: "debug the crash", role: "debug" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(cockpitdCall).not.toHaveBeenCalled();
+    expect(buildDispatchRequest).not.toHaveBeenCalled();
+  });
+
+  it("debug spawn cd-prefixes into the scratch worktree path (#279 fix)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude");
+    addWorktreeMock.mockReturnValue("/tmp/brove/.worktrees/brove-side-1");
+
+    const promise = runSideSpawn({ project: "brove", topic: "debug the crash", role: "debug" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    // First sendToPane call is the CLI launch — must cd into the scratch worktree
+    const launchCall = sendToPane.mock.calls[0];
+    expect(launchCall?.[1]).toContain("cd '/tmp/brove/.worktrees/brove-side-1'");
+  });
+
+  it("debug first turn includes scratch worktree path in context block", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude");
+    addWorktreeMock.mockReturnValue("/tmp/brove/.worktrees/brove-side-1");
+
+    const promise = runSideSpawn({ project: "brove", topic: "debug the crash", role: "debug" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    const firstTurnCall = sendToPane.mock.calls[1];
+    expect(firstTurnCall?.[1]).toContain("Scratch worktree: /tmp/brove/.worktrees/brove-side-1");
   });
 
   it("throws for unknown --role", async () => {
@@ -338,8 +425,12 @@ describe("runSideList / runSideClose / runSideSend", () => {
     status.mockReset();
     sendToPane.mockReset();
     closePane.mockReset();
+    existsSyncMock.mockReset();
+    removeWorktreeMock.mockReset();
+    worktreePathMock.mockReset();
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    worktreePathMock.mockReturnValue("/tmp/brove/.worktrees/brove-side-1");
   });
 
   it("runSideList returns only 🗒-prefixed sessions for this project", async () => {
@@ -367,8 +458,32 @@ describe("runSideList / runSideClose / runSideSend", () => {
 
   it("runSideClose throws when session not found", async () => {
     listSurfaces.mockResolvedValue([]);
+    existsSyncMock.mockReturnValue(false);
 
     await expect(runSideClose("brove", "side-99")).rejects.toThrow("not found");
+  });
+
+  it("runSideClose prunes scratch worktree when worktree path exists (debug session)", async () => {
+    listSurfaces.mockResolvedValue([{ surfaceId: "s1", title: "🗒 brove:side-1" }]);
+    closePane.mockResolvedValue(undefined);
+    existsSyncMock.mockReturnValue(true); // worktree path exists → debug session
+
+    await runSideClose("brove", "side-1");
+
+    expect(removeWorktreeMock).toHaveBeenCalledWith(
+      "/tmp/brove",
+      "/tmp/brove/.worktrees/brove-side-1",
+    );
+  });
+
+  it("runSideClose does NOT call removeWorktree when worktree path absent (research session)", async () => {
+    listSurfaces.mockResolvedValue([{ surfaceId: "s1", title: "🗒 brove:side-1" }]);
+    closePane.mockResolvedValue(undefined);
+    existsSyncMock.mockReturnValue(false); // no worktree → research session
+
+    await runSideClose("brove", "side-1");
+
+    expect(removeWorktreeMock).not.toHaveBeenCalled();
   });
 
   it("runSideSend sends to the matching pane without touching daemon", async () => {

--- a/src/commands/side.ts
+++ b/src/commands/side.ts
@@ -15,8 +15,12 @@ import {
 import type { PaneRef, PanePlacement } from "../runtimes/types.js";
 import { resolveCaptainWorkspace, sendFirstTurnWhenReady } from "./crew.js";
 import { resolveTextInput } from "../lib/resolve-text-input.js";
+import { addWorktree, removeWorktree, worktreePath } from "../lib/git-worktree.js";
 
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "cockpit", "templates");
+
+// Debug scratch worktrees branch off develop (same as crew --worktree).
+const WORKTREE_BASE_BRANCH = "develop";
 
 const SIDE_ROLES = ["research", "debug"] as const;
 type SideRole = (typeof SIDE_ROLES)[number];
@@ -51,14 +55,16 @@ function nextAutoName(existingTitles: string[], project: string): string {
 }
 
 /** Builds the first-turn message: topic + injected context the agent needs
- *  for handoff (spokeVault, project, role). */
+ *  for handoff (spokeVault, project, role). For debug sessions, scratchWorktree
+ *  is the isolated worktree path the session is running in. */
 export function buildSideFirstTurn(
   topic: string,
   project: string,
   role: string,
   spokeVault: string,
+  scratchWorktree?: string,
 ): string {
-  return [
+  const lines = [
     topic,
     "",
     "---",
@@ -66,7 +72,11 @@ export function buildSideFirstTurn(
     `Project: ${project}`,
     `Role: ${role}`,
     `Spoke vault: ${spokeVault}`,
-  ].join("\n");
+  ];
+  if (scratchWorktree) {
+    lines.push(`Scratch worktree: ${scratchWorktree}`);
+  }
+  return lines.join("\n");
 }
 
 export interface SideSpawnInput {
@@ -85,11 +95,6 @@ export async function runSideSpawn(input: SideSpawnInput): Promise<PaneRef> {
     throw new Error(`Project '${input.project}' not found. Run 'cockpit projects list'.`);
   }
 
-  if (input.role === "debug") {
-    throw new Error(
-      "Side role 'debug' is not yet implemented (Phase 2). Use --role research.",
-    );
-  }
   if (!SIDE_ROLES.includes(input.role as SideRole)) {
     throw new Error(
       `Unknown side role '${input.role}'. Valid roles: ${SIDE_ROLES.join(", ")}.`,
@@ -122,6 +127,19 @@ export async function runSideSpawn(input: SideSpawnInput): Promise<PaneRef> {
   }
   const name = input.name ?? nextAutoName(existingTitles, input.project);
 
+  // Debug sessions run in an isolated scratch git worktree so instrumentation
+  // edits never touch the captain's checkout. Research sessions share the root
+  // checkout. The #279 fix (cd into spawnCwd before launching CLI) applies to both.
+  const spawnCwd = input.role === "debug"
+    ? addWorktree({
+        repoRoot: proj.path,
+        worktreeDir: config.defaults.worktreeDir ?? ".worktrees",
+        project: input.project,
+        name,
+        base: WORKTREE_BASE_BRANCH,
+      })
+    : proj.path;
+
   const agents = new CapabilityRegistry({
     claude: createClaudeDriver(),
     codex: createCodexDriver(),
@@ -147,7 +165,7 @@ export async function runSideSpawn(input: SideSpawnInput): Promise<PaneRef> {
 
   const cliCommand = agent.buildCommand({
     prompt: input.topic,
-    workdir: proj.path,
+    workdir: spawnCwd,
     role: "side",
     promptFile: fs.existsSync(promptFile) ? promptFile : undefined,
     interactive: true,
@@ -155,7 +173,7 @@ export async function runSideSpawn(input: SideSpawnInput): Promise<PaneRef> {
     ...(sideModel ? { model: sideModel } : {}),
   });
 
-  await runtime.sendToPane(pane, `cd ${shellQuote(proj.path)} && ${cliCommand}`);
+  await runtime.sendToPane(pane, `cd ${shellQuote(spawnCwd)} && ${cliCommand}`);
   const preLaunchScreen = (await runtime.readPaneScreen(pane)) ?? "";
 
   const firstTurn = buildSideFirstTurn(
@@ -163,6 +181,7 @@ export async function runSideSpawn(input: SideSpawnInput): Promise<PaneRef> {
     input.project,
     input.role,
     proj.spokeVault ?? "",
+    input.role === "debug" ? spawnCwd : undefined,
   );
   await sendFirstTurnWhenReady(runtime, pane, firstTurn, preLaunchScreen);
 
@@ -200,6 +219,8 @@ export async function runSideList(
 }
 
 export async function runSideClose(project: string, name: string): Promise<void> {
+  const config = loadConfig();
+  const proj = config.projects[project];
   const { runtime, workspaceId } = await resolveCaptainWorkspace(project);
   const want = titleFor(project, name);
   const surfaces = await runtime.listSurfaces(workspaceId);
@@ -210,6 +231,24 @@ export async function runSideClose(project: string, name: string): Promise<void>
     );
   }
   await runtime.closePane(pane);
+  // Prune the scratch worktree if this was a debug session. Detection is
+  // filesystem-based: debug spawns create a worktree at the deterministic path;
+  // research spawns do not. If the path exists, remove it (best-effort).
+  if (proj) {
+    const wtPath = worktreePath(
+      proj.path,
+      config.defaults.worktreeDir ?? ".worktrees",
+      project,
+      name,
+    );
+    if (fs.existsSync(wtPath)) {
+      try {
+        removeWorktree(proj.path, wtPath);
+      } catch (e) {
+        process.stderr.write(`(worktree remove failed: ${(e as Error).message})\n`);
+      }
+    }
+  }
 }
 
 export const sideCommand = new Command("side").description(


### PR DESCRIPTION
## Summary

Phase 2 of the side-sessions framework (issue #283). Phase 1 (framework + research role) is merged via PR #284. This phase wires the `--role debug` path completely.

- **`--role debug` fully wired** in `src/commands/side.ts`: creates an isolated scratch git worktree (`addWorktree`, branch off `develop`), applies the #279 cwd fix (cd-prefixes the CLI launch into the worktree path), passes `spawnCwd` to `buildCommand.workdir`. Still **off the daemon lifecycle** — no `cockpitdCall`/`buildDispatchRequest` (invariant preserved from Phase 1).
- **`side close` prunes debug worktrees**: filesystem-based detection — if `worktreePath(proj.path, ...)` exists on close, call `removeWorktree` (best-effort; branch is preserved).
- **`orchestrator/side.debug.claude.md`**: debug role template — bug intake first (repro / when-where / expected-vs-actual / recent changes), `superpowers:systematic-debugging`, scratch-only edits, structured handoff with draft-patch reference.
- **`scripts/record-side-handoff.sh`**: role is now a positional parameter (was hardcoded `research`); both templates updated.
- **`plugin/skills/side-session/SKILL.md`**: documents debug role capabilities, intake-first requirement, scratch worktree lifecycle, structured handoff formats for both roles.

## Tests

5 new Phase 2 assertions in `side.test.ts`:
- `--role debug` calls `addWorktree` with correct `repoRoot`/`project`/`base`
- `--role research` does NOT call `addWorktree`
- debug spawn does NOT call `cockpitdCall` (off-lifecycle invariant)
- debug spawn cd-prefixes into scratch worktree path (#279 fix)
- debug first turn includes `Scratch worktree:` in context block
- `runSideClose` calls `removeWorktree` when worktree path exists
- `runSideClose` does NOT call `removeWorktree` when path absent

**1053/1053 tests pass** (`npm test` on clean run).

## Checklist

- [x] `--role debug` fully wired: scratch worktree (with #279 cwd fix), off-lifecycle, intake-first
- [x] `orchestrator/side.debug.claude.md` template
- [x] `side close` prunes debug worktree
- [x] skill updated for debug role
- [x] tests pass (1053/1053)
- [ ] PR against develop — captain reviews before merge

Closes #283 (Phase 2 of 2).