### PR TITLE
fix(daemon): coalesce concurrent daemon restarts via in-process flag + filesystem lock (#93)

### DIFF
--- a/src/control/__tests__/daemon-lock.test.ts
+++ b/src/control/__tests__/daemon-lock.test.ts
@@ -1,0 +1,177 @@
+// src/control/__tests__/daemon-lock.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("node:fs", () => ({
+  openSync: vi.fn(),
+  writeSync: vi.fn(),
+  closeSync: vi.fn(),
+  unlinkSync: vi.fn(),
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  constants: { O_EXCL: 2048, O_CREAT: 512, O_WRONLY: 1 },
+}));
+
+import { existsSync, readFileSync, openSync, writeSync, closeSync, unlinkSync } from "node:fs";
+import {
+  tryAcquireDaemonLock,
+  releaseDaemonLock,
+  daemonLockPath,
+  _resetRestartInFlightForTest,
+} from "../launchd.js";
+
+const LOCK_PATH = daemonLockPath();
+
+// Stub Atomics.wait to prevent real 50 ms sleeps in the retry loop.
+const stubbedAtomics = { wait: vi.fn(() => "ok" as ReturnType<typeof Atomics.wait>) };
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.stubGlobal("Atomics", stubbedAtomics);
+  _resetRestartInFlightForTest();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("daemonLockPath", () => {
+  it("ends with daemon.lock inside .config/cockpit", () => {
+    expect(LOCK_PATH).toMatch(/\.config[/\\]cockpit[/\\]daemon\.lock$/);
+  });
+});
+
+describe("tryAcquireDaemonLock — no existing lock", () => {
+  it("acquires lock and writes PID when no lock file exists", () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(openSync).mockReturnValue(3 as unknown as number);
+
+    const result = tryAcquireDaemonLock();
+
+    expect(result).toBe(true);
+    expect(openSync).toHaveBeenCalledOnce();
+    expect(writeSync).toHaveBeenCalledWith(3, String(process.pid));
+    expect(closeSync).toHaveBeenCalledWith(3);
+  });
+
+  it("does not call unlinkSync when no lock file exists", () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(openSync).mockReturnValue(3 as unknown as number);
+
+    tryAcquireDaemonLock();
+
+    expect(unlinkSync).not.toHaveBeenCalled();
+  });
+});
+
+describe("tryAcquireDaemonLock — stale lock (dead PID)", () => {
+  it("removes stale lock when owning PID is dead and then acquires", () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue("99999");
+    vi.spyOn(process, "kill").mockImplementationOnce(() => {
+      throw Object.assign(new Error("kill ESRCH 99999"), { code: "ESRCH" });
+    });
+    vi.mocked(openSync).mockReturnValue(4 as unknown as number);
+
+    const result = tryAcquireDaemonLock();
+
+    expect(unlinkSync).toHaveBeenCalledWith(LOCK_PATH);
+    expect(result).toBe(true);
+  });
+
+  it("removes lock with non-numeric PID and acquires", () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue("not-a-pid");
+    vi.mocked(openSync).mockReturnValue(5 as unknown as number);
+
+    const result = tryAcquireDaemonLock();
+
+    expect(unlinkSync).toHaveBeenCalledWith(LOCK_PATH);
+    expect(result).toBe(true);
+  });
+
+  it("removes lock with zero PID and acquires", () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue("0");
+    vi.mocked(openSync).mockReturnValue(6 as unknown as number);
+
+    const result = tryAcquireDaemonLock();
+
+    expect(unlinkSync).toHaveBeenCalledWith(LOCK_PATH);
+    expect(result).toBe(true);
+  });
+});
+
+describe("tryAcquireDaemonLock — live process holds lock", () => {
+  it("does not steal lock when owning PID is alive", () => {
+    const livePid = process.pid + 1;
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(String(livePid));
+    vi.spyOn(process, "kill").mockImplementation((): true => true); // alive — no throw
+    vi.mocked(openSync).mockImplementation(() => { throw new Error("EEXIST"); });
+
+    const result = tryAcquireDaemonLock();
+
+    expect(unlinkSync).not.toHaveBeenCalled();
+    expect(result).toBe(false);
+  });
+
+  it("retries before giving up when lock is held", () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(openSync).mockImplementation(() => { throw new Error("EEXIST"); });
+
+    tryAcquireDaemonLock();
+
+    // 20 attempts, Atomics.wait called for the first 19 retries
+    expect(stubbedAtomics.wait).toHaveBeenCalledTimes(19);
+  });
+});
+
+describe("releaseDaemonLock", () => {
+  it("calls unlinkSync on the lock path", () => {
+    releaseDaemonLock();
+    expect(unlinkSync).toHaveBeenCalledWith(LOCK_PATH);
+  });
+
+  it("does not throw when the lock file is already gone", () => {
+    vi.mocked(unlinkSync).mockImplementation(() => { throw Object.assign(new Error("ENOENT"), { code: "ENOENT" }); });
+    expect(() => releaseDaemonLock()).not.toThrow();
+  });
+});
+
+describe("in-process restartInFlight dedup", () => {
+  it("tryAcquireDaemonLock is not called on the second ensureDaemon invocation in the same process", async () => {
+    // Import ensureDaemon after all mocks are set up.
+    // We mock node:child_process to prevent real launchctl calls.
+    vi.doMock("node:child_process", () => ({ execFileSync: vi.fn() }));
+
+    // First call: no lock file, O_EXCL succeeds, execFileSync throws (daemonEntryPath)
+    // so the function catches and returns. The flag is set to true.
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(openSync).mockReturnValue(7 as unknown as number);
+
+    // Track how many times tryAcquireDaemonLock acquires the lock
+    const acquireCalls: boolean[] = [];
+    const originalOpen = vi.mocked(openSync);
+    originalOpen.mockImplementation(() => {
+      acquireCalls.push(true);
+      return 7 as unknown as number;
+    });
+
+    const { ensureDaemon, _resetRestartInFlightForTest: reset } = await import("../launchd.js");
+    reset();
+
+    ensureDaemon();
+    const firstAcquireCount = acquireCalls.length;
+
+    // Second call in same process — restartInFlight is now true
+    ensureDaemon();
+
+    // Lock acquisition only happened once (the second call returned early)
+    expect(acquireCalls.length).toBe(firstAcquireCount);
+
+    reset(); // clean up for other tests
+  });
+});

