### PR TITLE
fix(tests): type writeResult mock to resolve tsc errors (#300)

### DIFF
--- a/src/control/__tests__/headless-launcher.test.ts
+++ b/src/control/__tests__/headless-launcher.test.ts
@@ -138,7 +138,7 @@ describe("runHeadless", () => {
 
   it("caps stdout buffer at 4 MB: oversized output is trimmed to the tail", async () => {
     const child = fakeChild();
-    const writeResult = vi.fn(() => "/tmp/r.txt");
+    const writeResult = vi.fn((_id: string, _payload: string) => "/tmp/r.txt");
     const { result } = runHeadless({
       provider: "claude", task: "x", id: "t-cap",
       spawn: (() => child) as any, emit: () => {},
@@ -150,7 +150,7 @@ describe("runHeadless", () => {
     child.emit("close", 0);
     await result;
     // payload passed to writeResult must be ≤ 4 MB cap
-    const captured = writeResult.mock.calls[0]?.[1] as string;
+    const captured = writeResult.mock.calls[0]![1];
     expect(captured.length).toBeLessThanOrEqual(4 * MB);
     expect(captured.length).toBeGreaterThan(0);
   });


### PR DESCRIPTION
## Summary
- Types the `vi.fn` mock for `writeResult` with `(_id: string, _payload: string)` to match the real `RunHeadlessOpts.writeResult` signature
- Switches `?.` to `!` on `calls[0]` since the call is guaranteed after `await result`
- Removes the now-unnecessary `as string` cast

## Root cause
PR #293 added a test that called `writeResult.mock.calls[0]?.[1]` but the mock was declared as zero-arg (`vi.fn(() => "/tmp/r.txt")`). TypeScript correctly rejected the tuple index access.

## Test plan
- [x] `npm run build` (tsc) exits 0 — no more TS2352/TS2493 errors
- [x] `npm test --run` — 93 files, 1071 tests, all green
- [ ] No runtime code changed — type-annotation-only fix