### PR TITLE
feat(dashboard): system observability web dashboard (Tier 0–4, read-only)

### DIFF
--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -1,13 +1,19 @@
 import { Command } from "commander";
 import { execSync } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import chalk from "chalk";
 import { loadConfig } from "../config.js";
 import { createCmuxDriver, RuntimeRegistry } from "../runtimes/index.js";
 import { readAllStatuses } from "../dashboard/read-status.js";
 import { renderDashboard } from "../dashboard/render.js";
 import { syncHub, type SyncHubResult } from "../dashboard/sync-hub.js";
+import { startWebServer } from "../dashboard/web-server.js";
+import { defaultProbeRunners } from "../dashboard/probes.js";
 import type { PaneRef } from "../runtimes/types.js";
 import { resolveCmuxBin } from "../lib/cmux-bin.js";
+
+const SOCK = join(homedir(), ".config", "cockpit", "cockpit.sock");
 
 function detectCurrentWorkspace(): string {
   const out = execSync(`"${resolveCmuxBin()}" current-workspace`, { encoding: "utf-8" }).trim();
@@ -68,16 +74,43 @@ export async function runDashboardPane(input: DashboardPaneInput): Promise<PaneR
   return pane;
 }
 
+export interface DashboardWebInput {
+  port: number;
+  interval: number; // seconds
+}
+
+/**
+ * Start the localhost-only observability web dashboard. Separate process from
+ * the daemon (crash-isolated, read-only socket client). Keeps running until the
+ * process is killed; the HTTP server + tick loop hold the event loop open.
+ */
+export async function runDashboardWeb(input: DashboardWebInput): Promise<void> {
+  const handle = await startWebServer({
+    port: input.port,
+    intervalMs: input.interval * 1000,
+    sockPath: SOCK,
+    runners: defaultProbeRunners(),
+  });
+  console.log(chalk.green(`✔ Cockpit system dashboard → http://127.0.0.1:${handle.port}`));
+  console.log(chalk.dim(`  polling the daemon every ${input.interval}s · localhost only · read-only · Ctrl-C to stop`));
+}
+
 export const dashboardCommand = new Command("dashboard")
   .description("Live status grid of all projects (derived from daemon task state)")
   .option("--once", "Print one snapshot and exit (used by --pane's refresh loop)")
   .option("--pane", "Open a refreshing sidebar pane in the current cmux workspace")
+  .option("--web", "Serve the live system-health web dashboard on 127.0.0.1 (HTTP + SSE)")
+  .option("--port <port>", "Port for --web (default 7878)", (v) => parseInt(v, 10), 7878)
   .option("--direction <dir>", "Pane split direction (right|left|up|down)", "right")
