### PR TITLE
fix(headless): coalesce task.progress writes + cap stdout/stderr buffers (#88)

### DIFF
--- a/src/control/__tests__/headless-launcher.test.ts
+++ b/src/control/__tests__/headless-launcher.test.ts
@@ -97,4 +97,80 @@ describe("runHeadless", () => {
     child.emit("close", 0);
     await result;
   });
+
+  it("coalesces task.progress: 100 rapid chunks emit far fewer than 100 progress events", async () => {
+    const child = fakeChild();
+    const events: any[] = [];
+    const { result } = runHeadless({
+      provider: "claude", task: "x", id: "t-coalesce",
+      spawn: (() => child) as any, emit: (e) => events.push(e),
+    });
+    for (let i = 0; i < 100; i++) child.stdout.emit("data", "chunk");
+    child.emit("close", 0);
+    await result;
+    const progressCount = events.filter(e => e.type === "task.progress").length;
+    // Before fix: 100 progress events. After fix: ≤ ~5 via batch+final-flush.
+    expect(progressCount).toBeLessThan(10);
+    expect(progressCount).toBeGreaterThan(0);
+  });
+
+  it("always emits a final task.progress flush on close for any pending chunks", async () => {
+    const child = fakeChild();
+    const events: any[] = [];
+    const { result } = runHeadless({
+      provider: "claude", task: "x", id: "t-flush",
+      spawn: (() => child) as any, emit: (e) => events.push(e),
+    });
+    // 3 chunks — under the batch threshold, so none should emit mid-stream
+    // (after the first immediate one), but close must flush the remainder
+    child.stdout.emit("data", "a");
+    child.stdout.emit("data", "b");
+    child.stdout.emit("data", "c");
+    child.emit("close", 0);
+    await result;
+    // task.done must follow any progress flush
+    const types = events.map(e => e.type);
+    const lastProgressIdx = types.lastIndexOf("task.progress");
+    const doneIdx = types.indexOf("task.done");
+    expect(doneIdx).toBeGreaterThan(-1);
+    expect(lastProgressIdx).toBeLessThan(doneIdx); // progress always before done
+  });
+
+  it("caps stdout buffer at 4 MB: oversized output is trimmed to the tail", async () => {
+    const child = fakeChild();
+    const writeResult = vi.fn(() => "/tmp/r.txt");
+    const { result } = runHeadless({
+      provider: "claude", task: "x", id: "t-cap",
+      spawn: (() => child) as any, emit: () => {},
+      writeResult,
+    });
+    const MB = 1024 * 1024;
+    // 5 MB of non-JSON data; claude adapter falls back to raw payload on parse error
+    child.stdout.emit("data", "a".repeat(5 * MB));
+    child.emit("close", 0);
+    await result;
+    // payload passed to writeResult must be ≤ 4 MB cap
+    const captured = writeResult.mock.calls[0]?.[1] as string;
+    expect(captured.length).toBeLessThanOrEqual(4 * MB);
+    expect(captured.length).toBeGreaterThan(0);
+  });
+
+  it("caps stderr buffer at 4 MB: oversized stderr is trimmed before parse", async () => {
+    const child = fakeChild();
+    const events: any[] = [];
+    const { result } = runHeadless({
+      provider: "claude", task: "x", id: "t-errcap",
+      spawn: (() => child) as any, emit: (e) => events.push(e),
+    });
+    const MB = 1024 * 1024;
+    child.stderr.emit("data", "e".repeat(5 * MB));
+    child.emit("close", 1); // non-zero exit → uses err as parseInput
+    await result;
+    const failed = events.find(e => e.type === "task.failed");
+    expect(failed).toBeTruthy();
+    // error field comes from adapter.parseResult(err, 1) → err.slice(-2000)
+    // the important thing is the process didn't OOM building a 5 MB err string
+    // (we can't directly observe the trimmed err, but the event must exist)
+    expect(failed.exitCode).toBe(1);
+  });
 });

--- a/src/control/headless-launcher.ts
+++ b/src/control/headless-launcher.ts
@@ -25,6 +25,13 @@ export interface HeadlessHandle {
   kill: () => void;
 }
 
