### PR TITLE
feat(crew): isolated worktree default for crew spawn (#296)

### DIFF
--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -177,7 +177,7 @@ To add, edit, or remove routing rules: use the `cockpit:add-pick-crew-rule` skil
 
 - **Reuse with `send` before spawning a new one.** Same task track, same crew. New track = new crew.
 - **Close crews you're done with** (`cockpit crew close ...`) so they don't accumulate.
-- Do NOT manually run `git worktree add`. The crew operates in the captain's checkout. If a task genuinely requires worktree isolation, ask the user.
+- Crews run in **isolated worktrees by default** (parallel-safe, branch per crew). Pass `--shared` only for tiny/one-off tasks that don't need branch isolation. Never hand-run `git worktree add` — `cockpit crew spawn` handles it.
 - Do NOT edit source code yourself — always delegate to crew.
 - Respect `maxCrew` — don't exceed the configured concurrent crew count.
 - **For complex multi-step tasks** (3+ steps, multiple files), tell the crew to use GSD inside the task prompt: *"This is a complex task. Use `/gsd:plan-phase` and `/gsd:execute-phase` for wave-based execution with fresh context per step."*

--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -139,6 +139,9 @@ describe("cockpit crew spawn", () => {
     writePerCrewOpencodeConfig.mockReset();
     writePerCrewOpencodeConfig.mockReturnValue("/tmp/per-crew/opencode.json");
     addWorktree.mockReset();
+    // Default: worktree isolation is now the default (#296) — return a reasonable path so tests
+    // that don't explicitly opt out don't fail trying to use an undefined cwd.
+    addWorktree.mockReturnValue("/tmp/brove/.worktrees/brove-crew-1");
     removeWorktree.mockReset();
     existsSyncMock.mockReset();
     readFileSyncMock.mockReset();
@@ -172,13 +175,13 @@ describe("cockpit crew spawn", () => {
       provider: "claude",
       mode: "interactive",
       project: "brove",
-      cwd: "/tmp/brove",
+      cwd: "/tmp/brove/.worktrees/brove-crew-1",
       task: "do the thing",
     }));
     expect(cockpitdCall).toHaveBeenCalledTimes(1);
-    // Cockpit hooks written to .claude/settings.local.json (auto-loaded source).
+    // Cockpit hooks written to .claude/settings.local.json (auto-loaded source) inside the worktree.
     expect(writePerCrewSettingsLocal).toHaveBeenCalledWith(expect.objectContaining({
-      projectCwd: "/tmp/brove",
+      projectCwd: "/tmp/brove/.worktrees/brove-crew-1",
     }));
     expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({
       interactive: true,
@@ -204,7 +207,7 @@ describe("cockpit crew spawn", () => {
     expect(result.title).toBe("🔧 brove:crew-1");
   });
 
-  it("--worktree creates an isolated worktree and spawns the crew with its path as cwd", async () => {
+  it("default spawn creates an isolated worktree and spawns the crew with its path as cwd", async () => {
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
     listSurfaces.mockResolvedValue([]);
@@ -215,7 +218,7 @@ describe("cockpit crew spawn", () => {
     const wtPath = "/tmp/brove/.worktrees/brove-crew-1";
     addWorktree.mockReturnValue(wtPath);
 
-    const promise = runCrewSpawn({ project: "brove", task: "do the thing", worktree: true });
+    const promise = runCrewSpawn({ project: "brove", task: "do the thing" });
     await vi.advanceTimersByTimeAsync(3000);
     await promise;
 
@@ -233,16 +236,16 @@ describe("cockpit crew spawn", () => {
     expect(writePerCrewSettingsLocal).toHaveBeenCalledWith(expect.objectContaining({ projectCwd: wtPath }));
   });
 
-  it("without --worktree never creates a worktree (cwd stays the root checkout)", async () => {
+  it("--shared opt-out skips worktree creation (cwd stays the root checkout)", async () => {
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
     listSurfaces.mockResolvedValue([]);
     newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
     buildCommand.mockReturnValue("claude ...");
-    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-nowt" } }));
-    cockpitdCall.mockResolvedValue({ id: "task-nowt" });
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-shared" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-shared" });
 
-    const promise = runCrewSpawn({ project: "brove", task: "do the thing" });
+    const promise = runCrewSpawn({ project: "brove", task: "do the thing", shared: true });
     await vi.advanceTimersByTimeAsync(3000);
     await promise;
 
@@ -264,14 +267,14 @@ describe("cockpit crew spawn", () => {
     cockpitdCall.mockResolvedValue({ id: "task-wtc" });
     addWorktree.mockReturnValue("/tmp/brove/.wt/brove-crew-1");
 
-    const promise = runCrewSpawn({ project: "brove", task: "task", worktree: true });
+    const promise = runCrewSpawn({ project: "brove", task: "task" });
     await vi.advanceTimersByTimeAsync(3000);
     await promise;
 
     expect(addWorktree).toHaveBeenCalledWith(expect.objectContaining({ worktreeDir: ".wt" }));
   });
 
-  it("--worktree claude crew: launch command starts with cd into worktree path", async () => {
+  it("claude crew: launch command starts with cd into worktree path (default isolation)", async () => {
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
     listSurfaces.mockResolvedValue([]);
@@ -282,7 +285,7 @@ describe("cockpit crew spawn", () => {
     const wtPath = "/tmp/brove/.worktrees/brove-crew-1";
     addWorktree.mockReturnValue(wtPath);
 
-    const promise = runCrewSpawn({ project: "brove", task: "feature work", worktree: true });
+    const promise = runCrewSpawn({ project: "brove", task: "feature work" });
     await vi.advanceTimersByTimeAsync(3000);
     await promise;
 
@@ -291,7 +294,7 @@ describe("cockpit crew spawn", () => {
     expect(launchCmd).toMatch(/^cd '\/tmp\/brove\/\.worktrees\/brove-crew-1' && /);
   });
 
-  it("non-worktree claude crew: launch command starts with cd into main checkout (no-op harmless)", async () => {
+  it("--shared claude crew: launch command starts with cd into main checkout (no-op harmless)", async () => {
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
     listSurfaces.mockResolvedValue([]);
@@ -300,7 +303,7 @@ describe("cockpit crew spawn", () => {
     buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-nowt2" } }));
     cockpitdCall.mockResolvedValue({ id: "task-nowt2", project: "brove", provider: "claude", mode: "interactive" });
 
-    const promise = runCrewSpawn({ project: "brove", task: "small fix" });
+    const promise = runCrewSpawn({ project: "brove", task: "small fix", shared: true });
     await vi.advanceTimersByTimeAsync(3000);
     await promise;
 
@@ -309,7 +312,7 @@ describe("cockpit crew spawn", () => {
     expect(launchCmd).toMatch(/^cd '\/tmp\/brove' && /);
   });
 
-  it("--worktree opencode crew: launch command starts with cd into worktree path", async () => {
+  it("opencode crew: launch command starts with cd into worktree path (default isolation)", async () => {
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
     listSurfaces.mockResolvedValue([]);
@@ -320,7 +323,7 @@ describe("cockpit crew spawn", () => {
     const wtPath = "/tmp/brove/.worktrees/brove-crew-1";
     addWorktree.mockReturnValue(wtPath);
 
-    const promise = runCrewSpawn({ project: "brove", task: "feature work", worktree: true, agent: "opencode", agentExplicit: true });
+    const promise = runCrewSpawn({ project: "brove", task: "feature work", agent: "opencode", agentExplicit: true });
     await vi.advanceTimersByTimeAsync(3000);
     await promise;
 
@@ -377,7 +380,7 @@ describe("cockpit crew spawn", () => {
       provider: "opencode",
       mode: "interactive",
       project: "brove",
-      cwd: "/tmp/brove",
+      cwd: "/tmp/brove/.worktrees/brove-crew-1",
       task: "do the thing",
       budgetMs: 86400000,
     }));
@@ -438,7 +441,7 @@ describe("cockpit crew spawn", () => {
       provider: "codex",
       mode: "interactive",
       project: "brove",
-      cwd: "/tmp/brove",
+      cwd: "/tmp/brove/.worktrees/brove-crew-1",
       task: "do the thing",
     }));
     expect(cockpitdCall).toHaveBeenCalledTimes(1);
@@ -1258,6 +1261,7 @@ describe("completion-protocol suffix in first turns (#278)", () => {
     writePerCrewOpencodeConfig.mockReset();
     writePerCrewOpencodeConfig.mockReturnValue("/tmp/per-crew/opencode.json");
     addWorktree.mockReset();
+    addWorktree.mockReturnValue("/tmp/brove/.worktrees/brove-crew-1");
     existsSyncMock.mockReset();
     existsSyncMock.mockReturnValue(false);
     resolveCrewRoute.mockReset();

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -234,9 +234,10 @@ export interface CrewSpawnInput {
   direction?: PanePlacement;
   agent?: string;
   approvalPolicy?: string;
-  /** Opt-in (#216): run this crew in its own git worktree + branch instead of
-   *  the shared root checkout. For feature tasks; small/one-off tasks omit it. */
-  worktree?: boolean;
+  /** Opt-out (#296): run this crew in the root checkout instead of an isolated
+   *  worktree. Pass true for small/one-off tasks that don't need branch isolation.
+   *  Default (undefined/false) = isolated worktree — parallel-safe. */
+  shared?: boolean;
   /** CP3 opt-in: gate risky tools (bash) so the captain approves them.
    *  codex maps this to approvalPolicy='untrusted'; opencode maps it to a
    *  bash:"ask" per-crew config. Default (false) = fully autonomous. */
@@ -275,13 +276,13 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
   }
   const name = input.name ?? nextAutoName(existingTitles, input.project);
 
-  // Feature crews (--worktree) run in an isolated worktree+branch so a crew's
-  // `git checkout` can't drag the captain's (shared) HEAD. Small crews keep
-  // running on the root checkout — spawnCwd stays proj.path, behavior unchanged.
+  // Crews run in an isolated worktree+branch by default so multiple parallel
+  // crews never collide on a shared HEAD (#296). Pass shared:true (CLI: --shared)
+  // for small/one-off tasks that should run on the root checkout.
   // Build/daemon still run from the MAIN checkout's dist (#216): worktrees edit
   // source only. The worktree path becomes the crew's cwd via the existing cwd
   // plumbing (dispatch record + buildCommand workdir).
-  const spawnCwd = input.worktree
+  const spawnCwd = !input.shared
     ? addWorktree({
         repoRoot: proj.path,
         worktreeDir: config.defaults.worktreeDir ?? ".worktrees",
@@ -697,14 +698,14 @@ crewCommand
   .option("--direction <dir>", "Placement: tab (default) or split direction (right|left|up|down)", "tab")
   .option("--agent <name>", "Agent CLI to use (claude|codex|gemini|opencode)", "claude")
   .option("--approval", "gate risky tools so the captain approves them (codex: approvalPolicy='untrusted'; opencode: bash:'ask')", false)
-  .option("--worktree", "run the crew in its own git worktree + branch (feature tasks; small tasks omit to share the root checkout)", false)
+  .option("--shared", "run the crew in the root checkout instead of an isolated worktree (for small/one-off tasks)", false)
   .option("--task-file <path>", "Read task prompt from file instead of positional arg ('-' for stdin)")
   .option("--model <alias>", "Override crew model for this spawn (e.g. sonnet, opus); takes precedence over config defaults.roles.crew.model")
   .action(
     async (
       project: string,
       task: string | undefined,
-      opts: { name?: string; direction: PanePlacement; agent: string; approval: boolean; worktree: boolean; taskFile?: string; model?: string },
+      opts: { name?: string; direction: PanePlacement; agent: string; approval: boolean; shared: boolean; taskFile?: string; model?: string },
       cmd: Command,
     ) => {
       try {
@@ -720,7 +721,7 @@ crewCommand
           // --approval is provider-agnostic: codex consumes approvalPolicy,
           // opencode consumes the `approval` flag (→ bash:"ask" per-crew config).
           ...(opts.approval ? { approvalPolicy: "untrusted", approval: true } : {}),
-          ...(opts.worktree ? { worktree: true } : {}),
+          ...(opts.shared ? { shared: true } : {}),
           ...(opts.model ? { model: opts.model } : {}),
         });
         console.log(chalk.green(`✔ Crew '${pane.title}' spawned (${pane.surfaceId})`));


### PR DESCRIPTION
## Summary

- **Default is now isolated**: `cockpit crew spawn` creates a per-crew git worktree+branch by default, so parallel crews never collide on a shared HEAD
- **Opt-out with `--shared`**: pass `--shared` for tiny/one-off tasks that don't need branch isolation (replaces the old `--worktree` opt-in)
- **Skill updated**: `captain-ops/SKILL.md` rule updated to reflect the new default and explain when to use `--shared`

## Changes

| File | What changed |
|------|-------------|
| `src/commands/crew.ts` | `CrewSpawnInput.worktree?` → `shared?`; `spawnCwd` logic inverted; CLI `--worktree` → `--shared` |
| `src/commands/__tests__/crew.test.ts` | Tests updated for new default; `--shared` opt-out tests; `addWorktree` mock in `beforeEach` |
| `plugin/skills/captain-ops/SKILL.md` | Rule updated: "default = isolated, pass `--shared` for tiny tasks" |

## Invariants preserved

- **#216**: worktrees edit source only; build + live daemon still run from MAIN checkout's `dist`
- **Codex / opencode paths**: both inherit `spawnCwd` unchanged — no path silently stays on root
- **Worktree cleanup**: `cockpit crew close` still calls `removeWorktree` when `task.cwd !== proj.path`

## Test plan

- [x] `npx vitest run src/commands/__tests__/crew.test.ts` — 62/62 pass
- [x] `npx vitest run` — 1062/1062 pass (full suite, no regressions)
- [x] gitnexus impact on `runCrewSpawn`: LOW risk, 0 affected processes
- [x] gitnexus detect_changes: LOW risk before commit