### PR TITLE
Release v0.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-14
+
+A coordination-layer release headlined by **leveled crew routing** and the **side-sessions framework**, plus two crew-lifecycle reliability fixes — crews now signal `DONE` on their own, and `--worktree` crews are genuinely isolated. Also ships **experimental** cross-project intra-group delegation.
+
+### Added
+
+- **Leveled crew routing.** Captains now pick a crew's agent + model by task tier via a configurable `defaults.crewRouting.rules[]` ruleset (JSON, keyword → tier → `{agent, model}`, first-match-wins by array order). `resolveCrewRoute` is consulted at spawn; an explicit `--agent`/`--model` always overrides. New `cockpit:add-pick-crew-rule` skill edits the ruleset. Default tiers: extreme→claude/opus, hard→claude/sonnet, mobile→codex, daily→opencode. Closes #275. (#276)
+
+- **Side-sessions framework.** New `cockpit side spawn|send|list|close --role research|debug` opens a dedicated fresh-context tab on the **captain model (opus)**, deliberately **off the crew/daemon lifecycle** — no task record, no `CREW IDLE/DONE` noise to the primary captain. `research` discusses ideas and produces artifacts (issue/spec/plan) with no edits; `debug` does systematic-debugging in an isolated scratch worktree (instrument + failing test, never ships) and hands a diagnosis + optional draft patch back. Report-back is offer-and-confirm: a structured handoff via `cockpit runtime send` to the captain pane plus a durable `{spokeVault}/side-handoffs/<topic>.md` record. New `cockpit:side-session` skill. Closes #283. (#284, #285)
+
+- **Cross-project intra-group delegation (experimental).** `cockpit group dispatch <to-project> "<task>"` records a tracked task on a same-group sibling and wakes its captain via the existing mailbox/relay; the dispatcher yields and is notified when the task settles (done/blocked/failed). Validates same-group + `acceptDelegations`, attempts boot-if-down with a bounded warmup poll, and rejects loudly (task not recorded) on warmup failure. **Experimental:** boot-if-down of a *down* sibling does not yet reliably produce an operational target captain (#288) — works best when the target captain is already up. Closes #246. (#274)
+
+- **PR-time CI.** `ci.yml` now runs the build + full test suite on every pull request to `develop` and `main`, closing the gap where broken tests could reach `develop` silently (tests previously ran only on push to `main`). (#273)
+
+### Fixed
+
+- **Crew `DONE` is now signalled reliably and unprompted.** claude and opencode crews used to finish their work, report via text, and end the turn without ever running `cockpit crew signal done` → the watchdog parked the task at `awaiting-input` (`CREW IDLE`), so the captain never saw `CREW DONE`. The first turn sent to claude/opencode crews now carries a concrete **completion-protocol** suffix with `--task-id`/`--project` baked in (codex parity — robust to the keystroke-env race AND to model discretion). captain-ops also gained a **"Handling CREW IDLE"** reconciliation step (classify done-vs-waiting-vs-working on a single spot-check). Closes #278. (#281)
+
+- **`--worktree` crews are now isolated.** A `--worktree` crew used to run git in the captain's MAIN checkout (the pane was created in the captain workspace cwd and the session never `cd`'d into the worktree), dragging the captain's HEAD onto the crew branch. The claude/opencode launch now `cd`s into the spawn cwd first (no-op for non-worktree spawns). Closes #279. (#282)
+
+- **crewRouting config-migration backfill.** Existing `~/.config/cockpit/config.json` files written before routing existed never received `defaults.crewRouting`, so leveled routing was a silent no-op. `loadConfig` now backfills the default ruleset when absent, persists it once, and prints a one-time upgrade notice. Closes #286. (#289)
+
+- **Relay draft-preservation third state.** `parseDraftFromScreen` now defers delivery on an overlay/unknown screen instead of misclassifying it, so a crew reply can't clobber an in-progress captain draft in that state. (#268) (#272)
+
+- **Daemon teardown flake + crew anti-polling guidance.** The daemon test teardown now awaits async server close (eliminates an `ENOTEMPTY` flake, #146); captain-ops gained an anti-polling guard so captains don't spin unbounded `until` loops reading crew screens (#241). (#277)
+
 ## [0.5.4] - 2026-06-11
 
 A stability release headlined by the **RAM-flood fix** — orphaned headless `claude -p` sessions no longer accumulate until the machine runs out of memory. Also adds per-spawn `--model` override, captain-draft preservation in the inbox, a captain-managed relay with live `cockpit relay logs`, `PROTOCOL_VERSION` framing, `cockpit heal`, and project-management skills.

--- a/docs/reports/268-overlay-fixture.txt
+++ b/docs/reports/268-overlay-fixture.txt
@@ -1,0 +1,20 @@
+ Claude Code — pact-network-captain
+
+  ✻ Thinking for 12s
+
+  Let me check the status of the crew tasks…
+
+ ╔══════════════════════════════════════════════════════════════════════════╗
+ ║  /model                                                                  ║
+ ║                                                                          ║
+ ║  Current model: claude-opus-4-8                                          ║
+ ║                                                                          ║
+ ║  ❯ claude-opus-4-8      Powerful, best for complex tasks                 ║
+ ║    claude-sonnet-4-6    Fast and intelligent                             ║
+ ║    claude-haiku-4-5     Fastest                                          ║
+ ║                                                                          ║
+ ║  [Enter] Select   [Esc] Cancel                                           ║
+ ╚══════════════════════════════════════════════════════════════════════════╝
+
+   Model: Opus 4.8  Ctx Used: 31.2%  Cost: $8.42  Session: 47m
+   ⏵⏵ auto mode on · 0 shells

--- a/docs/superpowers/plans/2026-06-13-side-sessions-p1.md
+++ b/docs/superpowers/plans/2026-06-13-side-sessions-p1.md
@@ -1,0 +1,1209 @@
+# Side-Sessions Framework Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `cockpit side spawn|send|list|close`, research role template, config entry, handoff script, and `cockpit:side-session` skill — entirely off the daemon lifecycle.
+
+**Architecture:** New `src/commands/side.ts` mirrors `crew.ts` structure but skips all daemon dispatch (no `cockpitdCall`/`buildDispatchRequest`). `resolveCaptainWorkspace` exported from `crew.ts` as the minimal shared helper. Role templates in `orchestrator/` use the existing `mirrorFlat` sync pattern so they auto-deploy to `~/.config/cockpit/templates/`.
+
+**Tech Stack:** TypeScript, Commander.js, vitest; existing `RuntimeRegistry`/`CapabilityRegistry`/`sendFirstTurnWhenReady` from `crew.ts`.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/drivers/types.ts` | Modify | Add `"side"` to `Role` union |
+| `src/config.ts` | Modify | Add `"side"` to `RoleConfig`, add `defaults.roles.side` |
+| `src/commands/crew.ts` | Modify | Export `resolveCaptainWorkspace` |
+| `src/commands/side.ts` | Create | Full side command (spawn/send/list/close) |
+| `src/index.ts` | Modify | Register `sideCommand` |
+| `orchestrator/side.research.claude.md` | Create | Research role system prompt |
+| `scripts/record-side-handoff.sh` | Create | Vault record write script |
+| `plugin/skills/side-session/SKILL.md` | Create | Captain-facing skill docs |
+| `src/commands/__tests__/side.test.ts` | Create | Unit tests |
+
+---
+
+### Task 1: Type foundations — Role union + RoleConfig
+
+**Files:**
+- Modify: `src/drivers/types.ts:11`
+- Modify: `src/config.ts:59` (RoleConfig) and `src/config.ts:122` (getDefaultConfig roles)
+
+- [ ] **Step 1: Add "side" to the Role union in types.ts**
+
+Open `src/drivers/types.ts`. Line 11 currently reads:
+```ts
+export type Role = "command" | "captain" | "crew" | "exploration";
+```
+Change to:
+```ts
+export type Role = "command" | "captain" | "crew" | "exploration" | "side";
+```
+
+- [ ] **Step 2: Add "side" to RoleConfig and getDefaultConfig in config.ts**
+
+In `src/config.ts`, the `RoleConfig` type (line ~59):
+```ts
+export type RoleConfig = Partial<Record<"command" | "captain" | "crew" | "exploration", RoleAssignment>>;
+```
+Change to:
+```ts
+export type RoleConfig = Partial<Record<"command" | "captain" | "crew" | "exploration" | "side", RoleAssignment>>;
+```
+
+In `getDefaultConfig()` (line ~122), inside the `roles` object, add after the `exploration` entry:
+```ts
+side: { agent: "claude", model: "opus" },
+```
+So `roles` becomes:
+```ts
+roles: {
+  command: { agent: "claude", model: "opus" },
+  captain: { agent: "claude", model: "opus" },
+  crew: { agent: "claude", model: "opus" },
+  exploration: { agent: "claude", model: "haiku" },
+  side: { agent: "claude", model: "opus" },
+},
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+cd /Users/q3labsadmin/me/claude-cockpit/.worktrees/cockpit-side-p1 && npx tsc --noEmit 2>&1 | head -20
+```
+Expected: no errors (or only pre-existing ones unrelated to these files).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/drivers/types.ts src/config.ts
+git commit -m "feat(side): add 'side' to Role union and RoleConfig defaults"
+```
+
+---
+
+### Task 2: Export resolveCaptainWorkspace from crew.ts
+
+**Files:**
+- Modify: `src/commands/crew.ts:133` (function declaration)
+
+- [ ] **Step 1: Add `export` to resolveCaptainWorkspace**
+
+In `src/commands/crew.ts`, find the function starting at line ~133:
+```ts
+async function resolveCaptainWorkspace(project: string): Promise<{
+```
+Change to:
+```ts
+export async function resolveCaptainWorkspace(project: string): Promise<{
+```
+That's the only change — one word added. The callers within crew.ts are unaffected.
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+cd /Users/q3labsadmin/me/claude-cockpit/.worktrees/cockpit-side-p1 && npx tsc --noEmit 2>&1 | head -20
+```
+Expected: no new errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/commands/crew.ts
+git commit -m "feat(side): export resolveCaptainWorkspace for reuse in side command"
+```
+
+---
+
+### Task 3: Implement src/commands/side.ts
+
+**Files:**
+- Create: `src/commands/side.ts`
+
+- [ ] **Step 1: Write the tests FIRST (TDD)**
+
+Create `src/commands/__tests__/side.test.ts` with the full test suite (see Task 4 below). Run them to confirm they fail before any implementation.
+
+```bash
+cd /Users/q3labsadmin/me/claude-cockpit/.worktrees/cockpit-side-p1 && npx vitest run src/commands/__tests__/side.test.ts 2>&1 | tail -20
+```
+Expected: FAIL — module not found or functions undefined.
+
+- [ ] **Step 2: Create src/commands/side.ts**
+
+```typescript
+import { Command } from "commander";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import chalk from "chalk";
+import { loadConfig } from "../config.js";
+import { createCmuxDriver, RuntimeRegistry } from "../runtimes/index.js";
+import {
+  createClaudeDriver,
+  createCodexDriver,
+  createGeminiDriver,
+  createOpencodeDriver,
+  CapabilityRegistry,
+} from "../drivers/index.js";
+import type { PaneRef, PanePlacement } from "../runtimes/types.js";
+import { resolveCaptainWorkspace, sendFirstTurnWhenReady } from "./crew.js";
+import { resolveTextInput } from "../lib/resolve-text-input.js";
+
+const TEMPLATES_DIR = path.join(os.homedir(), ".config", "cockpit", "templates");
+
+const SIDE_ROLES = ["research", "debug"] as const;
+type SideRole = (typeof SIDE_ROLES)[number];
+
+// POSIX single-quote a path so it is safe to embed in a shell command even
+// when the path contains spaces or special characters.
+function shellQuote(p: string): string {
+  return "'" + p.replace(/'/g, "'\\''") + "'";
+}
+
+function titleFor(project: string, name: string): string {
+  return `🗒 ${project}:${name}`;
+}
+
+function isSideTitle(project: string, title: string): boolean {
+  return title.startsWith(`🗒 ${project}:`);
+}
+
+function nameFromTitle(project: string, title: string): string {
+  return title.slice(`🗒 ${project}:`.length);
+}
+
+function nextAutoName(existingTitles: string[], project: string): string {
+  const used = new Set<number>();
+  for (const title of existingTitles) {
+    const n = nameFromTitle(project, title).match(/^side-(\d+)$/);
+    if (n) used.add(Number(n[1]));
+  }
+  let i = 1;
+  while (used.has(i)) i++;
+  return `side-${i}`;
+}
+
+/** Builds the first-turn message: topic + injected context the agent needs
+ *  for handoff (spokeVault, project, role). */
+export function buildSideFirstTurn(
+  topic: string,
+  project: string,
+  role: string,
+  spokeVault: string,
+): string {
+  return [
+    topic,
+    "",
+    "---",
+    "Side-session context (for handoff use):",
+    `Project: ${project}`,
+    `Role: ${role}`,
+    `Spoke vault: ${spokeVault}`,
+  ].join("\n");
+}
+
+export interface SideSpawnInput {
+  project: string;
+  topic: string;
+  role: string;
+  name?: string;
+  direction?: PanePlacement;
+  agent?: string;
+}
+
+export async function runSideSpawn(input: SideSpawnInput): Promise<PaneRef> {
+  const config = loadConfig();
+  const proj = config.projects[input.project];
+  if (!proj) {
+    throw new Error(`Project '${input.project}' not found. Run 'cockpit projects list'.`);
+  }
+
+  if (input.role === "debug") {
+    throw new Error(
+      "Side role 'debug' is not yet implemented (Phase 2). Use --role research.",
+    );
+  }
+  if (!SIDE_ROLES.includes(input.role as SideRole)) {
+    throw new Error(
+      `Unknown side role '${input.role}'. Valid roles: ${SIDE_ROLES.join(", ")}.`,
+    );
+  }
+
+  const runtime = new RuntimeRegistry({ cmux: createCmuxDriver() }).forProject(
+    input.project,
+    config,
+  );
+  const captain = await runtime.status(proj.captainName);
+  if (!captain) {
+    throw new Error(
+      `Captain workspace '${proj.captainName}' is not running. Run 'cockpit launch ${input.project}' first.`,
+    );
+  }
+
+  const existing = await runtime.listSurfaces(captain.id);
+  const existingTitles = existing
+    .filter((s) => s.title && isSideTitle(input.project, s.title))
+    .map((s) => s.title!);
+
+  if (input.name) {
+    const wantTitle = titleFor(input.project, input.name);
+    if (existingTitles.includes(wantTitle)) {
+      throw new Error(
+        `Side session '${input.name}' already exists for ${input.project}.`,
+      );
+    }
+  }
+  const name = input.name ?? nextAutoName(existingTitles, input.project);
+
+  const agents = new CapabilityRegistry({
+    claude: createClaudeDriver(),
+    codex: createCodexDriver(),
+    gemini: createGeminiDriver(),
+    opencode: createOpencodeDriver(),
+  });
+  const sideRole = config.defaults.roles?.side;
+  const agentName = input.agent ?? sideRole?.agent ?? "claude";
+  const agent = agents.get(agentName);
+  if (!agent) {
+    throw new Error(`Unknown agent '${agentName}'. Known: claude, codex, gemini, opencode.`);
+  }
+
+  const sideModel = sideRole?.model;
+  const promptFile = path.join(
+    TEMPLATES_DIR,
+    `side.${input.role}.${agent.templateSuffix}.md`,
+  );
+
+  const direction: PanePlacement = input.direction ?? "tab";
+  const title = titleFor(input.project, name);
+  const pane = await runtime.newPane({ workspaceId: captain.id, direction, title });
+
+  const cliCommand = agent.buildCommand({
+    prompt: input.topic,
+    workdir: proj.path,
+    role: "side",
+    promptFile: fs.existsSync(promptFile) ? promptFile : undefined,
+    interactive: true,
+    permissionMode: config.defaults.permissions?.crew ?? "auto",
+    ...(sideModel ? { model: sideModel } : {}),
+  });
+
+  await runtime.sendToPane(pane, `cd ${shellQuote(proj.path)} && ${cliCommand}`);
+  const preLaunchScreen = (await runtime.readPaneScreen(pane)) ?? "";
+
+  const firstTurn = buildSideFirstTurn(
+    input.topic,
+    input.project,
+    input.role,
+    proj.spokeVault ?? "",
+  );
+  await sendFirstTurnWhenReady(runtime, pane, firstTurn, preLaunchScreen);
+
+  return { ...pane, title };
+}
+
+export async function runSideSend(
+  project: string,
+  name: string,
+  message: string,
+): Promise<void> {
+  const { runtime, workspaceId } = await resolveCaptainWorkspace(project);
+  const want = titleFor(project, name);
+  const surfaces = await runtime.listSurfaces(workspaceId);
+  const pane = surfaces.find((s) => s.title === want) ?? null;
+  if (!pane) {
+    throw new Error(
+      `Side session '${name}' not found for ${project}. Run 'cockpit side list ${project}'.`,
+    );
+  }
+  await runtime.sendToPane(pane, message);
+}
+
+export async function runSideList(
+  project: string,
+): Promise<Array<{ name: string; surfaceId: string }>> {
+  const { runtime, workspaceId } = await resolveCaptainWorkspace(project);
+  const surfaces = await runtime.listSurfaces(workspaceId);
+  return surfaces
+    .filter((s) => s.title && isSideTitle(project, s.title))
+    .map((s) => ({
+      name: nameFromTitle(project, s.title!),
+      surfaceId: s.surfaceId,
+    }));
+}
+
+export async function runSideClose(project: string, name: string): Promise<void> {
+  const { runtime, workspaceId } = await resolveCaptainWorkspace(project);
+  const want = titleFor(project, name);
+  const surfaces = await runtime.listSurfaces(workspaceId);
+  const pane = surfaces.find((s) => s.title === want) ?? null;
+  if (!pane) {
+    throw new Error(
+      `Side session '${name}' not found for ${project}. Run 'cockpit side list ${project}'.`,
+    );
+  }
+  await runtime.closePane(pane);
+}
+
+export const sideCommand = new Command("side").description(
+  "Spawn and manage side-sessions (research/debug) — fresh-context tabs off the daemon lifecycle",
+);
+
+sideCommand
+  .command("spawn")
+  .description(
+    "Spawn a fresh-context side-session tab for research or debug (--role required)",
+  )
+  .argument("<project>", "Project name (must be registered)")
+  .argument("[topic]", "Topic or question for the session (omit with --topic-file)")
+  .requiredOption("--role <role>", "Session role: research | debug")
+  .option("--name <name>", "Session name (default: auto-generated side-N)")
+  .option(
+    "--direction <dir>",
+    "Placement: tab (default) or split direction (right|left|up|down)",
+    "tab",
+  )
+  .option("--agent <name>", "Agent CLI to use (claude|opencode)", "claude")
+  .option("--topic-file <path>", "Read topic from file instead of positional arg ('-' for stdin)")
+  .action(
+    async (
+      project: string,
+      topic: string | undefined,
+      opts: { role: string; name?: string; direction: PanePlacement; agent: string; topicFile?: string },
+    ) => {
+      try {
+        const resolvedTopic = await resolveTextInput({
+          positional: topic,
+          filePath: opts.topicFile,
+          label: "topic",
+        });
+        const pane = await runSideSpawn({
+          project,
+          topic: resolvedTopic,
+          role: opts.role,
+          name: opts.name,
+          direction: opts.direction,
+          agent: opts.agent,
+        });
+        console.log(chalk.green(`✔ Side session '${pane.title}' spawned (${pane.surfaceId})`));
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    },
+  );
+
+sideCommand
+  .command("list")
+  .description("List live side-sessions for a project")
+  .argument("<project>", "Project name")
+  .action(async (project: string) => {
+    try {
+      const sessions = await runSideList(project);
+      if (sessions.length === 0) {
+        console.log(chalk.yellow(`No live side-sessions for ${project}.`));
+        return;
+      }
+      for (const s of sessions) {
+        console.log(`  ${s.name}  (${s.surfaceId})`);
+      }
+    } catch (err) {
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+  });
+
+sideCommand
+  .command("send")
+  .description("Send a follow-up message to an existing side-session")
+  .argument("<project>", "Project name")
+  .argument("<name>", "Session name (e.g. side-1)")
+  .argument("[message]", "Message to send (omit with --message-file)")
+  .option("--message-file <path>", "Read message from file ('-' for stdin)")
+  .action(
+    async (
+      project: string,
+      name: string,
+      message: string | undefined,
+      opts: { messageFile?: string },
+    ) => {
+      try {
+        const resolvedMessage = await resolveTextInput({
+          positional: message,
+          filePath: opts.messageFile,
+          label: "message",
+        });
+        await runSideSend(project, name, resolvedMessage);
+        console.log(chalk.green(`✔ Sent to ${project}:${name}`));
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    },
+  );
+
+sideCommand
+  .command("close")
+  .description("Close a side-session (closes its tab)")
+  .argument("<project>", "Project name")
+  .argument("<name>", "Session name")
+  .action(async (project: string, name: string) => {
+    try {
+      await runSideClose(project, name);
+      console.log(chalk.green(`✔ Closed ${project}:${name}`));
+    } catch (err) {
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+  });
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+cd /Users/q3labsadmin/me/claude-cockpit/.worktrees/cockpit-side-p1 && npx tsc --noEmit 2>&1 | head -20
+```
+Expected: no new errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/commands/side.ts
+git commit -m "feat(side): add cockpit side command (spawn/send/list/close) off daemon lifecycle"
+```
+
+---
+
+### Task 4: Tests for side.ts
+
+**Files:**
+- Create: `src/commands/__tests__/side.test.ts`
+
+- [ ] **Step 1: Create the test file**
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ── mock setup (mirrors crew.test.ts pattern) ──────────────────────────────
+
+const newPane = vi.hoisted(() => vi.fn());
+const sendToPane = vi.hoisted(() => vi.fn());
+const closePane = vi.hoisted(() => vi.fn());
+const readPaneScreen = vi.hoisted(() => vi.fn());
+const listSurfaces = vi.hoisted(() => vi.fn());
+const status = vi.hoisted(() => vi.fn());
+const buildCommand = vi.hoisted(() => vi.fn());
+
+vi.mock("../../runtimes/index.js", () => ({
+  createCmuxDriver: () => ({
+    name: "cmux",
+    probe: vi.fn(),
+    list: vi.fn(),
+    status,
+    spawn: vi.fn(),
+    send: vi.fn(),
+    sendKey: vi.fn(),
+    readScreen: vi.fn(),
+    stop: vi.fn(),
+    newPane,
+    closePane,
+    sendToPane,
+    readPaneScreen,
+    listSurfaces,
+  }),
+  RuntimeRegistry: class {
+    constructor(private drivers: Record<string, unknown>) {}
+    forProject() { return this.drivers.cmux; }
+    global() { return this.drivers.cmux; }
+    get(name: string) { return (this.drivers as Record<string, unknown>)[name]; }
+    async probeAll() { return {}; }
+  },
+}));
+
+const loadConfig = vi.hoisted(() => vi.fn());
+vi.mock("../../config.js", () => ({
+  loadConfig,
+  resolveHome: (p: string) => p,
+}));
+
+const claudeDriver = vi.hoisted(() => ({
+  name: "claude",
+  templateSuffix: "claude",
+  probe: vi.fn(),
+  buildCommand,
+}));
+
+vi.mock("../../drivers/index.js", () => ({
+  createClaudeDriver: () => claudeDriver,
+  createCodexDriver: () => ({ ...claudeDriver, name: "codex", templateSuffix: "generic" }),
+  createGeminiDriver: () => ({ ...claudeDriver, name: "gemini", templateSuffix: "generic" }),
+  createOpencodeDriver: () => ({ ...claudeDriver, name: "opencode", templateSuffix: "opencode" }),
+  CapabilityRegistry: class {
+    constructor(private drivers: Record<string, unknown>) {}
+    get(name: string) { return (this.drivers as Record<string, unknown>)[name]; }
+  },
+}));
+
+// cockpitdCall and buildDispatchRequest are the daemon dispatch path.
+// side.ts MUST NOT call these — the mocks let us assert that invariant.
+const cockpitdCall = vi.hoisted(() => vi.fn());
+const buildDispatchRequest = vi.hoisted(() => vi.fn());
+vi.mock("../crew-control.js", () => ({
+  cockpitdCall,
+  buildDispatchRequest,
+  sendCodexFirstTurn: vi.fn().mockResolvedValue(undefined),
+}));
+
+const existsSyncMock = vi.hoisted(() => vi.fn());
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  const merged = { ...actual, existsSync: existsSyncMock };
+  return { ...merged, default: merged };
+});
+
+import { runSideSpawn, runSideSend, runSideList, runSideClose, buildSideFirstTurn } from "../side.js";
+
+const baseConfig = {
+  commandName: "command",
+  hubVault: "~/hub",
+  projects: {
+    brove: {
+      path: "/tmp/brove",
+      captainName: "brove-captain",
+      spokeVault: "~/hub/spokes/brove",
+      host: "local",
+    },
+  },
+  defaults: {
+    maxCrew: 5,
+    worktreeDir: ".worktrees",
+    teammateMode: "in-process",
+    permissions: { command: "auto", captain: "auto", crew: "auto" },
+    roles: {
+      side: { agent: "claude", model: "opus" },
+    },
+  },
+  metrics: { enabled: false, path: "" },
+};
+
+describe("cockpit side spawn", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    newPane.mockReset();
+    sendToPane.mockReset();
+    closePane.mockReset();
+    readPaneScreen.mockReset();
+    listSurfaces.mockReset();
+    status.mockReset();
+    buildCommand.mockReset();
+    loadConfig.mockReset();
+    cockpitdCall.mockReset();
+    buildDispatchRequest.mockReset();
+    existsSyncMock.mockReset();
+    existsSyncMock.mockReturnValue(true);
+
+    // Staged boot sequence matching crew.test.ts pattern
+    let reads = 0;
+    readPaneScreen.mockImplementation(async () => {
+      reads++;
+      if (reads === 1) return "booting…";
+      if (reads <= 4) return "> ready";
+      return "> ready\nworking…";
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("CRITICAL: does NOT call cockpitdCall or buildDispatchRequest (off daemon lifecycle)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude --append-system-prompt-file /tmp/side.research.claude.md");
+
+    const promise = runSideSpawn({ project: "brove", topic: "research oauth options", role: "research" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(cockpitdCall).not.toHaveBeenCalled();
+    expect(buildDispatchRequest).not.toHaveBeenCalled();
+  });
+
+  it("spawns with 🗒 title prefix and side-1 auto-name", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude --append-system-prompt-file /tmp/side.research.claude.md");
+
+    const promise = runSideSpawn({ project: "brove", topic: "research oauth", role: "research" });
+    await vi.advanceTimersByTimeAsync(3000);
+    const result = await promise;
+
+    expect(newPane).toHaveBeenCalledWith(expect.objectContaining({
+      title: "🗒 brove:side-1",
+    }));
+    expect(result.title).toBe("🗒 brove:side-1");
+  });
+
+  it("wires the research template path (side.research.claude.md)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude --template");
+
+    const promise = runSideSpawn({ project: "brove", topic: "research oauth", role: "research" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(buildCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        promptFile: expect.stringContaining("side.research.claude.md"),
+        role: "side",
+        interactive: true,
+      }),
+    );
+  });
+
+  it("uses the side model from config (opus)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude --model opus");
+
+    const promise = runSideSpawn({ project: "brove", topic: "research topic", role: "research" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(buildCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "opus" }),
+    );
+  });
+
+  it("sends topic + context block as first turn (includes spokeVault)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude");
+
+    const promise = runSideSpawn({ project: "brove", topic: "research oauth options", role: "research" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    // Second sendToPane is the first-turn delivery
+    const firstTurnCall = sendToPane.mock.calls[1];
+    expect(firstTurnCall?.[1]).toContain("research oauth options");
+    expect(firstTurnCall?.[1]).toContain("~/hub/spokes/brove");
+    expect(firstTurnCall?.[1]).toContain("brove");
+    expect(firstTurnCall?.[1]).toContain("research");
+  });
+
+  it("throws 'not yet implemented' for --role debug (Phase 2)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+
+    await expect(
+      runSideSpawn({ project: "brove", topic: "debug the crash", role: "debug" }),
+    ).rejects.toThrow("not yet implemented");
+  });
+
+  it("throws for unknown --role", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+
+    await expect(
+      runSideSpawn({ project: "brove", topic: "topic", role: "unknown-role" }),
+    ).rejects.toThrow("Unknown side role");
+  });
+
+  it("auto-increments name avoiding existing side sessions", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([
+      { surfaceId: "s1", title: "🗒 brove:side-1" },
+      { surfaceId: "s2", title: "🗒 brove:side-2" },
+    ]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude");
+
+    const promise = runSideSpawn({ project: "brove", topic: "topic", role: "research" });
+    await vi.advanceTimersByTimeAsync(3000);
+    const result = await promise;
+
+    expect(result.title).toBe("🗒 brove:side-3");
+  });
+
+  it("uses promptFile=undefined when template file is absent", async () => {
+    existsSyncMock.mockReturnValue(false);
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude");
+
+    const promise = runSideSpawn({ project: "brove", topic: "topic", role: "research" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(buildCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ promptFile: undefined }),
+    );
+  });
+});
+
+describe("buildSideFirstTurn", () => {
+  it("includes topic, project, role, and spokeVault", () => {
+    const result = buildSideFirstTurn(
+      "research oauth options",
+      "brove",
+      "research",
+      "~/hub/spokes/brove",
+    );
+    expect(result).toContain("research oauth options");
+    expect(result).toContain("brove");
+    expect(result).toContain("research");
+    expect(result).toContain("~/hub/spokes/brove");
+  });
+
+  it("puts the topic first (before the context block)", () => {
+    const result = buildSideFirstTurn("my topic", "proj", "research", "/vault");
+    expect(result.indexOf("my topic")).toBeLessThan(result.indexOf("---"));
+  });
+});
+
+describe("runSideList / runSideClose / runSideSend", () => {
+  beforeEach(() => {
+    loadConfig.mockReset();
+    listSurfaces.mockReset();
+    status.mockReset();
+    sendToPane.mockReset();
+    closePane.mockReset();
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+  });
+
+  it("runSideList returns only 🗒-prefixed sessions", async () => {
+    listSurfaces.mockResolvedValue([
+      { surfaceId: "s1", title: "🗒 brove:side-1" },
+      { surfaceId: "s2", title: "🔧 brove:crew-1" },  // crew — must be excluded
+      { surfaceId: "s3", title: "🗒 brove:side-2" },
+    ]);
+
+    const result = await runSideList("brove");
+
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.name)).toEqual(["side-1", "side-2"]);
+  });
+
+  it("runSideClose closes the matching pane", async () => {
+    listSurfaces.mockResolvedValue([{ surfaceId: "s1", title: "🗒 brove:side-1" }]);
+    closePane.mockResolvedValue(undefined);
+
+    await runSideClose("brove", "side-1");
+
+    expect(closePane).toHaveBeenCalledWith(expect.objectContaining({ surfaceId: "s1" }));
+  });
+
+  it("runSideClose throws when session not found", async () => {
+    listSurfaces.mockResolvedValue([]);
+
+    await expect(runSideClose("brove", "side-99")).rejects.toThrow("not found");
+  });
+
+  it("runSideSend sends to the matching pane without touching daemon", async () => {
+    listSurfaces.mockResolvedValue([{ surfaceId: "s1", title: "🗒 brove:side-1" }]);
+
+    await runSideSend("brove", "side-1", "follow-up message");
+
+    expect(sendToPane).toHaveBeenCalledWith(
+      expect.objectContaining({ surfaceId: "s1" }),
+      "follow-up message",
+    );
+    expect(cockpitdCall).not.toHaveBeenCalled();
+  });
+});
+
+describe("crew spawn regression — daemon path unchanged", () => {
+  it("cockpit crew spawn still calls cockpitdCall (daemon path intact)", async () => {
+    // Import crew lazily to avoid mock ordering issues
+    const { runCrewSpawn } = await import("../crew.js");
+
+    vi.useFakeTimers();
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude");
+    buildDispatchRequest.mockImplementation((o: unknown) => ({ kind: "dispatch", record: { ...(o as object), id: "task-cl1" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-cl1", project: "brove", provider: "claude", mode: "interactive" });
+
+    const { writePerCrewSettingsLocal } = await import("../../lib/per-crew-settings.js");
+    (writePerCrewSettingsLocal as ReturnType<typeof vi.fn>).mockReturnValue("/tmp/.claude/settings.local.json");
+
+    const promise = runCrewSpawn({ project: "brove", task: "do the thing" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(cockpitdCall).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+cd /Users/q3labsadmin/me/claude-cockpit/.worktrees/cockpit-side-p1 && npx vitest run src/commands/__tests__/side.test.ts 2>&1 | tail -30
+```
+Expected: All tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/commands/__tests__/side.test.ts
+git commit -m "test(side): unit tests for side command including no-daemon-dispatch invariant"
+```
+
+---
+
+### Task 5: Research role template
+
+**Files:**
+- Create: `orchestrator/side.research.claude.md`
+
+- [ ] **Step 1: Create the template**
+
+```markdown
+# Side-Session — Research Role
+
+You are a **research assistant** running in a dedicated side-session alongside the primary captain. Your context is fresh and isolated from the captain's orchestration loop.
+
+## Mandate
+
+Research, discuss, and produce **artifacts** the primary captain can act on:
+
+- GitHub issues (`gh issue create …`)
+- Design specs and plans (markdown files in the project)
+- Analysis and investigation documents
+
+You operate at the **thinking and planning layer** — your job is to produce clear, actionable artifacts so the primary captain can dispatch a crew to implement.
+
+## Capability Rules
+
+| Capability | Allowed |
+|-----------|:-------:|
+| Read code, docs, git history | ✅ |
+| Run read-only commands (`grep`, `find`, `cat`, `git log`) | ✅ |
+| Run tests in read-only / diagnostic mode | ✅ |
+| Create GitHub issues (`gh issue create`) | ✅ |
+| Write spec/plan/doc files | ✅ |
+| **Edit project source code** | ❌ |
+| **Spawn crew sessions** (`cockpit crew spawn`) | ❌ |
+| **Merge branches or push changes** | ❌ |
+
+If you find yourself about to edit source code or run `cockpit crew spawn` — **stop**. Document the finding as an artifact instead and include it in the handoff.
+
+## Handoff Protocol
+
+When you have produced a result that deserves the primary captain's attention:
+
+1. **Ask the user:** "Notify the primary captain now? (y/n)"
+
+2. **On yes:**
+
+   a. Write the durable vault record (replace `<spoke-vault>`, `<topic>`, `<summary>` with actual values from your first-turn context):
+   ```bash
+   ~/.config/cockpit/scripts/record-side-handoff.sh "<spoke-vault>" "<topic>" "<summary>"
+   ```
+
+   b. Send the structured handoff to the primary captain via relay:
+   ```bash
+   cockpit runtime send <project> "$(cat <<'HANDOFF'
+🗒 Side handoff [research] — <topic>
+Summary: <one-line summary>
+Artifacts: <list: gh issue #NNN | spec: path/to/file.md | …>
+Next: <recommended next action for the captain>
+HANDOFF
+)"
+   ```
+
+3. **On no:** keep working; you can trigger the handoff whenever you're ready.
+
+The `<project>`, `<spoke-vault>` values are in the "Side-session context" block of your first turn.
+
+## Karpathy Discipline
+
+- **Think before researching** — surface your approach and assumptions
+- **Simplicity first** — produce the minimal artifact that answers the question
+- **Surgical** — stay on the research topic; don't go down tangents
+- **Goal-driven** — define what "done" looks like before you start digging
+```
+
+The filename `side.research.claude.md` ends in `.claude.md`, which matches the `MANAGED_TARGETS` regex in `src/lib/runtime-sync.ts`: `/\.(claude\.md|generic\.md|opencode\.md|CLAUDE\.md)$/`. This means it will be automatically deployed to `~/.config/cockpit/templates/side.research.claude.md` on next CLI invocation.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add orchestrator/side.research.claude.md
+git commit -m "feat(side): add research role template (side.research.claude.md)"
+```
+
+---
+
+### Task 6: Handoff vault record script
+
+**Files:**
+- Create: `scripts/record-side-handoff.sh`
+
+Scripts ending in `.sh` in the `scripts/` dir are synced to `~/.config/cockpit/scripts/` with `chmod 755` by `mirrorFlat`.
+
+- [ ] **Step 1: Create the script**
+
+```bash
+#!/bin/bash
+# Usage: record-side-handoff.sh <spoke-vault-path> <topic> <summary>
+# Writes a durable handoff record to {spokeVault}/side-handoffs/<topic>.md
+set -euo pipefail
+
+VAULT="${1:?Usage: record-side-handoff.sh <vault-path> <topic> <summary>}"
+TOPIC="${2:?}"
+SUMMARY="${3:?}"
+DATE=$(date +"%Y-%m-%d")
+SLUG=$(echo "$TOPIC" | head -c 60 | tr ' ' '-' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]//g')
+FILENAME="${VAULT}/side-handoffs/${SLUG}.md"
+
+mkdir -p "${VAULT}/side-handoffs"
+
+cat > "$FILENAME" << EOF
+---
+type: side-handoff
+role: research
+date: ${DATE}
+topic: ${TOPIC}
+---
+
+## Summary
+${SUMMARY}
+
+## Full handoff
+
+(Appended by side-session — see cockpit relay for the captain's copy.)
+EOF
+
+echo "Recorded side handoff: $FILENAME"
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/record-side-handoff.sh
+git commit -m "feat(side): add record-side-handoff.sh vault record script"
+```
+
+---
+
+### Task 7: Skill — cockpit:side-session
+
+**Files:**
+- Create: `plugin/skills/side-session/SKILL.md`
+
+The `plugin/` tree is synced as a whole via `mirrorDir` in `MANAGED_TARGETS`. The skill will be auto-deployed to `~/.config/cockpit/plugin/skills/side-session/SKILL.md`.
+
+- [ ] **Step 1: Create the skill file**
+
+```markdown
+---
+name: side-session
+description: Spawn and manage side-sessions (research/debug) — dedicated fresh-context tabs off the captain's daemon lifecycle. Use when you want to research a topic, discuss an idea, or debug without polluting captain context.
+---
+
+# Side-Sessions
+
+A side-session is a dedicated tab with **fresh context** running the captain model (opus), loaded with a role-specific template. It runs **outside the crew/daemon lifecycle** — no `CREW IDLE/DONE` noise back to the primary captain. Its only upward signal is an explicit, user-confirmed structured handoff.
+
+## Spawn a side-session
+
+```bash
+# Research a topic, discuss an idea, produce a spec or GH issue
+cockpit side spawn <project> "<topic>" --role research
+
+# Debug mode (Phase 2 — not yet available)
+cockpit side spawn <project> "<topic>" --role debug
+```
+
+Options:
+- `--name <name>` — custom tab name (default: auto `side-N`)
+- `--direction <tab|right|down|left|up>` — placement (default: tab)
+- `--agent <claude|opencode>` — agent to use (default: claude)
+- `--topic-file <path>` — read topic from a file
+
+## Manage side-sessions
+
+```bash
+cockpit side list <project>                              # see live side tabs
+cockpit side send <project> <name> "<follow-up>"         # send a follow-up turn
+cockpit side close <project> <name>                      # close when done
+```
+
+## Role: research
+
+**Can:** Read code/docs, run read-only commands, create GH issues, write specs/plans.
+**Cannot:** Edit source code, spawn crews, merge/ship changes.
+
+The session works in fresh context and produces artifacts (specs, GH issues, analysis). When done, it asks the user to confirm before sending a structured handoff to the primary captain.
+
+## Handoff workflow
+
+```
+1. Research session produces an artifact (spec, issue, analysis).
+2. Session asks: "Notify the primary captain now? (y/n)"
+3. On yes:
+   - Writes durable record: {spokeVault}/side-handoffs/<topic>.md
+   - Sends: cockpit runtime send <project> "🗒 Side handoff [research] — <topic> ..."
+4. Primary captain receives handoff via relay.
+5. Captain does NOT auto-spawn a crew — waits for user's go.
+```
+
+### Structured handoff format
+
+```
+🗒 Side handoff [research] — <topic>
+Summary: <one-line summary>
+Artifacts: <gh issue #NNN | spec: path/to/file.md | …>
+Next: <recommended next action>
+```
+
+## Spawn by the primary captain
+
+When the user asks you to start a side research session, spawn one:
+
+```bash
+cockpit side spawn <project> "<the research question or topic>" --role research
+```
+
+Then note the session name from the output (e.g. `side-1`) and tell the user they can steer it with:
+
+```bash
+cockpit side send <project> side-1 "<follow-up>"
+cockpit side close <project> side-1
+```
+
+When the session completes, its handoff will arrive via relay with the `🗒 Side handoff` prefix.
+
+## Key invariant
+
+`cockpit side spawn` does **NOT** create a daemon task record. There is no `CREW IDLE/DONE` event for side-sessions. The only signal path is the explicit `cockpit runtime send` the side-session sends on user confirmation.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add plugin/skills/side-session/SKILL.md
+git commit -m "feat(side): add cockpit:side-session skill"
+```
+
+---
+
+### Task 8: Register sideCommand in src/index.ts
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Add import and registration**
+
+In `src/index.ts`, add the import after the `crewCommand` import (line ~16):
+```ts
+import { sideCommand } from "./commands/side.js";
+```
+
+Add the `addCommand` call after `program.addCommand(crewCommand)` (line ~95):
+```ts
+program.addCommand(sideCommand);
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+cd /Users/q3labsadmin/me/claude-cockpit/.worktrees/cockpit-side-p1 && npx tsc --noEmit 2>&1 | head -20
+```
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "feat(side): register cockpit side command in CLI"
+```
+
+---
+
+### Task 9: Full test suite run + build
+
+- [ ] **Step 1: Run only the side tests to confirm they pass**
+
+```bash
+cd /Users/q3labsadmin/me/claude-cockpit/.worktrees/cockpit-side-p1 && npx vitest run src/commands/__tests__/side.test.ts 2>&1 | tail -20
+```
+Expected: All PASS, 0 failures.
+
+- [ ] **Step 2: Run the full test suite (npm test)**
+
+```bash
+cd /Users/q3labsadmin/me/claude-cockpit/.worktrees/cockpit-side-p1 && npm test 2>&1 | tail -30
+```
+Expected: All tests pass. Zero failures. Suite exits cleanly.
+
+- [ ] **Step 3: Build the package**
+
+```bash
+cd /Users/q3labsadmin/me/claude-cockpit/.worktrees/cockpit-side-p1 && npm run build 2>&1 | tail -10
+```
+Expected: No errors; `dist/` updated.
+
+- [ ] **Step 4: Final commit if anything was adjusted**
+
+```bash
+git add -p  # stage only if there were any tweaks
+git commit -m "chore(side): fix any test or compile issues after full suite run"
+```
+
+---
+
+## Self-Review
+
+### Spec coverage check
+
+| Spec requirement | Task |
+|-----------------|------|
+| CLI noun `cockpit side spawn\|send\|list\|close` | Task 3 |
+| `--role` REQUIRED; error if omitted | Task 3 (`requiredOption`) |
+| `research` fully wired; `debug` stubbed with message | Task 3 |
+| Off the daemon lifecycle (no TaskRecord/cockpitdCall) | Task 3 + Task 4 (critical test) |
+| Extract shared helper (resolveCaptainWorkspace) | Task 2 |
+| `orchestrator/side.research.claude.md` template | Task 5 |
+| `defaults.roles.side` config (agent: claude, model: opus) | Task 1 |
+| Offer+confirm handoff (runtime send + vault record) | Task 5 (template), Task 6 (script) |
+| `cockpit:side-session` skill | Task 7 |
+| Register in `src/index.ts` | Task 8 |
+| Tests incl. no-daemon-dispatch invariant | Task 4 |
+| `npm test` green | Task 9 |
+
+### Placeholder scan
+No TBD/TODO/placeholder items found in tasks. All code blocks are complete.
+
+### Type consistency
+- `SideRole = "research" | "debug"` used consistently in task 3 and tests
+- `buildSideFirstTurn` exported and tested as pure function
+- `SIDE_ROLES` const array used for validation
+- `Role` union extended to include "side" in task 1 — all driver buildCommand calls use it correctly

--- a/docs/superpowers/specs/2026-06-12-cross-project-delegation-design.md
+++ b/docs/superpowers/specs/2026-06-12-cross-project-delegation-design.md
@@ -1,0 +1,95 @@
+# Cross-project (intra-group) delegation — design
+
+**Issue:** #246 — Clearer cross-project communication flow
+**Date:** 2026-06-12
+**Status:** Approved design, pending implementation
+
+## Problem
+
+Sibling projects in a group (e.g. `scaffold-stylus` ↔ `scaffold-stylus-docs`, `brove` ↔ `brove-docs`) have no first-class way for one captain to ask another to do work. Group awareness today is passive (config `group`/`groupRole` + claude-mem context). There is no defined channel for a stylus captain to say "stylus-docs, please document this change" and have it land as actionable, tracked work in the sibling.
+
+## Decisions (from brainstorm)
+
+| Decision | Choice |
+|----------|--------|
+| What happens on B's side | **Auto-accept + work** — B's captain automatically takes the task and spawns a crew. |
+| Trigger surface | **`cockpit group dispatch`** (Phase 1), later extended by **`runtime send --to-captain`** (Phase 2). |
+| Boot semantics | If B (captain workspace + relay) is **not up**, dispatch boots it and waits for warmup before delivering. |
+| Report-back | **Auto relay-back + wake A** — B's done/blocked signal routes back and wakes A's captain. A dispatches-and-yields, never polls (consistent with #241). |
+| Reach | **Same-group only** for now. Cross-group is out of scope (captains can read config to stay *aware* of other groups; no dispatch channel to them). |
+| Safety toggle | B's config gets `acceptDelegations` (**default true**); a project can opt out. |
+
+## Architecture — one new field, reuse the per-project relay
+
+The key insight: cockpit already routes per-project. `TaskRecord` has a `project` field (`src/control/types.ts:43`); the mailbox is per-project (`${project}.log`); each captain runs a per-project notify-relay that watches its own project and wakes its captain. **A cross-project task is just a normal task that remembers where it came from.**
+
+### Data model
+
+Add one optional field to `TaskRecord`:
+
+```ts
+originProject?: string;  // set when this task was delegated from a sibling captain
+```
+
+A delegated task is recorded with `project: B, originProject: A`. No new bus, no new transport:
+- **Delivery to B:** B's existing relay already watches project B → it wakes B's captain with the request.
+- **Report-back to A:** when the task settles, the daemon sees `originProject: A` and fans the signal back to **A's** mailbox → A's relay wakes A's captain.
+
+### `cockpit group dispatch <to-project> "<task>"` — flow
+
+1. **Resolve & gate.** A = current project (from cwd/config), B = `<to-project>`. Reject if B is not in A's `group`. Reject if B has `acceptDelegations: false` (clear message, no silent drop).
+2. **Ensure B is up.** If B's captain workspace / relay are not running, `cockpit launch B` and start B's relay, then **wait for warmup** — bounded poll on relay heartbeat / captain-pane readiness with a hard timeout (no unbounded loop). If warmup times out, fail the dispatch with a clear error (task not recorded).
+3. **Record.** Write the task to the daemon: `{ project: B, originProject: A, status: submitted, task: "<task>" }`.
+4. **Deliver.** B's relay wakes B's captain: `📨 Cross-project task from <A>: <task>`. If `acceptDelegations` is true, B's captain auto-accepts and spawns a crew (opencode default) to do the work.
+5. **Yield.** A's `group dispatch` returns immediately; A's captain dispatches-and-yields. No polling.
+
+### Report-back round-trip
+
+When B's crew signals `done` / `blocked` / `failed`:
+1. Daemon updates the task record.
+2. Daemon sees `originProject: A` and writes a report event to A's mailbox.
+3. A's relay wakes A's captain: `✅ Delegated task → B: done` (or `⛔ Delegated task → B: blocked — <reason>`).
+
+Both sides are event-driven; neither polls.
+
+### Safety
+
+- **Same-group check** is the hard boundary — enforced in `group dispatch` before anything is recorded or booted.
+- **`acceptDelegations`** (per-project config, default `true`) lets a project opt out of being driven. When `false`, dispatch is rejected (Phase 1 keeps it simple — no notify-only downgrade).
+
+### captain-ops skill
+
+Add a "Cross-project delegation" section to the captain-ops skill:
+- When to use `group dispatch` (a task genuinely belongs to a sibling).
+- The same-group rule and `acceptDelegations` behavior.
+- That report-back auto-wakes the captain — **dispatch and yield, do not poll** the sibling.
+
+## Components & boundaries
+
+| Unit | Responsibility | Depends on |
+|------|----------------|------------|
+| `group` command (`src/commands/group.ts`, new) | Parse `group dispatch`, resolve A/B, same-group gate, boot-if-down + warmup wait, record task, return | config, launch, daemon client, relay status |
+| `TaskRecord.originProject` (`src/control/types.ts`) | Carry origin so report-back can route | — |
+| Daemon report-back (`src/control/…`) | On settle, if `originProject` set, write report event to origin's mailbox | mailbox, state-machine |
+| `acceptDelegations` (config) | Per-project opt-out | config schema |
+| captain-ops skill section | Teach captains the flow | — |
+
+## Phasing
+
+- **Phase 1 (this issue, #246):** `group dispatch` + `originProject` + report-back + same-group gate + `acceptDelegations` + captain-ops section. Tests for: same-group gate, boot-if-down warmup timeout, record shape, report-back fan-out to origin.
+- **Phase 2 (later, separate issue):** `cockpit runtime send --to-captain <project> "<msg>"` for free-form peer captain↔captain comms, riding the same `originProject` rail. Not built now.
+
+## Out of scope
+
+- Cross-group delegation.
+- Notify-only downgrade when `acceptDelegations: false`.
+- Multi-hop delegation chains (A→B→C tracking).
+- Phase 2 peer comms.
+
+## Success criteria
+
+1. `cockpit group dispatch <sibling> "<task>"` from project A records a task on B with `originProject: A`, booting B if it was down.
+2. B's captain is woken with the request and (when `acceptDelegations` is true) auto-spawns a crew.
+3. On completion/block, A's captain is auto-woken with the outcome — without A polling.
+4. Dispatch to a non-same-group project, or to a project with `acceptDelegations: false`, is rejected with a clear message.
+5. captain-ops documents the flow and the dispatch-and-yield discipline.

--- a/docs/superpowers/specs/2026-06-13-crew-done-lifecycle-fix-design.md
+++ b/docs/superpowers/specs/2026-06-13-crew-done-lifecycle-fix-design.md
@@ -1,0 +1,66 @@
+# Crew DONE Lifecycle Fix — Design Spec
+
+**Date:** 2026-06-13
+**Issue:** #278 (lifecycle); relates to #279 (worktree), #148/#64 (done plumbing — healthy).
+**Status:** Design approved (scope B, captain-side backstop). Awaiting implementation.
+
+## Problem (proven live 2026-06-13)
+
+Crew completion does not reliably emit `task.done` → no **CREW DONE**. Cross-agent lifecycle test:
+
+| Agent | Emitted `done` unprompted |
+|-------|:--:|
+| claude | ❌ (finished + opened PR, never ran signal → watchdog IDLE) |
+| opencode | ❌ (finished + committed, never ran signal → watchdog IDLE) |
+| codex | ✅ (ran signal — concrete per-turn imperative with ids baked in) |
+
+Two failure modes:
+- **Mode 1 (mechanism):** `COCKPIT_CREW_TASK_ID` is injected only as a racy keystroke-inline env prefix; when it drops, the crew literally can't signal.
+- **Mode 2 (discretion):** even with env present, emitting `done` depends on the model choosing to run a CLI command, which claude/opencode skip after reporting via text.
+
+Codex avoids both because its developerInstructions are a concrete imperative — *"run EXACTLY `cockpit crew signal done --task-id <id> --project <proj> …`"* — ids baked in, at the point of action.
+
+## Fix (scope B = crew-side win + captain-side backstop)
+
+### Part 1 — Crew-side: concrete per-turn imperative (codex parity) for claude + opencode
+
+Append a standard **completion-protocol** suffix to the first-turn text sent to claude and opencode crews (in `src/commands/crew.ts`, where the first turn is composed — claude ~L369, opencode ~L419). Built from the dispatched `rec.id` and project:
+
+```
+---
+COMPLETION PROTOCOL (required): When this task is fully complete, your FINAL action
+MUST be to run exactly:
+  cockpit crew signal done --task-id <rec.id> --project <project> --message "<one-line summary>"
+Run it as a discrete final step AFTER you report results. If you are blocked or need a
+decision, instead run: cockpit crew signal blocked --task-id <rec.id> --project <project> --question "<q>"
+```
+
+- **Baking in `--task-id`/`--project`** makes the signal robust to the env race (kills Mode 1) AND puts a concrete imperative at the point of action (kills most of Mode 2).
+- Keep the existing env injection and template wording (unchanged); this suffix is additive and is the load-bearing reliability lever.
+- Mirror the same suffix for the `blocked` path so a waiting crew also terminalizes its intent explicitly.
+- Codex already does this — no change to codex.
+
+### Part 2 — Captain-side: IDLE reconciliation (behavioral, in `plugin/skills/captain-ops/SKILL.md`)
+
+CREW IDLE is **ambiguous** — it can mean "finished but didn't signal" OR "genuinely waiting for the captain." Add a **"Handling CREW IDLE"** subsection instructing the captain to **classify** with a single on-demand spot-check (allowed — not polling), then act:
+
+| What the spot-check shows | Captain action |
+|---------------------------|----------------|
+| Completed work (PR/commit opened + reported done) but no CREW DONE | Treat as the #278 case: review the work; if good, terminalize (merge + `crew close`). If not actually done, **re-task** it (the #148 reopen flow): tell it what's next. |
+| Genuinely waiting for the captain (asked a question / needs a decision) | Respond — send the next instruction via `crew send`. Do NOT terminalize. |
+| Still mid-task / transient idle | Leave it; wait for the next relay event. |
+
+This is the backstop: even if Part 1's imperative is skipped, the lifecycle still terminalizes (or correctly continues) because the captain reconciles intent instead of letting the task silently strand at IDLE.
+
+## Out of scope
+- Daemon/hook-driven auto-done (Approach C) — rejected: risks conflating `done`≠`blocked`≠`awaiting-input` (anti-#2576).
+- The #279 worktree-cwd fix — separate issue (pairs with this but not bundled).
+
+## Testing
+- Unit (`src/commands/__tests__/crew.test.ts`): assert the claude and opencode first-turn text includes the completion-protocol suffix with the correct `--task-id`/`--project` substituted; assert codex path unchanged.
+- Manual lifecycle re-check: spawn a normal claude crew and an opencode crew (no explicit signal instruction beyond the new built-in suffix) → confirm CREW DONE now fires unprompted for both. Re-run the same 3-agent check from #278.
+
+## Success criteria
+- A normal claude/opencode crew that completes a task emits `task.done` → CREW DONE **without** the captain telling it to.
+- The signal works even if the keystroke env injection dropped (ids are in the command).
+- captain-ops documents how to classify and handle CREW IDLE (done vs waiting vs working).

--- a/docs/superpowers/specs/2026-06-13-side-sessions-design.md
+++ b/docs/superpowers/specs/2026-06-13-side-sessions-design.md
@@ -1,0 +1,106 @@
+# Side-Sessions Framework — Design Spec
+
+**Date:** 2026-06-13
+**Status:** Design (re-brainstormed from the narrower research-captain idea). Awaiting spec review → implementation plan.
+**Issue:** _(to be filed)_
+**Supersedes:** the earlier research-captain-only design (now one role within this framework).
+
+## Problem
+
+Side work — researching/discussing a new idea, or **debugging** — currently happens inside the **primary captain's** session. This bloats the captain's context and degrades its core job (orchestrating crews). Debugging is the worst offender: it's context-heavy and noisy, and it competes with incoming crew reports for the captain's attention. The user wants dedicated, fresh-context surfaces for this kind of work, kept off the primary captain.
+
+## Solution summary
+
+A **side-sessions framework**: spin up a dedicated tab with **fresh context**, running the **captain model (opus)**, loaded with a **role-specific** template. Driven by the user (or by the primary captain on request). Each side-session is deliberately **outside the crew/daemon lifecycle** — no daemon task record, no `CREW IDLE/DONE` noise back to the primary captain. Its only upward signal is an explicit, user-confirmed **structured handoff**. The primary captain stays focused on crew orchestration.
+
+Two built-in roles to start: **research** and **debug**. More can be added in code later.
+
+## Locked decisions
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 1 | Generalization | A role-parameterized framework, not a single role. `cockpit side spawn --role <role>`. |
+| 2 | Role set | **Fixed built-in** roles (research + debug now; more added in code). Not user-pluggable (yet). |
+| 3 | Spawn paths | **Both**: CLI (`cockpit side …`) the user runs directly, and a skill (`cockpit:side-session`) so the primary captain can spawn one on request. |
+| 4 | Lifecycle wiring | **Off** the crew/daemon lifecycle — no task record, no IDLE/DONE noise. |
+| 5 | Report-back | **Offer + confirm**: on producing a result, the side-session asks "notify the primary captain now?"; sends only on yes. |
+| 6 | Report-back payload | **Structured handoff** (role, topic, artifact refs, one-line summary) via `cockpit runtime send`, **plus** a durable record written to `{spokeVault}/side-handoffs/<topic>.md` (survives captain /compact). |
+| 7 | Model | Captain model, via `defaults.roles.side.model` (default `opus`, overridable). |
+| 8 | Naming | role-family `side`; CLI `cockpit side`; tab icon 🗒; skill `cockpit:side-session`. |
+
+## Capability matrix (per role)
+
+| Capability | research | debug |
+|-----------|:--:|:--:|
+| Discuss / read code & docs | ✅ | ✅ |
+| Run code / tests / commands | read-oriented | ✅ (reproduce, run failing tests) |
+| **Edit source** | ❌ | ✅ **scratch only** — isolated worktree/branch, for instrumentation + a failing test; never shipped |
+| Spawn crews | ❌ | ❌ |
+| Ship a fix / merge | ❌ | ❌ |
+| Produced artifacts | GH issue, spec, plan | root-cause diagnosis + **optional draft patch** (scratch branch/patch) + optional issue |
+
+The hard boundary for both: **a side-session never ships changes or orchestrates crews.** The primary captain owns all execution. Debug's scratch edits exist only to *pinpoint* the bug; the fix is handed back for a crew to implement cleanly.
+
+## Architecture (generalizes the approved Approach A)
+
+### Components
+1. **Role templates** — `orchestrator/side.research.md`, `orchestrator/side.debug.md` (+ `.generic.md` variants for non-Claude parity). Each: role mandate, capability rules (from the matrix), the offer+confirm handoff protocol, and the structured handoff format. Debug template also invokes `superpowers:systematic-debugging` and is told to work in its scratch worktree.
+   - **Debug intake (required first step):** before instrumenting, the debug role must gather bug context from the user — repro steps, **when/where the bug appears**, expected vs actual, recent changes. If the user already supplied this in the topic, confirm and proceed; otherwise ask for it. This is systematic-debugging Phase 1 (reproduce + gather evidence) and prevents guessing. Only after intake does it dig into the scratch worktree.
+2. **CLI noun** — `cockpit side <verb>`, mirroring `crew`:
+   - `cockpit side spawn <project> "<topic>" --role research|debug [--name] [--direction] [--agent]` — opens a dedicated tab `🗒 <project>:<name>`, boots an interactive session with the role template + side model, sends the topic as the first turn. **`--role` is REQUIRED** — error if omitted (no default; explicit mode).
+   - `cockpit side send / list / close`.
+   - **Does NOT** call the daemon dispatch path (no TaskRecord). Reuses shared tab/template/model plumbing extracted from `crew spawn`.
+   - For `--role debug`, the spawn creates an isolated **scratch git worktree** (now safe post-#279) so instrumentation never touches the captain's checkout; pruned on close. Research needs no worktree.
+3. **Skill** — `cockpit:side-session`: lets the primary captain spawn a side-session on request; documents both spawn paths, the role capabilities, and the handoff semantics.
+4. **Report-back** — `cockpit runtime send <project>` (relay-delivered to the primary captain pane) + a durable `{spokeVault}/side-handoffs/<topic>.md` record. The side-session composes the handoff on user confirmation.
+5. **Config** — `defaults.roles.side` (agent + model; default claude/opus).
+
+### Why still off the daemon lifecycle
+A side-session is user-driven, not an orchestrated task. Wiring it to the daemon would emit `CREW IDLE/DONE` to the primary captain — the exact context pollution we're removing. So `cockpit side` shares only the surface/template/model plumbing with `crew`, never the dispatch/lifecycle path.
+
+## Data flow
+
+```
+USER ──side spawn --role debug──▶ 🗒 side-session (fresh ctx, opus, debug template, scratch worktree)
+   ▲                                      │ systematic-debugging: reproduce, instrument, write failing test
+   │  discuss / steer                     │ (scratch edits — never shipped)
+   └──────────────────────────────────────┘
+                                          │ root cause found -> diagnosis (+ optional draft patch)
+                                          ▼
+                            "Notify primary captain now? (y/n)"  ──no──▶ keep going
+                                          │ yes
+                                          ▼
+       runtime send <structured handoff>  +  {spokeVault}/side-handoffs/<topic>.md
+                                          │
+                                          ▼
+                 PRIMARY CAPTAIN pane (relay) — acknowledges, dispatches a crew to implement the fix
+```
+
+### Structured handoff format (example, debug)
+```
+🗒 Side handoff [debug] — <topic>
+Root cause: <one line>
+Artifacts: issue #284  |  draft patch: side-handoffs/<topic>.md (or scratch branch side/<topic>)
+Next: <what a crew should implement>
+```
+
+## Boundaries & guardrails
+- Both roles: never `cockpit crew spawn`, never merge/ship. Never `--dangerously-skip-permissions`.
+- Debug's edits live ONLY in its scratch worktree/branch; closing the side-session prunes the scratch worktree (reuse the #279-fixed worktree plumbing + crew-close cleanup).
+- Primary captain, on receiving a handoff: does NOT auto-spawn a crew — acknowledges and waits for the user's go (semi-automatic default).
+
+## Testing
+- Unit: `side spawn` builds the correct tab/template/model invocation per role and does NOT call the daemon dispatch path (assert no TaskRecord). `--role debug` creates a scratch worktree; `--role research` does not.
+- Unit: handoff string composition + vault-record path.
+- Manual: spawn each role, run a short session, confirm the handoff lands in the primary captain pane + the vault record is written, and that no `CREW IDLE/DONE` events fire for the side-session.
+
+## Out of scope (this iteration)
+- User-pluggable roles (fixed built-in for now).
+- Side-sessions spawning crews or shipping fixes (explicitly excluded).
+- Persisting side-session context across restarts beyond the handoff record (ephemeral per topic; reuse via `side send` while the tab lives).
+- Non-Claude interactivity beyond what the agent already supports.
+
+## Resolved (spec-review decisions)
+1. `cockpit side spawn` **requires `--role`** — no default; error if omitted.
+2. Debug scratch = **isolated git worktree** (pruned on close). Plus: the debug role performs a **bug-info intake first** (repro / when-it-appears / symptoms) before instrumenting — see Debug intake above.
+3. **One shared side model**: `defaults.roles.side.model` (default `opus`) for all roles. Per-role models deferred.

--- a/orchestrator/side.debug.claude.md
+++ b/orchestrator/side.debug.claude.md
@@ -1,0 +1,78 @@
+# Side-Session — Debug Role
+
+You are a **debug assistant** running in a dedicated side-session alongside the primary captain. Your context is fresh and isolated from the captain's orchestration loop. You are running inside an **isolated scratch git worktree** — your edits are confined here and are never shipped.
+
+## Mandate
+
+Investigate and diagnose bugs. Your job is to **pinpoint the root cause** and hand it back so a crew can implement the fix cleanly. You do NOT ship fixes. You do NOT spawn crews.
+
+## Bug Intake (required first step)
+
+**Before instrumenting or reading code**, gather the following from the user. If the topic already contains all of this, confirm and proceed. Otherwise, ask:
+
+1. **Repro steps** — the exact steps to reproduce the bug
+2. **When/where it appears** — which environment, which code path, which user action
+3. **Expected vs actual** — what should happen vs what does happen
+4. **Recent changes** — any recent commits, deploys, or config changes that could be related
+
+This is the systematic-debugging Phase 1 (reproduce + gather evidence). Only after intake do you dig into the scratch worktree.
+
+## Systematic Debugging
+
+Use the `superpowers:systematic-debugging` skill to guide your investigation:
+
+```bash
+# In Claude: invoke via the Skill tool
+# In other agents: read .claude/skills/superpowers/systematic-debugging/SKILL.md
+```
+
+Work through: reproduce → isolate → form hypothesis → instrument → verify → root cause.
+
+## Capability Rules
+
+| Capability | Allowed |
+|-----------|:-------:|
+| Read code, docs, git history | ✅ |
+| Run code / tests / commands | ✅ (reproduce + verify) |
+| **Edit source — scratch only** | ✅ **in this worktree** — instrumentation, logging, a failing test |
+| **Edit source outside worktree** | ❌ |
+| Spawn crew sessions | ❌ |
+| Merge branches or push changes | ❌ |
+| Ship a fix | ❌ |
+
+Your scratch edits exist only to *pinpoint* the bug. The fix belongs in a crew task. Never run `cockpit crew spawn`. Never run `git push` or `git merge`.
+
+## Handoff Protocol
+
+When you have a root cause (with or without a draft patch):
+
+1. **Ask the user:** "Notify the primary captain now? (y/n)"
+
+2. **On yes:**
+
+   a. Write the durable vault record (replace placeholders with actual values from the "Side-session context" block in your first turn):
+   ```bash
+   ~/.config/cockpit/scripts/record-side-handoff.sh "<spoke-vault>" "<topic>" "debug" "<one-line root cause>"
+   ```
+
+   b. Send the structured handoff to the primary captain via relay:
+   ```bash
+   cockpit runtime send <project> "$(cat <<'HANDOFF'
+🗒 Side handoff [debug] — <topic>
+Root cause: <one-line root cause>
+Artifacts: <list: failing test path | instrumentation: <file> | draft patch: scratch branch crew/<name> | issue #NNN>
+Next: <what a crew should implement to fix this>
+HANDOFF
+)"
+   ```
+
+3. **On no:** keep working; you can trigger the handoff whenever you're ready.
+
+The `<project>`, `<spoke-vault>`, and `<name>` (your scratch branch) are in the "Side-session context" block of your first turn. The draft patch (if any) lives on the scratch branch — reference it by name; do NOT merge it.
+
+## Karpathy Discipline
+
+- **Think before instrumenting** — surface your hypothesis before adding log statements
+- **Simplicity first** — minimal instrumentation to confirm/deny the hypothesis
+- **Surgical** — only touch files relevant to the bug; no cleanup, no refactors
+- **Goal-driven** — define what "root cause confirmed" looks like before you start

--- a/orchestrator/side.research.claude.md
+++ b/orchestrator/side.research.claude.md
@@ -1,0 +1,63 @@
+# Side-Session — Research Role
+
+You are a **research assistant** running in a dedicated side-session alongside the primary captain. Your context is fresh and isolated from the captain's orchestration loop.
+
+## Mandate
+
+Research, discuss, and produce **artifacts** the primary captain can act on:
+
+- GitHub issues (`gh issue create …`)
+- Design specs and plans (markdown files in the project)
+- Analysis and investigation documents
+
+You operate at the **thinking and planning layer** — your job is to produce clear, actionable artifacts so the primary captain can dispatch a crew to implement.
+
+## Capability Rules
+
+| Capability | Allowed |
+|-----------|:-------:|
+| Read code, docs, git history | ✅ |
+| Run read-only commands (`grep`, `find`, `cat`, `git log`) | ✅ |
+| Run tests in diagnostic mode | ✅ |
+| Create GitHub issues (`gh issue create`) | ✅ |
+| Write spec/plan/doc files | ✅ |
+| **Edit project source code** | ❌ |
+| **Spawn crew sessions** (`cockpit crew spawn`) | ❌ |
+| **Merge branches or push changes** | ❌ |
+
+If you find yourself about to edit source code or run `cockpit crew spawn` — **stop**. Document the finding as an artifact instead and include it in the handoff.
+
+## Handoff Protocol
+
+When you have produced a result that deserves the primary captain's attention:
+
+1. **Ask the user:** "Notify the primary captain now? (y/n)"
+
+2. **On yes:**
+
+   a. Write the durable vault record (replace placeholders with actual values from the "Side-session context" block in your first turn):
+   ```bash
+   ~/.config/cockpit/scripts/record-side-handoff.sh "<spoke-vault>" "<topic>" "<one-line summary>"
+   ```
+
+   b. Send the structured handoff to the primary captain via relay:
+   ```bash
+   cockpit runtime send <project> "$(cat <<'HANDOFF'
+🗒 Side handoff [research] — <topic>
+Summary: <one-line summary>
+Artifacts: <list: gh issue #NNN | spec: path/to/file.md | …>
+Next: <recommended next action for the captain>
+HANDOFF
+)"
+   ```
+
+3. **On no:** keep working; you can trigger the handoff whenever you're ready.
+
+The `<project>` and `<spoke-vault>` values are in the "Side-session context" block of your first turn.
+
+## Karpathy Discipline
+
+- **Think before researching** — surface your approach and assumptions upfront
+- **Simplicity first** — produce the minimal artifact that answers the question
+- **Surgical** — stay on the research topic; don't go down tangents
+- **Goal-driven** — define what "done" looks like before you start digging

--- a/orchestrator/side.research.claude.md
+++ b/orchestrator/side.research.claude.md
@@ -37,7 +37,7 @@ When you have produced a result that deserves the primary captain's attention:
 
    a. Write the durable vault record (replace placeholders with actual values from the "Side-session context" block in your first turn):
    ```bash
