### PR TITLE
feat(control): consume cmux native event stream for crew idle (B1)

### DIFF
--- a/docs/research/2026-06-16-cmux-events-stream.md
+++ b/docs/research/2026-06-16-cmux-events-stream.md
@@ -1,0 +1,108 @@
+# cmux native event stream — investigation (audit item B1)
+
+**Date:** 2026-06-16 · **Branch:** `feat/cmux-events-stream` · **cmux:** 0.64.16 (96)
+
+Goal: reduce cockpit's fragile screen-scraping by consuming cmux's native event
+stream. **Additive & safe** — the events consumer runs alongside the existing
+relay-proxy / pane-reader path, which stays as the fallback during migration.
+
+## STEP 0 — does `cmux events` exist? YES.
+
+`cmux events` streams **newline-delimited JSON** over the cmux Unix socket.
+
+```
+cmux events [--after <seq>] [--cursor-file <path>] [--name <event>]
+            [--category <category>] [--reconnect] [--limit <n>]
+            [--no-ack] [--no-heartbeat]
+```
+
+- `--reconnect` — reconnect forever, resume from last received seq (in-process).
+- `--cursor-file <path>` — read the starting seq from a file, update it after
+  each event. **Durable resume across daemon restarts.**
+- `--after <seq>` — replay retained events after a sequence.
+- `--category` / `--name` — server-side filters, repeatable.
+- `--no-heartbeat` — suppress the 15s heartbeat frames.
+
+### Frame shapes (live-captured)
+
+**Ack** (first frame; suppress with `--no-ack`):
+```json
+{"type":"ack","protocol":"cmux-events","version":1,"boot_id":"…",
+ "subscription_id":"…","heartbeat_interval_seconds":15,"replay_count":0,
+ "resume":{"after_seq":null,"gap":false,"latest_seq":1434,"next_seq":1435,
+           "oldest_seq":1,"requested_after_seq":1434},
+ "filters":{"categories":[],"names":[]}}
+```
+`resume.gap:true` signals retained-buffer overflow (events were dropped).
+
+**Event**:
+```json
+{"type":"event","protocol":"cmux-events","version":1,"seq":1435,
+ "boot_id":"…","id":"…-1435","category":"agent",
+ "name":"agent.hook.PreToolUse","occurred_at":"2026-06-15T17:02:17.362Z",
+ "source":"claude","workspace_id":"2AED…","surface_id":null,"pane_id":null,
+ "window_id":null,
+ "payload":{ "_source":"claude","session_id":"claude-7ba3…","_ppid":70993,
+   "cwd":"/Users/q3labsadmin/me/claude-cockpit",
+   "hook_event_name":"PreToolUse","phase":"received|completed",
+   "tool_name":"Bash","workspace_id":"2AED…", … }}
+```
+
+### Categories / names observed live
+
+| category       | names                                                                  |
+|----------------|------------------------------------------------------------------------|
+| `agent`        | `agent.hook.PreToolUse`, `agent.hook.Stop`, `agent.hook.SubagentStop`  |
+| `feed`         | `feed.item.received`, `feed.item.completed`                             |
+| `notification` | `notification.created/requested/cleared/clear_requested`               |
+| `sidebar`      | `sidebar.metadata.updated`                                              |
+
+The `agent` category is what we want: it mirrors Claude Code hook events
+(`PreToolUse`, `Stop`, `SubagentStop`, etc.) with `payload.cwd`,
+`payload.session_id`, `payload._source` (agent kind), and `workspace_id`.
+
+## Key architectural difference vs the opencode SSE bridge
+
+`OpencodeSseBridge` subscribes **per-crew** to that crew's `opencode --port N`
+HTTP server. `cmux events` is a **single global stream** for the whole cmux app,
+carrying every agent's hook events. So the cmux bridge is **one** long-lived
+subscription owned by the daemon, and each frame is **correlated** to a crew
+TaskRecord rather than arriving pre-addressed.
+
+### Correlation key: `payload.cwd` → `TaskRecord.cwd`
+
+Interactive crews run in an **isolated worktree** whose path becomes the record's
+`cwd` (`crew.ts` sets `cwd: spawnCwd`). Each worktree path is unique, so
+`payload.cwd === rec.cwd` cleanly maps a hook event to its crew. We only consider
+**non-terminal interactive** records, matching `_source` to the record provider.
+
+Limitation (prototype): a `--shared` crew runs with `cwd === projRoot`, which
+collides with the captain's cwd — those fall back to the existing scrape path.
+This is acceptable: scrape remains the fallback by design.
+
+## Mapping (minimal, idempotent)
+
+| cmux event                         | ControlEvent emitted      | effect                         |
+|------------------------------------|---------------------------|--------------------------------|
+| `agent.hook.Stop` (main session)   | `task.turn.completed`     | working → awaiting-input       |
+| `agent.hook.SubagentStop`          | *(ignored)*               | subagent end ≠ turn end        |
+
+`Stop` is the high-value signal: it's exactly the "turn ended / crew idle" state
+the pane-reader currently infers by scraping the screen. `task.turn.completed` is
+**liveness, not completion** (anti-#2576): terminal state still comes from the
+explicit `cockpit crew signal done`. The state-machine reducer already absorbs
+duplicate/late `task.turn.completed`, so feeding it from BOTH the events bridge
+and the existing path is harmless — the core property that makes this additive.
+
+## Lifecycle
+
+- Started once in the daemon boot IIFE (next to opencode re-subscribe).
+- Durable resume via `--cursor-file <stateRoot>/cmux-events.seq` + `--reconnect`.
+- Stopped in the daemon's returned `stop()` (kill the child).
+- Gated behind `defaults.cmuxEventsBridge` (default **on**); set false to fall
+  back to scrape-only.
+
+## Conclusion
+
+`cmux events` exists, is stable JSON, exposes the agent hook surface we need, and
+resumes durably. Safe to prototype a consumer alongside the scrape fallback.

--- a/docs/research/2026-06-16-cmux-events-stream.md
+++ b/docs/research/2026-06-16-cmux-events-stream.md
@@ -102,7 +102,46 @@ and the existing path is harmless — the core property that makes this additive
 - Gated behind `defaults.cmuxEventsBridge` (default **on**); set false to fall
   back to scrape-only.
 
+## B4 check — does the stream carry agent run-state? YES, via agent hooks.
+
+The audit asked whether the stream exposes claude/codex **working vs idle** so
+cockpit could drop the read-screen spinner heuristics
+(`classifyStartupSurface` / `CC_WORKING_RE`). There is **no dedicated
+"agent.status" query method** (`cmux capabilities` has no agent run-state
+method; the closest is `surface.report_shell_state`). But run-state **is**
+derivable from the `agent` event category itself:
+
+- `agent.hook.PreToolUse` / `UserPromptSubmit` → the agent is **working**.
+- `agent.hook.Stop` → the agent is **idle** (turn ended).
+
+So B4 is feasible **on top of this same stream**: a future PR could map
+PreToolUse→working / Stop→idle to replace the spinner scrape entirely. This PR
+already consumes `Stop`; extending to PreToolUse-as-working is the natural next
+step. (Reporting only, per the task — not implemented here.)
+
+## Surface lifecycle events — audit premise does NOT match cmux 0.64.16
+
+The audit assumed the stream emits `surface.created/closed/selected` +
+`workspace.selected` (for an event-driven crew-surface reaper — STEP 2 — and an
+authoritative stale-ref prune — STEP 3). **Live verification contradicts this.**
+Creating and then closing a workspace while subscribed with
+`--category surface` produced only `surface.input_sent` / `surface.key_sent`
+(keystroke echoes) — **no** `surface.created` / `surface.closed` /
+`surface.selected` frame fired. There is also no `~/.cmuxterm/events.jsonl`
+file; the stream is socket-based (`cmux events`).
+
+**Implication:** an event-driven surface reaper / stale-ref prune cannot be built
+on `surface.closed` in cmux 0.64.16 — that event does not exist. The
+**agent-hook** approach this PR ships (`agent.hook.Stop` → turn-end / idle) is
+the achievable B1 win. STEP 3's relay "Workspace not found" noise must be fixed
+the polled way (a per-sweep workspace-list guard + prune-once log), independent
+of the event stream — flagged to the captain as a separate follow-up, since it's
+in the relay/probe path and not unblocked by any event here.
+
 ## Conclusion
 
-`cmux events` exists, is stable JSON, exposes the agent hook surface we need, and
-resumes durably. Safe to prototype a consumer alongside the scrape fallback.
+`cmux events` exists, is stable JSON, exposes the **agent hook** surface we need
+(idle via `Stop`, working via `PreToolUse` — enough for B1 and a future B4), and
+resumes durably. It does **not** expose surface lifecycle events, so the
+event-driven reaper/prune the audit hypothesized is not possible on this version.
+Safe to prototype the agent-hook consumer alongside the scrape fallback — done.

--- a/src/config.ts
+++ b/src/config.ts
@@ -89,6 +89,9 @@ export interface CockpitConfig {
     taskTimeoutMs?: number;
     /** #275 rule-based crew routing: keyword rules map task text to {agent, model}. Optional — absent = fall through to defaults.roles.crew. */
     crewRouting?: CrewRoutingConfig;
+    /** B1: consume cmux's native event stream for crew turn-end (idle) detection
+     *  alongside the scrape fallback. Default true; set false for scrape-only. */
+    cmuxEventsBridge?: boolean;
   };
   metrics: {
     enabled: boolean;
@@ -131,6 +134,7 @@ export function getDefaultConfig(): CockpitConfig {
         side: { agent: "claude", model: "opus" },
       },
       taskTimeoutMs: 8 * 60 * 60 * 1000,
+      cmuxEventsBridge: true,
       crewRouting: {
         rules: [
           { tier: "extreme", match: "redesign|architect|rewrite|from scratch|deep reasoning", agent: "claude", model: "opus" },

--- a/src/control/__tests__/cockpitd-cmux-events.test.ts
+++ b/src/control/__tests__/cockpitd-cmux-events.test.ts
@@ -1,0 +1,35 @@
+// src/control/__tests__/cockpitd-cmux-events.test.ts
+//
+// B1: the daemon wires the cmux native-events bridge additively — it starts on
+// boot and stops on daemon shutdown. An injected fake keeps this off the real
+// `cmux events` process (the real default is skipped under vitest).
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startCockpitd } from "../cockpitd.js";
+
+describe("cockpitd cmux events bridge wiring", () => {
+  let stop: (() => void) | undefined;
+  let dir: string;
+  afterEach(() => { stop?.(); if (dir) rmSync(dir, { recursive: true, force: true }); });
+
+  it("starts the injected bridge on boot and stops it on shutdown", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-cmuxev-"));
+    const bridge = { start: vi.fn(), stop: vi.fn() };
+    const handle = startCockpitd({
+      stateRoot: join(dir, "state"),
+      sockPath: join(dir, "c.sock"),
+      sweepMs: 0,
+      cmuxEventsBridge: bridge,
+    });
+    stop = handle.stop;
+    // Boot work runs in an async IIFE; let it flush.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(bridge.start).toHaveBeenCalledTimes(1);
+
+    await handle.stop();
+    stop = undefined;
+    expect(bridge.stop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/control/cmux/__tests__/events-bridge.test.ts
+++ b/src/control/cmux/__tests__/events-bridge.test.ts
@@ -1,0 +1,161 @@
+// Tests for the cmux native-events → ControlEvent bridge (audit B1).
+// The bridge subscribes ONCE to `cmux events` (a single global newline-delimited
+// JSON stream over the cmux socket) and correlates each agent hook frame to a
+// crew TaskRecord by cwd, mapping `agent.hook.Stop` → `task.turn.completed`.
+// This is the events-stream alternative to scraping a crew's pane for idle.
+import { describe, it, expect, vi } from "vitest";
+import { Readable } from "node:stream";
+import { EventEmitter } from "node:events";
+import { CmuxEventsBridge } from "../events-bridge.js";
+import type { ControlEvent } from "../../types.js";
+
+/** A fake `cmux events` child: stdout streams the given lines, then exits. */
+function fakeChild(lines: string[]) {
+  const stdout = Readable.from(lines.map((l) => Buffer.from(l)));
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: Readable;
+    kill: () => void;
+  };
+  child.stdout = stdout;
+  child.kill = vi.fn(() => stdout.destroy());
+  // Emit "exit" once stdout drains, mirroring a real child whose stream ended.
+  stdout.on("end", () => child.emit("exit", 0, null));
+  return child;
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+const ack =
+  '{"type":"ack","protocol":"cmux-events","resume":{"latest_seq":1,"gap":false}}\n';
+
+function stopFrame(cwd: string, phase = "completed", name = "agent.hook.Stop") {
+  return (
+    JSON.stringify({
+      type: "event",
+      category: "agent",
+      name,
+      seq: 2,
+      source: "claude",
+      workspace_id: "ws1",
+      payload: { _source: "claude", session_id: "claude-abc", cwd, phase },
+    }) + "\n"
+  );
+}
+
+describe("CmuxEventsBridge", () => {
+  it("maps agent.hook.Stop → task.turn.completed for the matching crew cwd", async () => {
+    const events: ControlEvent[] = [];
+    const resolve = (e: { cwd?: string }) =>
+      e.cwd === "/wt/crew-a" ? { id: "task-a" } : undefined;
+    const spawnImpl = vi.fn((_bin: string, _args: string[]) =>
+      fakeChild([ack, stopFrame("/wt/crew-a")]),
+    );
+
+    const bridge = new CmuxEventsBridge({
+      emit: (e) => events.push(e),
+      resolve,
+      cursorFile: "/tmp/seq",
+      spawnImpl: spawnImpl as never,
+      stopAfterFirstRun: true,
+    });
+    bridge.start();
+    await flush();
+    await flush();
+
+    // It invoked `cmux events` with reconnect + cursor-file + agent category.
+    const args = spawnImpl.mock.calls[0][1];
+    expect(args).toContain("events");
+    expect(args).toContain("--reconnect");
+    expect(args).toContain("--cursor-file");
+    expect(args).toContain("/tmp/seq");
+    expect(args).toEqual(expect.arrayContaining(["--category", "agent"]));
+
+    expect(events).toEqual([
+      { type: "task.turn.completed", id: "task-a", turnId: "claude-abc" },
+    ]);
+    bridge.stop();
+  });
+
+  it("ignores frames with no matching crew, the ack, and SubagentStop", async () => {
+    const events: ControlEvent[] = [];
+    const resolve = (e: { cwd?: string }) =>
+      e.cwd === "/wt/known" ? { id: "t" } : undefined;
+    const lines = [
+      ack,
+      stopFrame("/wt/unknown"), // no matching record
+      stopFrame("/wt/known", "completed", "agent.hook.SubagentStop"), // subagent ≠ turn
+      stopFrame("/wt/known"), // the only one that should fire
+    ];
+    const bridge = new CmuxEventsBridge({
+      emit: (e) => events.push(e),
+      resolve,
+      cursorFile: "/tmp/seq",
+      spawnImpl: (() => fakeChild(lines)) as never,
+      stopAfterFirstRun: true,
+    });
+    bridge.start();
+    await flush();
+    await flush();
+    expect(events).toEqual([
+      { type: "task.turn.completed", id: "t", turnId: "claude-abc" },
+    ]);
+    bridge.stop();
+  });
+
+  it("emits once per Stop, ignoring the received-phase duplicate", async () => {
+    const events: ControlEvent[] = [];
+    const lines = [
+      ack,
+      stopFrame("/wt/x", "received"), // the paired received frame — must NOT fire
+      stopFrame("/wt/x", "completed"),
+    ];
+    const bridge = new CmuxEventsBridge({
+      emit: (e) => events.push(e),
+      resolve: () => ({ id: "x" }),
+      cursorFile: "/tmp/seq",
+      spawnImpl: (() => fakeChild(lines)) as never,
+      stopAfterFirstRun: true,
+    });
+    bridge.start();
+    await flush();
+    await flush();
+    expect(events.filter((e) => e.type === "task.turn.completed")).toHaveLength(1);
+    bridge.stop();
+  });
+
+  it("survives a malformed line without emitting", async () => {
+    const events: ControlEvent[] = [];
+    const bridge = new CmuxEventsBridge({
+      emit: (e) => events.push(e),
+      resolve: () => ({ id: "x" }),
+      cursorFile: "/tmp/seq",
+      spawnImpl: (() => fakeChild([ack, "not json\n", stopFrame("/wt/x")])) as never,
+      stopAfterFirstRun: true,
+    });
+    bridge.start();
+    await flush();
+    await flush();
+    expect(events).toHaveLength(1);
+    bridge.stop();
+  });
+
+  it("buffers partial lines across chunk boundaries", async () => {
+    const events: ControlEvent[] = [];
+    const full = stopFrame("/wt/x");
+    const mid = Math.floor(full.length / 2);
+    // Split one JSON frame across two stdout chunks.
+    const bridge = new CmuxEventsBridge({
+      emit: (e) => events.push(e),
+      resolve: () => ({ id: "x" }),
+      cursorFile: "/tmp/seq",
+      spawnImpl: (() =>
+        fakeChild([ack, full.slice(0, mid), full.slice(mid)])) as never,
+      stopAfterFirstRun: true,
+    });
+    bridge.start();
+    await flush();
+    await flush();
+    expect(events).toHaveLength(1);
+    bridge.stop();
+  });
+});

--- a/src/control/cmux/events-bridge.ts
+++ b/src/control/cmux/events-bridge.ts
@@ -1,0 +1,189 @@
+// src/control/cmux/events-bridge.ts
+// Daemon-side bridge from cmux's native event stream to cockpit ControlEvents
+// (audit item B1 — reduce fragile screen-scraping).
+//
+// Unlike the per-crew OpencodeSseBridge, `cmux events` is a SINGLE global stream
+// for the whole cmux app: one newline-delimited JSON frame per cmux event,
+// carrying every agent's hook events. So this bridge is ONE long-lived
+// subscription owned by the daemon. Each `agent` frame is correlated back to a
+// crew TaskRecord by cwd (each interactive crew runs in a unique worktree path),
+// and `agent.hook.Stop` — the "turn ended / crew idle" signal the pane reader
+// currently infers by scraping — is mapped to `task.turn.completed`.
+//
+// ADDITIVE & SAFE: this runs ALONGSIDE the existing relay-proxy/pane-reader path,
+// which stays as the fallback. `task.turn.completed` is liveness, NOT completion
+// (anti-#2576): terminal state still comes from the explicit `cockpit crew signal
+// done`. The state-machine reducer already absorbs duplicate/late
+// task.turn.completed, so feeding it from BOTH paths is harmless.
+import type { ChildProcess } from "node:child_process";
+import { spawn as nodeSpawn } from "node:child_process";
+import { resolveCmuxBin } from "../../lib/cmux-bin.js";
+import type { ControlEvent } from "../types.js";
+
+/** Minimal subset of ChildProcess this bridge needs (injectable for tests). */
+export interface CmuxEventsChild {
+  stdout: NodeJS.ReadableStream | null;
+  kill(signal?: NodeJS.Signals): boolean | void;
+  on(event: "exit", cb: (code: number | null) => void): unknown;
+  on(event: "error", cb: (err: Error) => void): unknown;
+}
+
+/** A correlated hook frame, passed to the caller's record resolver. */
+export interface CmuxAgentHook {
+  cwd?: string;
+  /** The emitting agent kind (`payload._source`, e.g. "claude"). */
+  source?: string;
+  /** The agent session id (`payload.session_id`). */
+  sessionId?: string;
+}
+
+export interface CmuxEventsBridgeDeps {
+  /** Ingress into the daemon's event pipeline (resolves project + handles). */
+  emit: (ev: ControlEvent) => void;
+  /**
+   * Map an agent hook frame to its owning crew record, or undefined if none.
+   * The daemon supplies this from the store (non-terminal interactive records
+   * matched by cwd). Keeping it injected keeps the bridge pure and testable.
+   */
+  resolve: (hook: CmuxAgentHook) => { id: string } | undefined;
+  /** Durable resume cursor passed to `cmux events --cursor-file`. */
+  cursorFile: string;
+  /** Injectable spawn for tests; defaults to spawning the real cmux binary. */
+  spawnImpl?: (bin: string, args: string[]) => CmuxEventsChild;
+  /** Injectable cmux binary path; defaults to resolveCmuxBin(). */
+  cmuxBin?: string;
+  /** Injectable backoff for tests; defaults to setTimeout. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Backoff between respawn attempts after the child exits (ms, default 1000). */
+  reconnectMs?: number;
+  log?: (msg: string) => void;
+  /** Test-only: stop after the first child exits (don't respawn). */
+  stopAfterFirstRun?: boolean;
+}
+
+/**
+ * One long-lived `cmux events` subscription for the whole daemon. The CLI's
+ * `--reconnect` resumes the socket in-process; `--cursor-file` makes resume
+ * durable across daemon (and child) restarts. If the child process itself dies,
+ * we respawn with backoff so the consumer self-heals.
+ */
+export class CmuxEventsBridge {
+  private child: CmuxEventsChild | null = null;
+  private stopped = false;
+  private buf = "";
+  private deps: CmuxEventsBridgeDeps;
+
+  constructor(deps: CmuxEventsBridgeDeps) {
+    this.deps = deps;
+  }
+
+  /** Begin the subscription. Idempotent. */
+  start(): void {
+    if (this.child || this.stopped) return;
+    void this.run();
+  }
+
+  /** Stop the subscription and kill the child (daemon shutdown). */
+  stop(): void {
+    this.stopped = true;
+    const c = this.child;
+    this.child = null;
+    if (c) {
+      try { c.kill(); } catch { /* already gone */ }
+    }
+  }
+
+  private async run(): Promise<void> {
+    const spawnImpl =
+      this.deps.spawnImpl ??
+      ((bin, args) => nodeSpawn(bin, args, { stdio: ["ignore", "pipe", "ignore"] }) as ChildProcess as unknown as CmuxEventsChild);
+    const bin = this.deps.cmuxBin ?? resolveCmuxBin();
+    const sleep = this.deps.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+    const reconnectMs = this.deps.reconnectMs ?? 1000;
+    const args = [
+      "events",
+      "--reconnect",
+      "--cursor-file", this.deps.cursorFile,
+      "--category", "agent",
+      "--no-heartbeat",
+    ];
+
+    while (!this.stopped) {
+      this.buf = "";
+      let child: CmuxEventsChild;
+      try {
+        child = spawnImpl(bin, args);
+      } catch (e) {
+        this.deps.log?.(`cmux events spawn failed: ${(e as Error).message}`);
+        if (this.deps.stopAfterFirstRun) return;
+        await sleep(reconnectMs);
+        continue;
+      }
+      this.child = child;
+      await new Promise<void>((resolve) => {
+        let settled = false;
+        const done = () => { if (!settled) { settled = true; resolve(); } };
+        child.stdout?.on("data", (b: Buffer | string) => this.onData(b));
+        child.stdout?.on("end", done);
+        child.on("exit", done);
+        child.on("error", (err) => {
+          this.deps.log?.(`cmux events child error: ${err.message}`);
+          done();
+        });
+      });
+      this.child = null;
+      if (this.stopped || this.deps.stopAfterFirstRun) break;
+      // Child died (cmux app restart, binary error): resume from the cursor.
+      await sleep(reconnectMs);
+    }
+  }
+
+  private onData(chunk: Buffer | string): void {
+    this.buf += typeof chunk === "string" ? chunk : chunk.toString("utf-8");
+    let nl: number;
+    while ((nl = this.buf.indexOf("\n")) >= 0) {
+      const line = this.buf.slice(0, nl);
+      this.buf = this.buf.slice(nl + 1);
+      this.handleLine(line);
+    }
+  }
+
+  private handleLine(rawLine: string): void {
+    const line = rawLine.trim();
+    if (!line || line[0] !== "{") return;
+    let f:
+      | {
+          type?: string;
+          category?: string;
+          name?: string;
+          source?: string;
+          payload?: { _source?: string; session_id?: string; cwd?: string; phase?: string };
+        }
+      | undefined;
+    try {
+      f = JSON.parse(line);
+    } catch {
+      return; // partial/non-JSON keepalive or ack we don't parse
+    }
+    // Only agent hook events; ignore ack/heartbeat and other categories.
+    if (f?.type !== "event" || f.category !== "agent") return;
+    // `Stop` is the main-session turn-end; `SubagentStop` is a nested agent
+    // finishing (NOT a turn end) — only Stop maps to task.turn.completed.
+    if (f.name !== "agent.hook.Stop") return;
+    const p = f.payload ?? {};
+    // Each hook fires a "received" then "completed" phase frame; act on the
+    // settled one so we emit exactly once per Stop.
+    if (p.phase === "received") return;
+    const rec = this.deps.resolve({
+      cwd: p.cwd,
+      source: p._source ?? f.source,
+      sessionId: p.session_id,
+    });
+    if (!rec) return;
+    this.deps.emit({
+      type: "task.turn.completed",
+      id: rec.id,
+      turnId: p.session_id ?? "cmux",
+    });
+  }
+}

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -14,6 +14,7 @@ import { startServer, encodeFrame, type AttachFrame, type AttachInbound } from "
 import { runHeadless } from "./headless-launcher.js";
 import { CodexInteractiveDriver, shouldReattachCodex } from "./codex/driver.js";
 import { OpencodeSseBridge } from "./opencode/sse-bridge.js";
+import { CmuxEventsBridge } from "./cmux/events-bridge.js";
 import { makeGate } from "./codex/gate.js";
 import { appendToMailbox, rotateIfNeeded, mailboxStats, readCursor } from "./mailbox.js";
 import { createRelayHealer } from "./relay-healer.js";
@@ -93,6 +94,9 @@ export interface CockpitdOpts {
     /** CP3: POST the captain's approve/deny decision to the crew's server. */
     answer: (taskId: string, decision: "approve" | "deny") => Promise<boolean>;
   };
+  /** B1: inject a fake cmux events bridge for tests. Defaults to a real one
+   *  (gated on defaults.cmuxEventsBridge). */
+  cmuxEventsBridge?: { start: () => void; stop: () => void };
 }
 
 // ── Tier 0/2 snapshot gathering (I/O at the edge; the pure assembly lives in
@@ -342,6 +346,35 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
     log,
   });
 
+  // B1: cmux native-events bridge. ADDITIVE — runs alongside the relay-proxy /
+  // pane-reader scrape path, which stays as the fallback. A single global
+  // `cmux events` subscription maps each crew's `agent.hook.Stop` (turn-end /
+  // idle) to task.turn.completed, correlating the frame's cwd to a non-terminal
+  // interactive record (each crew runs in a unique worktree path). The reducer
+  // absorbs duplicate/late turn.completed, so feeding it from both paths is safe.
+  const cmuxEventsBridge =
+    opts.cmuxEventsBridge ??
+    new CmuxEventsBridge({
+      emit: (ev) => {
+        const found = store.listAll().find((r) => r.id === ev.id);
+        if (!found) return;
+        void d.handle({ kind: "event", project: found.project, event: ev });
+      },
+      resolve: (hook) => {
+        if (!hook.cwd) return undefined;
+        return store
+          .listAll()
+          .find(
+            (r) =>
+              r.mode === "interactive" &&
+              !TERMINAL_STATES.has(r.state) &&
+              r.cwd === hook.cwd,
+          );
+      },
+      cursorFile: join(stateRoot, "cmux-events.seq"),
+      log,
+    });
+
   const ingest = (project: string) => (e: import("./types.js").ControlEvent) =>
     void d.handle({ kind: "event", project, event: e });
 
@@ -563,6 +596,17 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       if (!rec.serverPort) continue;
       opencodeBridge.start({ taskId: rec.id, port: rec.serverPort });
     }
+
+    // B1: start the single cmux native-events subscription (additive; the scrape
+    // fallback is unaffected). Opt out via defaults.cmuxEventsBridge:false. The
+    // REAL (non-injected) bridge is skipped under vitest so daemon tests never
+    // spawn a real `cmux events` child; an injected fake always starts so the
+    // wiring stays testable.
+    const enableCmuxEvents = loadConfig().defaults.cmuxEventsBridge !== false;
+    const cmuxEventsSafe = !!opts.cmuxEventsBridge || !process.env.VITEST;
+    if (enableCmuxEvents && cmuxEventsSafe) {
+      try { cmuxEventsBridge.start(); } catch (e) { log(`cmux events bridge start failed: ${(e as Error).message}`); }
+    }
   })();
 
   const server = startServer(sockPath, {
@@ -712,6 +756,7 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
     stop(): Promise<void> {
       if (timer) clearInterval(timer);
       if (rotationTimer) clearInterval(rotationTimer);
+      try { cmuxEventsBridge.stop(); } catch { /* best-effort */ }
       for (const kill of activeHeadlessKills) kill();
       return new Promise<void>((resolve) => server.close(() => { log("stopped"); resolve(); }));
     },


### PR DESCRIPTION
## What & why

Audit item **B1**: reduce cockpit's fragile screen-scraping by consuming cmux's **native event stream**. Interactive crew idle/turn-end is currently inferred by scraping the crew's pane (`crew-pane-reader.ts`) and probing surfaces. cmux 0.64.16 exposes `cmux events` — a durable, reconnectable JSON event bus that emits each agent's Claude Code hook events (`PreToolUse`, `Stop`, …). This PR adds a consumer for it.

**ADDITIVE & SAFE — prototype, keep fallback during migration.** The new bridge runs **alongside** the existing relay-proxy / pane-reader scrape path, which is left untouched as the fallback. Nothing is ripped out.

## STEP 0 — live investigation (cmux 0.64.16)

Full notes: `docs/research/2026-06-16-cmux-events-stream.md`. Key findings:

- `cmux events` **exists** and streams newline-delimited JSON over the cmux socket.
- Subscription used: `cmux events --reconnect --cursor-file <stateRoot>/cmux-events.seq --category agent --no-heartbeat`
  - `--reconnect` resumes the socket in-process; `--cursor-file` makes resume **durable across daemon/child restarts**; `--category agent` filters server-side.
- Event frame carries `category`, `name` (e.g. `agent.hook.Stop`), `seq`, `workspace_id`, and a `payload` with `cwd`, `session_id`, `_source`, `phase` (`received`→`completed`).
- Categories observed: `agent`, `feed`, `notification`, `sidebar`. We consume **`agent`**.

## Design

`cmux events` is a **single global stream** (not per-crew like the opencode SSE bridge), so this is **one** daemon-owned subscription. Each `agent.hook.Stop` frame is correlated to a **non-terminal interactive** crew record by **`payload.cwd === rec.cwd`** (each crew runs in a unique worktree path — set as `cwd: spawnCwd` in `crew.ts`), then emitted as `task.turn.completed`.

| cmux event | emitted | effect |
|---|---|---|
| `agent.hook.Stop` (completed phase) | `task.turn.completed` | working → awaiting-input |
| `agent.hook.SubagentStop` | *(ignored)* | subagent end ≠ turn end |

`task.turn.completed` is **liveness, not completion** (anti-#2576): terminal state still comes from explicit `cockpit crew signal done`. The state-machine reducer already absorbs duplicate/late `task.turn.completed`, so feeding it from **both** the events bridge and the scrape path is harmless — that's what makes this additive.

**Limitation (prototype):** a `--shared` crew runs with `cwd === projRoot` (collides with the captain), so those fall back to the scrape path. Acceptable by design.

## Changes

- **`src/control/cmux/events-bridge.ts`** — `CmuxEventsBridge` (mirrors `OpencodeSseBridge`): durable resume, respawn-on-exit with backoff, injectable spawn for tests.
- **`src/control/cockpitd.ts`** — additive wiring: construct + boot-start + shutdown-stop. The real subscription is **skipped under vitest** so daemon tests never spawn a real `cmux events` child; injected fakes still start.
- **`src/config.ts`** — `defaults.cmuxEventsBridge` flag (default **true**; set `false` for scrape-only).
- **tests** — bridge unit tests (mapping, correlation, dedup, malformed-line, chunk-boundary) + daemon wiring test.
- **docs** — STEP 0 findings.

## Verification

- `npx tsc --noEmit` clean.
- Full suite: **1189 passed (102 files)**, no regressions.
- gitnexus impact on `startCockpitd`: **LOW** (additive, no signature change).

## Files explicitly NOT touched

`src/runtimes/cmux.ts` and `src/commands/crew.ts` (owned by another crew).
