### PR TITLE
fix(group): boot-if-down warmup fix for cold captain launches (#288)

### DIFF
--- a/src/commands/__tests__/group.test.ts
+++ b/src/commands/__tests__/group.test.ts
@@ -63,10 +63,11 @@ const makeConfig = (overrides: Record<string, any> = {}) => {
 };
 
 describe("groupCommand dispatch description", () => {
-  it("marks dispatch as [experimental]", () => {
+  it("registers a dispatch subcommand", () => {
     const dispatch = groupCommand.commands.find((c) => c.name() === "dispatch");
     expect(dispatch).toBeDefined();
-    expect(dispatch!.description()).toMatch(/\[experimental\]/i);
+    // [experimental] marker dropped once #288 boot-if-down path was fixed
+    expect(dispatch!.description()).toMatch(/dispatch a task/i);
   });
 });
 

--- a/src/commands/group.ts
+++ b/src/commands/group.ts
@@ -16,7 +16,10 @@ import { sendRequest } from "../control/protocol.js";
 import type { TaskRecord, Provider, Mode } from "../control/types.js";
 
 const SOCK = join(homedir(), ".config", "cockpit", "cockpit.sock");
-const WARMUP_TIMEOUT_MS = 30_000;
+// #288: 30s was too short — cold captain boot + relay supervisor startup takes
+// 45-90s. 120s gives the full chain (Claude init + checklist + relay register)
+// comfortable headroom while still failing fast on a genuinely broken launch.
+const WARMUP_TIMEOUT_MS = 120_000;
 const WARMUP_POLL_MS = 1_000;
 
 /** Resolve the current project name by matching cwd against config paths. */
@@ -138,19 +141,18 @@ export const groupCommand = new Command("group")
   .description("Cross-project intra-group operations (Phase 1: dispatch)")
   .addCommand(
     new Command("dispatch")
-      .description("[experimental] Dispatch a task to a sibling project in the same group")
+      .description("Dispatch a task to a sibling project in the same group")
       .argument("<to-project>", "Target project name (must be in the same group)")
       .argument("<task>", "Task description to dispatch")
       .option("--provider <p>", "claude|opencode|codex", "claude")
       .option("--mode <m>", "headless|interactive", "headless")
-      .action(async (toProject: string, task: string, opts: { provider?: Provider; mode?: Mode }) => {
+      .option("--warmup-timeout <s>", "seconds to wait for target captain relay to boot (default: 120)", (v) => parseInt(v, 10) * 1000)
+      .action(async (toProject: string, task: string, opts: { provider?: Provider; mode?: Mode; warmupTimeout?: number }) => {
         const fromProject = resolveCurrentProject(loadConfig());
         if (!fromProject) {
           console.error(chalk.red("Could not determine current project from cwd. Run from inside a registered project directory."));
           process.exit(1);
         }
-
-        console.error(chalk.yellow("⚠ cross-project delegation is experimental (#288): boot-if-down of a down sibling may not yet produce an operational captain."));
 
         try {
           const result = await runGroupDispatch({
@@ -159,6 +161,7 @@ export const groupCommand = new Command("group")
             task,
             provider: opts.provider,
             mode: opts.mode,
+            warmupTimeoutMs: opts.warmupTimeout,
           });
           console.log(chalk.green(`✔ Dispatched to '${toProject}' (task ${result.id.slice(0, 8)})`));
           console.log(chalk.dim(`  originProject: ${result.originProject ?? "none"}`));

--- a/src/commands/launch.ts
+++ b/src/commands/launch.ts
@@ -223,10 +223,12 @@ async function launchWorkspace(
   });
 
   if (initialPrompt) {
-    // Small delay to let agent initialize before sending prompt
+    // #288: cold-boot Claude sessions need ~8s to initialize before they can
+    // receive input. 3s was too short — startup prompt arrived at the loading
+    // screen and was silently dropped, so relay supervisor never ran.
     setTimeout(() => {
       runtime.send(ref.id, initialPrompt).catch(() => { /* best-effort */ });
-    }, 3000);
+    }, 8000);
   }
 
   if (navigate) {


### PR DESCRIPTION
## Summary

Fixes `cockpit group dispatch` failing when targeting a DOWN sibling captain. Two timing gaps in the boot-if-down path caused the 30s warmup to always expire before the relay could register.

**Root cause chain:**
1. `cockpit launch <target>` spawns the captain workspace and sends the startup prompt after **3s** — too short for a cold Claude Code session (takes 5-15s to initialize). The prompt landed on the loading screen and was silently dropped.
2. Even when the prompt was received, the full relay boot chain (Claude init → `cockpit:captain-ops` checklist → `cockpit relay supervise` → daemon registration) takes **45-90s**. The 30s warmup always expired first.

**Fixes:**
- `launch.ts`: startup prompt delay 3s → 8s (gives Claude Code time to initialize before input is delivered)
- `group.ts`: `WARMUP_TIMEOUT_MS` 30s → 120s (covers full cold-boot chain with comfortable headroom)
- `group.ts`: add `--warmup-timeout <s>` CLI option for operator tuning
- Drop `[experimental]` marker now that the path works end-to-end

## Verification

Tested against a real grouped pair (`brove` group — brove → brove-docs) with brove-docs DOWN:

```
$ cd ~/Q3/Brove/brove
$ cockpit group dispatch brove-docs "Verify #288 boot-if-down fix: confirm you received this dispatch and reply with your relay status"
✔ Dispatched to 'brove-docs' (task d3f947f7)
  originProject: brove
  You will be notified when the task settles (done/blocked/failed).
```

brove-docs captain response (read from cmux pane after ~82s):
> "Cross-project task handled: brove's #288 boot-if-down verification — confirmed receipt and replied with relay status (booted, healthy, dispatch delivered end-to-end)."

**Confirmed working**: captain booted, relay came up, warmup poll succeeded, task dispatched, captain received notification and replied.

## Test plan

- [x] `npm test` — 1058 tests green
- [x] `src/commands/__tests__/group.test.ts` — all 5 pass (including updated description assertion)
- [x] Real-pair live verification: brove → brove-docs (target DOWN → operational)