### PR TITLE
fix(watchdog): key stall-check off per-dispatch lastHeartbeatAt (#89)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (4014 symbols, 6562 relationships, 110 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (4358 symbols, 6976 relationships, 115 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/src/control/__tests__/watchdog.test.ts
+++ b/src/control/__tests__/watchdog.test.ts
@@ -1,6 +1,7 @@
 // src/control/__tests__/watchdog.test.ts
 import { describe, it, expect } from "vitest";
 import { evaluateStall, recoverStall } from "../watchdog.js";
+import { reduce } from "../state-machine.js";
 import type { TaskRecord } from "../types.js";
 
 function rec(o: Partial<TaskRecord> = {}): TaskRecord {
@@ -89,5 +90,54 @@ describe("idle interactive-codex = warn-don't-autofail (spec §4.8, #90 slice)",
     const idle = evaluateStall(rec(), 100_000)!;
     expect(evaluateStall(idle, 200_000)).toBeNull(); // no re-stall while idle
     expect(recoverStall(idle, 101_000)).toBeNull();  // recoverStall only acts on 'stalled'
+  });
+});
+
+// ── Issue #89: masking-heartbeat regression ──────────────────────────────────
+// A late { type: "heartbeat" } from a dead attempt updates rec.lastHeartbeat
+// but bypasses stampAttempt, so attempts[-1].lastHeartbeatAt stays anchored to
+// the new dispatch's task.started time. evaluateStall must key off lastHeartbeatAt
+// so the stale pulse from the dead attempt cannot hide a hung new dispatch.
+describe("masking-heartbeat regression (#89)", () => {
+  function baseRec(): TaskRecord {
+    return {
+      id: "t1", project: "p", provider: "claude", mode: "headless",
+      state: "submitted", task: "do x", createdAt: 0,
+      lastHeartbeat: 0, lastEvent: "", heartbeatBudgetMs: 5000,
+      attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 0 }],
+    };
+  }
+
+  it("stale heartbeat from dead attempt does not mask stall on hung re-dispatch", () => {
+    // Attempt A starts at T=100.
+    let r = reduce(baseRec(), { type: "task.started", id: "t1", pid: 10 }, 100);
+    expect(r.attempts.at(-1)!.lastHeartbeatAt).toBe(100);
+
+    // Attempt A crashes at T=200 → terminal.
+    r = reduce(r, { type: "task.failed", id: "t1", error: "crash" }, 200);
+    expect(r.state).toBe("failed");
+
+    // Re-dispatch: captain reopens at T=300.
+    r = reduce(r, { type: "task.reopened", id: "t1" }, 300);
+    expect(r.state).toBe("working");
+
+    // New dispatch: task.started at T=400 stamps lastHeartbeatAt on the attempt.
+    r = reduce(r, { type: "task.started", id: "t1", pid: 20 }, 400);
+    expect(r.attempts.at(-1)!.lastHeartbeatAt).toBe(400);
+
+    // New dispatch is HUNG — no output, no events from pid 20.
+
+    // Late heartbeat from dead attempt A arrives at T=4500 (still within 5s budget
+    // if measured from rec.lastHeartbeat). It updates rec.lastHeartbeat but does NOT
+    // call stampAttempt, so lastHeartbeatAt stays anchored at 400.
+    r = reduce(r, { type: "heartbeat", id: "t1" }, 4500);
+    expect(r.lastHeartbeat).toBe(4500);
+    expect(r.attempts.at(-1)!.lastHeartbeatAt).toBe(400); // unchanged
+
+    // Watchdog fires at T=5401.
+    // Old (buggy) path: now - rec.lastHeartbeat = 5401-4500 = 901 ≤ 5000 → null (false-alive).
+    // Fixed path:       now - lastHeartbeatAt    = 5401-400  = 5001 > 5000 → stalled.
+    const result = evaluateStall(r, 5401);
+    expect(result?.state).toBe("stalled");
   });
 });

