### PR TITLE
fix(cmux): restore captain focus after newPane tab (#295)

### DIFF
--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -230,6 +230,53 @@ describe("cmux driver", () => {
     expect(cmds.every((c) => !c.includes("--direction"))).toBe(true);
   });
 
+  // #295: new tab steals cmux focus, leaking user keystrokes into crew launch command.
+  // Fix: snapshot selected surface before new-surface, restore focus after creation.
+  it("newPane with direction=tab restores focus to the previously-selected surface (#295)", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      const cmd = args.join(" ");
+      if (cmd.includes("tree")) {
+        return [
+          'surface surface:5 [terminal] "captain" [selected]',
+          'surface surface:6 [terminal] "crew-1"',
+        ].join("\n");
+      }
+      if (cmd.includes("new-surface")) return "OK surface:8 workspace:1";
+      return "";
+    });
+    await driver.newPane({ workspaceId: "workspace:1", direction: "tab" });
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) =>
+      c.includes("move-surface") &&
+      c.includes("--surface surface:5") &&
+      c.includes("--index 0") &&
+      c.includes("--focus true"))).toBe(true);
+  });
+
+  it("newPane with direction=tab skips focus restore gracefully when tree is unreadable (#295)", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      const cmd = args.join(" ");
+      if (cmd.includes("tree")) throw new Error("tree unreadable");
+      if (cmd.includes("new-surface")) return "OK surface:8 workspace:1";
+      return "";
+    });
+    const pane = await driver.newPane({ workspaceId: "workspace:1", direction: "tab" });
+    expect(pane.surfaceId).toBe("surface:8");
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.every((c) => !c.includes("move-surface"))).toBe(true);
+  });
+
+  it("newPane with split direction does NOT query tree or restore focus (#295)", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("new-pane")) return "OK surface:27 pane:25 workspace:1";
+      return "";
+    });
+    await driver.newPane({ workspaceId: "workspace:1", direction: "right" });
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.every((c) => !c.includes("tree"))).toBe(true);
+    expect(cmds.every((c) => !c.includes("move-surface"))).toBe(true);
+  });
+
   it("newPane with direction=tab and title renames the new surface", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
       if (args.includes("new-surface")) return "OK surface:42 workspace:7";

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -242,6 +242,19 @@ export function createCmuxDriver(): RuntimeDriver {
     },
 
     async newPane(opts: RuntimePaneOptions): Promise<PaneRef> {
+      // #295: snapshot the focused surface before creating a new tab so we can
+      // restore focus afterward. new-surface steals focus; the captain's
+      // keystrokes would otherwise land in the crew's launch command line.
+      // Applies only to tabs (new-surface); split-panes keep cmux default focus.
+      let priorSurface: string | undefined;
+      let priorIndex = -1;
+      if (opts.direction === "tab") {
+        try {
+          const before = parseSurfaceOrder(cmux(["tree", "--workspace", opts.workspaceId]));
+          priorIndex = before.findIndex((s) => s.selected);
+          if (priorIndex >= 0) priorSurface = before[priorIndex].id;
+        } catch { /* best-effort: if we can't read the tree, skip refocus */ }
+      }
       const cmd = opts.direction === "tab"
         ? ["new-surface", "--type", "terminal", "--workspace", opts.workspaceId]
         : ["new-pane", "--type", "terminal", "--direction", opts.direction, "--workspace", opts.workspaceId];
@@ -255,6 +268,11 @@ export function createCmuxDriver(): RuntimeDriver {
         try {
           cmux(["rename-tab", "--workspace", opts.workspaceId, "--surface", surfaceId, "--title", opts.title]);
         } catch { /* rename is best-effort */ }
+      }
+      if (opts.direction === "tab" && priorSurface) {
+        try {
+          cmux(["move-surface", "--surface", priorSurface, "--index", String(priorIndex), "--focus", "true"]);
+        } catch { /* refocus is best-effort */ }
       }
       return { workspaceId: opts.workspaceId, surfaceId };
     },


### PR DESCRIPTION
## Problem

When a crew tab is spawned via `newPane()` with `direction: 'tab'`, cmux's `new-surface` command automatically focuses the new tab. Any keystrokes the user is typing in the captain pane during spawn land in the crew's `cd <cwd> && <cliCommand>` line, corrupting the launch command.

## Root cause

`newPane()` in `src/runtimes/cmux.ts` did not restore focus after creating a new tab surface. The existing `spawnInjector(placement: 'background')` already solved the identical problem for relay tabs — it snapshots the selected surface via `cmux tree`, creates the new surface, then calls `move-surface --focus true` to restore.

## Fix

Mirror the `spawnInjector` background focus-restore pattern in `newPane` for `direction === 'tab'`:

1. Snapshot the currently-selected surface via `parseSurfaceOrder(cmux tree)` before `new-surface`
2. Restore focus via `move-surface --surface <prior> --index <priorIndex> --focus true` after creation and rename
3. Both steps are best-effort (`try/catch`) — silently skipped if the tree is unreadable
4. Split-pane directions (`right|left|up|down`) are unaffected (no tree query, no focus restore)

Crew launch is not broken: `sendToPane` targets the new surface by explicit `--surface surfaceId`, so focus is irrelevant to programmatic first-turn delivery.

## Tests

Added 3 new unit tests (TDD red-first):
- `newPane tab restores focus to previously-selected surface (#295)` — asserts `move-surface --focus true` call
- `newPane tab skips focus restore gracefully when tree is unreadable (#295)` — asserts best-effort behavior
- `newPane with split direction does NOT query tree or restore focus (#295)` — asserts splits are untouched

Full suite: **1065/1065 tests pass**.

## Verification

The fix is structurally identical to the tested and proven `spawnInjector background` path. The new tests assert the same `move-surface --surface <prior> --index <idx> --focus true` call shape that the existing `spawnInjector background restores focus` test asserts.