### PR TITLE
feat(crew-attach): auto-retry on daemon bounce with anti-flood guardrails (#100)

### DIFF
--- a/src/commands/__tests__/crew-attach.test.ts
+++ b/src/commands/__tests__/crew-attach.test.ts
@@ -7,6 +7,12 @@ import {
   formatApproval,
   formatDoneFollowup,
   formatGatePromoted,
+  formatConnectionLost,
+  formatReattachFailed,
+  computeBackoffDelay,
+  isConnectionStable,
+  STABLE_MS,
+  RETRY_BUDGET_MS,
 } from "../crew-attach.js";
 
 describe("crew-attach formatters", () => {
@@ -48,5 +54,96 @@ describe("crew-attach formatters", () => {
   it("dim helpers contain expected text", () => {
     expect(stripAnsi(formatDoneFollowup())).toContain("done — type a follow-up");
     expect(stripAnsi(formatGatePromoted("g-123"))).toContain("g-123");
+  });
+
+  it("formatConnectionLost contains retry message", () => {
+    const plain = stripAnsi(formatConnectionLost());
+    expect(plain).toContain("connection lost");
+    expect(plain).toContain("retrying");
+  });
+
+  it("formatReattachFailed contains task id and re-run command", () => {
+    const plain = stripAnsi(formatReattachFailed("task-abc-123"));
+    expect(plain).toContain("reattach failed");
+    expect(plain).toContain("cockpit crew attach task-abc-123");
+  });
+});
+
+describe("crew-attach backoff logic", () => {
+  it("computeBackoffDelay: attempt 0→1s, 1→2s, 2→4s, 3→8s, 4+→16s cap", () => {
+    expect(computeBackoffDelay(0)).toBe(1_000);
+    expect(computeBackoffDelay(1)).toBe(2_000);
+    expect(computeBackoffDelay(2)).toBe(4_000);
+    expect(computeBackoffDelay(3)).toBe(8_000);
+    expect(computeBackoffDelay(4)).toBe(16_000);
+    expect(computeBackoffDelay(5)).toBe(16_000);
+    expect(computeBackoffDelay(10)).toBe(16_000);
+  });
+
+  it("isConnectionStable: not stable before STABLE_MS with no frames", () => {
+    const t0 = 100_000;
+    expect(isConnectionStable(t0, 0, t0 + STABLE_MS - 1)).toBe(false);
+  });
+
+  it("isConnectionStable: stable at exactly STABLE_MS with no frames", () => {
+    const t0 = 100_000;
+    expect(isConnectionStable(t0, 0, t0 + STABLE_MS)).toBe(true);
+  });
+
+  it("isConnectionStable: stable immediately with >=1 frame, regardless of elapsed time", () => {
+    const t0 = 100_000;
+    expect(isConnectionStable(t0, 1, t0 + 10)).toBe(true);
+    expect(isConnectionStable(t0, 5, t0 + 1)).toBe(true);
+  });
+
+  it("flapping guard: 50ms immediate-close with no frames is NOT stable", () => {
+    const t0 = 100_000;
+    expect(isConnectionStable(t0, 0, t0 + 50)).toBe(false);
+  });
+
+  it("STABLE_MS is 5 seconds", () => {
+    expect(STABLE_MS).toBe(5_000);
+  });
+
+  it("RETRY_BUDGET_MS is 60 seconds", () => {
+    expect(RETRY_BUDGET_MS).toBe(60_000);
+  });
+
+  it("flapping: backoff grows on each unstable disconnect (no reset)", () => {
+    // Simulate flapping: each connect closes immediately (unstable)
+    // backoff should grow, not reset
+    let attempt = 0;
+    const delays: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      delays.push(computeBackoffDelay(attempt));
+      attempt += 1; // unstable → increment
+    }
+    expect(delays).toEqual([1_000, 2_000, 4_000, 8_000, 16_000]);
+  });
+
+  it("stable-reset: backoff resets to 0 after a stable connection", () => {
+    // Simulate: grow to attempt=3 via flapping, then get a stable connection
+    let attempt = 3;
+    // stable disconnect → reset to 0
+    attempt = 0;
+    // next flap → delay should be back to 1s
+    expect(computeBackoffDelay(attempt)).toBe(1_000);
+  });
+
+  it("budget exhaustion: flapping from attempt 0 exceeds budget after 7 close events", () => {
+    // Trace: delays are 1,2,4,8,16,16,16... (cap at 16s)
+    // cumulative: 1,3,7,15,31,47,63 → exceeds 60s on 7th
+    let attempt = 0;
+    let total = 0;
+    let closeCount = 0;
+    while (true) {
+      const delay = computeBackoffDelay(attempt);
+      total += delay;
+      closeCount += 1;
+      if (total > RETRY_BUDGET_MS) break;
+      attempt += 1; // unstable
+    }
+    expect(closeCount).toBe(7);
+    expect(total).toBeGreaterThan(RETRY_BUDGET_MS);
   });
 });

--- a/src/commands/__tests__/crew-attach.test.ts
+++ b/src/commands/__tests__/crew-attach.test.ts
@@ -101,6 +101,14 @@ describe("crew-attach backoff logic", () => {
     expect(isConnectionStable(t0, 0, t0 + 50)).toBe(false);
   });
 
+  it("daemon-down guard: connectTimeMs=0 (never established) is NOT stable, even with huge elapsed", () => {
+    // If 'connect' event never fires, connectTimeMs stays 0.
+    // Date.now() - 0 is ~1.7e12 >> STABLE_MS, so without the connectTimeMs>0 guard
+    // this would wrongly return true and reset backoff/budget every attempt.
+    expect(isConnectionStable(0, 0, Date.now())).toBe(false);
+    expect(isConnectionStable(0, 0, STABLE_MS * 1000)).toBe(false);
+  });
+
   it("STABLE_MS is 5 seconds", () => {
     expect(STABLE_MS).toBe(5_000);
   });

--- a/src/commands/crew-attach.ts
+++ b/src/commands/crew-attach.ts
@@ -83,8 +83,45 @@ export function formatConnectionClosed(): string {
   return chalk.dim("(connection closed)");
 }
 
+export function formatConnectionLost(): string {
+  return chalk.dim("(connection lost — retrying...)");
+}
+
+export function formatReattachFailed(taskId: string): string {
+  return chalk.red(`(reattach failed — re-run: cockpit crew attach ${taskId})`);
+}
+
 export function formatGatePromoted(gateId: string): string {
   return chalk.dim(`(no client was attached; question promoted to gate ${gateId})`);
+}
+
+// --- Retry/backoff pure logic (exported for tests) ---
+
+/** Minimum elapsed ms on a connection before it's considered stable (no-frame path). */
+export const STABLE_MS = 5_000;
+
+/** Total retry budget per disconnect episode before giving up. */
+export const RETRY_BUDGET_MS = 60_000;
+
+/**
+ * Exponential backoff delay for reconnect attempt N (0-indexed).
+ * Caps at 16s to bound the per-attempt wait.
+ */
+export function computeBackoffDelay(attempt: number): number {
+  return Math.min(1000 * Math.pow(2, attempt), 16_000);
+}
+
+/**
+ * Returns true if the connection should be considered "stable" —
+ * meaning backoff should reset on the next disconnect.
+ * Stable = received >=1 real frame OR survived >= STABLE_MS.
+ */
+export function isConnectionStable(
+  connectTimeMs: number,
+  framesReceived: number,
+  nowMs: number
+): boolean {
+  return framesReceived > 0 || nowMs - connectTimeMs >= STABLE_MS;
 }
 
 // --- CLI command ---
@@ -93,13 +130,23 @@ export const crewAttachCommand = new Command("attach")
   .description("Attach to a live interactive task (renders deltas; takes follow-ups). Spec §4.6.")
   .argument("<taskId>", "task id to attach to")
   .action((taskId: string) => {
-    const conn = createConnection(socketPath());
-    const send = (m: AttachInbound) => conn.write(JSON.stringify(m) + "\n");
-    conn.on("connect", () => send({ op: "attach", taskId }));
-    let pendingRequestId: number | undefined;
-    let buf = "";
+    // --- Retry state (persists across reconnects) ---
+    let attempt = 0;       // 0-indexed; grows on unstable disconnect, resets on stable
+    let totalSpentMs = 0;  // cumulative backoff spent this episode; resets on stable
+    let retryLogged = false; // dedup: print "connection lost" once per episode
 
-    // Renderer state
+    // --- Per-connection state (reset each connect()) ---
+    let connectTimeMs = 0;
+    let framesReceived = 0;
+    let taskClosed = false;
+    let disconnecting = false;
+
+    // Mutable send ref — updated on each new connection so readline/SIGINT always
+    // writes to the current socket. Noop during backoff gaps.
+    let send: (m: AttachInbound) => void = () => {};
+
+    // --- Renderer state (persists across reconnects) ---
+    let pendingRequestId: number | undefined;
     let turnCount = 0;
     let turnStartMs = 0;
     let inTurn = false;
@@ -109,23 +156,87 @@ export const crewAttachCommand = new Command("attach")
     const elapsed = () => (turnStartMs ? Date.now() - turnStartMs : 0);
     const writeStatus = () => process.stdout.write(formatStatus(state, turnCount, elapsed()) + "\n");
 
-    conn.on("data", (chunk) => {
-      buf += chunk.toString();
-      const lastNl = buf.lastIndexOf("\n");
-      if (lastNl < 0) return;
-      const consumable = buf.slice(0, lastNl + 1);
-      buf = buf.slice(lastNl + 1);
-      for (const f of decodeFrames(consumable)) render(f);
-    });
-    conn.on("close", () => { process.stderr.write("\n" + formatConnectionClosed() + "\n"); process.exit(0); });
-    conn.on("error", (e) => { process.stderr.write(`\n${chalk.red(`(socket error: ${e.message})`)}\n`); process.exit(1); });
+    let buf = "";
+
+    function handleDisconnect(errorMsg?: string): void {
+      if (disconnecting) return; // guard: error fires before close in Node.js
+      disconnecting = true;
+      send = () => {}; // noop until next connect()
+
+      if (errorMsg) {
+        process.stderr.write(`\n${chalk.red(`(socket error: ${errorMsg})`)}\n`);
+      }
+
+      if (taskClosed) {
+        // Task ended cleanly via "closed" frame — no retry needed.
+        process.stderr.write("\n" + formatConnectionClosed() + "\n");
+        process.exit(0);
+        return;
+      }
+
+      const stable = isConnectionStable(connectTimeMs, framesReceived, Date.now());
+
+      if (stable) {
+        // New episode: the lost connection was healthy, so reset budget and backoff.
+        attempt = 0;
+        totalSpentMs = 0;
+        retryLogged = false;
+      }
+
+      if (!retryLogged) {
+        process.stderr.write("\n" + formatConnectionLost() + "\n");
+        retryLogged = true;
+      }
+
+      const delay = computeBackoffDelay(attempt);
+      if (!stable) attempt += 1; // grow backoff only on unstable; stable already reset to 0
+
+      totalSpentMs += delay;
+      if (totalSpentMs > RETRY_BUDGET_MS) {
+        process.stderr.write(formatReattachFailed(taskId) + "\n");
+        process.exit(1);
+        return;
+      }
+
+      setTimeout(connect, delay);
+    }
+
+    function connect(): void {
+      connectTimeMs = 0;
+      framesReceived = 0;
+      taskClosed = false;
+      disconnecting = false;
+      buf = "";
+
+      const conn = createConnection(socketPath());
+      send = (m: AttachInbound) => conn.write(JSON.stringify(m) + "\n");
+
+      conn.on("connect", () => {
+        connectTimeMs = Date.now();
+        send({ op: "attach", taskId });
+      });
+
+      conn.on("data", (chunk) => {
+        buf += chunk.toString();
+        const lastNl = buf.lastIndexOf("\n");
+        if (lastNl < 0) return;
+        const consumable = buf.slice(0, lastNl + 1);
+        buf = buf.slice(lastNl + 1);
+        for (const f of decodeFrames(consumable)) render(f);
+      });
+
+      conn.on("close", () => handleDisconnect());
+      conn.on("error", (e) => handleDisconnect(e.message));
+    }
 
     function render(f: AttachFrame): void {
       switch (f.type) {
         case "delta":
+          framesReceived += 1;
           process.stdout.write(f.text);
           break;
         case "turn-started":
+          framesReceived += 1;
           turnCount += 1;
           turnStartMs = Date.now();
           inTurn = true;
@@ -134,35 +245,43 @@ export const crewAttachCommand = new Command("attach")
           writeStatus();
           break;
         case "turn-completed":
+          framesReceived += 1;
           process.stdout.write("\n" + formatTurnFooter(elapsed()) + "\n");
           state = "idle";
           inTurn = false;
           process.stdout.write(formatDoneFollowup() + "\n> ");
           break;
         case "input-requested":
+          framesReceived += 1;
           pendingRequestId = f.requestId;
           state = "awaiting-input";
           process.stdout.write("\n" + formatInputQuestion(f.question) + "\n" + formatInputPrompt());
           break;
         case "approval-requested":
+          framesReceived += 1;
           pendingRequestId = f.requestId;
           state = "blocked";
           process.stdout.write("\n" + formatApproval(f.kind, f.question) + "\n" + formatApprovalPrompt());
           break;
         case "gate-promoted":
+          framesReceived += 1;
           process.stdout.write("\n" + formatGatePromoted(f.gateId) + "\n> ");
           break;
         case "reattached":
+          framesReceived += 1;
           process.stdout.write("\n" + (attachedOnce ? formatReattached() : formatAttached()) + "\n> ");
           attachedOnce = true;
           break;
         case "closed":
+          taskClosed = true;
           process.stdout.write("\n" + formatClosed(f.reason) + "\n");
           break;
         case "_keepalive":
           break;
       }
     }
+
+    connect();
 
     const rl = createInterface({ input: process.stdin, terminal: false });
     rl.on("line", (text) => {

--- a/src/commands/crew-attach.ts
+++ b/src/commands/crew-attach.ts
@@ -121,7 +121,7 @@ export function isConnectionStable(
   framesReceived: number,
   nowMs: number
 ): boolean {
-  return framesReceived > 0 || nowMs - connectTimeMs >= STABLE_MS;
+  return connectTimeMs > 0 && (framesReceived > 0 || nowMs - connectTimeMs >= STABLE_MS);
 }
 
 // --- CLI command ---


### PR DESCRIPTION
## Summary

- **STABLE-RESET backoff**: Exponential backoff (1s → 16s cap), but the counter resets **only after a stable connection** (survived >5s OR received ≥1 real frame), not on raw TCP `connect`. This is the key flapping guard: a daemon that crash-loops immediately after TCP connect never triggers a backoff reset.
- **Total cap**: 60s cumulative retry budget per disconnect episode. On exhaustion: prints `(reattach failed — re-run: cockpit crew attach <id>)` and exits non-zero.
- **Dedup log**: `(connection lost — retrying...)` printed exactly once per disconnect episode, not once per attempt. Silent during the retry storm.

### Key design details

- `send` is a mutable reference updated on each new connection — readline and SIGINT always write to the current socket; noop during backoff gaps.
- `taskClosed` flag (set by the daemon's `closed` frame) skips retry and exits 0 cleanly.
- Node.js fires `error` then `close` on socket errors — `disconnecting` guard prevents double-processing.
- Renderer state (`turnCount`, `attachedOnce`, `pendingRequestId`, etc.) persists across reconnects.
- Pure functions `computeBackoffDelay` and `isConnectionStable` exported for unit testing.

## Test plan

- [x] 18 unit tests pass (`vitest run src/commands/__tests__/crew-attach.test.ts`)
- [x] `tsc --noEmit` clean
- [x] Formatter tests: `formatConnectionLost`, `formatReattachFailed` with task ID
- [x] Backoff shape: 0→1s, 1→2s, 2→4s, 3→8s, 4+→16s cap
- [x] Stability detection: frame-based (instant) and time-based (≥5s)
- [x] Flapping guard: 50ms immediate-close is NOT stable → backoff grows
- [x] Budget exhaustion: 7 unstable close events exceeds 60s budget
- [x] Stable-reset: backoff returns to 1s after a healthy connection

Fixes #100.