+// Max bytes retained in the stdout/stderr capture buffers (oldest dropped).
+const OUT_CAP = 4 * 1024 * 1024;
+const ERR_CAP = 4 * 1024 * 1024;
+// Emit task.progress at most once per interval OR once per batch, whichever first.
+const PROGRESS_INTERVAL_MS = 250;
+const PROGRESS_CHUNK_BATCH = 50;
+
 export function runHeadless(opts: RunHeadlessOpts): HeadlessHandle {
   const adapter = getHeadlessAdapter(opts.provider);
   const argv = adapter.buildCommand(opts.task, opts.sessionId);
@@ -36,18 +43,46 @@ export function runHeadless(opts: RunHeadlessOpts): HeadlessHandle {
 
   let out = "";
   let err = "";
+
+  // Debounce state — coalesces task.progress to avoid O(chunks) file writes.
+  let lastProgressAt = 0;
+  let chunksSinceProgress = 0;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function flushProgress(): void {
+    if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
+    lastProgressAt = Date.now();
+    chunksSinceProgress = 0;
+    opts.emit({ type: "task.progress", id: opts.id }); // stdout activity = liveness
+  }
+
   child.stdout?.on("data", (d) => {
     out += String(d);
-    opts.emit({ type: "task.progress", id: opts.id }); // stdout activity = liveness
+    if (out.length > OUT_CAP) out = out.slice(out.length - OUT_CAP);
+    chunksSinceProgress++;
+    const now = Date.now();
+    if (chunksSinceProgress >= PROGRESS_CHUNK_BATCH || now - lastProgressAt >= PROGRESS_INTERVAL_MS) {
+      flushProgress();
+    } else if (!debounceTimer) {
+      const delay = PROGRESS_INTERVAL_MS - (now - lastProgressAt);
+      debounceTimer = setTimeout(() => { debounceTimer = null; flushProgress(); }, delay);
+    }
   });
-  child.stderr?.on("data", (d) => { err += String(d); });
+  child.stderr?.on("data", (d) => {
+    err += String(d);
+    if (err.length > ERR_CAP) err = err.slice(err.length - ERR_CAP);
+  });
 
   const result = new Promise<void>((resolve) => {
     child.once("error", (e: Error) => {
+      if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
       opts.emit({ type: "task.failed", id: opts.id, error: `spawn error: ${e.message}`, exitCode: undefined });
       resolve(); // never hang the daemon; resolve() is idempotent
     });
     child.on("close", (code) => {
+      // Flush any batched-but-not-yet-emitted activity before the terminal event.
+      if (chunksSinceProgress > 0) flushProgress();
+      else if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
       const parseInput = (code !== 0 && err) ? err : (out || err);
       const res = adapter.parseResult(parseInput, code ?? 0);
       if (res.outcome === "failed") {


### PR DESCRIPTION
## Problem

Two write-amplification / RAM issues in `runHeadless` (`src/control/headless-launcher.ts`):

1. **O(chunks) file writes**: `task.progress` was emitted on every stdout chunk. Each event flows through `ingest → daemon.handle → reduce() → store.put`, and `reduce` always returns a new object (updating `lastHeartbeat: now`), so `store.put` fires a `writeFileSync + rename` per chunk. A chatty provider (e.g. streaming claude output) could generate hundreds of file writes per second.

2. **Unbounded `out`/`err` capture**: the `out` and `err` strings accumulated without limit until process exit. Under concurrency or long unattended runs this causes RAM growth that doesn't release until the child closes.

## Fix

**Coalescing** (`PROGRESS_INTERVAL_MS = 250ms`, `PROGRESS_CHUNK_BATCH = 50`):
- First chunk always emits immediately (cold-start liveness).
- Subsequent chunks: emit if ≥250ms elapsed OR ≥50 chunks accumulated since last emit, whichever first.
- A debounce timer fires if neither threshold is hit within the interval.
- On `close`: flush any pending chunks as a final `task.progress` before the terminal event, then cancel any outstanding timer. Terminal state transitions (`task.done`/`task.failed`) are unaffected and emit promptly.

**Buffer cap** (`OUT_CAP = ERR_CAP = 4 MB`):
- After each append: if buffer exceeds 4 MB, trim to the last 4 MB (keep newest, drop oldest).
- Only the retained in-memory buffer is capped. The `emit` subscriber path (liveness signals) is unaffected since `task.progress` carries no content.

## Verification

4 new tests in `headless-launcher.test.ts`:

| Test | What it proves |
|------|----------------|
| `coalesces task.progress: 100 rapid chunks…` | 100 synchronous chunks → <10 progress events (actual: 3) |
| `always emits a final task.progress flush on close…` | progress event always precedes `task.done` in event order |
| `caps stdout buffer at 4 MB…` | 5 MB single-chunk → `writeResult` receives ≤4 MB payload |
| `caps stderr buffer at 4 MB…` | 5 MB stderr + exit 1 → `task.failed` emitted without OOM |

All **1062 tests pass** (`npm test` on clean checkout).

## Numbers

- Before: 100 chunks → 100 `store.put` calls → 100 `writeFileSync+rename` pairs
- After: 100 chunks → 3 `store.put` calls (97% reduction for rapid bursts)
- RAM: `out`/`err` buffers now bounded at 4 MB each regardless of run duration