### PR TITLE
fix(launch): deliver captain startup prompt once (broaden working-state detection) (#292 follow-up)

### DIFF
--- a/src/commands/__tests__/launch.test.ts
+++ b/src/commands/__tests__/launch.test.ts
@@ -150,6 +150,33 @@ describe("deliverStartupPrompt (#292 deterministic startup delivery)", () => {
     expect(rt.sends).toEqual(["GO", "GO", "GO"]);
   });
 
+  // DEBUG-REPRO (#292 follow-up): the captain startup checklist runs shell
+  // commands from its FIRST step (read-handoff.sh, wiki-query.sh, relay
+  // supervise). While a shell command is in flight, CC's spinner reads
+  // "✻ Crunched for 27s · 1 shell still running" — a WORKING screen that carries
+  // NO "↓ X.Xk tokens" counter (tokens only stream during generation, not tool
+  // waits) and no "esc to interrupt" (absent from this CC version's footer; 0
+  // hits in docs/reports/258-parse-bug-fixture.txt). CC_WORKING_RE therefore
+  // misses it and classifyStartupSurface returns "idle". The confirm/poll loop
+  // reads that working captain as "idle" on every settle sample, concludes the
+  // keystrokes were dropped, and re-sends — 3 duplicate startup runs.
+  // Source of truth: 258 fixture line 4 (working, no token counter).
+  it("FAILS PRE-FIX: a working-but-shell-waiting captain is misread as idle → 3 dupes", async () => {
+    const SHELL_WAITING = [
+      "✻ Crunched for 27s · 1 shell still running",
+      HR, "❯ ", HR,
+      "   Model: Opus 4.8  Ctx Used: 52.0%",
+      "  ⏵⏵ auto mode on · 1 shell",
+    ].join("\n");
+    // idle (ready) → send → captain is now WORKING on a shell cmd for the whole
+    // turn. Every confirm/poll sample returns SHELL_WAITING.
+    const rt = fakeRuntime([IDLE, SHELL_WAITING]);
+    await deliverStartupPrompt(rt, "workspace:1", "GO", FAST);
+    // Correct behavior: send exactly once — the prompt landed and the captain
+    // is working. Pre-fix this is ["GO","GO","GO"].
+    expect(rt.sends).toEqual(["GO"]);
+  });
+
   it("never throws even if readScreen rejects", async () => {
     const rt = {
       sends: [] as string[],

--- a/src/commands/__tests__/launch.test.ts
+++ b/src/commands/__tests__/launch.test.ts
@@ -161,7 +161,7 @@ describe("deliverStartupPrompt (#292 deterministic startup delivery)", () => {
   // reads that working captain as "idle" on every settle sample, concludes the
   // keystrokes were dropped, and re-sends — 3 duplicate startup runs.
   // Source of truth: 258 fixture line 4 (working, no token counter).
-  it("FAILS PRE-FIX: a working-but-shell-waiting captain is misread as idle → 3 dupes", async () => {
+  it("does NOT re-send when the captain is working on a shell command (no token counter)", async () => {
     const SHELL_WAITING = [
       "✻ Crunched for 27s · 1 shell still running",
       HR, "❯ ", HR,

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -199,11 +199,19 @@ export function readInputBoxRaw(screen: string): string | null {
 // silently dropped (#235). Grounded in docs/reports/258-parse-bug-fixture.txt.
 const CC_INITIALIZED_RE = /⏵⏵|Ctx Used|for shortcuts|accept edits/i;
 
-// A live turn shows a working spinner carrying a token-down-counter ("↓ 4.3k
-// tokens") and/or the "esc to interrupt" hint — neither appears on an idle,
-// input-ready screen. The whimsical spinner verb ("Working…", "Cerebrating…")
-// varies across versions, so we key on these stable markers instead.
-const CC_WORKING_RE = /↓\s*[\d.]+\s*k?\s*tokens?\b|esc to interrupt/i;
+// A live turn shows a working spinner. The whimsical verb ("Working…",
+// "Cerebrating…", "Crunched…") varies across versions, so we key on stable
+// markers instead. CRUCIAL: a turn is NOT always streaming tokens — during a
+// tool wait (e.g. the shell commands the captain startup checklist runs first)
+// the spinner reads "✻ Crunched for 27s · 1 shell still running", which carries
+// NO token-down-counter and no "esc to interrupt". Keying only on those two
+// (the original #292 mistake) misread a shell-waiting captain as "idle", so the
+// startup-prompt loop re-sent on every poll → 3 duplicate startup runs. We now
+// also match the shell-running hint and the in-parens elapsed timer ("(4s",
+// "(1m 4s") — both confined to the live spinner line, never on an idle,
+// input-ready screen. Grounded in docs/reports/258-parse-bug-fixture.txt
+// (line 4: shell-wait, no counter; line 22: token-stream).
+const CC_WORKING_RE = /↓\s*[\d.]+\s*k?\s*tokens?\b|esc to interrupt|\bshell still running\b|·\s*\d+\s*shell\b|\(\d+m?\s*\d*s\b/i;
 
 /**
  * Classify a captain surface's read-screen into the three states #292's


### PR DESCRIPTION
## Root cause

`classifyStartupSurface` used `CC_WORKING_RE` to detect when a captain was busy (working spinner visible). The original regex only matched the token-streaming form of the spinner:

```
↓ X.Xk tokens  |  esc to interrupt
```

However, the captain's startup checklist runs shell commands as its **first action** (`read-handoff.sh`, `wiki-query.sh`, `relay supervise`). While a shell is in flight, CC's spinner reads:

```
✻ Crunched for 27s · 1 shell still running
```

This carries **no token counter** (tokens only stream during generation, not tool waits) and **no "esc to interrupt"** in this CC version. So `CC_WORKING_RE` missed it, `classifyStartupSurface` returned `"idle"`, and the confirm/poll loop inside `deliverStartupPrompt` concluded the keystrokes were dropped — re-sending on every settle sample (bounded by `maxAttempts=3`). Systematic, not a race: **3 duplicate startup runs every cold boot**.

Grounded in `docs/reports/258-parse-bug-fixture.txt` line 4 (shell-wait, no counter) vs line 22 (streaming, with counter).

## Fix

Broaden `CC_WORKING_RE` with two additional spinner-line markers:

| Pattern | Matches |
|---------|---------|
| `\bshell still running\b` | `✻ Crunched for 27s · 1 shell still running` |
| `·\s*\d+\s*shell\b` | `· 1 shell` mid-line separator |
| `\(\d+m?\s*\d*s\b` | `(1m 4s` elapsed timer present in non-shell spinner lines |

All three are **confined to the live spinner line** and are absent from idle/input-ready screens (verified against the fixture and the status-bar format `Session: 1hr 42m`).

## Impact analysis (GitNexus)

- `classifyStartupSurface`: **LOW risk, 0 external callers** — module-internal function
- `CC_WORKING_RE`: **LOW risk, 0 external callers** — module-internal const

## Tests

- Added failing repro test: `does NOT re-send when the captain is working on a shell command (no token counter)`
- All suites green: **107 tests** (93 cmux + 14 launch)

Closes #292 follow-up.