### PR TITLE
fix(control): prune stale relay-health records (STEP 3) + document hibernation deferral (C2)

### DIFF
--- a/docs/research/2026-06-16-cmux-events-stream.md
+++ b/docs/research/2026-06-16-cmux-events-stream.md
@@ -145,3 +145,38 @@ in the relay/probe path and not unblocked by any event here.
 resumes durably. It does **not** expose surface lifecycle events, so the
 event-driven reaper/prune the audit hypothesized is not possible on this version.
 Safe to prototype the agent-hook consumer alongside the scrape fallback — done.
+
+## STEP 3 follow-up — relay stale-ref noise, fixed the polled way
+
+Implemented in `feat/lifecycle-hardening`. The observed per-cycle noise was the
+daemon sweep re-healing relay records for projects whose **captain workspace is
+permanently gone** (live `cockpitd.log` showed `relay heal pact-network: captain
+workspace not present` every cycle for `pact-network`/`oneplan`). Mechanism: a
+failing/absent cmux lookup degrades gracefully in code, but cmux's CLI **stderr
+is inherited** by the daemon (`execFileSync` default), so each retry also echoes
+cmux's own `Error: not_found …` to our stderr.
+
+Fix (polled, no surface events needed): `createRelayHealer` now returns
+`"captain-absent"` when the captain workspace no longer resolves; the sweep
+prunes that relay-health record (and its debounce) so the heal/log fires **once**
+then goes quiet. A captain restart re-registers a fresh relay, so recovery is
+unaffected. The crew-surface probe poll set was already pruned of terminal crews
+(`cockpitd` evicts `inFlightProbes`/`probeResults` on terminal state, and
+`proxiedSurfaceAlive` only enqueues non-terminal records), so no change there.
+
+## C2 — agent hibernation: investigated, deferred (global-only, unsafe)
+
+`cmux agent-hibernation --help` in 0.64.16 is `cmux agent-hibernation <on|off>`
+— a **GLOBAL, app-wide** toggle with no per-session or per-workspace argument
+("Configure idle and live-terminal limits from Settings"). Enabling it would
+hibernate **every** agent/terminal session, including the **captain** and the
+**notify-relay** — both must stay responsive to deliver notifications — which
+would break orchestration. Idle trigger is configured globally (Settings/JSON),
+not scopeable to crews.
+
+**Decision: do NOT enable.** Wired a documented OFF flag
+`defaults.cmuxAgentHibernation` (default `false`) in `src/config.ts` as a
+decision record + forward hook for if/when cmux adds crew-only scoping. Because
+it is global-only, the surface-liveness reaper needs no "hibernated = alive"
+change in this PR (nothing is hibernated). Revisit if cmux exposes per-session
+hibernation.

--- a/src/commands/heal.ts
+++ b/src/commands/heal.ts
@@ -14,6 +14,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { queryHealth } from "./health-view.js";
 import { createRelayHealer } from "../control/relay-healer.js";
+import type { RelayHealOutcome } from "../control/daemon.js";
 import { ensureDaemon as _ensureDaemon } from "../control/launchd.js";
 import type { ComponentHealth, HealthState } from "../control/liveness.js";
 
