### PR TITLE
feat(control): agent-hook run-state → suppress #292 false-stall (B4/A3)

### DIFF
--- a/docs/research/2026-06-16-cmux-events-stream.md
+++ b/docs/research/2026-06-16-cmux-events-stream.md
@@ -119,6 +119,23 @@ PreToolUse→working / Stop→idle to replace the spinner scrape entirely. This 
 already consumes `Stop`; extending to PreToolUse-as-working is the natural next
 step. (Reporting only, per the task — not implemented here.)
 
+**STATUS — IMPLEMENTED (B4/A3, branch `feat/agent-hook-runstate`).** The
+working-state half now ships, but as a *false-stall suppressor*, not a spinner
+replacement. `deriveRunState()` classifies `PreToolUse`/`UserPromptSubmit` →
+`working` and `Stop` → `idle`. The bridge feeds a `working` hook into the
+liveness path **additively** as `task.progress` (the reducer's documented
+real-activity signal, state-machine.ts), which refreshes `lastHeartbeatAt` — the
+exact clock `evaluateStall` keys off — so a crew mid long, screen-quiet tool call
+is **not** false-idled (#292), and a crew the scrape path wrongly idled resumes
+to `working`. No change to `liveness.ts`/`watchdog.ts` was needed: suppression is
+achieved through the heartbeat clock they already consult. Screen-scraping stays
+as the fallback; the whole path is gated by `defaults.cmuxEventsBridge`.
+Re-verified live on 2026-06-16 that `agent.hook.PreToolUse` reaches
+`cmux events --category agent`. `UserPromptSubmit` is mapped opportunistically
+(not observed in 0.64.16 captures; harmless if it never fires). The spinner-scrape
+*replacement* (dropping `classifyStartupSurface`/`CC_WORKING_RE`) remains future
+work and is explicitly out of scope — that path is the most bug-fixed in the repo.
+
 ## Surface lifecycle events — audit premise does NOT match cmux 0.64.16
 
 The audit assumed the stream emits `surface.created/closed/selected` +

--- a/src/control/cmux/__tests__/events-bridge.test.ts
+++ b/src/control/cmux/__tests__/events-bridge.test.ts
@@ -6,8 +6,10 @@
 import { describe, it, expect, vi } from "vitest";
 import { Readable } from "node:stream";
 import { EventEmitter } from "node:events";
-import { CmuxEventsBridge } from "../events-bridge.js";
-import type { ControlEvent } from "../../types.js";
+import { CmuxEventsBridge, deriveRunState } from "../events-bridge.js";
+import { reduce } from "../../state-machine.js";
+import { evaluateStall } from "../../watchdog.js";
+import type { ControlEvent, TaskRecord } from "../../types.js";
 
 /** A fake `cmux events` child: stdout streams the given lines, then exits. */
 function fakeChild(lines: string[]) {
@@ -40,6 +42,11 @@ function stopFrame(cwd: string, phase = "completed", name = "agent.hook.Stop") {
       payload: { _source: "claude", session_id: "claude-abc", cwd, phase },
     }) + "\n"
   );
