### PR TITLE
feat(cmux): modernize driver — focus-neutral spawn, --json parsing, --window scoping, per-workspace env

### DIFF
--- a/docs/reports/2026-06-15-cmux-compat-audit-0.62-0.64.md
+++ b/docs/reports/2026-06-15-cmux-compat-audit-0.62-0.64.md
@@ -1,0 +1,108 @@
+# cmux Compatibility & Opportunity Audit — 0.62.0 → 0.64.16
+
+**Date:** 2026-06-15
+**cmux window audited:** 0.62.0 (2026-03-12) → 0.64.16 (2026-06-15) — 24 releases, ~3 months
+**Sources:** `manaflow-ai/cmux` `CHANGELOG.md` + `docs/cli-contract.md` (raw from `main`)
+**Trigger:** user updated cmux to 0.64.16; deprecation spam + broken `--fresh` surfaced. Cockpit's code last referenced cmux ~0.62.2, so this audit covers the drift since then.
+**Method:** cross-referenced every cmux invocation / output-assumption across cockpit's integration surface — `src/runtimes/cmux.ts`, `src/notifiers/cmux.ts`, `src/commands/launch.ts`, `src/commands/notify-relay.ts`, `src/control/interactive/pane-classifier.ts`, `src/control/liveness.ts`, `src/control/cockpitd.ts`.
+
+---
+
+## Executive summary
+
+- **No hard breaks** beyond the two already fixed in-flight (workspace-verb migration + pinned-workspace close). cmux's contract keeps the text output cockpit pins to stable.
+- **Category A (must-adapt): 4 findings** — 1 correctness regression risk (A1 focus-restore), 1 already-folded defensive item (A4 id-format), 2 cosmetic/latent (A2, A3).
+- **Category B (simplify integration): 4 findings** — biggest lever is **B1 `cmux events` JSON stream**, which can retire the daemon's relay-proxy cmux-blindness workaround. **B3 focus-neutral spawn is the same fix as A1.**
+- **Category C (adopt new capability): 5 findings** — workspace groups, agent hibernation, per-workspace env lead.
+- **Single most important architecture finding:** `cmux events` (reconnectable JSON event bus) — replaces screen-scraping for liveness/focus/surface enumeration.
+
+### Disposition (2026-06-15 decisions)
+| Item | Disposition |
+|------|-------------|
+| Verb migration + `CMUX_QUIET=1` + pinned-close unpin | **In-flight crew** `cmux-compat` (branch `fix/cmux-0.64-compat`) |
+| A4 `--id-format refs` hardening | **Folded into in-flight crew** |
+| A1 + B3 (focus-neutral spawn) | **Pre-release crew — gates v1.0.0** |
+| A2 (OSC sanitizer) | Confirm no-op in pre-release crew |
+| A3, B1, B2, B4, C1–C5 | **This audit + single tracking GH issue** → carve sub-issues later |
+
+---
+
+## Category A — Behavioral changes cockpit must adapt to
+
+### A1. Focus-restore `move-surface --index --focus` dance is now fragile — **DEGRADES (correctness)**
+- **cmux:** 0.64.16 "Freeform 2D canvas layout for workspace panes" (#5987) + "Stagger restored terminal surface spawns" (#6149).
+- **cockpit:** `src/runtimes/cmux.ts:331-360` (`newPane`), `:402-425` (`spawnInjector`), `parseSurfaceOrder` `:60-69`. Records the `[selected]` surface's **array index** from `cmux tree`, then `move-surface --surface <prior> --index <priorIndex> --focus true`.
+- **Why:** the new canvas layout + staggered restore weaken the "tree order == linear tab-strip index" invariant. During staggered restore the tree can be transiently incomplete → `priorIndex` points at the wrong surface; under canvas layout "index" is no longer a 1-D strip position. Already best-effort (`try/catch`), so failure mode is **silent loss of focus restoration** = regression of the #295 focus-steal (captain keystrokes land in the fresh crew's launch line).
+- **Fix:** move off index-based refocus → focus-neutral spawn (see **B3** — same work). Gates v1.0.0.
+
+### A2. `cmux send` OSC fix — **COSMETIC (no change)**
+- **cmux:** 0.64.14 "Fix OSC control sequences printed as literal text when sent via `cmux send`" (#5509).
+- **cockpit:** `sanitizeForCmuxSend` `cmux.ts:75-81` only collapses `\n\r\t` (newline→Enter protection), never relied on OSC passthrough. No conflict. Confirm + move on.
+
+### A3. `read-screen` chrome-scraping is version-drifting — **DEGRADES (latent)**
+- **cmux:** TUI-chrome-adjacent changes — 0.64.0 "Auto-hide terminal scroll bar on alt-screen", 0.64.13 "Anchor textbox autocomplete to cursor", 0.64.15 React/Solid agent-session panels (#4429).
+- **cockpit:** `CC_INITIALIZED_RE`/`CC_WORKING_RE` `cmux.ts:200,214`; `parseDraftFromScreen` `:97-161`; `classifyPaneTail` `pane-classifier.ts:93-113` — all pinned to specific glyphs (`⏵⏵`, `❯`, `─{10,}` HR, `▌█`) and English spinner phrases.
+- **Why:** every cmux/CC chrome change is a silent breakage risk. This is the structural fragility the whole report flags.
+- **Fix:** no forced change now; durable answer is **B4** (structured agent state), which cmux has not yet exposed over the socket. **Tracked in the GH issue.**
+
+### A4. `--id-format` default assumption — **COSMETIC (folded into in-flight crew)**
+- **cmux:** global `--id-format refs|uuids|both`.
+- **cockpit:** every parser assumes `workspace:N`/`surface:N` ref form — `parseList` `:45`, `parseSurfaceOrder` `:64`, `listSurfaces` `:491`, spawn id-extraction `:261`. If the default ever changes, all silently return empty.
+- **Fix:** pass `--id-format refs` explicitly on read commands (`workspace list`, `tree`). **Folded into crew `cmux-compat`.**
+
+---
+
+## Category B — New cmux APIs that could reduce/simplify cockpit integration
+
+### B1. ⭐ Reconnectable JSON event stream (`cmux events` / `events.jsonl`)
+- **cmux:** CLI contract §Events; `capabilities` advertises `events.stream`; `~/.cmuxterm/events.jsonl` emits surface selection/focus/creation/closure + workspace selection; cursor-file + `--after-seq` resume. 0.64.10 reorder events; 0.64.15 event-stream allocation fix (#5664) → load-bearing, maintained.
+- **Replaces:** the surface-liveness reaper's per-sweep `tree` scrape (`crew-pane-reader.ts`), and **the entire relay-proxy cmux-blindness workaround** (`relay-proxy-poll`/`result` in `notify-relay.ts:331-365`, `cockpitd.ts:208-217,590-608`) that exists only because the launchd daemon can't poll cmux. A daemon-side subscriber gives authoritative surface-create/close/select events with built-in resume.
+- **Value:** HIGH (biggest architectural simplification). Prototype a daemon `cmux events --reconnect --cursor-file … --category surface,workspace` consumer; map `surface.closed`→reaper, `surface.selected`→focus tracking. Keep scrape path as fallback during migration.
+
+### B2. `--json` output on `tree`/list
+- **cmux:** global `--json`; 0.64.16 "Expose each workspace's custom title to the control socket" (#6013).
+- **Replaces:** the four hand-rolled regex parsers (`parseList`, `parseSurfaceOrder`, `listSurfaces`, stdout id-extraction). Custom titles become first-class instead of quoted-substring matching (`send` routing `:293-305`).
+- **Value:** MEDIUM-HIGH. Eliminates ~5 brittle regexes + the A4 risk in one move.
+
+### B3. Focus-neutral spawn (`split-off`, `workspace.create --layout`)
+- **cmux:** 0.64.0 "Focus-neutral split-off layout command" (#3484) + "`--layout` on `workspace.create`" (#2916); contract: `split-off` "Move a surface into a new split without changing focus by default".
+- **Replaces:** the snapshot-index-then-`move-surface --focus` logic in `newPane`/`spawnInjector` (`cmux.ts:331-360`, `402-425`) — i.e. **the A1 fix.** `split-off` exists specifically to not steal focus, which is the #295 problem hand-rolled around.
+- **Value:** MEDIUM-HIGH. **Bundled with A1, gates v1.0.0.**
+
+### B4. Hook-less live-agent / fork detection + agent-session panels
+- **cmux:** 0.64.16 "Detect live claude/codex processes so hook-less agent sessions stay fork-able" (#6133); 0.64.15 agent-session panels (#4429); 0.64.3 live status driving the tab status bar (#5235).
+- **Replaces (eventually):** the CC-chrome heuristics (`classifyStartupSurface`, `CC_WORKING_RE`/`CC_INITIALIZED_RE`, parts of `classifyPaneTail`) — cmux now tracks agent run-state internally.
+- **Value:** MEDIUM (watch-and-adopt; not yet socket-exposed). Long-term answer to A3. **Tracked.**
+
+> The #302 buffer-liveness backspace probe in `sendToSurface` (`cmux.ts:429-479`) protects the captain's *own* draft and has **no cmux-side equivalent** in this window — keep it.
+
+---
+
+## Category C — New cmux features worth integrating (ranked)
+
+### C1. Workspace groups CLI (`cmux workspace-group`) — HIGH
+- **cmux:** 0.64.11 (#5018) create/remove/set-color/set-icon/move/focus groups + per-group new-workspace placement; 0.64.15 group commands in cloud relay (#5856).
+- **For cockpit:** maps 1:1 onto captain + N crews per project. Replaces ad-hoc `pinToTop` (`cmux.ts:276-285`) + `🔧 project:name` title convention with a first-class colored/iconed container; per-group placement lands new crews in the right group automatically. Aligns with the "sibling projects aware of each other" goal.
+
+### C2. Agent Hibernation — HIGH (targets the RAM-flood pain)
+- **cmux:** 0.64.11 (#4165) pauses idle agent sessions, restore-on-demand; 0.64.14 5s idle default (#5449); `agent-hibernation <on|off>`.
+- **For cockpit:** directly addresses the documented RAM-flood / orphaned-headless-session theme and the 24h idle crew budget (`liveness.ts:48-49`). Enable in launch defaults; **verify a hibernated crew reads as "alive" to the reaper, not "gone".**
+
+### C3. Per-workspace environment variables (`workspace env` / `--env` / `--env-file`) — MEDIUM-HIGH
+- **cmux:** 0.64.16 (#6116) per-workspace env inherited by every shell, re-applied on restore, protected `CMUX_*` keys.
+- **For cockpit:** replaces the `envPrefix` string concatenation (`crew.ts:399,449`); survives restore; cleaner shell-safety (#118). Could finally give **codex crews a stable `COCKPIT_CREW_TASK_ID`** (the known codex-signal gap).
+
+### C4. Detachable SSH PTY daemon + `workspace reconnect/disconnect` — MEDIUM (future remote crews)
+- **cmux:** 0.64.11 (#4807) detachable SSH PTY; 0.64.13 SSH agent forwarding (#5301).
+- **For cockpit:** dropped connection wouldn't kill an in-flight remote crew turn. Roadmap note for remote/cloud crews; no action now.
+
+### C5. `--window` routing — MEDIUM-LOW
+- **cmux:** 0.64.8 (#4211) `--window` for window-scoped commands.
+- **For cockpit:** scope `list`/`tree` to the captain's window to avoid multi-window collisions when resolving a captain by name. Low priority until a collision is reported.
+
+---
+
+## Explicitly NOT a concern (so the release doesn't chase them)
+- **Notification CLI** (0.64.5/0.64.11 panel parity, redesign, dismiss/mark-read/jump-to-unread): cockpit uses its own mailbox + notify-relay; never calls `cmux notify`/`set-status`/`list-notifications`. Optional only.
+- **Browser automation suite** (0.64.13–16): cockpit doesn't drive cmux's browser.
+- **GUI-only** (iOS app, themes, sidebar font, markdown/diff viewers, minimap): no CLI/socket dependency — except the freeform **canvas** (A1).

--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -15,6 +15,34 @@ vi.mock("node:child_process", () => ({
 const argvOf = (call: unknown[]): string[] => call[1] as string[];
 const cmdOf = (call: unknown[]): string => (call[1] as string[]).join(" ");
 
+// Build a `cmux workspace list --json` payload for list()/status() tests (B2).
+function wsListJson(...wss: { ref: string; title?: string; cwd?: string }[]): string {
+  return JSON.stringify({
+    window_ref: "window:1",
+    workspaces: wss.map((w, i) => ({
+      ref: w.ref,
+      custom_title: w.title ?? null,
+      has_custom_title: w.title != null,
+      current_directory: w.cwd ?? "/home/u",
+      index: i,
+    })),
+  });
+}
+
+// Build a `cmux tree --json` payload (one window/workspace/pane) for
+// listSurfaces()/send() tests (B2).
+function treeJson(workspaceRef: string, ...surfaces: { ref: string; title: string }[]): string {
+  return JSON.stringify({
+    windows: [{
+      ref: "window:1",
+      workspaces: [{
+        ref: workspaceRef,
+        panes: [{ ref: "pane:1", surfaces: surfaces.map((s, i) => ({ ref: s.ref, title: s.title, index: i })) }],
+      }],
+    }],
+  });
+}
+
 // Build a minimal screen in the real Claude Code format for parseDraftFromScreen tests.
 // Layout: optional transcript lines, then top-HR, then inputLine, then bottom-HR, then
 // a two-line status block. The HR lines use U+2500 ─ (110 chars) matching a real screen.
@@ -97,14 +125,14 @@ describe("cmux driver", () => {
     expect(result.version).toBe("");
   });
 
-  it("list calls 'workspace list' (migrated from list-workspaces) and parses output", async () => {
+  it("list parses `workspace list --json` into WorkspaceRefs (B2)", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      if (args[0] === "workspace" && args[1] === "list") {
-        return [
-          "workspace:1  🏛️ command  (running)",
-          "workspace:2  brove-captain  [selected]",
-          "workspace:3  ⚡ reactor  (running)",
-        ].join("\n");
+      if (args.includes("list") && args.includes("--json")) {
+        return wsListJson(
+          { ref: "workspace:1", title: "🏛️ command" },
+          { ref: "workspace:2", title: "brove-captain" },
+          { ref: "workspace:3", title: "⚡ reactor" },
+        );
       }
       return "";
     });
@@ -116,9 +144,28 @@ describe("cmux driver", () => {
     expect(cmds.every((c) => !c.includes("list-workspaces"))).toBe(true);
   });
 
+  it("list falls back to cwd as the name for an untitled workspace", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("list") && args.includes("--json")) {
+        return wsListJson({ ref: "workspace:1", cwd: "/Users/u" });
+      }
+      return "";
+    });
+    const refs = await driver.list();
+    expect(refs).toEqual([{ id: "workspace:1", name: "/Users/u", status: "running" }]);
+  });
+
+  it("list returns [] when the JSON payload is malformed", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("list") && args.includes("--json")) return "not json";
+      return "";
+    });
+    expect(await driver.list()).toEqual([]);
+  });
+
   it("status returns null when name not in list", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      if (args[0] === "workspace" && args[1] === "list") return "workspace:1  other-ws  (running)";
+      if (args.includes("list") && args.includes("--json")) return wsListJson({ ref: "workspace:1", title: "other-ws" });
       return "";
     });
     const ref = await driver.status("brove-captain");
@@ -127,7 +174,7 @@ describe("cmux driver", () => {
 
   it("status returns WorkspaceRef when name matches", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      if (args[0] === "workspace" && args[1] === "list") return "workspace:5  brove-captain  (running)";
+      if (args.includes("list") && args.includes("--json")) return wsListJson({ ref: "workspace:5", title: "brove-captain" });
       return "";
     });
     const ref = await driver.status("brove-captain");
@@ -144,26 +191,24 @@ describe("cmux driver", () => {
 
   it("send routes to surface named after workspace when one exists", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      const cmd = args.join(" ");
-      if (args[0] === "workspace" && args[1] === "list") return "workspace:2  test-ws  (running)";
-      if (cmd.includes("tree"))           return '  └── surface surface:5 [terminal] "test-ws"';
+      if (args.includes("list") && args.includes("--json")) return wsListJson({ ref: "workspace:2", title: "test-ws" });
+      if (args.includes("tree"))                            return treeJson("workspace:2", { ref: "surface:5", title: "test-ws" });
       return "";
     });
     await driver.send("workspace:2", "hello tab");
-    const cmds = execFileMock.mock.calls.map(cmdOf).filter((c) => !c.includes("list-workspaces") && !c.includes("tree"));
+    const cmds = execFileMock.mock.calls.map(cmdOf).filter((c) => !c.includes("list") && !c.includes("tree"));
     expect(cmds.some((c) => c.includes("send ") && c.includes("--surface surface:5") && c.includes("hello tab") && !c.includes("send-key"))).toBe(true);
     expect(cmds.some((c) => c.includes("send-key") && c.includes("--surface surface:5") && c.includes("Enter"))).toBe(true);
   });
 
   it("send falls back to workspace-level when no surface matches workspace name", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      const cmd = args.join(" ");
-      if (args[0] === "workspace" && args[1] === "list") return "workspace:2  test-ws  (running)";
-      if (cmd.includes("tree"))           return '  └── surface surface:5 [terminal] "crew-1"';
+      if (args.includes("list") && args.includes("--json")) return wsListJson({ ref: "workspace:2", title: "test-ws" });
+      if (args.includes("tree"))                            return treeJson("workspace:2", { ref: "surface:5", title: "crew-1" });
       return "";
     });
     await driver.send("workspace:2", "fallback message");
-    const cmds = execFileMock.mock.calls.map(cmdOf).filter((c) => !c.includes("list-workspaces") && !c.includes("tree"));
+    const cmds = execFileMock.mock.calls.map(cmdOf).filter((c) => !c.includes("list") && !c.includes("tree"));
     expect(cmds.some((c) => c.includes("send ") && !c.includes("--surface") && c.includes("fallback message"))).toBe(true);
     expect(cmds.some((c) => c.includes("send-key") && c.includes("Enter") && !c.includes("--surface"))).toBe(true);
   });
@@ -535,17 +580,15 @@ describe("cmux driver", () => {
     })).rejects.toThrow(/did not return a surface/);
   });
 
-  it("listSurfaces parses cmux tree output and returns surfaces with titles", async () => {
+  it("listSurfaces parses `tree --json` and returns surfaces with titles (B2)", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
       if (args.includes("tree")) {
-        return [
-          'window window:1 [current] ◀ active',
-          '└── workspace workspace:10 "⚓ pact-network-captain"',
-          '    └── pane pane:29 [focused]',
-          '        ├── surface surface:29 [terminal] "✳ Run startup checklist" [selected]',
-          '        ├── surface surface:30 [terminal] "🔧 pact-network:crew-1"',
-          '        └── surface surface:31 [terminal] "🔧 pact-network:crew-2"',
-        ].join("\n");
+        return treeJson(
+          "workspace:10",
+          { ref: "surface:29", title: "✳ Run startup checklist" },
+          { ref: "surface:30", title: "🔧 pact-network:crew-1" },
+          { ref: "surface:31", title: "🔧 pact-network:crew-2" },
+        );
       }
       return "";
     });
@@ -555,15 +598,43 @@ describe("cmux driver", () => {
       { workspaceId: "workspace:10", surfaceId: "surface:30", title: "🔧 pact-network:crew-1" },
       { workspaceId: "workspace:10", surfaceId: "surface:31", title: "🔧 pact-network:crew-2" },
     ]);
-    // Verify --id-format refs is passed to lock in the refs default
+    // The tree read must request both JSON (B2) and refs id-format (#325).
     const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.includes("tree") && c.includes("--json"))).toBe(true);
     expect(cmds.some((c) => c.includes("tree") && c.includes("--id-format refs"))).toBe(true);
+  });
+
+  it("listSurfaces only returns surfaces of the requested workspace", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("tree")) {
+        return JSON.stringify({
+          windows: [{
+            ref: "window:1",
+            workspaces: [
+              { ref: "workspace:10", panes: [{ surfaces: [{ ref: "surface:1", title: "keep" }] }] },
+              { ref: "workspace:99", panes: [{ surfaces: [{ ref: "surface:2", title: "skip" }] }] },
+            ],
+          }],
+        });
+      }
+      return "";
+    });
+    const surfaces = await driver.listSurfaces("workspace:10");
+    expect(surfaces).toEqual([{ workspaceId: "workspace:10", surfaceId: "surface:1", title: "keep" }]);
   });
 
   it("listSurfaces returns empty array when cmux throws", async () => {
     execFileMock.mockImplementation(() => { throw new Error("workspace not found"); });
     const surfaces = await driver.listSurfaces("workspace:99");
     expect(surfaces).toEqual([]);
+  });
+
+  it("listSurfaces returns empty array when the JSON payload is malformed", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("tree")) return "not json";
+      return "";
+    });
+    expect(await driver.listSurfaces("workspace:10")).toEqual([]);
   });
 });
 

