### PR TITLE
fix(launch): deterministic startup-prompt delivery on slow cold boots (#292)

### DIFF
--- a/src/commands/__tests__/launch.test.ts
+++ b/src/commands/__tests__/launch.test.ts
@@ -21,7 +21,7 @@ vi.mock("../../lib/cmux-bin.js", () => ({
   resetCmuxBinCache: vi.fn(),
 }));
 
-import { cmuxLocal, buildRelaySupervisorCommand } from "../launch.js";
+import { cmuxLocal, buildRelaySupervisorCommand, deliverStartupPrompt } from "../launch.js";
 
 describe("cmuxLocal (launch.ts direct-cmux helper)", () => {
   beforeEach(() => {
@@ -77,5 +77,85 @@ describe("buildRelaySupervisorCommand (#186 self-healing relay)", () => {
     const cmd = buildRelaySupervisorCommand("brove");
     const body = cmd.replace(/^while .*?; do /, "").replace(/; done$/, "");
     expect(body).toContain("cockpit notify-relay brove --as captain");
+  });
+});
+
+// #292: the captain startup prompt was delivered on a fixed 8s setTimeout. CC
+// cold-init takes 5–15s, so on a slow boot the prompt landed on the splash screen
+// and was silently dropped (#235), so the captain never ran startup and the relay
+// never booted. deliverStartupPrompt replaces the magic delay with a deterministic
+// poll-send-confirm loop: wait for input-readiness, send, and bounded re-send if
+// the keystrokes were dropped — without ever re-sending a prompt that landed.
+describe("deliverStartupPrompt (#292 deterministic startup delivery)", () => {
+  // Real CC layouts the classifier keys on (see cmux.ts / 258 fixture).
+  const HR = "─".repeat(110);
+  const SPLASH = " ✻ Welcome to Claude Code\n   Loading…";
+  const IDLE = [HR, "❯ ", HR, "   Model: Opus 4.8  Ctx Used: 52.0%", "  ⏵⏵ auto mode on"].join("\n");
+  const WORKING = ["✢ Cerebrating… (4s · ↓ 1.2k tokens)", HR, "❯ ", HR, "  ⏵⏵ auto mode on"].join("\n");
+
+  const FAST = { readyTimeoutMs: 100, settleMs: 1, pollMs: 1, maxAttempts: 3 };
+
+  // A fake runtime whose read-screen returns scripted screens by call index
+  // (clamped to the last), recording every send for assertions.
+  function fakeRuntime(screens: string[]) {
+    let i = 0;
+    const sends: string[] = [];
+    return {
+      sends,
+      readScreen: vi.fn(async () => screens[Math.min(i++, screens.length - 1)]),
+      send: vi.fn(async (_ref: string, msg: string) => { sends.push(msg); }),
+    };
+  }
+
+  it("waits out the splash and sends only once the surface is input-ready", async () => {
+    // loading (initial) → idle (ready) → working (confirm: landed)
+    const rt = fakeRuntime([SPLASH, IDLE, WORKING]);
+    await deliverStartupPrompt(rt, "workspace:1", "GO", FAST);
+    expect(rt.sends).toEqual(["GO"]);
+    // It must NOT have sent while the screen was still the splash.
+    expect(rt.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT re-send when the first prompt landed (guards duplicate runs)", async () => {
+    // idle (ready) → working (confirm: landed) — exactly one send.
+    const rt = fakeRuntime([IDLE, WORKING]);
+    await deliverStartupPrompt(rt, "workspace:1", "GO", FAST);
+    expect(rt.sends).toEqual(["GO"]);
+  });
+
+  it("re-sends (bounded) when the first keystrokes were dropped", async () => {
+    // idle → (send) → still idle after settle (dropped) → idle → (send) → working.
+    const rt = fakeRuntime([IDLE, IDLE, IDLE, WORKING]);
+    await deliverStartupPrompt(rt, "workspace:1", "GO", FAST);
+    expect(rt.sends).toEqual(["GO", "GO"]);
+  });
+
+  it("never re-sends into an already-working session", async () => {
+    const rt = fakeRuntime([WORKING]);
+    await deliverStartupPrompt(rt, "workspace:1", "GO", FAST);
+    expect(rt.sends).toEqual([]);
+  });
+
+  it("falls back to a single best-effort send if readiness never appears (no hang)", async () => {
+    // Unrecognized chrome forever (e.g. a non-Claude agent): time out, send once.
+    const rt = fakeRuntime([SPLASH]);
+    await deliverStartupPrompt(rt, "workspace:1", "GO", FAST);
+    expect(rt.sends).toEqual(["GO"]);
+  });
+
+  it("stops re-sending after maxAttempts even if it never lands", async () => {
+    // Stuck idle forever (every keystroke dropped): bounded to maxAttempts sends.
+    const rt = fakeRuntime([IDLE]);
+    await deliverStartupPrompt(rt, "workspace:1", "GO", { ...FAST, maxAttempts: 3 });
+    expect(rt.sends).toEqual(["GO", "GO", "GO"]);
+  });
+
+  it("never throws even if readScreen rejects", async () => {
+    const rt = {
+      sends: [] as string[],
+      readScreen: vi.fn(async () => { throw new Error("surface gone"); }),
+      send: vi.fn(async () => {}),
+    };
+    await expect(deliverStartupPrompt(rt, "workspace:1", "GO", FAST)).resolves.toBeUndefined();
   });
 });

--- a/src/commands/launch.ts
+++ b/src/commands/launch.ts
@@ -14,7 +14,7 @@ import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js"
 import { ensureSpokeLayout } from "../lib/vault-layout.js";
 import { resolveCmuxBin } from "../lib/cmux-bin.js";
 import { buildRelaySupervisorCommand, NOTIFY_RELAY_TAB_TITLE } from "../control/relay-supervisor.js";
-import { CMUX_TIMEOUT } from "../runtimes/cmux.js";
+import { CMUX_TIMEOUT, classifyStartupSurface } from "../runtimes/cmux.js";
 
 const CMUX_APP = "/Applications/cmux.app";
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "cockpit", "templates");
@@ -185,6 +185,73 @@ function buildAgentCmd(
 // them from "../launch").
 export { buildRelaySupervisorCommand, NOTIFY_RELAY_TAB_TITLE };
 
+export interface StartupDeliveryOptions {
+  /** Max time to wait for the surface to leave the cold-init splash. */
+  readyTimeoutMs?: number;
+  /** Pause after a send before checking whether the turn started. */
+  settleMs?: number;
+  /** Poll cadence while waiting for readiness. */
+  pollMs?: number;
+  /** Hard cap on (re)send attempts. */
+  maxAttempts?: number;
+}
+
+/**
+ * #292: deliver the captain/command startup prompt deterministically instead of
+ * on a fixed 8s timer. CC cold-init takes 5–15s, so a fixed delay either wastes
+ * boot time or — on a slow boot — drops the prompt on the splash screen (#235),
+ * leaving the captain idle and the relay unbooted.
+ *
+ * The loop, per attempt: (1) poll until the surface is past the splash; (2) if a
+ * turn is already running, stop — never queue a duplicate startup run; (3) send;
+ * (4) after a short settle, re-check — a real submit flips the surface to
+ * "working", so we re-send ONLY while it's still "idle" (keystrokes were dropped).
+ * Re-sending strictly on observed-still-idle is what guards against duplicate
+ * runs: a prompt that landed is never sent twice. Best-effort and never throws.
+ */
+export async function deliverStartupPrompt(
+  runtime: Pick<RuntimeDriver, "readScreen" | "send">,
+  refId: string,
+  prompt: string,
+  opts: StartupDeliveryOptions = {},
+): Promise<void> {
+  const readyTimeoutMs = opts.readyTimeoutMs ?? 30_000;
+  const settleMs = opts.settleMs ?? 2_500;
+  const pollMs = opts.pollMs ?? 1_000;
+  const maxAttempts = opts.maxAttempts ?? 3;
+  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+  const read = async () => runtime.readScreen(refId).catch(() => "");
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    // Phase 1 — wait out cold init (poll, don't guess with a fixed delay).
+    const deadline = Date.now() + readyTimeoutMs;
+    let state = classifyStartupSurface(await read());
+    while (state === "loading" && Date.now() < deadline) {
+      await sleep(pollMs);
+      state = classifyStartupSurface(await read());
+    }
+
+    // A turn is already in flight (a prior attempt landed, or a resumed session
+    // auto-continued). Never keystroke into it — that would queue a duplicate run.
+    if (state === "working") return;
+
+    // Phase 2 — deliver. We send on "idle" (input-ready) and, as a non-hanging
+    // fallback, on a "loading" timeout (e.g. a non-Claude agent whose chrome we
+    // don't recognize) so a launch is never left silently without its prompt.
+    await runtime.send(refId, prompt).catch(() => { /* best-effort */ });
+
+    // Timed out waiting for chrome — sent blind once; nothing to confirm, stop.
+    if (state === "loading") return;
+
+    // Phase 3 — confirm. A real submit flips the surface to "working" within a
+    // second or two (a startup turn runs far longer than settleMs). If it's no
+    // longer "idle", the prompt landed → done. If still "idle", the keystrokes
+    // were dropped (#235) → loop and re-send (bounded by maxAttempts).
+    await sleep(settleMs);
+    if (classifyStartupSurface(await read()) !== "idle") return;
+  }
+}
+
 async function launchWorkspace(
   runtime: RuntimeDriver,
   name: string,
@@ -223,12 +290,13 @@ async function launchWorkspace(
   });
 
   if (initialPrompt) {
-    // #288: cold-boot Claude sessions need ~8s to initialize before they can
-    // receive input. 3s was too short — startup prompt arrived at the loading
-    // screen and was silently dropped, so relay supervisor never ran.
-    setTimeout(() => {
-      runtime.send(ref.id, initialPrompt).catch(() => { /* best-effort */ });
-    }, 8000);
+    // #292: deterministic delivery — poll for input-readiness, send, and bounded
+    // re-send if the first turn was dropped (replaces the racy fixed 8s delay
+    // that dropped the prompt on slow 5–15s cold boots). Fire-and-forget, as the
+    // old setTimeout was, so launch stays non-blocking and `--all` dispatches
+    // captains in parallel; the loop's pending poll timers keep the CLI process
+    // alive until delivery completes.
+    void deliverStartupPrompt(runtime, ref.id, initialPrompt);
   }
 
   if (navigate) {

--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { createCmuxDriver, sanitizeForCmuxSend, parseDraftFromScreen, DeferDelivery } from "../cmux.js";
+import { createCmuxDriver, sanitizeForCmuxSend, parseDraftFromScreen, classifyStartupSurface, DeferDelivery } from "../cmux.js";
 
 const execFileMock = vi.hoisted(() => vi.fn());
 vi.mock("node:child_process", () => ({
@@ -985,5 +985,51 @@ describe("sendToSurface Approach B (#258 deliver-when-empty)", () => {
     expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")))).toBe(false);
     expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes(DRAFT)))).toBe(false);
     expect(calls.some((a) => a.includes("send-key") && a.includes("Enter"))).toBe(false);
+  });
+});
+
+// #292: deterministic startup-prompt delivery needs to tell three surface states
+// apart so launch can wait out cold init, send when ready, and never re-send into
+// a working session. The signals are grounded in real read-screen captures:
+//   loading — splash/cold-init: none of the persistent CC bottom-status chrome yet
+//   idle    — TUI up, input box accepting keystrokes (⏵⏵ / Ctx Used / for shortcuts)
+//   working — a live turn: token-down-counter "↓ Nk tokens" and/or "esc to interrupt"
+describe("classifyStartupSurface (#292 startup-readiness classifier)", () => {
+  // Real CC working spinner line (see docs/reports/258-parse-bug-fixture.txt).
+  const WORKING_STATUS = [
+    "✢ Cerebrating… (1m 4s · ↓ 4.3k tokens)",
+    HR,
+    "❯ ",
+    HR,
+    "   Model: Opus 4.8  Ctx Used: 52.0%",
+    "  ⏵⏵ auto mode on · 1 shell",
+  ].join("\n");
+
+  it("returns 'loading' for an empty screen", () => {
+    expect(classifyStartupSurface("")).toBe("loading");
+  });
+
+  it("returns 'loading' for a cold-init splash with no CC status chrome", () => {
+    const splash = ["", " ✻ Welcome to Claude Code", "   Loading…", ""].join("\n");
+    expect(classifyStartupSurface(splash)).toBe("loading");
+  });
+
+  it("returns 'idle' once the CC bottom-status chrome is present and no turn is running", () => {
+    // makeTestScreen renders the real idle layout: HR-boxed empty ❯ + status block.
+    expect(classifyStartupSurface(makeTestScreen("❯ "))).toBe("idle");
+  });
+
+  it("returns 'working' when the live token-down-counter is on screen", () => {
+    expect(classifyStartupSurface(WORKING_STATUS)).toBe("working");
+  });
+
+  it("returns 'working' when 'esc to interrupt' is shown", () => {
+    const screen = makeTestScreen("❯ ", "Working… (3s · esc to interrupt)");
+    expect(classifyStartupSurface(screen)).toBe("working");
+  });
+
+  it("prefers 'working' over 'idle' when both chrome and a live turn are present", () => {
+    // The 258 fixture shape: idle-looking input box but an active spinner above.
+    expect(classifyStartupSurface(WORKING_STATUS)).toBe("working");
   });
 });

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -192,6 +192,33 @@ export function readInputBoxRaw(screen: string): string | null {
   return parts.join("").replace(/\s+$/, ""); // trim only the trailing edge
 }
 
+// #292: Claude Code renders a persistent bottom status block once its TUI is past
+// the cold-init splash — the auto-mode indicator (⏵⏵), the context meter
+// ("Ctx Used"), the shortcuts hint, or the accept-edits toggle. Absence of all of
+// these means we're still on the loading/splash screen, where keystrokes are
+// silently dropped (#235). Grounded in docs/reports/258-parse-bug-fixture.txt.
+const CC_INITIALIZED_RE = /⏵⏵|Ctx Used|for shortcuts|accept edits/i;
+
+// A live turn shows a working spinner carrying a token-down-counter ("↓ 4.3k
+// tokens") and/or the "esc to interrupt" hint — neither appears on an idle,
+// input-ready screen. The whimsical spinner verb ("Working…", "Cerebrating…")
+// varies across versions, so we key on these stable markers instead.
+const CC_WORKING_RE = /↓\s*[\d.]+\s*k?\s*tokens?\b|esc to interrupt/i;
+
+/**
+ * Classify a captain surface's read-screen into the three states #292's
+ * deterministic startup delivery needs:
+ *   "loading" — splash / cold-init; keystrokes would be dropped, do not send yet.
+ *   "idle"    — TUI up and accepting input; safe to deliver the startup prompt.
+ *   "working" — a turn is in flight; sending would queue a DUPLICATE startup run.
+ * "working" is checked first so an active spinner above an (empty) input box wins.
+ */
+export function classifyStartupSurface(screen: string): "loading" | "idle" | "working" {
+  if (CC_WORKING_RE.test(screen)) return "working";
+  if (CC_INITIALIZED_RE.test(screen)) return "idle";
+  return "loading";
+}
+
 export function createCmuxDriver(): RuntimeDriver {
   return {
     name: "cmux",


### PR DESCRIPTION
## Problem

Closes #292. Follow-up to #288/#291.

`launchWorkspace` delivered the captain/command startup prompt on a fixed `setTimeout(..., 8000)`. Claude Code cold-init takes **5–15s**, so on a slow boot the prompt landed on the splash/loading screen and was silently dropped (the #235 first-turn-drop race). When that happens the captain never runs its startup checklist, the relay supervisor never boots, and the 120s warmup fails regardless of headroom. Affects **all** launches, not just `--all` group dispatch.

## Fix

Replace the magic delay with **deterministic** delivery — `deliverStartupPrompt`, a poll-send-confirm loop:

1. **Wait for readiness** — poll the surface until it's past the cold-init splash, instead of guessing a delay (handles the full 5–15s range with headroom).
2. **Send** when the input box is ready (`idle`).
3. **Confirm + bounded re-send** — a real submit flips the surface to `working` within ~1–2s; re-send **only** while it's still `idle` (keystrokes were dropped). Because re-send is gated on *observed-still-idle*, a prompt that landed is **never sent twice** — this is the guard against duplicate startup runs the issue asked for.

State is read via `classifyStartupSurface(screen)` → `loading | idle | working`, a pure classifier keyed on real CC status-block markers (`⏵⏵`, `Ctx Used`) and the live working-spinner (`↓ Nk tokens`, `esc to interrupt`), grounded in `docs/reports/258-parse-bug-fixture.txt`.

Delivery stays **fire-and-forget** (as the old `setTimeout` was), so launch remains non-blocking and `--all` dispatches captains in parallel. If readiness never appears (e.g. a non-Claude agent whose chrome we don't recognize), it falls back to a single best-effort send so a launch is never left silently without its prompt — no hang.

## Tests

TDD. New coverage:
- `classifyStartupSurface` — loading/idle/working from real fixture shapes (6 cases).
- `deliverStartupPrompt` — waits out splash before sending; no re-send when landed (duplicate guard); bounded re-send on drop; never sends into an already-working session; best-effort fallback on readiness timeout; bounded by maxAttempts; never throws on readScreen failure (7 cases).

`npx tsc` green; targeted `vitest run` for both files green (106 passing). Full suite intentionally not run (per-CPU worker pool floods RAM across worktrees).

## Scope

Surgical — only `src/commands/launch.ts` + `src/runtimes/cmux.ts` and their tests. No signature changes (impact analysis: LOW). Ties into #235.