-   ~/.config/cockpit/scripts/record-side-handoff.sh "<spoke-vault>" "<topic>" "<one-line summary>"
+   ~/.config/cockpit/scripts/record-side-handoff.sh "<spoke-vault>" "<topic>" "research" "<one-line summary>"
    ```
 
    b. Send the structured handoff to the primary captain via relay:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-cockpit",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-cockpit",
-      "version": "0.5.4",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-cockpit",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "Multi-project agent orchestration for Claude Code",
   "type": "module",
   "bin": {

--- a/plugin/skills/add-pick-crew-rule/SKILL.md
+++ b/plugin/skills/add-pick-crew-rule/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: add-pick-crew-rule
+description: Add, edit, or remove a leveled crew routing rule in config.json without hand-editing JSON. Routing rules map task-text keywords to a tier → {agent, model}.
+---
+
+# Manage Crew Routing Rules
+
+Crew routing rules live in `defaults.crewRouting.rules` inside `~/.config/cockpit/config.json`.
+Each rule has the shape:
+
+```jsonc
+{
+  "tier":  "<label>",      // human label, e.g. "extreme" / "hard" / "daily"
+  "match": "<regex>",      // case-insensitive regex tested against the task text
+  "agent": "claude|codex|gemini|opencode",
+  "model": "opus|sonnet"   // omit for codex/opencode (they use their own defaults)
+}
+```
+
+Rules are evaluated in order; the **first match wins**.
+
+## Adding a rule
+
+1. Read the current config:
+   ```bash
+   cat ~/.config/cockpit/config.json
+   ```
+
+2. Identify the `defaults.crewRouting.rules` array. If it is absent, add it.
+
+3. Build the new rule object. Validate:
+   - `tier` is a non-empty string
+   - `match` is a valid regex (test it mentally against a sample task string)
+   - `agent` is one of `claude`, `codex`, `gemini`, `opencode`
+   - `model` is only set for claude rules (`opus` or `sonnet`); omit for other agents
+
+4. Insert the rule at the correct position — **rules are evaluated in order**.
+   Higher-priority / more specific tiers (e.g. "extreme") belong before broader ones
+   (e.g. "hard"). Append low-priority catch-alls last.
+
+5. Write the updated config back via the existing save path:
+   ```typescript
+   // The saveConfig helper in src/config.ts handles atomic write + newline.
+   // If editing the live file directly, use JSON.stringify(config, null, 2) + "\n".
+   ```
+
+6. Verify the rule fires as expected:
+   ```bash
+   # Quick smoke-test (no live crew spawned):
+   node -e "
+     const {loadConfig} = require(process.env.HOME + '/.config/cockpit/node_modules/...');
+     // or just log the matching rule manually
+     const rules = require(process.env.HOME + '/.config/cockpit/config.json')
+       .defaults?.crewRouting?.rules ?? [];
+     const task = 'YOUR TEST TASK HERE';
+     const hit = rules.find(r => new RegExp(r.match,'i').test(task));
+     console.log(hit ?? 'no match');
+   "
+   ```
+
+## Editing an existing rule
+
+Read → locate the rule by `tier` or `match` → update the field(s) → write back.
+
+## Removing a rule
+
+Read → filter out the rule by `tier` or `match` → write back.
+
+## Precedence reminder
+
+- Explicit `--agent` / `--model` on `cockpit crew spawn` **always** override routing.
+- If no rule matches, the spawn falls through to `defaults.roles.crew` behavior (unchanged from pre-routing behavior).
+
+## Example rules
+
+```jsonc
+// Route deep-reasoning work to the strongest model
+{ "tier": "extreme", "match": "redesign|architect|rewrite|from scratch|deep reasoning", "agent": "claude", "model": "opus" }
+
+// Route standard feature/refactor work to a faster model
+{ "tier": "hard",    "match": "refactor|migrate|implement|feature|daemon|control-plane", "agent": "claude", "model": "sonnet" }
+
+// Route mobile tasks to codex (no model — uses codex default)
+{ "tier": "mobile",  "match": "mobile|ios|swift|android|kotlin|react native", "agent": "codex" }
+
+// Route trivial edits to opencode (cheapest path)
+{ "tier": "daily",   "match": "typo|rename|bump|docs|comment|lint|format", "agent": "opencode" }
+```

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -220,6 +220,40 @@ If your config has `group` / `groupRole`:
 - Use **claude-mem** to search for context from sibling projects
 - `primary` role: your changes may need propagation to forks/dependents
 
+## Cross-Project Delegation
+
+When a task genuinely belongs to a sibling project in the same group, use **`cockpit group dispatch <to-project> '<task>'`** instead of hand-writing a message. This records a tracked task on the sibling's project and auto-wakes its captain via the existing mailbox/relay.
+
+### Rules
+
+1. **Same-group only.** `group dispatch` rejects any target whose `group` field differs from yours. Cross-group dispatch is out of scope — use claude-mem / wiki queries for awareness.
+2. **`acceptDelegations`.** If the sibling's project config has `acceptDelegations: false`, the command rejects with a clear error. The default is `true`.
+3. **Boot-if-down.** If the sibling's captain workspace / notify-relay are not running, `group dispatch` boots them (`cockpit launch <project>`) and waits for warmup with a bounded poll (30s hard timeout). If warmup fails, the dispatch is rejected (task not recorded).
+
+### Dispatch-and-yield (do NOT poll)
+
+Once the task is recorded to the daemon, `group dispatch` **returns immediately**. The sibling's captain auto-accepts (because `acceptDelegations` is true) and spawns a crew. When the task settles — done, blocked, or failed — the daemon fans the outcome back to **your** mailbox automatically. Your relay wakes you up. **You never poll the sibling.**
+
+HARD RULE: Do NOT add a polling loop after `group dispatch`. The report-back is event-driven; trust it.
+
+### Report-back format
+
+| Settlement | Message |
+|------------|---------|
+| done | `✅ Cross-project task → B: done — <task snippet>` |
+| blocked | `⛔ Cross-project task → B: blocked — <question>` |
+| failed | `⛔ Cross-project task → B: failed — <error>` |
+| stalled | `⚠️ Cross-project task → B: stalled (no heartbeat)` |
+
+### Example
+
+```bash
+# You are captain of "scaffold-stylus". Ask the docs sibling to update docs.
+cockpit group dispatch scaffold-stylus-docs "Document the new --format flag added in PR #42"
+# → "✔ Dispatched to 'scaffold-stylus-docs' (task abc12345)"
+# → (returns immediately; you are notified when settled)
+```
+
 ## Recording Learnings
 
 Recording learnings is **opt-in**. Record when something genuinely surprised you or a useful pattern emerged — not on a schedule.

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -147,6 +147,32 @@ Open as a side-by-side pane when you want live preview:
 cockpit crew spawn brove "Fix typo in README" --direction right
 ```
 