--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -263,49 +263,32 @@ describe("cmux driver", () => {
     expect(cmds.every((c) => !c.includes("--direction"))).toBe(true);
   });
 
-  // #295: new tab steals cmux focus, leaking user keystrokes into crew launch command.
-  // Fix: snapshot selected surface before new-surface, restore focus after creation.
-  it("newPane with direction=tab restores focus to the previously-selected surface (#295)", async () => {
+  // audit A1+B3: a crew tab must be created focus-neutrally. cmux 0.64.16's
+  // new-surface defaults to --focus false; we pass it explicitly and NO LONGER
+  // snapshot the tree or move-surface to restore focus (the old #295 dance,
+  // which the 0.64 freeform canvas broke).
+  it("newPane with direction=tab creates the surface with --focus false and no refocus dance", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      const cmd = args.join(" ");
-      if (cmd.includes("tree")) {
-        return [
-          'surface surface:5 [terminal] "captain" [selected]',
-          'surface surface:6 [terminal] "crew-1"',
-        ].join("\n");
-      }
-      if (cmd.includes("new-surface")) return "OK surface:8 workspace:1";
+      if (args.includes("new-surface")) return "OK surface:8 workspace:1";
       return "";
     });
     await driver.newPane({ workspaceId: "workspace:1", direction: "tab" });
     const cmds = execFileMock.mock.calls.map(cmdOf);
-    expect(cmds.some((c) =>
-      c.includes("move-surface") &&
-      c.includes("--surface surface:5") &&
-      c.includes("--index 0") &&
-      c.includes("--focus true"))).toBe(true);
-  });
-
-  it("newPane with direction=tab skips focus restore gracefully when tree is unreadable (#295)", async () => {
-    execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      const cmd = args.join(" ");
-      if (cmd.includes("tree")) throw new Error("tree unreadable");
-      if (cmd.includes("new-surface")) return "OK surface:8 workspace:1";
-      return "";
-    });
-    const pane = await driver.newPane({ workspaceId: "workspace:1", direction: "tab" });
-    expect(pane.surfaceId).toBe("surface:8");
-    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.includes("new-surface") && c.includes("--focus false"))).toBe(true);
+    // No tree snapshot, no move-surface, never asks for focus true.
+    expect(cmds.every((c) => !c.includes("tree"))).toBe(true);
     expect(cmds.every((c) => !c.includes("move-surface"))).toBe(true);
