### PR TITLE
fix(relay): non-destructive ghost-immune delivery via buffer-liveness probe (#302)

### DIFF
--- a/docs/specs/2026-06-14-302-nondestructive-delivery-proposal.md
+++ b/docs/specs/2026-06-14-302-nondestructive-delivery-proposal.md
@@ -1,7 +1,69 @@
 # Issue #302 — Non-destructive, ghost-immune relay delivery (PHASE 1 proposal)
 
-**Status:** Awaiting captain approval. No code written yet.
+**Status:** IMPLEMENTED. Build + full suite green; live end-to-end verified.
 **Branch (Phase 2):** `fix/302-nondestructive-delivery` off `develop`.
+
+---
+
+## Phase 2 results (implemented)
+
+**Change (surgical):**
+- `cmux.ts` — `DeferDelivery` now carries the observed `draft`; `sendToSurface`'s
+  destructive `force` branch (backspace×N clear + **re-paste of screen-read draft**)
+  is **deleted** and replaced by the buffer-liveness **probe** (`{ probe: true }`);
+  added `readInputBoxRaw` (full multi-line box capture for the before/after diff).
+- `notify-relay.ts` — tracks per-seq content stability; triggers the probe once
+  content is byte-stable for `stableProbePolls` (default 3 ≈ 3s) **or** the
+  300-defer backstop; `force`→`probe`. New `DEFAULT_STABLE_PROBE_POLLS`.
+- `types.ts` / `config.ts` — `sendToSurface` opt `force`→`probe`; new
+  `relay.stableProbePolls` config key.
+
+**Probe rule:** read box; send ONE backspace; re-read. If `after === before.slice(0,-1)`
+and non-empty → **real draft** → restore the one removed char, defer (never clobber,
+never re-paste the full draft). Else (ghost dismissed/invariant, or now empty) → deliver.
+
+**Stability/stall fix (reconciliation with the race that killed backspace in #258):**
+the probe is *inherently race-safe* — its only delivering branch is "no real draft,"
+and an actively-typing captain always presents a real draft → the probe hits the
+restore-and-defer branch (a brief 1-char flicker at worst), never a clobber. The
+stability gate additionally avoids even that flicker by only probing when content is
+stable. So the 300-defer backstop is kept but is now harmless (it can no longer
+clobber). **Worst-case failure mode is a stall, never materialization.**
+
+**Verification:**
+- `npm run build` (tsc) clean; `vitest run` full suite **1078/1078 green** (new: 6
+  cmux probe tests + 1 reworked walk-away test + 3 relay stability tests).
+- **STEP 0 live** (gate): backspace is buffer-aware — empty box invariant, real draft
+  loses last char, #294 queue-ghost dismisses to empty.
+- **Live end-to-end** against a real CC 2.1.x box via the *compiled* driver: real
+  draft → DEFERRED (draft intact); empty → DELIVERED; ghost → DELIVERED with buffer
+  confirmed empty (typing a char replaced the placeholder — **ghost not materialized**).
+  Throwaway sessions torn down, no orphaned `claude`.
+
+**Not run here (captain deploy-time):** the full crew-lifecycle checklist against
+*live deployed* crews requires the globally-installed relay to be rebuilt from this
+branch. Relevant checkpoints to re-confirm post-deploy: #258 preserve-draft, #268
+overlay/null defer, #294 ghost fast-path, and the new #302 stall-free ghost delivery.
+
+---
+
+## STEP 0 — live verification (DONE, gate PASSED)
+
+Bounded throwaway `claude --permission-mode plan` in a temp git dir, driven via `cmux
+send-key`/`read-screen`, torn down clean (no orphaned `claude`). CC 2.1.x.
+
+| Case | Before backspace | After ONE backspace | Signature |
+|------|------------------|---------------------|-----------|
+| Empty buffer | `❯ \xa0` | `❯ \xa0` (identical) | **invariant** |
+| Real draft | `hello world` | `hello worl` | **clean last-char removal** |
+| Real ghost (#294 queue placeholder) | `Press up to edit queued messages` | `❯ ` (empty); buffer confirmed empty — typing `X`→`X`, not appended | **dismissed to empty** |
+
+**Refined rule (stronger than the original Case-A assumption):** a real draft is the ONLY thing
+that yields the "last char removed, still non-empty" signature. Every ghost either stays invariant
+or dismisses to empty — never that signature. So **protect only on the positive real-draft
+signature; otherwise the buffer holds no preservable draft → deliver.** Even an exotic ghost misread
+as real degrades to *defer* (we re-type only the one char we removed, then defer) — **never
+materialization, never submission.** #302's headline harm is structurally impossible.
 
 ---
 

--- a/docs/specs/2026-06-14-302-nondestructive-delivery-proposal.md
+++ b/docs/specs/2026-06-14-302-nondestructive-delivery-proposal.md
@@ -1,0 +1,120 @@
+# Issue #302 — Non-destructive, ghost-immune relay delivery (PHASE 1 proposal)
+
+**Status:** Awaiting captain approval. No code written yet.
+**Branch (Phase 2):** `fix/302-nondestructive-delivery` off `develop`.
+
+---
+
+## 1. Why this subsystem churned 3× (#258) — documented so we don't regress
+
+Source: PR #266 → #267 → #269, the line-600 test comment, and live findings.
+
+| Attempt | Mechanism | Why abandoned (live-proven, not unit) |
+|--------|-----------|---------------------------------------|
+| #266 | **kill-ring**: `ctrl-u` / `ctrl+a`+`ctrl+k` to clear, restore after | **`ctrl-u`/`ctrl-k` are NO-OPs in Claude Code's input.** Proven live via `cmux send-key` (PR #267 body). Corroborated two more ways: (a) the regression test at `cmux.test.ts:600` asserts `ctrl-u` is never used "that key is a no-op against Claude Code's input box"; (b) strings of CC 0.80.0 bundle show `ctrl+u` bound to **half-page scroll** (`"ctrl+u/ctrl+d to scroll"`, `case"u":return"halfPage…"`), and `yank` exists **only in vi-mode** (`implement yank mode for vi`). CC's default input is **not** a readline line-editor. |
+| (interim) | **backspace×N clear + restore** with a fixed idle-stability window | (a) backspace×N is **slow** (~600 ms for a long draft) so it **races live keystrokes**; (b) a fixed idle window **mis-fires for slow typists** (between-keystroke gaps exceed the window). (PR #267 body.) |
+| #267 | **Approach B — deliver-only-when-empty (read-the-box idle-defer)** | **Chosen.** `sendToSurface` reads the box; any draft → throw `DeferDelivery`, relay retries next poll (never touches keystrokes); empty → deliver. Eliminates the clear/restore race entirely because the box is empty most of the time. #269 then scoped the parse to the live input box (between the two `───` HRs) and made the walk-away force-fallback configurable (`relay.maxDeferDeliveries`, default 300 ≈ 5 min). #268 added the 3rd state: `null` (HR boundaries absent = overlay/scroll) → always defer. |
+
+**Invariants we must NOT regress:**
+- **#258:** never clobber / never prematurely submit a real in-progress draft.
+- **#268:** `null` (box not visible) → always defer; never keystroke into an unknown UI.
+- **#294:** CC ghost/placeholder text must never be treated as a real draft to act on.
+
+## 2. The current bug (#302) — exact mechanism
+
+`src/runtimes/cmux.ts` `sendToSurface` **force branch** (lines ~379-388):
+
+```
+backspace × (draft.length + 2)        // clear
+cmux send <crew msg> ; send-key Enter // deliver
+cmux send <draft>                     // RESTORE  ← re-pastes screen-read text
+```
+
+The walk-away force fallback fires after `maxDefers` (300) consecutive defers. The force path
+trusts that `draft` (read from `parseDraftFromScreen`) is **real user input worth restoring**,
+and re-pastes it. When the "draft" is actually a CC **contextual autosuggest ghost** (arbitrary
+text, e.g. "wait for both crews to finish"), the final `cmux send <draft>` **materializes the dim
+ghost into a real, normal-coloured draft** — the user never typed it.
+
+**Why #294's parse heuristics can't fix this:** CC renders an autosuggest ghost as arbitrary
+plain text with no leading `▌` (cursor is drawn via ANSI, hex-proven in #294) and `cmux read-screen`
+is plain-text only (no `--raw/--ansi/--cursor`). A ghost is **byte-identical** to a real draft.
+**There is no content signal.** Pattern-matching ghosts (`^Press … to …`, leading-glyph) is
+whack-a-mole and will never be complete.
+
+## 3. Candidate mechanisms evaluated
+
+**(a) Blind kill-ring (Ctrl-U cut → deliver → Ctrl-Y restore).** *Rejected.* The premise ("Ctrl-U
+cuts only real input") is false for CC: Ctrl-U does not cut, it scrolls (§1). CC's input is not a
+readline editor outside vi-mode, and there is no stable yank we can drive via `cmux send-key`.
+Re-testing live would only re-confirm #267. **Dead on arrival.**
+
+**(b) CC native message QUEUE** ("Press up to edit queued message(s)" — confirmed in the CC bundle).
+*Rejected as the primary mechanism.* The queue only engages while CC is **Working/generating**; the
+relay cannot force that state, and the common #302 case is CC **idle**. Worse, while Working a
+captain's in-progress draft + our `send`+Enter still **merges into the queued entry** — it does not
+sidestep the draft-merge problem. Useful only as a future optimization, not a fix.
+
+**(c) Buffer-liveness probe (RECOMMENDED).** A new primitive that recovers kill-ring's *ghost-immunity
+property* using only **backspace**, which CC **does** support. Key insight: **a ghost is not in the
+real input buffer; backspace is buffer-aware.** So we distinguish ghost vs real draft by *effect on
+the buffer*, not by *content* — exactly the signal #302 says is missing from the screen text.
+
+## 4. RECOMMENDATION — Buffer-liveness probe (replace only the force branch)
+
+Leave the hot path untouched (Approach B defer stays). Change **only** the force branch of
+`sendToSurface`. On force:
+
+1. Read screen → content `C`. If empty → deliver `MSG`+Enter (unchanged).
+2. If `C` non-empty: send **one** `backspace`, re-read screen → `C'`.
+   - **Case A — `C' == C` (buffer-invariant):** the box content is a **ghost / static UI**, not in
+     the buffer (the backspace was a harmless no-op on an empty buffer). **Deliver `MSG`+Enter.**
+     Typing `MSG` replaces the ghost render; Enter submits only `MSG`. **Ghost never materialized.**
+   - **Case B — `C'` is `C` minus its last char:** a **real draft** is present. Re-type that one
+     known char to restore it, then **defer** (throw `DeferDelivery`). We **never force-merge into a
+     real draft** — the relay keeps the message queued; the captain submits/clears later and it
+     lands. **Real draft preserved.**
+   - **Case C/D — empty after one backspace, or a different non-empty string:** ambiguous edge
+     (≤1-char content, or autosuggest re-render). Treat as real (restore + defer) — fail safe
+     toward never-materialize. Bounded, rare.
+
+**Crucially: the relay NEVER re-pastes the whole screen-read draft.** Removing that single
+`cmux send <draft>` line is what makes ghost-materialization *structurally impossible* — ending the
+whack-a-mole permanently. The probe is what keeps crew delivery flowing during a persistent ghost
+**without** ever clobbering a real draft.
+
+### Invariants preserved
+- **#258:** Case B restores the draft char-for-char and defers — never submits/merges it. ✓
+- **#268:** `null` path unchanged — still always defers. ✓
+- **#294:** existing ghost heuristics in `parseDraftFromScreen` can stay as a cheap defer-noise
+  pre-filter but are **no longer load-bearing**; the probe is the backstop, so an *unknown* ghost
+  pattern is now safe (it just resolves to Case A and delivers). ✓
+- **New #302 invariant:** the relay never types screen-read content into the box (no full-draft
+  re-paste; Case B only re-types the single char *it itself* removed). ✓
+
+### Risk / the ONE thing to verify live in Phase 2 (step 0)
+The probe rests on: **CC's autosuggest ghost on an empty buffer is invariant under a no-op
+backspace, and backspace on an empty buffer is a true no-op** (Case A holds; doesn't dismiss-to-empty
+or re-render a different suggestion). #267 already proved backspace deletes only real chars; the
+open question is the ghost's render reaction. **Phase 2 step 0 = a bounded live test** (throwaway
+cmux surface + claude, send-key backspace against a displayed ghost vs a real draft, diff
+read-screen, then tear down — no orphaned `claude`). If Case A fails, fallback = keep no-repaste +
+treat force-with-content as "defer forever, log loudly" (never materialize; crew msg waits) —
+strictly better than today but doesn't auto-deliver through a persistent ghost.
+
+### Impact analysis (per CLAUDE.md)
+`gitnexus_impact(sendToSurface, upstream)` → **LOW**, 0 static callers (invoked dynamically via the
+`RuntimeDriver` cast at `notify-relay.ts:268`). Blast radius is the relay defer loop only, already
+mapped. Change is surgical: the force branch of `sendToSurface` + its one test
+(`cmux.test.ts:587` "saves draft, clears…restores", which encodes the behavior we're replacing).
+
+## 5. Phase 2 plan (after approval)
+0. Live-verify Case A (bounded, self-cleaning claude test).
+1. TDD: rewrite `cmux.test.ts:587` to the probe contract (Case A delivers, no full-draft re-paste;
+   Case B restores 1 char + `DeferDelivery`); add ghost-materialization regression (ghost content →
+   force → asserts MSG submitted and ghost text NEVER re-sent).
+2. Implement surgically in the force branch only (karpathy). `gitnexus_impact` before edit;
+   `gitnexus_detect_changes` before commit.
+3. `npm run build` (tsc gate) + `npm test` green; targeted cmux + notify-relay suites.
+4. Crew-lifecycle checklist (`docs/testing/crew-lifecycle-checklist.md`): #258 preserve draft,
+   #268 overlay/null defer, #294 ghost. Clean up orphaned vitest.

--- a/src/commands/__tests__/notify-relay.test.ts
+++ b/src/commands/__tests__/notify-relay.test.ts
@@ -9,7 +9,7 @@ import { mkdtempSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { appendToMailbox, writeCursor, readCursor } from "../../control/mailbox.js";
-import { runNotifyRelay, DEFAULT_STATE_ROOT, STALE_THRESHOLD_MS, DEFAULT_MAX_DEFERS } from "../notify-relay.js";
+import { runNotifyRelay, DEFAULT_STATE_ROOT, STALE_THRESHOLD_MS, DEFAULT_MAX_DEFERS, DEFAULT_STABLE_PROBE_POLLS } from "../notify-relay.js";
 import { DeferDelivery } from "../../runtimes/cmux.js";
 import type { TaskRecord, ControlEvent } from "../../control/types.js";
 
@@ -268,14 +268,14 @@ describe("notify-relay idle-defer (#258 phase 2)", () => {
     expect(sendSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 
-  it("force-delivers after maxDeferDeliveries consecutive defers so message is never stuck", async () => {
+  it("probes after maxDeferDeliveries consecutive defers so message is never stuck (backstop)", async () => {
     const stateRoot = freshState();
     await append(stateRoot, "CREW DONE [claude/deadbeef]: x");
     const TEST_MAX_DEFERS = 3; // inject small value so test runs fast
-    // Always defer unless force=true
+    // Always defer (bare DeferDelivery = no content → never stable) unless probe=true
     const sendSpy = vi.fn().mockImplementation(
-      (_surface: unknown, _msg: string, opts?: { force?: boolean }) => {
-        if (opts?.force) return Promise.resolve();
+      (_surface: unknown, _msg: string, opts?: { probe?: boolean }) => {
+        if (opts?.probe) return Promise.resolve();
         return Promise.reject(new DeferDelivery());
       },
     );
@@ -288,27 +288,27 @@ describe("notify-relay idle-defer (#258 phase 2)", () => {
       pollMs: 50,
       maxDeferDeliveries: TEST_MAX_DEFERS,
     });
-    // TEST_MAX_DEFERS polls + 1 force-deliver; at 50ms each = ~200ms; allow 500ms margin
+    // TEST_MAX_DEFERS polls + 1 probe-deliver; at 50ms each = ~200ms; allow 500ms margin
     await new Promise((r) => setTimeout(r, 500));
     stop();
     const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
     expect(cursor?.lastAckedSeq).toBe(1);
-    // The call that succeeded must have had force=true
-    const forcedCall = sendSpy.mock.calls.find(
-      (c) => (c[2] as { force?: boolean } | undefined)?.force === true,
+    // The call that succeeded must have had probe=true
+    const probedCall = sendSpy.mock.calls.find(
+      (c) => (c[2] as { probe?: boolean } | undefined)?.probe === true,
     );
-    expect(forcedCall).toBeDefined();
-    // Total calls = TEST_MAX_DEFERS defers + 1 force-deliver
+    expect(probedCall).toBeDefined();
+    // Total calls = TEST_MAX_DEFERS defers + 1 probe-deliver
     expect(sendSpy.mock.calls.length).toBeGreaterThanOrEqual(TEST_MAX_DEFERS + 1);
   });
 
   it("honors config-injected maxDeferDeliveries override", async () => {
     const stateRoot = freshState();
     await append(stateRoot, "CREW DONE [claude/deadbeef]: x");
-    // With maxDeferDeliveries=1, force-deliver should trigger after a single defer
+    // With maxDeferDeliveries=1, probe should trigger after a single (no-content) defer
     const sendSpy = vi.fn().mockImplementation(
-      (_surface: unknown, _msg: string, opts?: { force?: boolean }) => {
-        if (opts?.force) return Promise.resolve();
+      (_surface: unknown, _msg: string, opts?: { probe?: boolean }) => {
+        if (opts?.probe) return Promise.resolve();
         return Promise.reject(new DeferDelivery());
       },
     );
@@ -325,11 +325,87 @@ describe("notify-relay idle-defer (#258 phase 2)", () => {
     stop();
     const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
     expect(cursor?.lastAckedSeq).toBe(1);
-    // First call defers, second call force-delivers
     expect(sendSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
-    const forcedCall = sendSpy.mock.calls.find(
-      (c) => (c[2] as { force?: boolean } | undefined)?.force === true,
+    const probedCall = sendSpy.mock.calls.find(
+      (c) => (c[2] as { probe?: boolean } | undefined)?.probe === true,
     );
-    expect(forcedCall).toBeDefined();
+    expect(probedCall).toBeDefined();
+  });
+});
+
+// #302 — kill the ~5-min stall (the original #294 pain). When parseDraftFromScreen
+// reports the SAME non-empty content for K consecutive polls (~a few seconds), the
+// captain is NOT actively typing, so it is safe to PROBE early instead of waiting
+// for the 300-defer backstop. An UNRECOGNIZED ghost stabilizes in seconds → probed →
+// delivered fast. An actively-typing captain's content CHANGES → never stable → never
+// probed → pure defer (no keystroke race). DeferDelivery carries the observed draft.
+describe("notify-relay stability-probe (#302)", () => {
+  it("DEFAULT_STABLE_PROBE_POLLS is a small value (~few seconds at 1s cadence)", () => {
+    expect(DEFAULT_STABLE_PROBE_POLLS).toBeGreaterThanOrEqual(2);
+    expect(DEFAULT_STABLE_PROBE_POLLS).toBeLessThanOrEqual(10);
+  });
+
+  it("probes EARLY (before maxDefers) once content is stable for stableProbePolls consecutive polls", async () => {
+    const stateRoot = freshState();
+    await append(stateRoot, "CREW DONE [claude/deadbeef]: x");
+    // Stable non-empty content every poll; resolve only when probe=true.
+    const sendSpy = vi.fn().mockImplementation(
+      (_surface: unknown, _msg: string, opts?: { probe?: boolean }) => {
+        if (opts?.probe) return Promise.resolve();
+        return Promise.reject(new DeferDelivery("wait for both crews to finish"));
+      },
+    );
+    const stop = await runNotifyRelay({
+      project: "demo",
+      subscriber: "captain",
+      stateRoot,
+      runtime: fakeRuntime(sendSpy) as never,
+      captainName: "captain",
+      pollMs: 30,
+      maxDeferDeliveries: 300, // backstop far away — stability must trigger first
+      stableProbePolls: 2,
+    });
+    await new Promise((r) => setTimeout(r, 300));
+    stop();
+    const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    expect(cursor?.lastAckedSeq).toBe(1);
+    const probedCall = sendSpy.mock.calls.find(
+      (c) => (c[2] as { probe?: boolean } | undefined)?.probe === true,
+    );
+    expect(probedCall, "probe must fire from stability, not the 300 backstop").toBeDefined();
+    // Far fewer than 300 calls — stability triggered early
+    expect(sendSpy.mock.calls.length).toBeLessThan(20);
+  });
+
+  it("never probes while content KEEPS CHANGING between polls (active typing — no keystroke race)", async () => {
+    const stateRoot = freshState();
+    await append(stateRoot, "CREW DONE [claude/deadbeef]: x");
+    // Different content each poll → never stable → must never probe within the window.
+    let n = 0;
+    const sendSpy = vi.fn().mockImplementation(
+      (_surface: unknown, _msg: string, opts?: { probe?: boolean }) => {
+        if (opts?.probe) return Promise.resolve();
+        return Promise.reject(new DeferDelivery("draft " + (n++)));
+      },
+    );
+    const stop = await runNotifyRelay({
+      project: "demo",
+      subscriber: "captain",
+      stateRoot,
+      runtime: fakeRuntime(sendSpy) as never,
+      captainName: "captain",
+      pollMs: 30,
+      maxDeferDeliveries: 300,
+      stableProbePolls: 2,
+    });
+    await new Promise((r) => setTimeout(r, 300));
+    stop();
+    // Cursor never advanced (never delivered) and no probe ever fired.
+    const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    expect(cursor?.lastAckedSeq ?? 0).toBe(0);
+    const probedCall = sendSpy.mock.calls.find(
+      (c) => (c[2] as { probe?: boolean } | undefined)?.probe === true,
+    );
+    expect(probedCall).toBeUndefined();
   });
 });

--- a/src/commands/notify-relay.ts
+++ b/src/commands/notify-relay.ts
@@ -34,6 +34,13 @@ export const DEFAULT_STATE_ROOT = join(homedir(), ".config", "cockpit", "state")
 // Override via config key relay.maxDeferDeliveries.
 export const DEFAULT_MAX_DEFERS = 300;
 
+// #302 stability-probe: consecutive polls of byte-identical non-empty draft
+// content after which it is safe to PROBE (captain is not actively typing).
+// ~3s at the 1s poll cadence — kills the ~5min stall for unrecognized ghosts
+// while never racing a live typist (changing content resets the counter).
+// Override via config key relay.stableProbePolls.
+export const DEFAULT_STABLE_PROBE_POLLS = 3;
+
 // How often the in-cmux probe scrapes interactive crew panes for a block. The
 // daemon can't do this (launchd can't connect to cmux), so it lives here.
 export const PROBE_INTERVAL_MS = 10_000;
@@ -181,6 +188,8 @@ interface RunOpts {
   log?: (m: string) => void;
   /** Max consecutive defers before force-deliver. Default: DEFAULT_MAX_DEFERS. */
   maxDeferDeliveries?: number;
+  /** Consecutive stable-content polls before probing early (#302). Default: DEFAULT_STABLE_PROBE_POLLS. */
+  stableProbePolls?: number;
 }
 
 export async function runNotifyRelay(opts: RunOpts): Promise<() => void> {
@@ -204,10 +213,15 @@ export async function runNotifyRelay(opts: RunOpts): Promise<() => void> {
 
   const sessionStartMs = (opts.now ?? (() => Date.now()))();
   const maxDefers = opts.maxDeferDeliveries ?? DEFAULT_MAX_DEFERS;
+  const stableProbePolls = opts.stableProbePolls ?? DEFAULT_STABLE_PROBE_POLLS;
 
   // #258 idle-defer: consecutive defer counts per mailbox seq.
   // Keyed by entry.seq; deleted on successful delivery.
   const deferCounts = new Map<number, number>();
+  // #302 stability tracking: last observed draft content + how many consecutive
+  // polls it stayed byte-identical. Stable non-empty content → safe to probe.
+  const lastContent = new Map<number, string | null>();
+  const stableCounts = new Map<number, number>();
 
   const cursor = await readCursor({
     stateRoot: opts.stateRoot,
@@ -262,14 +276,29 @@ export async function runNotifyRelay(opts: RunOpts): Promise<() => void> {
         if (msg) {
           try {
             const deferCount = deferCounts.get(entry.seq) ?? 0;
-            const force = deferCount >= maxDefers;
+            // #302: probe early once content has been stable for stableProbePolls
+            // polls (captain not typing) — kills the ~5min stall; the 300-defer
+            // backstop still guarantees delivery never hangs forever.
+            const stable = (stableCounts.get(entry.seq) ?? 0) >= stableProbePolls;
+            const probe = stable || deferCount >= maxDefers;
             await (opts.runtime as RuntimeDriver & {
-              sendToSurface: (s: unknown, m: string, o?: { force?: boolean }) => Promise<void>;
-            }).sendToSurface(captainSurface, msg, force ? { force: true } : undefined);
+              sendToSurface: (s: unknown, m: string, o?: { probe?: boolean }) => Promise<void>;
+            }).sendToSurface(captainSurface, msg, probe ? { probe: true } : undefined);
             deferCounts.delete(entry.seq);
+            stableCounts.delete(entry.seq);
+            lastContent.delete(entry.seq);
           } catch (e) {
             if (e instanceof DeferDelivery) {
               deferCounts.set(entry.seq, (deferCounts.get(entry.seq) ?? 0) + 1);
+              // Track content stability: byte-identical non-empty draft across
+              // consecutive polls means the captain isn't actively typing (#302).
+              const content = e.draft;
+              if (content && content === lastContent.get(entry.seq)) {
+                stableCounts.set(entry.seq, (stableCounts.get(entry.seq) ?? 0) + 1);
+              } else {
+                stableCounts.set(entry.seq, 0);
+              }
+              lastContent.set(entry.seq, content);
               log(`deferred: captain typing (seq=${entry.seq})`);
               // Don't advance cursor; the next poll will retry from the same seq.
               return;
@@ -405,6 +434,7 @@ export const notifyRelayCommand = new Command("notify-relay")
         captainName: projCfg.captainName,
         pollMs: 1000,
         maxDeferDeliveries: config.relay?.maxDeferDeliveries ?? DEFAULT_MAX_DEFERS,
+        stableProbePolls: config.relay?.stableProbePolls ?? DEFAULT_STABLE_PROBE_POLLS,
       });
       process.on("SIGTERM", () => process.exit(0));
     } catch (err) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -75,6 +75,8 @@ export interface CockpitConfig {
   relay?: {
     /** Max consecutive defers before force-delivering a message (~1s poll cadence). Default: 300 (~5min). */
     maxDeferDeliveries?: number;
+    /** Consecutive stable-content polls before probing early to avoid a stall (#302). Default: 3 (~3s). */
+    stableProbePolls?: number;
   };
   defaults: {
     maxCrew: number;

--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -584,40 +584,83 @@ describe("sendToSurface draft-preservation", () => {
     expect(sends[0]).toContain("crew is done");
   });
 
-  it("saves draft, clears input via backspaces, delivers, then restores draft without submitting (force=true)", async () => {
-    // "hello this is my draft" = 22 chars → 24 backspaces (draft.length + 2 margin)
-    const DRAFT = "hello this is my draft";
+  // #302 — the old destructive force path (backspace×N clear + re-paste the
+  // screen-read draft) is replaced by a non-destructive BUFFER-LIVENESS PROBE.
+  // Verified live (CC 2.1.x): a real draft is the ONLY thing that yields the
+  // "last char removed, still non-empty" signature under ONE backspace; a ghost
+  // either stays invariant or dismisses to empty. So the probe protects ONLY a
+  // real draft and NEVER re-pastes screen-read content (the materialization vector).
+  //
+  // Stateful mock of CC's input box: `box` is the content rendered between the
+  // HRs; one backspace transforms it per `onBackspace`; read-screen renders the
+  // current box. This lets a probe observe a DIFFERENT screen before vs after.
+  function probeMock(initial: string, onBackspace: (s: string) => string) {
+    let box = initial;
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      if (args.includes("read-screen")) {
-        return makeTestScreen(`│ > ${DRAFT}  │`, "│ Some conversation history │");
-      }
+      if (args.includes("read-screen")) return makeTestScreen(`❯ ${box}`);
+      if (args.includes("send-key") && args.includes("backspace")) { box = onBackspace(box); return ""; }
       return "";
     });
-    await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done", { force: true });
+  }
+
+  it("probe: real draft (last-char-removal signature) → restores the one removed char and defers; never re-pastes the draft, never delivers", async () => {
+    const DRAFT = "hello world";
+    probeMock(DRAFT, (s) => s.slice(0, -1)); // real draft: backspace removes exactly the last char
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done", { probe: true }),
+    ).rejects.toBeInstanceOf(DeferDelivery);
     const calls = execFileMock.mock.calls.map(argvOf);
+    // Exactly ONE backspace — the probe, NOT a backspace×N clear
+    expect(calls.filter((a) => a.includes("send-key") && a.includes("backspace"))).toHaveLength(1);
+    // Crew message must NEVER be delivered (we deferred to protect the draft)
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")))).toBe(false);
+    // The full draft must NEVER be re-pasted (this was the #302 materialization vector)
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes(DRAFT)))).toBe(false);
+    // Only the single removed char ("d") is restored
+    const sends = calls.filter((a) => a[0] === "send");
+    expect(sends).toHaveLength(1);
+    expect(sends[0][sends[0].length - 1]).toBe("d");
+  });
 
-    // No ctrl-u: that key is a no-op against Claude Code's input box
-    expect(calls.every((a) => !a.includes("ctrl-u"))).toBe(true);
+  it("probe: ghost that DISMISSES to empty under backspace → delivers message+Enter, NEVER re-sends the ghost text (#302 materialization regression)", async () => {
+    const GHOST = "wait for both crews to finish";
+    probeMock(GHOST, () => ""); // verified live: the #294 queue ghost dismisses to empty
+    await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done", { probe: true });
+    const calls = execFileMock.mock.calls.map(argvOf);
+    // The ghost text is NEVER typed back into the box
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("wait for both crews")))).toBe(false);
+    // The crew message IS delivered and submitted
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")))).toBe(true);
+    expect(calls.some((a) => a.includes("send-key") && a.includes("Enter"))).toBe(true);
+  });
 
-    // Backspaces must precede the message send
-    const msgSendIdx = calls.findIndex((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")));
-    const backspacesBefore = calls.slice(0, msgSendIdx).filter((a) => a.includes("send-key") && a.includes("backspace")).length;
-    expect(backspacesBefore, "backspace count = draft.length + 2").toBe(DRAFT.length + 2);
+  it("probe: ghost INVARIANT under backspace (stays identical) → delivers, never re-sends the ghost", async () => {
+    const GHOST = "some persistent suggestion";
+    probeMock(GHOST, (s) => s); // invariant: backspace is a no-op on non-buffer ghost
+    await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done", { probe: true });
+    const calls = execFileMock.mock.calls.map(argvOf);
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("persistent suggestion")))).toBe(false);
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")))).toBe(true);
+  });
 
-    const enterIdx = calls.findIndex((a, i) => i > msgSendIdx && a.includes("send-key") && a.includes("Enter"));
-    // findLastIndex is ES2023; reverse-scan manually to stay within repo's tsconfig target
-    let restoreIdx = -1;
-    for (let i = calls.length - 1; i >= 0; i--) {
-      const a: string[] = calls[i];
-      if (a[0] === "send" && a.some((s: string) => s.includes(DRAFT))) { restoreIdx = i; break; }
-    }
-    expect(msgSendIdx).toBeGreaterThanOrEqual(0);
-    expect(enterIdx, "Enter after message").toBeGreaterThan(msgSendIdx);
-    // Restore send comes after Enter (draft goes back without submitting)
-    expect(restoreIdx, "restore after Enter").toBeGreaterThan(enterIdx);
-    // Restore must NOT be followed by another Enter
-    const cmdsAfterRestore = execFileMock.mock.calls.slice(restoreIdx + 1).map(cmdOf);
-    expect(cmdsAfterRestore.every((c) => !c.includes("Enter"))).toBe(true);
+  it("non-probe call with a draft present defers WITHOUT any keystroke (hot path unchanged — never races typing)", async () => {
+    probeMock("typing in progress", (s) => s.slice(0, -1));
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done"),
+    ).rejects.toBeInstanceOf(DeferDelivery);
+    const calls = execFileMock.mock.calls.map(argvOf);
+    expect(calls.some((a) => a.includes("backspace"))).toBe(false);
+    expect(calls.some((a) => a[0] === "send")).toBe(false);
+  });
+
+  it("DeferDelivery carries the observed draft text so the relay can track content stability", async () => {
+    probeMock("my draft text", (s) => s.slice(0, -1));
+    let caught: unknown;
+    try {
+      await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done");
+    } catch (e) { caught = e; }
+    expect(caught).toBeInstanceOf(DeferDelivery);
+    expect((caught as DeferDelivery).draft).toBe("my draft text");
   });
 
   // #268: unreadable screen → draft stays null → DeferDelivery (never deliver into unknown state).
@@ -921,31 +964,26 @@ describe("sendToSurface Approach B (#258 deliver-when-empty)", () => {
     expect(calls.every((a) => !a.includes("backspace"))).toBe(true);
   });
 
-  it("non-empty draft + force=true → backspace clear, deliver, restore without Enter", async () => {
+  // #302: a real walk-away draft under {probe:true} is detected by the
+  // last-char-removal signature → restore + defer; it is NEVER force-delivered
+  // (the old backspace×N clear + re-paste, which materialized ghosts, is gone).
+  it("real walk-away draft + probe=true → one backspace, restore one char, defers (never force-clobbers)", async () => {
     const DRAFT = "my walk-away draft";
+    let box = DRAFT;
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      if (args.includes("read-screen")) return makeTestScreen(`❯ ${DRAFT}`);
+      if (args.includes("read-screen")) return makeTestScreen(`❯ ${box}`);
+      if (args.includes("send-key") && args.includes("backspace")) { box = box.slice(0, -1); return ""; }
       return "";
     });
-    await driver.sendToSurface(
-      { workspaceId: "workspace:3", surfaceId: "surface:8" },
-      "crew done",
-      { force: true },
-    );
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done", { probe: true }),
+    ).rejects.toBeInstanceOf(DeferDelivery);
     const calls = execFileMock.mock.calls.map(argvOf);
-    const msgIdx = calls.findIndex((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")));
-    const backspacesBefore = calls.slice(0, msgIdx).filter((a) => a.includes("send-key") && a.includes("backspace")).length;
-    expect(backspacesBefore, "backspace count = draft.length + 2").toBe(DRAFT.length + 2);
-    const enterIdx = calls.findIndex((a, i) => i > msgIdx && a.includes("send-key") && a.includes("Enter"));
-    let restoreIdx = -1;
-    for (let i = calls.length - 1; i >= 0; i--) {
-      const a: string[] = calls[i];
-      if (a[0] === "send" && a.some((s: string) => s.includes(DRAFT))) { restoreIdx = i; break; }
-    }
-    expect(enterIdx, "Enter after message").toBeGreaterThan(msgIdx);
-    expect(restoreIdx, "restore after Enter").toBeGreaterThan(enterIdx);
-    // Restore must NOT be followed by another Enter
-    const afterRestore = execFileMock.mock.calls.slice(restoreIdx + 1).map(cmdOf);
-    expect(afterRestore.every((c) => !c.includes("Enter"))).toBe(true);
+    // Exactly ONE backspace (the probe), not draft.length+2
+    expect(calls.filter((a) => a.includes("send-key") && a.includes("backspace"))).toHaveLength(1);
+    // Message NOT delivered, full draft NEVER re-pasted, no Enter submitted
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")))).toBe(false);
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes(DRAFT)))).toBe(false);
+    expect(calls.some((a) => a.includes("send-key") && a.includes("Enter"))).toBe(false);
   });
 });

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -16,8 +16,10 @@ export class CmuxTimeoutError extends Error {
 
 // #258 Approach B: thrown by sendToSurface when the captain has any draft in
 // the input box. The relay defers delivery until the input is empty.
+// #302: carries the observed draft text so the relay can detect content
+// stability (same content for K polls = not actively typing → safe to probe).
 export class DeferDelivery extends Error {
-  constructor() {
+  constructor(public readonly draft: string | null = null) {
     super("deferred: captain composing");
     this.name = "DeferDelivery";
   }
@@ -156,6 +158,38 @@ export function parseDraftFromScreen(screen: string): string | null {
   }
 
   return "";
+}
+
+/**
+ * Extract the RAW input-box content for the #302 buffer-liveness probe — all
+ * content lines between the last two HRs, joined, with the prompt glyph and any
+ * trailing cursor glyph stripped (but NOT the #294 ghost heuristics: the probe
+ * needs the literal rendered text to diff before/after a backspace). Returns
+ * null if the box boundaries aren't visible (overlay/scroll). Unlike
+ * parseDraftFromScreen this captures EVERY content line, so a multi-line draft's
+ * change on its last line is not missed.
+ */
+export function readInputBoxRaw(screen: string): string | null {
+  if (!screen) return null;
+  const lines = screen.split(/\r?\n/);
+  const HR_RE = /^\s*─{10,}\s*$/;
+  let bottomHR = -1;
+  let topHR = -1;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (HR_RE.test(lines[i])) {
+      if (bottomHR === -1) bottomHR = i;
+      else { topHR = i; break; }
+    }
+  }
+  if (topHR === -1) return null;
+  const parts: string[] = [];
+  for (const line of lines.slice(topHR + 1, bottomHR)) {
+    let s = line.replace(/│/g, " ");        // drop box-drawing borders
+    s = s.replace(/^\s*[>❯]\s?/, "");        // drop the leading prompt glyph + one space
+    s = s.replace(/\s*[▌█▔▎▏]+\s*$/, "");    // drop a trailing cursor glyph
+    parts.push(s);
+  }
+  return parts.join("").replace(/\s+$/, ""); // trim only the trailing edge
 }
 
 export function createCmuxDriver(): RuntimeDriver {
@@ -357,39 +391,56 @@ export function createCmuxDriver(): RuntimeDriver {
       return { workspaceId: wsId, surfaceId, title: opts.title };
     },
 
-    async sendToSurface(surface: PaneRef, text: string, opts?: { force?: boolean }): Promise<void> {
+    async sendToSurface(surface: PaneRef, text: string, opts?: { probe?: boolean }): Promise<void> {
+      const ws = surface.workspaceId;
+      const sf = surface.surfaceId;
+      const deliver = () => {
+        cmux(["send", "--workspace", ws, "--surface", sf, sanitizeForCmuxSend(text)]);
+        cmux(["send-key", "--workspace", ws, "--surface", sf, "Enter"]);
+      };
+
       // #258/#268 Approach B: deliver only when the captain's input is positively
       // confirmed empty. null = box not visible (overlay/menu/scroll) → always defer.
-      let draft: string | null = null;
+      let screen = "";
       try {
-        const screen = cmux(["read-screen", "--workspace", surface.workspaceId, "--surface", surface.surfaceId]);
-        draft = parseDraftFromScreen(screen);
-      } catch { /* screen unreadable — draft stays null, will defer below */ }
+        screen = cmux(["read-screen", "--workspace", ws, "--surface", sf]);
+      } catch { /* screen unreadable — parseDraftFromScreen("") → null → defer below */ }
+      const draft = parseDraftFromScreen(screen);
 
       // null = box not confirmed visible → never keystroke into an overlay (#268).
-      if (draft === null) {
-        throw new DeferDelivery();
+      if (draft === null) throw new DeferDelivery(null);
+
+      // Empty input — nothing to protect, deliver directly.
+      if (draft === "") { deliver(); return; }
+
+      // A draft is present. On the hot path (no probe) we NEVER keystroke — we
+      // defer and carry the content so the relay can track stability (#302).
+      if (!opts?.probe) throw new DeferDelivery(draft);
+
+      // #302 buffer-liveness probe (replaces the old destructive backspace×N
+      // clear + re-paste, which MATERIALIZED ghost suggestions). A real draft is
+      // the ONLY thing that yields the "last char removed, still non-empty"
+      // signature under ONE backspace (verified live, CC 2.1.x); a ghost either
+      // stays invariant or dismisses to empty. So we PROTECT only on that exact
+      // signature, and we NEVER re-paste screen-read content.
+      const before = readInputBoxRaw(screen);
+      cmux(["send-key", "--workspace", ws, "--surface", sf, "backspace"]);
+      let afterScreen = "";
+      try {
+        afterScreen = cmux(["read-screen", "--workspace", ws, "--surface", sf]);
+      } catch { /* unreadable after probe — treat as no real draft, fall through to deliver */ }
+      const after = readInputBoxRaw(afterScreen);
+
+      if (before !== null && after !== null && after.length > 0 && after === before.slice(0, -1)) {
+        // Confirmed REAL draft. Restore the single char our probe removed (NOT a
+        // full re-paste — at most one known char), then defer. Never clobber, and
+        // a ghost can never reach this branch, so it can never be materialized.
+        cmux(["send", "--workspace", ws, "--surface", sf, before.slice(-1)]);
+        throw new DeferDelivery(draft);
       }
 
-      if (draft && !opts?.force) {
-        // Captain is composing — defer until input clears (relay retries next poll).
-        throw new DeferDelivery();
-      }
-
-      if (draft && opts?.force) {
-        // Walk-away last-resort: backspace×(N+2) clears, deliver, restore draft.
-        const backspaceCount = draft.length + 2;
-        for (let i = 0; i < backspaceCount; i++) {
-          cmux(["send-key", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, "backspace"]);
-        }
-        cmux(["send", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, sanitizeForCmuxSend(text)]);
-        cmux(["send-key", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, "Enter"]);
-        cmux(["send", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, sanitizeForCmuxSend(draft)]);
-      } else {
-        // Input is empty — deliver directly, nothing to protect.
-        cmux(["send", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, sanitizeForCmuxSend(text)]);
-        cmux(["send-key", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, "Enter"]);
-      }
+      // No real draft (ghost dismissed/invariant, or buffer now empty) → deliver.
+      deliver();
     },
 
     async listSurfaces(workspaceId: string): Promise<PaneRef[]> {

--- a/src/runtimes/types.ts
+++ b/src/runtimes/types.ts
@@ -73,6 +73,8 @@ export interface RuntimeDriver {
   // targets one surface directly. Used by the notify-relay injector to
   // deliver messages to the captain's primary surface. Throws if the surface
   // no longer exists.
-  // opts.force=true skips the idle-defer stability check (#258 phase 2).
-  sendToSurface(surface: PaneRef, text: string, opts?: { force?: boolean }): Promise<void>;
+  // opts.probe=true runs the #302 buffer-liveness probe: deliver only if no real
+  // draft is present (protects a real draft, never materializes a ghost). Without
+  // it, any draft defers (#258/#268 deliver-when-empty).
+  sendToSurface(surface: PaneRef, text: string, opts?: { probe?: boolean }): Promise<void>;
 }


### PR DESCRIPTION
Closes #302. Follow-up to #294/#258.

## Problem
The relay's force-delivery path (`sendToSurface` force branch: backspace×(len+2) clear + `cmux send` **re-paste of screen-read draft**) **materialized** a CC contextual autosuggest ghost into a real draft — text the user never typed. `cmux read-screen` is plain-text only, so a ghost is byte-identical to a real draft; pattern-matching (#294) is whack-a-mole.

## Why kill-ring / backspace were not the answer (documented, not regressed)
- **kill-ring** (`ctrl-u`/`ctrl-k`): **no-ops in CC's input** — proven live in #267, asserted in the suite, and confirmed in the CC bundle (`ctrl+u` = half-page scroll; `yank` = vi-mode only). DOA.
- **backspace×N clear + fixed idle window** (interim): slow (~600ms) → races keystrokes; window mis-fires for slow typists. → Approach B (deliver-when-empty defer) was chosen and is kept.

## Fix — buffer-liveness probe (replaces only the force branch)
**Key insight (verified live, CC 2.1.x):** a real draft is the ONLY thing that yields the "last char removed, still non-empty" signature under ONE backspace. A ghost stays invariant or dismisses to empty. So:
- read box → send ONE backspace → re-read.
- `after === before.slice(0,-1)` and non-empty → **real draft** → restore the one removed char, **defer** (never clobber, never re-paste the full draft).
- else (ghost dismissed/invariant, or now empty) → **deliver**.

The relay **never re-pastes screen-read content** → ghost materialization is **structurally impossible**. Worst-case failure degrades to a *stall*, never materialization.

## Stall fix (original #294 pain: ~5min defer)
The relay now **probes early** once draft content is byte-stable for `stableProbePolls` (default 3 ≈ 3s) — an unrecognized ghost is delivered in seconds. An actively-typing captain's content **changes** between polls → never stable → never probed (**no keystroke race** — exactly the race that killed the backspace approach). The 300-defer backstop is kept but is now harmless: the probe is inherently race-safe (its only delivering branch is "no real draft"; a live typist always presents a real draft → restore-and-defer).

### Design decision (requested): stability-probe IS included
Rationale: fixing only materialization leaves the headline 5-min stall. The probe being race-safe means triggering it early on content-stability carries no risk — the only downside of a mistimed probe is a 1-char flicker, and the stability gate avoids even that. Kept the maxDefers backstop per request; it can no longer clobber.

## Invariants preserved
- **#258** real draft never clobbered/submitted (restore + defer)
- **#268** `null`/overlay → always defer
- **#294** ghost fast-path retained; now non-load-bearing (probe is the backstop, ending whack-a-mole)
- **#302** relay never types screen-read content into the box

## Changes
- `cmux.ts`: `DeferDelivery` carries `draft`; force branch → probe; add `readInputBoxRaw` (multi-line box capture)
- `notify-relay.ts`: per-seq content-stability tracking; probe trigger; `DEFAULT_STABLE_PROBE_POLLS`
- `types.ts`/`config.ts`: `sendToSurface` opt `force`→`probe`; `relay.stableProbePolls` config key

## Verification
- `npm run build` (tsc) clean; `vitest run` **1078/1078** (6 new cmux probe tests, 1 reworked walk-away test, 3 relay stability tests)
- **STEP 0 live** (gate): backspace is buffer-aware — empty invariant, real draft loses last char, #294 queue-ghost dismisses to empty
- **Live e2e** vs a real CC 2.1.x box via the compiled driver: real draft → DEFERRED (intact); empty → DELIVERED; ghost → DELIVERED, buffer confirmed empty (**ghost not materialized**). Throwaway sessions torn down, no orphans.

Full write-up: `docs/specs/2026-06-14-302-nondestructive-delivery-proposal.md`

> Post-deploy: re-run the crew-lifecycle checklist against live crews once the global relay is rebuilt from this branch.