+}
+
+/** A "working" agent hook frame (PreToolUse / UserPromptSubmit). */
+function workingFrame(cwd: string, name = "agent.hook.PreToolUse", phase = "completed") {
+  return stopFrame(cwd, phase, name);
 }
 
 describe("CmuxEventsBridge", () => {
@@ -157,5 +164,128 @@ describe("CmuxEventsBridge", () => {
     await flush();
     expect(events).toHaveLength(1);
     bridge.stop();
+  });
+});
+
+// B4/A3 — run-state derivation: PreToolUse/UserPromptSubmit → working, Stop → idle.
+describe("deriveRunState", () => {
+  it("maps PreToolUse and UserPromptSubmit to working", () => {
+    expect(deriveRunState("agent.hook.PreToolUse")).toBe("working");
+    expect(deriveRunState("agent.hook.UserPromptSubmit")).toBe("working");
+  });
+  it("maps Stop to idle", () => {
+    expect(deriveRunState("agent.hook.Stop")).toBe("idle");
+  });
+  it("ignores SubagentStop and unknown names (subagent end ≠ turn end)", () => {
+    expect(deriveRunState("agent.hook.SubagentStop")).toBeNull();
+    expect(deriveRunState("agent.hook.PostToolUse")).toBeNull();
+    expect(deriveRunState("")).toBeNull();
+  });
+});
+
+// B4/A3 — the bridge emits task.progress for a working hook so the crew's
+// liveness clock stays fresh while a turn is live (false-stall suppression).
+describe("CmuxEventsBridge working hooks → task.progress", () => {
+  it("maps agent.hook.PreToolUse → task.progress for the matching crew cwd", async () => {
+    const events: ControlEvent[] = [];
+    const bridge = new CmuxEventsBridge({
+      emit: (e) => events.push(e),
+      resolve: (h) => (h.cwd === "/wt/crew-a" ? { id: "task-a" } : undefined),
+      cursorFile: "/tmp/seq",
+      spawnImpl: (() => fakeChild([ack, workingFrame("/wt/crew-a")])) as never,
+      stopAfterFirstRun: true,
+    });
+    bridge.start();
+    await flush();
+    await flush();
+    expect(events).toEqual([{ type: "task.progress", id: "task-a", note: "agent.hook.PreToolUse" }]);
+    bridge.stop();
+  });
+
+  it("maps agent.hook.UserPromptSubmit → task.progress", async () => {
+    const events: ControlEvent[] = [];
+    const bridge = new CmuxEventsBridge({
+      emit: (e) => events.push(e),
+      resolve: () => ({ id: "t" }),
+      cursorFile: "/tmp/seq",
+      spawnImpl: (() =>
+        fakeChild([ack, workingFrame("/wt/x", "agent.hook.UserPromptSubmit")])) as never,
+      stopAfterFirstRun: true,
+    });
+    bridge.start();
+    await flush();
+    await flush();
+    expect(events).toEqual([{ type: "task.progress", id: "t", note: "agent.hook.UserPromptSubmit" }]);
+    bridge.stop();
+  });
+
+  it("ignores the received-phase duplicate of a working hook (emits once)", async () => {
+    const events: ControlEvent[] = [];
+    const bridge = new CmuxEventsBridge({
+      emit: (e) => events.push(e),
+      resolve: () => ({ id: "x" }),
+      cursorFile: "/tmp/seq",
+      spawnImpl: (() =>
+        fakeChild([ack, workingFrame("/wt/x", "agent.hook.PreToolUse", "received"), workingFrame("/wt/x")])) as never,
+      stopAfterFirstRun: true,
+    });
+    bridge.start();
+    await flush();
+    await flush();
+    expect(events.filter((e) => e.type === "task.progress")).toHaveLength(1);
+    bridge.stop();
+  });
+
+  it("does not emit for a working hook whose cwd matches no crew", async () => {
+    const events: ControlEvent[] = [];
+    const bridge = new CmuxEventsBridge({
+      emit: (e) => events.push(e),
+      resolve: () => undefined,
+      cursorFile: "/tmp/seq",
+      spawnImpl: (() => fakeChild([ack, workingFrame("/wt/unknown")])) as never,
+      stopAfterFirstRun: true,
+    });
+    bridge.start();
+    await flush();
+    await flush();
+    expect(events).toHaveLength(0);
+    bridge.stop();
+  });
+});
+
+// B4/A3 — end-to-end suppression: a working hook's task.progress refreshes the
+// liveness clock the watchdog keys off, so evaluateStall stops false-idling a
+// crew that is mid long tool-call but quiet on screen (#292 false-stalled).
+describe("working-hook run-state suppresses false-stall (#292)", () => {
+  function workingCrew(lastHeartbeatAt: number): TaskRecord {
+    return {
+      id: "task-a",
+      name: "crew-a",
+      project: "cockpit",
+      provider: "claude",
+      mode: "interactive",
+      state: "working",
+      task: "do a thing",
+      createdAt: 0,
+      lastHeartbeat: lastHeartbeatAt,
+      lastEvent: "task.started",
+      heartbeatBudgetMs: 60_000,
+      attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt }],
+    };
+  }
+
+  it("without a working hook, a quiet crew past budget false-idles", () => {
+    const now = 100_000; // 100s since the last heartbeat at t=0, budget 60s
+    const idle = evaluateStall(workingCrew(0), now);
+    expect(idle?.state).toBe("awaiting-input");
+  });
+
+  it("a PreToolUse-derived task.progress refreshes liveness so the crew does NOT idle", () => {
+    const now = 100_000;
+    // The bridge's working-hook event lands as task.progress just before the sweep.
+    const progressed = reduce(workingCrew(0), { type: "task.progress", id: "task-a", note: "agent.hook.PreToolUse" }, now);
+    // evaluateStall now keys off the refreshed lastHeartbeatAt → no false idle.
+    expect(evaluateStall(progressed, now)).toBeNull();
+    expect(progressed.state).toBe("working");
   });
 });