--- a/src/control/state-machine.ts
+++ b/src/control/state-machine.ts
@@ -45,16 +45,19 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
         question: undefined, // resuming after a blocked→reply clears the question
       };
     case "task.progress":
+      // task.progress is a real-activity signal (stdout chunk for headless,
+      // PostToolUse/SubagentStop hook for interactive). Stamp the attempt so
+      // lastHeartbeatAt stays current and the watchdog stall-check (#89) can
+      // key off it without false-stalling long-running headless tasks.
+      // From blocked: liveness only — do not auto-unblock (explicit reply required).
+      // From awaiting-input: resume to working (PostToolUse on the next turn).
+      if (rec.state === "blocked") return { ...rec, lastHeartbeat: now, lastEvent: ev.type };
+      if (rec.state === "awaiting-input") return { ...stampAttempt(base, {}, now), state: "working" };
+      return stampAttempt(base, {}, now);
     case "heartbeat":
-      // `heartbeat` and `task.progress` intentionally share this case arm
-      // (both are liveness signals); split if the watchdog later needs to
-      // differentiate them.
-      // Anti-#2576: liveness only. A turn-end is NOT completion.
-      // From blocked, a bare progress/heartbeat does not auto-unblock
-      // (state stays "blocked"); only lastEvent + lastHeartbeat update.
-      // From awaiting-input, transition back to working — the Stop hook
-      // puts the task into awaiting-input between turns (fixes #131 false
-      // stall); PostToolUse on the next turn resumes the working state.
+      // Raw liveness ping — intentionally does NOT stamp the attempt so a late
+      // heartbeat from a dead dispatch cannot mask stalls on the new one (#89).
+      // From awaiting-input: resume to working (mirrors task.progress).
       if (rec.state === "blocked") return { ...rec, lastHeartbeat: now, lastEvent: ev.type };
       if (rec.state === "awaiting-input") return { ...base, state: "working" };
       return base;

--- a/src/control/watchdog.ts
+++ b/src/control/watchdog.ts
@@ -18,7 +18,10 @@ import type { TaskRecord } from "./types.js";
  */
 export function evaluateStall(rec: TaskRecord, now: number): TaskRecord | null {
   if (rec.state !== "working") return null;
-  if (now - rec.lastHeartbeat <= rec.heartbeatBudgetMs) return null;
+  // Key off the latest attempt's lastHeartbeatAt so a stale event from a dead
+  // prior attempt cannot refresh the liveness clock of the new dispatch (#89).
+  const liveness = rec.attempts.at(-1)?.lastHeartbeatAt ?? rec.lastHeartbeat;
+  if (now - liveness <= rec.heartbeatBudgetMs) return null;
   if (rec.mode === "interactive") {
     return { ...rec, state: "awaiting-input", lastEvent: "watchdog.idle" };
   }


### PR DESCRIPTION
## Summary

- **Bug**: `evaluateStall` keyed off `rec.lastHeartbeat` (task-level), which any late event from a dead prior dispatch could refresh. A hung new dispatch would appear alive if a stale heartbeat arrived after re-dispatch's `task.started`.
- **Fix**: `evaluateStall` now uses `rec.attempts.at(-1)?.lastHeartbeatAt ?? rec.lastHeartbeat`. The per-attempt timestamp is only stamped by `stampAttempt` (turn events, `task.started`, `task.progress`) — bare `heartbeat` events bypass it intentionally, so dead-attempt noise cannot mask a stall.
- **Headless liveness**: Added `stampAttempt` to the `task.progress` case so stdout-activity from a running headless crew keeps `lastHeartbeatAt` current, preventing false stalls on long-running tasks.

## Test plan

- [x] Regression test: fail attempt A → reopen → `task.started` (attempt B) → replay late `{ type: "heartbeat" }` from dead attempt A → confirm `evaluateStall` still flags hung B as stalled
- [x] All existing watchdog + state-machine tests still pass (46 tests)
- [x] `tsc --noEmit` clean