+    expect(cmds.every((c) => !c.includes("--focus true"))).toBe(true);
   });
 
-  it("newPane with split direction does NOT query tree or restore focus (#295)", async () => {
+  it("newPane with split direction creates the pane with --focus false and queries nothing", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
       if (args.includes("new-pane")) return "OK surface:27 pane:25 workspace:1";
       return "";
     });
     await driver.newPane({ workspaceId: "workspace:1", direction: "right" });
     const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.includes("new-pane") && c.includes("--focus false"))).toBe(true);
     expect(cmds.every((c) => !c.includes("tree"))).toBe(true);
     expect(cmds.every((c) => !c.includes("move-surface"))).toBe(true);
   });
@@ -473,9 +456,7 @@ describe("cmux driver", () => {
   // (new-surface) keeps the captain pane full-height with no split.
   it("spawnInjector background uses new-surface (no split-pane, no resize-pane)", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      const cmd = args.join(" ");
-      if (cmd.includes("tree")) return 'surface surface:5 [terminal] "cap" [selected]';
-      if (cmd.includes("new-surface")) return "OK surface:8 pane:2 workspace:1";
+      if (args.includes("new-surface")) return "OK surface:8 pane:2 workspace:1";
       return "";
     });
     const pane = await driver.spawnInjector({
@@ -494,9 +475,7 @@ describe("cmux driver", () => {
 
   it("spawnInjector background sends the command + Enter to the new surface", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      const cmd = args.join(" ");
-      if (cmd.includes("tree")) return 'surface surface:5 [terminal] "cap" [selected]';
-      if (cmd.includes("new-surface")) return "OK surface:8 pane:2 workspace:1";
+      if (args.includes("new-surface")) return "OK surface:8 pane:2 workspace:1";
       return "";
     });
     await driver.spawnInjector({
@@ -509,19 +488,12 @@ describe("cmux driver", () => {
     expect(cmds.some((c) => c.includes("send-key") && c.includes("--surface surface:8") && c.includes("Enter"))).toBe(true);
   });
 
-  // The background relay tab must never steal focus from the captain: after
-  // spawning it we re-select whichever surface was selected before, in its
-  // original position.
-  it("spawnInjector background restores focus to the previously-selected surface", async () => {
+  // audit A1+B3: the background relay tab must never steal focus from the
+  // captain. cmux 0.64.16's new-surface defaults to --focus false, so we pass it
+  // explicitly and DROP the old snapshot-then-move-surface refocus dance.
+  it("spawnInjector background creates the surface with --focus false and no refocus dance", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      const cmd = args.join(" ");
-      if (cmd.includes("tree")) {
-        return [
-          'surface surface:5 [terminal] "cap" [selected]',
-          'surface surface:6 [terminal] "crew-1"',
-        ].join("\n");
-      }
-      if (cmd.includes("new-surface")) return "OK surface:8 pane:2 workspace:1";
+      if (args.includes("new-surface")) return "OK surface:8 pane:2 workspace:1";
       return "";
     });
     await driver.spawnInjector({
@@ -530,18 +502,15 @@ describe("cmux driver", () => {
       placement: "background",
     });
     const cmds = execFileMock.mock.calls.map(cmdOf);
-    expect(cmds.some((c) =>
-      c.includes("move-surface") &&
-      c.includes("--surface surface:5") &&
-      c.includes("--index 0") &&
-      c.includes("--focus true"))).toBe(true);
+    expect(cmds.some((c) => c.includes("new-surface") && c.includes("--focus false"))).toBe(true);
+    expect(cmds.every((c) => !c.includes("tree"))).toBe(true);
+    expect(cmds.every((c) => !c.includes("move-surface"))).toBe(true);
+    expect(cmds.every((c) => !c.includes("--focus true"))).toBe(true);
   });
 
-  it("spawnInjector visible uses new-surface and leaves the new tab focused (no refocus)", async () => {
+  it("spawnInjector visible creates the surface with --focus true and no refocus dance", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      const cmd = args.join(" ");
-      if (cmd.includes("tree")) return 'surface surface:5 [terminal] "cap" [selected]';
-      if (cmd.includes("new-surface")) return "OK surface:8 pane:2 workspace:1";
+      if (args.includes("new-surface")) return "OK surface:8 pane:2 workspace:1";
       return "";
     });
     await driver.spawnInjector({
@@ -550,7 +519,7 @@ describe("cmux driver", () => {
       placement: "visible",
     });
     const cmds = execFileMock.mock.calls.map(cmdOf);
-    expect(cmds.some((c) => c.includes("new-surface"))).toBe(true);
+    expect(cmds.some((c) => c.includes("new-surface") && c.includes("--focus true"))).toBe(true);
     expect(cmds.every((c) => !c.includes("move-surface"))).toBe(true);
   });
 

--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -52,6 +52,17 @@ describe("cmux driver", () => {
       expect(((cmuxCall as unknown[])[2] as Record<string, unknown>).timeout).toBeGreaterThan(0);
     });
 
+    it("passes CMUX_QUIET=1 in the subprocess env to silence deprecation notices", async () => {
+      execFileMock.mockReturnValue("");
+      await driver.probe();
+      const cmuxCall = execFileMock.mock.calls.find((c: unknown[]) =>
+        (c[1] as string[]).includes("--version"),
+      );
+      expect(cmuxCall).toBeDefined();
+      const env = (optsOf(cmuxCall as unknown[]).env) as Record<string, string>;
+      expect(env.CMUX_QUIET).toBe("1");
+    });
+
     it("throws a clean CmuxTimeoutError when execFileSync times out (unwrapped caller)", async () => {
       execFileMock.mockImplementation(() => {
         const err = new Error("cmux hung");

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -49,17 +49,50 @@ function cmux(args: string[]): string {
   }
 }
 
+// Shape of `cmux workspace list --json` (cmux 0.64.16). Only the fields we
+// consume are typed; everything else in the payload is ignored.
+interface CmuxWorkspaceListJson {
+  workspaces?: Array<{
+    ref?: string;
+    custom_title?: string | null;
+    has_custom_title?: boolean;
+    current_directory?: string | null;
+  }>;
+}
+
+// Shape of `cmux tree --json` (cmux 0.64.16). Surfaces nest as
+// windows[].workspaces[].panes[].surfaces[]; only consumed fields are typed.
+interface CmuxTreeJson {
+  windows?: Array<{
+    workspaces?: Array<{
+      ref?: string;
+      panes?: Array<{
+        surfaces?: Array<{ ref?: string; surface_ref?: string; title?: string | null }>;
+      }>;
+    }>;
+  }>;
+}
+
+// Parse `cmux workspace list --json` into WorkspaceRefs. Replaces the old
+// regex over the human-readable `list-workspaces` text (audit B2). The display
+// name is the workspace's custom title when set (byte-identical to what the
+// text form showed, e.g. "⚓ cockpit-captain" — this is what cockpit matches
+// captains by), falling back to the cwd for untitled workspaces.
 function parseList(output: string): WorkspaceRef[] {
+  let parsed: CmuxWorkspaceListJson;
+  try {
+    parsed = JSON.parse(output) as CmuxWorkspaceListJson;
+  } catch {
+    return [];
+  }
   const refs: WorkspaceRef[] = [];
-  for (const line of output.split("\n")) {
-    const match = line.match(/(workspace:\d+)\s+(.+?)(?:\s+\(.*\))?(?:\s+\[selected\])?$/);
-    if (match) {
-      refs.push({
-        id: match[1],
-        name: match[2].trim(),
-        status: "running",
-      });
-    }
+  for (const ws of parsed.workspaces ?? []) {
+    if (!ws.ref) continue;
+    refs.push({
+      id: ws.ref,
+      name: (ws.has_custom_title && ws.custom_title) ? ws.custom_title : (ws.current_directory ?? ws.ref),
+      status: "running",
+    });
   }
   return refs;
 }
@@ -240,7 +273,9 @@ export function createCmuxDriver(): RuntimeDriver {
 
     async list(): Promise<WorkspaceRef[]> {
       try {
-        return parseList(cmux(["workspace", "list", "--id-format", "refs"]));
+        // --json: structured output (B2); --id-format refs: ids as
+        // workspace:N refs, not numeric (from #325). Both are required.
+        return parseList(cmux(["workspace", "list", "--json", "--id-format", "refs"]));
       } catch {
         return [];
       }
@@ -463,18 +498,32 @@ export function createCmuxDriver(): RuntimeDriver {
     async listSurfaces(workspaceId: string): Promise<PaneRef[]> {
       let output: string;
       try {
-        output = cmux(["tree", "--workspace", workspaceId, "--id-format", "refs"]);
+        // --json: structured output (B2); --id-format refs: surface ids as
+        // surface:N refs, not numeric (from #325). Both are required.
+        output = cmux(["tree", "--workspace", workspaceId, "--json", "--id-format", "refs"]);
       } catch {
         return [];
       }
+      let parsed: CmuxTreeJson;
+      try {
+        parsed = JSON.parse(output) as CmuxTreeJson;
+      } catch {
+        return [];
+      }
+      // Navigate windows[].workspaces[].panes[].surfaces[], collecting every
+      // surface that belongs to the requested workspace. Replaces the old regex
+      // over `cmux tree` text (audit B2). Surface refs are globally unique, so
+      // filtering by the parent workspace ref is sufficient.
       const surfaces: PaneRef[] = [];
-      // tree output line example:
-      //     ├── surface surface:30 [terminal] "🔧 pact-network:crew-1" [selected]
-      const re = /surface\s+(surface:\d+)\s+\[\w+\]\s+"([^"]*)"/;
-      for (const line of output.split("\n")) {
-        const match = line.match(re);
-        if (match) {
-          surfaces.push({ workspaceId, surfaceId: match[1], title: match[2] });
+      for (const win of parsed.windows ?? []) {
+        for (const ws of win.workspaces ?? []) {
+          if (ws.ref !== workspaceId) continue;
+          for (const pane of ws.panes ?? []) {
+            for (const sf of pane.surfaces ?? []) {
+              const ref = sf.ref ?? sf.surface_ref;
+              if (ref) surfaces.push({ workspaceId, surfaceId: ref, title: sf.title ?? "" });
+            }
+          }
         }
       }
       return surfaces;

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -64,20 +64,6 @@ function parseList(output: string): WorkspaceRef[] {
   return refs;
 }
 
-// Parse `cmux tree` into the ordered list of surfaces in a workspace, marking
-// which one is currently selected. Order matches the tab strip, so the array
-// index doubles as the surface's position for move-surface --index.
-function parseSurfaceOrder(tree: string): { id: string; selected: boolean }[] {
-  const surfaces: { id: string; selected: boolean }[] = [];
-  for (const line of tree.split("\n")) {
-    const match = line.match(/surface\s+(surface:\d+)/);
-    if (match) {
-      surfaces.push({ id: match[1], selected: line.includes("[selected]") });
-    }
-  }
-  return surfaces;
-}
-
 // cmux `send` treats \n, \r (and \t) as Enter/Tab keystrokes, so any newline in a
 // multi-line message would submit it line-by-line. Collapse all newline/CR/tab
 // (real bytes AND literal backslash-escapes) to single spaces so the whole message
@@ -343,22 +329,16 @@ export function createCmuxDriver(): RuntimeDriver {
     },
 
     async newPane(opts: RuntimePaneOptions): Promise<PaneRef> {
-      // #295: snapshot the focused surface before creating a new tab so we can
-      // restore focus afterward. new-surface steals focus; the captain's
-      // keystrokes would otherwise land in the crew's launch command line.
-      // Applies only to tabs (new-surface); split-panes keep cmux default focus.
-      let priorSurface: string | undefined;
-      let priorIndex = -1;
-      if (opts.direction === "tab") {
-        try {
-          const before = parseSurfaceOrder(cmux(["tree", "--workspace", opts.workspaceId, "--id-format", "refs"]));
-          priorIndex = before.findIndex((s) => s.selected);
-          if (priorIndex >= 0) priorSurface = before[priorIndex].id;
-        } catch { /* best-effort: if we can't read the tree, skip refocus */ }
-      }
+      // #295 / audit A1+B3: a crew tab must never steal focus from the captain.
+      // cmux 0.64.16's new-surface and new-pane both DEFAULT to --focus false,
+      // so we pass it explicitly (intent + resilience if the default changes)
+      // and create the surface focus-neutrally. This REPLACES the old
+      // snapshot-then-move-surface refocus dance, which depended on the fragile
+      // "tree order == array index" invariant that the 0.64 freeform canvas +
+      // staggered restore broke — risking a focus-steal regression.
       const cmd = opts.direction === "tab"
-        ? ["new-surface", "--type", "terminal", "--workspace", opts.workspaceId]
-        : ["new-pane", "--type", "terminal", "--direction", opts.direction, "--workspace", opts.workspaceId];
+        ? ["new-surface", "--type", "terminal", "--workspace", opts.workspaceId, "--focus", "false"]
+        : ["new-pane", "--type", "terminal", "--direction", opts.direction, "--workspace", opts.workspaceId, "--focus", "false"];
       const output = cmux(cmd);
       const surfaceId = output.match(/surface:\d+/)?.[0];
       if (!surfaceId) {
@@ -369,11 +349,6 @@ export function createCmuxDriver(): RuntimeDriver {
         try {
           cmux(["rename-tab", "--workspace", opts.workspaceId, "--surface", surfaceId, "--title", opts.title]);
         } catch { /* rename is best-effort */ }
-      }
-      if (opts.direction === "tab" && priorSurface) {
-        try {
-          cmux(["move-surface", "--surface", priorSurface, "--index", String(priorIndex), "--focus", "true"]);
-        } catch { /* refocus is best-effort */ }
       }
       return { workspaceId: opts.workspaceId, surfaceId };
     },
@@ -410,20 +385,15 @@ export function createCmuxDriver(): RuntimeDriver {
       // relay still runs as a cmux descendant in the same workspace, preserving
       // the in-cmux delivery requirement (#112).
       //
-      // "background" then re-selects whatever surface was focused before, in its
-      // original position, so the relay tab never steals focus from the
-      // captain. "visible" leaves the new tab focused for debug ergonomics.
+      // cmux 0.64.16's new-surface DEFAULTS to --focus false, so "background"
+      // passes --focus false and the relay tab is created without ever stealing
+      // focus from the captain — no snapshot-then-move-surface refocus dance
+      // (audit A1+B3; the 0.64 freeform canvas broke the old tree-order==index
+      // assumption it relied on). "visible" passes --focus true to leave the
+      // debug tab focused for ergonomics.
       const wsId = opts.captainWorkspace.id;
-      let priorSurface: string | undefined;
-      let priorIndex = -1;
-      if (opts.placement === "background") {
-        try {
-          const before = parseSurfaceOrder(cmux(["tree", "--workspace", wsId, "--id-format", "refs"]));
-          priorIndex = before.findIndex((s) => s.selected);
-          if (priorIndex >= 0) priorSurface = before[priorIndex].id;
-        } catch { /* best-effort: if we can't read the tree, skip refocus */ }
-      }
-      const output = cmux(["new-surface", "--type", "terminal", "--workspace", wsId]);
+      const focus = opts.placement === "visible" ? "true" : "false";
+      const output = cmux(["new-surface", "--type", "terminal", "--workspace", wsId, "--focus", focus]);
       const surfaceId = output.match(/surface:\d+/)?.[0];
       if (!surfaceId) {
         throw new Error(`cmux spawnInjector did not return a surface id: ${output}`);
@@ -435,11 +405,6 @@ export function createCmuxDriver(): RuntimeDriver {
       }
       cmux(["send", "--workspace", wsId, "--surface", surfaceId, opts.command]);
       cmux(["send-key", "--workspace", wsId, "--surface", surfaceId, "Enter"]);
-      if (opts.placement === "background" && priorSurface) {
-        try {
-          cmux(["move-surface", "--surface", priorSurface, "--index", String(priorIndex), "--focus", "true"]);
-        } catch { /* refocus is best-effort */ }
-      }
       return { workspaceId: wsId, surfaceId, title: opts.title };
     },
 

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -32,7 +32,15 @@ export class DeferDelivery extends Error {
 // literal argument — backticks, $(), quotes are never parsed. See #118.
 function cmux(args: string[]): string {
   try {
-    return execFileSync(resolveCmuxBin(), args, { encoding: "utf-8", timeout: CMUX_TIMEOUT }).trim();
+    // CMUX_QUIET=1 silences cmux 0.64's one-time deprecation hints (e.g. the
+    // "list-workspaces is now an alias for cmux workspace list" notice). Those
+    // notices print to the command's stdout and would otherwise pollute the
+    // output we parse. Inherit the rest of the environment unchanged.
+    return execFileSync(resolveCmuxBin(), args, {
+      encoding: "utf-8",
+      timeout: CMUX_TIMEOUT,
+      env: { ...process.env, CMUX_QUIET: "1" },
+    }).trim();
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ETIMEDOUT") {
       throw new CmuxTimeoutError(args.join(" "));


### PR DESCRIPTION
Modernizes cockpit's cmux runtime driver for **cmux 0.64.16**. Single integration point: `src/runtimes/cmux.ts` (+ its unit tests). All cmux command shapes were verified live against 0.64.16 before coding.

## Delivered

### PART 1 — Focus-neutral spawn (audit A1/B3) ✅
Deleted the fragile focus-restore dance. `newPane(tab)` and `spawnInjector` used to snapshot the selected surface's **array index** via `parseSurfaceOrder(cmux tree)` then `move-surface --index --focus true` to restore focus after a focus-stealing `new-surface`. cmux 0.64.16's freeform canvas + staggered restore break the "tree order == index" invariant, risking a #295 focus-steal regression.

**Fix:** `cmux new-surface`/`new-pane` now **default to `--focus false`** (verified via `--help`). We pass `--focus false` explicitly (background tabs) / `--focus true` (visible debug tabs) and removed the snapshot + `move-surface` blocks. `parseSurfaceOrder` is deleted (was only used by the dance).

**Verified live:** creating a surface with `--focus false` in the captain workspace left the selected surface unchanged (`surface:9 → surface:9`).

### PART 2 — `--json` parsing (audit B2) ✅
Replaced regex over human-readable text with structured JSON:
- `list()` → `cmux workspace list --json`; `parseList` reads `ref` + `custom_title` (byte-identical to the captain name the text form produced), falling back to `current_directory` for untitled workspaces.
- `listSurfaces()` → `cmux tree --json`; navigates `windows[].workspaces[].panes[].surfaces[]`, filtered by parent workspace ref.
- Both fall back to `[]` on malformed JSON.
- `spawn()`'s inline initial-tab lookup is intentionally left on the text format (out of scope, unchanged → no blast radius on the launch path).

### PART 5 — `CMUX_QUIET=1` ✅
The `cmux()` helper now passes `env: { ...process.env, CMUX_QUIET: "1" }` to `execFileSync`, silencing 0.64's one-time deprecation hints (e.g. the `list-workspaces` alias notice) that print to stdout and would pollute parsed output. Timeout + error handling unchanged.

### PART 6 — Audit report ✅
Adds `docs/reports/2026-06-15-cmux-compat-audit-0.62-0.64.md` (previously untracked) to the branch.

## Deferred — need a decision (reported, not implemented)

### PART 3 — Per-workspace env (audit C3) ⚠️ NOT IMPLEMENTED
**Why:** `--env`/`--env-file` is a flag on `cmux workspace create` — the **workspace** level. But **all** crews (claude/opencode/codex/generic) spawn via `newPane` = a `new-surface` (tab) **inside the captain's existing workspace**; none create their own workspace. `cmux new-surface` has **no `--env` flag** (verified via `--help`).

Consequently a workspace-level env cannot give each crew a distinct `COCKPIT_CREW_TASK_ID`: every tab in the captain's single workspace would share one env, and `reapCrewChildren` relies on a per-crew `COCKPIT_CREW_TASK_ID=<taskId>` marker in each process's env. Implementing C3 as specified would require crews to spawn in their **own** workspace — a major architectural change (contradicts the #117 "relay must be a cmux descendant in the same workspace" / focus design), well outside surgical scope. (Note: codex's stable task-id is already solved via `--task-id`, per prior work.)

**Recommendation:** file a follow-up issue to decide between (a) keeping the current shell env-prefix, or (b) a crews-in-own-workspace redesign.

### PART 4 — `--window` scoping (audit C5, lower priority) ⚠️ NOT IMPLEMENTED
**Why:** cockpit addresses everything by **globally-unique refs** (`workspace:N`, `surface:N`), for which `--window` is redundant (it only disambiguates indexes/names across windows). The driver's read sites (`list`/`listSurfaces`) also receive no window id, so adding `--window` cleanly would require threading a window param through the `RuntimeDriver` interface — not surgical, and "only where clean" per the task. No clean injection point exists today.

## Verification
- `npm run build` (tsc) — clean.
- `npx vitest run src/runtimes/__tests__/cmux.test.ts` — **97 passed** (added tests per part: CMUX_QUIET env, focus-neutral spawn × tab/split/background/visible, JSON parseList + listSurfaces incl. malformed-JSON + workspace-filtering).
- Driver consumer suites (registry, crew, side, notify-relay, notify-relay-probe, shutdown) — **122 passed** (JSON switch is transparent at the `WorkspaceRef`/`PaneRef` boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