--- a/src/control/cmux/events-bridge.ts
+++ b/src/control/cmux/events-bridge.ts
@@ -6,15 +6,21 @@
 // for the whole cmux app: one newline-delimited JSON frame per cmux event,
 // carrying every agent's hook events. So this bridge is ONE long-lived
 // subscription owned by the daemon. Each `agent` frame is correlated back to a
-// crew TaskRecord by cwd (each interactive crew runs in a unique worktree path),
-// and `agent.hook.Stop` — the "turn ended / crew idle" signal the pane reader
-// currently infers by scraping — is mapped to `task.turn.completed`.
+// crew TaskRecord by cwd (each interactive crew runs in a unique worktree path)
+// and classified into a run-state (deriveRunState):
+//   - `agent.hook.Stop` — the "turn ended / crew idle" signal the pane reader
+//     infers by scraping — → `task.turn.completed`.
+//   - `agent.hook.PreToolUse` / `UserPromptSubmit` (a turn is live) →
+//     `task.progress` (B4/A3): a real-activity signal that refreshes the crew's
+//     liveness clock so the watchdog does not false-stall a crew mid long,
+//     screen-quiet tool call (#292).
 //
 // ADDITIVE & SAFE: this runs ALONGSIDE the existing relay-proxy/pane-reader path,
-// which stays as the fallback. `task.turn.completed` is liveness, NOT completion
+// which stays as the fallback. Both emissions are liveness, NOT completion
 // (anti-#2576): terminal state still comes from the explicit `cockpit crew signal
 // done`. The state-machine reducer already absorbs duplicate/late
-// task.turn.completed, so feeding it from BOTH paths is harmless.
+// task.turn.completed and task.progress (a blocked crew stays blocked), so
+// feeding them from BOTH paths is harmless.
 import type { ChildProcess } from "node:child_process";
 import { spawn as nodeSpawn } from "node:child_process";
 import { resolveCmuxBin } from "../../lib/cmux-bin.js";
@@ -26,6 +32,35 @@ export interface CmuxEventsChild {
   kill(signal?: NodeJS.Signals): boolean | void;
   on(event: "exit", cb: (code: number | null) => void): unknown;
   on(event: "error", cb: (err: Error) => void): unknown;
+}
+
+/** Per-surface agent run-state derived from the hook stream (B4/A3). */
+export type RunState = "working" | "idle";
+
+/**
+ * Pure. Classify an `agent.hook.*` event name into the crew's run-state, or
+ * null for hooks that carry no run-state signal.
+ *
+ *   PreToolUse / UserPromptSubmit → "working"  (a turn is live)
+ *   Stop                          → "idle"     (turn ended)
+ *   SubagentStop / anything else  → null       (subagent end ≠ turn end)
+ *
+ * `Stop` is the existing turn-end signal (→ task.turn.completed). The "working"
+ * hooks are the B4/A3 addition: they let the daemon keep a crew's liveness clock
+ * fresh while it is mid (possibly long, screen-quiet) tool call, so the watchdog
+ * does not false-stall it (#292). Only `PreToolUse` is live-confirmed in cmux
+ * 0.64.16; `UserPromptSubmit` is mapped opportunistically (harmless if absent).
+ */
+export function deriveRunState(eventName: string): RunState | null {
+  switch (eventName) {
+    case "agent.hook.PreToolUse":
+    case "agent.hook.UserPromptSubmit":
+      return "working";
+    case "agent.hook.Stop":
+      return "idle";
+    default:
+      return null;
+  }
 }
 
 /** A correlated hook frame, passed to the caller's record resolver. */
@@ -167,12 +202,14 @@ export class CmuxEventsBridge {
     }
     // Only agent hook events; ignore ack/heartbeat and other categories.
     if (f?.type !== "event" || f.category !== "agent") return;
-    // `Stop` is the main-session turn-end; `SubagentStop` is a nested agent
-    // finishing (NOT a turn end) — only Stop maps to task.turn.completed.
-    if (f.name !== "agent.hook.Stop") return;
+    // Classify the hook into a run-state. `Stop` is the main-session turn-end;
+    // PreToolUse/UserPromptSubmit mean a turn is live; SubagentStop and any
+    // other hook carry no turn-level run-state and are ignored.
+    const runState = f.name ? deriveRunState(f.name) : null;
+    if (!runState) return;
     const p = f.payload ?? {};
     // Each hook fires a "received" then "completed" phase frame; act on the
