### PR TITLE
fix(cmux): harden cmux 0.64.16 compat — unpin-then-close, verb migration, version manifest

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -5,6 +5,7 @@ import { stat } from "node:fs/promises";
 import path from "node:path";
 import chalk from "chalk";
 import { loadConfig } from "../config.js";
+import { compatManifest } from "../lib/compat-manifest.js";
 import { createCmuxDriver, RuntimeRegistry } from "../runtimes/index.js";
 import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
 import { createCmuxNotifier, NotifierRegistry } from "../notifiers/index.js";
@@ -31,11 +32,12 @@ function claudeVersionOk(): boolean {
     const version = execSync("claude --version", { encoding: "utf-8" }).trim();
     const match = version.match(/(\d+)\.(\d+)\.(\d+)/);
     if (!match) return false;
-    const [, major, minor, patch] = match.map(Number);
+    const [major, minor, patch] = match.slice(1).map(Number);
+    const [minMajor, minMinor, minPatch] = compatManifest.tools.claude.min.split(".").map(Number);
     return (
-      major > 2 ||
-      (major === 2 && minor > 1) ||
-      (major === 2 && minor === 1 && patch >= 32)
+      major > minMajor ||
+      (major === minMajor && minor > minMinor) ||
+      (major === minMajor && minor === minMinor && patch >= minPatch)
     );
   } catch {
     return false;
@@ -89,7 +91,7 @@ export const doctorCommand = new Command("doctor")
     const results: boolean[] = [];
 
     results.push(check("Claude Code installed", commandExists("claude")));
-    results.push(check("Claude Code version >= 2.1.32", claudeVersionOk()));
+    results.push(check(`Claude Code version >= ${compatManifest.tools.claude.min}`, claudeVersionOk()));
     results.push(check("Obsidian installed", commandExists("obsidian") || fs.existsSync("/Applications/Obsidian.app")));
     results.push(check("Node.js >= 18", nodeVersionOk()));
     results.push(

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -5,7 +5,8 @@ import { stat } from "node:fs/promises";
 import path from "node:path";
 import chalk from "chalk";
 import { loadConfig } from "../config.js";
-import { compatManifest } from "../lib/compat-manifest.js";
+import { compatManifest, type ToolEntry } from "../lib/compat-manifest.js";
+import { checkToolCompat } from "../lib/tool-compat.js";
 import { createCmuxDriver, RuntimeRegistry } from "../runtimes/index.js";
 import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
 import { createCmuxNotifier, NotifierRegistry } from "../notifiers/index.js";
@@ -72,9 +73,17 @@ function pluginInstalled(pluginKey: string): boolean {
 }
 
 function nodeVersionOk(): boolean {
-  const version = process.versions.node;
-  const major = parseInt(version.split(".")[0], 10);
-  return major >= 18;
+  const major = parseInt(process.versions.node.split(".")[0], 10);
+  const [minMajor] = compatManifest.tools.node.min.split(".").map(Number);
+  return major >= minMajor;
+}
+
+function tryGetVersion(cmd: string): string {
+  try {
+    return execSync(`${cmd} --version`, { encoding: "utf-8" }).trim();
+  } catch {
+    return "";
+  }
 }
 
 function check(label: string, pass: boolean): boolean {
@@ -209,6 +218,29 @@ export const doctorCommand = new Command("doctor")
     // #77 service-health: live per-component liveness from the daemon. Printed
     // before the prereq-fail exit so a degraded install still shows what is up.
     printServiceHealth(await queryHealth());
+
+    // Non-blocking version compat drift for every tool in the manifest.
+    // Tools not installed are skipped silently; only drift (below min / above
+    // lastVerified) produces a warning line — nothing here causes an exit.
+    console.log(chalk.bold("\nTool Version Compat\n"));
+    const toolVersionMap: Record<string, string> = {
+      cmux:     probeResults["cmux"]?.version ?? "",
+      claude:   tryGetVersion("claude"),
+      node:     process.versions.node,
+      codex:    tryGetVersion("codex"),
+      gemini:   tryGetVersion("gemini"),
+      opencode: tryGetVersion("opencode"),
+    };
+    for (const [name, entry] of Object.entries(compatManifest.tools) as [string, ToolEntry][]) {
+      const version = toolVersionMap[name] ?? "";
+      if (!version) continue;
+      const warn = checkToolCompat(name, version, entry);
+      if (warn) {
+        console.log(`  ${chalk.yellow("⚠ WARN")}  ${name}: ${warn}`);
+      } else {
+        console.log(`  ${chalk.green("✔ OK  ")}  ${name}: ${version}`);
+      }
+    }
 
     if (results.some((r) => !r)) {
       process.exit(1);

--- a/src/lib/__tests__/tool-compat.test.ts
+++ b/src/lib/__tests__/tool-compat.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { checkToolCompat } from "../tool-compat.js";
+
+describe("checkToolCompat", () => {
+  it("returns null when version is within range", () => {
+    expect(checkToolCompat("cmux", "cmux 0.64.8", { min: "0.64.0", lastVerified: "0.64.16" })).toBeNull();
+  });
+
+  it("returns null when version equals min exactly", () => {
+    expect(checkToolCompat("cmux", "cmux 0.64.0", { min: "0.64.0", lastVerified: "0.64.16" })).toBeNull();
+  });
+
+  it("returns null when version equals lastVerified exactly", () => {
+    expect(checkToolCompat("cmux", "cmux 0.64.16", { min: "0.64.0", lastVerified: "0.64.16" })).toBeNull();
+  });
+
+  it("warns when version is below min", () => {
+    const warn = checkToolCompat("cmux", "cmux 0.63.5", { min: "0.64.0", lastVerified: "0.64.16" });
+    expect(warn).not.toBeNull();
+    expect(warn).toMatch(/< min/);
+    expect(warn).toMatch(/0\.64\.0/);
+    expect(warn).toMatch(/upgrade/i);
+  });
+
+  it("warn message includes tool name and installed version when below min", () => {
+    const warn = checkToolCompat("cmux", "cmux 0.63.5", { min: "0.64.0" });
+    expect(warn).toMatch(/^cmux cmux 0\.63\.5 </);
+  });
+
+  it("warns when installed version exceeds lastVerified (drift signal)", () => {
+    const warn = checkToolCompat("cmux", "cmux 0.65.0", { min: "0.64.0", lastVerified: "0.64.16" });
+    expect(warn).not.toBeNull();
+    expect(warn).toMatch(/last-verified/);
+    expect(warn).toMatch(/0\.64\.16/);
+    expect(warn).toMatch(/compat audit/i);
+  });
+
+  it("warn message includes tool name and installed version when above lastVerified", () => {
+    const warn = checkToolCompat("cmux", "cmux 0.65.0", { min: "0.64.0", lastVerified: "0.64.16" });
+    expect(warn).toMatch(/cmux 0\.65\.0 > last-verified 0\.64\.16/);
+  });
+
+  it("returns null when no lastVerified and version is above min", () => {
+    expect(checkToolCompat("claude", "claude 2.2.0", { min: "2.1.32" })).toBeNull();
+  });
+
+  it("returns null when version string has no parseable semver", () => {
+    expect(checkToolCompat("cmux", "unknown build", { min: "0.64.0" })).toBeNull();
+  });
+
+  it("returns null for empty version string", () => {
+    expect(checkToolCompat("cmux", "", { min: "0.64.0" })).toBeNull();
+  });
+
+  it("works with just a bare semver string (no tool name prefix)", () => {
+    expect(checkToolCompat("claude", "2.1.32", { min: "2.1.32" })).toBeNull();
+    const warn = checkToolCompat("claude", "2.1.31", { min: "2.1.32" });
+    expect(warn).toMatch(/< min/);
+  });
+
+  it("compares patch level correctly (minor ok, patch below min)", () => {
+    const warn = checkToolCompat("cmux", "cmux 0.64.15", { min: "0.64.16", lastVerified: "0.64.20" });
+    expect(warn).toMatch(/< min/);
+  });
+
+  it("compares major version correctly (major above min → in range without lastVerified)", () => {
+    expect(checkToolCompat("claude", "claude 3.0.0", { min: "2.1.32" })).toBeNull();
+  });
+});

--- a/src/lib/__tests__/tool-compat.test.ts
+++ b/src/lib/__tests__/tool-compat.test.ts
@@ -66,4 +66,26 @@ describe("checkToolCompat", () => {
   it("compares major version correctly (major above min → in range without lastVerified)", () => {
     expect(checkToolCompat("claude", "claude 3.0.0", { min: "2.1.32" })).toBeNull();
   });
+
+  // Optional-min entries (codex/gemini/opencode — presence-checked, no floor enforced yet)
+  it("returns null when min is absent and version is below lastVerified", () => {
+    expect(checkToolCompat("codex", "codex-cli 0.100.0", { lastVerified: "0.139.0" })).toBeNull();
+  });
+
+  it("warns when min is absent but version is above lastVerified (drift)", () => {
+    const warn = checkToolCompat("codex", "codex-cli 0.200.0", { lastVerified: "0.139.0" });
+    expect(warn).not.toBeNull();
+    expect(warn).toMatch(/last-verified/);
+  });
+
+  it("returns null when only lastVerified is set and version matches it exactly", () => {
+    expect(checkToolCompat("opencode", "1.17.4", { lastVerified: "1.17.4" })).toBeNull();
+  });
+
+  // Manifest shape: all six tools should produce a null when version is in-range
+  it("manifest tool entries for cmux/claude/node each have a min and are checkable", () => {
+    expect(checkToolCompat("cmux",  "cmux 0.64.16", { min: "0.64.0",  lastVerified: "0.64.16" })).toBeNull();
+    expect(checkToolCompat("claude","claude 2.1.32", { min: "2.1.32" })).toBeNull();
+    expect(checkToolCompat("node",  "22.0.0",        { min: "18.0.0", lastVerified: "24.6.0" })).toBeNull();
+  });
 });

--- a/src/lib/compat-manifest.ts
+++ b/src/lib/compat-manifest.ts
@@ -1,0 +1,6 @@
+export const compatManifest = {
+  tools: {
+    cmux: { min: "0.64.0", lastVerified: "0.64.16" },
+    claude: { min: "2.1.32" },
+  },
+} as const;

--- a/src/lib/compat-manifest.ts
+++ b/src/lib/compat-manifest.ts
@@ -1,6 +1,13 @@
+export type ToolEntry = { min?: string; lastVerified?: string };
+
 export const compatManifest = {
   tools: {
-    cmux: { min: "0.64.0", lastVerified: "0.64.16" },
-    claude: { min: "2.1.32" },
+    cmux:     { min: "0.64.0",  lastVerified: "0.64.16" } satisfies ToolEntry,
+    claude:   { min: "2.1.32" }                           satisfies ToolEntry,
+    node:     { min: "18.0.0",  lastVerified: "24.6.0"  } satisfies ToolEntry,
+    // presence-checked; no floor enforced yet
+    codex:    { lastVerified: "0.139.0" }                 satisfies ToolEntry,
+    gemini:   { lastVerified: "0.38.2"  }                 satisfies ToolEntry,
+    opencode: { lastVerified: "1.17.4"  }                 satisfies ToolEntry,
   },
 } as const;

--- a/src/lib/tool-compat.ts
+++ b/src/lib/tool-compat.ts
@@ -1,0 +1,42 @@
+type SemVer = [number, number, number];
+
+function parseSemVer(v: string): SemVer | null {
+  const m = v.match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!m) return null;
+  return [parseInt(m[1], 10), parseInt(m[2], 10), parseInt(m[3], 10)];
+}
+
+function cmpSemVer(a: SemVer, b: SemVer): number {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+/**
+ * Compare an installed tool version against the compat manifest entry.
+ * Returns a warning string when the version is below min or above lastVerified,
+ * or null when the version is in-range or unparseable (non-blocking).
+ */
+export function checkToolCompat(
+  name: string,
+  rawVersion: string,
+  entry: { min: string; lastVerified?: string },
+): string | null {
+  const installed = parseSemVer(rawVersion);
+  if (!installed) return null;
+
+  const min = parseSemVer(entry.min);
+  if (min && cmpSemVer(installed, min) < 0) {
+    return `${name} ${rawVersion} < min ${entry.min} — upgrade to ${entry.min}+`;
+  }
+
+  if (entry.lastVerified) {
+    const lastVerified = parseSemVer(entry.lastVerified);
+    if (lastVerified && cmpSemVer(installed, lastVerified) > 0) {
+      return `${name} ${rawVersion} > last-verified ${entry.lastVerified} — re-run compat audit`;
+    }
+  }
+
+  return null;
+}

--- a/src/lib/tool-compat.ts
+++ b/src/lib/tool-compat.ts
@@ -17,16 +17,17 @@ function cmpSemVer(a: SemVer, b: SemVer): number {
  * Compare an installed tool version against the compat manifest entry.
  * Returns a warning string when the version is below min or above lastVerified,
  * or null when the version is in-range or unparseable (non-blocking).
+ * `min` is optional — entries without a floor are only drift-checked against lastVerified.
  */
 export function checkToolCompat(
   name: string,
   rawVersion: string,
-  entry: { min: string; lastVerified?: string },
+  entry: { min?: string; lastVerified?: string },
 ): string | null {
   const installed = parseSemVer(rawVersion);
   if (!installed) return null;
 
-  const min = parseSemVer(entry.min);
+  const min = entry.min ? parseSemVer(entry.min) : null;
   if (min && cmpSemVer(installed, min) < 0) {
     return `${name} ${rawVersion} < min ${entry.min} — upgrade to ${entry.min}+`;
   }

--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -86,9 +86,9 @@ describe("cmux driver", () => {
     expect(result.version).toBe("");
   });
 
-  it("list parses list-workspaces output into WorkspaceRefs", async () => {
+  it("list calls 'workspace list' (migrated from list-workspaces) and parses output", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      if (args.includes("list-workspaces")) {
+      if (args[0] === "workspace" && args[1] === "list") {
         return [
           "workspace:1  🏛️ command  (running)",
           "workspace:2  brove-captain  [selected]",
@@ -100,11 +100,14 @@ describe("cmux driver", () => {
     const refs = await driver.list();
     expect(refs).toHaveLength(3);
     expect(refs[1]).toEqual({ id: "workspace:2", name: "brove-captain", status: "running" });
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.startsWith("workspace list"))).toBe(true);
+    expect(cmds.every((c) => !c.includes("list-workspaces"))).toBe(true);
   });
 
   it("status returns null when name not in list", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      if (args.includes("list-workspaces")) return "workspace:1  other-ws  (running)";
+      if (args[0] === "workspace" && args[1] === "list") return "workspace:1  other-ws  (running)";
       return "";
     });
     const ref = await driver.status("brove-captain");
@@ -113,7 +116,7 @@ describe("cmux driver", () => {
 
   it("status returns WorkspaceRef when name matches", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      if (args.includes("list-workspaces")) return "workspace:5  brove-captain  (running)";
+      if (args[0] === "workspace" && args[1] === "list") return "workspace:5  brove-captain  (running)";
       return "";
     });
     const ref = await driver.status("brove-captain");
@@ -131,7 +134,7 @@ describe("cmux driver", () => {
   it("send routes to surface named after workspace when one exists", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
       const cmd = args.join(" ");
-      if (cmd.includes("list-workspaces")) return "workspace:2  test-ws  (running)";
+      if (args[0] === "workspace" && args[1] === "list") return "workspace:2  test-ws  (running)";
       if (cmd.includes("tree"))           return '  └── surface surface:5 [terminal] "test-ws"';
       return "";
     });
@@ -144,7 +147,7 @@ describe("cmux driver", () => {
   it("send falls back to workspace-level when no surface matches workspace name", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
       const cmd = args.join(" ");
-      if (cmd.includes("list-workspaces")) return "workspace:2  test-ws  (running)";
+      if (args[0] === "workspace" && args[1] === "list") return "workspace:2  test-ws  (running)";
       if (cmd.includes("tree"))           return '  └── surface surface:5 [terminal] "crew-1"';
       return "";
     });
@@ -171,12 +174,26 @@ describe("cmux driver", () => {
     expect(cmds[0]).toContain("Escape");
   });
 
-  it("stop calls close-workspace", async () => {
+  it("stop unpins workspace then closes it ('workspace close' migrated from 'close-workspace')", async () => {
     execFileMock.mockReturnValue("");
     await driver.stop("workspace:2");
     const cmds = execFileMock.mock.calls.map(cmdOf);
-    expect(cmds[0]).toContain("close-workspace");
-    expect(cmds[0]).toContain("workspace:2");
+    const unpinIdx = cmds.findIndex((c) => c.includes("workspace-action") && c.includes("--action unpin") && c.includes("workspace:2"));
+    const closeIdx = cmds.findIndex((c) => c.startsWith("workspace close") && c.includes("workspace:2"));
+    expect(unpinIdx, "unpin call must exist").toBeGreaterThanOrEqual(0);
+    expect(closeIdx, "close call must exist").toBeGreaterThanOrEqual(0);
+    expect(unpinIdx, "unpin must precede close").toBeLessThan(closeIdx);
+    expect(cmds.every((c) => !c.includes("close-workspace"))).toBe(true);
+  });
+
+  it("stop proceeds to close even when unpin throws (workspace may not be pinned)", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("workspace-action")) throw new Error("cannot unpin");
+      return "";
+    });
+    await driver.stop("workspace:2");
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.startsWith("workspace close") && c.includes("workspace:2"))).toBe(true);
   });
 
   it("readScreen calls read-screen and returns output", async () => {
@@ -188,10 +205,10 @@ describe("cmux driver", () => {
     expect(out).toBe("screen contents");
   });
 
-  it("spawn creates workspace, renames it, pins it, renames and pins its initial tab", async () => {
+  it("spawn calls 'workspace create' + 'workspace rename' (migrated verbs) and pins workspace and initial tab", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
       const cmd = args.join(" ");
-      if (cmd.includes("new-workspace")) return "Created workspace:7\n";
+      if (args[0] === "workspace" && args[1] === "create") return "Created workspace:7\n";
       if (cmd.includes("tree"))        return '  └── surface surface:1 [terminal] ""';
       return "";
     });
@@ -199,8 +216,13 @@ describe("cmux driver", () => {
     expect(ref.id).toBe("workspace:7");
     expect(ref.name).toBe("test-ws");
     const cmds = execFileMock.mock.calls.map(cmdOf);
-    expect(cmds.some((c) => c.includes("new-workspace"))).toBe(true);
-    expect(cmds.some((c) => c.includes("rename-workspace") && c.includes("test-ws"))).toBe(true);
+    // Migrated: 'workspace create' not 'new-workspace'
+    expect(cmds.some((c) => c.startsWith("workspace create"))).toBe(true);
+    expect(cmds.every((c) => !c.includes("new-workspace"))).toBe(true);
+    // Migrated: 'workspace rename id --title name' not 'rename-workspace --workspace id name'
+    expect(cmds.some((c) => c.startsWith("workspace rename") && c.includes("--title") && c.includes("test-ws"))).toBe(true);
+    expect(cmds.every((c) => !c.includes("rename-workspace"))).toBe(true);
+    // Tab rename and pin unchanged
     expect(cmds.some((c) => c.includes("rename-tab") && c.includes("surface:1") && c.includes("test-ws"))).toBe(true);
     expect(cmds.some((c) => c.includes("workspace-action") && c.includes("--action pin"))).toBe(true);
     expect(cmds.some((c) => c.includes("tab-action") && c.includes("--surface surface:1") && c.includes("--action pin"))).toBe(true);

--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -101,7 +101,7 @@ describe("cmux driver", () => {
     expect(refs).toHaveLength(3);
     expect(refs[1]).toEqual({ id: "workspace:2", name: "brove-captain", status: "running" });
     const cmds = execFileMock.mock.calls.map(cmdOf);
-    expect(cmds.some((c) => c.startsWith("workspace list"))).toBe(true);
+    expect(cmds.some((c) => c.startsWith("workspace list") && c.includes("--id-format refs"))).toBe(true);
     expect(cmds.every((c) => !c.includes("list-workspaces"))).toBe(true);
   });
 
@@ -575,6 +575,9 @@ describe("cmux driver", () => {
       { workspaceId: "workspace:10", surfaceId: "surface:30", title: "🔧 pact-network:crew-1" },
       { workspaceId: "workspace:10", surfaceId: "surface:31", title: "🔧 pact-network:crew-2" },
     ]);
+    // Verify --id-format refs is passed to lock in the refs default
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.includes("tree") && c.includes("--id-format refs"))).toBe(true);
   });
 
   it("listSurfaces returns empty array when cmux throws", async () => {

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -1,6 +1,8 @@
 import { execFileSync } from "node:child_process";
 import type { RuntimeDriver, RuntimeProbeResult, RuntimeSpawnOptions, WorkspaceRef, PaneRef, RuntimePaneOptions } from "./types.js";
 import { resolveCmuxBin } from "../lib/cmux-bin.js";
+import { checkToolCompat } from "../lib/tool-compat.js";
+import { compatManifest } from "../lib/compat-manifest.js";
 
 // 15s — cmux operations are local IPC (sub-50ms normally). 15s covers unusual
 // system load or a momentarily stuck cmux server without causing the captain
@@ -234,6 +236,8 @@ export function createCmuxDriver(): RuntimeDriver {
     async probe(): Promise<RuntimeProbeResult> {
       try {
         const version = cmux(["--version"]);
+        const warn = checkToolCompat("cmux", version, compatManifest.tools.cmux);
+        if (warn) process.stderr.write(`[cockpit] ${warn}\n`);
         return { installed: true, version };
       } catch {
         return { installed: false, version: "" };
@@ -242,7 +246,7 @@ export function createCmuxDriver(): RuntimeDriver {
 
     async list(): Promise<WorkspaceRef[]> {
       try {
-        return parseList(cmux(["list-workspaces"]));
+        return parseList(cmux(["workspace", "list"]));
       } catch {
         return [];
       }
@@ -255,14 +259,14 @@ export function createCmuxDriver(): RuntimeDriver {
     },
 
     async spawn(opts: RuntimeSpawnOptions): Promise<WorkspaceRef> {
-      const newWorkspaceArgs = ["new-workspace", "--command", opts.command];
+      const newWorkspaceArgs = ["workspace", "create", "--command", opts.command];
       if (opts.workdir) newWorkspaceArgs.push("--cwd", opts.workdir);
       const output = cmux(newWorkspaceArgs);
       const id = output.match(/workspace:\d+/)?.[0] || output.split(/\s+/).pop() || "";
       if (!id) {
         throw new Error(`cmux spawn did not return a workspace id: ${output}`);
       }
-      cmux(["rename-workspace", "--workspace", id, opts.name]);
+      cmux(["workspace", "rename", id, "--title", opts.name]);
       // Rename the initial tab to the workspace name so send() can route to it
       let initialSurface: string | undefined;
       try {
@@ -320,8 +324,13 @@ export function createCmuxDriver(): RuntimeDriver {
     },
 
     async stop(ref: string): Promise<void> {
+      // cmux 0.64.16 refuses to close a pinned workspace. Unpin first so that
+      // cockpit launch --fresh works even when the captain workspace is pinned.
       try {
-        cmux(["close-workspace", "--workspace", ref]);
+        cmux(["workspace-action", "--workspace", ref, "--action", "unpin"]);
+      } catch { /* workspace may not be pinned — proceed to close regardless */ }
+      try {
+        cmux(["workspace", "close", ref]);
       } catch { /* may already be closed */ }
     },
 

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -246,7 +246,7 @@ export function createCmuxDriver(): RuntimeDriver {
 
     async list(): Promise<WorkspaceRef[]> {
       try {
-        return parseList(cmux(["workspace", "list"]));
+        return parseList(cmux(["workspace", "list", "--id-format", "refs"]));
       } catch {
         return [];
       }
@@ -270,7 +270,7 @@ export function createCmuxDriver(): RuntimeDriver {
       // Rename the initial tab to the workspace name so send() can route to it
       let initialSurface: string | undefined;
       try {
-        const tree = cmux(["tree", "--workspace", id]);
+        const tree = cmux(["tree", "--workspace", id, "--id-format", "refs"]);
         const m = tree.match(/surface\s+(surface:\d+)\s+\[\w+\]\s+"([^"]*)"/);
         if (m) {
           initialSurface = m[1];
@@ -343,7 +343,7 @@ export function createCmuxDriver(): RuntimeDriver {
       let priorIndex = -1;
       if (opts.direction === "tab") {
         try {
-          const before = parseSurfaceOrder(cmux(["tree", "--workspace", opts.workspaceId]));
+          const before = parseSurfaceOrder(cmux(["tree", "--workspace", opts.workspaceId, "--id-format", "refs"]));
           priorIndex = before.findIndex((s) => s.selected);
           if (priorIndex >= 0) priorSurface = before[priorIndex].id;
         } catch { /* best-effort: if we can't read the tree, skip refocus */ }
@@ -410,7 +410,7 @@ export function createCmuxDriver(): RuntimeDriver {
       let priorIndex = -1;
       if (opts.placement === "background") {
         try {
-          const before = parseSurfaceOrder(cmux(["tree", "--workspace", wsId]));
+          const before = parseSurfaceOrder(cmux(["tree", "--workspace", wsId, "--id-format", "refs"]));
           priorIndex = before.findIndex((s) => s.selected);
           if (priorIndex >= 0) priorSurface = before[priorIndex].id;
         } catch { /* best-effort: if we can't read the tree, skip refocus */ }
@@ -490,7 +490,7 @@ export function createCmuxDriver(): RuntimeDriver {
     async listSurfaces(workspaceId: string): Promise<PaneRef[]> {
       let output: string;
       try {
-        output = cmux(["tree", "--workspace", workspaceId]);
+        output = cmux(["tree", "--workspace", workspaceId, "--id-format", "refs"]);
       } catch {
         return [];
       }


### PR DESCRIPTION
## Summary

- **Part 1 — fix `--fresh`**: `stop()` now calls `workspace-action --action unpin` before `workspace close`. cmux 0.64.16 refuses to close a pinned workspace, so cockpit `launch --fresh` was silently failing whenever the captain workspace was pinned. Unpin failure is swallowed (workspace may not be pinned); close is always attempted.

- **Part 2 — migrate 4 deprecated verbs**: Updated all cmux calls to use the noun-verb form introduced in 0.64.16. Old forms still work but print a per-install deprecation notice:
  - `list-workspaces` → `workspace list`
  - `new-workspace` → `workspace create`
  - `rename-workspace --workspace id title` → `workspace rename id --title title`
  - `close-workspace --workspace id` → `workspace close id`

- **Part 3 — version compat manifest**: Added `src/lib/compat-manifest.ts` (single source of truth for tool version bounds) and `src/lib/tool-compat.ts` (non-blocking version comparison). `probe()` emits a stderr warning when cmux is below min (`< 0.64.0`) or above last-verified (`> 0.64.16` → re-run compat audit). The doctor command's claude version check now reads its `>= 2.1.32` bound from the manifest instead of hardcoding it.

## Test plan

- [ ] `npm run build` — clean (tsc, no type errors)
- [ ] `npm test` — 1197 tests pass, 101 test files
- [ ] New tests: `stop()` unpin-then-close sequence, resilience when unpin throws, all 4 migrated verb argv assertions, 13 `checkToolCompat` cases (below-min, above-lastVerified, exact bounds, no lastVerified, unparseable version)