### PR TITLE
release: v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-06-15
+
+A reliability patch addressing relay ghost-materialization, headless launcher I/O pressure, cross-project boot-if-down, and crew spawn focus leakage — plus a build fix and a CI gate.
+
+### Fixed
+
+- **Cross-project boot-if-down now works reliably.** The target captain is brought to operational before warmup is judged; warmup timeout extended from 30 s → 120 s and exposed as `--warmup-timeout` flag. Closes #288. (#291)
+
+- **Headless launcher I/O pressure reduced.** Task-progress writes are coalesced via a 250 ms / 50-chunk debounce with a final flush, stopping O(chunks) file writes. stdout/stderr capture is capped at a 4 MB tail to bound memory. Closes #88. (#293)
+
+- **Relay no longer materializes Claude Code ghost-suggestions into drafts.** A buffer-liveness probe replaces the destructive re-paste mechanism: the probe distinguishes a ghost auto-suggestion from a real draft without clearing the input, so a ghost can never be committed as a crew message. The ~5-min defer stall from the previous heuristic is also eliminated via an early stability-probe path. Closes #294 and #302. (#297, #303)
+
+- **`crew spawn` (tab) no longer steals cmux focus.** Captain focus is restored after the new-pane call, preventing keystroke leakage into the crew launch command. Closes #295. (#299)
+
+- **TypeScript build error in headless-launcher tests fixed.** The `writeResult` mock was typed incorrectly, breaking `npm run build`. Closes #300. (#301)
+
+### Changed
+
+- **`crew spawn` defaults to an isolated git worktree+branch.** Parallel crews no longer collide on a shared working tree; opt out with `--shared` for small single-file tasks. Closes #296. (#298)
+
+- **CI `build-and-test` is a required merge gate on `develop`.** Broken builds and test failures are now caught at PR time rather than after merge.
+
 ## [0.6.0] - 2026-06-14
 
 A coordination-layer release headlined by **leveled crew routing** and the **side-sessions framework**, plus two crew-lifecycle reliability fixes — crews now signal `DONE` on their own, and `--worktree` crews are genuinely isolated. Also ships **experimental** cross-project intra-group delegation.

--- a/docs/reports/294-ghost-placeholder-fixture.txt
+++ b/docs/reports/294-ghost-placeholder-fixture.txt
@@ -1,0 +1,25 @@
+  
+
+⏺ Mình đã có design-spec đầy đủ từ iOS cho cả 6 màn (layout, spacing, màu Constants.*, font "Be Vietnam Pro", ~25 asset, các custom component như
+  PrimaryButton/SecondaryButton/BoardPinRow/BorderBeam...). Đây là project port UI đa-màn khá lớn.
+
+  Theo nguyên tắc "port asset trước" — để mình audit xem asset/font nào đã có trong Android, cái nào thiếu (đây là việc phải làm trước khi port màn):
+
+⏺ Running 1 shell command…
+  ⎿  $ cd /Users/q3labsadmin/me/LumiLabs/oneplan-wt-board/android/app/src/main/res
+     echo "=== Board-related assets already in Android res? ==="
+     for a in board_instagram board_tiktok empty_board create_board_thumbnail process_pin board_compass board_pin restaurant coffee night_club hotel shopping 
+     park mus…
+
+✳ Working… (14m 7s · ↓ 49.8k tokens · thinking more with high effort)
+  ⎿  Tip: Use Plan Mode to prepare for a complex request before making changes. Press shift+tab twice to enable.
+
+  ❯ nhớ là cũng cần port các feature và flow gaps bạn tìm được nhé                                                                                             
+
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+❯ Press up to edit queued messages
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+   Model: Opus 4.8  Ctx Used: 49.0%  Cost: $66.05  Session: 28hr 22m 
+   Session ID: 332e6ae9-ee58-4a63-9a98-88af6004a3c0  Thinking: high 
+   ⎇ ui-polish  𖠰 main 
+  ⏵⏵ auto mode on · PR #79 · 1 shell