+### Leveled crew routing
+
+When you spawn a crew without an explicit `--agent` or `--model`, cockpit automatically
+consults the routing rules in `defaults.crewRouting.rules` (config.json) and picks the
+right tier for the task:
+
+| Tier | Matches | Routes to |
+|------|---------|-----------|
+| extreme | redesign, architect, rewrite, from scratch | claude/opus |
+| hard | refactor, migrate, implement, feature | claude/sonnet |
+| mobile | mobile, ios, swift, android, kotlin | codex |
+| daily | typo, rename, bump, docs, lint | opencode |
+
+The chosen route is printed as a dim one-liner before the spawn completes, e.g.:
+```
+routed: tier=hard → claude/sonnet (rule: "refactor|migrate|implement|feature|daemon|control-plane")
+```
+
+**Override at any time** — explicit flags always win over routing:
+```bash
+cockpit crew spawn brove "refactor auth" --agent codex     # forces codex despite "hard" tier
+cockpit crew spawn brove "fix typo" --model opus           # forces opus despite "daily" tier
+```
+
+To add, edit, or remove routing rules: use the `cockpit:add-pick-crew-rule` skill.
+
 ### Rules
 
 - **Reuse with `send` before spawning a new one.** Same task track, same crew. New track = new crew.

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -161,12 +161,17 @@ cockpit crew spawn brove "Fix typo in README" --direction right
 
 ## Task Coordination
 
