### PR TITLE
fix: crewRouting config-migration backfill + group dispatch [experimental] marker

### DIFF
--- a/src/commands/__tests__/group.test.ts
+++ b/src/commands/__tests__/group.test.ts
@@ -17,7 +17,7 @@ vi.mock("../../config.js", () => ({
   resolveHome: (p: string) => p,
 }));
 
-import { runGroupDispatch } from "../group.js";
+import { runGroupDispatch, groupCommand } from "../group.js";
 
 const makeConfig = (overrides: Record<string, any> = {}) => {
   const projects: Record<string, any> = {
@@ -61,6 +61,14 @@ const makeConfig = (overrides: Record<string, any> = {}) => {
     metrics: { enabled: false, path: "/tmp/metrics.json" },
   };
 };
+
+describe("groupCommand dispatch description", () => {
+  it("marks dispatch as [experimental]", () => {
+    const dispatch = groupCommand.commands.find((c) => c.name() === "dispatch");
+    expect(dispatch).toBeDefined();
+    expect(dispatch!.description()).toMatch(/\[experimental\]/i);
+  });
+});
 
 describe("runGroupDispatch", () => {
   beforeEach(() => {

--- a/src/commands/group.ts
+++ b/src/commands/group.ts
@@ -138,7 +138,7 @@ export const groupCommand = new Command("group")
   .description("Cross-project intra-group operations (Phase 1: dispatch)")
   .addCommand(
     new Command("dispatch")
-      .description("Dispatch a task to a sibling project in the same group")
+      .description("[experimental] Dispatch a task to a sibling project in the same group")
       .argument("<to-project>", "Target project name (must be in the same group)")
       .argument("<task>", "Task description to dispatch")
       .option("--provider <p>", "claude|opencode|codex", "claude")
@@ -149,6 +149,8 @@ export const groupCommand = new Command("group")
           console.error(chalk.red("Could not determine current project from cwd. Run from inside a registered project directory."));
           process.exit(1);
         }
+
+        console.error(chalk.yellow("⚠ cross-project delegation is experimental (#288): boot-if-down of a down sibling may not yet produce an operational captain."));
 
         try {
           const result = await runGroupDispatch({

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,5 +1,5 @@
 // src/config.test.ts
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { getDefaultConfig, loadConfig, saveConfig } from "./config.js";
 import fs from "node:fs";
 import os from "node:os";
@@ -58,6 +58,102 @@ describe("config", () => {
     const config = getDefaultConfig();
     expect(config.defaults.models!.crew).toBe("opus");
     expect(config.defaults.permissions.crew).toBe("auto");
+  });
+
+  it("backfills crewRouting when absent and writes it to disk", () => {
+    const configWithoutRouting = {
+      commandName: "command",
+      hubVault: "/tmp/hub",
+      projects: {},
+      defaults: {
+        maxCrew: 5,
+        worktreeDir: ".worktrees",
+        teammateMode: "in-process",
+        permissions: { command: "auto", captain: "auto", crew: "auto" },
+      },
+      metrics: { enabled: true, path: "/tmp/metrics.json" },
+    };
+    fs.writeFileSync(configPath, JSON.stringify(configWithoutRouting));
+
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const loaded = loadConfig(configPath);
+    spy.mockRestore();
+
+    // in-memory result has crewRouting backfilled
+    expect(loaded.defaults.crewRouting).toBeDefined();
+    expect(loaded.defaults.crewRouting!.rules.length).toBeGreaterThan(0);
+
+    // file on disk was updated (migration persisted)
+    const onDisk = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    expect(onDisk.defaults.crewRouting).toBeDefined();
+  });
+
+  it("does not re-persist or re-notice when crewRouting already present", () => {
+    const configWithRouting = {
+      commandName: "command",
+      hubVault: "/tmp/hub",
+      projects: {},
+      defaults: {
+        maxCrew: 5,
+        worktreeDir: ".worktrees",
+        teammateMode: "in-process",
+        permissions: { command: "auto", captain: "auto", crew: "auto" },
+        crewRouting: { rules: [{ tier: "custom", match: "custom", agent: "opencode" }] },
+      },
+      metrics: { enabled: true, path: "/tmp/metrics.json" },
+    };
+    fs.writeFileSync(configPath, JSON.stringify(configWithRouting));
+    const originalMtime = fs.statSync(configPath).mtimeMs;
+
+    // Small delay to ensure mtime would differ if the file were rewritten
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const loaded = loadConfig(configPath);
+
+    // custom rules preserved — not replaced with defaults
+    expect(loaded.defaults.crewRouting!.rules[0].tier).toBe("custom");
+    // file not rewritten (mtime unchanged)
+    expect(fs.statSync(configPath).mtimeMs).toBe(originalMtime);
+    // no stderr notice emitted
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("does not crash or persist when config file does not exist (fallback path)", () => {
+    const missingPath = path.join(tmpDir, "nonexistent.json");
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const loaded = loadConfig(missingPath);
+    spy.mockRestore();
+
+    // fallback returns default config (which has crewRouting) without writing any file
+    expect(loaded.defaults.crewRouting).toBeDefined();
+    expect(fs.existsSync(missingPath)).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("emits a stderr notice exactly once on the backfill path", () => {
+    const configWithoutRouting = {
+      commandName: "command",
+      hubVault: "/tmp/hub",
+      projects: {},
+      defaults: {
+        maxCrew: 5,
+        worktreeDir: ".worktrees",
+        teammateMode: "in-process",
+        permissions: { command: "auto", captain: "auto", crew: "auto" },
+      },
+      metrics: { enabled: true, path: "/tmp/metrics.json" },
+    };
+    fs.writeFileSync(configPath, JSON.stringify(configWithoutRouting));
+
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    loadConfig(configPath);
+    // Second call — file now has crewRouting, so no second notice
+    loadConfig(configPath);
+
+    // notice fired exactly once
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0]).toMatch(/cockpit upgrade/i);
+    spy.mockRestore();
   });
 
   it("migrates old models config to roles on load", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import chalk from "chalk";
 
 export interface ProjectConfig {
   path: string;
@@ -163,6 +164,18 @@ export function loadConfig(configPath = DEFAULT_CONFIG_PATH): CockpitConfig {
     // Ensure agents has at least claude
     if (!config.agents) {
       config.agents = { claude: { cli: "claude", driver: "claude" } };
+    }
+
+    // #286: backfill crewRouting for configs written before routing existed
+    if (!config.defaults.crewRouting) {
+      config.defaults.crewRouting = getDefaultConfig().defaults.crewRouting;
+      saveConfig(config, configPath);
+      console.error(
+        chalk.cyan(
+          "⬆ cockpit upgrade: added default crew routing rules to your config (leveled routing now active). " +
+          "Edit defaults.crewRouting in ~/.config/cockpit/config.json or use the cockpit:add-pick-crew-rule skill.",
+        ),
+      );
     }
 
     return config;


### PR DESCRIPTION
## Summary

- **#286** — `loadConfig` now backfills `defaults.crewRouting` into existing `~/.config/cockpit/config.json` files written before routing existed. Persists to disk on first run so the one-time upgrade notice fires exactly once (on the backfill path only). The `catch`/no-file fallback path is untouched.
- **#288** — `cockpit group dispatch` description updated to `[experimental]` and a one-line `chalk.yellow` stderr warning is emitted on each dispatch call while boot-if-down of a down sibling is unverified.

## Test plan

- [x] `loadConfig` with a config missing `crewRouting` → backfilled in-memory AND written to disk
- [x] `loadConfig` with `crewRouting` already present → unchanged, file not rewritten, no notice
- [x] `loadConfig` with missing file (fallback path) → no crash, no file written, no notice
- [x] Notice emitted exactly once (second `loadConfig` after persist sees it present → silent)
- [x] `groupCommand.commands.find("dispatch").description()` includes `[experimental]`
- [x] `npm test` — 1058 tests, 93 files, all green

Closes #286, closes #288.