@@ -124,7 +125,7 @@ export async function runHealStatus(opts: HealStatusOpts): Promise<number> {
 export interface HealRelayOpts {
   project: string;
   queryHealth: typeof queryHealth;
-  relayHealer: (project: string) => Promise<void>;
+  relayHealer: (project: string) => Promise<RelayHealOutcome | void>;
   stdout: NodeJS.WritableStream;
   stderr: NodeJS.WritableStream;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -92,6 +92,17 @@ export interface CockpitConfig {
     /** B1: consume cmux's native event stream for crew turn-end (idle) detection
      *  alongside the scrape fallback. Default true; set false for scrape-only. */
     cmuxEventsBridge?: boolean;
+    /**
+     * Audit C2 — agent hibernation (reclaim idle-crew RAM). INTENTIONALLY OFF and
+     * INERT: cmux 0.64.16's `cmux agent-hibernation <on|off>` is GLOBAL (app-wide,
+     * no per-session/per-workspace scope), so enabling it would also hibernate the
+     * CAPTAIN and the notify-relay — both must stay responsive to deliver
+     * notifications — breaking orchestration. We do NOT call `agent-hibernation on`
+     * anywhere; this flag is a documented decision record + a forward hook for when
+     * cmux gains crew-only scoping. Until then leave false.
+     * See docs/research/2026-06-16-cmux-events-stream.md (C2 finding).
+     */
+    cmuxAgentHibernation?: boolean;
   };
   metrics: {
     enabled: boolean;
@@ -135,6 +146,9 @@ export function getDefaultConfig(): CockpitConfig {
       },
       taskTimeoutMs: 8 * 60 * 60 * 1000,
       cmuxEventsBridge: true,
+      // Audit C2: OFF by design — cmux hibernation is global-only and would
+      // hibernate the captain/relay. See the field doc above.
+      cmuxAgentHibernation: false,
       crewRouting: {
         rules: [
           { tier: "extreme", match: "redesign|architect|rewrite|from scratch|deep reasoning", agent: "claude", model: "opus" },

--- a/src/control/__tests__/daemon-relay-health.test.ts
+++ b/src/control/__tests__/daemon-relay-health.test.ts
@@ -93,6 +93,60 @@ describe("daemon relay health (#207)", () => {
     expect(healed).toEqual([]);
   });
 
+  it("prunes a relay whose captain workspace is gone — heals + logs ONCE (audit STEP 3)", async () => {
+    let t = 1000;
+    const healed: string[] = [];
+    const store = createStore(dir);
+    // Fixture: a stale relay ref whose captain workspace no longer resolves.
+    const d = createDaemon({
+      store,
+      now: () => t,
+      healRelay: (p) => { healed.push(p); return "captain-absent"; },
+    });
+    d.registerRelay({ project: "dead-proj", pid: 42, startedAt: 900 });
+
+    // Gone past the window → heal fires once and reports the captain absent.
+    t = 1000 + RELAY_GONE_MS + 1;
+    await d.sweep();
+    expect(healed).toEqual(["dead-proj"]);
+    // The stale record is pruned, so the liveness surface no longer carries it…
+    expect(d.getRelayHealth()).toEqual([]);
+
+    // …and every subsequent sweep is quiet: no re-heal, no per-cycle spam.
+    for (let i = 0; i < 3; i++) {
+      t += RELAY_GONE_MS + 1;
+      await d.sweep();
+    }
+    expect(healed).toEqual(["dead-proj"]);
+  });
+
+  it("a captain that restarts after a prune re-registers and heals again", async () => {
+    let t = 1000;
+    const healed: string[] = [];
+    const store = createStore(dir);
+    let captainPresent = false;
+    const d = createDaemon({
+      store,
+      now: () => t,
+      healRelay: (p) => { healed.push(p); return captainPresent ? "healed" : "captain-absent"; },
+    });
+    d.registerRelay({ project: "p", pid: 42, startedAt: 900 });
+
+    // Captain gone → first sweep heals once and prunes.
+    t = 1000 + RELAY_GONE_MS + 1;
+    await d.sweep();
+    expect(healed).toEqual(["p"]);
+    expect(d.getRelayHealth()).toEqual([]);
+
+    // Captain comes back: a fresh relay registers, then goes dark again later.
+    captainPresent = true;
+    t += 1000;
+    d.registerRelay({ project: "p", pid: 99, startedAt: t });
+    t += RELAY_GONE_MS + 1;
+    await d.sweep();
+    expect(healed).toEqual(["p", "p"]); // heals again — the prune did not blacklist it
+  });
+
   it("a throwing healRelay never breaks the sweep", async () => {
     let t = 1000;
     const store = createStore(dir);

--- a/src/control/daemon.ts
+++ b/src/control/daemon.ts
@@ -6,6 +6,15 @@ import { reduce } from "./state-machine.js";
 import { evaluateStall, recoverStall } from "./watchdog.js";
 import { classifyHealth, RELAY_STALE_MS, RELAY_GONE_MS, type RelayHealth } from "./liveness.js";
 
+/**
+ * Result of a relay-heal attempt (audit STEP 3). "captain-absent" tells the
+ * sweep the captain workspace is permanently gone — the relay can never be
+ * healed, so its health record is pruned to stop per-cycle "captain workspace
+ * not present" log spam. Any other value (or void, for legacy impls) leaves the
+ * record in place so the liveness surface keeps reporting it.
+ */
+export type RelayHealOutcome = "captain-absent" | "healed" | "skipped";
+
 export interface DaemonDeps {
   store: Store;
   now: () => number;
@@ -66,7 +75,7 @@ export interface DaemonDeps {
    * getRelayHealth() + the liveness surface, not by this hook. Errors are
    * swallowed by the sweep so a refused cmux write never trips the daemon.
    */
-  healRelay?: (project: string) => Promise<void> | void;
+  healRelay?: (project: string) => Promise<RelayHealOutcome | void> | RelayHealOutcome | void;
   /**
    * #225 hard crew task-timeout: wall-clock ceiling in ms. When a non-terminal
    * task's age (now - createdAt) exceeds this, the sweep fires a CREW TIMEOUT
@@ -434,15 +443,22 @@ export function createDaemon(deps: DaemonDeps) {
       // surface (getRelayHealth) already exposes the "gone" state regardless —
       // that is the never-silently-blind guarantee; heal is the secondary try.
       if (deps.healRelay) {
-        for (const rh of relayHealth.values()) {
+        // Snapshot first: a "captain-absent" prune deletes from relayHealth mid-loop.
+        for (const rh of [...relayHealth.values()]) {
           if (classifyHealth(rh.lastSeenMs, t, RELAY_STALE_MS, RELAY_GONE_MS) !== "gone") continue;
           const last = lastHealAttempt.get(rh.project);
           if (last != null && t - last <= RELAY_GONE_MS) continue; // debounce
           lastHealAttempt.set(rh.project, t);
           try {
-            const r = deps.healRelay(rh.project);
-            if (r && typeof (r as Promise<void>).catch === "function") {
-              (r as Promise<void>).catch(() => {});
+            const outcome = await deps.healRelay(rh.project);
+            // audit STEP 3 stale-ref prune: the captain workspace is permanently
+            // gone, so this relay can never be healed and re-probing it every
+            // sweep just spams "captain workspace not present". Drop the record
+            // (and its debounce) so the loop goes quiet after a single attempt; a
+            // captain restart re-registers a fresh relay via registerRelay.
+            if (outcome === "captain-absent") {
+              relayHealth.delete(rh.project);
+              lastHealAttempt.delete(rh.project);
             }
           } catch {
             // best-effort — a refused cmux write (lineage) must not trip the sweep

--- a/src/control/relay-healer.ts
+++ b/src/control/relay-healer.ts
@@ -7,6 +7,7 @@
 import { loadConfig } from "../config.js";
 import { createCmuxDriver, RuntimeRegistry } from "../runtimes/index.js";
 import { buildRelaySupervisorCommand, NOTIFY_RELAY_TAB_TITLE } from "./relay-supervisor.js";
+import type { RelayHealOutcome } from "./daemon.js";
 
 /**
  * Best-effort relay heal (#207, SECONDARY). Re-spawns the notify-relay tab in
@@ -19,17 +20,19 @@ import { buildRelaySupervisorCommand, NOTIFY_RELAY_TAB_TITLE } from "./relay-sup
  */
 export function createRelayHealer(
   log: (m: string) => void = () => {},
-): (project: string) => Promise<void> {
+): (project: string) => Promise<RelayHealOutcome> {
   return async (project) => {
     try {
       const config = loadConfig();
       const proj = config.projects[project];
-      if (!proj) return;
+      if (!proj) return "skipped";
       const runtime = new RuntimeRegistry({ cmux: createCmuxDriver() }).forProject(project, config);
       const ws = await runtime.status(proj.captainName);
       if (!ws) {
-        log(`relay heal ${project}: captain workspace not present; nothing to heal into`);
-        return;
+        // Captain workspace gone for good — signal the sweep to prune this relay
+        // record so this log fires ONCE, not every cycle (audit STEP 3).
+        log(`relay heal ${project}: captain workspace not present; pruning stale relay record`);
+        return "captain-absent";
       }
       // Dedup: close any pre-existing relay tab before respawning fresh.
       try {
@@ -47,10 +50,14 @@ export function createRelayHealer(
         placement: "background",
       });
       log(`relay heal ${project}: re-spawned notify-relay tab`);
+      return "healed";
     } catch (e) {
       // Expected under launchd (cmux lineage refusal). The surface still shows
-      // the relay down with its actionable; this is the secondary path.
+      // the relay down with its actionable; this is the secondary path. Captain
+      // workspace WAS resolvable here (status succeeded), so do not prune —
+      // return "skipped" so the record stays and the surface keeps reporting it.
       log(`relay heal ${project} failed (expected under launchd lineage): ${(e as Error).message}`);
+      return "skipped";
     }
   };
 }


### PR DESCRIPTION
Two control-plane hardening items from the cmux 0.64.16 audit. Branch off `develop`.

## ITEM 1 — Fix `relay heal …: captain workspace not present` per-cycle noise (audit STEP 3)

**Root cause (verified live in `cockpitd.log`):** the daemon sweep re-heals relay-health records for projects whose **captain workspace is permanently gone** (saw it firing every cycle for `pact-network` and `oneplan`). The healer's `runtime.status()` correctly returns null and the code degrades gracefully — but cmux's CLI **stderr is inherited** by the daemon (`execFileSync` default; confirmed empirically: a bogus `cmux tree --workspace …` prints `Error: not_found …` to the parent's stderr even when the throw is caught). So every retry re-emits the noise.

cmux 0.64.16 exposes **no** surface-lifecycle events (verified in the B4 research), so this is fixed the **polled** way:

- `createRelayHealer` now returns `"captain-absent"` when the captain workspace no longer resolves.
- The sweep **prunes** that relay-health record (and its debounce entry) on `"captain-absent"`, so the heal attempt + log fire **exactly once**, then the loop goes quiet.
- A captain restart re-registers a fresh relay (`registerRelay`), so recovery is unaffected — the prune does **not** blacklist the project.

The crew-surface probe poll set ("prune terminal crews") was **already** handled: `cockpitd` evicts `inFlightProbes`/`probeResults` on terminal state and `proxiedSurfaceAlive` only enqueues non-terminal records — so no change needed there.

**Tests:** new daemon-relay-health cases — prune-on-stale-ref (fixture whose captain doesn't resolve → heals + logs once, record pruned, subsequent sweeps silent) and prune-then-recover (captain restarts → re-registers → heals again).

## ITEM 2 — Agent hibernation (audit C2): investigated, deferred — global-only, unsafe

Ran `cmux agent-hibernation --help` / `cmux docs agents` live. The verb is **`cmux agent-hibernation <on|off>` — a GLOBAL, app-wide toggle** with no per-session/per-workspace argument ("Configure idle and live-terminal limits from Settings"). 

**Enabling it would hibernate every agent/terminal session, including the captain and the notify-relay** — both must stay responsive to deliver notifications — which **breaks orchestration**. The idle trigger is configured globally, not scopeable to crews.

**Decision: do NOT enable.** Wired a documented OFF flag `defaults.cmuxAgentHibernation` (default `false`) in `src/config.ts` as a decision record + forward hook for if/when cmux gains crew-only scoping. Because nothing is hibernated, the surface-liveness reaper needs no "hibernated = alive" change in this PR.

Full write-up (both items) appended to `docs/research/2026-06-16-cmux-events-stream.md`.

## Verification
- `npm run build` (tsc) — green
- Targeted `npx vitest run` — daemon-relay-health, cockpitd-relay-health, daemon, relay-proxy, config, heal, config-drift → **all green** (132 tests across touched areas)

Per repo constraints: did **not** touch `src/runtimes/cmux.ts` or `src/commands/crew.ts` (owned by another crew).
