### PR TITLE
feat: two-way Telegram integration (#65)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (4014 symbols, 6562 relationships, 110 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (4531 symbols, 7257 relationships, 127 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -62,6 +62,12 @@ Every coding task in this repo follows [`plugin/skills/karpathy-principles/SKILL
 2. **Simplicity first** — no speculative abstractions, no impossible-case error handling
 3. **Surgical changes** — every changed line traces to the request; no drive-by refactors
 4. **Goal-driven execution** — define verifiable success criteria before implementing
+
+## Remote Control
+
+- **Telegram remote control** (opt-in, #65): push crew lifecycle to Telegram forum
+  topics (one per session) and reply back to the captain. Configure via
+  `cockpit telegram link <project>`. See README "Telegram remote control".
 # Memory Context
 
 # [claude-cockpit] recent context, 2026-06-01 10:23pm GMT+7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (4358 symbols, 6976 relationships, 115 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (4531 symbols, 7257 relationships, 127 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ captain.
 
 Check status any time with `cockpit telegram status`.
 
+> **Security:** Every member of a linked supergroup can send messages to your
+> captain, which runs under `--permission-mode auto`. Keep your project group
+> **private** and restricted to trusted people. If the group is compromised,
+> anyone who joins gains remote-control access. An optional per-user allowlist
+> is tracked in [#321](https://github.com/tu11aa/claude-cockpit/issues/321).
+
 ### How it works
 
 - **Outbound** rides the daemon's existing notification fan-out — Telegram is a

--- a/README.md
+++ b/README.md
@@ -90,6 +90,39 @@ See `obsidian/plugins.md` for Dataview, Templater setup.
 | `cockpit shutdown [project]` | Graceful shutdown |
 | `cockpit feedback` | Open opt-in feedback issue |
 
+## Telegram remote control (#65)
+
+Drive cockpit from your phone. Crew lifecycle events (done / blocked / idle) push
+to Telegram forum topics — one topic per session — and replies route back to the
+captain.
+
+### Setup
+
+1. Create a bot with [@BotFather](https://t.me/botfather); copy the token.
+2. Add the token to `~/.config/cockpit/config.json`:
+   ```json
+   { "telegram": { "botToken": "123456:ABC...", "chats": {} } }
+   ```
+3. Create a Telegram **supergroup with Topics enabled** for the project, and add
+   your bot as an **admin** (with "Manage topics").
+4. Run `cockpit telegram link <project>` — this binds the group to the project.
+5. Restart the daemon: `launchctl kickstart -kp gui/$(id -u)/com.cockpit.daemon`.
+
+Check status any time with `cockpit telegram status`.
+
+### How it works
+
+- **Outbound** rides the daemon's existing notification fan-out — Telegram is a
+  parallel consumer; your laptop notifications are unaffected if Telegram or the
+  network is down (best-effort).
+- **Inbound** replies are delivered to the captain (the coordinator), which routes
+  them onward to crews.
+- The feature is **opt-in**: with no `telegram` config, the daemon behaves exactly
+  as before.
+
+Deferred enhancements: inline approve/deny buttons (#309), webhook ingress (#310),
+direct-to-crew injection (#249).
+
 ## Architecture
 
 ### Roles

--- a/src/__tests__/config.telegram.test.ts
+++ b/src/__tests__/config.telegram.test.ts
@@ -1,0 +1,43 @@
+// src/__tests__/config.telegram.test.ts
+import { describe, it, expect } from "vitest";
+import { writeFileSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadConfig } from "../config.js";
+
+describe("telegram config", () => {
+  it("round-trips a telegram block through loadConfig", () => {
+    const dir = mkdtempSync(join(tmpdir(), "cfg-"));
+    const p = join(dir, "config.json");
+    writeFileSync(
+      p,
+      JSON.stringify({
+        commandName: "x",
+        hubVault: "/tmp/hub",
+        projects: {},
+        defaults: { maxCrew: 5, worktreeDir: ".w", teammateMode: "in-process", permissions: { command: "auto", captain: "auto" } },
+        metrics: { enabled: false, path: "/tmp/m.json" },
+        telegram: { botToken: "123:ABC", chats: { cockpit: -100123 } },
+      }),
+    );
+    const cfg = loadConfig(p);
+    expect(cfg.telegram?.botToken).toBe("123:ABC");
+    expect(cfg.telegram?.chats.cockpit).toBe(-100123);
+  });
+
+  it("leaves telegram undefined when absent", () => {
+    const dir = mkdtempSync(join(tmpdir(), "cfg-"));
+    const p = join(dir, "config.json");
+    writeFileSync(
+      p,
+      JSON.stringify({
+        commandName: "x",
+        hubVault: "/tmp/hub",
+        projects: {},
+        defaults: { maxCrew: 5, worktreeDir: ".w", teammateMode: "in-process", permissions: { command: "auto", captain: "auto" } },
+        metrics: { enabled: false, path: "/tmp/m.json" },
+      }),
+    );
+    expect(loadConfig(p).telegram).toBeUndefined();
+  });
+});

--- a/src/commands/__tests__/telegram.test.ts
+++ b/src/commands/__tests__/telegram.test.ts
@@ -1,0 +1,32 @@
+// src/commands/__tests__/telegram.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { resolveLinkChatId, buildStatusReport } from "../telegram.js";
+import type { TgUpdate } from "../../control/telegram/client.js";
+
+describe("telegram link", () => {
+  it("picks the chat_id from the most recent my_chat_member where the bot became admin/member", () => {
+    const updates: TgUpdate[] = [
+      { update_id: 1, my_chat_member: { chat: { id: -100, type: "supergroup", title: "cockpit" }, new_chat_member: { status: "administrator" } } },
+      { update_id: 2, message: { chat: { id: -100, type: "supergroup" }, text: "hi" } },
+    ];
+    expect(resolveLinkChatId(updates)).toBe(-100);
+  });
+
+  it("returns undefined when no my_chat_member update is present", () => {
+    expect(resolveLinkChatId([{ update_id: 1, message: { chat: { id: -100, type: "supergroup" }, text: "hi" } }])).toBeUndefined();
+  });
+});
+
+describe("telegram status", () => {
+  it("reports linked projects and token validity", () => {
+    const report = buildStatusReport({ tokenValid: true, chats: { cockpit: -100, brove: -200 } });
+    expect(report).toContain("token: valid");
+    expect(report).toContain("cockpit");
+    expect(report).toContain("-100");
+    expect(report).toContain("brove");
+  });
+
+  it("reports when telegram is not configured", () => {
+    expect(buildStatusReport({ tokenValid: false, chats: {} })).toContain("no projects linked");
+  });
+});

--- a/src/commands/__tests__/telegram.test.ts
+++ b/src/commands/__tests__/telegram.test.ts
@@ -15,6 +15,22 @@ describe("telegram link", () => {
   it("returns undefined when no my_chat_member update is present", () => {
     expect(resolveLinkChatId([{ update_id: 1, message: { chat: { id: -100, type: "supergroup" }, text: "hi" } }])).toBeUndefined();
   });
+
+  it("ignores removal events (left/kicked) — does not link on bot removal", () => {
+    const updates: TgUpdate[] = [
+      { update_id: 1, my_chat_member: { chat: { id: -100, type: "supergroup" }, new_chat_member: { status: "left" } } },
+      { update_id: 2, my_chat_member: { chat: { id: -200, type: "supergroup" }, new_chat_member: { status: "kicked" } } },
+    ];
+    expect(resolveLinkChatId(updates)).toBeUndefined();
+  });
+
+  it("picks the latest member/administrator join over an earlier left event", () => {
+    const updates: TgUpdate[] = [
+      { update_id: 1, my_chat_member: { chat: { id: -100, type: "supergroup" }, new_chat_member: { status: "left" } } },
+      { update_id: 2, my_chat_member: { chat: { id: -200, type: "supergroup" }, new_chat_member: { status: "member" } } },
+    ];
+    expect(resolveLinkChatId(updates)).toBe(-200);
+  });
 });
 
 describe("telegram status", () => {

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1,0 +1,73 @@
+// src/commands/telegram.ts
+import { Command } from "commander";
+import chalk from "chalk";
+import { loadConfig, saveConfig, type CockpitConfig } from "../config.js";
+import { createTelegramClient, type TgUpdate } from "../control/telegram/index.js";
+
+/** Pure: the chat_id of the most recent my_chat_member update (bot added to a group). */
+export function resolveLinkChatId(updates: TgUpdate[]): number | undefined {
+  for (let i = updates.length - 1; i >= 0; i--) {
+    const m = updates[i].my_chat_member;
+    if (m) return m.chat.id;
+  }
+  return undefined;
+}
+
+/** Pure: render `telegram status`. */
+export function buildStatusReport(args: { tokenValid: boolean; chats: Record<string, number> }): string {
+  const lines = [`token: ${args.tokenValid ? "valid" : "invalid/unset"}`];
+  const entries = Object.entries(args.chats);
+  if (entries.length === 0) lines.push("no projects linked");
+  else for (const [project, id] of entries) lines.push(`  ${project} → ${id}`);
+  return lines.join("\n");
+}
+
+async function runLink(project: string, configPath?: string): Promise<number> {
+  const config: CockpitConfig = loadConfig(configPath);
+  if (!config.telegram?.botToken) {
+    console.error(chalk.red("telegram link: set telegram.botToken in ~/.config/cockpit/config.json first"));
+    return 1;
+  }
+  if (!config.projects[project]) {
+    console.error(chalk.red(`telegram link: unknown project '${project}'`));
+    return 1;
+  }
+  const client = createTelegramClient(config.telegram.botToken);
+  const updates = await client.getUpdates(0, 0);
+  const chatId = resolveLinkChatId(updates);
+  if (chatId === undefined) {
+    console.error(chalk.yellow("telegram link: no group found. Add the bot to your project supergroup (as admin), then re-run."));
+    return 1;
+  }
+  config.telegram.chats = { ...config.telegram.chats, [project]: chatId };
+  saveConfig(config, configPath);
+  console.log(chalk.green(`✔ linked '${project}' → chat ${chatId}`));
+  return 0;
+}
+
+async function runStatus(configPath?: string): Promise<number> {
+  const config = loadConfig(configPath);
+  let tokenValid = false;
+  if (config.telegram?.botToken) {
+    try {
+      await createTelegramClient(config.telegram.botToken).getMe();
+      tokenValid = true;
+    } catch { tokenValid = false; }
+  }
+  console.log(buildStatusReport({ tokenValid, chats: config.telegram?.chats ?? {} }));
+  return 0;
+}
+
+export const telegramCommand = new Command("telegram")
+  .description("Configure Telegram remote control (#65)")
+  .addCommand(
+    new Command("link")
+      .description("Bind a project to the supergroup the bot was added to")
+      .argument("<project>", "project to link")
+      .action(async (project: string) => process.exit(await runLink(project))),
+  )
+  .addCommand(
+    new Command("status")
+      .description("Show token validity and linked projects")
+      .action(async () => process.exit(await runStatus())),
+  );

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -4,11 +4,15 @@ import chalk from "chalk";
 import { loadConfig, saveConfig, type CockpitConfig } from "../config.js";
 import { createTelegramClient, type TgUpdate } from "../control/telegram/index.js";
 
-/** Pure: the chat_id of the most recent my_chat_member update (bot added to a group). */
+const JOINED_STATUSES = new Set(["member", "administrator", "creator"]);
+
+/** Pure: the chat_id of the most recent my_chat_member where the bot was added (not removed). */
 export function resolveLinkChatId(updates: TgUpdate[]): number | undefined {
   for (let i = updates.length - 1; i >= 0; i--) {
     const m = updates[i].my_chat_member;
-    if (m) return m.chat.id;
+    if (m && m.new_chat_member && JOINED_STATUSES.has(m.new_chat_member.status)) {
+      return m.chat.id;
+    }
   }
   return undefined;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,6 +59,14 @@ export interface RoleAssignment {
 
 export type RoleConfig = Partial<Record<"command" | "captain" | "crew" | "exploration" | "side", RoleAssignment>>;
 
+export interface TelegramConfig {
+  /** Bot token from BotFather. Lives in ~/.config/cockpit (never in the repo). */
+  botToken: string;
+  /** project name → Telegram supergroup chat_id (negative for supergroups).
+   *  The set of values here is ALSO the inbound allowlist: only these chats may command. */
+  chats: Record<string, number>;
+}
+
 export interface CockpitConfig {
   /** Package version that last reconciled this config. Absent on legacy/fresh configs. */
   _cockpitVersion?: string;
@@ -69,6 +77,8 @@ export interface CockpitConfig {
   runtime?: string;
   workspace?: string;
   notifier?: string;
+  /** #65 Telegram integration. Absent = feature off (daemon behaves exactly as before). */
+  telegram?: TelegramConfig;
   projection?: {
     targets?: string[];
   };

--- a/src/control/__tests__/cockpitd.telegram.test.ts
+++ b/src/control/__tests__/cockpitd.telegram.test.ts
@@ -1,0 +1,40 @@
+// src/control/__tests__/cockpitd.telegram.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { startCockpitd } from "../cockpitd.js";
+import type { TelegramSubsystem } from "../telegram/subsystem.js";
+
+function tmpRoots() {
+  const root = mkdtempSync(join(tmpdir(), "cd-"));
+  return { stateRoot: join(root, "state"), sockPath: join(root, "d.sock") };
+}
+
+describe("cockpitd telegram wiring", () => {
+  it("starts inbound on boot and stops on teardown; composed notify swallows pushLifecycle throws", async () => {
+    const { stateRoot, sockPath } = tmpRoots();
+    const pushLifecycle = vi.fn(async () => { throw new Error("tg down"); });
+    const telegram: TelegramSubsystem = { pushLifecycle, startInbound: vi.fn(), stop: vi.fn() };
+    const notify = vi.fn(async () => {});
+
+    const h = startCockpitd({ stateRoot, sockPath, sweepMs: 0, rotationIntervalMs: 0, notify, telegram });
+    expect(telegram.startInbound).toHaveBeenCalled();
+
+    // Drive one lifecycle event through the daemon's composed notify to verify
+    // pushLifecycle is called best-effort (fire-and-forget via void; never throws to caller).
+    await notify({ project: "cockpit", message: "CREW DONE", record: { id: "t1", project: "cockpit", name: "crew-1", provider: "claude", state: "done" } as any, event: { type: "task.done", id: "t1" } as any });
+    // The daemon's composed notify uses `void telegram.pushLifecycle(...)` — errors never surface.
+    // We can't call the composed notify directly, but stop() completing confirms no crash.
+    await h.stop();
+    expect(telegram.stop).toHaveBeenCalled();
+  });
+
+  it("does not start telegram when opts.telegram is absent and config has none", async () => {
+    const { stateRoot, sockPath } = tmpRoots();
+    const h = startCockpitd({ stateRoot, sockPath, sweepMs: 0, rotationIntervalMs: 0 });
+    // No throw, daemon boots fine without telegram.
+    await h.stop();
+    expect(true).toBe(true);
+  });
+});

--- a/src/control/__tests__/cockpitd.telegram.test.ts
+++ b/src/control/__tests__/cockpitd.telegram.test.ts
@@ -16,7 +16,7 @@ describe("cockpitd telegram wiring", () => {
     const { stateRoot, sockPath } = tmpRoots();
     const pushLifecycle = vi.fn(async () => { throw new Error("tg down"); });
     const telegram: TelegramSubsystem = { pushLifecycle, startInbound: vi.fn(), stop: vi.fn() };
-    const notify = vi.fn(async () => {});
+    const notify = vi.fn(async (_args: unknown) => {});
 
     const h = startCockpitd({ stateRoot, sockPath, sweepMs: 0, rotationIntervalMs: 0, notify, telegram });
     expect(telegram.startInbound).toHaveBeenCalled();

--- a/src/control/__tests__/cockpitd.telegram.test.ts
+++ b/src/control/__tests__/cockpitd.telegram.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { startCockpitd } from "../cockpitd.js";
+import { sendRequest } from "../protocol.js";
 import type { TelegramSubsystem } from "../telegram/subsystem.js";
 
 function tmpRoots() {
@@ -11,21 +12,39 @@ function tmpRoots() {
   return { stateRoot: join(root, "state"), sockPath: join(root, "d.sock") };
 }
 
-describe("cockpitd telegram wiring", () => {
-  it("starts inbound on boot and stops on teardown; composed notify swallows pushLifecycle throws", async () => {
-    const { stateRoot, sockPath } = tmpRoots();
-    const pushLifecycle = vi.fn(async () => { throw new Error("tg down"); });
-    const telegram: TelegramSubsystem = { pushLifecycle, startInbound: vi.fn(), stop: vi.fn() };
-    const notify = vi.fn(async (_args: unknown) => {});
+const SEED_RECORD = {
+  id: "t1", project: "cockpit", provider: "claude", mode: "interactive",
+  state: "submitted", task: "x", createdAt: 1, lastHeartbeat: 1,
+  lastEvent: "", heartbeatBudgetMs: 1000,
+  attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }],
+} as const;
 
-    const h = startCockpitd({ stateRoot, sockPath, sweepMs: 0, rotationIntervalMs: 0, notify, telegram });
+describe("cockpitd telegram wiring", () => {
+  it("starts inbound on boot; crash-contained: throwing pushLifecycle never crashes the daemon", async () => {
+    const { stateRoot, sockPath } = tmpRoots();
+    const pushLifecycle = vi.fn(async () => { throw new Error("tg network down"); });
+    const telegram: TelegramSubsystem = { pushLifecycle, startInbound: vi.fn(), stop: vi.fn() };
+
+    const h = startCockpitd({ stateRoot, sockPath, sweepMs: 0, rotationIntervalMs: 0, telegram });
     expect(telegram.startInbound).toHaveBeenCalled();
 
-    // Drive one lifecycle event through the daemon's composed notify to verify
-    // pushLifecycle is called best-effort (fire-and-forget via void; never throws to caller).
-    await notify({ project: "cockpit", message: "CREW DONE", record: { id: "t1", project: "cockpit", name: "crew-1", provider: "claude", state: "done" } as any, event: { type: "task.done", id: "t1" } as any });
-    // The daemon's composed notify uses `void telegram.pushLifecycle(...)` — errors never surface.
-    // We can't call the composed notify directly, but stop() completing confirms no crash.
+    // Seed a task, transition to working, then to done (an ATTENTION_STATE that
+    // triggers composedNotify → fire-and-forgets pushLifecycle). The throw must
+    // not surface to the daemon event loop.
+    await sendRequest(sockPath, { kind: "seed", record: SEED_RECORD });
+    await sendRequest(sockPath, { kind: "event", project: "cockpit", event: { type: "task.started", id: "t1" } });
+    const r1 = await sendRequest(sockPath, { kind: "event", project: "cockpit", event: { type: "task.done", id: "t1" } }) as { state: string };
+    expect(r1.state).toBe("done");
+
+    // Wait a tick for the fire-and-forget void to execute.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(pushLifecycle).toHaveBeenCalledTimes(1);
+    expect(pushLifecycle).toHaveBeenCalledWith(expect.objectContaining({ project: "cockpit", record: expect.objectContaining({ state: "done" }) }));
+
+    // Daemon is still alive after the throw — processes a subsequent request.
+    const r2 = await sendRequest(sockPath, { kind: "status", project: "cockpit", id: "t1" }) as { state: string };
+    expect(r2.state).toBe("done");
+
     await h.stop();
     expect(telegram.stop).toHaveBeenCalled();
   });
@@ -33,7 +52,6 @@ describe("cockpitd telegram wiring", () => {
   it("does not start telegram when opts.telegram is absent and config has none", async () => {
     const { stateRoot, sockPath } = tmpRoots();
     const h = startCockpitd({ stateRoot, sockPath, sweepMs: 0, rotationIntervalMs: 0 });
-    // No throw, daemon boots fine without telegram.
     await h.stop();
     expect(true).toBe(true);
   });

--- a/src/control/__tests__/mailbox-captain-message.test.ts
+++ b/src/control/__tests__/mailbox-captain-message.test.ts
@@ -1,0 +1,23 @@
+// src/control/__tests__/mailbox-captain-message.test.ts
+import { describe, it, expect } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { appendCaptainMessage, readFromCursor } from "../mailbox.js";
+
+describe("appendCaptainMessage", () => {
+  it("appends a deliverable captain.message entry with a monotonic seq", async () => {
+    const root = mkdtempSync(join(tmpdir(), "mbox-"));
+    const seq1 = await appendCaptainMessage({ stateRoot: root, project: "cockpit", message: "hello", taskId: "t1", name: "crew-1" });
+    const seq2 = await appendCaptainMessage({ stateRoot: root, project: "cockpit", message: "again" });
+    expect(seq2).toBe(seq1 + 1);
+
+    const entries = [];
+    for await (const e of readFromCursor({ stateRoot: root, project: "cockpit", fromSeq: 1 })) entries.push(e);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].kind).toBe("captain.message");
+    expect(entries[0].message).toBe("hello");
+    expect(entries[0].name).toBe("crew-1");
+    expect(entries[1].taskId).toBe("captain");
+  });
+});

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -16,7 +16,7 @@ import { CodexInteractiveDriver, shouldReattachCodex } from "./codex/driver.js";
 import { OpencodeSseBridge } from "./opencode/sse-bridge.js";
 import { makeGate } from "./codex/gate.js";
 import { appendToMailbox, rotateIfNeeded, appendCaptainMessage, mailboxStats, readCursor } from "./mailbox.js";
-import { createTelegramClient, createTelegramSubsystem, type TelegramSubsystem } from "./telegram/index.js";
+import { createTelegramClient, createTelegramSubsystem, redactToken, type TelegramSubsystem } from "./telegram/index.js";
 import { createRelayHealer } from "./relay-healer.js";
 import { projectHealth, type ComponentHealth } from "./liveness.js";
 import { assembleDaemonSnapshot, type DaemonSnapshotInputs, type ResultArtifacts } from "./snapshot.js";
@@ -582,14 +582,17 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
     // Build from config unless a test already injected a subsystem (which started above).
     if (!telegram && cfg.telegram) {
       try {
+        const { botToken } = cfg.telegram;
+        // Redact the bot token from any error the subsystem logs (it appears in API URLs).
+        const tgLog = (m: string) => log(redactToken(botToken, m));
         telegram = await createTelegramSubsystem({
-          client: createTelegramClient(cfg.telegram.botToken),
+          client: createTelegramClient(botToken),
           chats: cfg.telegram.chats,
           stateRoot,
           appendCaptainMessage,
           resolveCrewName: (project, taskId) =>
             store.listAll().find((r) => r.project === project && r.id === taskId)?.name,
-          log,
+          log: tgLog,
         });
         telegram.startInbound();
       } catch (e) {

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -15,7 +15,8 @@ import { runHeadless } from "./headless-launcher.js";
 import { CodexInteractiveDriver, shouldReattachCodex } from "./codex/driver.js";
 import { OpencodeSseBridge } from "./opencode/sse-bridge.js";
 import { makeGate } from "./codex/gate.js";
-import { appendToMailbox, rotateIfNeeded, mailboxStats, readCursor } from "./mailbox.js";
+import { appendToMailbox, rotateIfNeeded, appendCaptainMessage, mailboxStats, readCursor } from "./mailbox.js";
+import { createTelegramClient, createTelegramSubsystem, type TelegramSubsystem } from "./telegram/index.js";
 import { createRelayHealer } from "./relay-healer.js";
 import { projectHealth, type ComponentHealth } from "./liveness.js";
 import { assembleDaemonSnapshot, type DaemonSnapshotInputs, type ResultArtifacts } from "./snapshot.js";
@@ -90,6 +91,8 @@ export interface CockpitdOpts {
     /** CP3: POST the captain's approve/deny decision to the crew's server. */
     answer: (taskId: string, decision: "approve" | "deny") => Promise<boolean>;
   };
+  /** Inject a fake Telegram subsystem for tests. Absent + no config.telegram = feature off. */
+  telegram?: TelegramSubsystem;
 }
 
 // ── Tier 0/2 snapshot gathering (I/O at the edge; the pure assembly lives in
@@ -183,7 +186,8 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   let lastSweepAt: number | null = null;
   // #225: hard crew task-timeout ceiling, read once at boot. Falls back to the
   // daemon's DEFAULT_TASK_TIMEOUT_MS (8h) when unset in config.
-  const taskTimeoutMs = loadConfig().defaults.taskTimeoutMs;
+  const cfg = loadConfig();
+  const taskTimeoutMs = cfg.defaults.taskTimeoutMs;
   const isPidAlive = opts.isPidAlive ?? defaultIsPidAlive;
   const spawn = opts.spawn ?? realSpawn;
   const resultsDir = join(stateRoot, "_results");
@@ -368,10 +372,26 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       log(`mailbox append failed project=${args.project}: ${(e as Error).message}`);
     }
   };
-  const notify = opts.notify ?? defaultNotify;
+  const baseNotify = opts.notify ?? defaultNotify;
+
+  // #65 Telegram: opt-in, crash-contained. Mutable so the lazy boot IIFE can
+  // assign the subsystem after reconcile while composedNotify closes over it.
+  let telegram: TelegramSubsystem | null = opts.telegram ?? null;
+  // Injected subsystems (tests) start immediately; config-built ones start inside the IIFE.
+  if (telegram) telegram.startInbound();
+  const composedNotify = async (args: {
+    project: string;
+    message: string;
+    record: TaskRecord;
+    event: ControlEvent;
+  }): Promise<void> => {
+    await baseNotify(args);
+    // best-effort, never blocks/throws into the daemon
+    void telegram?.pushLifecycle({ project: args.project, message: args.message, record: args.record });
+  };
 
   const d = createDaemon({
-    store, now: () => Date.now(), isPidAlive, notify, taskTimeoutMs,
+    store, now: () => Date.now(), isPidAlive, notify: composedNotify, taskTimeoutMs,
     // #139 backstop: terminalize interactive crews whose cmux pane is provably
     // gone (sweep/reconcile reaper). Three-valued; "unknown" never reaps.
     isSurfaceAlive: opts.isSurfaceAlive ?? proxiedSurfaceAlive,
@@ -557,6 +577,26 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       if (!rec.serverPort) continue;
       opencodeBridge.start({ taskId: rec.id, port: rec.serverPort });
     }
+
+    // #65 Telegram subsystem boot (after reconcile so the store is warm).
+    // Build from config unless a test already injected a subsystem (which started above).
+    if (!telegram && cfg.telegram) {
+      try {
+        telegram = await createTelegramSubsystem({
+          client: createTelegramClient(cfg.telegram.botToken),
+          chats: cfg.telegram.chats,
+          stateRoot,
+          appendCaptainMessage,
+          resolveCrewName: (project, taskId) =>
+            store.listAll().find((r) => r.project === project && r.id === taskId)?.name,
+          log,
+        });
+        telegram.startInbound();
+      } catch (e) {
+        log(`telegram init failed (feature disabled this boot): ${(e as Error).message}`);
+        telegram = null;
+      }
+    }
   })();
 
   const server = startServer(sockPath, {
@@ -707,6 +747,7 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       if (timer) clearInterval(timer);
       if (rotationTimer) clearInterval(rotationTimer);
       for (const kill of activeHeadlessKills) kill();
+      telegram?.stop();
       return new Promise<void>((resolve) => server.close(() => { log("stopped"); resolve(); }));
     },
   };

--- a/src/control/mailbox.ts
+++ b/src/control/mailbox.ts
@@ -9,7 +9,7 @@ export interface MailboxEntry {
   /** Optional human-readable name carried from TaskRecord. Absent on legacy
    *  records — readers must fall back to shortId(taskId). */
   name?: string;
-  kind: ControlEvent["type"];
+  kind: ControlEvent["type"] | "captain.message";
   provider: TaskRecord["provider"];
   payload: Record<string, unknown>;
   /** Daemon-rendered captain-facing message (unified-formatter, #214/#210).
@@ -120,6 +120,45 @@ export async function appendToMailbox(opts: AppendOpts): Promise<number> {
       provider: opts.taskRecord.provider,
       payload: extractPayload(opts.event),
       message: opts.message ?? null,
+    };
+    await fs.appendFile(file, JSON.stringify(entry) + "\n", { encoding: "utf-8" });
+    return seq;
+  });
+}
+
+interface CaptainMessageOpts {
+  stateRoot: string;
+  project: string;
+  message: string;
+  /** Source crew task id, if the reply targeted a specific crew topic. Defaults to "captain". */
+  taskId?: string;
+  /** Source crew name, surfaced in the entry for parity with task entries. */
+  name?: string;
+}
+
+/**
+ * Append a daemon-originated, captain-directed message (e.g. an inbound Telegram
+ * reply). Reuses the mailbox seq/lock machinery so the existing relay delivers
+ * it verbatim via deliverable() — no relay change needed. Kind is the synthetic
+ * "captain.message"; no state-machine transition is involved (this never flows
+ * through d.handle()).
+ */
+export async function appendCaptainMessage(opts: CaptainMessageOpts): Promise<number> {
+  return withProjectLock(opts.project, async () => {
+    const dir = inboxDir(opts.stateRoot);
+    await fs.mkdir(dir, { recursive: true });
+    const file = logPath(opts.stateRoot, opts.project);
+    const lastSeq = await readMaxSeq(opts.stateRoot, opts.project);
+    const seq = lastSeq + 1;
+    const entry: MailboxEntry = {
+      seq,
+      ts: new Date().toISOString(),
+      taskId: opts.taskId ?? "captain",
+      ...(opts.name !== undefined ? { name: opts.name } : {}),
+      kind: "captain.message",
+      provider: "claude",
+      payload: {},
+      message: opts.message,
     };
     await fs.appendFile(file, JSON.stringify(entry) + "\n", { encoding: "utf-8" });
     return seq;

--- a/src/control/telegram/__tests__/client.test.ts
+++ b/src/control/telegram/__tests__/client.test.ts
@@ -1,6 +1,6 @@
 // src/control/telegram/__tests__/client.test.ts
 import { describe, it, expect, vi } from "vitest";
-import { createTelegramClient } from "../client.js";
+import { createTelegramClient, redactToken } from "../client.js";
 
 function fakeFetch(responses: Record<string, unknown>) {
   return vi.fn(async (url: string, init?: { body?: string }) => {
@@ -50,6 +50,15 @@ describe("telegram client", () => {
     expect(got).toEqual(updates);
     const body = JSON.parse((f.mock.calls[0][1] as { body: string }).body);
     expect(body).toEqual({ offset: 5, timeout: 0 });
+  });
+
+  it("redactToken replaces bot token occurrences with ***", () => {
+    const token = "123456:ABC-secret";
+    expect(redactToken(token, `https://api.telegram.org/bot${token}/sendMessage`))
+      .toBe("https://api.telegram.org/bot***/sendMessage");
+    expect(redactToken(token, `cause: fetch ${token} failed`))
+      .toBe("cause: fetch *** failed");
+    expect(redactToken(token, "no token here")).toBe("no token here");
   });
 
   it("throws on a Telegram error response", async () => {

--- a/src/control/telegram/__tests__/client.test.ts
+++ b/src/control/telegram/__tests__/client.test.ts
@@ -1,0 +1,63 @@
+// src/control/telegram/__tests__/client.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { createTelegramClient } from "../client.js";
+
+function fakeFetch(responses: Record<string, unknown>) {
+  return vi.fn(async (url: string, init?: { body?: string }) => {
+    const method = url.split("/").pop()!;
+    const body = init?.body ? JSON.parse(init.body) : {};
+    const result = responses[method];
+    return {
+      ok: true,
+      json: async () => ({ ok: true, result, _sentBody: body }),
+    } as unknown as Response;
+  });
+}
+
+describe("telegram client", () => {
+  it("createForumTopic returns the message_thread_id", async () => {
+    const f = fakeFetch({ createForumTopic: { message_thread_id: 42, name: "🔧 crew-1" } });
+    const c = createTelegramClient("T", f as unknown as typeof fetch);
+    const id = await c.createForumTopic(-100, "🔧 crew-1");
+    expect(id).toBe(42);
+    expect(f).toHaveBeenCalledWith(
+      "https://api.telegram.org/botT/createForumTopic",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("sendMessage includes message_thread_id when given", async () => {
+    const f = fakeFetch({ sendMessage: { message_id: 1 } });
+    const c = createTelegramClient("T", f as unknown as typeof fetch);
+    await c.sendMessage(-100, "hi", 42);
+    const body = JSON.parse((f.mock.calls[0][1] as { body: string }).body);
+    expect(body).toEqual({ chat_id: -100, text: "hi", message_thread_id: 42 });
+  });
+
+  it("sendMessage omits message_thread_id when undefined", async () => {
+    const f = fakeFetch({ sendMessage: { message_id: 1 } });
+    const c = createTelegramClient("T", f as unknown as typeof fetch);
+    await c.sendMessage(-100, "hi");
+    const body = JSON.parse((f.mock.calls[0][1] as { body: string }).body);
+    expect(body).toEqual({ chat_id: -100, text: "hi" });
+  });
+
+  it("getUpdates returns the result array", async () => {
+    const updates = [{ update_id: 7, message: { chat: { id: -100 }, text: "yo" } }];
+    const f = fakeFetch({ getUpdates: updates });
+    const c = createTelegramClient("T", f as unknown as typeof fetch);
+    const got = await c.getUpdates(5, 0);
+    expect(got).toEqual(updates);
+    const body = JSON.parse((f.mock.calls[0][1] as { body: string }).body);
+    expect(body).toEqual({ offset: 5, timeout: 0 });
+  });
+
+  it("throws on a Telegram error response", async () => {
+    const f = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ ok: false, description: "Unauthorized" }),
+    } as unknown as Response));
+    const c = createTelegramClient("T", f as unknown as typeof fetch);
+    await expect(c.getMe()).rejects.toThrow("Unauthorized");
+  });
+});

--- a/src/control/telegram/__tests__/format.test.ts
+++ b/src/control/telegram/__tests__/format.test.ts
@@ -1,0 +1,17 @@
+// src/control/telegram/__tests__/format.test.ts
+import { describe, it, expect } from "vitest";
+import { crewTopicName, inboundCaptainMessage } from "../format.js";
+
+describe("telegram formatters", () => {
+  it("crewTopicName prefixes the crew name with a wrench", () => {
+    expect(crewTopicName("crew-2")).toBe("🔧 crew-2");
+  });
+
+  it("inboundCaptainMessage tags the source crew", () => {
+    expect(inboundCaptainMessage("crew-2", "use lucia")).toBe("📩 [from Telegram · crew-2] use lucia");
+  });
+
+  it("inboundCaptainMessage handles a captain-topic reply (no task name)", () => {
+    expect(inboundCaptainMessage(undefined, "status?")).toBe("📩 [from Telegram] status?");
+  });
+});

--- a/src/control/telegram/__tests__/state.test.ts
+++ b/src/control/telegram/__tests__/state.test.ts
@@ -30,8 +30,19 @@ describe("telegram state", () => {
     const s = await loadTelegramState(freshRoot());
     await s.setTopic("cockpit", "t1", 42);
     await s.setTopic("brove", "t2", 7);
-    expect(s.findTask(42)).toEqual({ project: "cockpit", taskId: "t1" });
-    expect(s.findTask(7)).toEqual({ project: "brove", taskId: "t2" });
-    expect(s.findTask(999)).toBeUndefined();
+    expect(s.findTask("cockpit", 42)).toEqual({ project: "cockpit", taskId: "t1" });
+    expect(s.findTask("brove", 7)).toEqual({ project: "brove", taskId: "t2" });
+    expect(s.findTask("cockpit", 999)).toBeUndefined();
+  });
+
+  it("findTask scopes to project — same threadId in two projects resolves independently", async () => {
+    const s = await loadTelegramState(freshRoot());
+    // Both projects' first crew topic gets threadId=2 (small ids are common)
+    await s.setTopic("cockpit", "t1", 2);
+    await s.setTopic("brove", "t2", 2);
+    expect(s.findTask("cockpit", 2)).toEqual({ project: "cockpit", taskId: "t1" });
+    expect(s.findTask("brove", 2)).toEqual({ project: "brove", taskId: "t2" });
+    // Does not cross-match
+    expect(s.findTask("cockpit", 7)).toBeUndefined();
   });
 });

--- a/src/control/telegram/__tests__/state.test.ts
+++ b/src/control/telegram/__tests__/state.test.ts
@@ -1,0 +1,37 @@
+// src/control/telegram/__tests__/state.test.ts
+import { describe, it, expect } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadTelegramState } from "../state.js";
+
+function freshRoot() {
+  return mkdtempSync(join(tmpdir(), "tg-"));
+}
+
+describe("telegram state", () => {
+  it("starts empty and defaults offset to 0", async () => {
+    const s = await loadTelegramState(freshRoot());
+    expect(s.offset()).toBe(0);
+    expect(s.getTopic("cockpit", "t1")).toBeUndefined();
+  });
+
+  it("persists offset and topics across reloads", async () => {
+    const root = freshRoot();
+    const s = await loadTelegramState(root);
+    await s.setOffset(99);
+    await s.setTopic("cockpit", "t1", 42);
+    const s2 = await loadTelegramState(root);
+    expect(s2.offset()).toBe(99);
+    expect(s2.getTopic("cockpit", "t1")).toBe(42);
+  });
+
+  it("findTask reverse-maps a thread id to {project, taskId}", async () => {
+    const s = await loadTelegramState(freshRoot());
+    await s.setTopic("cockpit", "t1", 42);
+    await s.setTopic("brove", "t2", 7);
+    expect(s.findTask(42)).toEqual({ project: "cockpit", taskId: "t1" });
+    expect(s.findTask(7)).toEqual({ project: "brove", taskId: "t2" });
+    expect(s.findTask(999)).toBeUndefined();
+  });
+});

--- a/src/control/telegram/__tests__/subsystem.test.ts
+++ b/src/control/telegram/__tests__/subsystem.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from "vitest";
 import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { createTelegramSubsystem } from "../subsystem.js";
+import { createTelegramSubsystem, processInboundUpdate } from "../subsystem.js";
 import type { TelegramClient } from "../client.js";
 import type { TaskRecord } from "../../types.js";
 
@@ -72,5 +72,53 @@ describe("telegram subsystem — outbound", () => {
     const client = fakeClient({ sendMessage: vi.fn(async () => { throw new Error("network down"); }) });
     const sub = await createTelegramSubsystem(baseDeps(client, root));
     await expect(sub.pushLifecycle({ project: "cockpit", message: "x", record: rec() })).resolves.toBeUndefined();
+  });
+});
+
+describe("telegram subsystem — inbound routing (pure)", () => {
+  const chats = { cockpit: -100, brove: -200 };
+
+  it("routes a crew-topic reply to that crew's captain via appendCaptainMessage", async () => {
+    const append = vi.fn(async () => 1);
+    const findTask = (thread: number) => (thread === 42 ? { project: "cockpit", taskId: "t1" } : undefined);
+    const handled = await processInboundUpdate({
+      update: { update_id: 5, message: { chat: { id: -100, type: "supergroup" }, message_thread_id: 42, text: "use lucia" } },
+      chats, findTask, resolveCrewName: () => "crew-2",
+      appendCaptainMessage: append, stateRoot: "/tmp", log: () => {},
+    });
+    expect(handled).toBe(true);
+    expect(append).toHaveBeenCalledWith({ stateRoot: "/tmp", project: "cockpit", message: "📩 [from Telegram · crew-2] use lucia", taskId: "t1", name: "crew-2" });
+  });
+
+  it("routes a general-topic reply to the captain (no task)", async () => {
+    const append = vi.fn(async () => 1);
+    await processInboundUpdate({
+      update: { update_id: 6, message: { chat: { id: -100, type: "supergroup" }, text: "status?" } },
+      chats, findTask: () => undefined, resolveCrewName: () => undefined,
+      appendCaptainMessage: append, stateRoot: "/tmp", log: () => {},
+    });
+    expect(append).toHaveBeenCalledWith({ stateRoot: "/tmp", project: "cockpit", message: "📩 [from Telegram] status?", taskId: undefined, name: undefined });
+  });
+
+  it("ignores updates from a non-allowlisted chat", async () => {
+    const append = vi.fn(async () => 1);
+    const handled = await processInboundUpdate({
+      update: { update_id: 7, message: { chat: { id: -999, type: "supergroup" }, text: "rm -rf" } },
+      chats, findTask: () => undefined, resolveCrewName: () => undefined,
+      appendCaptainMessage: append, stateRoot: "/tmp", log: () => {},
+    });
+    expect(handled).toBe(false);
+    expect(append).not.toHaveBeenCalled();
+  });
+
+  it("ignores updates with no text (e.g. join events)", async () => {
+    const append = vi.fn(async () => 1);
+    const handled = await processInboundUpdate({
+      update: { update_id: 8, message: { chat: { id: -100, type: "supergroup" } } },
+      chats, findTask: () => undefined, resolveCrewName: () => undefined,
+      appendCaptainMessage: append, stateRoot: "/tmp", log: () => {},
+    });
+    expect(handled).toBe(false);
+    expect(append).not.toHaveBeenCalled();
   });
 });

--- a/src/control/telegram/__tests__/subsystem.test.ts
+++ b/src/control/telegram/__tests__/subsystem.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createTelegramSubsystem, processInboundUpdate } from "../subsystem.js";
+import { loadTelegramState } from "../state.js";
 import type { TelegramClient } from "../client.js";
 import type { TaskRecord } from "../../types.js";
 
@@ -67,6 +68,18 @@ describe("telegram subsystem — outbound", () => {
     expect(client.closeForumTopic).toHaveBeenCalledWith(-100, 42);
   });
 
+  it("concurrent pushLifecycle for the same new task calls createForumTopic only once", async () => {
+    const root = mkdtempSync(join(tmpdir(), "tg-"));
+    const client = fakeClient();
+    const sub = await createTelegramSubsystem(baseDeps(client, root));
+    await Promise.all([
+      sub.pushLifecycle({ project: "cockpit", message: "a", record: rec() }),
+      sub.pushLifecycle({ project: "cockpit", message: "b", record: rec() }),
+    ]);
+    expect(client.createForumTopic).toHaveBeenCalledTimes(1);
+    expect(client.sendMessage).toHaveBeenCalledTimes(2);
+  });
+
   it("never throws when the client fails (best-effort)", async () => {
     const root = mkdtempSync(join(tmpdir(), "tg-"));
     const client = fakeClient({ sendMessage: vi.fn(async () => { throw new Error("network down"); }) });
@@ -80,7 +93,7 @@ describe("telegram subsystem — inbound routing (pure)", () => {
 
   it("routes a crew-topic reply to that crew's captain via appendCaptainMessage", async () => {
     const append = vi.fn(async () => 1);
-    const findTask = (thread: number) => (thread === 42 ? { project: "cockpit", taskId: "t1" } : undefined);
+    const findTask = (_project: string, thread: number) => (thread === 42 ? { project: "cockpit", taskId: "t1" } : undefined);
     const handled = await processInboundUpdate({
       update: { update_id: 5, message: { chat: { id: -100, type: "supergroup" }, message_thread_id: 42, text: "use lucia" } },
       chats, findTask, resolveCrewName: () => "crew-2",
@@ -109,6 +122,27 @@ describe("telegram subsystem — inbound routing (pure)", () => {
     });
     expect(handled).toBe(false);
     expect(append).not.toHaveBeenCalled();
+  });
+
+  it("inbound loop advances offset past a poisoned update whose appendCaptainMessage throws", async () => {
+    const root = mkdtempSync(join(tmpdir(), "tg-"));
+    const poison = { update_id: 5, message: { chat: { id: -100, type: "supergroup" }, text: "hi" } };
+    const getUpdates = vi.fn()
+      .mockResolvedValueOnce([poison])
+      // Slow subsequent polls to prevent tight looping; test completes before this resolves.
+      .mockImplementation(() => new Promise<[]>((r) => setTimeout(() => r([]), 5000)));
+    const appendCaptainMessage = vi.fn()
+      .mockRejectedValueOnce(new Error("mailbox locked"))
+      .mockResolvedValue(1);
+    const client = fakeClient({ getUpdates });
+    const sub = await createTelegramSubsystem({ ...baseDeps(client, root), appendCaptainMessage });
+    sub.startInbound();
+    // Let the loop process one batch (first getUpdates returns [poison])
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    sub.stop();
+    // Offset must have advanced to 6 (poison_id+1) despite the throw
+    const state = await loadTelegramState(root);
+    expect(state.offset()).toBe(6);
   });
 
   it("ignores updates with no text (e.g. join events)", async () => {

--- a/src/control/telegram/__tests__/subsystem.test.ts
+++ b/src/control/telegram/__tests__/subsystem.test.ts
@@ -1,0 +1,76 @@
+// src/control/telegram/__tests__/subsystem.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createTelegramSubsystem } from "../subsystem.js";
+import type { TelegramClient } from "../client.js";
+import type { TaskRecord } from "../../types.js";
+
+function fakeClient(over: Partial<TelegramClient> = {}): TelegramClient {
+  return {
+    getMe: vi.fn(async () => {}),
+    getUpdates: vi.fn(async () => []),
+    sendMessage: vi.fn(async () => {}),
+    createForumTopic: vi.fn(async () => 42),
+    closeForumTopic: vi.fn(async () => {}),
+    ...over,
+  };
+}
+
+function rec(over: Partial<TaskRecord> = {}): TaskRecord {
+  return { id: "t1", project: "cockpit", name: "crew-1", provider: "claude", state: "working", mode: "interactive", task: "x", lastHeartbeat: 0, createdAt: 0, ...over } as TaskRecord;
+}
+
+const baseDeps = (client: TelegramClient, root: string) => ({
+  client,
+  chats: { cockpit: -100 },
+  stateRoot: root,
+  appendCaptainMessage: vi.fn(async () => 1),
+  resolveCrewName: () => "crew-1",
+  log: () => {},
+});
+
+describe("telegram subsystem — outbound", () => {
+  it("creates a topic on first push and sends into it", async () => {
+    const root = mkdtempSync(join(tmpdir(), "tg-"));
+    const client = fakeClient();
+    const sub = await createTelegramSubsystem(baseDeps(client, root));
+    await sub.pushLifecycle({ project: "cockpit", message: "CREW BLOCKED: ?", record: rec() });
+    expect(client.createForumTopic).toHaveBeenCalledWith(-100, "🔧 crew-1");
+    expect(client.sendMessage).toHaveBeenCalledWith(-100, "CREW BLOCKED: ?", 42);
+  });
+
+  it("reuses an existing topic on the second push (no second create)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "tg-"));
+    const client = fakeClient();
+    const sub = await createTelegramSubsystem(baseDeps(client, root));
+    await sub.pushLifecycle({ project: "cockpit", message: "a", record: rec() });
+    await sub.pushLifecycle({ project: "cockpit", message: "b", record: rec() });
+    expect(client.createForumTopic).toHaveBeenCalledTimes(1);
+    expect(client.sendMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("no-ops for an unlinked project", async () => {
+    const root = mkdtempSync(join(tmpdir(), "tg-"));
+    const client = fakeClient();
+    const sub = await createTelegramSubsystem(baseDeps(client, root));
+    await sub.pushLifecycle({ project: "brove", message: "x", record: rec({ project: "brove" }) });
+    expect(client.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("closes the topic after a terminal-state push", async () => {
+    const root = mkdtempSync(join(tmpdir(), "tg-"));
+    const client = fakeClient();
+    const sub = await createTelegramSubsystem(baseDeps(client, root));
+    await sub.pushLifecycle({ project: "cockpit", message: "CREW DONE", record: rec({ state: "done" }) });
+    expect(client.closeForumTopic).toHaveBeenCalledWith(-100, 42);
+  });
+
+  it("never throws when the client fails (best-effort)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "tg-"));
+    const client = fakeClient({ sendMessage: vi.fn(async () => { throw new Error("network down"); }) });
+    const sub = await createTelegramSubsystem(baseDeps(client, root));
+    await expect(sub.pushLifecycle({ project: "cockpit", message: "x", record: rec() })).resolves.toBeUndefined();
+  });
+});

--- a/src/control/telegram/client.ts
+++ b/src/control/telegram/client.ts
@@ -36,6 +36,11 @@ interface TgResponse<T> {
   description?: string;
 }
 
+/** Replaces all occurrences of a bot token in a string with "***". */
+export function redactToken(token: string, text: string): string {
+  return text.replaceAll(token, "***");
+}
+
 export function createTelegramClient(
   botToken: string,
   fetchImpl: typeof fetch = fetch,

--- a/src/control/telegram/client.ts
+++ b/src/control/telegram/client.ts
@@ -1,0 +1,77 @@
+// src/control/telegram/client.ts
+
+export interface TgChat {
+  id: number;
+  type: string;
+  title?: string;
+}
+
+export interface TgUpdate {
+  update_id: number;
+  message?: {
+    chat: TgChat;
+    message_thread_id?: number;
+    text?: string;
+    from?: { id: number; username?: string };
+  };
+  /** Emitted when the bot is added to / removed from a chat — used by `telegram link`. */
+  my_chat_member?: {
+    chat: TgChat;
+    new_chat_member?: { status: string };
+  };
+}
+
+export interface TelegramClient {
+  getMe(): Promise<void>;
+  getUpdates(offset: number, timeoutS: number, signal?: AbortSignal): Promise<TgUpdate[]>;
+  sendMessage(chatId: number, text: string, threadId?: number): Promise<void>;
+  /** Returns the new topic's message_thread_id. */
+  createForumTopic(chatId: number, name: string): Promise<number>;
+  closeForumTopic(chatId: number, threadId: number): Promise<void>;
+}
+
+interface TgResponse<T> {
+  ok: boolean;
+  result?: T;
+  description?: string;
+}
+
+export function createTelegramClient(
+  botToken: string,
+  fetchImpl: typeof fetch = fetch,
+): TelegramClient {
+  const base = `https://api.telegram.org/bot${botToken}`;
+
+  async function call<T>(method: string, body: Record<string, unknown>, signal?: AbortSignal): Promise<T> {
+    const res = await fetchImpl(`${base}/${method}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      signal,
+    });
+    const json = (await res.json()) as TgResponse<T>;
+    if (!json.ok) throw new Error(json.description ?? `telegram ${method} failed`);
+    return json.result as T;
+  }
+
+  return {
+    async getMe() {
+      await call<unknown>("getMe", {});
+    },
+    async getUpdates(offset, timeoutS, signal) {
+      return call<TgUpdate[]>("getUpdates", { offset, timeout: timeoutS }, signal);
+    },
+    async sendMessage(chatId, text, threadId) {
+      const body: Record<string, unknown> = { chat_id: chatId, text };
+      if (threadId !== undefined) body.message_thread_id = threadId;
+      await call<unknown>("sendMessage", body);
+    },
+    async createForumTopic(chatId, name) {
+      const r = await call<{ message_thread_id: number }>("createForumTopic", { chat_id: chatId, name });
+      return r.message_thread_id;
+    },
+    async closeForumTopic(chatId, threadId) {
+      await call<unknown>("closeForumTopic", { chat_id: chatId, message_thread_id: threadId });
+    },
+  };
+}

--- a/src/control/telegram/format.ts
+++ b/src/control/telegram/format.ts
@@ -1,0 +1,11 @@
+// src/control/telegram/format.ts
+
+/** Forum-topic title for a crew session. */
+export function crewTopicName(crewName: string): string {
+  return `🔧 ${crewName}`;
+}
+
+/** Captain-facing rendering of an inbound Telegram reply. */
+export function inboundCaptainMessage(crewName: string | undefined, text: string): string {
+  return crewName ? `📩 [from Telegram · ${crewName}] ${text}` : `📩 [from Telegram] ${text}`;
+}

--- a/src/control/telegram/index.ts
+++ b/src/control/telegram/index.ts
@@ -1,5 +1,5 @@
 // src/control/telegram/index.ts
-export { createTelegramClient } from "./client.js";
+export { createTelegramClient, redactToken } from "./client.js";
 export type { TelegramClient, TgUpdate } from "./client.js";
 export { createTelegramSubsystem, processInboundUpdate } from "./subsystem.js";
 export type { TelegramSubsystem } from "./subsystem.js";

--- a/src/control/telegram/index.ts
+++ b/src/control/telegram/index.ts
@@ -1,0 +1,6 @@
+// src/control/telegram/index.ts
+export { createTelegramClient } from "./client.js";
+export type { TelegramClient, TgUpdate } from "./client.js";
+export { createTelegramSubsystem, processInboundUpdate } from "./subsystem.js";
+export type { TelegramSubsystem } from "./subsystem.js";
+export { loadTelegramState } from "./state.js";

--- a/src/control/telegram/state.ts
+++ b/src/control/telegram/state.ts
@@ -1,0 +1,64 @@
+// src/control/telegram/state.ts
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+
+interface PersistShape {
+  offset: number;
+  topics: Record<string, number>; // `${project}::${taskId}` -> message_thread_id
+}
+
+export interface TelegramState {
+  offset(): number;
+  setOffset(n: number): Promise<void>;
+  getTopic(project: string, taskId: string): number | undefined;
+  setTopic(project: string, taskId: string, threadId: number): Promise<void>;
+  findTask(threadId: number): { project: string; taskId: string } | undefined;
+}
+
+function statePath(stateRoot: string): string {
+  return join(stateRoot, "telegram-state.json");
+}
+
+function key(project: string, taskId: string): string {
+  return `${project}::${taskId}`;
+}
+
+export async function loadTelegramState(stateRoot: string): Promise<TelegramState> {
+  let data: PersistShape = { offset: 0, topics: {} };
+  try {
+    data = JSON.parse(await fs.readFile(statePath(stateRoot), "utf-8")) as PersistShape;
+    if (typeof data.offset !== "number") data.offset = 0;
+    if (!data.topics) data.topics = {};
+  } catch {
+    // ENOENT / corrupt → start fresh
+  }
+
+  async function persist(): Promise<void> {
+    await fs.mkdir(stateRoot, { recursive: true });
+    const tmp = statePath(stateRoot) + ".tmp";
+    await fs.writeFile(tmp, JSON.stringify(data), "utf-8");
+    await fs.rename(tmp, statePath(stateRoot));
+  }
+
+  return {
+    offset: () => data.offset,
+    async setOffset(n) {
+      data.offset = n;
+      await persist();
+    },
+    getTopic: (project, taskId) => data.topics[key(project, taskId)],
+    async setTopic(project, taskId, threadId) {
+      data.topics[key(project, taskId)] = threadId;
+      await persist();
+    },
+    findTask(threadId) {
+      for (const [k, v] of Object.entries(data.topics)) {
+        if (v === threadId) {
+          const sep = k.indexOf("::");
+          return { project: k.slice(0, sep), taskId: k.slice(sep + 2) };
+        }
+      }
+      return undefined;
+    },
+  };
+}

--- a/src/control/telegram/state.ts
+++ b/src/control/telegram/state.ts
@@ -12,7 +12,7 @@ export interface TelegramState {
   setOffset(n: number): Promise<void>;
   getTopic(project: string, taskId: string): number | undefined;
   setTopic(project: string, taskId: string, threadId: number): Promise<void>;
-  findTask(threadId: number): { project: string; taskId: string } | undefined;
+  findTask(project: string, threadId: number): { project: string; taskId: string } | undefined;
 }
 
 function statePath(stateRoot: string): string {
@@ -51,11 +51,11 @@ export async function loadTelegramState(stateRoot: string): Promise<TelegramStat
       data.topics[key(project, taskId)] = threadId;
       await persist();
     },
-    findTask(threadId) {
+    findTask(project, threadId) {
+      const prefix = `${project}::`;
       for (const [k, v] of Object.entries(data.topics)) {
-        if (v === threadId) {
-          const sep = k.indexOf("::");
-          return { project: k.slice(0, sep), taskId: k.slice(sep + 2) };
+        if (v === threadId && k.startsWith(prefix)) {
+          return { project, taskId: k.slice(prefix.length) };
         }
       }
       return undefined;

--- a/src/control/telegram/subsystem.ts
+++ b/src/control/telegram/subsystem.ts
@@ -26,7 +26,7 @@ export interface TelegramSubsystem {
 export interface InboundRouterDeps {
   update: TgUpdate;
   chats: Record<string, number>;
-  findTask: (threadId: number) => { project: string; taskId: string } | undefined;
+  findTask: (project: string, threadId: number) => { project: string; taskId: string } | undefined;
   resolveCrewName: (project: string, taskId: string) => string | undefined;
   appendCaptainMessage: TelegramSubsystemDeps["appendCaptainMessage"];
   stateRoot: string;
@@ -47,7 +47,7 @@ export async function processInboundUpdate(deps: InboundRouterDeps): Promise<boo
   const [project] = entry;
 
   // Resolve target task from the topic thread (absent / unknown → captain).
-  const found = msg.message_thread_id !== undefined ? deps.findTask(msg.message_thread_id) : undefined;
+  const found = msg.message_thread_id !== undefined ? deps.findTask(project, msg.message_thread_id) : undefined;
   const taskId = found?.taskId;
   const crewName = found ? deps.resolveCrewName(found.project, found.taskId) : undefined;
 
@@ -63,13 +63,25 @@ export async function processInboundUpdate(deps: InboundRouterDeps): Promise<boo
 
 export async function createTelegramSubsystem(deps: TelegramSubsystemDeps): Promise<TelegramSubsystem> {
   const state: TelegramState = await loadTelegramState(deps.stateRoot);
+  // Serialize topic creation per (project, taskId) — prevents duplicate createForumTopic
+  // calls when two rapid lifecycle events race on a new task.
+  const creating = new Map<string, Promise<number>>();
 
   async function topicFor(project: string, chatId: number, record: TaskRecord): Promise<number> {
     const existing = state.getTopic(project, record.id);
     if (existing !== undefined) return existing;
-    const threadId = await deps.client.createForumTopic(chatId, crewTopicName(record.name ?? record.id));
-    await state.setTopic(project, record.id, threadId);
-    return threadId;
+    const k = `${project}::${record.id}`;
+    let inflight = creating.get(k);
+    if (!inflight) {
+      inflight = (async () => {
+        const threadId = await deps.client.createForumTopic(chatId, crewTopicName(record.name ?? record.id));
+        await state.setTopic(project, record.id, threadId);
+        creating.delete(k);
+        return threadId;
+      })();
+      creating.set(k, inflight);
+    }
+    return inflight;
   }
 
   async function pushLifecycle(args: { project: string; message: string; record: TaskRecord }): Promise<void> {
@@ -82,7 +94,9 @@ export async function createTelegramSubsystem(deps: TelegramSubsystemDeps): Prom
         await deps.client.closeForumTopic(chatId, threadId);
       }
     } catch (e) {
-      deps.log(`telegram push failed project=${args.project}: ${(e as Error).message}`);
+      const err = e as Error;
+      const cause = err.cause ? ` cause=${String(err.cause)}` : "";
+      deps.log(`telegram push failed project=${args.project}: ${err.message}${cause}`);
     }
   }
 
@@ -94,22 +108,32 @@ export async function createTelegramSubsystem(deps: TelegramSubsystemDeps): Prom
       while (!stopped) {
         try {
           abort = new AbortController();
-          const updates = await deps.client.getUpdates(state.offset(), 30, abort.signal);
+          // Combine manual stop signal with a client-side timeout so a black-holed
+          // TCP connection is reaped after ~35s rather than hanging indefinitely.
+          const signal = AbortSignal.any([abort.signal, AbortSignal.timeout(35_000)]);
+          const updates = await deps.client.getUpdates(state.offset(), 30, signal);
           for (const update of updates) {
-            await processInboundUpdate({
-              update,
-              chats: deps.chats,
-              findTask: state.findTask.bind(state),
-              resolveCrewName: deps.resolveCrewName,
-              appendCaptainMessage: deps.appendCaptainMessage,
-              stateRoot: deps.stateRoot,
-              log: deps.log,
-            });
+            try {
+              await processInboundUpdate({
+                update,
+                chats: deps.chats,
+                findTask: state.findTask.bind(state),
+                resolveCrewName: deps.resolveCrewName,
+                appendCaptainMessage: deps.appendCaptainMessage,
+                stateRoot: deps.stateRoot,
+                log: deps.log,
+              });
+            } catch (e) {
+              deps.log(`telegram inbound update ${update.update_id} failed: ${(e as Error).message}`);
+            }
+            // Advance offset regardless of per-update failure — prevents poison-update wedge.
             await state.setOffset(update.update_id + 1);
           }
         } catch (e) {
           if (stopped) return;
-          deps.log(`telegram inbound loop error: ${(e as Error).message}`);
+          const err = e as Error;
+          const cause = err.cause ? ` cause=${String(err.cause)}` : "";
+          deps.log(`telegram inbound loop error: ${err.message}${cause}`);
           await new Promise((r) => setTimeout(r, 3000)); // backoff; never tight-loops
         }
       }

--- a/src/control/telegram/subsystem.ts
+++ b/src/control/telegram/subsystem.ts
@@ -1,0 +1,125 @@
+// src/control/telegram/subsystem.ts
+import { loadTelegramState, type TelegramState } from "./state.js";
+import { crewTopicName, inboundCaptainMessage } from "./format.js";
+import type { TelegramClient, TgUpdate } from "./client.js";
+import type { TaskRecord } from "../types.js";
+import { TERMINAL_STATES } from "../types.js";
+
+export interface TelegramSubsystemDeps {
+  client: TelegramClient;
+  /** project → supergroup chat_id (also the inbound allowlist). */
+  chats: Record<string, number>;
+  stateRoot: string;
+  /** Inbound delivery seam — bound to mailbox.appendCaptainMessage by the daemon. */
+  appendCaptainMessage: (opts: { stateRoot: string; project: string; message: string; taskId?: string; name?: string }) => Promise<number>;
+  /** Resolve a crew display name from a taskId (store lookup), used on inbound. */
+  resolveCrewName: (project: string, taskId: string) => string | undefined;
+  log: (m: string) => void;
+}
+
+export interface TelegramSubsystem {
+  pushLifecycle(args: { project: string; message: string; record: TaskRecord }): Promise<void>;
+  startInbound(): void;
+  stop(): void;
+}
+
+export interface InboundRouterDeps {
+  update: TgUpdate;
+  chats: Record<string, number>;
+  findTask: (threadId: number) => { project: string; taskId: string } | undefined;
+  resolveCrewName: (project: string, taskId: string) => string | undefined;
+  appendCaptainMessage: TelegramSubsystemDeps["appendCaptainMessage"];
+  stateRoot: string;
+  log: (m: string) => void;
+}
+
+/** Pure-ish: route ONE update. Returns true if it produced a captain message. */
+export async function processInboundUpdate(deps: InboundRouterDeps): Promise<boolean> {
+  const msg = deps.update.message;
+  if (!msg || !msg.text) return false;
+
+  // Allowlist: chat must be a linked supergroup. Reverse chat_id → project.
+  const entry = Object.entries(deps.chats).find(([, id]) => id === msg.chat.id);
+  if (!entry) {
+    deps.log(`telegram inbound ignored: chat ${msg.chat.id} not allowlisted`);
+    return false;
+  }
+  const [project] = entry;
+
+  // Resolve target task from the topic thread (absent / unknown → captain).
+  const found = msg.message_thread_id !== undefined ? deps.findTask(msg.message_thread_id) : undefined;
+  const taskId = found?.taskId;
+  const crewName = found ? deps.resolveCrewName(found.project, found.taskId) : undefined;
+
+  await deps.appendCaptainMessage({
+    stateRoot: deps.stateRoot,
+    project,
+    message: inboundCaptainMessage(crewName, msg.text),
+    taskId,
+    name: crewName,
+  });
+  return true;
+}
+
+export async function createTelegramSubsystem(deps: TelegramSubsystemDeps): Promise<TelegramSubsystem> {
+  const state: TelegramState = await loadTelegramState(deps.stateRoot);
+
+  async function topicFor(project: string, chatId: number, record: TaskRecord): Promise<number> {
+    const existing = state.getTopic(project, record.id);
+    if (existing !== undefined) return existing;
+    const threadId = await deps.client.createForumTopic(chatId, crewTopicName(record.name ?? record.id));
+    await state.setTopic(project, record.id, threadId);
+    return threadId;
+  }
+
+  async function pushLifecycle(args: { project: string; message: string; record: TaskRecord }): Promise<void> {
+    try {
+      const chatId = deps.chats[args.project];
+      if (chatId === undefined) return; // project not linked
+      const threadId = await topicFor(args.project, chatId, args.record);
+      await deps.client.sendMessage(chatId, args.message, threadId);
+      if (TERMINAL_STATES.has(args.record.state)) {
+        await deps.client.closeForumTopic(chatId, threadId);
+      }
+    } catch (e) {
+      deps.log(`telegram push failed project=${args.project}: ${(e as Error).message}`);
+    }
+  }
+
+  let stopped = false;
+  let abort: AbortController | undefined;
+
+  function startInbound(): void {
+    void (async () => {
+      while (!stopped) {
+        try {
+          abort = new AbortController();
+          const updates = await deps.client.getUpdates(state.offset(), 30, abort.signal);
+          for (const update of updates) {
+            await processInboundUpdate({
+              update,
+              chats: deps.chats,
+              findTask: state.findTask.bind(state),
+              resolveCrewName: deps.resolveCrewName,
+              appendCaptainMessage: deps.appendCaptainMessage,
+              stateRoot: deps.stateRoot,
+              log: deps.log,
+            });
+            await state.setOffset(update.update_id + 1);
+          }
+        } catch (e) {
+          if (stopped) return;
+          deps.log(`telegram inbound loop error: ${(e as Error).message}`);
+          await new Promise((r) => setTimeout(r, 3000)); // backoff; never tight-loops
+        }
+      }
+    })();
+  }
+
+  function stop(): void {
+    stopped = true;
+    abort?.abort();
+  }
+
+  return { pushLifecycle, startInbound, stop };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import { codexChatSmokeCommand } from "./commands/codex-chat-smoke.js";
 import { configCommand } from "./commands/config.js";
 import { healCommand } from "./commands/heal.js";
 import { groupCommand } from "./commands/group.js";
+import { telegramCommand } from "./commands/telegram.js";
 import { detectDrift } from "./lib/config-drift.js";
 import { needsCheck, withStamp } from "./lib/config-version.js";
 import { getDefaultConfig } from "./config.js";
@@ -112,6 +113,7 @@ program.addCommand(codexChatSmokeCommand);
 program.addCommand(configCommand);
 program.addCommand(healCommand);
 program.addCommand(groupCommand);
+program.addCommand(telegramCommand);
 
 program.parseAsync().catch((e) => {
   process.stderr.write(`error: ${e instanceof Error ? e.message : String(e)}\n`);


### PR DESCRIPTION
## Summary

- **Outbound:** daemon lifecycle events (crew done/blocked/idle) push to Telegram forum topics — one topic per crew session, auto-provisioned on first event. Best-effort: a failed send never blocks or delays cmux relay delivery.
- **Inbound:** `getUpdates` long-poll loop maps `(chat_id, message_thread_id)` → captain message via the existing mailbox relay — no new cmux proxy, no relay change. Replies become `captain.message` mailbox entries the existing relay delivers verbatim.
- **CLI:** `cockpit telegram link <project>` / `cockpit telegram status` for setup.
- **Opt-in + crash-contained:** zero impact when `telegram` config is absent; subsystem failures cannot throw into the daemon event loop, mailbox, state-machine, or watchdog.

## Architecture decisions (from spec)

- O1 (outbound): composes the daemon's existing `notify` fan-out with `void telegram.pushLifecycle(...)` — cmux relay untouched.
- O2 (inbound): new `captain.message` mailbox kind; relay's `deliverable()` already handles it — no relay change.
- Security: `chat_id` allowlist derived from `config.telegram.chats`; inbound text becomes a captain message, never a shell command.
- No third-party SDK — plain `fetch` over Bot API.
- Forum Topics: one supergroup per project; `message_thread_id` is the routing key both directions.

## New files

- `src/control/telegram/client.ts` — Bot API HTTP client (fetch-based, injectable)
- `src/control/telegram/state.ts` — persistent offset + topic registry
- `src/control/telegram/format.ts` — topic-name + inbound-message formatters (pure)
- `src/control/telegram/subsystem.ts` — outbound push + inbound long-poll; crash-contained
- `src/control/telegram/index.ts` — barrel
- `src/commands/telegram.ts` — `cockpit telegram link|status`
- Test files for each of the above

## Modified files

- `src/config.ts` — `TelegramConfig` type + `CockpitConfig.telegram?`
- `src/control/mailbox.ts` — widen `kind` union; add `appendCaptainMessage`
- `src/control/cockpitd.ts` — wire subsystem (compose notify, start inbound, stop); add `opts.telegram`
- `src/index.ts` — register `telegramCommand`
- `README.md` / `AGENTS.md` — setup guide + feature note

## Test plan

- [x] `npm test` — 1146 tests pass, 0 failures
- [x] `npm run build` — tsc exits 0
- [x] `node dist/index.js telegram status` — prints `token: invalid/unset` / `no projects linked` (no crash)
- [x] TDD for all 11 tasks: write failing test → implement → pass → commit
- [x] Existing mailbox + relay tests unaffected (backward-compatible `kind` widening)
- [x] Daemon isolation test: injected throwing subsystem never crashes the daemon
- [x] Concurrent crew snapshot work (other branch) kept isolated — cockpitd.ts changes are surgical