-    // settled one so we emit exactly once per Stop.
+    // settled one so we emit exactly once per hook.
     if (p.phase === "received") return;
     const rec = this.deps.resolve({
       cwd: p.cwd,
@@ -180,10 +217,20 @@ export class CmuxEventsBridge {
       sessionId: p.session_id,
     });
     if (!rec) return;
-    this.deps.emit({
-      type: "task.turn.completed",
-      id: rec.id,
-      turnId: p.session_id ?? "cmux",
-    });
+    if (runState === "idle") {
+      // Turn-end / idle — the signal the pane reader infers by scraping.
+      this.deps.emit({
+        type: "task.turn.completed",
+        id: rec.id,
+        turnId: p.session_id ?? "cmux",
+      });
+      return;
+    }
+    // working: feed a real-activity signal into the liveness path. task.progress
+    // refreshes lastHeartbeatAt (the clock evaluateStall keys off), so a crew
+    // that is mid long tool-call but screen-quiet is NOT false-stalled (#292),
+    // and a crew the scrape path wrongly idled resumes to 'working'. ADDITIVE:
+    // the reducer absorbs this idempotently, and a blocked crew stays blocked.
+    this.deps.emit({ type: "task.progress", id: rec.id, note: f.name });
   }
 }


### PR DESCRIPTION
## What

Audit items **B4/A3** — complete the agent-hook run-state picture and use it to suppress the documented **#292 "false stalled"** misclassification. **Additive + control-plane only.** Builds on PR #328 (events-bridge consuming `agent.hook.Stop` → crew idle).

## Why

The events-bridge already maps `agent.hook.Stop` → `task.turn.completed` (idle). It did not track the **working** half. When a crew is mid long, screen-quiet tool call, the scrape/watchdog path can false-idle/false-stall it (#292).

## How (surgical, additive)

- **`deriveRunState(name)`** (pure, tested): `PreToolUse`/`UserPromptSubmit` → `working`; `Stop` → `idle`; `SubagentStop`/other → `null`.
- The bridge feeds a **working** hook into the liveness path as **`task.progress`** — the reducer's *documented* real-activity signal. That refreshes `lastHeartbeatAt`, the exact clock `evaluateStall` keys off, so:
  - a crew mid long screen-quiet tool call is **not** false-idled (#292 suppression), and
  - a crew the scrape path wrongly idled **resumes to `working`** (`awaiting-input` → `working`); a **blocked** crew **stays blocked** (anti-#2576 / #174 preserved).
- **No change to `liveness.ts`/`watchdog.ts`** — suppression flows through the heartbeat clock they already consult. Most surgical possible integration.
- **`Stop` → `task.turn.completed`** mapping unchanged.

## Scope guards (per task)

- **Gated** behind the existing `defaults.cmuxEventsBridge` flag — when off, no working-hooks emit and **screen-scraping is the sole fallback**.
- **Screen-scraping untouched and preserved as fallback.** No edits to `parseDraftFromScreen` / `readInputBoxRaw` / `classifyStartupSurface` / `sendToSurface` (#258/#268/#294/#297/#302 — explicitly out of scope).
- The spinner-scrape **replacement** (dropping `CC_WORKING_RE`) remains deferred future work.

## Verification

- **Live-verified** `agent.hook.PreToolUse` reaches `cmux events --category agent` on cmux 0.64.16 (frame captured this session). `UserPromptSubmit` is mapped **opportunistically** — not observed in 0.64.16 captures, harmless if it never fires (documented).
- `npm run build` (tsc) clean.
- Targeted tests green: `deriveRunState` unit tests, working-hook → `task.progress` bridge tests (incl. received-phase dedup + unmatched-cwd), and an **end-to-end false-stall suppression** test (`reduce` + `evaluateStall`). 61 passing across bridge/state-machine/watchdog/cockpitd-cmux-events suites.

## Files

- `src/control/cmux/events-bridge.ts` — `deriveRunState` + working-hook → `task.progress`
- `src/control/cmux/__tests__/events-bridge.test.ts` — derivation + mapping + suppression tests
- `docs/research/2026-06-16-cmux-events-stream.md` — B4 section marked IMPLEMENTED