-You don't have an Agent Team or `TaskCreate`/`TaskUpdate` tools — those were Claude-specific. Track crew progress by:
-1. `cockpit crew read <project> <name>` — read tail of a crew's screen (default ~40 lines; `--full` for entire scrollback).
-2. `cockpit crew tasks <project>` — compact task listing (one line per task); `--id <prefix>` to filter; `--state-only <id>` for single-word state.
-3. `cockpit crew list <project>` — see all live crews and pick the right one.
-4. Inspecting the crew tab visually in cmux when you want richer context (you have its surface ref from the spawn output).
-5. Asking the user to check the dashboard if you need a cross-project view (see issue #44).
+**HARD RULE: Do NOT poll crew screens in a loop.** Crew lifecycle events (idle / done / blocked) arrive via the **notify-relay** automatically — trust the relay signal. Polling loops hang indefinitely, exhaust context, and mask real blockers.
+
+You don't have an Agent Team or `TaskCreate`/`TaskUpdate` tools — those were Claude-specific. When you need crew status:
+1. **Wait for the relay to notify you.** When a crew finishes, signals blocked, or goes idle, the notify-relay delivers the event to your captain pane. This is the primary mechanism — do not replace it with polling.
+2. `cockpit crew read <project> <name>` — **on-demand spot-check only** (a single read when you have a specific reason, e.g. reviewing a finished diff). Never in a loop, never with `until`.
+3. `cockpit crew tasks <project>` — **on-demand** compact task listing; `--id <prefix>` to filter; `--state-only <id>` for a single-word state check.
+4. `cockpit crew list <project>` — see all live crews and pick the right one.
+5. Inspecting the crew tab visually in cmux when you want richer context (you have its surface ref from the spawn output).
+6. Asking the user to check the dashboard if you need a cross-project view (see issue #44).
+
+If you ever need a bounded check (not a loop), use a fixed counter (≤ 3 attempts with a sleep between), or watch the mailbox seq — never an unbounded `until` loop.
 
 When a crew sends you a status message via `cockpit runtime send <project> "<message>"`, it lands in your captain pane. Acknowledge, then update your handoff if a meaningful decision was made.
 

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -199,6 +199,25 @@ You don't have an Agent Team or `TaskCreate`/`TaskUpdate` tools — those were C
 
 If you ever need a bounded check (not a loop), use a fixed counter (≤ 3 attempts with a sleep between), or watch the mailbox seq — never an unbounded `until` loop.
 
+### Handling CREW IDLE
+
+CREW IDLE is **ambiguous** — the watchdog did not detect a heartbeat, which can happen when:
+- **(a)** The crew finished but never ran `cockpit crew signal done` (issue #278 — common for claude/opencode before the completion-protocol fix).
+- **(b)** The crew is genuinely waiting for the captain (asked a question or needs a decision).
+- **(c)** The crew is still mid-task and the idle pulse was transient.
+
+On CREW IDLE, do a **single on-demand spot-check** (allowed — not a polling loop), then classify:
+
+| Spot-check shows | Captain action |
+|-----------------|----------------|
+| Completed work (PR opened, commits pushed, results reported) but no CREW DONE | Treat as the #278 case — review; if good, terminalize (`merge` + `crew close`). If not actually done, **re-task**: send the next instruction via `crew send` (the #148 re-open flow). |
+| Crew asked a question or is waiting for a decision | Respond via `crew send`. Do NOT terminalize — it will signal done after the next turn. |
+| Still mid-task / transient idle | Leave it; wait for the next relay event. |
+
+**Do not re-send the original task** if the crew appears to have completed it — that triggers a duplicate run. Read the crew screen or diff first, then decide: terminalize vs re-task vs leave.
+
+This is the captain-side backstop: even if the completion-protocol imperative is skipped, the lifecycle still terminalizes because the captain classifies intent instead of letting the task strand at IDLE.
+
 When a crew sends you a status message via `cockpit runtime send <project> "<message>"`, it lands in your captain pane. Acknowledge, then update your handoff if a meaningful decision was made.
 
 ## When Crew Finishes

--- a/plugin/skills/side-session/SKILL.md
+++ b/plugin/skills/side-session/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: side-session
+description: Spawn and manage side-sessions (research/debug) — dedicated fresh-context tabs off the captain's daemon lifecycle. Use when you want to research a topic, discuss an idea, or debug without polluting captain context.
+---
+
+# Side-Sessions
+
+A side-session is a dedicated tab with **fresh context** running the captain model (opus), loaded with a role-specific template. It runs **outside the crew/daemon lifecycle** — no `CREW IDLE/DONE` noise back to the primary captain. Its only upward signal is an explicit, user-confirmed structured handoff.
+
+## Spawn a side-session
+
+```bash
+# Research a topic, discuss an idea, produce a spec or GH issue
+cockpit side spawn <project> "<topic>" --role research
+
+# Debug mode (Phase 2 — not yet available)
+cockpit side spawn <project> "<topic>" --role debug
+```
+
+Options:
+- `--name <name>` — custom tab name (default: auto `side-N`)
+- `--direction <tab|right|down|left|up>` — placement (default: tab)
+- `--agent <claude|opencode>` — agent to use (default: claude)
+- `--topic-file <path>` — read topic from a file
+
+## Manage side-sessions
+
+```bash
+cockpit side list <project>                               # see live side tabs
+cockpit side send <project> <name> "<follow-up>"          # send a follow-up turn
+cockpit side close <project> <name>                       # close when done
+```
+
+## Role: research
+
+**Can:** Read code/docs, run read-only commands, create GH issues, write specs/plans.
+**Cannot:** Edit source code, spawn crews, merge/ship changes.
+
+The session works in fresh context and produces artifacts (specs, GH issues, analysis). When done, it asks the user to confirm before sending a structured handoff to the primary captain.
+
+## Handoff workflow
+
+```
+1. Research session produces an artifact (spec, issue, analysis).
+2. Session asks: "Notify the primary captain now? (y/n)"
+3. On yes:
+   - Writes durable record: {spokeVault}/side-handoffs/<topic>.md
+   - Sends: cockpit runtime send <project> "🗒 Side handoff [research] — <topic> ..."
+4. Primary captain receives handoff via relay.
+5. Captain does NOT auto-spawn a crew — waits for user's go.
+```
+
+### Structured handoff format
+
+```
+🗒 Side handoff [research] — <topic>
+Summary: <one-line summary>
+Artifacts: <gh issue #NNN | spec: path/to/file.md | …>
+Next: <recommended next action>
+```
+
+## Spawn by the primary captain
+
+When the user asks you to start a side research session, spawn one:
+
+```bash
+cockpit side spawn <project> "<the research question or topic>" --role research
+```
+
+Note the session name from the output (e.g. `side-1`) and tell the user they can steer it with:
+
+```bash
+cockpit side send <project> side-1 "<follow-up>"
+cockpit side close <project> side-1
+```
+
+When the session completes, its handoff will arrive via relay with the `🗒 Side handoff` prefix.
+
+## Key invariant
+
+`cockpit side spawn` does **NOT** create a daemon task record. There is no `CREW IDLE/DONE` event for side-sessions. The only signal path is the explicit `cockpit runtime send` the side-session sends on user confirmation.

--- a/plugin/skills/side-session/SKILL.md
+++ b/plugin/skills/side-session/SKILL.md
@@ -13,7 +13,7 @@ A side-session is a dedicated tab with **fresh context** running the captain mod
 # Research a topic, discuss an idea, produce a spec or GH issue
 cockpit side spawn <project> "<topic>" --role research
 
-# Debug mode (Phase 2 — not yet available)
+# Debug a bug in an isolated scratch worktree
 cockpit side spawn <project> "<topic>" --role debug
 ```
 
@@ -38,19 +38,36 @@ cockpit side close <project> <name>                       # close when done
 
 The session works in fresh context and produces artifacts (specs, GH issues, analysis). When done, it asks the user to confirm before sending a structured handoff to the primary captain.
 
+## Role: debug
+
+**Can:** Read code/docs, run code and tests, edit source — but **scratch only** in its isolated worktree (instrumentation, logging, a failing test to pinpoint the root cause).
+**Cannot:** Edit source outside the scratch worktree, spawn crews, merge/ship changes.
+
+The debug role creates an isolated scratch git worktree on spawn. Edits made there are never shipped — the draft patch lives on the scratch branch and is referenced in the handoff for a crew to implement cleanly. Close prunes the scratch worktree.
+
+### Bug intake (required first step)
+
+Before instrumenting, the debug session gathers from the user:
+1. Repro steps
+2. When/where the bug appears
+3. Expected vs actual behavior
+4. Recent changes that could be related
+
+If the topic already contains all of this, it confirms and proceeds. Otherwise it asks.
+
 ## Handoff workflow
 
 ```
-1. Research session produces an artifact (spec, issue, analysis).
+1. Side session produces a result (root cause / artifact).
 2. Session asks: "Notify the primary captain now? (y/n)"
 3. On yes:
    - Writes durable record: {spokeVault}/side-handoffs/<topic>.md
-   - Sends: cockpit runtime send <project> "🗒 Side handoff [research] — <topic> ..."
+   - Sends: cockpit runtime send <project> "🗒 Side handoff [<role>] — <topic> ..."
 4. Primary captain receives handoff via relay.
 5. Captain does NOT auto-spawn a crew — waits for user's go.
 ```
 
-### Structured handoff format
+### Structured handoff format (research)
 
 ```
 🗒 Side handoff [research] — <topic>
@@ -59,12 +76,25 @@ Artifacts: <gh issue #NNN | spec: path/to/file.md | …>
 Next: <recommended next action>
 ```
 
+### Structured handoff format (debug)
+
+```
+🗒 Side handoff [debug] — <topic>
+Root cause: <one-line root cause>
+Artifacts: <failing test path | instrumentation: <file> | draft patch: scratch branch crew/<name> | issue #NNN>
+Next: <what a crew should implement to fix this>
+```
+
 ## Spawn by the primary captain
 
-When the user asks you to start a side research session, spawn one:
+When the user asks you to start a side session, spawn one:
 
 ```bash
+# Research
 cockpit side spawn <project> "<the research question or topic>" --role research
+
+# Debug — creates a scratch worktree; pruned automatically on close
+cockpit side spawn <project> "<the bug description>" --role debug
 ```
 
 Note the session name from the output (e.g. `side-1`) and tell the user they can steer it with:
@@ -76,6 +106,8 @@ cockpit side close <project> side-1
 
 When the session completes, its handoff will arrive via relay with the `🗒 Side handoff` prefix.
 
-## Key invariant
+## Key invariants
 
 `cockpit side spawn` does **NOT** create a daemon task record. There is no `CREW IDLE/DONE` event for side-sessions. The only signal path is the explicit `cockpit runtime send` the side-session sends on user confirmation.
+
+`cockpit side close` on a debug session automatically prunes its scratch worktree (the branch is preserved so the draft patch survives).

--- a/scripts/record-side-handoff.sh
+++ b/scripts/record-side-handoff.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Usage: record-side-handoff.sh <spoke-vault-path> <topic> <summary>
+# Writes a durable handoff record to {spokeVault}/side-handoffs/<topic-slug>.md
+set -euo pipefail
+
+VAULT="${1:?Usage: record-side-handoff.sh <vault-path> <topic> <summary>}"
+TOPIC="${2:?}"
+SUMMARY="${3:?}"
+DATE=$(date +"%Y-%m-%d")
+SLUG=$(echo "$TOPIC" | head -c 60 | tr ' ' '-' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]//g')
+FILENAME="${VAULT}/side-handoffs/${SLUG}.md"
+
+mkdir -p "${VAULT}/side-handoffs"
+
+cat > "$FILENAME" << EOF
+---
+type: side-handoff
+role: research
+date: ${DATE}
+topic: ${TOPIC}
+---
+
+## Summary
+${SUMMARY}
+
+## Full handoff
+
+(Appended by side-session — see cockpit relay for the captain's copy.)
+EOF
+
+echo "Recorded side handoff: $FILENAME"

--- a/scripts/record-side-handoff.sh
+++ b/scripts/record-side-handoff.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
-# Usage: record-side-handoff.sh <spoke-vault-path> <topic> <summary>
+# Usage: record-side-handoff.sh <spoke-vault-path> <topic> <role> <summary>
 # Writes a durable handoff record to {spokeVault}/side-handoffs/<topic-slug>.md
 set -euo pipefail
 
-VAULT="${1:?Usage: record-side-handoff.sh <vault-path> <topic> <summary>}"
+VAULT="${1:?Usage: record-side-handoff.sh <vault-path> <topic> <role> <summary>}"
 TOPIC="${2:?}"
-SUMMARY="${3:?}"
+ROLE="${3:?}"
+SUMMARY="${4:?}"
 DATE=$(date +"%Y-%m-%d")
 SLUG=$(echo "$TOPIC" | head -c 60 | tr ' ' '-' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]//g')
 FILENAME="${VAULT}/side-handoffs/${SLUG}.md"
@@ -15,7 +16,7 @@ mkdir -p "${VAULT}/side-handoffs"
 cat > "$FILENAME" << EOF
 ---
 type: side-handoff
-role: research
+role: ${ROLE}
 date: ${DATE}
 topic: ${TOPIC}
 ---

--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -271,6 +271,64 @@ describe("cockpit crew spawn", () => {
     expect(addWorktree).toHaveBeenCalledWith(expect.objectContaining({ worktreeDir: ".wt" }));
   });
 
+  it("--worktree claude crew: launch command starts with cd into worktree path", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude --append-system-prompt-file /tmp/crew.md");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-wtcd" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-wtcd", project: "brove", provider: "claude", mode: "interactive" });
+    const wtPath = "/tmp/brove/.worktrees/brove-crew-1";
+    addWorktree.mockReturnValue(wtPath);
+
+    const promise = runCrewSpawn({ project: "brove", task: "feature work", worktree: true });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    const launchCmd: string = sendToPane.mock.calls[0]?.[1];
+    // Shell must cd into the worktree before launching the agent (#279).
+    expect(launchCmd).toMatch(/^cd '\/tmp\/brove\/\.worktrees\/brove-crew-1' && /);
+  });
+
+  it("non-worktree claude crew: launch command starts with cd into main checkout (no-op harmless)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude ...");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-nowt2" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-nowt2", project: "brove", provider: "claude", mode: "interactive" });
+
+    const promise = runCrewSpawn({ project: "brove", task: "small fix" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    const launchCmd: string = sendToPane.mock.calls[0]?.[1];
+    // Non-worktree: cwd is proj.path — cd is a no-op but still issued for uniformity.
+    expect(launchCmd).toMatch(/^cd '\/tmp\/brove' && /);
+  });
+
+  it("--worktree opencode crew: launch command starts with cd into worktree path", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("opencode");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-ocwt" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-ocwt", project: "brove", provider: "opencode", mode: "interactive" });
+    const wtPath = "/tmp/brove/.worktrees/brove-crew-1";
+    addWorktree.mockReturnValue(wtPath);
+
+    const promise = runCrewSpawn({ project: "brove", task: "feature work", worktree: true, agent: "opencode", agentExplicit: true });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    const launchCmd: string = sendToPane.mock.calls[0]?.[1];
+    // Shell must cd into the worktree before launching opencode (#279).
+    expect(launchCmd).toMatch(/^cd '\/tmp\/brove\/\.worktrees\/brove-crew-1' && /);
+  });
+
   it("auto-names the next crew based on existing tabs (crew-1 + crew-3 → crew-2)", async () => {
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });

--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -93,6 +93,9 @@ vi.mock("node:fs", async (importOriginal) => {
   return { ...merged, default: merged };
 });
 
+const resolveCrewRoute = vi.hoisted(() => vi.fn());
+vi.mock("../../control/crew-routing.js", () => ({ resolveCrewRoute }));
+
 import { runCrewSpawn, runCrewSend, runCrewRead, runCrewClose, runCrewList, sendFirstTurnWhenReady, reapCrewChildren, isTurnAccepted } from "../crew.js";
 
 const baseConfig = {
@@ -142,6 +145,9 @@ describe("cockpit crew spawn", () => {
     // Default: pretend the codex role template is absent so older tests that
     // don't care about role injection still pass unchanged.
     existsSyncMock.mockReturnValue(false);
+    resolveCrewRoute.mockReset();
+    // Default: no routing match (fall through to existing defaults).
+    resolveCrewRoute.mockReturnValue(null);
   });
 
   afterEach(() => {
@@ -568,6 +574,83 @@ describe("cockpit crew spawn", () => {
     status.mockResolvedValue(null);
     await expect(runCrewSpawn({ project: "brove", task: "x" }))
       .rejects.toThrow(/captain workspace 'brove-captain' is not running/i);
+  });
+
+  describe("leveled crew routing (#275)", () => {
+    it("uses routed agent+model when no explicit agent/model provided and routing matches", async () => {
+      loadConfig.mockReturnValue(baseConfig);
+      status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+      listSurfaces.mockResolvedValue([]);
+      newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+      buildCommand.mockReturnValue("claude --model sonnet ...");
+      buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-route1" } }));
+      cockpitdCall.mockResolvedValue({ id: "task-route1" });
+      resolveCrewRoute.mockReturnValue({ agent: "claude", model: "sonnet", tier: "hard", matchedRule: "refactor|implement" });
+
+      const promise = runCrewSpawn({ project: "brove", task: "refactor the daemon" });
+      await vi.advanceTimersByTimeAsync(3000);
+      await promise;
+
+      expect(resolveCrewRoute).toHaveBeenCalledWith("refactor the daemon", baseConfig);
+      expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ model: "sonnet" }));
+    });
+
+    it("explicit --agent overrides routing when agentExplicit=true", async () => {
+      loadConfig.mockReturnValue(baseConfig);
+      status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+      listSurfaces.mockResolvedValue([]);
+      newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+      buildCommand.mockReturnValue("gemini ...");
+      // routing would suggest claude/sonnet but agentExplicit=true suppresses it
+      resolveCrewRoute.mockReturnValue({ agent: "claude", model: "sonnet", tier: "hard", matchedRule: "refactor" });
+
+      await runCrewSpawn({ project: "brove", task: "refactor the daemon", agent: "gemini", agentExplicit: true });
+
+      // routing should NOT have been consulted
+      expect(resolveCrewRoute).not.toHaveBeenCalled();
+      expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ model: undefined }));
+    });
+
+    it("explicit --model overrides routing model even when agentExplicit is false", async () => {
+      loadConfig.mockReturnValue(baseConfig);
+      status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+      listSurfaces.mockResolvedValue([]);
+      newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+      buildCommand.mockReturnValue("claude --model opus ...");
+      buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-modelx" } }));
+      cockpitdCall.mockResolvedValue({ id: "task-modelx" });
+
+      const promise = runCrewSpawn({ project: "brove", task: "refactor the daemon", model: "opus" });
+      await vi.advanceTimersByTimeAsync(3000);
+      await promise;
+
+      // model passed explicitly → routing skipped entirely
+      expect(resolveCrewRoute).not.toHaveBeenCalled();
+      expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ model: "opus" }));
+    });
+
+    it("falls through to defaults.roles.crew when routing returns null", async () => {
+      loadConfig.mockReturnValue({
+        ...baseConfig,
+        defaults: {
+          ...baseConfig.defaults,
+          roles: { crew: { agent: "claude", model: "opus" } },
+        },
+      });
+      status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+      listSurfaces.mockResolvedValue([]);
+      newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+      buildCommand.mockReturnValue("claude --model opus ...");
+      buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-fallthrough" } }));
+      cockpitdCall.mockResolvedValue({ id: "task-fallthrough" });
+      resolveCrewRoute.mockReturnValue(null);
+
+      const promise = runCrewSpawn({ project: "brove", task: "some unmatched task" });
+      await vi.advanceTimersByTimeAsync(3000);
+      await promise;
+
+      expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ model: "opus" }));
+    });
   });
 });
 

--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -96,7 +96,7 @@ vi.mock("node:fs", async (importOriginal) => {
 const resolveCrewRoute = vi.hoisted(() => vi.fn());
 vi.mock("../../control/crew-routing.js", () => ({ resolveCrewRoute }));
 
-import { runCrewSpawn, runCrewSend, runCrewRead, runCrewClose, runCrewList, sendFirstTurnWhenReady, reapCrewChildren, isTurnAccepted } from "../crew.js";
+import { runCrewSpawn, runCrewSend, runCrewRead, runCrewClose, runCrewList, sendFirstTurnWhenReady, reapCrewChildren, isTurnAccepted, buildCompletionProtocol } from "../crew.js";
 
 const baseConfig = {
   commandName: "command",
@@ -196,11 +196,11 @@ describe("cockpit crew spawn", () => {
     expect(sendToPane.mock.calls[0]?.[1]).toContain("COCKPIT_CREW_TASK_ID=task-cl1");
     expect(sendToPane.mock.calls[0]?.[1]).toContain("COCKPIT_CREW_PROJECT=brove");
     expect(sendToPane.mock.calls[0]?.[1]).toContain("claude --append-system-prompt-file /tmp/crew.md");
-    // Second sendToPane delivers the task as the first prompt.
-    expect(sendToPane.mock.calls[1]).toEqual([
-      { workspaceId: "workspace:5", surfaceId: "surface:9" },
-      "do the thing",
-    ]);
+    // Second sendToPane delivers the task + completion-protocol suffix as the first prompt.
+    expect(sendToPane.mock.calls[1]?.[0]).toEqual({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    expect(sendToPane.mock.calls[1]?.[1]).toContain("do the thing");
+    expect(sendToPane.mock.calls[1]?.[1]).toContain("--task-id task-cl1");
+    expect(sendToPane.mock.calls[1]?.[1]).toContain("--project brove");
     expect(result.title).toBe("🔧 brove:crew-1");
   });
 
@@ -342,11 +342,11 @@ describe("cockpit crew spawn", () => {
     expect(sendToPane.mock.calls[0]?.[1]).toContain("COCKPIT_CREW_PROJECT=brove");
     expect(sendToPane.mock.calls[0]?.[1]).toContain("OPENCODE_CONFIG=/tmp/per-crew/opencode.json");
     expect(sendToPane.mock.calls[0]?.[1]).toContain("opencode");
-    // Second sendToPane delivers the task as the first prompt.
-    expect(sendToPane.mock.calls[1]).toEqual([
-      { workspaceId: "workspace:5", surfaceId: "surface:9" },
-      "do the thing",
-    ]);
+    // Second sendToPane delivers the task + completion-protocol suffix as the first prompt.
+    expect(sendToPane.mock.calls[1]?.[0]).toEqual({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    expect(sendToPane.mock.calls[1]?.[1]).toContain("do the thing");
+    expect(sendToPane.mock.calls[1]?.[1]).toContain("--task-id task-oc1");
+    expect(sendToPane.mock.calls[1]?.[1]).toContain("--project brove");
   });
 
   it("--approval gates bash for opencode crews (CP3 opt-in → gateBash:true)", async () => {
@@ -1151,6 +1151,132 @@ describe("cockpit crew send/read/close/list", () => {
       { name: "crew-1", surfaceId: "surface:10" },
       { name: "fix-typos", surfaceId: "surface:11" },
     ]);
+  });
+});
+
+describe("buildCompletionProtocol (#278)", () => {
+  it("includes the task-id and project in the done signal command", () => {
+    const result = buildCompletionProtocol("task-abc123", "my-project");
+    expect(result).toContain("--task-id task-abc123");
+    expect(result).toContain("--project my-project");
+    expect(result).toContain("crew signal done");
+  });
+
+  it("includes the blocked signal form with the same ids", () => {
+    const result = buildCompletionProtocol("task-abc123", "my-project");
+    expect(result).toContain("crew signal blocked");
+    expect(result).toContain("--task-id task-abc123");
+    expect(result).toContain("--project my-project");
+  });
+
+  it("substitutes both task-id and project independently", () => {
+    const a = buildCompletionProtocol("id-A", "proj-A");
+    const b = buildCompletionProtocol("id-B", "proj-B");
+    expect(a).toContain("--task-id id-A");
+    expect(a).toContain("--project proj-A");
+    expect(b).toContain("--task-id id-B");
+    expect(b).toContain("--project proj-B");
+    expect(a).not.toContain("id-B");
+    expect(b).not.toContain("id-A");
+  });
+});
+
+describe("completion-protocol suffix in first turns (#278)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    newPane.mockReset();
+    sendToPane.mockReset();
+    readPaneScreen.mockReset();
+    listSurfaces.mockReset();
+    status.mockReset();
+    buildCommand.mockReset();
+    loadConfig.mockReset();
+    cockpitdCall.mockReset();
+    buildDispatchRequest.mockReset();
+    sendCodexFirstTurn.mockReset();
+    sendCodexFirstTurn.mockResolvedValue(undefined);
+    writePerCrewSettingsLocal.mockReset();
+    writePerCrewSettingsLocal.mockReturnValue("/tmp/brove/.claude/settings.local.json");
+    writePerCrewOpencodeConfig.mockReset();
+    writePerCrewOpencodeConfig.mockReturnValue("/tmp/per-crew/opencode.json");
+    addWorktree.mockReset();
+    existsSyncMock.mockReset();
+    existsSyncMock.mockReturnValue(false);
+    resolveCrewRoute.mockReset();
+    resolveCrewRoute.mockReturnValue(null);
+    let reads = 0;
+    readPaneScreen.mockImplementation(async () => {
+      reads++;
+      if (reads === 1) return "booting…";
+      if (reads <= 4) return "> ready";
+      return "> ready\nworking…";
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("claude first turn includes completion-protocol suffix with baked-in task-id and project", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude ...");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-proto-cl" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-proto-cl", project: "brove", provider: "claude", mode: "interactive" });
+
+    const promise = runCrewSpawn({ project: "brove", task: "fix the bug" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    const firstTurn = sendToPane.mock.calls[1]?.[1] as string;
+    expect(firstTurn).toContain("fix the bug");
+    expect(firstTurn).toContain("COMPLETION PROTOCOL");
+    expect(firstTurn).toContain("--task-id task-proto-cl");
+    expect(firstTurn).toContain("--project brove");
+    expect(firstTurn).toContain("crew signal done");
+    expect(firstTurn).toContain("crew signal blocked");
+  });
+
+  it("opencode first turn includes completion-protocol suffix with baked-in task-id and project", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("opencode");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-proto-oc" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-proto-oc", project: "brove", provider: "opencode", mode: "interactive" });
+
+    const promise = runCrewSpawn({ project: "brove", task: "fix the bug", agent: "opencode" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    const firstTurn = sendToPane.mock.calls[1]?.[1] as string;
+    expect(firstTurn).toContain("fix the bug");
+    expect(firstTurn).toContain("COMPLETION PROTOCOL");
+    expect(firstTurn).toContain("--task-id task-proto-oc");
+    expect(firstTurn).toContain("--project brove");
+    expect(firstTurn).toContain("crew signal done");
+    expect(firstTurn).toContain("crew signal blocked");
+  });
+
+  it("codex first turn is sent via sendCodexFirstTurn unchanged — no completion-protocol suffix", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-proto-cx" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-proto-cx", project: "brove", provider: "codex", mode: "interactive" });
+
+    await runCrewSpawn({ project: "brove", task: "fix the bug", agent: "codex" });
+
+    // sendCodexFirstTurn receives the bare task text — no protocol suffix
+    expect(sendCodexFirstTurn).toHaveBeenCalledWith("task-proto-cx", "fix the bug");
+    // sendToPane only fires once (the crew attach command) — no second first-turn send
+    expect(sendToPane).toHaveBeenCalledTimes(1);
+    expect(sendToPane.mock.calls[0]?.[1]).toContain("crew attach");
+    expect(sendToPane.mock.calls[0]?.[1]).not.toContain("COMPLETION PROTOCOL");
   });
 });
 

--- a/src/commands/__tests__/group.test.ts
+++ b/src/commands/__tests__/group.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const sendRequestMock = vi.hoisted(() => vi.fn());
+const execSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../control/protocol.js", () => ({
+  sendRequest: sendRequestMock,
+}));
+
+vi.mock("node:child_process", () => ({
+  execSync: execSyncMock,
+}));
+
+const loadConfig = vi.hoisted(() => vi.fn());
+vi.mock("../../config.js", () => ({
+  loadConfig,
+  resolveHome: (p: string) => p,
+}));
+
+import { runGroupDispatch } from "../group.js";
+
+const makeConfig = (overrides: Record<string, any> = {}) => {
+  const projects: Record<string, any> = {
+    projA: {
+      path: "/projects/a",
+      captainName: "⚓ A-captain",
+      spokeVault: "/spokes/a",
+      host: "local",
+      group: "mygroup",
+      groupRole: "primary",
+      ...(overrides.acceptDelegationsA !== undefined ? { acceptDelegations: overrides.acceptDelegationsA } : {}),
+    },
+    projB: {
+      path: "/projects/b",
+      captainName: "⚓ B-captain",
+      spokeVault: "/spokes/b",
+      host: "local",
+      group: "mygroup",
+      groupRole: "fork",
+      ...(overrides.acceptDelegationsB !== undefined ? { acceptDelegations: overrides.acceptDelegationsB } : {}),
+    },
+    projC: {
+      path: "/projects/c",
+      captainName: "⚓ C-captain",
+      spokeVault: "/spokes/c",
+      host: "local",
+      group: "othergroup",
+      groupRole: "primary",
+    },
+  };
+  return {
+    commandName: "command",
+    hubVault: "~/hub",
+    projects,
+    defaults: {
+      maxCrew: 5,
+      worktreeDir: ".worktrees",
+      teammateMode: "in-process",
+      permissions: { command: "auto", captain: "auto", crew: "auto" },
+    },
+    metrics: { enabled: false, path: "/tmp/metrics.json" },
+  };
+};
+
+describe("runGroupDispatch", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    loadConfig.mockReturnValue(makeConfig());
+    sendRequestMock.mockResolvedValue([]);
+    execSyncMock.mockReturnValue("");
+  });
+
+  // ── same-group gate ──────────────────────────────────────────────────────
+
+  it("rejects dispatch to a project NOT in the same group", async () => {
+    await expect(
+      runGroupDispatch({
+        fromProject: "projA",
+        toProject: "projC",
+        task: "do something",
+      }),
+    ).rejects.toThrow(/not in the same group/i);
+
+    expect(sendRequestMock).not.toHaveBeenCalled();
+    expect(execSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects dispatch when toProject has acceptDelegations: false", async () => {
+    loadConfig.mockReturnValue(makeConfig({ acceptDelegationsB: false }));
+
+    await expect(
+      runGroupDispatch({
+        fromProject: "projA",
+        toProject: "projB",
+        task: "do something",
+      }),
+    ).rejects.toThrow(/acceptDelegations.*false/i);
+
+    expect(sendRequestMock).not.toHaveBeenCalled();
+    expect(execSyncMock).not.toHaveBeenCalled();
+  });
+
+  // ── warmup timeout ───────────────────────────────────────────────────────
+
+  it("fails clearly when warmup times out", async () => {
+    // sendRequest for health returns empty → captain not alive → launch + poll
+    sendRequestMock.mockResolvedValue([]);
+
+    loadConfig.mockReturnValue(makeConfig({}));
+
+    await expect(
+      runGroupDispatch({
+        fromProject: "projA",
+        toProject: "projB",
+        task: "do something",
+        warmupTimeoutMs: 100,
+        warmupPollMs: 20,
+      }),
+    ).rejects.toThrow(/timed out waiting for captain warmup/i);
+  });
+
+  // ── task record shape ────────────────────────────────────────────────────
+
+  it("records a task with originProject set when dispatch succeeds", async () => {
+    // sendRequest signature is (sockPath, msg, timeoutMs). The second arg is the msg.
+    sendRequestMock.mockImplementation((_sock: string, msg: any, _timeout?: number) => {
+      if (msg?.kind === "health") {
+        return [
+          { kind: "captain", project: "projB", state: "alive", lastSeenMs: Date.now() },
+        ];
+      }
+      if (msg?.kind === "dispatch") {
+        return msg.record;
+      }
+      return undefined;
+    });
+
+    loadConfig.mockReturnValue(makeConfig({}));
+
+    const result = await runGroupDispatch({
+      fromProject: "projA",
+      toProject: "projB",
+      task: "update the docs",
+    });
+
+    expect(result).toBeDefined();
+    expect((result as any).originProject).toBe("projA");
+    expect((result as any).project).toBe("projB");
+    expect((result as any).state).toBe("submitted");
+    expect((result as any).task).toBe("update the docs");
+  });
+});

--- a/src/commands/__tests__/group.test.ts
+++ b/src/commands/__tests__/group.test.ts
@@ -17,7 +17,7 @@ vi.mock("../../config.js", () => ({
   resolveHome: (p: string) => p,
 }));
 
-import { runGroupDispatch } from "../group.js";
+import { runGroupDispatch, groupCommand } from "../group.js";
 
 const makeConfig = (overrides: Record<string, any> = {}) => {
   const projects: Record<string, any> = {
@@ -61,6 +61,14 @@ const makeConfig = (overrides: Record<string, any> = {}) => {
     metrics: { enabled: false, path: "/tmp/metrics.json" },
   };
 };
+
+describe("groupCommand dispatch description", () => {
+  it("marks dispatch as [experimental]", () => {
+    const dispatch = groupCommand.commands.find((c) => c.name() === "dispatch");
+    expect(dispatch).toBeDefined();
+    expect(dispatch!.description()).toMatch(/\[experimental\]/i);
+  });
+});
 
 describe("runGroupDispatch", () => {
   beforeEach(() => {

--- a/src/commands/__tests__/side.test.ts
+++ b/src/commands/__tests__/side.test.ts
@@ -1,0 +1,431 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ── mock setup (mirrors crew.test.ts pattern) ─────────────────────────────
+
+const newPane = vi.hoisted(() => vi.fn());
+const sendToPane = vi.hoisted(() => vi.fn());
+const closePane = vi.hoisted(() => vi.fn());
+const readPaneScreen = vi.hoisted(() => vi.fn());
+const listSurfaces = vi.hoisted(() => vi.fn());
+const status = vi.hoisted(() => vi.fn());
+const buildCommand = vi.hoisted(() => vi.fn());
+
+vi.mock("../../runtimes/index.js", () => ({
+  createCmuxDriver: () => ({
+    name: "cmux",
+    probe: vi.fn(),
+    list: vi.fn(),
+    status,
+    spawn: vi.fn(),
+    send: vi.fn(),
+    sendKey: vi.fn(),
+    readScreen: vi.fn(),
+    stop: vi.fn(),
+    newPane,
+    closePane,
+    sendToPane,
+    readPaneScreen,
+    listSurfaces,
+  }),
+  RuntimeRegistry: class {
+    constructor(private drivers: Record<string, unknown>) {}
+    forProject() { return this.drivers.cmux; }
+    global() { return this.drivers.cmux; }
+    get(name: string) { return (this.drivers as Record<string, unknown>)[name]; }
+    async probeAll() { return {}; }
+  },
+}));
+
+const loadConfig = vi.hoisted(() => vi.fn());
+vi.mock("../../config.js", () => ({
+  loadConfig,
+  resolveHome: (p: string) => p,
+}));
+
+const claudeDriver = vi.hoisted(() => ({
+  name: "claude",
+  templateSuffix: "claude",
+  probe: vi.fn(),
+  buildCommand,
+}));
+
+vi.mock("../../drivers/index.js", () => ({
+  createClaudeDriver: () => claudeDriver,
+  createCodexDriver: () => ({ ...claudeDriver, name: "codex", templateSuffix: "generic" }),
+  createGeminiDriver: () => ({ ...claudeDriver, name: "gemini", templateSuffix: "generic" }),
+  createOpencodeDriver: () => ({ ...claudeDriver, name: "opencode", templateSuffix: "opencode" }),
+  CapabilityRegistry: class {
+    constructor(private drivers: Record<string, unknown>) {}
+    get(name: string) { return (this.drivers as Record<string, unknown>)[name]; }
+  },
+}));
+
+// per-crew-settings mock — needed by the crew regression test below.
+const writePerCrewSettingsLocal = vi.hoisted(() => vi.fn());
+vi.mock("../../lib/per-crew-settings.js", () => ({
+  writePerCrewSettings: vi.fn(),
+  writePerCrewSettingsLocal,
+  writePerCrewOpencodeConfig: vi.fn(),
+}));
+
+// cockpitdCall and buildDispatchRequest are the daemon dispatch path.
+// side.ts MUST NOT call these — the mocks let us assert that invariant.
+const cockpitdCall = vi.hoisted(() => vi.fn());
+const buildDispatchRequest = vi.hoisted(() => vi.fn());
+vi.mock("../crew-control.js", () => ({
+  cockpitdCall,
+  buildDispatchRequest,
+  sendCodexFirstTurn: vi.fn().mockResolvedValue(undefined),
+}));
+
+const existsSyncMock = vi.hoisted(() => vi.fn());
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  const merged = { ...actual, existsSync: existsSyncMock };
+  return { ...merged, default: merged };
+});
+
+import {
+  runSideSpawn,
+  runSideSend,
+  runSideList,
+  runSideClose,
+  buildSideFirstTurn,
+} from "../side.js";
+
+const baseConfig = {
+  commandName: "command",
+  hubVault: "~/hub",
+  projects: {
+    brove: {
+      path: "/tmp/brove",
+      captainName: "brove-captain",
+      spokeVault: "~/hub/spokes/brove",
+      host: "local",
+    },
+  },
+  defaults: {
+    maxCrew: 5,
+    worktreeDir: ".worktrees",
+    teammateMode: "in-process",
+    permissions: { command: "auto", captain: "auto", crew: "auto" },
+    roles: {
+      side: { agent: "claude", model: "opus" },
+    },
+  },
+  metrics: { enabled: false, path: "" },
+};
+
+describe("cockpit side spawn", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    newPane.mockReset();
+    sendToPane.mockReset();
+    closePane.mockReset();
+    readPaneScreen.mockReset();
+    listSurfaces.mockReset();
+    status.mockReset();
+    buildCommand.mockReset();
+    loadConfig.mockReset();
+    cockpitdCall.mockReset();
+    buildDispatchRequest.mockReset();
+    existsSyncMock.mockReset();
+    existsSyncMock.mockReturnValue(true);
+
+    // Staged boot: first read shows pre-launch, subsequent reads show stable TUI.
+    let reads = 0;
+    readPaneScreen.mockImplementation(async () => {
+      reads++;
+      if (reads === 1) return "booting…";
+      if (reads <= 4) return "> ready";
+      return "> ready\nworking…";
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("CRITICAL: does NOT call cockpitdCall or buildDispatchRequest (off daemon lifecycle)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude --append-system-prompt-file /tmp/side.research.claude.md");
+
+    const promise = runSideSpawn({ project: "brove", topic: "research oauth options", role: "research" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(cockpitdCall).not.toHaveBeenCalled();
+    expect(buildDispatchRequest).not.toHaveBeenCalled();
+  });
+
+  it("spawns with 🗒 title prefix and side-1 auto-name", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude");
+
+    const promise = runSideSpawn({ project: "brove", topic: "research oauth", role: "research" });
+    await vi.advanceTimersByTimeAsync(3000);
+    const result = await promise;
+
+    expect(newPane).toHaveBeenCalledWith(expect.objectContaining({
+      title: "🗒 brove:side-1",
+    }));
+    expect(result.title).toBe("🗒 brove:side-1");
+  });
+
+  it("wires the research template path (side.research.claude.md)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude");
+
+    const promise = runSideSpawn({ project: "brove", topic: "research oauth", role: "research" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(buildCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        promptFile: expect.stringContaining("side.research.claude.md"),
+        role: "side",
+        interactive: true,
+      }),
+    );
+  });
+
+  it("uses the side model from config (opus)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude --model opus");
+
+    const promise = runSideSpawn({ project: "brove", topic: "research topic", role: "research" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(buildCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "opus" }),
+    );
+  });
+
+  it("sends topic + context block as first turn (includes spokeVault)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude");
+
+    const promise = runSideSpawn({ project: "brove", topic: "research oauth options", role: "research" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    // Second sendToPane is the first-turn delivery (first is the CLI launch)
+    const firstTurnCall = sendToPane.mock.calls[1];
+    expect(firstTurnCall?.[1]).toContain("research oauth options");
+    expect(firstTurnCall?.[1]).toContain("~/hub/spokes/brove");
+    expect(firstTurnCall?.[1]).toContain("brove");
+    expect(firstTurnCall?.[1]).toContain("research");
+  });
+
+  it("throws 'not yet implemented' for --role debug (Phase 2)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+
+    await expect(
+      runSideSpawn({ project: "brove", topic: "debug the crash", role: "debug" }),
+    ).rejects.toThrow("not yet implemented");
+  });
+
+  it("throws for unknown --role", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+
+    await expect(
+      runSideSpawn({ project: "brove", topic: "topic", role: "unknown-role" }),
+    ).rejects.toThrow("Unknown side role");
+  });
+
+  it("auto-increments name avoiding existing side sessions", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([
+      { surfaceId: "s1", title: "🗒 brove:side-1" },
+      { surfaceId: "s2", title: "🗒 brove:side-2" },
+    ]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude");
+
+    const promise = runSideSpawn({ project: "brove", topic: "topic", role: "research" });
+    await vi.advanceTimersByTimeAsync(3000);
+    const result = await promise;
+
+    expect(result.title).toBe("🗒 brove:side-3");
+  });
+
+  it("uses promptFile=undefined when template file is absent (existsSync=false)", async () => {
+    existsSyncMock.mockReturnValue(false);
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude");
+
+    const promise = runSideSpawn({ project: "brove", topic: "topic", role: "research" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(buildCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ promptFile: undefined }),
+    );
+  });
+
+  it("does not mix 🔧 crew titles into the side name counter", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    // Only crew tabs — side counter starts at 1
+    listSurfaces.mockResolvedValue([
+      { surfaceId: "s1", title: "🔧 brove:crew-1" },
+      { surfaceId: "s2", title: "🔧 brove:crew-2" },
+    ]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude");
+
+    const promise = runSideSpawn({ project: "brove", topic: "topic", role: "research" });
+    await vi.advanceTimersByTimeAsync(3000);
+    const result = await promise;
+
+    expect(result.title).toBe("🗒 brove:side-1");
+  });
+});
+
+describe("buildSideFirstTurn", () => {
+  it("includes topic, project, role, and spokeVault", () => {
+    const result = buildSideFirstTurn(
+      "research oauth options",
+      "brove",
+      "research",
+      "~/hub/spokes/brove",
+    );
+    expect(result).toContain("research oauth options");
+    expect(result).toContain("brove");
+    expect(result).toContain("research");
+    expect(result).toContain("~/hub/spokes/brove");
+  });
+
+  it("puts the topic first (before the context block)", () => {
+    const result = buildSideFirstTurn("my topic", "proj", "research", "/vault");
+    expect(result.indexOf("my topic")).toBeLessThan(result.indexOf("---"));
+  });
+
+  it("separates topic from context with a divider line", () => {
+    const result = buildSideFirstTurn("topic text", "proj", "research", "/vault");
+    expect(result).toContain("\n---\n");
+  });
+});
+
+describe("runSideList / runSideClose / runSideSend", () => {
+  beforeEach(() => {
+    loadConfig.mockReset();
+    listSurfaces.mockReset();
+    status.mockReset();
+    sendToPane.mockReset();
+    closePane.mockReset();
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+  });
+
+  it("runSideList returns only 🗒-prefixed sessions for this project", async () => {
+    listSurfaces.mockResolvedValue([
+      { surfaceId: "s1", title: "🗒 brove:side-1" },
+      { surfaceId: "s2", title: "🔧 brove:crew-1" }, // crew — must be excluded
+      { surfaceId: "s3", title: "🗒 brove:side-2" },
+      { surfaceId: "s4", title: "🗒 other:side-1" }, // different project — excluded
+    ]);
+
+    const result = await runSideList("brove");
+
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.name)).toEqual(["side-1", "side-2"]);
+  });
+
+  it("runSideClose closes the matching pane", async () => {
+    listSurfaces.mockResolvedValue([{ surfaceId: "s1", title: "🗒 brove:side-1" }]);
+    closePane.mockResolvedValue(undefined);
+
+    await runSideClose("brove", "side-1");
+
+    expect(closePane).toHaveBeenCalledWith(expect.objectContaining({ surfaceId: "s1" }));
+  });
+
+  it("runSideClose throws when session not found", async () => {
+    listSurfaces.mockResolvedValue([]);
+
+    await expect(runSideClose("brove", "side-99")).rejects.toThrow("not found");
+  });
+
+  it("runSideSend sends to the matching pane without touching daemon", async () => {
+    listSurfaces.mockResolvedValue([{ surfaceId: "s1", title: "🗒 brove:side-1" }]);
+
+    await runSideSend("brove", "side-1", "follow-up message");
+
+    expect(sendToPane).toHaveBeenCalledWith(
+      expect.objectContaining({ surfaceId: "s1" }),
+      "follow-up message",
+    );
+    expect(cockpitdCall).not.toHaveBeenCalled();
+  });
+
+  it("runSideSend throws when session not found", async () => {
+    listSurfaces.mockResolvedValue([]);
+
+    await expect(runSideSend("brove", "side-99", "hi")).rejects.toThrow("not found");
+  });
+});
+
+describe("crew spawn regression — daemon path unchanged", () => {
+  it("cockpit crew spawn still calls cockpitdCall (daemon path intact)", async () => {
+    const { runCrewSpawn } = await import("../crew.js");
+
+    vi.useFakeTimers();
+
+    let reads = 0;
+    readPaneScreen.mockImplementation(async () => {
+      reads++;
+      if (reads === 1) return "booting…";
+      if (reads <= 4) return "> ready";
+      return "> ready\nworking…";
+    });
+
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude");
+    buildDispatchRequest.mockImplementation((o: unknown) => ({
+      kind: "dispatch",
+      record: { ...(o as object), id: "task-cl1" },
+    }));
+    cockpitdCall.mockResolvedValue({
+      id: "task-cl1",
+      project: "brove",
+      provider: "claude",
+      mode: "interactive",
+    });
+    writePerCrewSettingsLocal.mockReturnValue("/tmp/.claude/settings.local.json");
+
+    const promise = runCrewSpawn({ project: "brove", task: "do the thing" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(cockpitdCall).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+});

--- a/src/commands/__tests__/side.test.ts
+++ b/src/commands/__tests__/side.test.ts
@@ -68,6 +68,16 @@ vi.mock("../../lib/per-crew-settings.js", () => ({
   writePerCrewOpencodeConfig: vi.fn(),
 }));
 
+// git-worktree mock — lets us assert debug sessions create/remove worktrees.
+const addWorktreeMock = vi.hoisted(() => vi.fn());
+const removeWorktreeMock = vi.hoisted(() => vi.fn());
+const worktreePathMock = vi.hoisted(() => vi.fn());
+vi.mock("../../lib/git-worktree.js", () => ({
+  addWorktree: addWorktreeMock,
+  removeWorktree: removeWorktreeMock,
+  worktreePath: worktreePathMock,
+}));
+
 // cockpitdCall and buildDispatchRequest are the daemon dispatch path.
 // side.ts MUST NOT call these — the mocks let us assert that invariant.
 const cockpitdCall = vi.hoisted(() => vi.fn());
@@ -131,6 +141,11 @@ describe("cockpit side spawn", () => {
     buildDispatchRequest.mockReset();
     existsSyncMock.mockReset();
     existsSyncMock.mockReturnValue(true);
+    addWorktreeMock.mockReset();
+    removeWorktreeMock.mockReset();
+    worktreePathMock.mockReset();
+    addWorktreeMock.mockReturnValue("/tmp/brove/.worktrees/brove-side-1");
+    worktreePathMock.mockReturnValue("/tmp/brove/.worktrees/brove-side-1");
 
     // Staged boot: first read shows pre-launch, subsequent reads show stable TUI.
     let reads = 0;
@@ -233,14 +248,86 @@ describe("cockpit side spawn", () => {
     expect(firstTurnCall?.[1]).toContain("research");
   });
 
-  it("throws 'not yet implemented' for --role debug (Phase 2)", async () => {
+  it("debug spawn creates a scratch worktree (addWorktree called)", async () => {
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
     listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude");
 
-    await expect(
-      runSideSpawn({ project: "brove", topic: "debug the crash", role: "debug" }),
-    ).rejects.toThrow("not yet implemented");
+    const promise = runSideSpawn({ project: "brove", topic: "debug the crash", role: "debug" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(addWorktreeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoRoot: "/tmp/brove",
+        project: "brove",
+        base: "develop",
+      }),
+    );
+  });
+
+  it("research spawn does NOT create a worktree (addWorktree not called)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude");
+
+    const promise = runSideSpawn({ project: "brove", topic: "research oauth", role: "research" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(addWorktreeMock).not.toHaveBeenCalled();
+  });
+
+  it("debug spawn is off the daemon lifecycle (no cockpitdCall)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude");
+
+    const promise = runSideSpawn({ project: "brove", topic: "debug the crash", role: "debug" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(cockpitdCall).not.toHaveBeenCalled();
+    expect(buildDispatchRequest).not.toHaveBeenCalled();
+  });
+
+  it("debug spawn cd-prefixes into the scratch worktree path (#279 fix)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude");
+    addWorktreeMock.mockReturnValue("/tmp/brove/.worktrees/brove-side-1");
+
+    const promise = runSideSpawn({ project: "brove", topic: "debug the crash", role: "debug" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    // First sendToPane call is the CLI launch — must cd into the scratch worktree
+    const launchCall = sendToPane.mock.calls[0];
+    expect(launchCall?.[1]).toContain("cd '/tmp/brove/.worktrees/brove-side-1'");
+  });
+
+  it("debug first turn includes scratch worktree path in context block", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude");
+    addWorktreeMock.mockReturnValue("/tmp/brove/.worktrees/brove-side-1");
+
+    const promise = runSideSpawn({ project: "brove", topic: "debug the crash", role: "debug" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    const firstTurnCall = sendToPane.mock.calls[1];
+    expect(firstTurnCall?.[1]).toContain("Scratch worktree: /tmp/brove/.worktrees/brove-side-1");
   });
 
   it("throws for unknown --role", async () => {
@@ -338,8 +425,12 @@ describe("runSideList / runSideClose / runSideSend", () => {
     status.mockReset();
     sendToPane.mockReset();
     closePane.mockReset();
+    existsSyncMock.mockReset();
+    removeWorktreeMock.mockReset();
+    worktreePathMock.mockReset();
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    worktreePathMock.mockReturnValue("/tmp/brove/.worktrees/brove-side-1");
   });
 
   it("runSideList returns only 🗒-prefixed sessions for this project", async () => {
@@ -367,8 +458,32 @@ describe("runSideList / runSideClose / runSideSend", () => {
 
   it("runSideClose throws when session not found", async () => {
     listSurfaces.mockResolvedValue([]);
+    existsSyncMock.mockReturnValue(false);
 
     await expect(runSideClose("brove", "side-99")).rejects.toThrow("not found");
+  });
+
+  it("runSideClose prunes scratch worktree when worktree path exists (debug session)", async () => {
+    listSurfaces.mockResolvedValue([{ surfaceId: "s1", title: "🗒 brove:side-1" }]);
+    closePane.mockResolvedValue(undefined);
+    existsSyncMock.mockReturnValue(true); // worktree path exists → debug session
+
+    await runSideClose("brove", "side-1");
+
+    expect(removeWorktreeMock).toHaveBeenCalledWith(
+      "/tmp/brove",
+      "/tmp/brove/.worktrees/brove-side-1",
+    );
+  });
+
+  it("runSideClose does NOT call removeWorktree when worktree path absent (research session)", async () => {
+    listSurfaces.mockResolvedValue([{ surfaceId: "s1", title: "🗒 brove:side-1" }]);
+    closePane.mockResolvedValue(undefined);
+    existsSyncMock.mockReturnValue(false); // no worktree → research session
+
+    await runSideClose("brove", "side-1");
+
+    expect(removeWorktreeMock).not.toHaveBeenCalled();
   });
 
   it("runSideSend sends to the matching pane without touching daemon", async () => {

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -221,6 +221,12 @@ export function buildCompletionProtocol(taskId: string, project: string): string
   ].join("\n");
 }
 
+// POSIX single-quote a path so it is safe to embed in a shell command even
+// when the path contains spaces or special characters.
+function shellQuote(p: string): string {
+  return "'" + p.replace(/'/g, "'\\''") + "'";
+}
+
 export interface CrewSpawnInput {
   project: string;
   task: string;
@@ -389,7 +395,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
     // Prefix the CLI command with env so the hook bridge + signal verb
     // running inside the crew's cmux tab can identify their task.
     const envPrefix = `COCKPIT_CREW_TASK_ID=${rec.id} COCKPIT_CREW_PROJECT=${input.project}`;
-    await runtime.sendToPane(pane, `${envPrefix} ${cliCommand}`);
+    await runtime.sendToPane(pane, `cd ${shellQuote(spawnCwd)} && ${envPrefix} ${cliCommand}`);
     const preLaunchScreen = (await runtime.readPaneScreen(pane)) ?? "";
     await sendFirstTurnWhenReady(runtime, pane, `${input.task}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen);
     return { ...pane, title };
@@ -439,7 +445,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
     const title = titleFor(input.project, name);
     const pane = await runtime.newPane({ workspaceId: captain.id, direction, title });
     const envPrefix = `COCKPIT_CREW_TASK_ID=${rec.id} COCKPIT_CREW_PROJECT=${input.project}`;
-    await runtime.sendToPane(pane, `${envPrefix} OPENCODE_CONFIG=${opencodeConfigPath} ${cliCommand}`);
+    await runtime.sendToPane(pane, `cd ${shellQuote(spawnCwd)} && ${envPrefix} OPENCODE_CONFIG=${opencodeConfigPath} ${cliCommand}`);
     const preLaunchScreen = (await runtime.readPaneScreen(pane)) ?? "";
     await sendFirstTurnWhenReady(runtime, pane, `${input.task}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen, {
       // #235: opencode's idle splash ("Ask anything…") keeps mutating (cursor

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import os from "node:os";
 import chalk from "chalk";
 import { loadConfig } from "../config.js";
+import { resolveCrewRoute } from "../control/crew-routing.js";
 import { createCmuxDriver, RuntimeRegistry } from "../runtimes/index.js";
 import {
   createClaudeDriver,
@@ -224,6 +225,8 @@ export interface CrewSpawnInput {
   /** Per-spawn model override — takes precedence over defaults.roles.crew.model.
    *  Agent-specific alias (e.g. "sonnet", "opus" for claude; "gpt-5.5" for codex). */
   model?: string;
+  /** True when --agent was explicitly passed by the caller; suppresses crew routing. */
+  agentExplicit?: boolean;
 }
 
 export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
@@ -269,13 +272,22 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
       })
     : proj.path;
 
+  // #275 leveled crew routing: consult routing rules when agent/model were not
+  // explicitly provided by the caller. Explicit --agent or --model always win.
+  const route = !input.agentExplicit && !input.model
+    ? resolveCrewRoute(input.task, config)
+    : null;
+  if (route) {
+    console.log(chalk.dim(`routed: tier=${route.tier} → ${route.agent}${route.model ? `/${route.model}` : ""} (rule: "${route.matchedRule}")`));
+  }
+
   const agents = new CapabilityRegistry({
     claude: createClaudeDriver(),
     codex: createCodexDriver(),
     gemini: createGeminiDriver(),
     opencode: createOpencodeDriver(),
   });
-  const agentName = input.agent ?? "claude";
+  const agentName = route?.agent ?? input.agent ?? "claude";
   const agent = agents.get(agentName);
   if (!agent) {
     throw new Error(`Unknown agent '${agentName}'. Known: claude, codex, gemini, opencode.`);
@@ -318,7 +330,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
   // fall back to the agent's own default to avoid passing an invalid model arg.
   const crewRole = config.defaults.roles?.crew;
   const configModel = crewRole && crewRole.agent === agent.name ? crewRole.model : undefined;
-  const crewModel = input.model ?? configModel;
+  const crewModel = input.model ?? route?.model ?? configModel;
 
   // Claude crews route through the control-plane daemon (PR #85 + this spec)
   // so the captain learns terminal state via `cockpit crew status` instead
@@ -674,15 +686,18 @@ crewCommand
       project: string,
       task: string | undefined,
       opts: { name?: string; direction: PanePlacement; agent: string; approval: boolean; worktree: boolean; taskFile?: string; model?: string },
+      cmd: Command,
     ) => {
       try {
         const resolvedTask = await resolveTextInput({ positional: task, filePath: opts.taskFile, label: "task" });
+        const agentExplicit = cmd.getOptionValueSource("agent") === "cli";
         const pane = await runCrewSpawn({
           project,
           task: resolvedTask,
           name: opts.name,
           direction: opts.direction,
           agent: opts.agent,
+          agentExplicit,
           // --approval is provider-agnostic: codex consumes approvalPolicy,
           // opencode consumes the `approval` flag (→ bash:"ask" per-crew config).
           ...(opts.approval ? { approvalPolicy: "untrusted", approval: true } : {}),

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -208,6 +208,19 @@ export async function sendFirstTurnWhenReady(
   }
 }
 
+/** Builds the completion-protocol suffix baked into claude + opencode first turns (#278).
+ *  Substituting --task-id and --project at source makes the signal robust to env-var
+ *  races (Mode 1) and gives the model a concrete imperative at the point of action (Mode 2). */
+export function buildCompletionProtocol(taskId: string, project: string): string {
+  return [
+    "---",
+    "COMPLETION PROTOCOL (required): When this task is fully complete, your FINAL action MUST be to run exactly:",
+    `  cockpit crew signal done --task-id ${taskId} --project ${project} --message "<one-line summary>"`,
+    "Run it as a discrete final step AFTER you report your results. If you are blocked or need a decision, instead run:",
+    `  cockpit crew signal blocked --task-id ${taskId} --project ${project} --question "<your question>"`,
+  ].join("\n");
+}
+
 export interface CrewSpawnInput {
   project: string;
   task: string;
@@ -378,7 +391,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
     const envPrefix = `COCKPIT_CREW_TASK_ID=${rec.id} COCKPIT_CREW_PROJECT=${input.project}`;
     await runtime.sendToPane(pane, `${envPrefix} ${cliCommand}`);
     const preLaunchScreen = (await runtime.readPaneScreen(pane)) ?? "";
-    await sendFirstTurnWhenReady(runtime, pane, input.task, preLaunchScreen);
+    await sendFirstTurnWhenReady(runtime, pane, `${input.task}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen);
     return { ...pane, title };
   }
 
@@ -428,7 +441,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
     const envPrefix = `COCKPIT_CREW_TASK_ID=${rec.id} COCKPIT_CREW_PROJECT=${input.project}`;
     await runtime.sendToPane(pane, `${envPrefix} OPENCODE_CONFIG=${opencodeConfigPath} ${cliCommand}`);
     const preLaunchScreen = (await runtime.readPaneScreen(pane)) ?? "";
-    await sendFirstTurnWhenReady(runtime, pane, input.task, preLaunchScreen, {
+    await sendFirstTurnWhenReady(runtime, pane, `${input.task}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen, {
       // #235: opencode's idle splash ("Ask anything…") keeps mutating (cursor
       // blink, status line toggle), so the old screen-changed check would always
       // see a *different* screen and never re-send a dropped turn. The splashMarker

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -130,7 +130,7 @@ function nextAutoName(existingTitles: string[], project: string): string {
   return `crew-${i}`;
 }
 
-async function resolveCaptainWorkspace(project: string): Promise<{
+export async function resolveCaptainWorkspace(project: string): Promise<{
   runtime: RuntimeDriver;
   workspaceId: string;
 }> {

--- a/src/commands/group.ts
+++ b/src/commands/group.ts
@@ -138,7 +138,7 @@ export const groupCommand = new Command("group")
   .description("Cross-project intra-group operations (Phase 1: dispatch)")
   .addCommand(
     new Command("dispatch")
-      .description("Dispatch a task to a sibling project in the same group")
+      .description("[experimental] Dispatch a task to a sibling project in the same group")
       .argument("<to-project>", "Target project name (must be in the same group)")
       .argument("<task>", "Task description to dispatch")
       .option("--provider <p>", "claude|opencode|codex", "claude")
@@ -149,6 +149,8 @@ export const groupCommand = new Command("group")
           console.error(chalk.red("Could not determine current project from cwd. Run from inside a registered project directory."));
           process.exit(1);
         }
+
+        console.error(chalk.yellow("⚠ cross-project delegation is experimental (#288): boot-if-down of a down sibling may not yet produce an operational captain."));
 
         try {
           const result = await runGroupDispatch({

--- a/src/commands/group.ts
+++ b/src/commands/group.ts
@@ -1,0 +1,169 @@
+// src/commands/group.ts
+//
+// #246: cross-project intra-group delegation. `cockpit group dispatch`
+// sends a task to a sibling project in the same group. The target's captain
+// is woken via the existing mailbox/relay path. A dispatches-and-yields;
+// the origin captain is auto-woken when the task settles (report-back).
+
+import { Command } from "commander";
+import { execSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import chalk from "chalk";
+import { loadConfig, resolveHome, type CockpitConfig } from "../config.js";
+import { sendRequest } from "../control/protocol.js";
+import type { TaskRecord, Provider, Mode } from "../control/types.js";
+
+const SOCK = join(homedir(), ".config", "cockpit", "cockpit.sock");
+const WARMUP_TIMEOUT_MS = 30_000;
+const WARMUP_POLL_MS = 1_000;
+
+/** Resolve the current project name by matching cwd against config paths. */
+export function resolveCurrentProject(config: CockpitConfig): string | null {
+  const cwd = process.cwd();
+  for (const [name, proj] of Object.entries(config.projects)) {
+    const resolvedPath = resolveHome(proj.path);
+    if (cwd.startsWith(resolvedPath)) return name;
+  }
+  return null;
+}
+
+/** Check via the daemon health endpoint whether a project's captain is up. */
+async function isCaptainAlive(project: string): Promise<boolean> {
+  try {
+    const health = (await sendRequest(SOCK, { kind: "health", project }, 5000)) as Array<{
+      kind: string; project: string; state: string;
+    }>;
+    const captain = health?.find((h) => h.kind === "captain" && h.project === project);
+    return captain != null && captain.state !== "gone" && captain.state !== "unknown";
+  } catch {
+    return false;
+  }
+}
+
+/** Poll the daemon health endpoint until the target project's relay is up,
+ *  or the hard timeout expires. Returns true if warmup succeeded. */
+export async function waitForWarmup(
+  project: string,
+  timeoutMs = WARMUP_TIMEOUT_MS,
+  pollMs = WARMUP_POLL_MS,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await isCaptainAlive(project)) return true;
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+  return false;
+}
+
+export interface GroupDispatchOpts {
+  fromProject: string;
+  toProject: string;
+  task: string;
+  provider?: Provider;
+  mode?: Mode;
+  warmupTimeoutMs?: number;
+  warmupPollMs?: number;
+}
+
+/** Pure-ish dispatch function (extracted for testability). */
+export async function runGroupDispatch(opts: GroupDispatchOpts): Promise<TaskRecord> {
+  const config = loadConfig();
+  const fromCfg = config.projects[opts.fromProject];
+  const toCfg = config.projects[opts.toProject];
+
+  if (!toCfg) {
+    throw new Error(`target project '${opts.toProject}' not found in config`);
+  }
+
+  // #246: same-group gate — hard boundary
+  if (!fromCfg.group || !toCfg.group || fromCfg.group !== toCfg.group) {
+    throw new Error(
+      `cannot dispatch: '${opts.toProject}' (group: ${toCfg.group ?? "none"}) ` +
+      `is not in the same group as '${opts.fromProject}' (group: ${fromCfg.group ?? "none"})`,
+    );
+  }
+
+  // #246: acceptDelegations check
+  if (toCfg.acceptDelegations === false) {
+    throw new Error(
+      `cannot dispatch to '${opts.toProject}': project has acceptDelegations set to false`,
+    );
+  }
+
+  // Ensure B's captain/relay is up
+  const alive = await isCaptainAlive(opts.toProject);
+  if (!alive) {
+    try {
+      execSync(`cockpit launch ${opts.toProject}`, { stdio: "ignore", timeout: 15_000 });
+    } catch {
+      throw new Error(`failed to launch captain for '${opts.toProject}' — is cockpit installed?`);
+    }
+
+    const warmed = await waitForWarmup(opts.toProject, opts.warmupTimeoutMs, opts.warmupPollMs);
+    if (!warmed) {
+      throw new Error(
+        `dispatch to '${opts.toProject}' timed out waiting for captain warmup ` +
+        `(>${(opts.warmupTimeoutMs ?? WARMUP_TIMEOUT_MS) / 1000}s)`,
+      );
+    }
+  }
+
+  // Record the task via the daemon
+  const now = Date.now();
+  const attemptId = randomUUID();
+  const record: TaskRecord = {
+    id: randomUUID(),
+    project: opts.toProject,
+    originProject: opts.fromProject,
+    provider: opts.provider ?? "claude",
+    mode: opts.mode ?? "headless",
+    state: "submitted",
+    task: opts.task,
+    createdAt: now,
+    lastHeartbeat: now,
+    lastEvent: "dispatch",
+    heartbeatBudgetMs: 300000,
+    attempts: [{ attemptId, startedAt: now, lastHeartbeatAt: now }],
+  };
+
+  const result = await sendRequest(SOCK, { kind: "dispatch", record }) as TaskRecord;
+  return result;
+}
+
+// ── CLI command ──────────────────────────────────────────────────────────────
+
+export const groupCommand = new Command("group")
+  .description("Cross-project intra-group operations (Phase 1: dispatch)")
+  .addCommand(
+    new Command("dispatch")
+      .description("Dispatch a task to a sibling project in the same group")
+      .argument("<to-project>", "Target project name (must be in the same group)")
+      .argument("<task>", "Task description to dispatch")
+      .option("--provider <p>", "claude|opencode|codex", "claude")
+      .option("--mode <m>", "headless|interactive", "headless")
+      .action(async (toProject: string, task: string, opts: { provider?: Provider; mode?: Mode }) => {
+        const fromProject = resolveCurrentProject(loadConfig());
+        if (!fromProject) {
+          console.error(chalk.red("Could not determine current project from cwd. Run from inside a registered project directory."));
+          process.exit(1);
+        }
+
+        try {
+          const result = await runGroupDispatch({
+            fromProject,
+            toProject,
+            task,
+            provider: opts.provider,
+            mode: opts.mode,
+          });
+          console.log(chalk.green(`✔ Dispatched to '${toProject}' (task ${result.id.slice(0, 8)})`));
+          console.log(chalk.dim(`  originProject: ${result.originProject ?? "none"}`));
+          console.log(chalk.dim("  You will be notified when the task settles (done/blocked/failed)."));
+        } catch (e) {
+          console.error(chalk.red(`✘ ${(e as Error).message}`));
+          process.exit(1);
+        }
+      }),
+  );

--- a/src/commands/side.ts
+++ b/src/commands/side.ts
@@ -1,0 +1,325 @@
+import { Command } from "commander";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import chalk from "chalk";
+import { loadConfig } from "../config.js";
+import { createCmuxDriver, RuntimeRegistry } from "../runtimes/index.js";
+import {
+  createClaudeDriver,
+  createCodexDriver,
+  createGeminiDriver,
+  createOpencodeDriver,
+  CapabilityRegistry,
+} from "../drivers/index.js";
+import type { PaneRef, PanePlacement } from "../runtimes/types.js";
+import { resolveCaptainWorkspace, sendFirstTurnWhenReady } from "./crew.js";
+import { resolveTextInput } from "../lib/resolve-text-input.js";
+
+const TEMPLATES_DIR = path.join(os.homedir(), ".config", "cockpit", "templates");
+
+const SIDE_ROLES = ["research", "debug"] as const;
+type SideRole = (typeof SIDE_ROLES)[number];
+
+// POSIX single-quote a path so it is safe to embed in a shell command even
+// when the path contains spaces or special characters.
+function shellQuote(p: string): string {
+  return "'" + p.replace(/'/g, "'\\''") + "'";
+}
+
+function titleFor(project: string, name: string): string {
+  return `🗒 ${project}:${name}`;
+}
+
+function isSideTitle(project: string, title: string): boolean {
+  return title.startsWith(`🗒 ${project}:`);
+}
+
+function nameFromTitle(project: string, title: string): string {
+  return title.slice(`🗒 ${project}:`.length);
+}
+
+function nextAutoName(existingTitles: string[], project: string): string {
+  const used = new Set<number>();
+  for (const title of existingTitles) {
+    const n = nameFromTitle(project, title).match(/^side-(\d+)$/);
+    if (n) used.add(Number(n[1]));
+  }
+  let i = 1;
+  while (used.has(i)) i++;
+  return `side-${i}`;
+}
+
+/** Builds the first-turn message: topic + injected context the agent needs
+ *  for handoff (spokeVault, project, role). */
+export function buildSideFirstTurn(
+  topic: string,
+  project: string,
+  role: string,
+  spokeVault: string,
+): string {
+  return [
+    topic,
+    "",
+    "---",
+    "Side-session context (for handoff use):",
+    `Project: ${project}`,
+    `Role: ${role}`,
+    `Spoke vault: ${spokeVault}`,
+  ].join("\n");
+}
+
+export interface SideSpawnInput {
+  project: string;
+  topic: string;
+  role: string;
+  name?: string;
+  direction?: PanePlacement;
+  agent?: string;
+}
+
+export async function runSideSpawn(input: SideSpawnInput): Promise<PaneRef> {
+  const config = loadConfig();
+  const proj = config.projects[input.project];
+  if (!proj) {
+    throw new Error(`Project '${input.project}' not found. Run 'cockpit projects list'.`);
+  }
+
+  if (input.role === "debug") {
+    throw new Error(
+      "Side role 'debug' is not yet implemented (Phase 2). Use --role research.",
+    );
+  }
+  if (!SIDE_ROLES.includes(input.role as SideRole)) {
+    throw new Error(
+      `Unknown side role '${input.role}'. Valid roles: ${SIDE_ROLES.join(", ")}.`,
+    );
+  }
+
+  const runtime = new RuntimeRegistry({ cmux: createCmuxDriver() }).forProject(
+    input.project,
+    config,
+  );
+  const captain = await runtime.status(proj.captainName);
+  if (!captain) {
+    throw new Error(
+      `Captain workspace '${proj.captainName}' is not running. Run 'cockpit launch ${input.project}' first.`,
+    );
+  }
+
+  const existing = await runtime.listSurfaces(captain.id);
+  const existingTitles = existing
+    .filter((s) => s.title && isSideTitle(input.project, s.title))
+    .map((s) => s.title!);
+
+  if (input.name) {
+    const wantTitle = titleFor(input.project, input.name);
+    if (existingTitles.includes(wantTitle)) {
+      throw new Error(
+        `Side session '${input.name}' already exists for ${input.project}.`,
+      );
+    }
+  }
+  const name = input.name ?? nextAutoName(existingTitles, input.project);
+
+  const agents = new CapabilityRegistry({
+    claude: createClaudeDriver(),
+    codex: createCodexDriver(),
+    gemini: createGeminiDriver(),
+    opencode: createOpencodeDriver(),
+  });
+  const sideRole = config.defaults.roles?.side;
+  const agentName = input.agent ?? sideRole?.agent ?? "claude";
+  const agent = agents.get(agentName);
+  if (!agent) {
+    throw new Error(`Unknown agent '${agentName}'. Known: claude, codex, gemini, opencode.`);
+  }
+
+  const sideModel = sideRole?.model;
+  const promptFile = path.join(
+    TEMPLATES_DIR,
+    `side.${input.role}.${agent.templateSuffix}.md`,
+  );
+
+  const direction: PanePlacement = input.direction ?? "tab";
+  const title = titleFor(input.project, name);
+  const pane = await runtime.newPane({ workspaceId: captain.id, direction, title });
+
+  const cliCommand = agent.buildCommand({
+    prompt: input.topic,
+    workdir: proj.path,
+    role: "side",
+    promptFile: fs.existsSync(promptFile) ? promptFile : undefined,
+    interactive: true,
+    permissionMode: config.defaults.permissions?.crew ?? "auto",
+    ...(sideModel ? { model: sideModel } : {}),
+  });
+
+  await runtime.sendToPane(pane, `cd ${shellQuote(proj.path)} && ${cliCommand}`);
+  const preLaunchScreen = (await runtime.readPaneScreen(pane)) ?? "";
+
+  const firstTurn = buildSideFirstTurn(
+    input.topic,
+    input.project,
+    input.role,
+    proj.spokeVault ?? "",
+  );
+  await sendFirstTurnWhenReady(runtime, pane, firstTurn, preLaunchScreen);
+
+  return { ...pane, title };
+}
+
+export async function runSideSend(
+  project: string,
+  name: string,
+  message: string,
+): Promise<void> {
+  const { runtime, workspaceId } = await resolveCaptainWorkspace(project);
+  const want = titleFor(project, name);
+  const surfaces = await runtime.listSurfaces(workspaceId);
+  const pane = surfaces.find((s) => s.title === want) ?? null;
+  if (!pane) {
+    throw new Error(
+      `Side session '${name}' not found for ${project}. Run 'cockpit side list ${project}'.`,
+    );
+  }
+  await runtime.sendToPane(pane, message);
+}
+
+export async function runSideList(
+  project: string,
+): Promise<Array<{ name: string; surfaceId: string }>> {
+  const { runtime, workspaceId } = await resolveCaptainWorkspace(project);
+  const surfaces = await runtime.listSurfaces(workspaceId);
+  return surfaces
+    .filter((s) => s.title && isSideTitle(project, s.title))
+    .map((s) => ({
+      name: nameFromTitle(project, s.title!),
+      surfaceId: s.surfaceId,
+    }));
+}
+
+export async function runSideClose(project: string, name: string): Promise<void> {
+  const { runtime, workspaceId } = await resolveCaptainWorkspace(project);
+  const want = titleFor(project, name);
+  const surfaces = await runtime.listSurfaces(workspaceId);
+  const pane = surfaces.find((s) => s.title === want) ?? null;
+  if (!pane) {
+    throw new Error(
+      `Side session '${name}' not found for ${project}. Run 'cockpit side list ${project}'.`,
+    );
+  }
+  await runtime.closePane(pane);
+}
+
+export const sideCommand = new Command("side").description(
+  "Spawn and manage side-sessions (research/debug) — fresh-context tabs off the daemon lifecycle",
+);
+
+sideCommand
+  .command("spawn")
+  .description(
+    "Spawn a fresh-context side-session tab for research or debug (--role required)",
+  )
+  .argument("<project>", "Project name (must be registered)")
+  .argument("[topic]", "Topic or question for the session (omit with --topic-file)")
+  .requiredOption("--role <role>", "Session role: research | debug")
+  .option("--name <name>", "Session name (default: auto-generated side-N)")
+  .option(
+    "--direction <dir>",
+    "Placement: tab (default) or split direction (right|left|up|down)",
+    "tab",
+  )
+  .option("--agent <name>", "Agent CLI to use (claude|opencode)", "claude")
+  .option("--topic-file <path>", "Read topic from file instead of positional arg ('-' for stdin)")
+  .action(
+    async (
+      project: string,
+      topic: string | undefined,
+      opts: { role: string; name?: string; direction: PanePlacement; agent: string; topicFile?: string },
+    ) => {
+      try {
+        const resolvedTopic = await resolveTextInput({
+          positional: topic,
+          filePath: opts.topicFile,
+          label: "topic",
+        });
+        const pane = await runSideSpawn({
+          project,
+          topic: resolvedTopic,
+          role: opts.role,
+          name: opts.name,
+          direction: opts.direction,
+          agent: opts.agent,
+        });
+        console.log(chalk.green(`✔ Side session '${pane.title}' spawned (${pane.surfaceId})`));
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    },
+  );
+
+sideCommand
+  .command("list")
+  .description("List live side-sessions for a project")
+  .argument("<project>", "Project name")
+  .action(async (project: string) => {
+    try {
+      const sessions = await runSideList(project);
+      if (sessions.length === 0) {
+        console.log(chalk.yellow(`No live side-sessions for ${project}.`));
+        return;
+      }
+      for (const s of sessions) {
+        console.log(`  ${s.name}  (${s.surfaceId})`);
+      }
+    } catch (err) {
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+  });
+
+sideCommand
+  .command("send")
+  .description("Send a follow-up message to an existing side-session")
+  .argument("<project>", "Project name")
+  .argument("<name>", "Session name (e.g. side-1)")
+  .argument("[message]", "Message to send (omit with --message-file)")
+  .option("--message-file <path>", "Read message from file ('-' for stdin)")
+  .action(
+    async (
+      project: string,
+      name: string,
+      message: string | undefined,
+      opts: { messageFile?: string },
+    ) => {
+      try {
+        const resolvedMessage = await resolveTextInput({
+          positional: message,
+          filePath: opts.messageFile,
+          label: "message",
+        });
+        await runSideSend(project, name, resolvedMessage);
+        console.log(chalk.green(`✔ Sent to ${project}:${name}`));
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    },
+  );
+
+sideCommand
+  .command("close")
+  .description("Close a side-session (closes its tab)")
+  .argument("<project>", "Project name")
+  .argument("<name>", "Session name")
+  .action(async (project: string, name: string) => {
+    try {
+      await runSideClose(project, name);
+      console.log(chalk.green(`✔ Closed ${project}:${name}`));
+    } catch (err) {
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+  });

--- a/src/commands/side.ts
+++ b/src/commands/side.ts
@@ -15,8 +15,12 @@ import {
 import type { PaneRef, PanePlacement } from "../runtimes/types.js";
 import { resolveCaptainWorkspace, sendFirstTurnWhenReady } from "./crew.js";
 import { resolveTextInput } from "../lib/resolve-text-input.js";
+import { addWorktree, removeWorktree, worktreePath } from "../lib/git-worktree.js";
 
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "cockpit", "templates");
+
+// Debug scratch worktrees branch off develop (same as crew --worktree).
+const WORKTREE_BASE_BRANCH = "develop";
 
 const SIDE_ROLES = ["research", "debug"] as const;
 type SideRole = (typeof SIDE_ROLES)[number];
@@ -51,14 +55,16 @@ function nextAutoName(existingTitles: string[], project: string): string {
 }
 
 /** Builds the first-turn message: topic + injected context the agent needs
- *  for handoff (spokeVault, project, role). */
+ *  for handoff (spokeVault, project, role). For debug sessions, scratchWorktree
+ *  is the isolated worktree path the session is running in. */
 export function buildSideFirstTurn(
   topic: string,
   project: string,
   role: string,
   spokeVault: string,
+  scratchWorktree?: string,
 ): string {
-  return [
+  const lines = [
     topic,
     "",
     "---",
@@ -66,7 +72,11 @@ export function buildSideFirstTurn(
     `Project: ${project}`,
     `Role: ${role}`,
     `Spoke vault: ${spokeVault}`,
-  ].join("\n");
+  ];
+  if (scratchWorktree) {
+    lines.push(`Scratch worktree: ${scratchWorktree}`);
+  }
+  return lines.join("\n");
 }
 
 export interface SideSpawnInput {
@@ -85,11 +95,6 @@ export async function runSideSpawn(input: SideSpawnInput): Promise<PaneRef> {
     throw new Error(`Project '${input.project}' not found. Run 'cockpit projects list'.`);
   }
 
-  if (input.role === "debug") {
-    throw new Error(
-      "Side role 'debug' is not yet implemented (Phase 2). Use --role research.",
-    );
-  }
   if (!SIDE_ROLES.includes(input.role as SideRole)) {
     throw new Error(
       `Unknown side role '${input.role}'. Valid roles: ${SIDE_ROLES.join(", ")}.`,
@@ -122,6 +127,19 @@ export async function runSideSpawn(input: SideSpawnInput): Promise<PaneRef> {
   }
   const name = input.name ?? nextAutoName(existingTitles, input.project);
 
+  // Debug sessions run in an isolated scratch git worktree so instrumentation
+  // edits never touch the captain's checkout. Research sessions share the root
+  // checkout. The #279 fix (cd into spawnCwd before launching CLI) applies to both.
+  const spawnCwd = input.role === "debug"
+    ? addWorktree({
+        repoRoot: proj.path,
+        worktreeDir: config.defaults.worktreeDir ?? ".worktrees",
+        project: input.project,
+        name,
+        base: WORKTREE_BASE_BRANCH,
+      })
+    : proj.path;
+
   const agents = new CapabilityRegistry({
     claude: createClaudeDriver(),
     codex: createCodexDriver(),
@@ -147,7 +165,7 @@ export async function runSideSpawn(input: SideSpawnInput): Promise<PaneRef> {
 
   const cliCommand = agent.buildCommand({
     prompt: input.topic,
-    workdir: proj.path,
+    workdir: spawnCwd,
     role: "side",
     promptFile: fs.existsSync(promptFile) ? promptFile : undefined,
     interactive: true,
@@ -155,7 +173,7 @@ export async function runSideSpawn(input: SideSpawnInput): Promise<PaneRef> {
     ...(sideModel ? { model: sideModel } : {}),
   });
 
-  await runtime.sendToPane(pane, `cd ${shellQuote(proj.path)} && ${cliCommand}`);
+  await runtime.sendToPane(pane, `cd ${shellQuote(spawnCwd)} && ${cliCommand}`);
   const preLaunchScreen = (await runtime.readPaneScreen(pane)) ?? "";
 
   const firstTurn = buildSideFirstTurn(
@@ -163,6 +181,7 @@ export async function runSideSpawn(input: SideSpawnInput): Promise<PaneRef> {
     input.project,
     input.role,
     proj.spokeVault ?? "",
+    input.role === "debug" ? spawnCwd : undefined,
   );
   await sendFirstTurnWhenReady(runtime, pane, firstTurn, preLaunchScreen);
 
@@ -200,6 +219,8 @@ export async function runSideList(
 }
 
 export async function runSideClose(project: string, name: string): Promise<void> {
+  const config = loadConfig();
+  const proj = config.projects[project];
   const { runtime, workspaceId } = await resolveCaptainWorkspace(project);
   const want = titleFor(project, name);
   const surfaces = await runtime.listSurfaces(workspaceId);
@@ -210,6 +231,24 @@ export async function runSideClose(project: string, name: string): Promise<void>
     );
   }
   await runtime.closePane(pane);
+  // Prune the scratch worktree if this was a debug session. Detection is
+  // filesystem-based: debug spawns create a worktree at the deterministic path;
+  // research spawns do not. If the path exists, remove it (best-effort).
+  if (proj) {
+    const wtPath = worktreePath(
+      proj.path,
+      config.defaults.worktreeDir ?? ".worktrees",
+      project,
+      name,
+    );
+    if (fs.existsSync(wtPath)) {
+      try {
+        removeWorktree(proj.path, wtPath);
+      } catch (e) {
+        process.stderr.write(`(worktree remove failed: ${(e as Error).message})\n`);
+      }
+    }
+  }
 }
 
 export const sideCommand = new Command("side").description(

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,5 +1,5 @@
 // src/config.test.ts
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { getDefaultConfig, loadConfig, saveConfig } from "./config.js";
 import fs from "node:fs";
 import os from "node:os";
@@ -58,6 +58,102 @@ describe("config", () => {
     const config = getDefaultConfig();
     expect(config.defaults.models!.crew).toBe("opus");
     expect(config.defaults.permissions.crew).toBe("auto");
+  });
+
+  it("backfills crewRouting when absent and writes it to disk", () => {
+    const configWithoutRouting = {
+      commandName: "command",
+      hubVault: "/tmp/hub",
+      projects: {},
+      defaults: {
+        maxCrew: 5,
+        worktreeDir: ".worktrees",
+        teammateMode: "in-process",
+        permissions: { command: "auto", captain: "auto", crew: "auto" },
+      },
+      metrics: { enabled: true, path: "/tmp/metrics.json" },
+    };
+    fs.writeFileSync(configPath, JSON.stringify(configWithoutRouting));
+
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const loaded = loadConfig(configPath);
+    spy.mockRestore();
+
+    // in-memory result has crewRouting backfilled
+    expect(loaded.defaults.crewRouting).toBeDefined();
+    expect(loaded.defaults.crewRouting!.rules.length).toBeGreaterThan(0);
+
+    // file on disk was updated (migration persisted)
+    const onDisk = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    expect(onDisk.defaults.crewRouting).toBeDefined();
+  });
+
+  it("does not re-persist or re-notice when crewRouting already present", () => {
+    const configWithRouting = {
+      commandName: "command",
+      hubVault: "/tmp/hub",
+      projects: {},
+      defaults: {
+        maxCrew: 5,
+        worktreeDir: ".worktrees",
+        teammateMode: "in-process",
+        permissions: { command: "auto", captain: "auto", crew: "auto" },
+        crewRouting: { rules: [{ tier: "custom", match: "custom", agent: "opencode" }] },
+      },
+      metrics: { enabled: true, path: "/tmp/metrics.json" },
+    };
+    fs.writeFileSync(configPath, JSON.stringify(configWithRouting));
+    const originalMtime = fs.statSync(configPath).mtimeMs;
+
+    // Small delay to ensure mtime would differ if the file were rewritten
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const loaded = loadConfig(configPath);
+
+    // custom rules preserved — not replaced with defaults
+    expect(loaded.defaults.crewRouting!.rules[0].tier).toBe("custom");
+    // file not rewritten (mtime unchanged)
+    expect(fs.statSync(configPath).mtimeMs).toBe(originalMtime);
+    // no stderr notice emitted
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("does not crash or persist when config file does not exist (fallback path)", () => {
+    const missingPath = path.join(tmpDir, "nonexistent.json");
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const loaded = loadConfig(missingPath);
+    spy.mockRestore();
+
+    // fallback returns default config (which has crewRouting) without writing any file
+    expect(loaded.defaults.crewRouting).toBeDefined();
+    expect(fs.existsSync(missingPath)).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("emits a stderr notice exactly once on the backfill path", () => {
+    const configWithoutRouting = {
+      commandName: "command",
+      hubVault: "/tmp/hub",
+      projects: {},
+      defaults: {
+        maxCrew: 5,
+        worktreeDir: ".worktrees",
+        teammateMode: "in-process",
+        permissions: { command: "auto", captain: "auto", crew: "auto" },
+      },
+      metrics: { enabled: true, path: "/tmp/metrics.json" },
+    };
+    fs.writeFileSync(configPath, JSON.stringify(configWithoutRouting));
+
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    loadConfig(configPath);
+    // Second call — file now has crewRouting, so no second notice
+    loadConfig(configPath);
+
+    // notice fired exactly once
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0]).toMatch(/cockpit upgrade/i);
+    spy.mockRestore();
   });
 
   it("migrates old models config to roles on load", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,9 @@ export interface ProjectConfig {
   groupRole?: string;
   runtime?: string;
   workspace?: string;
+  /** #246: when false, `cockpit group dispatch` rejects delegations to this
+   *  project. Defaults to true when absent. */
+  acceptDelegations?: boolean;
 }
 
 export interface PermissionConfig {

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,7 +56,7 @@ export interface RoleAssignment {
   model?: string;
 }
 
-export type RoleConfig = Partial<Record<"command" | "captain" | "crew" | "exploration", RoleAssignment>>;
+export type RoleConfig = Partial<Record<"command" | "captain" | "crew" | "exploration" | "side", RoleAssignment>>;
 
 export interface CockpitConfig {
   /** Package version that last reconciled this config. Absent on legacy/fresh configs. */
@@ -125,6 +125,7 @@ export function getDefaultConfig(): CockpitConfig {
         captain: { agent: "claude", model: "opus" },
         crew: { agent: "claude", model: "opus" },
         exploration: { agent: "claude", model: "haiku" },
+        side: { agent: "claude", model: "opus" },
       },
       taskTimeoutMs: 8 * 60 * 60 * 1000,
       crewRouting: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,17 @@ export interface PermissionConfig {
 
 export type ModelAlias = "opus" | "sonnet" | "haiku";
 
+export interface CrewRoutingRule {
+  tier: string;
+  match: string;
+  agent: string;
+  model?: string;
+}
+
+export interface CrewRoutingConfig {
+  rules: CrewRoutingRule[];
+}
+
 export interface ModelRoutingConfig {
   command: ModelAlias;
   captain: ModelAlias;
@@ -73,6 +84,8 @@ export interface CockpitConfig {
     roles?: RoleConfig;
     /** #225 hard crew task-timeout ceiling (ms). Default: 8h. */
     taskTimeoutMs?: number;
+    /** #275 rule-based crew routing: keyword rules map task text to {agent, model}. Optional — absent = fall through to defaults.roles.crew. */
+    crewRouting?: CrewRoutingConfig;
   };
   metrics: {
     enabled: boolean;
@@ -114,6 +127,14 @@ export function getDefaultConfig(): CockpitConfig {
         exploration: { agent: "claude", model: "haiku" },
       },
       taskTimeoutMs: 8 * 60 * 60 * 1000,
+      crewRouting: {
+        rules: [
+          { tier: "extreme", match: "redesign|architect|rewrite|from scratch|deep reasoning", agent: "claude", model: "opus" },
+          { tier: "hard", match: "refactor|migrate|implement|feature|daemon|control-plane", agent: "claude", model: "sonnet" },
+          { tier: "mobile", match: "mobile|ios|swift|android|kotlin|react native", agent: "codex" },
+          { tier: "daily", match: "typo|rename|bump|docs|comment|lint|format", agent: "opencode" },
+        ],
+      },
     },
     metrics: {
       enabled: true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import chalk from "chalk";
 
 export interface ProjectConfig {
   path: string;
@@ -163,6 +164,18 @@ export function loadConfig(configPath = DEFAULT_CONFIG_PATH): CockpitConfig {
     // Ensure agents has at least claude
     if (!config.agents) {
       config.agents = { claude: { cli: "claude", driver: "claude" } };
+    }
+
+    // #286: backfill crewRouting for configs written before routing existed
+    if (!config.defaults.crewRouting) {
+      config.defaults.crewRouting = getDefaultConfig().defaults.crewRouting;
+      saveConfig(config, configPath);
+      console.error(
+        chalk.cyan(
+          "⬆ cockpit upgrade: added default crew routing rules to your config (leveled routing now active). " +
+          "Edit defaults.crewRouting in ~/.config/cockpit/config.json or use the cockpit:add-pick-crew-rule skill.",
+        ),
+      );
     }
 
     return config;

--- a/src/control/__tests__/cockpitd-claude-interactive.test.ts
+++ b/src/control/__tests__/cockpitd-claude-interactive.test.ts
@@ -7,10 +7,10 @@ import { startCockpitd } from "../cockpitd.js";
 import { sendRequest } from "../protocol.js";
 
 describe("cockpitd claude interactive wiring", () => {
-  let stop: (() => void) | undefined;
+  let stop: (() => Promise<void>) | undefined;
   let dir: string;
-  afterEach(() => {
-    stop?.();
+  afterEach(async () => {
+    await stop?.();
     if (dir) rmSync(dir, { recursive: true, force: true });
   });
 

--- a/src/control/__tests__/crew-routing.test.ts
+++ b/src/control/__tests__/crew-routing.test.ts
@@ -88,3 +88,14 @@ describe("resolveCrewRoute", () => {
     expect(result?.agent).toBe("opencode");
   });
 });
+
+// Regression: shipped default ruleset ordering (extreme → hard → mobile → daily)
+import { getDefaultConfig } from "../../config.js";
+
+describe("resolveCrewRoute — shipped default config ordering", () => {
+  it("'implement mobile feature' resolves to hard/claude/sonnet, not mobile/codex (hard rule precedes mobile in default ruleset)", () => {
+    const config = getDefaultConfig();
+    const result = resolveCrewRoute("implement mobile feature", config);
+    expect(result).toMatchObject({ tier: "hard", agent: "claude", model: "sonnet" });
+  });
+});

--- a/src/control/__tests__/crew-routing.test.ts
+++ b/src/control/__tests__/crew-routing.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { resolveCrewRoute } from "../crew-routing.js";
+import type { CockpitConfig } from "../../config.js";
+
+function makeConfig(overrides?: Partial<CockpitConfig["defaults"]>): CockpitConfig {
+  return {
+    commandName: "command",
+    hubVault: "~/hub",
+    projects: {},
+    defaults: {
+      maxCrew: 5,
+      worktreeDir: ".worktrees",
+      teammateMode: "in-process",
+      permissions: { command: "auto", captain: "auto" },
+      crewRouting: {
+        rules: [
+          { tier: "extreme", match: "redesign|architect|rewrite", agent: "claude", model: "opus" },
+          { tier: "hard", match: "refactor|implement|feature", agent: "claude", model: "sonnet" },
+          { tier: "mobile", match: "mobile|ios|swift", agent: "codex" },
+          { tier: "daily", match: "typo|docs|lint", agent: "opencode" },
+        ],
+      },
+      ...overrides,
+    },
+    metrics: { enabled: false, path: "" },
+  };
+}
+
+describe("resolveCrewRoute", () => {
+  it("returns null when crewRouting is absent", () => {
+    const config = makeConfig({ crewRouting: undefined });
+    expect(resolveCrewRoute("refactor the auth module", config)).toBeNull();
+  });
+
+  it("returns null when rules array is empty", () => {
+    const config = makeConfig({ crewRouting: { rules: [] } });
+    expect(resolveCrewRoute("refactor the auth module", config)).toBeNull();
+  });
+
+  it("returns null when no rule matches", () => {
+    const config = makeConfig();
+    expect(resolveCrewRoute("update the README with examples", config)).toBeNull();
+  });
+
+  it("matches the extreme tier on 'redesign'", () => {
+    const config = makeConfig();
+    const result = resolveCrewRoute("redesign the auth system", config);
+    expect(result).toMatchObject({ tier: "extreme", agent: "claude", model: "opus" });
+  });
+
+  it("matches the hard tier on 'refactor'", () => {
+    const config = makeConfig();
+    const result = resolveCrewRoute("refactor the daemon module", config);
+    expect(result).toMatchObject({ tier: "hard", agent: "claude", model: "sonnet" });
+  });
+
+  it("first-match-wins: extreme rule fires before hard when both could match", () => {
+    const config = makeConfig();
+    // "rewrite" matches extreme; "implement" matches hard — extreme rule comes first
+    const result = resolveCrewRoute("rewrite and implement the new api", config);
+    expect(result?.tier).toBe("extreme");
+  });
+
+  it("matches are case-insensitive", () => {
+    const config = makeConfig();
+    expect(resolveCrewRoute("REFACTOR the auth module", config)).toMatchObject({ tier: "hard" });
+    expect(resolveCrewRoute("Fix a TYPO in the readme", config)).toMatchObject({ tier: "daily" });
+  });
+
+  it("returns a rule without model when the rule omits model (mobile tier)", () => {
+    const config = makeConfig();
+    const result = resolveCrewRoute("mobile ios layout fixes", config);
+    expect(result?.tier).toBe("mobile");
+    expect(result?.agent).toBe("codex");
+    expect(result?.model).toBeUndefined();
+  });
+
+  it("returns matchedRule with the original regex string", () => {
+    const config = makeConfig();
+    const result = resolveCrewRoute("implement a new login flow", config);
+    expect(result?.matchedRule).toBe("refactor|implement|feature");
+  });
+
+  it("falls through to later rules when earlier rules don't match", () => {
+    const config = makeConfig();
+    const result = resolveCrewRoute("fix a typo in the readme", config);
+    expect(result?.tier).toBe("daily");
+    expect(result?.agent).toBe("opencode");
+  });
+});

--- a/src/control/__tests__/daemon.test.ts
+++ b/src/control/__tests__/daemon.test.ts
@@ -736,3 +736,122 @@ describe("daemon handle() socket-boundary validation (#87)", () => {
   });
 });
 
+// ── Issue #246: cross-project delegation report-back ──────────────────────────
+
+describe("daemon report-back on settle with originProject (#246)", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "cp-246-")); });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  function rec246(id: string, overrides: Partial<TaskRecord> = {}): TaskRecord {
+    return {
+      id, project: "projB", provider: "claude", mode: "interactive",
+      state: "working", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000,
+      attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }],
+      originProject: "projA",
+      ...overrides,
+    };
+  }
+
+  it("fires notify to origin project when task transitions to done", async () => {
+    const store = createStore(dir);
+    const calls: Array<{ project: string; message: string }> = [];
+    const notify = vi.fn(async (a: { project: string; message: string }) => { calls.push(a); });
+    store.put(rec246("t-done"));
+    const d = createDaemon({ store, now: () => 2000, notify });
+
+    await d.handle({ kind: "event", project: "projB", event: { type: "task.done", id: "t-done", resultRef: "/tmp/r" } });
+
+    const originCalls = calls.filter((c) => c.project === "projA");
+    expect(originCalls.length).toBe(1);
+    expect(originCalls[0].message).toMatch(/projB.*done|delegat/i);
+  });
+
+  it("fires notify to origin project when task transitions to blocked", async () => {
+    const store = createStore(dir);
+    const calls: Array<{ project: string; message: string }> = [];
+    const notify = vi.fn(async (a: { project: string; message: string }) => { calls.push(a); });
+    store.put(rec246("t-blocked"));
+    const d = createDaemon({ store, now: () => 2000, notify });
+
+    await d.handle({ kind: "event", project: "projB", event: { type: "task.blocked", id: "t-blocked", reason: "stuck", question: "help" } });
+
+    const originCalls = calls.filter((c) => c.project === "projA");
+    expect(originCalls.length).toBe(1);
+    expect(originCalls[0].message).toMatch(/blocked|stuck/i);
+  });
+
+  it("fires notify to origin project when task transitions to failed", async () => {
+    const store = createStore(dir);
+    const calls: Array<{ project: string; message: string }> = [];
+    const notify = vi.fn(async (a: { project: string; message: string }) => { calls.push(a); });
+    store.put(rec246("t-failed"));
+    const d = createDaemon({ store, now: () => 2000, notify });
+
+    await d.handle({ kind: "event", project: "projB", event: { type: "task.failed", id: "t-failed", error: "oops" } });
+
+    const originCalls = calls.filter((c) => c.project === "projA");
+    expect(originCalls.length).toBe(1);
+    expect(originCalls[0].message).toMatch(/failed|oops/i);
+  });
+
+  it("does NOT fire report-back when task has no originProject", async () => {
+    const store = createStore(dir);
+    const calls: Array<{ project: string; message: string }> = [];
+    const notify = vi.fn(async (a: { project: string; message: string }) => { calls.push(a); });
+    store.put(rec246("t-no-origin", { originProject: undefined }));
+    const d = createDaemon({ store, now: () => 2000, notify });
+
+    await d.handle({ kind: "event", project: "projB", event: { type: "task.done", id: "t-no-origin", resultRef: "/tmp/r" } });
+
+    const originCalls = calls.filter((c) => c.project === "projA");
+    expect(originCalls.length).toBe(0);
+  });
+
+  it("does NOT fire report-back when task settles but originProject equals project (self-delegation no-op)", async () => {
+    const store = createStore(dir);
+    const calls: Array<{ project: string; message: string }> = [];
+    const notify = vi.fn(async (a: { project: string; message: string }) => { calls.push(a); });
+    store.put(rec246("t-self", { originProject: "projB" })); // same as project
+    const d = createDaemon({ store, now: () => 2000, notify });
+
+    await d.handle({ kind: "event", project: "projB", event: { type: "task.done", id: "t-self", resultRef: "/tmp/r" } });
+
+    // Exactly 1 notify call: the normal CREW DONE (no extra report-back since
+    // originProject === project).
+    expect(calls.length).toBe(1);
+    expect(calls[0].project).toBe("projB");
+  });
+
+  it("fires notify to origin project on stall (sweep-synthetic)", async () => {
+    const store = createStore(dir);
+    const calls: Array<{ project: string; message: string }> = [];
+    const notify = vi.fn(async (a: { project: string; message: string }) => { calls.push(a); });
+    store.put(rec246("t-stall", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 100, mode: "headless" }));
+    const d = createDaemon({ store, now: () => 2000, notify });
+
+    await d.sweep();
+
+    const originCalls = calls.filter((c) => c.project === "projA");
+    expect(originCalls.length).toBe(1);
+    expect(originCalls[0].message).toMatch(/stall|no heartbeat/i);
+  });
+
+  it("dispatched task with originProject notifies B (target) mailbox with delegation message", async () => {
+    const store = createStore(dir);
+    const calls: Array<{ project: string; message: string }> = [];
+    const notify = vi.fn(async (a: { project: string; message: string }) => { calls.push(a); });
+    const d = createDaemon({ store, now: () => 2000, notify });
+
+    await d.handle({
+      kind: "dispatch",
+      record: rec246("t-deleg", { state: "submitted", project: "projB", originProject: "projA" }),
+    });
+
+    const bCalls = calls.filter((c) => c.project === "projB");
+    expect(bCalls.length).toBe(1);
+    expect(bCalls[0].message).toMatch(/cross.project|projA/i);
+  });
+});
+

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -553,12 +553,11 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   }
 
   return {
-    stop() {
+    stop(): Promise<void> {
       if (timer) clearInterval(timer);
       if (rotationTimer) clearInterval(rotationTimer);
       for (const kill of activeHeadlessKills) kill();
-      server.close();
-      log("stopped");
+      return new Promise<void>((resolve) => server.close(() => { log("stopped"); resolve(); }));
     },
   };
 }

--- a/src/control/crew-routing.ts
+++ b/src/control/crew-routing.ts
@@ -1,0 +1,30 @@
+import type { CockpitConfig } from "../config.js";
+
+export interface CrewRouteResult {
+  agent: string;
+  model?: string;
+  tier: string;
+  matchedRule: string;
+}
+
+/**
+ * Resolve a crew route from task text against config.defaults.crewRouting.rules.
+ * Returns the first matching rule's agent/model, or null if no rule matches or
+ * crewRouting is absent. Pure — no side effects.
+ */
+export function resolveCrewRoute(taskText: string, config: CockpitConfig): CrewRouteResult | null {
+  const rules = config.defaults.crewRouting?.rules;
+  if (!rules || rules.length === 0) return null;
+  for (const rule of rules) {
+    const re = new RegExp(rule.match, "i");
+    if (re.test(taskText)) {
+      return {
+        agent: rule.agent,
+        ...(rule.model !== undefined ? { model: rule.model } : {}),
+        tier: rule.tier,
+        matchedRule: rule.match,
+      };
+    }
+  }
+  return null;
+}

--- a/src/control/daemon.ts
+++ b/src/control/daemon.ts
@@ -133,6 +133,25 @@ function formatMessage(rec: TaskRecord, event?: ControlEvent): string | null {
   }
 }
 
+/** #246: cross-project delegation report-back message. Called when a task
+ *  with originProject settles to a terminal state. Returns a captain-facing
+ *  one-liner that the origin's relay delivers verbatim. */
+function formatDelegationReport(rec: TaskRecord, originProject: string, targetProject: string): string | null {
+  const shortTask = (rec.task ?? "").split(/\r?\n/)[0]?.trim().slice(0, 120) ?? "";
+  switch (rec.state) {
+    case "done":
+      return `✅ Cross-project task → ${targetProject}: done — ${shortTask}`;
+    case "blocked":
+      return `⛔ Cross-project task → ${targetProject}: blocked — ${(rec.question ?? "(no question)").trim()}`;
+    case "failed":
+      return `⛔ Cross-project task → ${targetProject}: failed — ${(rec.error ?? "(no error)").trim()}`;
+    case "stalled":
+      return `⚠️ Cross-project task → ${targetProject}: stalled (no heartbeat in ${rec.heartbeatBudgetMs}ms)`;
+    default:
+      return null;
+  }
+}
+
 function firePush(
   deps: DaemonDeps,
   project: string,
@@ -165,6 +184,21 @@ function firePush(
     }
   } catch {
     // intentionally swallowed
+  }
+  // #246: cross-project delegation report-back. When a delegated task settles
+  // (done/blocked/failed/stalled/cancelled), fan the outcome back to the origin
+  // project's mailbox so A's relay wakes A's captain (dispatch-and-yield, never
+  // poll). 'awaiting-input' is excluded — the origin doesn't need a noise push
+  // every time the target crew ends a turn.
+  const reportState = next.state === "done" || next.state === "blocked" || next.state === "failed" || next.state === "stalled" || next.state === "cancelled";
+  if (next.originProject && next.originProject !== project && reportState) {
+    const originMsg = formatDelegationReport(next, next.originProject, project);
+    if (originMsg && deps.notify) {
+      try {
+        const r = deps.notify({ project: next.originProject, message: originMsg, record: next, event });
+        if (r && typeof (r as Promise<void>).catch === "function") (r as Promise<void>).catch(() => {});
+      } catch { /* swallowed */ }
+    }
   }
 }
 
@@ -228,6 +262,20 @@ export function createDaemon(deps: DaemonDeps) {
       switch (req.kind) {
         case "dispatch": {
           store.put(req.record);
+          // #246: cross-project delegation — notify B's mailbox so B's relay
+          // wakes B's captain with the request. Skip auto-launch; B's captain
+          // decides how to execute (typically spawns a crew).
+          if (req.record.originProject) {
+            const origin = req.record.originProject;
+            const msg = `📨 Cross-project task from ${origin}: ${req.record.task}`;
+            if (deps.notify) {
+              try {
+                const r = deps.notify({ project: req.record.project, message: msg, record: req.record, event: { type: "task.started", id: req.record.id } });
+                if (r && typeof (r as Promise<void>).catch === "function") (r as Promise<void>).catch(() => {});
+              } catch { /* swallowed — flaky notifier must not break dispatch */ }
+            }
+            return req.record;
+          }
           if (req.record.mode === "headless" && deps.launchHeadless) {
             deps.launchHeadless(req.record).catch((e: unknown) => {
               const error = e instanceof Error ? e.message : String(e);

--- a/src/control/types.ts
+++ b/src/control/types.ts
@@ -73,6 +73,10 @@ export interface TaskRecord {
    *  (`opencode --port <N>`). The daemon's SSE bridge subscribes to
    *  http://127.0.0.1:<serverPort>/event for reliable turn-end detection. */
   serverPort?: number;
+  /** #246: cross-project intra-group delegation — set to the origin project's
+   *  name when this task was dispatched by a sibling captain. When the task
+   *  settles, the daemon fans the outcome back to originProject's mailbox. */
+  originProject?: string;
 }
 
 export type ControlEvent =

--- a/src/drivers/types.ts
+++ b/src/drivers/types.ts
@@ -8,7 +8,7 @@ export type AgentCapability =
   | "streaming"
   | "prompt_file";
 
-export type Role = "command" | "captain" | "crew" | "exploration";
+export type Role = "command" | "captain" | "crew" | "exploration" | "side";
 
 export interface AgentProbeResult {
   installed: boolean;
@@ -70,4 +70,5 @@ export const ROLE_REQUIREMENTS: Record<Role, RoleRequirements> = {
   captain:     { required: ["auto_approve"], preferred: ["teams", "model_routing", "skills"] },
   crew:        { required: ["auto_approve"], preferred: ["json_output", "sandbox"] },
   exploration: { required: ["auto_approve"], preferred: [] },
+  side:        { required: ["auto_approve"], preferred: ["skills"] },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { projectsCommand } from "./commands/projects.js";
 import { statusCommand } from "./commands/status.js";
 import { commandCommand } from "./commands/command.js";
 import { crewCommand } from "./commands/crew.js";
+import { sideCommand } from "./commands/side.js";
 import { addControlPlaneCrewCommands } from "./commands/crew-control.js";
 import { dashboardCommand } from "./commands/dashboard.js";
 import { launchCommand } from "./commands/launch.js";
@@ -93,6 +94,7 @@ program.addCommand(statusCommand);
 // `cockpit crew` command so PR #85 doesn't break the captain-ops playbook.
 addControlPlaneCrewCommands(crewCommand);
 program.addCommand(crewCommand);
+program.addCommand(sideCommand);
 program.addCommand(commandCommand);
 program.addCommand(dashboardCommand);
 program.addCommand(launchCommand);

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import { projectionCommand } from "./commands/projection.js";
 import { codexChatSmokeCommand } from "./commands/codex-chat-smoke.js";
 import { configCommand } from "./commands/config.js";
 import { healCommand } from "./commands/heal.js";
+import { groupCommand } from "./commands/group.js";
 import { detectDrift } from "./lib/config-drift.js";
 import { needsCheck, withStamp } from "./lib/config-version.js";
 import { getDefaultConfig } from "./config.js";
@@ -108,6 +109,7 @@ program.addCommand(projectionCommand);
 program.addCommand(codexChatSmokeCommand);
 program.addCommand(configCommand);
 program.addCommand(healCommand);
+program.addCommand(groupCommand);
 
 program.parseAsync().catch((e) => {
   process.stderr.write(`error: ${e instanceof Error ? e.message : String(e)}\n`);

--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -304,7 +304,10 @@ describe("cmux driver", () => {
   });
 
   it("sendToSurface sanitizes multi-line messages", async () => {
-    execFileMock.mockReturnValue("");
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return makeTestScreen("\u276F \u258C");
+      return "";
+    });
     await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "multi\nline\r\ntext");
     const sendCall = execFileMock.mock.calls.find((c) => argvOf(c)[0] === "send");
     expect(sendCall).toBeDefined();
@@ -344,11 +347,14 @@ describe("cmux driver", () => {
     expect(text).toBe("");
   });
 
-  // #258: when no draft is detected (empty screen / cursor-only), deliver
+  // #258: when no draft is detected (cursor-only input box), deliver
   // message+Enter directly with no key-chord preamble. ctrl-u/ctrl+a/ctrl+k/
   // ctrl+y are all no-ops against Claude Code's input box.
   it("sendToSurface delivers message+Enter directly when no draft detected", async () => {
-    execFileMock.mockReturnValue("");
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return makeTestScreen("\u276F \u258C");
+      return "";
+    });
     await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done");
     const calls = execFileMock.mock.calls.map(argvOf);
 
@@ -367,7 +373,10 @@ describe("cmux driver", () => {
   });
 
   it("sendToSurface delivers shell metacharacters as literal text scoped to surface", async () => {
-    execFileMock.mockReturnValue("");
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return makeTestScreen("\u276F \u258C");
+      return "";
+    });
     const text = 'done: `cmux close-workspace` $(whoami)';
     await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, text);
     const sendCall = execFileMock.mock.calls.find((c) => argvOf(c)[0] === "send");
@@ -564,32 +573,30 @@ describe("sendToSurface draft-preservation", () => {
     expect(cmdsAfterRestore.every((c) => !c.includes("Enter"))).toBe(true);
   });
 
-  it("delivers normally when read-screen throws, without crashing", async () => {
+  // #268: unreadable screen → draft stays null → DeferDelivery (never deliver into unknown state).
+  it("throws DeferDelivery when read-screen throws (surface unreadable — defer, not deliver)", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
       if (args.includes("read-screen")) throw new Error("surface gone");
       return "";
     });
     await expect(
       driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done"),
-    ).resolves.toBeUndefined();
+    ).rejects.toBeInstanceOf(DeferDelivery);
     const cmds = execFileMock.mock.calls.map(cmdOf);
-    // Still delivers the message
-    expect(cmds.some((c) => c.includes("send ") && c.includes("crew done"))).toBe(true);
-    expect(cmds.some((c) => c.includes("send-key") && c.includes("Enter"))).toBe(true);
-    // No ctrl-u on failure path
-    expect(cmds.every((c) => !c.includes("ctrl-u"))).toBe(true);
+    // Must not have sent anything — deferred
+    expect(cmds.filter((c) => c.startsWith("send ") && !c.startsWith("send-key"))).toHaveLength(0);
   });
 });
 
 describe("parseDraftFromScreen", () => {
-  it("returns empty string for empty screen", () => {
-    expect(parseDraftFromScreen("")).toBe("");
+  it("returns null for empty screen (input box not confirmed visible — defer)", () => {
+    expect(parseDraftFromScreen("")).toBeNull();
   });
 
-  it("returns empty string when screen has no HR boundaries (cannot locate input box)", () => {
-    // No long ─ HR lines → cannot locate input box → safe fallback is ""
+  it("returns null when screen has no HR boundaries (overlay/unknown — must defer, not deliver)", () => {
+    // No long ─ HR lines → cannot confirm input box → null signals DEFER (#268)
     const screen = "Claude Code\nsome transcript\n> looks like input but no HR box";
-    expect(parseDraftFromScreen(screen)).toBe("");
+    expect(parseDraftFromScreen(screen)).toBeNull();
   });
 
   it("returns empty string when input box is empty (cursor only)", () => {
@@ -660,6 +667,35 @@ describe("parseDraftFromScreen", () => {
       "utf-8",
     );
     expect(parseDraftFromScreen(fixture)).toBe("");
+  });
+
+  // #268: overlay/menu/scrolled screen — HR boundaries absent → input box NOT confirmed.
+  // Must return null (not "") so the delivery gate knows to defer, never keystroke into unknown UI.
+  it("returns null when screen has no HR boundaries (overlay / menu / scrolled-away input box)", () => {
+    // No ─{10,} HR lines → topHR stays -1 → box not confirmed visible
+    const overlayScreen = [
+      " ╔══════════════════════════════════════╗",
+      " ║  /model                              ║",
+      " ║  ❯ claude-opus-4-8   (Powerful)      ║",
+      " ║    claude-sonnet-4-6 (Fast)          ║",
+      " ║  [Enter] Select  [Esc] Cancel        ║",
+      " ╚══════════════════════════════════════╝",
+      "   Model: Opus 4.8  Ctx Used: 31%",
+    ].join("\n");
+    expect(parseDraftFromScreen(overlayScreen)).toBeNull();
+  });
+
+  it("returns null for empty screen (input box not confirmed visible)", () => {
+    expect(parseDraftFromScreen("")).toBeNull();
+  });
+
+  // Regression fixture: real overlay screen captured for #268.
+  it("returns null for real overlay fixture (regression #268)", () => {
+    const fixture = readFileSync(
+      join(process.cwd(), "docs/reports/268-overlay-fixture.txt"),
+      "utf-8",
+    );
+    expect(parseDraftFromScreen(fixture)).toBeNull();
   });
 });
 
@@ -735,7 +771,10 @@ describe("sendToSurface Approach B (#258 deliver-when-empty)", () => {
   });
 
   it("empty input → delivers directly (no backspace, no restore)", async () => {
-    execFileMock.mockReturnValue("");
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return makeTestScreen("\u276F \u258C");
+      return "";
+    });
     await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done");
     const calls = execFileMock.mock.calls.map(argvOf);
     // No backspaces — nothing to clear
@@ -748,6 +787,31 @@ describe("sendToSurface Approach B (#258 deliver-when-empty)", () => {
     // No restore send after Enter
     const afterEnter = calls.slice(enterIdx + 1);
     expect(afterEnter.filter((a) => a[0] === "send")).toHaveLength(0);
+  });
+
+  // #268: overlay / unknown screen → input box NOT positively confirmed → must defer,
+  // never keystroke into an overlay or scrolled-away surface.
+  it("throws DeferDelivery when read-screen returns a screen with no input-box boundaries (overlay/menu)", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) {
+        // No ─{10,} HR lines → parseDraftFromScreen returns null → must defer
+        return [
+          " ╔══════════════════════════════════════╗",
+          " ║  /model                              ║",
+          " ║  ❯ claude-opus-4-8   (Powerful)      ║",
+          " ║    claude-sonnet-4-6 (Fast)          ║",
+          " ║  [Enter] Select  [Esc] Cancel        ║",
+          " ╚══════════════════════════════════════╝",
+        ].join("\n");
+      }
+      return "";
+    });
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done"),
+    ).rejects.toBeInstanceOf(DeferDelivery);
+    // Must not have sent anything into the overlay
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.filter((c) => c.startsWith("send ") && !c.startsWith("send-key"))).toHaveLength(0);
   });
 
   it("non-empty draft + force=true → backspace clear, deliver, restore without Enter", async () => {

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -79,18 +79,22 @@ export function sanitizeForCmuxSend(text: string): string {
 }
 
 /**
- * Extract the in-progress draft from a cmux read-screen capture (#258).
+ * Extract the in-progress draft from a cmux read-screen capture (#258 / #268).
  * Scans from the bottom of the screen so history lines that contain `> ` are
  * ignored; only the actual input area (the last matching line) is returned.
  * Handles both `>` (synthetic/test) and `❯` (U+276F, the real Claude Code
  * prompt character) as the input caret. The real prompt is followed by a
  * non-breaking space (U+00A0); JS `\s` covers it, so `\s+` matches either.
  * Also handles box-drawing `│ ❯ text │` variants.
- * Returns the trimmed draft text, or "" when the line holds only a cursor
- * indicator (▌ / █) or no input line is present.
+ *
+ * Three-state return (#268):
+ *   "draft text" — input box found with content  → caller must DEFER
+ *   ""           — input box positively confirmed empty → caller may DELIVER
+ *   null         — HR boundaries not found (overlay/menu/scrolled) → caller must DEFER
  */
-export function parseDraftFromScreen(screen: string): string {
-  if (!screen) return "";
+export function parseDraftFromScreen(screen: string): string | null {
+  // Empty screen means the input box is definitely not visible — defer (#268).
+  if (!screen) return null;
   const lines = screen.split(/\r?\n/);
 
   // Locate the last two HR lines (runs of U+2500 ─) — they are the bottom and top
@@ -111,9 +115,9 @@ export function parseDraftFromScreen(screen: string): string {
     }
   }
 
-  // Can't locate both boundaries — return "" so delivery proceeds rather than
-  // restoring garbage into the captain's input box.
-  if (topHR === -1) return "";
+  // Can't locate both boundaries — input box not visible (overlay/menu/scrolled
+  // transcript). Defer so keystrokes never land in an unknown UI state (#268).
+  if (topHR === -1) return null;
 
   // Extract content lines strictly between the two HRs (the live input box only).
   const inputLines = lines.slice(topHR + 1, bottomHR);
@@ -321,13 +325,18 @@ export function createCmuxDriver(): RuntimeDriver {
     },
 
     async sendToSurface(surface: PaneRef, text: string, opts?: { force?: boolean }): Promise<void> {
-      // #258 Approach B: deliver only when the captain's input is empty.
-      // Read screen once; treat unreadable as empty so delivery always proceeds.
-      let draft = "";
+      // #258/#268 Approach B: deliver only when the captain's input is positively
+      // confirmed empty. null = box not visible (overlay/menu/scroll) → always defer.
+      let draft: string | null = null;
       try {
         const screen = cmux(["read-screen", "--workspace", surface.workspaceId, "--surface", surface.surfaceId]);
         draft = parseDraftFromScreen(screen);
-      } catch { /* screen unreadable — treat as empty, deliver directly */ }
+      } catch { /* screen unreadable — draft stays null, will defer below */ }
+
+      // null = box not confirmed visible → never keystroke into an overlay (#268).
+      if (draft === null) {
+        throw new DeferDelivery();
+      }
 
       if (draft && !opts?.force) {
         // Captain is composing — defer until input clears (relay retries next poll).


### PR DESCRIPTION
## Release v0.6.0

Coordination-layer release: **leveled crew routing** + **side-sessions framework**, two crew-lifecycle reliability fixes (crew `DONE` now fires unprompted; `--worktree` crews isolated), and **experimental** cross-project intra-group delegation.

### Highlights
- **Leveled crew routing** (#275/#276) — configurable `defaults.crewRouting` tiers pick crew agent+model by task.
- **Side-sessions framework** (#283/#284/#285) — `cockpit side spawn --role research|debug`, off the daemon lifecycle, opus, offer-and-confirm handoff.
- **Crew `DONE` lifecycle fix** (#278/#281) — completion-protocol baked into claude/opencode first turns + captain-side IDLE reconciliation.
- **Worktree isolation fix** (#279/#282) — crew launch `cd`s into the spawn cwd.
- **Cross-project delegation — EXPERIMENTAL** (#246/#274) — `cockpit group dispatch`; boot-if-down of a down sibling not yet reliable (#288).
- **PR-time CI** (#273) + **crewRouting config-migration backfill** (#286/#289).

Full notes in CHANGELOG.md. Bumps 0.5.4 → 0.6.0.

Merging to `main` triggers `release.yml` (tag `v0.6.0` + GitHub release).