-  .option("--interval <seconds>", "Refresh interval for --pane", (v) => parseInt(v, 10), 10)
-  .action(async (opts: { once?: boolean; pane?: boolean; direction: "right" | "left" | "up" | "down"; interval: number }) => {
+  .option("--interval <seconds>", "Daemon poll interval for --web (default 5); refresh interval for --pane (default 10)", (v) => parseInt(v, 10))
+  .action(async (opts: { once?: boolean; pane?: boolean; web?: boolean; port: number; direction: "right" | "left" | "up" | "down"; interval?: number }) => {
     try {
+      if (opts.web) {
+        await runDashboardWeb({ port: opts.port, interval: opts.interval ?? 5 });
+        return;
+      }
       if (opts.pane) {
-        const pane = await runDashboardPane({ direction: opts.direction, interval: opts.interval });
+        const pane = await runDashboardPane({ direction: opts.direction, interval: opts.interval ?? 10 });
         console.log(chalk.green(`✔ Dashboard pane opened in ${pane.workspaceId} ${pane.surfaceId}`));
         return;
       }

--- a/src/control/__tests__/cockpitd-snapshot.test.ts
+++ b/src/control/__tests__/cockpitd-snapshot.test.ts
@@ -1,0 +1,55 @@
+// src/control/__tests__/cockpitd-snapshot.test.ts
+//
+// Thin integration smoke for the read-only `snapshot` verb: boots a daemon
+// against a temp state root, seeds a task, and asserts the assembled
+// DaemonSnapshot shape (Tier 0/1/2). Pure assembly is covered in snapshot.test.ts.
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startCockpitd } from "../cockpitd.js";
+import { sendRequest } from "../protocol.js";
+import type { DaemonSnapshot } from "../snapshot.js";
+
+describe("cockpitd snapshot verb", () => {
+  let stop: (() => void) | undefined;
+  let dir: string;
+  afterEach(() => { stop?.(); if (dir) rmSync(dir, { recursive: true, force: true }); });
+
+  it("returns a Tier 0/1/2 snapshot and leaves the health verb intact", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-snap-"));
+    const sock = join(dir, "c.sock");
+    const handle = startCockpitd({ stateRoot: join(dir, "state"), sockPath: sock, sweepMs: 0 });
+    stop = handle.stop;
+
+    await sendRequest(sock, { kind: "seed", record: {
+      id: "t1", project: "demo", provider: "claude", mode: "interactive",
+      state: "working", task: "wire snapshot", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000,
+      attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }] } });
+
+    const snap = await sendRequest(sock, { kind: "snapshot" }) as DaemonSnapshot;
+
+    // Tier 0 — daemon self
+    expect(snap.tier0.pid).toBe(process.pid);
+    expect(snap.tier0.uptimeMs).toBeGreaterThanOrEqual(0);
+    expect(typeof snap.tier0.version).toBe("string");
+    expect(["fresh", "stale"]).toContain(snap.tier0.build.state);
+    expect(snap.tier0.sweep.lastSweepAt).toBeNull(); // sweepMs:0 → never swept
+    expect(typeof snap.tier0.log.sizeBytes).toBe("number");
+
+    // Tier 1 — component health for the seeded project
+    expect(snap.tier1.some((c) => c.project === "demo")).toBe(true);
+
+    // Tier 2 — per-project data plane + global results
+    const demo = snap.tier2.projects.find((p) => p.project === "demo");
+    expect(demo).toBeDefined();
+    expect(demo!.store.byState.working).toBe(1);
+    expect(demo!.delivery.behind).toBeGreaterThanOrEqual(0);
+    expect(typeof snap.tier2.results.fileCount).toBe("number");
+
+    // The pre-existing health verb is unchanged.
+    const health = await sendRequest(sock, { kind: "health", project: "demo" }) as unknown[];
+    expect(Array.isArray(health)).toBe(true);
+  });
+});

--- a/src/control/__tests__/mailbox.test.ts
+++ b/src/control/__tests__/mailbox.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { appendToMailbox } from "../mailbox.js";
 import { readCursor, writeCursor } from "../mailbox.js";
 import { readFromCursor } from "../mailbox.js";
-import { rotateIfNeeded } from "../mailbox.js";
+import { rotateIfNeeded, mailboxStats } from "../mailbox.js";
 import { statSync } from "node:fs";
 import type { TaskRecord, ControlEvent } from "../types.js";
 
@@ -252,5 +252,40 @@ describe("rotateIfNeeded", () => {
     await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
     const items = await collect(readFromCursor({ stateRoot, project: "demo", fromSeq: 1 }));
     expect(items.map((i) => i.seq)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+});
+
+describe("mailboxStats", () => {
+  it("returns zeros for a project with no mailbox", async () => {
+    const stateRoot = freshState();
+    expect(await mailboxStats(stateRoot, "demo")).toEqual({
+      maxSeq: 0,
+      sizeBytes: 0,
+      oldestEntryAgeMs: 0,
+      rotationCount: 0,
+    });
+  });
+
+  it("reports maxSeq, a positive size and zero rotations for a live mailbox", async () => {
+    const stateRoot = freshState();
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    const stats = await mailboxStats(stateRoot, "demo");
+    expect(stats.maxSeq).toBe(2);
+    expect(stats.sizeBytes).toBeGreaterThan(0);
+    expect(stats.rotationCount).toBe(0);
+    expect(stats.oldestEntryAgeMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("counts rotated segments and keeps maxSeq across them", async () => {
+    const stateRoot = freshState();
+    for (let i = 0; i < 5; i++) {
+      await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    }
+    await rotateIfNeeded({ stateRoot, project: "demo", maxBytes: 50, maxAgeMs: 999999999, keepCount: 3 });
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    const stats = await mailboxStats(stateRoot, "demo");
+    expect(stats.rotationCount).toBe(1);
+    expect(stats.maxSeq).toBe(6);
   });
 });

--- a/src/control/__tests__/snapshot.test.ts
+++ b/src/control/__tests__/snapshot.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildFreshness,
+  assembleDaemonSnapshot,
+  type DaemonSnapshotInputs,
+} from "../snapshot.js";
+import type { ComponentHealth } from "../liveness.js";
+
+// ── buildFreshness ────────────────────────────────────────────────────────────
+describe("buildFreshness", () => {
+  it("is fresh when the process started after the dist was built", () => {
+    expect(buildFreshness(2000, 1000)).toBe("fresh");
+  });
+  it("is stale when the process started before the dist was built (running old code)", () => {
+    expect(buildFreshness(1000, 2000)).toBe("stale");
+  });
+  it("treats an exactly-equal boundary as fresh", () => {
+    expect(buildFreshness(1500, 1500)).toBe("fresh");
+  });
+});
+
+// ── assembleDaemonSnapshot ────────────────────────────────────────────────────
+const HEALTH: ComponentHealth[] = [
+  { kind: "relay", project: "cockpit", ref: "relay", state: "alive", lastSeenMs: 900 },
+  { kind: "captain", project: "cockpit", ref: "cockpit-captain", state: "alive", lastSeenMs: 900 },
+];
+
+function inputs(over: Partial<DaemonSnapshotInputs> = {}): DaemonSnapshotInputs {
+  return {
+    pid: 4821,
+    processStartedAt: 1_000,
+    version: "0.6.1",
+    distBuiltAt: 500,
+    lastSweepAt: 9_000,
+    sweepCadenceMs: 30_000,
+    log: { errorCount: 0, sizeBytes: 1234, windowMs: 3_600_000 },
+    health: HEALTH,
+    projects: [
+      {
+        project: "cockpit",
+        mailbox: { maxSeq: 12, sizeBytes: 1300, oldestEntryAgeMs: 60_000, rotationCount: 0 },
+        lastAckedSeq: 12,
+        storeByState: { working: 3, blocked: 1 },
+        corruptCount: 0,
+      },
+    ],
+    results: { fileCount: 294, totalBytes: 18_000_000 },
+    ...over,
+  };
+}
+
+describe("assembleDaemonSnapshot", () => {
+  const NOW = 10_000;
+
+  it("assembles Tier 0 daemon self-health with uptime, freshness and sweep age", () => {
+    const snap = assembleDaemonSnapshot(inputs(), NOW);
+    expect(snap.tier0.pid).toBe(4821);
+    expect(snap.tier0.uptimeMs).toBe(NOW - 1_000);
+    expect(snap.tier0.version).toBe("0.6.1");
+    expect(snap.tier0.build).toEqual({ state: "fresh", processStartedAt: 1_000, distBuiltAt: 500 });
+    expect(snap.tier0.sweep).toEqual({ lastSweepAt: 9_000, ageMs: 1_000, cadenceMs: 30_000 });
+    expect(snap.tier0.log).toEqual({ errorCount: 0, sizeBytes: 1234, windowMs: 3_600_000 });
+  });
+
+  it("flags a stale build in Tier 0", () => {
+    const snap = assembleDaemonSnapshot(inputs({ processStartedAt: 100, distBuiltAt: 9_999 }), NOW);
+    expect(snap.tier0.build.state).toBe("stale");
+  });
+
+  it("reports a null sweep age when the daemon has not yet swept", () => {
+    const snap = assembleDaemonSnapshot(inputs({ lastSweepAt: null }), NOW);
+    expect(snap.tier0.sweep.lastSweepAt).toBeNull();
+    expect(snap.tier0.sweep.ageMs).toBeNull();
+  });
+
+  it("passes Tier 1 component health through verbatim", () => {
+    const snap = assembleDaemonSnapshot(inputs(), NOW);
+    expect(snap.tier1).toEqual(HEALTH);
+  });
+
+  it("assembles Tier 2 per-project mailbox, delivery lag and store counts", () => {
+    const snap = assembleDaemonSnapshot(inputs(), NOW);
+    const p = snap.tier2.projects[0];
+    expect(p.project).toBe("cockpit");
+    expect(p.mailbox).toEqual({ maxSeq: 12, sizeBytes: 1300, oldestEntryAgeMs: 60_000, rotationCount: 0 });
+    expect(p.delivery).toEqual({ maxSeq: 12, lastAckedSeq: 12, behind: 0 });
+    expect(p.store).toEqual({ byState: { working: 3, blocked: 1 }, corruptCount: 0 });
+  });
+
+  it("computes delivery lag as maxSeq minus lastAckedSeq", () => {
+    const snap = assembleDaemonSnapshot(
+      inputs({
+        projects: [
+          {
+            project: "pact",
+            mailbox: { maxSeq: 10, sizeBytes: 200, oldestEntryAgeMs: 3 * 86_400_000, rotationCount: 1 },
+            lastAckedSeq: 6,
+            storeByState: {},
+            corruptCount: 2,
+          },
+        ],
+      }),
+      NOW,
+    );
+    expect(snap.tier2.projects[0].delivery.behind).toBe(4);
+    expect(snap.tier2.projects[0].store.corruptCount).toBe(2);
+  });
+
+  it("never reports negative delivery lag (cursor ahead of max seq)", () => {
+    const snap = assembleDaemonSnapshot(
+      inputs({
+        projects: [
+          {
+            project: "x",
+            mailbox: { maxSeq: 5, sizeBytes: 0, oldestEntryAgeMs: 0, rotationCount: 0 },
+            lastAckedSeq: 9,
+            storeByState: {},
+            corruptCount: 0,
+          },
+        ],
+      }),
+      NOW,
+    );
+    expect(snap.tier2.projects[0].delivery.behind).toBe(0);
+  });
+
+  it("passes global _results artifact stats through", () => {
+    const snap = assembleDaemonSnapshot(inputs(), NOW);
+    expect(snap.tier2.results).toEqual({ fileCount: 294, totalBytes: 18_000_000 });
+  });
+});

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -1,8 +1,12 @@
 // src/control/cockpitd.ts
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { spawn as realSpawn } from "node:child_process";
-import { writeFileSync, mkdirSync } from "node:fs";
+import {
+  writeFileSync, mkdirSync, readFileSync, readdirSync, statSync,
+  openSync, readSync, closeSync,
+} from "node:fs";
 import { randomUUID } from "node:crypto";
 import { createStore } from "./store.js";
 import { createDaemon } from "./daemon.js";
@@ -11,14 +15,29 @@ import { runHeadless } from "./headless-launcher.js";
 import { CodexInteractiveDriver, shouldReattachCodex } from "./codex/driver.js";
 import { OpencodeSseBridge } from "./opencode/sse-bridge.js";
 import { makeGate } from "./codex/gate.js";
-import { appendToMailbox, rotateIfNeeded } from "./mailbox.js";
+import { appendToMailbox, rotateIfNeeded, mailboxStats, readCursor } from "./mailbox.js";
 import { createRelayHealer } from "./relay-healer.js";
 import { projectHealth, type ComponentHealth } from "./liveness.js";
+import { assembleDaemonSnapshot, type DaemonSnapshotInputs, type ResultArtifacts } from "./snapshot.js";
 import { loadConfig } from "../config.js";
 import { readdir } from "node:fs/promises";
 import type { Gate, TaskRecord, ControlEvent } from "./types.js";
 import { TERMINAL_STATES } from "./types.js";
 import type { Socket } from "node:net";
+
+// This module's own compiled file — its mtime is the dist build-time used for
+// the Tier 0 build-freshness check (process start vs build time). package.json
+// (repo root) gives the running version. Both resolved once at load.
+const SELF_PATH = fileURLToPath(import.meta.url);
+function readPkgVersion(): string {
+  try {
+    const pkgPath = join(dirname(SELF_PATH), "..", "..", "package.json");
+    return (JSON.parse(readFileSync(pkgPath, "utf-8")).version as string) ?? "unknown";
+  } catch { return "unknown"; }
+}
+const PKG_VERSION = readPkgVersion();
+const SNAPSHOT_LOG_WINDOW_MS = 60 * 60 * 1000; // count daemon-log errors in the last hour
+const CURSOR_SUBSCRIBER = "captain"; // the relay drains the mailbox as "captain" (#207)
 
 export interface CockpitdOpts {
   stateRoot?: string;
@@ -73,6 +92,82 @@ export interface CockpitdOpts {
   };
 }
 
+// ── Tier 0/2 snapshot gathering (I/O at the edge; the pure assembly lives in
+//    snapshot.ts). Each helper tolerates missing files and never throws. ───────
+
+/** mtime (epoch ms) of the running daemon's compiled code, for build-freshness. */
+function distBuiltAt(): number {
+  try { return statSync(SELF_PATH).mtimeMs; } catch { return 0; }
+}
+
+/** Daemon-log error count (last window) + total size. Reads only the tail so a
+ *  large log never makes the snapshot tick expensive. */
+function gatherLogStats(path: string, now: number, windowMs: number): DaemonSnapshotInputs["log"] {
+  let sizeBytes = 0;
+  try { sizeBytes = statSync(path).size; }
+  catch { return { errorCount: 0, sizeBytes: 0, windowMs }; }
+  if (sizeBytes === 0) return { errorCount: 0, sizeBytes, windowMs };
+  const CAP = 256 * 1024;
+  const start = Math.max(0, sizeBytes - CAP);
+  const len = sizeBytes - start;
+  let text = "";
+  try {
+    const fd = openSync(path, "r");
+    try {
+      const buf = Buffer.alloc(len);
+      readSync(fd, buf, 0, len, start);
+      text = buf.toString("utf-8");
+    } finally { closeSync(fd); }
+  } catch { return { errorCount: 0, sizeBytes, windowMs }; }
+  const cutoff = now - windowMs;
+  let errorCount = 0;
+  for (const line of text.split("\n")) {
+    if (!/error|failed/i.test(line)) continue;
+    // Lines carry an ISO timestamp ("[cockpitd] 2026-... msg"); skip ones older
+    // than the window. Lines without a parseable timestamp are counted (conservative).
+    const m = line.match(/\d{4}-\d{2}-\d{2}T[\d:.]+Z/);
+    if (m) { const ts = Date.parse(m[0]); if (!Number.isNaN(ts) && ts < cutoff) continue; }
+    errorCount++;
+  }
+  return { errorCount, sizeBytes, windowMs };
+}
+
+/** Per-project store state counts + corrupt/quarantined file count. */
+function gatherStoreStats(
+  store: { list: (p: string) => TaskRecord[] },
+  stateRoot: string,
+  project: string,
+): { byState: Record<string, number>; corruptCount: number } {
+  const byState: Record<string, number> = {};
+  for (const r of store.list(project)) byState[r.state] = (byState[r.state] ?? 0) + 1;
+  let corruptCount = 0;
+  const dir = join(stateRoot, project);
+  try {
+    for (const n of readdirSync(dir)) {
+      if (n.includes(".corrupt.")) { corruptCount++; continue; }
+      if (!n.endsWith(".json")) continue;
+      try { JSON.parse(readFileSync(join(dir, n), "utf-8")); }
+      catch { corruptCount++; }
+    }
+  } catch { /* no project dir yet */ }
+  return { byState, corruptCount };
+}
+
+/** Global _results/ artifact count + total bytes (unbounded-growth watch). */
+function gatherResults(resultsDir: string): ResultArtifacts {
+  let fileCount = 0;
+  let totalBytes = 0;
+  try {
+    for (const n of readdirSync(resultsDir)) {
+      try {
+        const s = statSync(join(resultsDir, n));
+        if (s.isFile()) { fileCount++; totalBytes += s.size; }
+      } catch { /* vanished mid-scan */ }
+    }
+  } catch { /* no results dir */ }
+  return { fileCount, totalBytes };
+}
+
 export function defaultIsPidAlive(pid: number): boolean {
   try { process.kill(pid, 0); return true; }
   catch (e: any) { return e?.code === "EPERM"; } // EPERM = alive but not ours; ESRCH = dead
@@ -82,6 +177,10 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   const stateRoot = opts.stateRoot ?? join(homedir(), ".config", "cockpit", "state");
   const sockPath = opts.sockPath ?? join(homedir(), ".config", "cockpit", "cockpit.sock");
   const store = createStore(stateRoot);
+  // #44 dashboard: process start-time (for uptime + build-freshness) and the
+  // timestamp of the most recent sweep (Tier 0 "sweep last Ns ago").
+  const bootedAt = Date.now();
+  let lastSweepAt: number | null = null;
   // #225: hard crew task-timeout ceiling, read once at boot. Falls back to the
   // daemon's DEFAULT_TASK_TIMEOUT_MS (8h) when unset in config.
   const taskTimeoutMs = loadConfig().defaults.taskTimeoutMs;
@@ -373,6 +472,49 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
     return out;
   }
 
+  // #44 dashboard: the same project set buildHealth() covers (config ∪ relays ∪ tasks).
+  function knownProjects(): string[] {
+    const config = loadConfig();
+    return [...new Set<string>([
+      ...Object.keys(config.projects),
+      ...d.getRelayHealth().map((r) => r.project),
+      ...store.listAll().map((t) => t.project),
+    ])];
+  }
+
+  // #44 dashboard: gather all Tier 0/1/2 inputs (I/O) for the read-only snapshot
+  // verb, then hand them to the pure assembler. The daemon log lives next to the
+  // state root (~/.config/cockpit/cockpitd.log); deriving it from stateRoot keeps
+  // tests isolated to their temp dir.
+  async function gatherSnapshotInputs(now: number): Promise<DaemonSnapshotInputs> {
+    const logPath = join(dirname(stateRoot), "cockpitd.log");
+    const projects = await Promise.all(
+      knownProjects().map(async (project) => {
+        const cursor = await readCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER });
+        const storeStats = gatherStoreStats(store, stateRoot, project);
+        return {
+          project,
+          mailbox: await mailboxStats(stateRoot, project),
+          lastAckedSeq: cursor?.lastAckedSeq ?? 0,
+          storeByState: storeStats.byState,
+          corruptCount: storeStats.corruptCount,
+        };
+      }),
+    );
+    return {
+      pid: process.pid,
+      processStartedAt: bootedAt,
+      version: PKG_VERSION,
+      distBuiltAt: distBuiltAt(),
+      lastSweepAt,
+      sweepCadenceMs: opts.sweepMs ?? 30_000,
+      log: gatherLogStats(logPath, now, SNAPSHOT_LOG_WINDOW_MS),
+      health: buildHealth(),
+      projects,
+      results: gatherResults(resultsDir),
+    };
+  }
+
   // Crash recovery on boot. reconcile() is async (#139: it consults the
   // interactive surface-liveness probe to reap dead crews instead of stalling
   // them), so run it — and the reattach loops that depend on its terminalizing a
@@ -463,6 +605,13 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       if (msg.kind === "health") {
         return buildHealth(msg.project as string | undefined);
       }
+      // #44 dashboard: read-only full system snapshot (Tier 0/1/2). Additive —
+      // the `health` verb above is untouched. Pure assembly; all I/O is gathered
+      // here and fed in. Never mutates state.
+      if (msg.kind === "snapshot") {
+        const now = Date.now();
+        return assembleDaemonSnapshot(await gatherSnapshotInputs(now), now);
+      }
       // #239 Phase B: on any event that terminates a task, evict its entries from
       // inFlightProbes and probeResults so the Sets never leak. Tasks reaped by
       // sweep/reconcile (not via the socket) are naturally safe — proxiedSurfaceAlive
@@ -516,6 +665,7 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
     timer = setInterval(() => {
       if (sweeping) return;
       sweeping = true;
+      lastSweepAt = Date.now(); // Tier 0 observability: time of the most recent sweep
       void d.sweep()
         .catch((e: unknown) => log(`sweep failed: ${(e as Error).message}`))
         .finally(() => { sweeping = false; });

--- a/src/control/mailbox.ts
+++ b/src/control/mailbox.ts
@@ -202,6 +202,37 @@ export async function* readFromCursor(opts: ReadFromCursorOpts): AsyncIterable<M
   }
 }
 
+/** Read-only Tier 2 observability stats for one project's mailbox (#44 dashboard). */
+export interface MailboxStats {
+  /** Highest seq across the current log + rotated segments (0 when empty). */
+  maxSeq: number;
+  /** Size in bytes of the current (un-rotated) log file. */
+  sizeBytes: number;
+  /** Age of the oldest entry in the current log (0 when empty/missing). */
+  oldestEntryAgeMs: number;
+  /** Number of rotated segments on disk (<project>.log.1, .2, …). */
+  rotationCount: number;
+}
+
+/**
+ * Read-only stats for the dashboard's Tier 2 data-plane view. Never mutates;
+ * tolerates a missing inbox (returns zeros). The daemon gathers this and passes
+ * it to the pure snapshot assembler.
+ */
+export async function mailboxStats(stateRoot: string, project: string): Promise<MailboxStats> {
+  const file = logPath(stateRoot, project);
+  let sizeBytes = 0;
+  try { sizeBytes = (await fs.stat(file)).size; }
+  catch (e) { if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e; }
+  const rotated = await listRotatedOldestFirst(stateRoot, project);
+  return {
+    maxSeq: await readMaxSeq(stateRoot, project),
+    sizeBytes,
+    oldestEntryAgeMs: await oldestEntryAgeMs(file),
+    rotationCount: rotated.length,
+  };
+}
+
 interface RotateOpts {
   stateRoot: string;
   project: string;

--- a/src/control/snapshot.ts
+++ b/src/control/snapshot.ts
@@ -1,0 +1,134 @@
+// src/control/snapshot.ts
+//
+// PURE Tier 0/1/2 snapshot assembly (no I/O, no clock) for the read-only
+// `snapshot` socket verb — the observability-dashboard counterpart to
+// liveness.ts. Every derived value comes from already-gathered inputs + an
+// explicit `now`, so the whole module is trivially unit-testable. cockpitd.ts
+// performs the I/O (dist stat, log read, mailbox/store/results reads) and feeds
+// the gathered numbers in here; this module never touches the filesystem.
+import type { ComponentHealth } from "./liveness.js";
+
+export type BuildState = "fresh" | "stale";
+
+/**
+ * Pure. The deploy-hygiene check: a daemon whose process started BEFORE the
+ * current `dist/` build is running stale code (the recurring footgun). Fresh
+ * requires the process to have started at or after the last build.
+ *   processStartedAt >= distBuiltAt → "fresh"  (boundary inclusive)
+ *   else                            → "stale"
+ */
+export function buildFreshness(processStartedAt: number, distBuiltAt: number): BuildState {
+  return processStartedAt >= distBuiltAt ? "fresh" : "stale";
+}
+
+// ── Tier 0: daemon root ───────────────────────────────────────────────────────
+export interface DaemonRoot {
+  pid: number;
+  uptimeMs: number;
+  version: string;
+  build: { state: BuildState; processStartedAt: number; distBuiltAt: number };
+  /** lastSweepAt/ageMs are null until the first sweep has run. */
+  sweep: { lastSweepAt: number | null; ageMs: number | null; cadenceMs: number };
+  log: { errorCount: number; sizeBytes: number; windowMs: number };
+}
+
+// ── Tier 2: per-project data plane + global results ───────────────────────────
+export interface MailboxStats {
+  maxSeq: number;
+  sizeBytes: number;
+  oldestEntryAgeMs: number;
+  rotationCount: number;
+}
+
+export interface DeliveryLag {
+  maxSeq: number;
+  lastAckedSeq: number;
+  /** maxSeq − lastAckedSeq, clamped at 0 — "captain N behind". */
+  behind: number;
+}
+
+export interface StoreStats {
+  byState: Record<string, number>;
+  corruptCount: number;
+}
+
+export interface ResultArtifacts {
+  fileCount: number;
+  totalBytes: number;
+}
+
+export interface ProjectDataPlane {
+  project: string;
+  mailbox: MailboxStats;
+  delivery: DeliveryLag;
+  store: StoreStats;
+}
+
+export interface DaemonSnapshot {
+  tier0: DaemonRoot;
+  /** Tier 1 — per-component liveness across all projects (reuses projectHealth). */
+  tier1: ComponentHealth[];
+  tier2: {
+    projects: ProjectDataPlane[];
+    /** _results/ is a single global directory keyed by task id. */
+    results: ResultArtifacts;
+  };
+}
+
+/** Already-gathered (I/O-resolved) inputs the pure assembler turns into a DaemonSnapshot. */
+export interface DaemonSnapshotInputs {
+  pid: number;
+  processStartedAt: number;
+  version: string;
+  distBuiltAt: number;
+  lastSweepAt: number | null;
+  sweepCadenceMs: number;
+  log: { errorCount: number; sizeBytes: number; windowMs: number };
+  health: ComponentHealth[];
+  projects: Array<{
+    project: string;
+    mailbox: MailboxStats;
+    lastAckedSeq: number;
+    storeByState: Record<string, number>;
+    corruptCount: number;
+  }>;
+  results: ResultArtifacts;
+}
+
+/**
+ * Pure. Derive the full DaemonSnapshot from gathered inputs and an explicit now.
+ */
+export function assembleDaemonSnapshot(input: DaemonSnapshotInputs, now: number): DaemonSnapshot {
+  return {
+    tier0: {
+      pid: input.pid,
+      uptimeMs: now - input.processStartedAt,
+      version: input.version,
+      build: {
+        state: buildFreshness(input.processStartedAt, input.distBuiltAt),
+        processStartedAt: input.processStartedAt,
+        distBuiltAt: input.distBuiltAt,
+      },
+      sweep: {
+        lastSweepAt: input.lastSweepAt,
+        ageMs: input.lastSweepAt == null ? null : now - input.lastSweepAt,
+        cadenceMs: input.sweepCadenceMs,
+      },
+      log: input.log,
+    },
+    tier1: input.health,
+    tier2: {
+      projects: input.projects.map((p) => ({
+        project: p.project,
+        mailbox: p.mailbox,
+        delivery: {
+          maxSeq: p.mailbox.maxSeq,
+          lastAckedSeq: p.lastAckedSeq,
+          behind: Math.max(0, p.mailbox.maxSeq - p.lastAckedSeq),
+        },
+        store: { byState: p.storeByState, corruptCount: p.corruptCount },
+      })),
+      results: input.results,
+    },
+  };
+}

--- a/src/dashboard/__tests__/probes.test.ts
+++ b/src/dashboard/__tests__/probes.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import {
+  probeCmux,
+  probeAgentClis,
+  probeVaults,
+  probeProjectPaths,
+  probeSessions,
+  runExternalProbes,
+  type ProbeRunners,
+} from "../probes.js";
+import type { CockpitConfig } from "../../config.js";
+
+function cfg(over: Partial<CockpitConfig> = {}): CockpitConfig {
+  return {
+    commandName: "command",
+    hubVault: "/vaults/hub",
+    projects: {
+      cockpit: { path: "/repos/cockpit", captainName: "cockpit-captain", spokeVault: "/vaults/cockpit", host: "local" },
+    },
+    defaults: {
+      maxCrew: 4, worktreeDir: ".wt", teammateMode: "x",
+      permissions: { command: "auto", captain: "auto" },
+    },
+    metrics: { enabled: false, path: "/m" },
+    ...over,
+  };
+}
+
+// A runner set where every external call succeeds. Tests override per-case.
+function okRunners(over: Partial<ProbeRunners> = {}): ProbeRunners {
+  return {
+    probeCmuxBin: async () => true,
+    probeOnPath: async () => true,
+    pathExists: () => true,
+    loadConfig: () => cfg(),
+    loadSessionsHashes: () => ["hash-a"],
+    ...over,
+  };
+}
+
+describe("probeCmux", () => {
+  it("is alive when the cmux binary responds", async () => {
+    expect((await probeCmux(okRunners())).state).toBe("alive");
+  });
+  it("is gone when cmux is not reachable", async () => {
+    expect((await probeCmux(okRunners({ probeCmuxBin: async () => false }))).state).toBe("gone");
+  });
+  it("is unknown (never throws) when the probe itself throws", async () => {
+    const p = await probeCmux(okRunners({ probeCmuxBin: async () => { throw new Error("boom"); } }));
+    expect(p.state).toBe("unknown");
+  });
+  it("is unknown when the probe hangs past the timeout", async () => {
+    const p = await probeCmux(okRunners({ probeCmuxBin: () => new Promise(() => {}) }), 10);
+    expect(p.state).toBe("unknown");
+  });
+});
+
+describe("probeAgentClis", () => {
+  it("maps each known CLI to alive/gone by PATH resolution", async () => {
+    const probes = await probeAgentClis(okRunners({
+      probeOnPath: async (cli) => cli === "claude" || cli === "codex",
+    }));
+    const byCli = Object.fromEntries(probes.map((p) => [p.cli, p.state]));
+    expect(byCli).toEqual({ claude: "alive", codex: "alive", gemini: "gone", opencode: "gone" });
+  });
+  it("maps a thrown PATH lookup to unknown without failing the others", async () => {
+    const probes = await probeAgentClis(okRunners({
+      probeOnPath: async (cli) => { if (cli === "gemini") throw new Error("x"); return true; },
+    }));
+    const byCli = Object.fromEntries(probes.map((p) => [p.cli, p.state]));
+    expect(byCli.gemini).toBe("unknown");
+    expect(byCli.claude).toBe("alive");
+  });
+});
+
+describe("probeVaults", () => {
+  it("is alive when the vault dir and its .obsidian/ both exist", () => {
+    const v = probeVaults(okRunners(), cfg());
+    expect(v.hub.state).toBe("alive");
+    expect(v.spokes[0].project).toBe("cockpit");
+    expect(v.spokes[0].state).toBe("alive");
+  });
+  it("is gone when the vault directory is missing", () => {
+    const v = probeVaults(okRunners({ pathExists: () => false }), cfg());
+    expect(v.hub.state).toBe("gone");
+  });
+  it("is gone when the dir exists but has no .obsidian/", () => {
+    const v = probeVaults(okRunners({ pathExists: (p) => !p.endsWith(".obsidian") }), cfg());
+    expect(v.hub.state).toBe("gone");
+  });
+});
+
+describe("probeProjectPaths", () => {
+  it("is alive when the project path resolves, gone otherwise", () => {
+    const paths = probeProjectPaths(okRunners({ pathExists: (p) => p === "/repos/cockpit" }), cfg());
+    expect(paths[0]).toMatchObject({ project: "cockpit", state: "alive" });
+    const missing = probeProjectPaths(okRunners({ pathExists: () => false }), cfg());
+    expect(missing[0].state).toBe("gone");
+  });
+});
+
+describe("probeSessions", () => {
+  it("is alive when a single template hash is recorded", () => {
+    expect(probeSessions(okRunners()).state).toBe("alive");
+  });
+  it("is gone (drift) when multiple distinct template hashes are recorded", () => {
+    const s = probeSessions(okRunners({ loadSessionsHashes: () => ["a", "b"] }));
+    expect(s.state).toBe("gone");
+    expect(s.detail).toMatch(/drift/);
+  });
+  it("is unknown when no sessions are recorded", () => {
+    expect(probeSessions(okRunners({ loadSessionsHashes: () => [] })).state).toBe("unknown");
+  });
+  it("is unknown when sessions.json is unreadable", () => {
+    expect(probeSessions(okRunners({ loadSessionsHashes: () => { throw new Error("bad"); } })).state).toBe("unknown");
+  });
+});
+
+describe("runExternalProbes", () => {
+  it("assembles all tiers and keeps going when config is unparseable", async () => {
+    const probes = await runExternalProbes(okRunners({
+      loadConfig: () => { throw new Error("bad json"); },
+    }));
+    expect(probes.cmux.state).toBe("alive");
+    expect(probes.config.parseable.state).toBe("gone");
+    expect(probes.vaults.spokes).toEqual([]);
+    expect(probes.config.projectPaths).toEqual([]);
+  });
+  it("assembles a fully-healthy snapshot from healthy runners", async () => {
+    const probes = await runExternalProbes(okRunners());
+    expect(probes.cmux.state).toBe("alive");
+    expect(probes.config.parseable.state).toBe("alive");
+    expect(probes.vaults.hub.state).toBe("alive");
+    expect(probes.agentClis).toHaveLength(4);
+  });
+});

--- a/src/dashboard/__tests__/snapshot-merge.test.ts
+++ b/src/dashboard/__tests__/snapshot-merge.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { mergeSnapshot } from "../snapshot-merge.js";
+import type { DaemonSnapshot } from "../../control/snapshot.js";
+import type { ExternalProbes } from "../probes.js";
+
+const external: ExternalProbes = {
+  cmux: { state: "alive" },
+  agentClis: [{ cli: "claude", state: "alive" }],
+  vaults: { hub: { path: "/h", state: "alive" }, spokes: [] },
+  config: { parseable: { state: "alive" }, projectPaths: [], sessions: { state: "alive" } },
+};
+
+const daemon: DaemonSnapshot = {
+  tier0: {
+    pid: 1, uptimeMs: 5, version: "0.6.1",
+    build: { state: "fresh", processStartedAt: 1, distBuiltAt: 0 },
+    sweep: { lastSweepAt: 1, ageMs: 4, cadenceMs: 30_000 },
+    log: { errorCount: 0, sizeBytes: 0, windowMs: 3_600_000 },
+  },
+  tier1: [],
+  tier2: { projects: [], results: { fileCount: 0, totalBytes: 0 } },
+};
+
+describe("mergeSnapshot", () => {
+  it("combines a daemon snapshot with external probes and stamps generatedAt", () => {
+    const full = mergeSnapshot(daemon, external, 12_345);
+    expect(full.generatedAt).toBe(12_345);
+    expect(full.daemon).toBe(daemon);
+    expect(full.external).toBe(external);
+  });
+
+  it("keeps Tier 3/4 externals when the daemon is unreachable", () => {
+    const full = mergeSnapshot("unreachable", external, 9);
+    expect(full.daemon).toBe("unreachable");
+    expect(full.external.cmux.state).toBe("alive");
+    expect(full.external.agentClis).toHaveLength(1);
+  });
+});

--- a/src/dashboard/__tests__/web-render.test.ts
+++ b/src/dashboard/__tests__/web-render.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { renderHtml, renderContent, renderTickJson } from "../web-render.js";
+import type { FullSnapshot } from "../snapshot-merge.js";
+import type { DaemonSnapshot } from "../../control/snapshot.js";
+import type { ExternalProbes } from "../probes.js";
+
+const externalHealthy: ExternalProbes = {
+  cmux: { state: "alive" },
+  agentClis: [
+    { cli: "claude", state: "alive" },
+    { cli: "codex", state: "alive" },
+    { cli: "gemini", state: "alive" },
+    { cli: "opencode", state: "alive" },
+  ],
+  vaults: { hub: { path: "/h", state: "alive" }, spokes: [{ project: "cockpit", path: "/s", state: "alive" }] },
+  config: { parseable: { state: "alive" }, projectPaths: [{ project: "cockpit", path: "/r", state: "alive" }], sessions: { state: "alive" } },
+};
+
+function daemon(over: Partial<DaemonSnapshot["tier0"]> = {}, tier1: DaemonSnapshot["tier1"] = []): DaemonSnapshot {
+  return {
+    tier0: {
+      pid: 4821, uptimeMs: 6 * 3600_000, version: "0.6.1",
+      build: { state: "fresh", processStartedAt: 2000, distBuiltAt: 1000 },
+      sweep: { lastSweepAt: 1000, ageMs: 8000, cadenceMs: 30_000 },
+      log: { errorCount: 0, sizeBytes: 100, windowMs: 3_600_000 },
+      ...over,
+    },
+    tier1,
+    tier2: {
+      projects: [
+        {
+          project: "cockpit",
+          mailbox: { maxSeq: 12, sizeBytes: 1300, oldestEntryAgeMs: 60_000, rotationCount: 0 },
+          delivery: { maxSeq: 12, lastAckedSeq: 12, behind: 0 },
+          store: { byState: { working: 3, blocked: 1 }, corruptCount: 0 },
+        },
+      ],
+      results: { fileCount: 294, totalBytes: 18_000_000 },
+    },
+  };
+}
+
+function full(d: DaemonSnapshot | "unreachable", external = externalHealthy, generatedAt = 1_000_000): FullSnapshot {
+  return { generatedAt, daemon: d, external };
+}
+
+describe("renderHtml", () => {
+  it("emits a full HTML document with the live content and an SSE connection indicator", () => {
+    const html = renderHtml(full(daemon()));
+    expect(html).toMatch(/^<!DOCTYPE html>/i);
+    expect(html).toContain("COCKPIT SYSTEM HEALTH");
+    expect(html).toContain('id="content"');
+    expect(html).toContain('id="conn"');
+    expect(html).toContain("EventSource"); // bootstrap JS wires the SSE stream
+  });
+});
+
+describe("stale-build banner", () => {
+  it("renders the loud banner only when the build is stale", () => {
+    const stale = renderContent(full(daemon({ build: { state: "stale", processStartedAt: 1000, distBuiltAt: 9999 } })));
+    expect(stale).toContain("DAEMON RUNNING STALE CODE");
+    // remediation is copy-able text, not a button
+    expect(stale).toContain("npm run build");
+    expect(stale).not.toContain("<button");
+  });
+  it("omits the banner when the build is fresh", () => {
+    expect(renderContent(full(daemon()))).not.toContain("DAEMON RUNNING STALE CODE");
+  });
+});
+
+describe("daemon unreachable", () => {
+  it("shows the unreachable banner but still renders Tier 3/4", () => {
+    const out = renderContent(full("unreachable"));
+    expect(out).toContain("DAEMON UNREACHABLE");
+    expect(out).toContain("cmux"); // Tier 3 still rendered
+    expect(out).toContain("claude");
+  });
+});
+
+describe("severity rollup + remediation", () => {
+  const goneRelay: DaemonSnapshot["tier1"] = [
+    { kind: "relay", project: "pact", ref: "relay", state: "gone", lastSeenMs: 1, detail: "relay DOWN" },
+    { kind: "captain", project: "pact", ref: "pact-captain", state: "gone", lastSeenMs: 1 },
+  ];
+
+  it("bubbles a gone component up to its project header rollup", () => {
+    const out = renderContent(full(daemon({}, goneRelay)));
+    expect(out).toMatch(/data-rollup="gone"[^>]*>[^<]*pact/);
+  });
+
+  it("renders the heal command as copy-able remediation under the gone relay", () => {
+    const out = renderContent(full(daemon({}, goneRelay)));
+    expect(out).toContain("cockpit heal relay --project pact");
+  });
+
+  it("does not render remediation for healthy components", () => {
+    const aliveRelay: DaemonSnapshot["tier1"] = [
+      { kind: "relay", project: "cockpit", ref: "relay", state: "alive", lastSeenMs: 999_000 },
+    ];
+    expect(renderContent(full(daemon({}, aliveRelay)))).not.toContain("cockpit heal relay");
+  });
+});
+
+describe("escaping", () => {
+  it("HTML-escapes crew refs/details to prevent injection", () => {
+    const evil: DaemonSnapshot["tier1"] = [
+      { kind: "crew", project: "cockpit", ref: "<img src=x>", state: "alive", lastSeenMs: 999_000, detail: "working" },
+    ];
+    const out = renderContent(full(daemon({}, evil)));
+    expect(out).not.toContain("<img src=x>");
+    expect(out).toContain("&lt;img src=x&gt;");
+  });
+});
+
+describe("renderTickJson", () => {
+  it("returns JSON with content HTML and the generated timestamp", () => {
+    const parsed = JSON.parse(renderTickJson(full(daemon())));
+    expect(typeof parsed.contentHtml).toBe("string");
+    expect(parsed.contentHtml).toContain("COCKPIT SYSTEM HEALTH");
+    expect(parsed.generatedAt).toBe(1_000_000);
+  });
+});

--- a/src/dashboard/__tests__/web-server.test.ts
+++ b/src/dashboard/__tests__/web-server.test.ts
@@ -1,0 +1,65 @@
+// src/dashboard/__tests__/web-server.test.ts
+//
+// Thin integration smoke (no live daemon, no live network egress): the server
+// binds 127.0.0.1:0, the daemon socket is absent (→ unreachable), and the probe
+// runners are injected fakes. Asserts the page renders and degrades gracefully.
+import { describe, it, expect, afterEach } from "vitest";
+import { get } from "node:http";
+import { startWebServer, type WebServerHandle } from "../web-server.js";
+import type { ProbeRunners } from "../probes.js";
+
+function fakeRunners(): ProbeRunners {
+  return {
+    probeCmuxBin: async () => true,
+    probeOnPath: async () => true,
+    pathExists: () => true,
+    loadConfig: () => { throw new Error("no config in test"); },
+    loadSessionsHashes: () => [],
+  };
+}
+
+function fetchText(port: number, path: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    get({ host: "127.0.0.1", port, path }, (res) => {
+      let body = "";
+      res.setEncoding("utf-8");
+      res.on("data", (c) => (body += c));
+      res.on("end", () => resolve(body));
+    }).on("error", reject);
+  });
+}
+
+describe("startWebServer smoke", () => {
+  let handle: WebServerHandle | undefined;
+  afterEach(async () => { await handle?.close(); handle = undefined; });
+
+  it("serves the page on 127.0.0.1 and degrades when the daemon is unreachable", async () => {
+    handle = await startWebServer({
+      port: 0,
+      intervalMs: 60_000, // long — the test does one request then closes
+      sockPath: "/tmp/cockpit-nonexistent.sock",
+      runners: fakeRunners(),
+    });
+    const html = await fetchText(handle.port, "/");
+    expect(html).toMatch(/^<!DOCTYPE html>/i);
+    expect(html).toContain("COCKPIT SYSTEM HEALTH");
+    expect(html).toContain("DAEMON UNREACHABLE"); // no daemon socket → degraded, not blank
+    expect(html).toContain("cmux"); // Tier 3 probes still rendered
+  });
+
+  it("returns 404 for unknown paths", async () => {
+    handle = await startWebServer({
+      port: 0,
+      intervalMs: 60_000,
+      sockPath: "/tmp/cockpit-nonexistent.sock",
+      runners: fakeRunners(),
+    });
+    const status = await new Promise<number>((resolve, reject) => {
+      get({ host: "127.0.0.1", port: handle!.port, path: "/nope" }, (res) => {
+        res.resume();
+        resolve(res.statusCode ?? 0);
+      }).on("error", reject);
+    });
+    expect(status).toBe(404);
+  });
+});

--- a/src/dashboard/probes.ts
+++ b/src/dashboard/probes.ts
@@ -1,0 +1,225 @@
+// src/dashboard/probes.ts
+//
+// Tier 3 (external dependencies) + Tier 4 (config integrity) probes for the web
+// dashboard. These live in the DASHBOARD process, never the daemon: the daemon
+// runs under launchd and is outside cmux's process lineage, so it cannot probe
+// cmux (the "lineage wall"). Every probe is behind an injectable runner and is
+// independently try/caught with a short timeout — a thrown or hung probe yields
+// `unknown` and NEVER propagates, so one bad probe can never crash a tick.
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { existsSync, readFileSync } from "node:fs";
+import { execFile } from "node:child_process";
+import type { CockpitConfig } from "../config.js";
+import { loadConfig } from "../config.js";
+import { resolveCmuxBin } from "../lib/cmux-bin.js";
+
+export type ProbeState = "alive" | "gone" | "unknown";
+
+export interface Probe {
+  state: ProbeState;
+  /** Human-facing context for a degraded/unknown cell. */
+  detail?: string;
+}
+
+export interface ExternalProbes {
+  cmux: Probe;
+  agentClis: Array<{ cli: string } & Probe>;
+  vaults: {
+    hub: { path: string } & Probe;
+    spokes: Array<{ project: string; path: string } & Probe>;
+  };
+  config: {
+    parseable: Probe;
+    projectPaths: Array<{ project: string; path: string } & Probe>;
+    sessions: Probe;
+  };
+}
+
+/** Low-level I/O the probes depend on. Tests inject fakes; the dashboard process
+ *  injects {@link defaultProbeRunners}. */
+export interface ProbeRunners {
+  /** cmux reachable (e.g. `cmux --version` exited 0). */
+  probeCmuxBin: () => Promise<boolean>;
+  /** an agent CLI resolves on PATH. */
+  probeOnPath: (cli: string) => Promise<boolean>;
+  /** a directory/file exists (sync stat). */
+  pathExists: (p: string) => boolean;
+  /** load + parse config.json; throws when unparseable. */
+  loadConfig: () => CockpitConfig;
+  /** distinct templateHash values recorded in sessions.json; throws when unreadable. */
+  loadSessionsHashes: () => string[];
+}
+
+const DEFAULT_TIMEOUT_MS = 2000;
+const AGENT_CLIS = ["claude", "codex", "gemini", "opencode"] as const;
+
+/** Reject a promise that outlives `ms`, clearing the timer either way. */
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error("probe timeout")), ms);
+    timer.unref?.();
+  });
+  return Promise.race([p.finally(() => clearTimeout(timer)), timeout]);
+}
+
+// ── Tier 3 — external dependencies ────────────────────────────────────────────
+
+export async function probeCmux(run: ProbeRunners, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<Probe> {
+  try {
+    const ok = await withTimeout(run.probeCmuxBin(), timeoutMs);
+    return ok ? { state: "alive" } : { state: "gone", detail: "cmux not reachable" };
+  } catch {
+    return { state: "unknown" };
+  }
+}
+
+export async function probeAgentClis(
+  run: ProbeRunners,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<Array<{ cli: string } & Probe>> {
+  return Promise.all(
+    AGENT_CLIS.map(async (cli) => {
+      try {
+        const ok = await withTimeout(run.probeOnPath(cli), timeoutMs);
+        return ok ? { cli, state: "alive" as const } : { cli, state: "gone" as const, detail: `${cli} not on PATH` };
+      } catch {
+        return { cli, state: "unknown" as const };
+      }
+    }),
+  );
+}
+
+/** A vault is alive only when its directory AND its `.obsidian/` both exist. */
+function vaultProbe(run: ProbeRunners, dir: string): Probe {
+  try {
+    if (!dir) return { state: "unknown", detail: "no vault configured" };
+    if (!run.pathExists(dir)) return { state: "gone", detail: "vault directory missing" };
+    if (!run.pathExists(join(dir, ".obsidian"))) return { state: "gone", detail: "no .obsidian/ (not a vault)" };
+    return { state: "alive" };
+  } catch {
+    return { state: "unknown" };
+  }
+}
+
+export function probeVaults(run: ProbeRunners, config: CockpitConfig): ExternalProbes["vaults"] {
+  return {
+    hub: { path: config.hubVault, ...vaultProbe(run, config.hubVault) },
+    spokes: Object.entries(config.projects).map(([project, p]) => ({
+      project,
+      path: p.spokeVault,
+      ...vaultProbe(run, p.spokeVault),
+    })),
+  };
+}
+
+// ── Tier 4 — config integrity ─────────────────────────────────────────────────
+
+export function probeProjectPaths(
+  run: ProbeRunners,
+  config: CockpitConfig,
+): Array<{ project: string; path: string } & Probe> {
+  return Object.entries(config.projects).map(([project, p]) => {
+    try {
+      const ok = run.pathExists(p.path);
+      return ok
+        ? { project, path: p.path, state: "alive" as const }
+        : { project, path: p.path, state: "gone" as const, detail: "project path missing" };
+    } catch {
+      return { project, path: p.path, state: "unknown" as const };
+    }
+  });
+}
+
+/**
+ * sessions.json template-drift signal. Re-deriving the exact "current" template
+ * hash would couple the dashboard to the launcher's hashing internals + the
+ * installed templates dir; instead we surface the honest, dependency-free signal
+ * that the recorded sessions disagree: more than one distinct templateHash means
+ * some workspaces are running against an older template (drift). One hash =
+ * consistent; none recorded = unknown.
+ */
+export function probeSessions(run: ProbeRunners): Probe {
+  try {
+    const hashes = run.loadSessionsHashes();
+    if (hashes.length === 0) return { state: "unknown", detail: "no sessions recorded" };
+    if (hashes.length === 1) return { state: "alive" };
+    return { state: "gone", detail: `template drift: ${hashes.length} distinct hashes` };
+  } catch {
+    return { state: "unknown" };
+  }
+}
+
+// ── Top-level assembly ────────────────────────────────────────────────────────
+
+/**
+ * Run every Tier 3/4 probe and assemble {@link ExternalProbes}. config.json is
+ * loaded once (shared by vaults + project-path checks); if it fails to parse the
+ * config tier degrades but cmux/CLI probes still run.
+ */
+export async function runExternalProbes(
+  run: ProbeRunners,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<ExternalProbes> {
+  const [cmux, agentClis] = await Promise.all([
+    probeCmux(run, timeoutMs),
+    probeAgentClis(run, timeoutMs),
+  ]);
+
+  let config: CockpitConfig | null = null;
+  let parseable: Probe;
+  try {
+    config = run.loadConfig();
+    parseable = { state: "alive" };
+  } catch {
+    parseable = { state: "gone", detail: "config.json unparseable" };
+  }
+
+  const vaults = config
+    ? probeVaults(run, config)
+    : { hub: { path: "", state: "unknown" as const }, spokes: [] };
+  const projectPaths = config ? probeProjectPaths(run, config) : [];
+  const sessions = probeSessions(run);
+
+  return { cmux, agentClis, vaults, config: { parseable, projectPaths, sessions } };
+}
+
+// ── Default real-I/O runners (dashboard process; not unit-tested) ──────────────
+
+const SESSIONS_PATH = join(homedir(), ".config", "cockpit", "sessions.json");
+
+/** Resolve a bare binary name against the PATH dirs (dependency-free `which`). */
+function onPath(cli: string): boolean {
+  const dirs = (process.env.PATH ?? "").split(":").filter(Boolean);
+  return dirs.some((d) => existsSync(join(d, cli)));
+}
+
+/** Distinct templateHash values recorded across all workspaces in sessions.json. */
+function readSessionsHashes(): string[] {
+  const raw = JSON.parse(readFileSync(SESSIONS_PATH, "utf-8")) as {
+    workspaces?: Record<string, { templateHash?: string }>;
+  };
+  const hashes = Object.values(raw.workspaces ?? {})
+    .map((w) => w.templateHash)
+    .filter((h): h is string => typeof h === "string" && h.length > 0);
+  return [...new Set(hashes)];
+}
+
+/** The real runners used by `cockpit dashboard --web`. */
+export function defaultProbeRunners(): ProbeRunners {
+  return {
+    probeCmuxBin: () =>
+      new Promise<boolean>((resolve) => {
+        try {
+          execFile(resolveCmuxBin(), ["--version"], { timeout: 1500 }, (err) => resolve(!err));
+        } catch {
+          resolve(false);
+        }
+      }),
+    probeOnPath: async (cli) => onPath(cli),
+    pathExists: (p) => existsSync(p),
+    loadConfig: () => loadConfig(),
+    loadSessionsHashes: () => readSessionsHashes(),
+  };
+}

--- a/src/dashboard/snapshot-merge.ts
+++ b/src/dashboard/snapshot-merge.ts
@@ -1,0 +1,26 @@
+// src/dashboard/snapshot-merge.ts
+//
+// PURE merge of the two data sources behind the dashboard: the daemon's
+// Tier 0/1/2 `DaemonSnapshot` (or "unreachable") and the dashboard process's
+// Tier 3/4 `ExternalProbes`. The whole point of keeping this separate and pure
+// is the degrade-never-blank guarantee: when the daemon is unreachable the
+// external tiers still render, so a daemon outage never blanks the page.
+import type { DaemonSnapshot } from "../control/snapshot.js";
+import type { ExternalProbes } from "./probes.js";
+
+export interface FullSnapshot {
+  /** epoch ms this snapshot was assembled (drives "updated Ns ago"). */
+  generatedAt: number;
+  /** "unreachable" when the daemon socket query failed — Tier 0/1/2 are dark. */
+  daemon: DaemonSnapshot | "unreachable";
+  external: ExternalProbes;
+}
+
+/** Pure. Stamp the two sources into one FullSnapshot. */
+export function mergeSnapshot(
+  daemon: DaemonSnapshot | "unreachable",
+  external: ExternalProbes,
+  now: number,
+): FullSnapshot {
+  return { generatedAt: now, daemon, external };
+}

--- a/src/dashboard/web-render.ts
+++ b/src/dashboard/web-render.ts
@@ -1,0 +1,211 @@
+// src/dashboard/web-render.ts
+//
+// PURE render of a FullSnapshot to (a) a complete HTML document for the initial
+// GET / load and (b) a per-tick JSON payload pushed over SSE. No I/O, no clock —
+// every age is derived from snapshot-time deltas or `snap.generatedAt`, so the
+// render is deterministic and unit-tested. Severity rolls UP (a `gone` bubbles a
+// red dot to its project header); the stale-build banner renders only when stale;
+// remediation is COPY-ABLE TEXT via healCmdFor() (never buttons — read-only beta).
+import type { HealthState, ComponentHealth } from "../control/liveness.js";
+import { healCmdFor } from "../commands/heal.js";
+import { ageText } from "../commands/health-view.js";
+import type { FullSnapshot } from "./snapshot-merge.js";
+import type { DaemonSnapshot } from "../control/snapshot.js";
+import type { ExternalProbes, Probe, ProbeState } from "./probes.js";
+
+type AnyState = HealthState | ProbeState;
+
+const ICON: Record<AnyState, string> = { alive: "✔", stale: "•", gone: "✘", unknown: "○" };
+// Rollup ordering: gone is worst, unknown never out-ranks a real degradation.
+const SEV: Record<AnyState, number> = { alive: 0, unknown: 1, stale: 2, gone: 3 };
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function dot(state: AnyState): string {
+  return `<span class="s-${state}">${ICON[state]}</span>`;
+}
+
+function worst(states: AnyState[]): AnyState {
+  let w: AnyState = "alive";
+  for (const s of states) if (SEV[s] > SEV[w]) w = s;
+  return w;
+}
+
+function fmtBytes(n: number): string {
+  if (n < 1024) return `${n}B`;
+  if (n < 1024 ** 2) return `${(n / 1024).toFixed(1)}KB`;
+  if (n < 1024 ** 3) return `${(n / 1024 ** 2).toFixed(1)}MB`;
+  return `${(n / 1024 ** 3).toFixed(1)}GB`;
+}
+
+function fmtDur(ms: number): string {
+  const s = Math.max(0, Math.round(ms / 1000));
+  if (s < 60) return `${s}s`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  return `${h}h${m % 60}m`;
+}
+
+function fmtAge(ms: number | null): string {
+  return ms == null ? "—" : `${fmtDur(ms)} ago`;
+}
+
+function banner(kind: "err" | "warn", text: string): string {
+  return `<div class="banner ${kind}">${esc(text)}</div>`;
+}
+
+function remediation(text: string): string {
+  // Copy-able text, NOT a button — read-only beta surface.
+  return `<div class="rem">remediation: <code>${esc(text)}</code></div>`;
+}
+
+function probeCell(label: string, p: Probe): string {
+  const detail = p.detail ? ` <span class="dim">${esc(p.detail)}</span>` : "";
+  return `${dot(p.state)} ${esc(label)}${detail}`;
+}
+
+// ── Tier 0 — daemon root ──────────────────────────────────────────────────────
+function renderTier0(d: DaemonSnapshot): string {
+  const t0 = d.tier0;
+  const buildState: HealthState = t0.build.state === "fresh" ? "alive" : "gone";
+  const sweep = t0.sweep.ageMs == null ? "never swept" : `last ${fmtAge(t0.sweep.ageMs)} (${fmtDur(t0.sweep.cadenceMs)} cadence)`;
+  const logState: HealthState = t0.log.errorCount > 0 ? "stale" : "alive";
+  return [
+    `<section><h2>TIER 0 · DAEMON</h2>`,
+    `<div class="row">${dot("alive")} cockpitd pid ${t0.pid} · up ${fmtDur(t0.uptimeMs)} · v${esc(t0.version)}</div>`,
+    `<div class="row">${dot(buildState)} build ${t0.build.state} · sweep ${esc(sweep)}</div>`,
+    `<div class="row">${dot(logState)} log ${t0.log.errorCount} errors/${fmtDur(t0.log.windowMs)} (${fmtBytes(t0.log.sizeBytes)})</div>`,
+    `</section>`,
+  ].join("");
+}
+
+// ── Tier 3/4 — environment ────────────────────────────────────────────────────
+function renderEnv(ext: ExternalProbes): string {
+  const clis = ext.agentClis.map((c) => probeCell(c.cli, c)).join(" ");
+  const spokes = ext.vaults.spokes.map((s) => probeCell(s.project, s)).join(" ");
+  const paths = ext.config.projectPaths.map((p) => probeCell(p.project, p)).join(" ");
+  return [
+    `<section><h2>TIER 3/4 · ENVIRONMENT</h2>`,
+    `<div class="row">${probeCell("cmux", ext.cmux)}</div>`,
+    `<div class="row">CLIs: ${clis}</div>`,
+    `<div class="row">vaults: ${probeCell("hub", ext.vaults.hub)} ${spokes}</div>`,
+    `<div class="row">config: ${probeCell("config.json", ext.config.parseable)} ${probeCell("sessions", ext.config.sessions)} ${paths}</div>`,
+    `</section>`,
+  ].join("");
+}
+
+// ── Tier 1/2 — projects ───────────────────────────────────────────────────────
+function renderComponentRow(c: ComponentHealth, now: number): string {
+  const detail = c.detail ? ` · ${esc(c.detail)}` : "";
+  const row = `<div class="row comp">${dot(c.state)} ${esc(c.kind)} ${esc(c.ref)} ${esc(ageText(c.lastSeenMs, now))}${detail}</div>`;
+  const heal = healCmdFor(c);
+  return heal ? row + remediation(heal) : row;
+}
+
+function renderProjects(d: DaemonSnapshot, now: number): string {
+  const projects = new Set<string>([
+    ...d.tier1.map((c) => c.project),
+    ...d.tier2.projects.map((p) => p.project),
+  ]);
+  const out: string[] = [`<section><h2>PROJECTS</h2>`];
+  for (const project of projects) {
+    const comps = d.tier1.filter((c) => c.project === project);
+    const dp = d.tier2.projects.find((p) => p.project === project);
+    const rollupStates: AnyState[] = [
+      ...comps.map((c) => c.state),
+      dp && dp.delivery.behind > 0 ? "stale" : "alive",
+      dp && dp.store.corruptCount > 0 ? "gone" : "alive",
+    ];
+    const rollup = worst(rollupStates);
+    out.push(`<div class="proj"><div class="proj-head" data-rollup="${rollup}">${esc(project)} ${dot(rollup)}</div>`);
+    for (const c of comps) out.push(renderComponentRow(c, now));
+    if (dp) {
+      const counts = Object.entries(dp.store.byState).map(([s, n]) => `${n} ${esc(s)}`).join(" · ") || "no tasks";
+      out.push(
+        `<div class="row dp">mailbox: ${dp.mailbox.maxSeq} entries · captain ${dp.delivery.behind} behind · ${fmtBytes(dp.mailbox.sizeBytes)} · rotated ${dp.mailbox.rotationCount} · oldest ${fmtAge(dp.mailbox.oldestEntryAgeMs)}</div>`,
+        `<div class="row dp">store: ${counts} · ${dp.store.corruptCount} corrupt</div>`,
+      );
+    }
+    out.push(`</div>`);
+  }
+  out.push(
+    `<div class="row dp">_results: ${d.tier2.results.fileCount} files (${fmtBytes(d.tier2.results.totalBytes)})</div>`,
+    `</section>`,
+  );
+  return out.join("");
+}
+
+/** Pure. The live inner content (everything inside #content), re-pushed each tick. */
+export function renderContent(snap: FullSnapshot): string {
+  const now = snap.generatedAt;
+  const out: string[] = [`<h1>🚀 COCKPIT SYSTEM HEALTH</h1>`];
+
+  if (snap.daemon === "unreachable") {
+    out.push(banner("err", "✘ DAEMON UNREACHABLE — start it: cockpit heal daemon  (external checks below still live)"));
+  } else if (snap.daemon.tier0.build.state === "stale") {
+    out.push(banner("warn", "⚠ DAEMON RUNNING STALE CODE — process started before the current dist build"));
+    out.push(remediation("npm run build && cockpit heal daemon"));
+  }
+
+  if (snap.daemon !== "unreachable") out.push(renderTier0(snap.daemon));
+  out.push(renderEnv(snap.external));
+  if (snap.daemon !== "unreachable") out.push(renderProjects(snap.daemon, now));
+
+  return out.join("\n");
+}
+
+/** Pure. The per-tick SSE payload: re-rendered content + the snapshot timestamp. */
+export function renderTickJson(snap: FullSnapshot): string {
+  return JSON.stringify({ contentHtml: renderContent(snap), generatedAt: snap.generatedAt });
+}
+
+const STYLE = `
+body{font:13px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;background:#0b0e14;color:#c9d1d9;margin:0;padding:16px}
+h1{font-size:16px;margin:0 0 8px}h2{font-size:12px;color:#7d8590;letter-spacing:.08em;margin:16px 0 4px}
+#bar{display:flex;gap:16px;align-items:center;color:#7d8590;font-size:12px;margin-bottom:8px}
+#conn.live{color:#3fb950}#conn.down{color:#f85149}
+.row{padding:1px 0}.comp{padding-left:16px}.dp{padding-left:16px;color:#7d8590}
+.proj{margin:8px 0;border-left:2px solid #21262d;padding-left:8px}
+.proj-head{font-weight:600}
+.proj-head[data-rollup="gone"]{color:#f85149}.proj-head[data-rollup="stale"]{color:#d29922}
+.proj-head[data-rollup="unknown"]{color:#7d8590}
+.banner{padding:8px 12px;border-radius:6px;margin:8px 0;font-weight:600}
+.banner.err{background:#3d1416;color:#ff7b72}.banner.warn{background:#3d2e0a;color:#e3b341}
+.rem{padding-left:16px;color:#7d8590}.rem code{background:#161b22;padding:1px 6px;border-radius:4px;color:#79c0ff;user-select:all}
+.dim{color:#6e7681}
+.s-alive{color:#3fb950}.s-stale{color:#d29922}.s-gone{color:#f85149}.s-unknown{color:#6e7681}
+`.trim();
+
+/** Pure. The full HTML document for the initial GET / load (shell + content + SSE JS). */
+export function renderHtml(snap: FullSnapshot, opts: { port?: number } = {}): string {
+  const port = opts.port ? `:${opts.port}` : "";
+  const script = [
+    "const conn=document.getElementById('conn');",
+    "const updated=document.getElementById('updated');",
+    `let generatedAt=${snap.generatedAt};`,
+    "function tickAge(){if(!generatedAt)return;const s=Math.max(0,Math.round((Date.now()-generatedAt)/1000));updated.textContent='updated '+s+'s ago';}",
+    "setInterval(tickAge,1000);tickAge();",
+    "const es=new EventSource('/events');",
+    "es.onopen=function(){conn.textContent='\\u25CF live';conn.className='live';};",
+    "es.onerror=function(){conn.textContent='\\u25CB reconnecting';conn.className='down';};",
+    "es.onmessage=function(e){try{const d=JSON.parse(e.data);document.getElementById('content').innerHTML=d.contentHtml;generatedAt=d.generatedAt;tickAge();}catch(_){}};",
+  ].join("");
+  return [
+    "<!DOCTYPE html>",
+    '<html lang="en"><head><meta charset="utf-8">',
+    '<meta name="viewport" content="width=device-width,initial-scale=1">',
+    "<title>cockpit system health</title>",
+    `<style>${STYLE}</style></head><body>`,
+    `<div id="bar"><span id="conn">○ connecting</span><span id="updated"></span><span>${esc(port)}</span></div>`,
+    `<div id="content">${renderContent(snap)}</div>`,
+    `<script>${script}</script>`,
+    "</body></html>",
+  ].join("");
+}

--- a/src/dashboard/web-server.ts
+++ b/src/dashboard/web-server.ts
@@ -1,0 +1,111 @@
+// src/dashboard/web-server.ts
+//
+// The `cockpit dashboard --web` process: a localhost-only HTTP + SSE server that,
+// on each tick, queries the daemon's read-only `snapshot` verb, runs the Tier 3/4
+// external probes (which the daemon cannot — lineage wall), merges them, and
+// pushes the result to every connected browser. Crash-isolated from the daemon
+// (separate PID, read-only socket client) and bound to 127.0.0.1 with no auth.
+// Zero new deps: Node's built-in `http` + `EventSource` on the client.
+import { createServer, type Server, type ServerResponse } from "node:http";
+import { sendRequest } from "../control/protocol.js";
+import type { DaemonSnapshot } from "../control/snapshot.js";
+import { mergeSnapshot, type FullSnapshot } from "./snapshot-merge.js";
+import { runExternalProbes, type ProbeRunners } from "./probes.js";
+import { renderHtml, renderTickJson } from "./web-render.js";
+
+/**
+ * Query the daemon's read-only snapshot verb. Returns "unreachable" when the
+ * daemon socket can't be reached — the page degrades (banner + Tier 3/4) rather
+ * than blanking. Mirrors queryHealth() in health-view.ts.
+ */
+export async function querySnapshot(sockPath: string): Promise<DaemonSnapshot | "unreachable"> {
+  try {
+    const reply = await sendRequest(sockPath, { kind: "snapshot" });
+    return reply as DaemonSnapshot;
+  } catch {
+    return "unreachable";
+  }
+}
+
+export interface WebServerOpts {
+  port: number;
+  intervalMs: number;
+  sockPath: string;
+  runners: ProbeRunners;
+  host?: string;
+  now?: () => number;
+  probeTimeoutMs?: number;
+}
+
+export interface WebServerHandle {
+  /** The actually-bound port (useful when port 0 was requested in tests). */
+  port: number;
+  close: () => Promise<void>;
+}
+
+/**
+ * Start the dashboard web server. Binds 127.0.0.1 only, serves the static page on
+ * GET /, an SSE stream on GET /events, and pushes a fresh snapshot every
+ * intervalMs. Returns a handle whose close() stops the tick loop and the server.
+ */
+export async function startWebServer(opts: WebServerOpts): Promise<WebServerHandle> {
+  const host = opts.host ?? "127.0.0.1";
+  const now = opts.now ?? (() => Date.now());
+  const clients = new Set<ServerResponse>();
+  let latest: FullSnapshot | null = null;
+
+  async function tick(): Promise<void> {
+    const daemon = await querySnapshot(opts.sockPath);
+    const external = await runExternalProbes(opts.runners, opts.probeTimeoutMs);
+    latest = mergeSnapshot(daemon, external, now());
+    const payload = `data: ${renderTickJson(latest)}\n\n`;
+    for (const res of clients) {
+      try { res.write(payload); } catch { /* client gone; pruned on close */ }
+    }
+  }
+
+  const server: Server = createServer((req, res) => {
+    if (req.method !== "GET") { res.writeHead(405).end(); return; }
+    if (req.url === "/" || req.url === "/index.html") {
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+      res.end(latest ? renderHtml(latest, { port: opts.port }) : "<!DOCTYPE html><body>starting…</body>");
+      return;
+    }
+    if (req.url === "/events") {
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+      res.write("retry: 3000\n\n");
+      if (latest) res.write(`data: ${renderTickJson(latest)}\n\n`);
+      clients.add(res);
+      req.on("close", () => clients.delete(res));
+      return;
+    }
+    res.writeHead(404).end();
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(opts.port, host, resolve);
+  });
+  const addr = server.address();
+  const boundPort = typeof addr === "object" && addr ? addr.port : opts.port;
+
+  // Prime `latest` before the first request lands, then start the loop.
+  await tick();
+  const timer = setInterval(() => { void tick().catch(() => { /* a tick must never crash the loop */ }); }, opts.intervalMs);
+  timer.unref?.();
+
+  return {
+    port: boundPort,
+    close: () =>
+      new Promise<void>((resolve) => {
+        clearInterval(timer);
+        for (const res of clients) { try { res.end(); } catch { /* already closed */ } }
+        clients.clear();
+        server.close(() => resolve());
+      }),
+  };
+}


### PR DESCRIPTION
Implements the **cockpit system observability dashboard** per the approved spec
`docs/specs/2026-06-15-dashboard-observability-design.md` (issue #44, extended to
full-system health). A localhost-only web dashboard that watches every moving
part of cockpit at a glance, shippable as a beta.

## What this adds

**Daemon (additive — `health` verb untouched, its 3 consumers unaffected):**
- New read-only `snapshot` socket verb in `cockpitd.ts`.
- New pure `src/control/snapshot.ts` — `assembleDaemonSnapshot(inputs, now)` +
  `buildFreshness()`, mirroring `liveness.ts` (no I/O, fully unit-tested).
- cockpitd gathers Tier 0/1/2 inputs at the edge: pid/uptime/version, dist
  build-freshness (process-start vs dist mtime), last-sweep age, daemon-log error
  count+size; reuses `projectHealth()` for Tier 1; mailbox stats, cursor delivery
  lag (`maxSeq − lastAckedSeq`), store state counts + corrupt count, `_results`
  count+bytes for Tier 2.
- New exported `mailboxStats()` in `mailbox.ts`.

**Dashboard web process (`cockpit dashboard --web`):**
- `src/dashboard/web-server.ts` — Node built-in `http` + SSE on `127.0.0.1` only.
  Each tick: query the daemon `snapshot` verb + run Tier 3/4 external probes +
  merge + push to SSE clients.
- `src/dashboard/probes.ts` — Tier 3/4 probes behind injectable runners
  (`probeCmux` lives here because the daemon can't probe cmux — lineage wall;
  `probeAgentClis`, `probeVaults`, `probeConfig`). Each try/caught with a short
  timeout; a thrown/hung probe → `unknown`, never propagates.
- `src/dashboard/snapshot-merge.ts` — pure merge → `FullSnapshot`; the
  daemon-unreachable branch keeps Tier 3/4 (degrade, never blank).
- `src/dashboard/web-render.ts` — pure `FullSnapshot` → HTML doc + per-tick JSON.
  Severity rolls upward (a `gone` bubbles a red dot to the project header),
  stale-build banner only when stale, remediation via `healCmdFor()` rendered as
  **copy-able text (not buttons)**, SSE connection-state indicator.
- `--web` / `--port` (default 7878) / `--interval` (default 5s) on
  `src/commands/dashboard.ts`.

## Hard constraints honored
- **Zero new npm dependencies** (Node `http` + vanilla JS + `EventSource`).
- **localhost-only** (`127.0.0.1`), no auth.
- **Read-only** — remediation is copy-able text, no write/control surface.
- Pure-core, I/O at the edges; one test file per pure module.

## Testing
- TDD throughout (superpowers) + karpathy discipline (surgical, additive).
- New: snapshot assembly, mailboxStats, cockpitd snapshot smoke, probes, merge,
  render, web-server smoke (no live network/daemon in CI — fakes injected).
- **Full suite green on a clean checkout: 100 files / 1161 tests** (no PR-time CI,
  so verified locally). Manual e2e of `--web` confirmed: serves HTML, SSE streams,
  404s, and degrades to `DAEMON UNREACHABLE` when the daemon is the old build.

## Safety / blast radius
- `gitnexus_impact` on `startCockpitd` and `dashboardCommand`: both **LOW** risk,
  changes are additive (new verb / new CLI flags / new files / new export).
- The `health` verb and its consumers are untouched.

## Follow-up (deferred per spec)
- Clickable heal/restart actions (write surface) → fast-follow after the read
  model proves out. Auth / remote access and metrics retention are out of scope.

Closes #44.