--- a/docs/specs/2026-06-14-302-nondestructive-delivery-proposal.md
+++ b/docs/specs/2026-06-14-302-nondestructive-delivery-proposal.md
@@ -1,0 +1,182 @@
+# Issue #302 — Non-destructive, ghost-immune relay delivery (PHASE 1 proposal)
+
+**Status:** IMPLEMENTED. Build + full suite green; live end-to-end verified.
+**Branch (Phase 2):** `fix/302-nondestructive-delivery` off `develop`.
+
+---
+
+## Phase 2 results (implemented)
+
+**Change (surgical):**
+- `cmux.ts` — `DeferDelivery` now carries the observed `draft`; `sendToSurface`'s
+  destructive `force` branch (backspace×N clear + **re-paste of screen-read draft**)
+  is **deleted** and replaced by the buffer-liveness **probe** (`{ probe: true }`);
+  added `readInputBoxRaw` (full multi-line box capture for the before/after diff).
+- `notify-relay.ts` — tracks per-seq content stability; triggers the probe once
+  content is byte-stable for `stableProbePolls` (default 3 ≈ 3s) **or** the
+  300-defer backstop; `force`→`probe`. New `DEFAULT_STABLE_PROBE_POLLS`.
+- `types.ts` / `config.ts` — `sendToSurface` opt `force`→`probe`; new
+  `relay.stableProbePolls` config key.
+
+**Probe rule:** read box; send ONE backspace; re-read. If `after === before.slice(0,-1)`
+and non-empty → **real draft** → restore the one removed char, defer (never clobber,
+never re-paste the full draft). Else (ghost dismissed/invariant, or now empty) → deliver.
+
+**Stability/stall fix (reconciliation with the race that killed backspace in #258):**
+the probe is *inherently race-safe* — its only delivering branch is "no real draft,"
+and an actively-typing captain always presents a real draft → the probe hits the
+restore-and-defer branch (a brief 1-char flicker at worst), never a clobber. The
+stability gate additionally avoids even that flicker by only probing when content is
+stable. So the 300-defer backstop is kept but is now harmless (it can no longer
+clobber). **Worst-case failure mode is a stall, never materialization.**
+
+**Verification:**
+- `npm run build` (tsc) clean; `vitest run` full suite **1078/1078 green** (new: 6
+  cmux probe tests + 1 reworked walk-away test + 3 relay stability tests).
+- **STEP 0 live** (gate): backspace is buffer-aware — empty box invariant, real draft
+  loses last char, #294 queue-ghost dismisses to empty.
+- **Live end-to-end** against a real CC 2.1.x box via the *compiled* driver: real
+  draft → DEFERRED (draft intact); empty → DELIVERED; ghost → DELIVERED with buffer
+  confirmed empty (typing a char replaced the placeholder — **ghost not materialized**).
+  Throwaway sessions torn down, no orphaned `claude`.
+
+**Not run here (captain deploy-time):** the full crew-lifecycle checklist against
+*live deployed* crews requires the globally-installed relay to be rebuilt from this
+branch. Relevant checkpoints to re-confirm post-deploy: #258 preserve-draft, #268
+overlay/null defer, #294 ghost fast-path, and the new #302 stall-free ghost delivery.
+
+---
+
+## STEP 0 — live verification (DONE, gate PASSED)
+
+Bounded throwaway `claude --permission-mode plan` in a temp git dir, driven via `cmux
+send-key`/`read-screen`, torn down clean (no orphaned `claude`). CC 2.1.x.
+
+| Case | Before backspace | After ONE backspace | Signature |
+|------|------------------|---------------------|-----------|
+| Empty buffer | `❯ \xa0` | `❯ \xa0` (identical) | **invariant** |
+| Real draft | `hello world` | `hello worl` | **clean last-char removal** |
+| Real ghost (#294 queue placeholder) | `Press up to edit queued messages` | `❯ ` (empty); buffer confirmed empty — typing `X`→`X`, not appended | **dismissed to empty** |
+
+**Refined rule (stronger than the original Case-A assumption):** a real draft is the ONLY thing
+that yields the "last char removed, still non-empty" signature. Every ghost either stays invariant
+or dismisses to empty — never that signature. So **protect only on the positive real-draft
+signature; otherwise the buffer holds no preservable draft → deliver.** Even an exotic ghost misread
+as real degrades to *defer* (we re-type only the one char we removed, then defer) — **never
+materialization, never submission.** #302's headline harm is structurally impossible.
+
+---
+
+## 1. Why this subsystem churned 3× (#258) — documented so we don't regress
+
+Source: PR #266 → #267 → #269, the line-600 test comment, and live findings.
+
+| Attempt | Mechanism | Why abandoned (live-proven, not unit) |
+|--------|-----------|---------------------------------------|
+| #266 | **kill-ring**: `ctrl-u` / `ctrl+a`+`ctrl+k` to clear, restore after | **`ctrl-u`/`ctrl-k` are NO-OPs in Claude Code's input.** Proven live via `cmux send-key` (PR #267 body). Corroborated two more ways: (a) the regression test at `cmux.test.ts:600` asserts `ctrl-u` is never used "that key is a no-op against Claude Code's input box"; (b) strings of CC 0.80.0 bundle show `ctrl+u` bound to **half-page scroll** (`"ctrl+u/ctrl+d to scroll"`, `case"u":return"halfPage…"`), and `yank` exists **only in vi-mode** (`implement yank mode for vi`). CC's default input is **not** a readline line-editor. |
+| (interim) | **backspace×N clear + restore** with a fixed idle-stability window | (a) backspace×N is **slow** (~600 ms for a long draft) so it **races live keystrokes**; (b) a fixed idle window **mis-fires for slow typists** (between-keystroke gaps exceed the window). (PR #267 body.) |
+| #267 | **Approach B — deliver-only-when-empty (read-the-box idle-defer)** | **Chosen.** `sendToSurface` reads the box; any draft → throw `DeferDelivery`, relay retries next poll (never touches keystrokes); empty → deliver. Eliminates the clear/restore race entirely because the box is empty most of the time. #269 then scoped the parse to the live input box (between the two `───` HRs) and made the walk-away force-fallback configurable (`relay.maxDeferDeliveries`, default 300 ≈ 5 min). #268 added the 3rd state: `null` (HR boundaries absent = overlay/scroll) → always defer. |
+
+**Invariants we must NOT regress:**
+- **#258:** never clobber / never prematurely submit a real in-progress draft.
+- **#268:** `null` (box not visible) → always defer; never keystroke into an unknown UI.
+- **#294:** CC ghost/placeholder text must never be treated as a real draft to act on.
+
+## 2. The current bug (#302) — exact mechanism
+
+`src/runtimes/cmux.ts` `sendToSurface` **force branch** (lines ~379-388):
+
+```
+backspace × (draft.length + 2)        // clear
+cmux send <crew msg> ; send-key Enter // deliver
+cmux send <draft>                     // RESTORE  ← re-pastes screen-read text
+```
+
+The walk-away force fallback fires after `maxDefers` (300) consecutive defers. The force path
+trusts that `draft` (read from `parseDraftFromScreen`) is **real user input worth restoring**,
+and re-pastes it. When the "draft" is actually a CC **contextual autosuggest ghost** (arbitrary
+text, e.g. "wait for both crews to finish"), the final `cmux send <draft>` **materializes the dim
+ghost into a real, normal-coloured draft** — the user never typed it.
+
+**Why #294's parse heuristics can't fix this:** CC renders an autosuggest ghost as arbitrary
+plain text with no leading `▌` (cursor is drawn via ANSI, hex-proven in #294) and `cmux read-screen`
+is plain-text only (no `--raw/--ansi/--cursor`). A ghost is **byte-identical** to a real draft.
+**There is no content signal.** Pattern-matching ghosts (`^Press … to …`, leading-glyph) is
+whack-a-mole and will never be complete.
+
+## 3. Candidate mechanisms evaluated
+
+**(a) Blind kill-ring (Ctrl-U cut → deliver → Ctrl-Y restore).** *Rejected.* The premise ("Ctrl-U
+cuts only real input") is false for CC: Ctrl-U does not cut, it scrolls (§1). CC's input is not a
+readline editor outside vi-mode, and there is no stable yank we can drive via `cmux send-key`.
+Re-testing live would only re-confirm #267. **Dead on arrival.**
+
+**(b) CC native message QUEUE** ("Press up to edit queued message(s)" — confirmed in the CC bundle).
+*Rejected as the primary mechanism.* The queue only engages while CC is **Working/generating**; the
+relay cannot force that state, and the common #302 case is CC **idle**. Worse, while Working a
+captain's in-progress draft + our `send`+Enter still **merges into the queued entry** — it does not
+sidestep the draft-merge problem. Useful only as a future optimization, not a fix.
+
+**(c) Buffer-liveness probe (RECOMMENDED).** A new primitive that recovers kill-ring's *ghost-immunity
+property* using only **backspace**, which CC **does** support. Key insight: **a ghost is not in the
+real input buffer; backspace is buffer-aware.** So we distinguish ghost vs real draft by *effect on
+the buffer*, not by *content* — exactly the signal #302 says is missing from the screen text.
+
+## 4. RECOMMENDATION — Buffer-liveness probe (replace only the force branch)
+
+Leave the hot path untouched (Approach B defer stays). Change **only** the force branch of
+`sendToSurface`. On force:
+
+1. Read screen → content `C`. If empty → deliver `MSG`+Enter (unchanged).
+2. If `C` non-empty: send **one** `backspace`, re-read screen → `C'`.
+   - **Case A — `C' == C` (buffer-invariant):** the box content is a **ghost / static UI**, not in
+     the buffer (the backspace was a harmless no-op on an empty buffer). **Deliver `MSG`+Enter.**
+     Typing `MSG` replaces the ghost render; Enter submits only `MSG`. **Ghost never materialized.**
+   - **Case B — `C'` is `C` minus its last char:** a **real draft** is present. Re-type that one
+     known char to restore it, then **defer** (throw `DeferDelivery`). We **never force-merge into a
+     real draft** — the relay keeps the message queued; the captain submits/clears later and it
+     lands. **Real draft preserved.**
+   - **Case C/D — empty after one backspace, or a different non-empty string:** ambiguous edge
+     (≤1-char content, or autosuggest re-render). Treat as real (restore + defer) — fail safe
+     toward never-materialize. Bounded, rare.
+
+**Crucially: the relay NEVER re-pastes the whole screen-read draft.** Removing that single
+`cmux send <draft>` line is what makes ghost-materialization *structurally impossible* — ending the
+whack-a-mole permanently. The probe is what keeps crew delivery flowing during a persistent ghost
+**without** ever clobbering a real draft.
+
+### Invariants preserved
+- **#258:** Case B restores the draft char-for-char and defers — never submits/merges it. ✓
+- **#268:** `null` path unchanged — still always defers. ✓
+- **#294:** existing ghost heuristics in `parseDraftFromScreen` can stay as a cheap defer-noise
+  pre-filter but are **no longer load-bearing**; the probe is the backstop, so an *unknown* ghost
+  pattern is now safe (it just resolves to Case A and delivers). ✓
+- **New #302 invariant:** the relay never types screen-read content into the box (no full-draft
+  re-paste; Case B only re-types the single char *it itself* removed). ✓
+
+### Risk / the ONE thing to verify live in Phase 2 (step 0)
+The probe rests on: **CC's autosuggest ghost on an empty buffer is invariant under a no-op
+backspace, and backspace on an empty buffer is a true no-op** (Case A holds; doesn't dismiss-to-empty
+or re-render a different suggestion). #267 already proved backspace deletes only real chars; the
+open question is the ghost's render reaction. **Phase 2 step 0 = a bounded live test** (throwaway
+cmux surface + claude, send-key backspace against a displayed ghost vs a real draft, diff
+read-screen, then tear down — no orphaned `claude`). If Case A fails, fallback = keep no-repaste +
+treat force-with-content as "defer forever, log loudly" (never materialize; crew msg waits) —
+strictly better than today but doesn't auto-deliver through a persistent ghost.
+
+### Impact analysis (per CLAUDE.md)
+`gitnexus_impact(sendToSurface, upstream)` → **LOW**, 0 static callers (invoked dynamically via the
+`RuntimeDriver` cast at `notify-relay.ts:268`). Blast radius is the relay defer loop only, already
+mapped. Change is surgical: the force branch of `sendToSurface` + its one test
+(`cmux.test.ts:587` "saves draft, clears…restores", which encodes the behavior we're replacing).
+
+## 5. Phase 2 plan (after approval)
+0. Live-verify Case A (bounded, self-cleaning claude test).
+1. TDD: rewrite `cmux.test.ts:587` to the probe contract (Case A delivers, no full-draft re-paste;
+   Case B restores 1 char + `DeferDelivery`); add ghost-materialization regression (ghost content →
+   force → asserts MSG submitted and ghost text NEVER re-sent).
+2. Implement surgically in the force branch only (karpathy). `gitnexus_impact` before edit;
+   `gitnexus_detect_changes` before commit.
+3. `npm run build` (tsc gate) + `npm test` green; targeted cmux + notify-relay suites.
+4. Crew-lifecycle checklist (`docs/testing/crew-lifecycle-checklist.md`): #258 preserve draft,
+   #268 overlay/null defer, #294 ghost. Clean up orphaned vitest.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-cockpit",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-cockpit",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-cockpit",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Multi-project agent orchestration for Claude Code",
   "type": "module",
   "bin": {

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -177,7 +177,7 @@ To add, edit, or remove routing rules: use the `cockpit:add-pick-crew-rule` skil
 
 - **Reuse with `send` before spawning a new one.** Same task track, same crew. New track = new crew.
 - **Close crews you're done with** (`cockpit crew close ...`) so they don't accumulate.
-- Do NOT manually run `git worktree add`. The crew operates in the captain's checkout. If a task genuinely requires worktree isolation, ask the user.
+- Crews run in **isolated worktrees by default** (parallel-safe, branch per crew). Pass `--shared` only for tiny/one-off tasks that don't need branch isolation. Never hand-run `git worktree add` — `cockpit crew spawn` handles it.
 - Do NOT edit source code yourself — always delegate to crew.
 - Respect `maxCrew` — don't exceed the configured concurrent crew count.
 - **For complex multi-step tasks** (3+ steps, multiple files), tell the crew to use GSD inside the task prompt: *"This is a complex task. Use `/gsd:plan-phase` and `/gsd:execute-phase` for wave-based execution with fresh context per step."*

--- a/src/commands/__tests__/crew.test.ts
+++ b/src/commands/__tests__/crew.test.ts
@@ -139,6 +139,9 @@ describe("cockpit crew spawn", () => {
     writePerCrewOpencodeConfig.mockReset();
     writePerCrewOpencodeConfig.mockReturnValue("/tmp/per-crew/opencode.json");
     addWorktree.mockReset();
+    // Default: worktree isolation is now the default (#296) — return a reasonable path so tests
+    // that don't explicitly opt out don't fail trying to use an undefined cwd.
+    addWorktree.mockReturnValue("/tmp/brove/.worktrees/brove-crew-1");
     removeWorktree.mockReset();
     existsSyncMock.mockReset();
     readFileSyncMock.mockReset();
@@ -172,13 +175,13 @@ describe("cockpit crew spawn", () => {
       provider: "claude",
       mode: "interactive",
       project: "brove",
-      cwd: "/tmp/brove",
+      cwd: "/tmp/brove/.worktrees/brove-crew-1",
       task: "do the thing",
     }));
     expect(cockpitdCall).toHaveBeenCalledTimes(1);
-    // Cockpit hooks written to .claude/settings.local.json (auto-loaded source).
+    // Cockpit hooks written to .claude/settings.local.json (auto-loaded source) inside the worktree.
     expect(writePerCrewSettingsLocal).toHaveBeenCalledWith(expect.objectContaining({
-      projectCwd: "/tmp/brove",
+      projectCwd: "/tmp/brove/.worktrees/brove-crew-1",
     }));
     expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({
       interactive: true,
@@ -204,7 +207,7 @@ describe("cockpit crew spawn", () => {
     expect(result.title).toBe("🔧 brove:crew-1");
   });
 
-  it("--worktree creates an isolated worktree and spawns the crew with its path as cwd", async () => {
+  it("default spawn creates an isolated worktree and spawns the crew with its path as cwd", async () => {
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
     listSurfaces.mockResolvedValue([]);
@@ -215,7 +218,7 @@ describe("cockpit crew spawn", () => {
     const wtPath = "/tmp/brove/.worktrees/brove-crew-1";
     addWorktree.mockReturnValue(wtPath);
 
-    const promise = runCrewSpawn({ project: "brove", task: "do the thing", worktree: true });
+    const promise = runCrewSpawn({ project: "brove", task: "do the thing" });
     await vi.advanceTimersByTimeAsync(3000);
     await promise;
 
@@ -233,16 +236,16 @@ describe("cockpit crew spawn", () => {
     expect(writePerCrewSettingsLocal).toHaveBeenCalledWith(expect.objectContaining({ projectCwd: wtPath }));
   });
 
-  it("without --worktree never creates a worktree (cwd stays the root checkout)", async () => {
+  it("--shared opt-out skips worktree creation (cwd stays the root checkout)", async () => {
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
     listSurfaces.mockResolvedValue([]);
     newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
     buildCommand.mockReturnValue("claude ...");
-    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-nowt" } }));
-    cockpitdCall.mockResolvedValue({ id: "task-nowt" });
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-shared" } }));
+    cockpitdCall.mockResolvedValue({ id: "task-shared" });
 
-    const promise = runCrewSpawn({ project: "brove", task: "do the thing" });
+    const promise = runCrewSpawn({ project: "brove", task: "do the thing", shared: true });
     await vi.advanceTimersByTimeAsync(3000);
     await promise;
 
@@ -264,14 +267,14 @@ describe("cockpit crew spawn", () => {
     cockpitdCall.mockResolvedValue({ id: "task-wtc" });
     addWorktree.mockReturnValue("/tmp/brove/.wt/brove-crew-1");
 
-    const promise = runCrewSpawn({ project: "brove", task: "task", worktree: true });
+    const promise = runCrewSpawn({ project: "brove", task: "task" });
     await vi.advanceTimersByTimeAsync(3000);
     await promise;
 
     expect(addWorktree).toHaveBeenCalledWith(expect.objectContaining({ worktreeDir: ".wt" }));
   });
 
-  it("--worktree claude crew: launch command starts with cd into worktree path", async () => {
+  it("claude crew: launch command starts with cd into worktree path (default isolation)", async () => {
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
     listSurfaces.mockResolvedValue([]);
@@ -282,7 +285,7 @@ describe("cockpit crew spawn", () => {
     const wtPath = "/tmp/brove/.worktrees/brove-crew-1";
     addWorktree.mockReturnValue(wtPath);
 
-    const promise = runCrewSpawn({ project: "brove", task: "feature work", worktree: true });
+    const promise = runCrewSpawn({ project: "brove", task: "feature work" });
     await vi.advanceTimersByTimeAsync(3000);
     await promise;
 
@@ -291,7 +294,7 @@ describe("cockpit crew spawn", () => {
     expect(launchCmd).toMatch(/^cd '\/tmp\/brove\/\.worktrees\/brove-crew-1' && /);
   });
 
-  it("non-worktree claude crew: launch command starts with cd into main checkout (no-op harmless)", async () => {
+  it("--shared claude crew: launch command starts with cd into main checkout (no-op harmless)", async () => {
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
     listSurfaces.mockResolvedValue([]);
@@ -300,7 +303,7 @@ describe("cockpit crew spawn", () => {
     buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-nowt2" } }));
     cockpitdCall.mockResolvedValue({ id: "task-nowt2", project: "brove", provider: "claude", mode: "interactive" });
 
-    const promise = runCrewSpawn({ project: "brove", task: "small fix" });
+    const promise = runCrewSpawn({ project: "brove", task: "small fix", shared: true });
     await vi.advanceTimersByTimeAsync(3000);
     await promise;
 
@@ -309,7 +312,7 @@ describe("cockpit crew spawn", () => {
     expect(launchCmd).toMatch(/^cd '\/tmp\/brove' && /);
   });
 
-  it("--worktree opencode crew: launch command starts with cd into worktree path", async () => {
+  it("opencode crew: launch command starts with cd into worktree path (default isolation)", async () => {
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
     listSurfaces.mockResolvedValue([]);
@@ -320,7 +323,7 @@ describe("cockpit crew spawn", () => {
     const wtPath = "/tmp/brove/.worktrees/brove-crew-1";
     addWorktree.mockReturnValue(wtPath);
 
-    const promise = runCrewSpawn({ project: "brove", task: "feature work", worktree: true, agent: "opencode", agentExplicit: true });
+    const promise = runCrewSpawn({ project: "brove", task: "feature work", agent: "opencode", agentExplicit: true });
     await vi.advanceTimersByTimeAsync(3000);
     await promise;
 
@@ -377,7 +380,7 @@ describe("cockpit crew spawn", () => {
       provider: "opencode",
       mode: "interactive",
       project: "brove",
-      cwd: "/tmp/brove",
+      cwd: "/tmp/brove/.worktrees/brove-crew-1",
       task: "do the thing",
       budgetMs: 86400000,
     }));
@@ -438,7 +441,7 @@ describe("cockpit crew spawn", () => {
       provider: "codex",
       mode: "interactive",
       project: "brove",
-      cwd: "/tmp/brove",
+      cwd: "/tmp/brove/.worktrees/brove-crew-1",
       task: "do the thing",
     }));
     expect(cockpitdCall).toHaveBeenCalledTimes(1);
@@ -1258,6 +1261,7 @@ describe("completion-protocol suffix in first turns (#278)", () => {
     writePerCrewOpencodeConfig.mockReset();
     writePerCrewOpencodeConfig.mockReturnValue("/tmp/per-crew/opencode.json");
     addWorktree.mockReset();
+    addWorktree.mockReturnValue("/tmp/brove/.worktrees/brove-crew-1");
     existsSyncMock.mockReset();
     existsSyncMock.mockReturnValue(false);
     resolveCrewRoute.mockReset();

--- a/src/commands/__tests__/group.test.ts
+++ b/src/commands/__tests__/group.test.ts
@@ -63,10 +63,11 @@ const makeConfig = (overrides: Record<string, any> = {}) => {
 };
 
 describe("groupCommand dispatch description", () => {
-  it("marks dispatch as [experimental]", () => {
+  it("registers a dispatch subcommand", () => {
     const dispatch = groupCommand.commands.find((c) => c.name() === "dispatch");
     expect(dispatch).toBeDefined();
-    expect(dispatch!.description()).toMatch(/\[experimental\]/i);
+    // [experimental] marker dropped once #288 boot-if-down path was fixed
+    expect(dispatch!.description()).toMatch(/dispatch a task/i);
   });
 });
 

--- a/src/commands/__tests__/notify-relay.test.ts
+++ b/src/commands/__tests__/notify-relay.test.ts
@@ -9,7 +9,7 @@ import { mkdtempSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { appendToMailbox, writeCursor, readCursor } from "../../control/mailbox.js";
-import { runNotifyRelay, DEFAULT_STATE_ROOT, STALE_THRESHOLD_MS, DEFAULT_MAX_DEFERS } from "../notify-relay.js";
+import { runNotifyRelay, DEFAULT_STATE_ROOT, STALE_THRESHOLD_MS, DEFAULT_MAX_DEFERS, DEFAULT_STABLE_PROBE_POLLS } from "../notify-relay.js";
 import { DeferDelivery } from "../../runtimes/cmux.js";
 import type { TaskRecord, ControlEvent } from "../../control/types.js";
 
@@ -268,14 +268,14 @@ describe("notify-relay idle-defer (#258 phase 2)", () => {
     expect(sendSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 
-  it("force-delivers after maxDeferDeliveries consecutive defers so message is never stuck", async () => {
+  it("probes after maxDeferDeliveries consecutive defers so message is never stuck (backstop)", async () => {
     const stateRoot = freshState();
     await append(stateRoot, "CREW DONE [claude/deadbeef]: x");
     const TEST_MAX_DEFERS = 3; // inject small value so test runs fast
-    // Always defer unless force=true
+    // Always defer (bare DeferDelivery = no content → never stable) unless probe=true
     const sendSpy = vi.fn().mockImplementation(
-      (_surface: unknown, _msg: string, opts?: { force?: boolean }) => {
-        if (opts?.force) return Promise.resolve();
+      (_surface: unknown, _msg: string, opts?: { probe?: boolean }) => {
+        if (opts?.probe) return Promise.resolve();
         return Promise.reject(new DeferDelivery());
       },
     );
@@ -288,27 +288,27 @@ describe("notify-relay idle-defer (#258 phase 2)", () => {
       pollMs: 50,
       maxDeferDeliveries: TEST_MAX_DEFERS,
     });
-    // TEST_MAX_DEFERS polls + 1 force-deliver; at 50ms each = ~200ms; allow 500ms margin
+    // TEST_MAX_DEFERS polls + 1 probe-deliver; at 50ms each = ~200ms; allow 500ms margin
     await new Promise((r) => setTimeout(r, 500));
     stop();
     const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
     expect(cursor?.lastAckedSeq).toBe(1);
-    // The call that succeeded must have had force=true
-    const forcedCall = sendSpy.mock.calls.find(
-      (c) => (c[2] as { force?: boolean } | undefined)?.force === true,
+    // The call that succeeded must have had probe=true
+    const probedCall = sendSpy.mock.calls.find(
+      (c) => (c[2] as { probe?: boolean } | undefined)?.probe === true,
     );
-    expect(forcedCall).toBeDefined();
-    // Total calls = TEST_MAX_DEFERS defers + 1 force-deliver
+    expect(probedCall).toBeDefined();
+    // Total calls = TEST_MAX_DEFERS defers + 1 probe-deliver
     expect(sendSpy.mock.calls.length).toBeGreaterThanOrEqual(TEST_MAX_DEFERS + 1);
   });
 
   it("honors config-injected maxDeferDeliveries override", async () => {
     const stateRoot = freshState();
     await append(stateRoot, "CREW DONE [claude/deadbeef]: x");
-    // With maxDeferDeliveries=1, force-deliver should trigger after a single defer
+    // With maxDeferDeliveries=1, probe should trigger after a single (no-content) defer
     const sendSpy = vi.fn().mockImplementation(
-      (_surface: unknown, _msg: string, opts?: { force?: boolean }) => {
-        if (opts?.force) return Promise.resolve();
+      (_surface: unknown, _msg: string, opts?: { probe?: boolean }) => {
+        if (opts?.probe) return Promise.resolve();
         return Promise.reject(new DeferDelivery());
       },
     );
@@ -325,11 +325,87 @@ describe("notify-relay idle-defer (#258 phase 2)", () => {
     stop();
     const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
     expect(cursor?.lastAckedSeq).toBe(1);
-    // First call defers, second call force-delivers
     expect(sendSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
-    const forcedCall = sendSpy.mock.calls.find(
-      (c) => (c[2] as { force?: boolean } | undefined)?.force === true,
+    const probedCall = sendSpy.mock.calls.find(
+      (c) => (c[2] as { probe?: boolean } | undefined)?.probe === true,
     );
-    expect(forcedCall).toBeDefined();
+    expect(probedCall).toBeDefined();
+  });
+});
+
+// #302 — kill the ~5-min stall (the original #294 pain). When parseDraftFromScreen
+// reports the SAME non-empty content for K consecutive polls (~a few seconds), the
+// captain is NOT actively typing, so it is safe to PROBE early instead of waiting
+// for the 300-defer backstop. An UNRECOGNIZED ghost stabilizes in seconds → probed →
+// delivered fast. An actively-typing captain's content CHANGES → never stable → never
+// probed → pure defer (no keystroke race). DeferDelivery carries the observed draft.
+describe("notify-relay stability-probe (#302)", () => {
+  it("DEFAULT_STABLE_PROBE_POLLS is a small value (~few seconds at 1s cadence)", () => {
+    expect(DEFAULT_STABLE_PROBE_POLLS).toBeGreaterThanOrEqual(2);
+    expect(DEFAULT_STABLE_PROBE_POLLS).toBeLessThanOrEqual(10);
+  });
+
+  it("probes EARLY (before maxDefers) once content is stable for stableProbePolls consecutive polls", async () => {
+    const stateRoot = freshState();
+    await append(stateRoot, "CREW DONE [claude/deadbeef]: x");
+    // Stable non-empty content every poll; resolve only when probe=true.
+    const sendSpy = vi.fn().mockImplementation(
+      (_surface: unknown, _msg: string, opts?: { probe?: boolean }) => {
+        if (opts?.probe) return Promise.resolve();
+        return Promise.reject(new DeferDelivery("wait for both crews to finish"));
+      },
+    );
+    const stop = await runNotifyRelay({
+      project: "demo",
+      subscriber: "captain",
+      stateRoot,
+      runtime: fakeRuntime(sendSpy) as never,
+      captainName: "captain",
+      pollMs: 30,
+      maxDeferDeliveries: 300, // backstop far away — stability must trigger first
+      stableProbePolls: 2,
+    });
+    await new Promise((r) => setTimeout(r, 300));
+    stop();
+    const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    expect(cursor?.lastAckedSeq).toBe(1);
+    const probedCall = sendSpy.mock.calls.find(
+      (c) => (c[2] as { probe?: boolean } | undefined)?.probe === true,
+    );
+    expect(probedCall, "probe must fire from stability, not the 300 backstop").toBeDefined();
+    // Far fewer than 300 calls — stability triggered early
+    expect(sendSpy.mock.calls.length).toBeLessThan(20);
+  });
+
+  it("never probes while content KEEPS CHANGING between polls (active typing — no keystroke race)", async () => {
+    const stateRoot = freshState();
+    await append(stateRoot, "CREW DONE [claude/deadbeef]: x");
+    // Different content each poll → never stable → must never probe within the window.
+    let n = 0;
+    const sendSpy = vi.fn().mockImplementation(
+      (_surface: unknown, _msg: string, opts?: { probe?: boolean }) => {
+        if (opts?.probe) return Promise.resolve();
+        return Promise.reject(new DeferDelivery("draft " + (n++)));
+      },
+    );
+    const stop = await runNotifyRelay({
+      project: "demo",
+      subscriber: "captain",
+      stateRoot,
+      runtime: fakeRuntime(sendSpy) as never,
+      captainName: "captain",
+      pollMs: 30,
+      maxDeferDeliveries: 300,
+      stableProbePolls: 2,
+    });
+    await new Promise((r) => setTimeout(r, 300));
+    stop();
+    // Cursor never advanced (never delivered) and no probe ever fired.
+    const cursor = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    expect(cursor?.lastAckedSeq ?? 0).toBe(0);
+    const probedCall = sendSpy.mock.calls.find(
+      (c) => (c[2] as { probe?: boolean } | undefined)?.probe === true,
+    );
+    expect(probedCall).toBeUndefined();
   });
 });

--- a/src/commands/crew.ts
+++ b/src/commands/crew.ts
@@ -234,9 +234,10 @@ export interface CrewSpawnInput {
   direction?: PanePlacement;
   agent?: string;
   approvalPolicy?: string;
-  /** Opt-in (#216): run this crew in its own git worktree + branch instead of
-   *  the shared root checkout. For feature tasks; small/one-off tasks omit it. */
-  worktree?: boolean;
+  /** Opt-out (#296): run this crew in the root checkout instead of an isolated
+   *  worktree. Pass true for small/one-off tasks that don't need branch isolation.
+   *  Default (undefined/false) = isolated worktree — parallel-safe. */
+  shared?: boolean;
   /** CP3 opt-in: gate risky tools (bash) so the captain approves them.
    *  codex maps this to approvalPolicy='untrusted'; opencode maps it to a
    *  bash:"ask" per-crew config. Default (false) = fully autonomous. */
@@ -275,13 +276,13 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
   }
   const name = input.name ?? nextAutoName(existingTitles, input.project);
 
-  // Feature crews (--worktree) run in an isolated worktree+branch so a crew's
-  // `git checkout` can't drag the captain's (shared) HEAD. Small crews keep
-  // running on the root checkout — spawnCwd stays proj.path, behavior unchanged.
+  // Crews run in an isolated worktree+branch by default so multiple parallel
+  // crews never collide on a shared HEAD (#296). Pass shared:true (CLI: --shared)
+  // for small/one-off tasks that should run on the root checkout.
   // Build/daemon still run from the MAIN checkout's dist (#216): worktrees edit
   // source only. The worktree path becomes the crew's cwd via the existing cwd
   // plumbing (dispatch record + buildCommand workdir).
-  const spawnCwd = input.worktree
+  const spawnCwd = !input.shared
     ? addWorktree({
         repoRoot: proj.path,
         worktreeDir: config.defaults.worktreeDir ?? ".worktrees",
@@ -697,14 +698,14 @@ crewCommand
   .option("--direction <dir>", "Placement: tab (default) or split direction (right|left|up|down)", "tab")
   .option("--agent <name>", "Agent CLI to use (claude|codex|gemini|opencode)", "claude")
   .option("--approval", "gate risky tools so the captain approves them (codex: approvalPolicy='untrusted'; opencode: bash:'ask')", false)
-  .option("--worktree", "run the crew in its own git worktree + branch (feature tasks; small tasks omit to share the root checkout)", false)
+  .option("--shared", "run the crew in the root checkout instead of an isolated worktree (for small/one-off tasks)", false)
   .option("--task-file <path>", "Read task prompt from file instead of positional arg ('-' for stdin)")
   .option("--model <alias>", "Override crew model for this spawn (e.g. sonnet, opus); takes precedence over config defaults.roles.crew.model")
   .action(
     async (
       project: string,
       task: string | undefined,
-      opts: { name?: string; direction: PanePlacement; agent: string; approval: boolean; worktree: boolean; taskFile?: string; model?: string },
+      opts: { name?: string; direction: PanePlacement; agent: string; approval: boolean; shared: boolean; taskFile?: string; model?: string },
       cmd: Command,
     ) => {
       try {
@@ -720,7 +721,7 @@ crewCommand
           // --approval is provider-agnostic: codex consumes approvalPolicy,
           // opencode consumes the `approval` flag (→ bash:"ask" per-crew config).
           ...(opts.approval ? { approvalPolicy: "untrusted", approval: true } : {}),
-          ...(opts.worktree ? { worktree: true } : {}),
+          ...(opts.shared ? { shared: true } : {}),
           ...(opts.model ? { model: opts.model } : {}),
         });
         console.log(chalk.green(`✔ Crew '${pane.title}' spawned (${pane.surfaceId})`));

--- a/src/commands/group.ts
+++ b/src/commands/group.ts
@@ -16,7 +16,10 @@ import { sendRequest } from "../control/protocol.js";
 import type { TaskRecord, Provider, Mode } from "../control/types.js";
 
 const SOCK = join(homedir(), ".config", "cockpit", "cockpit.sock");
-const WARMUP_TIMEOUT_MS = 30_000;
+// #288: 30s was too short — cold captain boot + relay supervisor startup takes
+// 45-90s. 120s gives the full chain (Claude init + checklist + relay register)
+// comfortable headroom while still failing fast on a genuinely broken launch.
+const WARMUP_TIMEOUT_MS = 120_000;
 const WARMUP_POLL_MS = 1_000;
 
 /** Resolve the current project name by matching cwd against config paths. */
@@ -138,19 +141,18 @@ export const groupCommand = new Command("group")
   .description("Cross-project intra-group operations (Phase 1: dispatch)")
   .addCommand(
     new Command("dispatch")
-      .description("[experimental] Dispatch a task to a sibling project in the same group")
+      .description("Dispatch a task to a sibling project in the same group")
       .argument("<to-project>", "Target project name (must be in the same group)")
       .argument("<task>", "Task description to dispatch")
       .option("--provider <p>", "claude|opencode|codex", "claude")
       .option("--mode <m>", "headless|interactive", "headless")
-      .action(async (toProject: string, task: string, opts: { provider?: Provider; mode?: Mode }) => {
+      .option("--warmup-timeout <s>", "seconds to wait for target captain relay to boot (default: 120)", (v) => parseInt(v, 10) * 1000)
+      .action(async (toProject: string, task: string, opts: { provider?: Provider; mode?: Mode; warmupTimeout?: number }) => {
         const fromProject = resolveCurrentProject(loadConfig());
         if (!fromProject) {
           console.error(chalk.red("Could not determine current project from cwd. Run from inside a registered project directory."));
           process.exit(1);
         }
-
-        console.error(chalk.yellow("⚠ cross-project delegation is experimental (#288): boot-if-down of a down sibling may not yet produce an operational captain."));
 
         try {
           const result = await runGroupDispatch({
@@ -159,6 +161,7 @@ export const groupCommand = new Command("group")
             task,
             provider: opts.provider,
             mode: opts.mode,
+            warmupTimeoutMs: opts.warmupTimeout,
           });
           console.log(chalk.green(`✔ Dispatched to '${toProject}' (task ${result.id.slice(0, 8)})`));
           console.log(chalk.dim(`  originProject: ${result.originProject ?? "none"}`));

--- a/src/commands/launch.ts
+++ b/src/commands/launch.ts
@@ -223,10 +223,12 @@ async function launchWorkspace(
   });
 
   if (initialPrompt) {
-    // Small delay to let agent initialize before sending prompt
+    // #288: cold-boot Claude sessions need ~8s to initialize before they can
+    // receive input. 3s was too short — startup prompt arrived at the loading
+    // screen and was silently dropped, so relay supervisor never ran.
     setTimeout(() => {
       runtime.send(ref.id, initialPrompt).catch(() => { /* best-effort */ });
-    }, 3000);
+    }, 8000);
   }
 
   if (navigate) {

--- a/src/commands/notify-relay.ts
+++ b/src/commands/notify-relay.ts
@@ -34,6 +34,13 @@ export const DEFAULT_STATE_ROOT = join(homedir(), ".config", "cockpit", "state")
 // Override via config key relay.maxDeferDeliveries.
 export const DEFAULT_MAX_DEFERS = 300;
 
+// #302 stability-probe: consecutive polls of byte-identical non-empty draft
+// content after which it is safe to PROBE (captain is not actively typing).
+// ~3s at the 1s poll cadence — kills the ~5min stall for unrecognized ghosts
+// while never racing a live typist (changing content resets the counter).
+// Override via config key relay.stableProbePolls.
+export const DEFAULT_STABLE_PROBE_POLLS = 3;
+
 // How often the in-cmux probe scrapes interactive crew panes for a block. The
 // daemon can't do this (launchd can't connect to cmux), so it lives here.
 export const PROBE_INTERVAL_MS = 10_000;
@@ -181,6 +188,8 @@ interface RunOpts {
   log?: (m: string) => void;
   /** Max consecutive defers before force-deliver. Default: DEFAULT_MAX_DEFERS. */
   maxDeferDeliveries?: number;
+  /** Consecutive stable-content polls before probing early (#302). Default: DEFAULT_STABLE_PROBE_POLLS. */
+  stableProbePolls?: number;
 }
 
 export async function runNotifyRelay(opts: RunOpts): Promise<() => void> {
@@ -204,10 +213,15 @@ export async function runNotifyRelay(opts: RunOpts): Promise<() => void> {
 
   const sessionStartMs = (opts.now ?? (() => Date.now()))();
   const maxDefers = opts.maxDeferDeliveries ?? DEFAULT_MAX_DEFERS;
+  const stableProbePolls = opts.stableProbePolls ?? DEFAULT_STABLE_PROBE_POLLS;
 
   // #258 idle-defer: consecutive defer counts per mailbox seq.
   // Keyed by entry.seq; deleted on successful delivery.
   const deferCounts = new Map<number, number>();
+  // #302 stability tracking: last observed draft content + how many consecutive
+  // polls it stayed byte-identical. Stable non-empty content → safe to probe.
+  const lastContent = new Map<number, string | null>();
+  const stableCounts = new Map<number, number>();
 
   const cursor = await readCursor({
     stateRoot: opts.stateRoot,
@@ -262,14 +276,29 @@ export async function runNotifyRelay(opts: RunOpts): Promise<() => void> {
         if (msg) {
           try {
             const deferCount = deferCounts.get(entry.seq) ?? 0;
-            const force = deferCount >= maxDefers;
+            // #302: probe early once content has been stable for stableProbePolls
+            // polls (captain not typing) — kills the ~5min stall; the 300-defer
+            // backstop still guarantees delivery never hangs forever.
+            const stable = (stableCounts.get(entry.seq) ?? 0) >= stableProbePolls;
+            const probe = stable || deferCount >= maxDefers;
             await (opts.runtime as RuntimeDriver & {
-              sendToSurface: (s: unknown, m: string, o?: { force?: boolean }) => Promise<void>;
-            }).sendToSurface(captainSurface, msg, force ? { force: true } : undefined);
+              sendToSurface: (s: unknown, m: string, o?: { probe?: boolean }) => Promise<void>;
+            }).sendToSurface(captainSurface, msg, probe ? { probe: true } : undefined);
             deferCounts.delete(entry.seq);
+            stableCounts.delete(entry.seq);
+            lastContent.delete(entry.seq);
           } catch (e) {
             if (e instanceof DeferDelivery) {
               deferCounts.set(entry.seq, (deferCounts.get(entry.seq) ?? 0) + 1);
+              // Track content stability: byte-identical non-empty draft across
+              // consecutive polls means the captain isn't actively typing (#302).
+              const content = e.draft;
+              if (content && content === lastContent.get(entry.seq)) {
+                stableCounts.set(entry.seq, (stableCounts.get(entry.seq) ?? 0) + 1);
+              } else {
+                stableCounts.set(entry.seq, 0);
+              }
+              lastContent.set(entry.seq, content);
               log(`deferred: captain typing (seq=${entry.seq})`);
               // Don't advance cursor; the next poll will retry from the same seq.
               return;
@@ -405,6 +434,7 @@ export const notifyRelayCommand = new Command("notify-relay")
         captainName: projCfg.captainName,
         pollMs: 1000,
         maxDeferDeliveries: config.relay?.maxDeferDeliveries ?? DEFAULT_MAX_DEFERS,
+        stableProbePolls: config.relay?.stableProbePolls ?? DEFAULT_STABLE_PROBE_POLLS,
       });
       process.on("SIGTERM", () => process.exit(0));
     } catch (err) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -75,6 +75,8 @@ export interface CockpitConfig {
   relay?: {
     /** Max consecutive defers before force-delivering a message (~1s poll cadence). Default: 300 (~5min). */
     maxDeferDeliveries?: number;
+    /** Consecutive stable-content polls before probing early to avoid a stall (#302). Default: 3 (~3s). */
+    stableProbePolls?: number;
   };
   defaults: {
     maxCrew: number;

--- a/src/control/__tests__/headless-launcher.test.ts
+++ b/src/control/__tests__/headless-launcher.test.ts
@@ -138,7 +138,7 @@ describe("runHeadless", () => {
 
   it("caps stdout buffer at 4 MB: oversized output is trimmed to the tail", async () => {
     const child = fakeChild();
-    const writeResult = vi.fn(() => "/tmp/r.txt");
+    const writeResult = vi.fn((_id: string, _payload: string) => "/tmp/r.txt");
     const { result } = runHeadless({
       provider: "claude", task: "x", id: "t-cap",
       spawn: (() => child) as any, emit: () => {},
@@ -150,7 +150,7 @@ describe("runHeadless", () => {
     child.emit("close", 0);
     await result;
     // payload passed to writeResult must be ≤ 4 MB cap
-    const captured = writeResult.mock.calls[0]?.[1] as string;
+    const captured = writeResult.mock.calls[0]![1];
     expect(captured.length).toBeLessThanOrEqual(4 * MB);
     expect(captured.length).toBeGreaterThan(0);
   });

--- a/src/control/__tests__/headless-launcher.test.ts
+++ b/src/control/__tests__/headless-launcher.test.ts
@@ -97,4 +97,80 @@ describe("runHeadless", () => {
     child.emit("close", 0);
     await result;
   });
+
+  it("coalesces task.progress: 100 rapid chunks emit far fewer than 100 progress events", async () => {
+    const child = fakeChild();
+    const events: any[] = [];
+    const { result } = runHeadless({
+      provider: "claude", task: "x", id: "t-coalesce",
+      spawn: (() => child) as any, emit: (e) => events.push(e),
+    });
+    for (let i = 0; i < 100; i++) child.stdout.emit("data", "chunk");
+    child.emit("close", 0);
+    await result;
+    const progressCount = events.filter(e => e.type === "task.progress").length;
+    // Before fix: 100 progress events. After fix: ≤ ~5 via batch+final-flush.
+    expect(progressCount).toBeLessThan(10);
+    expect(progressCount).toBeGreaterThan(0);
+  });
+
+  it("always emits a final task.progress flush on close for any pending chunks", async () => {
+    const child = fakeChild();
+    const events: any[] = [];
+    const { result } = runHeadless({
+      provider: "claude", task: "x", id: "t-flush",
+      spawn: (() => child) as any, emit: (e) => events.push(e),
+    });
+    // 3 chunks — under the batch threshold, so none should emit mid-stream
+    // (after the first immediate one), but close must flush the remainder
+    child.stdout.emit("data", "a");
+    child.stdout.emit("data", "b");
+    child.stdout.emit("data", "c");
+    child.emit("close", 0);
+    await result;
+    // task.done must follow any progress flush
+    const types = events.map(e => e.type);
+    const lastProgressIdx = types.lastIndexOf("task.progress");
+    const doneIdx = types.indexOf("task.done");
+    expect(doneIdx).toBeGreaterThan(-1);
+    expect(lastProgressIdx).toBeLessThan(doneIdx); // progress always before done
+  });
+
+  it("caps stdout buffer at 4 MB: oversized output is trimmed to the tail", async () => {
+    const child = fakeChild();
+    const writeResult = vi.fn(() => "/tmp/r.txt");
+    const { result } = runHeadless({
+      provider: "claude", task: "x", id: "t-cap",
+      spawn: (() => child) as any, emit: () => {},
+      writeResult,
+    });
+    const MB = 1024 * 1024;
+    // 5 MB of non-JSON data; claude adapter falls back to raw payload on parse error
+    child.stdout.emit("data", "a".repeat(5 * MB));
+    child.emit("close", 0);
+    await result;
+    // payload passed to writeResult must be ≤ 4 MB cap
+    const captured = writeResult.mock.calls[0]?.[1] as string;
+    expect(captured.length).toBeLessThanOrEqual(4 * MB);
+    expect(captured.length).toBeGreaterThan(0);
+  });
+
+  it("caps stderr buffer at 4 MB: oversized stderr is trimmed before parse", async () => {
+    const child = fakeChild();
+    const events: any[] = [];
+    const { result } = runHeadless({
+      provider: "claude", task: "x", id: "t-errcap",
+      spawn: (() => child) as any, emit: (e) => events.push(e),
+    });
+    const MB = 1024 * 1024;
+    child.stderr.emit("data", "e".repeat(5 * MB));
+    child.emit("close", 1); // non-zero exit → uses err as parseInput
+    await result;
+    const failed = events.find(e => e.type === "task.failed");
+    expect(failed).toBeTruthy();
+    // error field comes from adapter.parseResult(err, 1) → err.slice(-2000)
+    // the important thing is the process didn't OOM building a 5 MB err string
+    // (we can't directly observe the trimmed err, but the event must exist)
+    expect(failed.exitCode).toBe(1);
+  });
 });

--- a/src/control/headless-launcher.ts
+++ b/src/control/headless-launcher.ts
@@ -25,6 +25,13 @@ export interface HeadlessHandle {
   kill: () => void;
 }
 
+// Max bytes retained in the stdout/stderr capture buffers (oldest dropped).
+const OUT_CAP = 4 * 1024 * 1024;
+const ERR_CAP = 4 * 1024 * 1024;
+// Emit task.progress at most once per interval OR once per batch, whichever first.
+const PROGRESS_INTERVAL_MS = 250;
+const PROGRESS_CHUNK_BATCH = 50;
+
 export function runHeadless(opts: RunHeadlessOpts): HeadlessHandle {
   const adapter = getHeadlessAdapter(opts.provider);
   const argv = adapter.buildCommand(opts.task, opts.sessionId);
@@ -36,18 +43,46 @@ export function runHeadless(opts: RunHeadlessOpts): HeadlessHandle {
 
   let out = "";
   let err = "";
+
+  // Debounce state — coalesces task.progress to avoid O(chunks) file writes.
+  let lastProgressAt = 0;
+  let chunksSinceProgress = 0;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function flushProgress(): void {
+    if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
+    lastProgressAt = Date.now();
+    chunksSinceProgress = 0;
+    opts.emit({ type: "task.progress", id: opts.id }); // stdout activity = liveness
+  }
+
   child.stdout?.on("data", (d) => {
     out += String(d);
-    opts.emit({ type: "task.progress", id: opts.id }); // stdout activity = liveness
+    if (out.length > OUT_CAP) out = out.slice(out.length - OUT_CAP);
+    chunksSinceProgress++;
+    const now = Date.now();
+    if (chunksSinceProgress >= PROGRESS_CHUNK_BATCH || now - lastProgressAt >= PROGRESS_INTERVAL_MS) {
+      flushProgress();
+    } else if (!debounceTimer) {
+      const delay = PROGRESS_INTERVAL_MS - (now - lastProgressAt);
+      debounceTimer = setTimeout(() => { debounceTimer = null; flushProgress(); }, delay);
+    }
   });
-  child.stderr?.on("data", (d) => { err += String(d); });
+  child.stderr?.on("data", (d) => {
+    err += String(d);
+    if (err.length > ERR_CAP) err = err.slice(err.length - ERR_CAP);
+  });
 
   const result = new Promise<void>((resolve) => {
     child.once("error", (e: Error) => {
+      if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
       opts.emit({ type: "task.failed", id: opts.id, error: `spawn error: ${e.message}`, exitCode: undefined });
       resolve(); // never hang the daemon; resolve() is idempotent
     });
     child.on("close", (code) => {
+      // Flush any batched-but-not-yet-emitted activity before the terminal event.
+      if (chunksSinceProgress > 0) flushProgress();
+      else if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
       const parseInput = (code !== 0 && err) ? err : (out || err);
       const res = adapter.parseResult(parseInput, code ?? 0);
       if (res.outcome === "failed") {

--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -584,40 +584,83 @@ describe("sendToSurface draft-preservation", () => {
     expect(sends[0]).toContain("crew is done");
   });
 
-  it("saves draft, clears input via backspaces, delivers, then restores draft without submitting (force=true)", async () => {
-    // "hello this is my draft" = 22 chars → 24 backspaces (draft.length + 2 margin)
-    const DRAFT = "hello this is my draft";
+  // #302 — the old destructive force path (backspace×N clear + re-paste the
+  // screen-read draft) is replaced by a non-destructive BUFFER-LIVENESS PROBE.
+  // Verified live (CC 2.1.x): a real draft is the ONLY thing that yields the
+  // "last char removed, still non-empty" signature under ONE backspace; a ghost
+  // either stays invariant or dismisses to empty. So the probe protects ONLY a
+  // real draft and NEVER re-pastes screen-read content (the materialization vector).
+  //
+  // Stateful mock of CC's input box: `box` is the content rendered between the
+  // HRs; one backspace transforms it per `onBackspace`; read-screen renders the
+  // current box. This lets a probe observe a DIFFERENT screen before vs after.
+  function probeMock(initial: string, onBackspace: (s: string) => string) {
+    let box = initial;
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      if (args.includes("read-screen")) {
-        return makeTestScreen(`│ > ${DRAFT}  │`, "│ Some conversation history │");
-      }
+      if (args.includes("read-screen")) return makeTestScreen(`❯ ${box}`);
+      if (args.includes("send-key") && args.includes("backspace")) { box = onBackspace(box); return ""; }
       return "";
     });
-    await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done", { force: true });
+  }
+
+  it("probe: real draft (last-char-removal signature) → restores the one removed char and defers; never re-pastes the draft, never delivers", async () => {
+    const DRAFT = "hello world";
+    probeMock(DRAFT, (s) => s.slice(0, -1)); // real draft: backspace removes exactly the last char
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done", { probe: true }),
+    ).rejects.toBeInstanceOf(DeferDelivery);
     const calls = execFileMock.mock.calls.map(argvOf);
+    // Exactly ONE backspace — the probe, NOT a backspace×N clear
+    expect(calls.filter((a) => a.includes("send-key") && a.includes("backspace"))).toHaveLength(1);
+    // Crew message must NEVER be delivered (we deferred to protect the draft)
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")))).toBe(false);
+    // The full draft must NEVER be re-pasted (this was the #302 materialization vector)
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes(DRAFT)))).toBe(false);
+    // Only the single removed char ("d") is restored
+    const sends = calls.filter((a) => a[0] === "send");
+    expect(sends).toHaveLength(1);
+    expect(sends[0][sends[0].length - 1]).toBe("d");
+  });
 
-    // No ctrl-u: that key is a no-op against Claude Code's input box
-    expect(calls.every((a) => !a.includes("ctrl-u"))).toBe(true);
+  it("probe: ghost that DISMISSES to empty under backspace → delivers message+Enter, NEVER re-sends the ghost text (#302 materialization regression)", async () => {
+    const GHOST = "wait for both crews to finish";
+    probeMock(GHOST, () => ""); // verified live: the #294 queue ghost dismisses to empty
+    await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done", { probe: true });
+    const calls = execFileMock.mock.calls.map(argvOf);
+    // The ghost text is NEVER typed back into the box
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("wait for both crews")))).toBe(false);
+    // The crew message IS delivered and submitted
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")))).toBe(true);
+    expect(calls.some((a) => a.includes("send-key") && a.includes("Enter"))).toBe(true);
+  });
 
-    // Backspaces must precede the message send
-    const msgSendIdx = calls.findIndex((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")));
-    const backspacesBefore = calls.slice(0, msgSendIdx).filter((a) => a.includes("send-key") && a.includes("backspace")).length;
-    expect(backspacesBefore, "backspace count = draft.length + 2").toBe(DRAFT.length + 2);
+  it("probe: ghost INVARIANT under backspace (stays identical) → delivers, never re-sends the ghost", async () => {
+    const GHOST = "some persistent suggestion";
+    probeMock(GHOST, (s) => s); // invariant: backspace is a no-op on non-buffer ghost
+    await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done", { probe: true });
+    const calls = execFileMock.mock.calls.map(argvOf);
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("persistent suggestion")))).toBe(false);
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")))).toBe(true);
+  });
 
-    const enterIdx = calls.findIndex((a, i) => i > msgSendIdx && a.includes("send-key") && a.includes("Enter"));
-    // findLastIndex is ES2023; reverse-scan manually to stay within repo's tsconfig target
-    let restoreIdx = -1;
-    for (let i = calls.length - 1; i >= 0; i--) {
-      const a: string[] = calls[i];
-      if (a[0] === "send" && a.some((s: string) => s.includes(DRAFT))) { restoreIdx = i; break; }
-    }
-    expect(msgSendIdx).toBeGreaterThanOrEqual(0);
-    expect(enterIdx, "Enter after message").toBeGreaterThan(msgSendIdx);
-    // Restore send comes after Enter (draft goes back without submitting)
-    expect(restoreIdx, "restore after Enter").toBeGreaterThan(enterIdx);
-    // Restore must NOT be followed by another Enter
-    const cmdsAfterRestore = execFileMock.mock.calls.slice(restoreIdx + 1).map(cmdOf);
-    expect(cmdsAfterRestore.every((c) => !c.includes("Enter"))).toBe(true);
+  it("non-probe call with a draft present defers WITHOUT any keystroke (hot path unchanged — never races typing)", async () => {
+    probeMock("typing in progress", (s) => s.slice(0, -1));
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done"),
+    ).rejects.toBeInstanceOf(DeferDelivery);
+    const calls = execFileMock.mock.calls.map(argvOf);
+    expect(calls.some((a) => a.includes("backspace"))).toBe(false);
+    expect(calls.some((a) => a[0] === "send")).toBe(false);
+  });
+
+  it("DeferDelivery carries the observed draft text so the relay can track content stability", async () => {
+    probeMock("my draft text", (s) => s.slice(0, -1));
+    let caught: unknown;
+    try {
+      await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done");
+    } catch (e) { caught = e; }
+    expect(caught).toBeInstanceOf(DeferDelivery);
+    expect((caught as DeferDelivery).draft).toBe("my draft text");
   });
 
   // #268: unreadable screen → draft stays null → DeferDelivery (never deliver into unknown state).
@@ -921,31 +964,26 @@ describe("sendToSurface Approach B (#258 deliver-when-empty)", () => {
     expect(calls.every((a) => !a.includes("backspace"))).toBe(true);
   });
 
-  it("non-empty draft + force=true → backspace clear, deliver, restore without Enter", async () => {
+  // #302: a real walk-away draft under {probe:true} is detected by the
+  // last-char-removal signature → restore + defer; it is NEVER force-delivered
+  // (the old backspace×N clear + re-paste, which materialized ghosts, is gone).
+  it("real walk-away draft + probe=true → one backspace, restore one char, defers (never force-clobbers)", async () => {
     const DRAFT = "my walk-away draft";
+    let box = DRAFT;
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      if (args.includes("read-screen")) return makeTestScreen(`❯ ${DRAFT}`);
+      if (args.includes("read-screen")) return makeTestScreen(`❯ ${box}`);
+      if (args.includes("send-key") && args.includes("backspace")) { box = box.slice(0, -1); return ""; }
       return "";
     });
-    await driver.sendToSurface(
-      { workspaceId: "workspace:3", surfaceId: "surface:8" },
-      "crew done",
-      { force: true },
-    );
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done", { probe: true }),
+    ).rejects.toBeInstanceOf(DeferDelivery);
     const calls = execFileMock.mock.calls.map(argvOf);
-    const msgIdx = calls.findIndex((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")));
-    const backspacesBefore = calls.slice(0, msgIdx).filter((a) => a.includes("send-key") && a.includes("backspace")).length;
-    expect(backspacesBefore, "backspace count = draft.length + 2").toBe(DRAFT.length + 2);
-    const enterIdx = calls.findIndex((a, i) => i > msgIdx && a.includes("send-key") && a.includes("Enter"));
-    let restoreIdx = -1;
-    for (let i = calls.length - 1; i >= 0; i--) {
-      const a: string[] = calls[i];
-      if (a[0] === "send" && a.some((s: string) => s.includes(DRAFT))) { restoreIdx = i; break; }
-    }
-    expect(enterIdx, "Enter after message").toBeGreaterThan(msgIdx);
-    expect(restoreIdx, "restore after Enter").toBeGreaterThan(enterIdx);
-    // Restore must NOT be followed by another Enter
-    const afterRestore = execFileMock.mock.calls.slice(restoreIdx + 1).map(cmdOf);
-    expect(afterRestore.every((c) => !c.includes("Enter"))).toBe(true);
+    // Exactly ONE backspace (the probe), not draft.length+2
+    expect(calls.filter((a) => a.includes("send-key") && a.includes("backspace"))).toHaveLength(1);
+    // Message NOT delivered, full draft NEVER re-pasted, no Enter submitted
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")))).toBe(false);
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes(DRAFT)))).toBe(false);
+    expect(calls.some((a) => a.includes("send-key") && a.includes("Enter"))).toBe(false);
   });
 });

--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -744,6 +744,50 @@ describe("parseDraftFromScreen", () => {
     );
     expect(parseDraftFromScreen(fixture)).toBeNull();
   });
+
+  // #294: Claude Code ghost-suggestion placeholder must be treated as empty.
+  // "Press up to edit queued messages" is a CC UI hint, NOT user-typed content.
+  // Captured from a live captain in Working state: ❯ + U+00A0 NBSP + ghost text, no cursor block.
+  it("returns '' for CC ghost 'Press up to edit queued messages' (Working state, no cursor — #294)", () => {
+    // U+276F ❯, U+00A0 NBSP, then the placeholder text CC shows when there are queued messages
+    const screen = makeTestScreen("❯\xa0Press up to edit queued messages");
+    expect(parseDraftFromScreen(screen)).toBe("");
+  });
+
+  // #294: idle-state variant — cursor block appears at position 0 BEFORE the ghost text.
+  // Leading ▌ means cursor is at the start, so nothing has actually been typed.
+  it("returns '' when cursor block precedes ghost text in idle state (leading cursor = empty — #294)", () => {
+    const screen = makeTestScreen("❯\xa0▌Press up to edit queued messages");
+    expect(parseDraftFromScreen(screen)).toBe("");
+  });
+
+  // Regression guard (#258): real typed draft must still return its text after #294 fix.
+  it("still returns real draft text after #294 fix (regression guard for #258)", () => {
+    const screen = makeTestScreen("❯\xa0hello world");
+    expect(parseDraftFromScreen(screen)).toBe("hello world");
+  });
+
+  // Captain follow-up on #297: if user types "hello world" then presses Ctrl-A/Home to move
+  // the cursor to the start, does cmux read-screen render "❯\xa0▌hello world" (leading ▌)?
+  // Verified: CC uses native ANSI cursor positioning, NOT a ▌ glyph — cursor-at-position-0
+  // on an idle CC session captures as ❯\xa0 (0xe2 0x9d 0xaf 0xc2 0xa0, no 0xe2 0x96 0x8c).
+  // cmux read-screen output is ❯\xa0hello world regardless of cursor position.
+  // Heuristic #1 (/^[▌█]/ skip) is therefore unreachable for real typed drafts — no clobber.
+  it("returns real draft when cursor is at start of typed text (no leading ▌ in CC output — #297)", () => {
+    // This is exactly what cmux read-screen yields after: type "hello world", press Ctrl-A.
+    const screen = makeTestScreen("❯\xa0hello world");
+    expect(parseDraftFromScreen(screen)).toBe("hello world");
+  });
+
+  // Regression fixture: real ghost screen captured from live captain during #294.
+  // Input box between HR boundaries contains ❯\xa0<ghost> — must return "".
+  it("returns '' for real ghost-placeholder fixture (regression #294)", () => {
+    const fixture = readFileSync(
+      join(process.cwd(), "docs/reports/294-ghost-placeholder-fixture.txt"),
+      "utf-8",
+    );
+    expect(parseDraftFromScreen(fixture)).toBe("");
+  });
 });
 
 describe("sanitizeForCmuxSend", () => {
@@ -859,6 +903,22 @@ describe("sendToSurface Approach B (#258 deliver-when-empty)", () => {
     // Must not have sent anything into the overlay
     const cmds = execFileMock.mock.calls.map(cmdOf);
     expect(cmds.filter((c) => c.startsWith("send ") && !c.startsWith("send-key"))).toHaveLength(0);
+  });
+
+  // #294: ghost placeholder must NOT trigger DeferDelivery — deliver immediately.
+  it("delivers immediately when input shows CC ghost placeholder (no DeferDelivery — #294)", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return makeTestScreen("❯\xa0Press up to edit queued messages");
+      return "";
+    });
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done"),
+    ).resolves.toBeUndefined();
+    const calls = execFileMock.mock.calls.map(argvOf);
+    const msgIdx = calls.findIndex((a) => a[0] === "send" && a.includes("crew done"));
+    expect(msgIdx, "message was delivered").toBeGreaterThanOrEqual(0);
+    // No backspaces — ghost is not real content
+    expect(calls.every((a) => !a.includes("backspace"))).toBe(true);
   });
 
   it("non-empty draft + force=true → backspace clear, deliver, restore without Enter", async () => {

--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -230,6 +230,53 @@ describe("cmux driver", () => {
     expect(cmds.every((c) => !c.includes("--direction"))).toBe(true);
   });
 
+  // #295: new tab steals cmux focus, leaking user keystrokes into crew launch command.
+  // Fix: snapshot selected surface before new-surface, restore focus after creation.
+  it("newPane with direction=tab restores focus to the previously-selected surface (#295)", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      const cmd = args.join(" ");
+      if (cmd.includes("tree")) {
+        return [
+          'surface surface:5 [terminal] "captain" [selected]',
+          'surface surface:6 [terminal] "crew-1"',
+        ].join("\n");
+      }
+      if (cmd.includes("new-surface")) return "OK surface:8 workspace:1";
+      return "";
+    });
+    await driver.newPane({ workspaceId: "workspace:1", direction: "tab" });
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) =>
+      c.includes("move-surface") &&
+      c.includes("--surface surface:5") &&
+      c.includes("--index 0") &&
+      c.includes("--focus true"))).toBe(true);
+  });
+
+  it("newPane with direction=tab skips focus restore gracefully when tree is unreadable (#295)", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      const cmd = args.join(" ");
+      if (cmd.includes("tree")) throw new Error("tree unreadable");
+      if (cmd.includes("new-surface")) return "OK surface:8 workspace:1";
+      return "";
+    });
+    const pane = await driver.newPane({ workspaceId: "workspace:1", direction: "tab" });
+    expect(pane.surfaceId).toBe("surface:8");
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.every((c) => !c.includes("move-surface"))).toBe(true);
+  });
+
+  it("newPane with split direction does NOT query tree or restore focus (#295)", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("new-pane")) return "OK surface:27 pane:25 workspace:1";
+      return "";
+    });
+    await driver.newPane({ workspaceId: "workspace:1", direction: "right" });
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.every((c) => !c.includes("tree"))).toBe(true);
+    expect(cmds.every((c) => !c.includes("move-surface"))).toBe(true);
+  });
+
   it("newPane with direction=tab and title renames the new surface", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
       if (args.includes("new-surface")) return "OK surface:42 workspace:7";

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -134,8 +134,23 @@ export function parseDraftFromScreen(screen: string): string | null {
       if (plainMatch) extracted = plainMatch[1].trim();
     }
     if (extracted !== undefined) {
+      // Heuristic #1 — Leading cursor glyph (▌/█) at position 0.
+      // CC renders its input cursor via native ANSI terminal positioning, NOT as a ▌ cell
+      // character: a live cmux read-screen of an idle CC session with cursor at position 0
+      // yields ❯\xa0 with no ▌ (confirmed by 258-parse-bug-fixture.txt L24 and a fresh
+      // crew session capture). Therefore ▌ at the start cannot arise from the user moving
+      // the cursor to the beginning of real typed text — it only appears when CC itself
+      // renders a UI placeholder at that position (#294). Safe to treat as empty. (#297)
+      if (/^[▌█▔▎▏▌█]/.test(extracted)) continue;
+
       // Strip terminal cursor glyphs (▌, █, etc.) that trail the caret position
       const draft = extracted.replace(/\s*[▌█▔▎▏▌█]+\s*$/, "").trim();
+
+      // Claude Code UI placeholder: appears in Working state when input is locked
+      // (user cannot type). "Press [key] to [action]" strings are UI instructions
+      // shown as ghost suggestions — never real user-typed content (#294).
+      if (/^Press\s+(?:up|down|left|right|enter|escape|esc|tab|any\s+key|ctrl|shift|alt)\s+to\s+/i.test(draft)) continue;
+
       if (draft) return draft;
     }
   }

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -242,6 +242,19 @@ export function createCmuxDriver(): RuntimeDriver {
     },
 
     async newPane(opts: RuntimePaneOptions): Promise<PaneRef> {
+      // #295: snapshot the focused surface before creating a new tab so we can
+      // restore focus afterward. new-surface steals focus; the captain's
+      // keystrokes would otherwise land in the crew's launch command line.
+      // Applies only to tabs (new-surface); split-panes keep cmux default focus.
+      let priorSurface: string | undefined;
+      let priorIndex = -1;
+      if (opts.direction === "tab") {
+        try {
+          const before = parseSurfaceOrder(cmux(["tree", "--workspace", opts.workspaceId]));
+          priorIndex = before.findIndex((s) => s.selected);
+          if (priorIndex >= 0) priorSurface = before[priorIndex].id;
+        } catch { /* best-effort: if we can't read the tree, skip refocus */ }
+      }
       const cmd = opts.direction === "tab"
         ? ["new-surface", "--type", "terminal", "--workspace", opts.workspaceId]
         : ["new-pane", "--type", "terminal", "--direction", opts.direction, "--workspace", opts.workspaceId];
@@ -255,6 +268,11 @@ export function createCmuxDriver(): RuntimeDriver {
         try {
           cmux(["rename-tab", "--workspace", opts.workspaceId, "--surface", surfaceId, "--title", opts.title]);
         } catch { /* rename is best-effort */ }
+      }
+      if (opts.direction === "tab" && priorSurface) {
+        try {
+          cmux(["move-surface", "--surface", priorSurface, "--index", String(priorIndex), "--focus", "true"]);
+        } catch { /* refocus is best-effort */ }
       }
       return { workspaceId: opts.workspaceId, surfaceId };
     },

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -16,8 +16,10 @@ export class CmuxTimeoutError extends Error {
 
 // #258 Approach B: thrown by sendToSurface when the captain has any draft in
 // the input box. The relay defers delivery until the input is empty.
+// #302: carries the observed draft text so the relay can detect content
+// stability (same content for K polls = not actively typing → safe to probe).
 export class DeferDelivery extends Error {
-  constructor() {
+  constructor(public readonly draft: string | null = null) {
     super("deferred: captain composing");
     this.name = "DeferDelivery";
   }
@@ -156,6 +158,38 @@ export function parseDraftFromScreen(screen: string): string | null {
   }
 
   return "";
+}
+
+/**
+ * Extract the RAW input-box content for the #302 buffer-liveness probe — all
+ * content lines between the last two HRs, joined, with the prompt glyph and any
+ * trailing cursor glyph stripped (but NOT the #294 ghost heuristics: the probe
+ * needs the literal rendered text to diff before/after a backspace). Returns
+ * null if the box boundaries aren't visible (overlay/scroll). Unlike
+ * parseDraftFromScreen this captures EVERY content line, so a multi-line draft's
+ * change on its last line is not missed.
+ */
+export function readInputBoxRaw(screen: string): string | null {
+  if (!screen) return null;
+  const lines = screen.split(/\r?\n/);
+  const HR_RE = /^\s*─{10,}\s*$/;
+  let bottomHR = -1;
+  let topHR = -1;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (HR_RE.test(lines[i])) {
+      if (bottomHR === -1) bottomHR = i;
+      else { topHR = i; break; }
+    }
+  }
+  if (topHR === -1) return null;
+  const parts: string[] = [];
+  for (const line of lines.slice(topHR + 1, bottomHR)) {
+    let s = line.replace(/│/g, " ");        // drop box-drawing borders
+    s = s.replace(/^\s*[>❯]\s?/, "");        // drop the leading prompt glyph + one space
+    s = s.replace(/\s*[▌█▔▎▏]+\s*$/, "");    // drop a trailing cursor glyph
+    parts.push(s);
+  }
+  return parts.join("").replace(/\s+$/, ""); // trim only the trailing edge
 }
 
 export function createCmuxDriver(): RuntimeDriver {
@@ -357,39 +391,56 @@ export function createCmuxDriver(): RuntimeDriver {
       return { workspaceId: wsId, surfaceId, title: opts.title };
     },
 
-    async sendToSurface(surface: PaneRef, text: string, opts?: { force?: boolean }): Promise<void> {
+    async sendToSurface(surface: PaneRef, text: string, opts?: { probe?: boolean }): Promise<void> {
+      const ws = surface.workspaceId;
+      const sf = surface.surfaceId;
+      const deliver = () => {
+        cmux(["send", "--workspace", ws, "--surface", sf, sanitizeForCmuxSend(text)]);
+        cmux(["send-key", "--workspace", ws, "--surface", sf, "Enter"]);
+      };
+
       // #258/#268 Approach B: deliver only when the captain's input is positively
       // confirmed empty. null = box not visible (overlay/menu/scroll) → always defer.
-      let draft: string | null = null;
+      let screen = "";
       try {
-        const screen = cmux(["read-screen", "--workspace", surface.workspaceId, "--surface", surface.surfaceId]);
-        draft = parseDraftFromScreen(screen);
-      } catch { /* screen unreadable — draft stays null, will defer below */ }
+        screen = cmux(["read-screen", "--workspace", ws, "--surface", sf]);
+      } catch { /* screen unreadable — parseDraftFromScreen("") → null → defer below */ }
+      const draft = parseDraftFromScreen(screen);
 
       // null = box not confirmed visible → never keystroke into an overlay (#268).
-      if (draft === null) {
-        throw new DeferDelivery();
+      if (draft === null) throw new DeferDelivery(null);
+
+      // Empty input — nothing to protect, deliver directly.
+      if (draft === "") { deliver(); return; }
+
+      // A draft is present. On the hot path (no probe) we NEVER keystroke — we
+      // defer and carry the content so the relay can track stability (#302).
+      if (!opts?.probe) throw new DeferDelivery(draft);
+
+      // #302 buffer-liveness probe (replaces the old destructive backspace×N
+      // clear + re-paste, which MATERIALIZED ghost suggestions). A real draft is
+      // the ONLY thing that yields the "last char removed, still non-empty"
+      // signature under ONE backspace (verified live, CC 2.1.x); a ghost either
+      // stays invariant or dismisses to empty. So we PROTECT only on that exact
+      // signature, and we NEVER re-paste screen-read content.
+      const before = readInputBoxRaw(screen);
+      cmux(["send-key", "--workspace", ws, "--surface", sf, "backspace"]);
+      let afterScreen = "";
+      try {
+        afterScreen = cmux(["read-screen", "--workspace", ws, "--surface", sf]);
+      } catch { /* unreadable after probe — treat as no real draft, fall through to deliver */ }
+      const after = readInputBoxRaw(afterScreen);
+
+      if (before !== null && after !== null && after.length > 0 && after === before.slice(0, -1)) {
+        // Confirmed REAL draft. Restore the single char our probe removed (NOT a
+        // full re-paste — at most one known char), then defer. Never clobber, and
+        // a ghost can never reach this branch, so it can never be materialized.
+        cmux(["send", "--workspace", ws, "--surface", sf, before.slice(-1)]);
+        throw new DeferDelivery(draft);
       }
 
-      if (draft && !opts?.force) {
-        // Captain is composing — defer until input clears (relay retries next poll).
-        throw new DeferDelivery();
-      }
-
-      if (draft && opts?.force) {
-        // Walk-away last-resort: backspace×(N+2) clears, deliver, restore draft.
-        const backspaceCount = draft.length + 2;
-        for (let i = 0; i < backspaceCount; i++) {
-          cmux(["send-key", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, "backspace"]);
-        }
-        cmux(["send", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, sanitizeForCmuxSend(text)]);
-        cmux(["send-key", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, "Enter"]);
-        cmux(["send", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, sanitizeForCmuxSend(draft)]);
-      } else {
-        // Input is empty — deliver directly, nothing to protect.
-        cmux(["send", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, sanitizeForCmuxSend(text)]);
-        cmux(["send-key", "--workspace", surface.workspaceId, "--surface", surface.surfaceId, "Enter"]);
-      }
+      // No real draft (ghost dismissed/invariant, or buffer now empty) → deliver.
+      deliver();
     },
 
     async listSurfaces(workspaceId: string): Promise<PaneRef[]> {

--- a/src/runtimes/types.ts
+++ b/src/runtimes/types.ts
@@ -73,6 +73,8 @@ export interface RuntimeDriver {
   // targets one surface directly. Used by the notify-relay injector to
   // deliver messages to the captain's primary surface. Throws if the surface
   // no longer exists.
-  // opts.force=true skips the idle-defer stability check (#258 phase 2).
-  sendToSurface(surface: PaneRef, text: string, opts?: { force?: boolean }): Promise<void>;
+  // opts.probe=true runs the #302 buffer-liveness probe: deliver only if no real
+  // draft is present (protects a real draft, never materializes a ghost). Without
+  // it, any draft defers (#258/#268 deliver-when-empty).
+  sendToSurface(surface: PaneRef, text: string, opts?: { probe?: boolean }): Promise<void>;
 }


### PR DESCRIPTION
## [0.6.1] - 2026-06-15

A reliability patch addressing relay ghost-materialization, headless launcher I/O pressure, cross-project boot-if-down, and crew spawn focus leakage — plus a build fix and a CI gate.

### Fixed

- **Cross-project boot-if-down now works reliably.** The target captain is brought to operational before warmup is judged; warmup timeout extended from 30 s → 120 s and exposed as `--warmup-timeout` flag. Closes #288. (#291)

- **Headless launcher I/O pressure reduced.** Task-progress writes are coalesced via a 250 ms / 50-chunk debounce with a final flush, stopping O(chunks) file writes. stdout/stderr capture is capped at a 4 MB tail to bound memory. Closes #88. (#293)

- **Relay no longer materializes Claude Code ghost-suggestions into drafts.** A buffer-liveness probe replaces the destructive re-paste mechanism: the probe distinguishes a ghost auto-suggestion from a real draft without clearing the input, so a ghost can never be committed as a crew message. The ~5-min defer stall from the previous heuristic is also eliminated via an early stability-probe path. Closes #294 and #302. (#297, #303)

- **`crew spawn` (tab) no longer steals cmux focus.** Captain focus is restored after the new-pane call, preventing keystroke leakage into the crew launch command. Closes #295. (#299)

- **TypeScript build error in headless-launcher tests fixed.** The `writeResult` mock was typed incorrectly, breaking `npm run build`. Closes #300. (#301)

### Changed

- **`crew spawn` defaults to an isolated git worktree+branch.** Parallel crews no longer collide on a shared working tree; opt out with `--shared` for small single-file tasks. Closes #296. (#298)

- **CI `build-and-test` is a required merge gate on `develop`.** Broken builds and test failures are now caught at PR time rather than after merge.