--- a/src/control/launchd.ts
+++ b/src/control/launchd.ts
@@ -1,6 +1,6 @@
 // src/control/launchd.ts
 import { execFileSync } from "node:child_process";
-import { mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { mkdirSync, writeFileSync, readFileSync, existsSync, openSync, writeSync, closeSync, unlinkSync, constants } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -146,6 +146,67 @@ export function kickstartArgv(target: string, plistChanged: boolean): string[] {
   return plistChanged ? ["kickstart", "-k", target] : ["kickstart", target];
 }
 
+// In-process dedup: JS is single-threaded and ensureDaemon is synchronous, so
+// true re-entrancy is impossible; this flag prevents sequential re-calls within
+// the same process (e.g. index.ts + crew-control.ts) from re-running the
+// bootout/bootstrap pair needlessly.
+let restartInFlight = false;
+
+/** @internal — reset only in tests; never call from production code */
+export function _resetRestartInFlightForTest(): void {
+  restartInFlight = false;
+}
+
+export function daemonLockPath(): string {
+  return join(homedir(), ".config", "cockpit", "daemon.lock");
+}
+
+/**
+ * Acquire a cross-process filesystem lock at ~/.config/cockpit/daemon.lock.
+ * Uses O_EXCL for atomic, race-free creation. Cleans up stale locks (dead PID)
+ * before the acquisition loop. Retries with a ~50 ms synchronous sleep up to
+ * 20 times (~1 s total) before giving up.
+ * Returns true on success, false if another live process holds the lock.
+ */
+export function tryAcquireDaemonLock(): boolean {
+  const lp = daemonLockPath();
+
+  // Stale-lock cleanup: if the owning PID is no longer alive, remove the file
+  // so the next O_EXCL attempt succeeds.
+  if (existsSync(lp)) {
+    try {
+      const pid = parseInt(readFileSync(lp, "utf-8").trim(), 10);
+      if (!Number.isFinite(pid) || pid <= 0) {
+        unlinkSync(lp);
+      } else {
+        try { process.kill(pid, 0); }
+        catch { unlinkSync(lp); } // ESRCH → process dead, steal the lock
+      }
+    } catch { /* read/parse/unlink error — fall through to O_EXCL attempt */ }
+  }
+
+  // Atomic acquisition: O_EXCL guarantees only one process creates the file.
+  for (let i = 0; i < 20; i++) {
+    try {
+      const fd = openSync(lp, constants.O_EXCL | constants.O_CREAT | constants.O_WRONLY);
+      writeSync(fd, String(process.pid));
+      closeSync(fd);
+      return true;
+    } catch {
+      if (i < 19) {
+        // Synchronous sleep: gives the lock-holder time to finish and release.
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 50);
+      }
+    }
+  }
+  return false; // another live process held the lock for > ~1 s — skip restart
+}
+
+/** Release the lock written by tryAcquireDaemonLock. */
+export function releaseDaemonLock(): void {
+  try { unlinkSync(daemonLockPath()); } catch { /* already cleaned up */ }
+}
+
 /**
  * Idempotent & cheap. Never throws fatally. Writes/reloads the plist ONLY when
  * its content actually changed; Distinguishes program-argument drift (warrants
@@ -155,8 +216,22 @@ export function kickstartArgv(target: string, plistChanged: boolean): string[] {
  * bootout's exit handler that produced exit-113 "service not loaded" errors.
  * The daemon entry is resolved internally (see daemonEntryPath) so no caller
  * can pass a wrong path.
+ *
+ * Concurrency guards:
+ *   - restartInFlight flag: prevents sequential re-calls within this process.
+ *   - tryAcquireDaemonLock: serialises concurrent SEPARATE cockpit processes
+ *     via a filesystem lock so only one runs bootout/bootstrap at a time.
  */
 export function ensureDaemon(nodeBin: string = process.execPath): void {
+  if (restartInFlight) return;
+  restartInFlight = true;
+
+  if (!tryAcquireDaemonLock()) {
+    // Another process is handling the restart; it will be done by the time the
+    // CLI tries to reach the daemon socket.
+    return;
+  }
+
   try {
     const p = plistPath();
     const entry = daemonEntryPath();
@@ -195,5 +270,7 @@ export function ensureDaemon(nodeBin: string = process.execPath): void {
   } catch (e) {
     // daemon ensure is best-effort (still don't throw); CLI fails loud on socket miss
     process.stderr.write(`[cockpit] warn: ensureDaemon failed (${e instanceof Error ? e.message : e})\n`);
+  } finally {
+    releaseDaemonLock();
   }
 }


### PR DESCRIPTION
## Summary

- **In-process dedup**: Module-level `restartInFlight` boolean prevents sequential re-calls within the same process (e.g. `index.ts` + `crew-control.ts`) from re-running the bootout/bootstrap pair.
- **Cross-process lock**: `tryAcquireDaemonLock` / `releaseDaemonLock` implement an O_EXCL filesystem lock at `~/.config/cockpit/daemon.lock`. Only one process runs `launchctl bootout`+`bootstrap` at a time; concurrent processes wait ~50 ms per retry (up to ~1 s) then skip — the winner already ensured the daemon.
- **Stale lock cleanup**: Before the O_EXCL acquisition loop, if a lock file exists but its PID is no longer alive (ESRCH from `process.kill(pid, 0)`), the lock is removed. Invalid/zero PIDs are also cleaned up. This prevents deadlock when a process dies holding the lock.
- `ensureDaemon` wires both guards: in-process flag first, then lock; bootout/bootstrap runs only inside the critical section.

## Test plan

- [ ] `vitest run src/control/__tests__/daemon-lock.test.ts` — 11 new tests covering: clean acquire, stale dead-PID cleanup, non-numeric PID cleanup, live-PID contention (no steal, returns false, retries logged), release, in-process dedup
- [ ] `vitest run src/control/__tests__/launchd.test.ts` — 19 existing tests still pass (no regressions)
- [ ] `vitest run src/control/__tests__/ensure-daemon-callsite.test.ts` — 3 callsite guard tests still pass
- [ ] `tsc` — green (no type errors)