### PR TITLE
fix(dashboard): snapshot/probe accuracy (vault check, project scope, lag, severity)

### DIFF
--- a/src/control/__tests__/cockpitd-snapshot.test.ts
+++ b/src/control/__tests__/cockpitd-snapshot.test.ts
@@ -19,7 +19,8 @@ describe("cockpitd snapshot verb", () => {
   it("returns a Tier 0/1/2 snapshot and leaves the health verb intact", async () => {
     dir = mkdtempSync(join(tmpdir(), "cp-snap-"));
     const sock = join(dir, "c.sock");
-    const handle = startCockpitd({ stateRoot: join(dir, "state"), sockPath: sock, sweepMs: 0 });
+    // registeredProjects scopes Tier 2 to known projects (avoids config.json dependency in tests)
+    const handle = startCockpitd({ stateRoot: join(dir, "state"), sockPath: sock, sweepMs: 0, registeredProjects: ["demo"] });
     stop = handle.stop;
 
     await sendRequest(sock, { kind: "seed", record: {
@@ -51,5 +52,28 @@ describe("cockpitd snapshot verb", () => {
     // The pre-existing health verb is unchanged.
     const health = await sendRequest(sock, { kind: "health", project: "demo" }) as unknown[];
     expect(Array.isArray(health)).toBe(true);
+  });
+
+  it("excludes unregistered (orphan) projects from tier2 projects list", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-snap-orphan-"));
+    const sock = join(dir, "c.sock");
+    // "registered" is the only registered project; "orphan" has a task but is not registered
+    const handle = startCockpitd({ stateRoot: join(dir, "state"), sockPath: sock, sweepMs: 0, registeredProjects: ["registered"] });
+    stop = handle.stop;
+
+    await sendRequest(sock, { kind: "seed", record: {
+      id: "t-reg", project: "registered", provider: "claude", mode: "interactive",
+      state: "working", task: "a", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000,
+      attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }] } });
+    await sendRequest(sock, { kind: "seed", record: {
+      id: "t-orp", project: "orphan", provider: "claude", mode: "interactive",
+      state: "done", task: "stale", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000,
+      attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }] } });
+
+    const snap = await sendRequest(sock, { kind: "snapshot" }) as DaemonSnapshot;
+    expect(snap.tier2.projects.find((p) => p.project === "registered")).toBeDefined();
+    expect(snap.tier2.projects.find((p) => p.project === "orphan")).toBeUndefined();
   });
 });

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -83,6 +83,9 @@ export interface CockpitdOpts {
   healRelay?: (project: string) => Promise<void> | void;
   /** Inject a fake headless launcher for tests to avoid real process spawns. */
   launchHeadless?: (rec: TaskRecord) => Promise<void>;
+  /** Override which projects appear in the Tier 2 per-project snapshot. Defaults
+   *  to Object.keys(loadConfig().projects). Tests inject this to avoid real config. */
+  registeredProjects?: string[];
   /** Inject a fake opencode SSE bridge for tests. Defaults to a real one. */
   opencodeBridge?: {
     start: (o: { taskId: string; port: number }) => void;
@@ -488,8 +491,11 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   // tests isolated to their temp dir.
   async function gatherSnapshotInputs(now: number): Promise<DaemonSnapshotInputs> {
     const logPath = join(dirname(stateRoot), "cockpitd.log");
+    // Scope Tier 2 per-project data to registered projects only. Orphan state
+    // directories from removed/test projects are excluded here.
+    const tier2Projects = opts.registeredProjects ?? Object.keys(loadConfig().projects);
     const projects = await Promise.all(
-      knownProjects().map(async (project) => {
+      tier2Projects.map(async (project) => {
         const cursor = await readCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER });
         const storeStats = gatherStoreStats(store, stateRoot, project);
         return {

--- a/src/dashboard/__tests__/probes.test.ts
+++ b/src/dashboard/__tests__/probes.test.ts
@@ -74,19 +74,32 @@ describe("probeAgentClis", () => {
 });
 
 describe("probeVaults", () => {
-  it("is alive when the vault dir and its .obsidian/ both exist", () => {
+  it("is alive when the hub dir and its .obsidian/ both exist, and spoke dir exists", () => {
     const v = probeVaults(okRunners(), cfg());
     expect(v.hub.state).toBe("alive");
     expect(v.spokes[0].project).toBe("cockpit");
     expect(v.spokes[0].state).toBe("alive");
   });
-  it("is gone when the vault directory is missing", () => {
+  it("hub is gone when the vault directory is missing", () => {
     const v = probeVaults(okRunners({ pathExists: () => false }), cfg());
     expect(v.hub.state).toBe("gone");
   });
-  it("is gone when the dir exists but has no .obsidian/", () => {
+  it("hub is gone when its dir exists but has no .obsidian/", () => {
     const v = probeVaults(okRunners({ pathExists: (p) => !p.endsWith(".obsidian") }), cfg());
     expect(v.hub.state).toBe("gone");
+  });
+  // Spokes live inside the hub vault — they correctly have no .obsidian/ of their own.
+  it("spoke is alive when its directory exists even without .obsidian/", () => {
+    const v = probeVaults(okRunners({ pathExists: (p) => !p.endsWith(".obsidian") }), cfg());
+    expect(v.spokes[0].state).toBe("alive");
+  });
+  it("spoke is gone when its directory is missing", () => {
+    // hub dir + hub .obsidian/ exist; spoke dir is missing
+    const v = probeVaults(
+      okRunners({ pathExists: (p) => p === cfg().hubVault || p.endsWith(".obsidian") }),
+      cfg(),
+    );
+    expect(v.spokes[0].state).toBe("gone");
   });
 });
 
@@ -103,9 +116,9 @@ describe("probeSessions", () => {
   it("is alive when a single template hash is recorded", () => {
     expect(probeSessions(okRunners()).state).toBe("alive");
   });
-  it("is gone (drift) when multiple distinct template hashes are recorded", () => {
+  it("is stale/caution (not fault) when multiple distinct template hashes are recorded", () => {
     const s = probeSessions(okRunners({ loadSessionsHashes: () => ["a", "b"] }));
-    expect(s.state).toBe("gone");
+    expect(s.state).toBe("stale"); // drift is expected across template versions — caution, not fault
     expect(s.detail).toMatch(/drift/);
   });
   it("is unknown when no sessions are recorded", () => {

--- a/src/dashboard/__tests__/web-render.test.ts
+++ b/src/dashboard/__tests__/web-render.test.ts
@@ -243,6 +243,65 @@ describe("delivery lag bar", () => {
   });
 });
 
+describe("global delivery-lag excludes offline-relay projects", () => {
+  it("global behind in metrics blob is 0 when the only relay is gone", () => {
+    const d = daemon();
+    d.tier1 = [
+      { kind: "relay", project: "cockpit", ref: "relay", state: "gone", lastSeenMs: 1 },
+      { kind: "captain", project: "cockpit", ref: "captain", state: "gone", lastSeenMs: 1 },
+    ];
+    d.tier2.projects[0].delivery = { maxSeq: 10, lastAckedSeq: 5, behind: 5 };
+    const out = renderContent(full(d));
+    const m = out.match(/id="cockpit-metrics">(.*?)<\/script>/s);
+    const metrics = JSON.parse(m![1].replace(/\\u003c/g, "<"));
+    expect(metrics.behind).toBe(0); // relay gone → not a live delivery problem
+  });
+  it("global behind is 0 when relay state is unknown (no relay registered)", () => {
+    const d = daemon();
+    d.tier1 = [
+      { kind: "relay", project: "cockpit", ref: "relay", state: "unknown", lastSeenMs: null },
+      { kind: "captain", project: "cockpit", ref: "captain", state: "unknown", lastSeenMs: null },
+    ];
+    d.tier2.projects[0].delivery = { maxSeq: 10, lastAckedSeq: 5, behind: 5 };
+    const out = renderContent(full(d));
+    const m = out.match(/id="cockpit-metrics">(.*?)<\/script>/s);
+    const metrics = JSON.parse(m![1].replace(/\\u003c/g, "<"));
+    expect(metrics.behind).toBe(0); // relay unknown → offline, excluded
+  });
+  it("global behind includes lag for projects whose relay is alive", () => {
+    const d = daemon();
+    // default tier1 from daemon() has no relay entries — relay is implicitly absent
+    // override with an alive relay
+    d.tier1 = [
+      { kind: "relay", project: "cockpit", ref: "relay", state: "alive", lastSeenMs: 999_000 },
+      { kind: "captain", project: "cockpit", ref: "captain", state: "alive", lastSeenMs: 999_000 },
+    ];
+    d.tier2.projects[0].delivery = { maxSeq: 10, lastAckedSeq: 7, behind: 3 };
+    const out = renderContent(full(d));
+    const m = out.match(/id="cockpit-metrics">(.*?)<\/script>/s);
+    const metrics = JSON.parse(m![1].replace(/\\u003c/g, "<"));
+    expect(metrics.behind).toBe(3); // relay alive → included
+  });
+});
+
+describe("global results location", () => {
+  it("global results line appears only in the daemon tab, not the projects tab", () => {
+    const out = renderContent(full(daemon()));
+    // exactly one occurrence
+    const occurrences = (out.match(/global results/g) ?? []).length;
+    expect(occurrences).toBe(1);
+    // must be inside the daemon panel
+    const daemonStart = out.indexOf('data-panel="daemon"');
+    const envStart = out.indexOf('data-panel="environment"');
+    const daemonSection = out.slice(daemonStart, envStart);
+    expect(daemonSection).toContain("global results");
+    // must NOT be inside the projects panel
+    const projStart = out.indexOf('data-panel="projects"');
+    const projectsSection = out.slice(projStart, daemonStart);
+    expect(projectsSection).not.toContain("global results");
+  });
+});
+
 describe("escaping", () => {
   it("HTML-escapes crew refs/details to prevent injection", () => {
     const evil: DaemonSnapshot["tier1"] = [

--- a/src/dashboard/probes.ts
+++ b/src/dashboard/probes.ts
@@ -14,7 +14,7 @@ import type { CockpitConfig } from "../config.js";
 import { loadConfig } from "../config.js";
 import { resolveCmuxBin } from "../lib/cmux-bin.js";
 
-export type ProbeState = "alive" | "gone" | "unknown";
+export type ProbeState = "alive" | "stale" | "gone" | "unknown";
 
 export interface Probe {
   state: ProbeState;

--- a/src/dashboard/probes.ts
+++ b/src/dashboard/probes.ts
@@ -91,12 +91,24 @@ export async function probeAgentClis(
   );
 }
 
-/** A vault is alive only when its directory AND its `.obsidian/` both exist. */
+/** Hub vault is alive only when its directory AND its `.obsidian/` both exist. */
 function vaultProbe(run: ProbeRunners, dir: string): Probe {
   try {
     if (!dir) return { state: "unknown", detail: "no vault configured" };
     if (!run.pathExists(dir)) return { state: "gone", detail: "vault directory missing" };
     if (!run.pathExists(join(dir, ".obsidian"))) return { state: "gone", detail: "no .obsidian/ (not a vault)" };
+    return { state: "alive" };
+  } catch {
+    return { state: "unknown" };
+  }
+}
+
+/** Spoke vault directories live INSIDE the hub vault and correctly have no
+ *  `.obsidian/` of their own. Alive = directory exists; gone = directory missing. */
+function spokeProbe(run: ProbeRunners, dir: string): Probe {
+  try {
+    if (!dir) return { state: "unknown", detail: "no vault configured" };
+    if (!run.pathExists(dir)) return { state: "gone", detail: "spoke directory missing" };
     return { state: "alive" };
   } catch {
     return { state: "unknown" };
@@ -109,7 +121,7 @@ export function probeVaults(run: ProbeRunners, config: CockpitConfig): ExternalP
     spokes: Object.entries(config.projects).map(([project, p]) => ({
       project,
       path: p.spokeVault,
-      ...vaultProbe(run, p.spokeVault),
+      ...spokeProbe(run, p.spokeVault),
     })),
   };
 }
@@ -145,7 +157,7 @@ export function probeSessions(run: ProbeRunners): Probe {
     const hashes = run.loadSessionsHashes();
     if (hashes.length === 0) return { state: "unknown", detail: "no sessions recorded" };
     if (hashes.length === 1) return { state: "alive" };
-    return { state: "gone", detail: `template drift: ${hashes.length} distinct hashes` };
+    return { state: "stale", detail: `template drift: ${hashes.length} distinct hashes` };
   } catch {
     return { state: "unknown" };
   }

--- a/src/dashboard/web-render.ts
+++ b/src/dashboard/web-render.ts
@@ -143,6 +143,16 @@ function trendCard(key: string, label: string, value: string, sub: string): stri
   ].join("");
 }
 
+/** Sum delivery lag across projects whose relay is alive or stale (online only).
+ *  A captain that is offline with unread mail is not a live delivery problem. */
+function liveDeliveryBehind(d: DaemonSnapshot): number {
+  return d.tier2.projects.reduce((sum, p) => {
+    const relay = d.tier1.find((c) => c.kind === "relay" && c.project === p.project);
+    const relayState = relay?.state ?? "unknown";
+    return relayState === "alive" || relayState === "stale" ? sum + p.delivery.behind : sum;
+  }, 0);
+}
+
 // ── Aggregate collection (pure) ─────────────────────────────────────────────────
 interface Collected {
   now: number;
@@ -178,8 +188,8 @@ function collect(snap: FullSnapshot): Collected {
     for (const p of snap.daemon.tier2.projects) {
       if (p.delivery.behind > 0) projStates.push("stale");
       if (p.store.corruptCount > 0) projStates.push("gone");
-      behind += p.delivery.behind;
     }
+    behind = liveDeliveryBehind(snap.daemon);
   }
   return {
     now,
@@ -334,10 +344,7 @@ function renderProjects(snap: FullSnapshot, now: number): string {
     }
     out.push(`</article>`);
   }
-  out.push(
-    `<div class="results">global results · <span class="mono">${d.tier2.results.fileCount}</span> files · ${fmtBytes(d.tier2.results.totalBytes)}</div>`,
-    `</section>`,
-  );
+  out.push(`</section>`);
   return out.join("");
 }
 
@@ -383,7 +390,7 @@ function renderDaemon(snap: FullSnapshot): string {
       `<div class="trend-sub">${t0.log.errorCount === 0 ? "clean over the last" : `over the last`} ${fmtDur(t0.log.windowMs)} · log ${fmtBytes(t0.log.sizeBytes)}</div>`,
       `</div>`,
     ].join(""),
-    trendCard("behind", "Delivery lag", `${snap.daemon.tier2.projects.reduce((a, p) => a + p.delivery.behind, 0)}`, "summed across all project mailboxes"),
+    trendCard("behind", "Delivery lag", `${liveDeliveryBehind(snap.daemon)}`, "summed across online projects only (offline excluded)"),
     `</div>`,
   );
 


### PR DESCRIPTION
## Summary

Five data-layer correctness fixes for the cockpit observability dashboard (post-merge audit of #319).

### #1 — Vault probe false alarms (CRITICAL → gone)
`probeVaults` was calling `vaultProbe()` on both the hub and all spokes. Spokes live **inside** the hub Obsidian vault and correctly have no `.obsidian/` of their own. This caused every spoke to fire `state: "gone"` with "no .obsidian/ (not a vault)" — 19 false fault alarms that drove the system status to CRITICAL.

**Fix:** new `spokeProbe()` checks directory existence only; `vaultProbe()` (with `.obsidian/` check) is kept for the hub only.

### #2 — Ghost projects in Tier 2 snapshot
`gatherSnapshotInputs` called `knownProjects()` (config ∪ relays ∪ all task store records), so orphan state dirs from removed/test projects (e.g. SMOKE, cpcodex) appeared as project cards in the dashboard (23 shown vs 19 registered).

**Fix:** adds `registeredProjects?: string[]` to `CockpitdOpts` (injectable for tests). Production defaults to `Object.keys(loadConfig().projects)`. Tier 2 per-project data is now scoped to registered projects only.

### #3 — Delivery lag counted offline projects
The global "delivery lag / N behind" aggregated unread mailbox entries across **all** projects, including those whose relay is `unknown` or `gone`. An offline captain with queued mail is not a live delivery problem.

**Fix:** new `liveDeliveryBehind(d)` helper filters to projects whose relay is `alive` or `stale`. Used in both `collect()` (Overview metrics blob) and the Daemon tab trend card.

### #4 — Template drift severity (fault → caution)
`probeSessions` returned `state: "gone"` for template drift (multiple distinct hashes in sessions.json). Drift across projects launched at different template versions is **expected**, not a fault.

**Fix:** downgraded to `state: "stale"` (amber caution). Template drift alone no longer drives the system to CRITICAL.

### #5 — Global results line duplicated
`"global results · N files · X MB"` appeared in both the Projects tab and the Daemon tab. It is a global daemon-level metric.

**Fix:** removed from `renderProjects`; kept in `renderDaemon` only.

## Test plan

- [ ] `npm test -- --run` → 1183/1183 ✓ (all existing + new tests green)
- [ ] New tests lock each fix:
  - **#1**: spoke-without-.obsidian = alive; spoke-missing-dir = gone; hub-without-.obsidian = gone
  - **#2**: orphan project absent from `tier2.projects`; registered project present
  - **#3**: metrics blob `behind` = 0 when relay gone/unknown; = N when relay alive
  - **#4**: `probeSessions` state = `"stale"` (not `"gone"`) on drift
  - **#5**: "global results" appears exactly once, inside daemon panel only
- [ ] Live verify: start dashboard, confirm overall status is no longer falsely CRITICAL, project list = registered only