### PR TITLE
Release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-06-16
+
+A patch release bundling the **web observability dashboard** and a **startup-delivery fix** — the work that accumulated on `develop` after 0.6.1, ahead of the cmux-compat changes that land in 0.7.0.
+
+### Added
+
+- **Web observability dashboard.** New `cockpit dashboard --web [--port] [--interval]` serves a zero-dependency localhost HTTP+SSE dashboard. It assembles a degrade-never-blank `FullSnapshot` (Tier 0–4: daemon state, crews, mailbox stats, and external probes for cmux / agent CLIs / vaults / config behind injectable runners) and renders pure HTML/SSE with a severity rollup, a stale banner, and remediation text. Ships a light, WCAG-AA theme with an explanatory title on every widget, tabs, and zero-dep SVG donut/sparkline charts. Read-only beta. Closes #314, #319. (#314, #319)
+
+### Fixed
+
+- **Dashboard snapshot/probe accuracy.** Corrected the hub-spoke vault health check, project-scoped probes, lag reporting, and severity classification; adds a `stale` `ProbeState` for template-drift caution. Data audited 68/68 fields accurate. Closes #320. (#320)
+
+- **Startup prompt delivered exactly once.** The captain launch path now recognizes non-streaming working states (a shell-waiting spinner carries no token down-counter), so a working captain is no longer misread as idle and re-sent the startup prompt — eliminating the 3× duplicate startup runs. (#312, #292 follow-up)
+
 ## [0.6.1] - 2026-06-15
 
 A reliability patch addressing relay ghost-materialization, headless launcher I/O pressure, cross-project boot-if-down, and crew spawn focus leakage — plus a build fix and a CI gate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **claude-cockpit** (4014 symbols, 6562 relationships, 110 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **claude-cockpit** (4358 symbols, 6976 relationships, 115 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/docs/plans/2026-06-15-telegram-integration.md
+++ b/docs/plans/2026-06-15-telegram-integration.md
@@ -1,0 +1,1442 @@
+# Telegram Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Drive cockpit from Telegram — push curated crew lifecycle events to per-session Telegram forum topics, and route replies back to the captain.
+
+**Architecture:** A daemon-resident, opt-in, crash-contained Telegram subsystem. Outbound: the daemon's existing `notify` fan-out is composed so each lifecycle event is *also* pushed to the crew's Telegram forum topic (in parallel with the mailbox; the cmux relay is untouched). Inbound: a `getUpdates` long-poll loop maps `(chat_id, message_thread_id)` → `{project, task}` and delivers the reply to the captain via a new mailbox `captain.message` entry, which the existing relay delivers verbatim. One Telegram supergroup per project; topics map 1:1 to sessions.
+
+**Tech Stack:** TypeScript (ESM, `.js` import specifiers), Node ≥18 global `fetch` (no Telegram SDK), Vitest, commander CLI. Spec: `docs/specs/2026-06-15-telegram-integration-design.md`.
+
+**Design decisions resolved from spec open questions:**
+- **O1 (outbound parallelism):** Telegram runs *in parallel* with the cmux relay by composing the daemon's `notify` hook — NOT by replacing `config.notifier`. The `NotifierDriver` registry (used only by the `cockpit notify` CLI) is left alone. The daemon `notify` fan-out is the real lifecycle-event seam.
+- **O2 (inbound queue):** Reuse the mailbox + relay. A new `captain.message` mailbox kind carries daemon-originated captain-directed messages; the relay's `deliverable()` already delivers any entry with a non-null `message`, so no relay change is required.
+
+**Security model:** The allowlist is *derived* from the linked chats — only a `chat_id` present in `config.telegram.chats` may command. No separate allowlist field. Inbound text is delivered as a captain *message*, never executed.
+
+---
+
+## File Structure
+
+**New files:**
+- `src/control/telegram/client.ts` — Bot API HTTP client (fetch-based).
+- `src/control/telegram/state.ts` — persistent offset + topic registry (`<stateRoot>/telegram-state.json`).
+- `src/control/telegram/format.ts` — topic-name + inbound-message formatters (pure).
+- `src/control/telegram/subsystem.ts` — outbound push + inbound long-poll loop; crash-contained orchestration.
+- `src/control/telegram/index.ts` — barrel re-exports.
+- `src/commands/telegram.ts` — `cockpit telegram link|status` CLI.
+- `src/control/telegram/__tests__/client.test.ts`
+- `src/control/telegram/__tests__/state.test.ts`
+- `src/control/telegram/__tests__/format.test.ts`
+- `src/control/telegram/__tests__/subsystem.test.ts`
+- `src/commands/__tests__/telegram.test.ts`
+
+**Modified files:**
+- `src/config.ts` — add `TelegramConfig` + `CockpitConfig.telegram`.
+- `src/control/mailbox.ts` — widen `MailboxEntry.kind`; add `appendCaptainMessage`.
+- `src/control/cockpitd.ts` — wire subsystem (compose `notify`, start inbound, stop); add `opts.telegram`.
+- `src/control/__tests__/cockpitd.*.test.ts` (new file `cockpitd.telegram.test.ts`) — daemon-isolation test.
+- `src/index.ts` (or wherever commands register) — register `telegramCommand`.
+- `README.md` / `AGENTS.md` — setup + feature note.
+
+---
+
+## Task 1: Telegram config types
+
+**Files:**
+- Modify: `src/config.ts` (after the `RoleConfig` type, ~line 60; add field to `CockpitConfig` ~line 71 near `notifier`)
+- Test: `src/__tests__/config.telegram.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/__tests__/config.telegram.test.ts
+import { describe, it, expect } from "vitest";
+import { writeFileSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadConfig } from "../config.js";
+
+describe("telegram config", () => {
+  it("round-trips a telegram block through loadConfig", () => {
+    const dir = mkdtempSync(join(tmpdir(), "cfg-"));
+    const p = join(dir, "config.json");
+    writeFileSync(
+      p,
+      JSON.stringify({
+        commandName: "x",
+        hubVault: "/tmp/hub",
+        projects: {},
+        defaults: { maxCrew: 5, worktreeDir: ".w", teammateMode: "in-process", permissions: { command: "auto", captain: "auto" } },
+        metrics: { enabled: false, path: "/tmp/m.json" },
+        telegram: { botToken: "123:ABC", chats: { cockpit: -100123 } },
+      }),
+    );
+    const cfg = loadConfig(p);
+    expect(cfg.telegram?.botToken).toBe("123:ABC");
+    expect(cfg.telegram?.chats.cockpit).toBe(-100123);
+  });
+
+  it("leaves telegram undefined when absent", () => {
+    const dir = mkdtempSync(join(tmpdir(), "cfg-"));
+    const p = join(dir, "config.json");
+    writeFileSync(
+      p,
+      JSON.stringify({
+        commandName: "x",
+        hubVault: "/tmp/hub",
+        projects: {},
+        defaults: { maxCrew: 5, worktreeDir: ".w", teammateMode: "in-process", permissions: { command: "auto", captain: "auto" } },
+        metrics: { enabled: false, path: "/tmp/m.json" },
+      }),
+    );
+    expect(loadConfig(p).telegram).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/__tests__/config.telegram.test.ts`
+Expected: FAIL — `telegram` property does not exist on `CockpitConfig`.
+
+- [ ] **Step 3: Add the types**
+
+In `src/config.ts`, add this interface above `CockpitConfig`:
+
+```typescript
+export interface TelegramConfig {
+  /** Bot token from BotFather. Lives in ~/.config/cockpit (never in the repo). */
+  botToken: string;
+  /** project name → Telegram supergroup chat_id (negative for supergroups).
+   *  The set of values here is ALSO the inbound allowlist: only these chats may command. */
+  chats: Record<string, number>;
+}
+```
+
+Then add to the `CockpitConfig` interface, right after `notifier?: string;` (line 71):
+
+```typescript
+  notifier?: string;
+  /** #65 Telegram integration. Absent = feature off (daemon behaves exactly as before). */
+  telegram?: TelegramConfig;
+```
+
+`loadConfig` already `JSON.parse`s the whole file, so no parsing change is needed — the field passes through.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/__tests__/config.telegram.test.ts`
+Expected: PASS (both cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config.ts src/__tests__/config.telegram.test.ts
+git commit -m "feat(telegram): config types (#65)"
+```
+
+---
+
+## Task 2: Telegram Bot API client
+
+**Files:**
+- Create: `src/control/telegram/client.ts`
+- Test: `src/control/telegram/__tests__/client.test.ts`
+
+The client is fetch-based and injectable (`fetchImpl`) so tests never hit the network. All Bot API calls are `POST https://api.telegram.org/bot<token>/<method>` with a JSON body; responses are `{ ok: boolean, result?: T, description?: string }`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/control/telegram/__tests__/client.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { createTelegramClient } from "../client.js";
+
+function fakeFetch(responses: Record<string, unknown>) {
+  return vi.fn(async (url: string, init?: { body?: string }) => {
+    const method = url.split("/").pop()!;
+    const body = init?.body ? JSON.parse(init.body) : {};
+    const result = responses[method];
+    return {
+      ok: true,
+      json: async () => ({ ok: true, result, _sentBody: body }),
+    } as unknown as Response;
+  });
+}
+
+describe("telegram client", () => {
+  it("createForumTopic returns the message_thread_id", async () => {
+    const f = fakeFetch({ createForumTopic: { message_thread_id: 42, name: "🔧 crew-1" } });
+    const c = createTelegramClient("T", f as unknown as typeof fetch);
+    const id = await c.createForumTopic(-100, "🔧 crew-1");
+    expect(id).toBe(42);
+    expect(f).toHaveBeenCalledWith(
+      "https://api.telegram.org/botT/createForumTopic",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("sendMessage includes message_thread_id when given", async () => {
+    const f = fakeFetch({ sendMessage: { message_id: 1 } });
+    const c = createTelegramClient("T", f as unknown as typeof fetch);
+    await c.sendMessage(-100, "hi", 42);
+    const body = JSON.parse((f.mock.calls[0][1] as { body: string }).body);
+    expect(body).toEqual({ chat_id: -100, text: "hi", message_thread_id: 42 });
+  });
+
+  it("sendMessage omits message_thread_id when undefined", async () => {
+    const f = fakeFetch({ sendMessage: { message_id: 1 } });
+    const c = createTelegramClient("T", f as unknown as typeof fetch);
+    await c.sendMessage(-100, "hi");
+    const body = JSON.parse((f.mock.calls[0][1] as { body: string }).body);
+    expect(body).toEqual({ chat_id: -100, text: "hi" });
+  });
+
+  it("getUpdates returns the result array", async () => {
+    const updates = [{ update_id: 7, message: { chat: { id: -100 }, text: "yo" } }];
+    const f = fakeFetch({ getUpdates: updates });
+    const c = createTelegramClient("T", f as unknown as typeof fetch);
+    const got = await c.getUpdates(5, 0);
+    expect(got).toEqual(updates);
+    const body = JSON.parse((f.mock.calls[0][1] as { body: string }).body);
+    expect(body).toEqual({ offset: 5, timeout: 0 });
+  });
+
+  it("throws on a Telegram error response", async () => {
+    const f = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ ok: false, description: "Unauthorized" }),
+    } as unknown as Response));
+    const c = createTelegramClient("T", f as unknown as typeof fetch);
+    await expect(c.getMe()).rejects.toThrow("Unauthorized");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/control/telegram/__tests__/client.test.ts`
+Expected: FAIL — module `../client.js` not found.
+
+- [ ] **Step 3: Implement the client**
+
+```typescript
+// src/control/telegram/client.ts
+
+export interface TgChat {
+  id: number;
+  type: string;
+  title?: string;
+}
+
+export interface TgUpdate {
+  update_id: number;
+  message?: {
+    chat: TgChat;
+    message_thread_id?: number;
+    text?: string;
+    from?: { id: number; username?: string };
+  };
+  /** Emitted when the bot is added to / removed from a chat — used by `telegram link`. */
+  my_chat_member?: {
+    chat: TgChat;
+    new_chat_member?: { status: string };
+  };
+}
+
+export interface TelegramClient {
+  getMe(): Promise<void>;
+  getUpdates(offset: number, timeoutS: number, signal?: AbortSignal): Promise<TgUpdate[]>;
+  sendMessage(chatId: number, text: string, threadId?: number): Promise<void>;
+  /** Returns the new topic's message_thread_id. */
+  createForumTopic(chatId: number, name: string): Promise<number>;
+  closeForumTopic(chatId: number, threadId: number): Promise<void>;
+}
+
+interface TgResponse<T> {
+  ok: boolean;
+  result?: T;
+  description?: string;
+}
+
+export function createTelegramClient(
+  botToken: string,
+  fetchImpl: typeof fetch = fetch,
+): TelegramClient {
+  const base = `https://api.telegram.org/bot${botToken}`;
+
+  async function call<T>(method: string, body: Record<string, unknown>, signal?: AbortSignal): Promise<T> {
+    const res = await fetchImpl(`${base}/${method}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      signal,
+    });
+    const json = (await res.json()) as TgResponse<T>;
+    if (!json.ok) throw new Error(json.description ?? `telegram ${method} failed`);
+    return json.result as T;
+  }
+
+  return {
+    async getMe() {
+      await call<unknown>("getMe", {});
+    },
+    async getUpdates(offset, timeoutS, signal) {
+      return call<TgUpdate[]>("getUpdates", { offset, timeout: timeoutS }, signal);
+    },
+    async sendMessage(chatId, text, threadId) {
+      const body: Record<string, unknown> = { chat_id: chatId, text };
+      if (threadId !== undefined) body.message_thread_id = threadId;
+      await call<unknown>("sendMessage", body);
+    },
+    async createForumTopic(chatId, name) {
+      const r = await call<{ message_thread_id: number }>("createForumTopic", { chat_id: chatId, name });
+      return r.message_thread_id;
+    },
+    async closeForumTopic(chatId, threadId) {
+      await call<unknown>("closeForumTopic", { chat_id: chatId, message_thread_id: threadId });
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/control/telegram/__tests__/client.test.ts`
+Expected: PASS (5 cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/control/telegram/client.ts src/control/telegram/__tests__/client.test.ts
+git commit -m "feat(telegram): Bot API client (#65)"
+```
+
+---
+
+## Task 3: Telegram state (offset + topic registry)
+
+**Files:**
+- Create: `src/control/telegram/state.ts`
+- Test: `src/control/telegram/__tests__/state.test.ts`
+
+Persists to `<stateRoot>/telegram-state.json`: the `getUpdates` offset and the topic map keyed by `${project}::${taskId}` → `message_thread_id`. `findTask(threadId)` is the inbound reverse lookup.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/control/telegram/__tests__/state.test.ts
+import { describe, it, expect } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadTelegramState } from "../state.js";
+
+function freshRoot() {
+  return mkdtempSync(join(tmpdir(), "tg-"));
+}
+
+describe("telegram state", () => {
+  it("starts empty and defaults offset to 0", async () => {
+    const s = await loadTelegramState(freshRoot());
+    expect(s.offset()).toBe(0);
+    expect(s.getTopic("cockpit", "t1")).toBeUndefined();
+  });
+
+  it("persists offset and topics across reloads", async () => {
+    const root = freshRoot();
+    const s = await loadTelegramState(root);
+    await s.setOffset(99);
+    await s.setTopic("cockpit", "t1", 42);
+    const s2 = await loadTelegramState(root);
+    expect(s2.offset()).toBe(99);
+    expect(s2.getTopic("cockpit", "t1")).toBe(42);
+  });
+
+  it("findTask reverse-maps a thread id to {project, taskId}", async () => {
+    const s = await loadTelegramState(freshRoot());
+    await s.setTopic("cockpit", "t1", 42);
+    await s.setTopic("brove", "t2", 7);
+    expect(s.findTask(42)).toEqual({ project: "cockpit", taskId: "t1" });
+    expect(s.findTask(7)).toEqual({ project: "brove", taskId: "t2" });
+    expect(s.findTask(999)).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/control/telegram/__tests__/state.test.ts`
+Expected: FAIL — module `../state.js` not found.
+
+- [ ] **Step 3: Implement the state store**
+
+```typescript
+// src/control/telegram/state.ts
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+
+interface PersistShape {
+  offset: number;
+  topics: Record<string, number>; // `${project}::${taskId}` -> message_thread_id
+}
+
+export interface TelegramState {
+  offset(): number;
+  setOffset(n: number): Promise<void>;
+  getTopic(project: string, taskId: string): number | undefined;
+  setTopic(project: string, taskId: string, threadId: number): Promise<void>;
+  findTask(threadId: number): { project: string; taskId: string } | undefined;
+}
+
+function statePath(stateRoot: string): string {
+  return join(stateRoot, "telegram-state.json");
+}
+
+function key(project: string, taskId: string): string {
+  return `${project}::${taskId}`;
+}
+
+export async function loadTelegramState(stateRoot: string): Promise<TelegramState> {
+  let data: PersistShape = { offset: 0, topics: {} };
+  try {
+    data = JSON.parse(await fs.readFile(statePath(stateRoot), "utf-8")) as PersistShape;
+    if (typeof data.offset !== "number") data.offset = 0;
+    if (!data.topics) data.topics = {};
+  } catch {
+    // ENOENT / corrupt → start fresh
+  }
+
+  async function persist(): Promise<void> {
+    await fs.mkdir(stateRoot, { recursive: true });
+    const tmp = statePath(stateRoot) + ".tmp";
+    await fs.writeFile(tmp, JSON.stringify(data), "utf-8");
+    await fs.rename(tmp, statePath(stateRoot));
+  }
+
+  return {
+    offset: () => data.offset,
+    async setOffset(n) {
+      data.offset = n;
+      await persist();
+    },
+    getTopic: (project, taskId) => data.topics[key(project, taskId)],
+    async setTopic(project, taskId, threadId) {
+      data.topics[key(project, taskId)] = threadId;
+      await persist();
+    },
+    findTask(threadId) {
+      for (const [k, v] of Object.entries(data.topics)) {
+        if (v === threadId) {
+          const sep = k.indexOf("::");
+          return { project: k.slice(0, sep), taskId: k.slice(sep + 2) };
+        }
+      }
+      return undefined;
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/control/telegram/__tests__/state.test.ts`
+Expected: PASS (3 cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/control/telegram/state.ts src/control/telegram/__tests__/state.test.ts
+git commit -m "feat(telegram): persistent offset + topic registry (#65)"
+```
+
+---
+
+## Task 4: Formatters
+
+**Files:**
+- Create: `src/control/telegram/format.ts`
+- Test: `src/control/telegram/__tests__/format.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/control/telegram/__tests__/format.test.ts
+import { describe, it, expect } from "vitest";
+import { crewTopicName, inboundCaptainMessage } from "../format.js";
+
+describe("telegram formatters", () => {
+  it("crewTopicName prefixes the crew name with a wrench", () => {
+    expect(crewTopicName("crew-2")).toBe("🔧 crew-2");
+  });
+
+  it("inboundCaptainMessage tags the source crew", () => {
+    expect(inboundCaptainMessage("crew-2", "use lucia")).toBe("📩 [from Telegram · crew-2] use lucia");
+  });
+
+  it("inboundCaptainMessage handles a captain-topic reply (no task name)", () => {
+    expect(inboundCaptainMessage(undefined, "status?")).toBe("📩 [from Telegram] status?");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/control/telegram/__tests__/format.test.ts`
+Expected: FAIL — module `../format.js` not found.
+
+- [ ] **Step 3: Implement the formatters**
+
+```typescript
+// src/control/telegram/format.ts
+
+/** Forum-topic title for a crew session. */
+export function crewTopicName(crewName: string): string {
+  return `🔧 ${crewName}`;
+}
+
+/** Captain-facing rendering of an inbound Telegram reply. */
+export function inboundCaptainMessage(crewName: string | undefined, text: string): string {
+  return crewName ? `📩 [from Telegram · ${crewName}] ${text}` : `📩 [from Telegram] ${text}`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/control/telegram/__tests__/format.test.ts`
+Expected: PASS (3 cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/control/telegram/format.ts src/control/telegram/__tests__/format.test.ts
+git commit -m "feat(telegram): topic + inbound message formatters (#65)"
+```
+
+---
+
+## Task 5: `captain.message` mailbox entry
+
+**Files:**
+- Modify: `src/control/mailbox.ts` (`MailboxEntry.kind` ~line 13; add `appendCaptainMessage` after `appendToMailbox` ~line 127)
+- Test: `src/control/__tests__/mailbox-captain-message.test.ts` (create)
+
+This is the inbound delivery seam (O2). The relay's `deliverable()` already delivers any entry whose `message` is non-null, regardless of kind, so adding a new kind requires **no relay change**.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/control/__tests__/mailbox-captain-message.test.ts
+import { describe, it, expect } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { appendCaptainMessage, readFromCursor } from "../mailbox.js";
+
+describe("appendCaptainMessage", () => {
+  it("appends a deliverable captain.message entry with a monotonic seq", async () => {
+    const root = mkdtempSync(join(tmpdir(), "mbox-"));
+    const seq1 = await appendCaptainMessage({ stateRoot: root, project: "cockpit", message: "hello", taskId: "t1", name: "crew-1" });
+    const seq2 = await appendCaptainMessage({ stateRoot: root, project: "cockpit", message: "again" });
+    expect(seq2).toBe(seq1 + 1);
+
+    const entries = [];
+    for await (const e of readFromCursor({ stateRoot: root, project: "cockpit", fromSeq: 1 })) entries.push(e);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].kind).toBe("captain.message");
+    expect(entries[0].message).toBe("hello");
+    expect(entries[0].name).toBe("crew-1");
+    expect(entries[1].taskId).toBe("captain");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/control/__tests__/mailbox-captain-message.test.ts`
+Expected: FAIL — `appendCaptainMessage` is not exported.
+
+- [ ] **Step 3: Widen the kind type and add the helper**
+
+In `src/control/mailbox.ts`, change the `kind` field of `MailboxEntry` (line 13):
+
+```typescript
+  kind: ControlEvent["type"] | "captain.message";
+```
+
+Then add this exported function immediately after `appendToMailbox` (after line 127):
+
+```typescript
+interface CaptainMessageOpts {
+  stateRoot: string;
+  project: string;
+  message: string;
+  /** Source crew task id, if the reply targeted a specific crew topic. Defaults to "captain". */
+  taskId?: string;
+  /** Source crew name, surfaced in the entry for parity with task entries. */
+  name?: string;
+}
+
+/**
+ * Append a daemon-originated, captain-directed message (e.g. an inbound Telegram
+ * reply). Reuses the mailbox seq/lock machinery so the existing relay delivers
+ * it verbatim via deliverable() — no relay change needed. Kind is the synthetic
+ * "captain.message"; no state-machine transition is involved (this never flows
+ * through d.handle()).
+ */
+export async function appendCaptainMessage(opts: CaptainMessageOpts): Promise<number> {
+  return withProjectLock(opts.project, async () => {
+    const dir = inboxDir(opts.stateRoot);
+    await fs.mkdir(dir, { recursive: true });
+    const file = logPath(opts.stateRoot, opts.project);
+    const lastSeq = await readMaxSeq(opts.stateRoot, opts.project);
+    const seq = lastSeq + 1;
+    const entry: MailboxEntry = {
+      seq,
+      ts: new Date().toISOString(),
+      taskId: opts.taskId ?? "captain",
+      ...(opts.name !== undefined ? { name: opts.name } : {}),
+      kind: "captain.message",
+      provider: "claude",
+      payload: {},
+      message: opts.message,
+    };
+    await fs.appendFile(file, JSON.stringify(entry) + "\n", { encoding: "utf-8" });
+    return seq;
+  });
+}
+```
+
+Note: `provider` is required on `MailboxEntry` and is metadata only (the relay ignores it for delivery); `"claude"` is a benign constant for captain messages.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/control/__tests__/mailbox-captain-message.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Run the existing mailbox + relay tests to confirm no regression**
+
+Run: `npx vitest run src/control/__tests__/mailbox.test.ts src/commands/__tests__/notify-relay.test.ts`
+Expected: PASS (the widened union is backward-compatible; `deliverable()` is unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/control/mailbox.ts src/control/__tests__/mailbox-captain-message.test.ts
+git commit -m "feat(telegram): captain.message mailbox entry for inbound delivery (#65)"
+```
+
+---
+
+## Task 6: Subsystem — outbound push
+
+**Files:**
+- Create: `src/control/telegram/subsystem.ts`
+- Test: `src/control/telegram/__tests__/subsystem.test.ts`
+
+`createTelegramSubsystem` owns the client + state and exposes `pushLifecycle`, `startInbound`, and `stop`. This task implements `pushLifecycle` only (outbound). It is **best-effort**: any throw is caught and logged; it never rejects to the caller.
+
+`pushLifecycle({ project, message, record })`:
+1. Resolve `chatId = chats[project]`. Not linked → no-op.
+2. Resolve `threadId = state.getTopic(project, record.id)`; if missing, `createForumTopic(chatId, crewTopicName(record.name))` and persist.
+3. `sendMessage(chatId, message, threadId)`.
+4. If `record.state` is terminal, `closeForumTopic` after sending.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/control/telegram/__tests__/subsystem.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createTelegramSubsystem } from "../subsystem.js";
+import type { TelegramClient } from "../client.js";
+import type { TaskRecord } from "../../types.js";
+
+function fakeClient(over: Partial<TelegramClient> = {}): TelegramClient {
+  return {
+    getMe: vi.fn(async () => {}),
+    getUpdates: vi.fn(async () => []),
+    sendMessage: vi.fn(async () => {}),
+    createForumTopic: vi.fn(async () => 42),
+    closeForumTopic: vi.fn(async () => {}),
+    ...over,
+  };
+}
+
+function rec(over: Partial<TaskRecord> = {}): TaskRecord {
+  return { id: "t1", project: "cockpit", name: "crew-1", provider: "claude", state: "working", mode: "interactive", task: "x", lastHeartbeat: 0, createdAt: 0 } as TaskRecord;
+}
+
+const baseDeps = (client: TelegramClient, root: string) => ({
+  client,
+  chats: { cockpit: -100 },
+  stateRoot: root,
+  appendCaptainMessage: vi.fn(async () => 1),
+  resolveCrewName: () => "crew-1",
+  log: () => {},
+});
+
+describe("telegram subsystem — outbound", () => {
+  it("creates a topic on first push and sends into it", async () => {
+    const root = mkdtempSync(join(tmpdir(), "tg-"));
+    const client = fakeClient();
+    const sub = await createTelegramSubsystem(baseDeps(client, root));
+    await sub.pushLifecycle({ project: "cockpit", message: "CREW BLOCKED: ?", record: rec() });
+    expect(client.createForumTopic).toHaveBeenCalledWith(-100, "🔧 crew-1");
+    expect(client.sendMessage).toHaveBeenCalledWith(-100, "CREW BLOCKED: ?", 42);
+  });
+
+  it("reuses an existing topic on the second push (no second create)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "tg-"));
+    const client = fakeClient();
+    const sub = await createTelegramSubsystem(baseDeps(client, root));
+    await sub.pushLifecycle({ project: "cockpit", message: "a", record: rec() });
+    await sub.pushLifecycle({ project: "cockpit", message: "b", record: rec() });
+    expect(client.createForumTopic).toHaveBeenCalledTimes(1);
+    expect(client.sendMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("no-ops for an unlinked project", async () => {
+    const root = mkdtempSync(join(tmpdir(), "tg-"));
+    const client = fakeClient();
+    const sub = await createTelegramSubsystem(baseDeps(client, root));
+    await sub.pushLifecycle({ project: "brove", message: "x", record: rec({ project: "brove" }) });
+    expect(client.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("closes the topic after a terminal-state push", async () => {
+    const root = mkdtempSync(join(tmpdir(), "tg-"));
+    const client = fakeClient();
+    const sub = await createTelegramSubsystem(baseDeps(client, root));
+    await sub.pushLifecycle({ project: "cockpit", message: "CREW DONE", record: rec({ state: "done" }) });
+    expect(client.closeForumTopic).toHaveBeenCalledWith(-100, 42);
+  });
+
+  it("never throws when the client fails (best-effort)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "tg-"));
+    const client = fakeClient({ sendMessage: vi.fn(async () => { throw new Error("network down"); }) });
+    const sub = await createTelegramSubsystem(baseDeps(client, root));
+    await expect(sub.pushLifecycle({ project: "cockpit", message: "x", record: rec() })).resolves.toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/control/telegram/__tests__/subsystem.test.ts`
+Expected: FAIL — module `../subsystem.js` not found.
+
+- [ ] **Step 3: Implement the subsystem (outbound half)**
+
+```typescript
+// src/control/telegram/subsystem.ts
+import { loadTelegramState, type TelegramState } from "./state.js";
+import { crewTopicName, inboundCaptainMessage } from "./format.js";
+import type { TelegramClient } from "./client.js";
+import type { TaskRecord } from "../types.js";
+import { TERMINAL_STATES } from "../types.js";
+
+export interface TelegramSubsystemDeps {
+  client: TelegramClient;
+  /** project → supergroup chat_id (also the inbound allowlist). */
+  chats: Record<string, number>;
+  stateRoot: string;
+  /** Inbound delivery seam — bound to mailbox.appendCaptainMessage by the daemon. */
+  appendCaptainMessage: (opts: { stateRoot: string; project: string; message: string; taskId?: string; name?: string }) => Promise<number>;
+  /** Resolve a crew display name from a taskId (store lookup), used on inbound. */
+  resolveCrewName: (project: string, taskId: string) => string | undefined;
+  log: (m: string) => void;
+}
+
+export interface TelegramSubsystem {
+  pushLifecycle(args: { project: string; message: string; record: TaskRecord }): Promise<void>;
+  startInbound(): void;
+  stop(): void;
+}
+
+export async function createTelegramSubsystem(deps: TelegramSubsystemDeps): Promise<TelegramSubsystem> {
+  const state: TelegramState = await loadTelegramState(deps.stateRoot);
+
+  async function topicFor(project: string, chatId: number, record: TaskRecord): Promise<number> {
+    const existing = state.getTopic(project, record.id);
+    if (existing !== undefined) return existing;
+    const threadId = await deps.client.createForumTopic(chatId, crewTopicName(record.name ?? record.id));
+    await state.setTopic(project, record.id, threadId);
+    return threadId;
+  }
+
+  async function pushLifecycle(args: { project: string; message: string; record: TaskRecord }): Promise<void> {
+    try {
+      const chatId = deps.chats[args.project];
+      if (chatId === undefined) return; // project not linked
+      const threadId = await topicFor(args.project, chatId, args.record);
+      await deps.client.sendMessage(chatId, args.message, threadId);
+      if (TERMINAL_STATES.has(args.record.state)) {
+        await deps.client.closeForumTopic(chatId, threadId);
+      }
+    } catch (e) {
+      deps.log(`telegram push failed project=${args.project}: ${(e as Error).message}`);
+    }
+  }
+
+  // startInbound + stop are implemented in Task 7.
+  return {
+    pushLifecycle,
+    startInbound: () => {},
+    stop: () => {},
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/control/telegram/__tests__/subsystem.test.ts`
+Expected: PASS (5 cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/control/telegram/subsystem.ts src/control/telegram/__tests__/subsystem.test.ts
+git commit -m "feat(telegram): subsystem outbound push (#65)"
+```
+
+---
+
+## Task 7: Subsystem — inbound long-poll loop
+
+**Files:**
+- Modify: `src/control/telegram/subsystem.ts`
+- Test: `src/control/telegram/__tests__/subsystem.test.ts` (append)
+
+The inbound loop calls `getUpdates(offset, 30s)` repeatedly. For each update with a `message.text`:
+1. **Allowlist:** `message.chat.id` must be a value in `chats` (reverse to project). Else ignore + log.
+2. Map `message.message_thread_id` → `{project, taskId}` via `state.findTask`. Absent thread / not found → captain topic (no specific crew).
+3. Render via `inboundCaptainMessage` and call `appendCaptainMessage` for that project.
+4. Advance and persist offset (`update_id + 1`).
+
+The loop is crash-contained: the whole body is wrapped; a thrown `getUpdates` (network) is caught, logged, and retried after a short backoff. `stop()` flips a flag and aborts the in-flight long-poll.
+
+- [ ] **Step 1: Write the failing test (append to subsystem.test.ts)**
+
+```typescript
+// append to src/control/telegram/__tests__/subsystem.test.ts
+import { processInboundUpdate } from "../subsystem.js";
+
+describe("telegram subsystem — inbound routing (pure)", () => {
+  const chats = { cockpit: -100, brove: -200 };
+
+  it("routes a crew-topic reply to that crew's captain via appendCaptainMessage", async () => {
+    const append = vi.fn(async () => 1);
+    const findTask = (thread: number) => (thread === 42 ? { project: "cockpit", taskId: "t1" } : undefined);
+    const handled = await processInboundUpdate({
+      update: { update_id: 5, message: { chat: { id: -100, type: "supergroup" }, message_thread_id: 42, text: "use lucia" } },
+      chats, findTask, resolveCrewName: () => "crew-2",
+      appendCaptainMessage: append, stateRoot: "/tmp", log: () => {},
+    });
+    expect(handled).toBe(true);
+    expect(append).toHaveBeenCalledWith({ stateRoot: "/tmp", project: "cockpit", message: "📩 [from Telegram · crew-2] use lucia", taskId: "t1", name: "crew-2" });
+  });
+
+  it("routes a general-topic reply to the captain (no task)", async () => {
+    const append = vi.fn(async () => 1);
+    await processInboundUpdate({
+      update: { update_id: 6, message: { chat: { id: -100, type: "supergroup" }, text: "status?" } },
+      chats, findTask: () => undefined, resolveCrewName: () => undefined,
+      appendCaptainMessage: append, stateRoot: "/tmp", log: () => {},
+    });
+    expect(append).toHaveBeenCalledWith({ stateRoot: "/tmp", project: "cockpit", message: "📩 [from Telegram] status?", taskId: undefined, name: undefined });
+  });
+
+  it("ignores updates from a non-allowlisted chat", async () => {
+    const append = vi.fn(async () => 1);
+    const handled = await processInboundUpdate({
+      update: { update_id: 7, message: { chat: { id: -999, type: "supergroup" }, text: "rm -rf" } },
+      chats, findTask: () => undefined, resolveCrewName: () => undefined,
+      appendCaptainMessage: append, stateRoot: "/tmp", log: () => {},
+    });
+    expect(handled).toBe(false);
+    expect(append).not.toHaveBeenCalled();
+  });
+
+  it("ignores updates with no text (e.g. join events)", async () => {
+    const append = vi.fn(async () => 1);
+    const handled = await processInboundUpdate({
+      update: { update_id: 8, message: { chat: { id: -100, type: "supergroup" } } },
+      chats, findTask: () => undefined, resolveCrewName: () => undefined,
+      appendCaptainMessage: append, stateRoot: "/tmp", log: () => {},
+    });
+    expect(handled).toBe(false);
+    expect(append).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/control/telegram/__tests__/subsystem.test.ts`
+Expected: FAIL — `processInboundUpdate` is not exported.
+
+- [ ] **Step 3: Implement inbound (pure router + loop)**
+
+Add the exported pure router and wire the loop into `createTelegramSubsystem`. In `src/control/telegram/subsystem.ts`:
+
+```typescript
+import type { TgUpdate } from "./client.js";
+
+export interface InboundRouterDeps {
+  update: TgUpdate;
+  chats: Record<string, number>;
+  findTask: (threadId: number) => { project: string; taskId: string } | undefined;
+  resolveCrewName: (project: string, taskId: string) => string | undefined;
+  appendCaptainMessage: TelegramSubsystemDeps["appendCaptainMessage"];
+  stateRoot: string;
+  log: (m: string) => void;
+}
+
+/** Pure-ish: route ONE update. Returns true if it produced a captain message. */
+export async function processInboundUpdate(deps: InboundRouterDeps): Promise<boolean> {
+  const msg = deps.update.message;
+  if (!msg || !msg.text) return false;
+
+  // Allowlist: chat must be a linked supergroup. Reverse chat_id → project.
+  const entry = Object.entries(deps.chats).find(([, id]) => id === msg.chat.id);
+  if (!entry) {
+    deps.log(`telegram inbound ignored: chat ${msg.chat.id} not allowlisted`);
+    return false;
+  }
+  const [project] = entry;
+
+  // Resolve target task from the topic thread (absent / unknown → captain).
+  const found = msg.message_thread_id !== undefined ? deps.findTask(msg.message_thread_id) : undefined;
+  const taskId = found?.taskId;
+  const crewName = found ? deps.resolveCrewName(found.project, found.taskId) : undefined;
+
+  await deps.appendCaptainMessage({
+    stateRoot: deps.stateRoot,
+    project,
+    message: inboundCaptainMessage(crewName, msg.text),
+    taskId,
+    name: crewName,
+  });
+  return true;
+}
+```
+
+Now replace the `startInbound` / `stop` stubs in the returned object with a real loop:
+
+```typescript
+  let stopped = false;
+  let abort: AbortController | undefined;
+
+  function startInbound(): void {
+    void (async () => {
+      while (!stopped) {
+        try {
+          abort = new AbortController();
+          const updates = await deps.client.getUpdates(state.offset(), 30, abort.signal);
+          for (const update of updates) {
+            await processInboundUpdate({
+              update,
+              chats: deps.chats,
+              findTask: state.findTask,
+              resolveCrewName: deps.resolveCrewName,
+              appendCaptainMessage: deps.appendCaptainMessage,
+              stateRoot: deps.stateRoot,
+              log: deps.log,
+            });
+            await state.setOffset(update.update_id + 1);
+          }
+        } catch (e) {
+          if (stopped) return;
+          deps.log(`telegram inbound loop error: ${(e as Error).message}`);
+          await new Promise((r) => setTimeout(r, 3000)); // backoff; never tight-loops
+        }
+      }
+    })();
+  }
+
+  function stop(): void {
+    stopped = true;
+    abort?.abort();
+  }
+
+  return { pushLifecycle, startInbound, stop };
+```
+
+(Delete the placeholder `startInbound`/`stop` from Task 6's return.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/control/telegram/__tests__/subsystem.test.ts`
+Expected: PASS (all outbound + inbound cases).
+
+- [ ] **Step 5: Add the barrel file**
+
+```typescript
+// src/control/telegram/index.ts
+export { createTelegramClient } from "./client.js";
+export type { TelegramClient, TgUpdate } from "./client.js";
+export { createTelegramSubsystem, processInboundUpdate } from "./subsystem.js";
+export type { TelegramSubsystem } from "./subsystem.js";
+export { loadTelegramState } from "./state.js";
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/control/telegram/subsystem.ts src/control/telegram/index.ts src/control/telegram/__tests__/subsystem.test.ts
+git commit -m "feat(telegram): inbound long-poll loop + captain routing (#65)"
+```
+
+---
+
+## Task 8: Wire subsystem into the daemon
+
+**Files:**
+- Modify: `src/control/cockpitd.ts` (imports; `CockpitdOpts` ~line 74; `notify` composition ~line 272; boot ~line 418; `stop()` ~line 556)
+- Test: `src/control/__tests__/cockpitd.telegram.test.ts` (create)
+
+Wires outbound (compose `notify`), inbound (`startInbound` after server start), and teardown (`stop`). The subsystem is injectable via `opts.telegram` so tests never construct a real client. The critical guarantee: **a throwing Telegram subsystem must not affect the daemon core.**
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/control/__tests__/cockpitd.telegram.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { startCockpitd } from "../cockpitd.js";
+import type { TelegramSubsystem } from "../telegram/subsystem.js";
+
+function tmpRoots() {
+  const root = mkdtempSync(join(tmpdir(), "cd-"));
+  return { stateRoot: join(root, "state"), sockPath: join(root, "d.sock") };
+}
+
+describe("cockpitd telegram wiring", () => {
+  it("calls pushLifecycle on a notify event without letting a throw escape", async () => {
+    const { stateRoot, sockPath } = tmpRoots();
+    const pushLifecycle = vi.fn(async () => { throw new Error("tg down"); });
+    const telegram: TelegramSubsystem = { pushLifecycle, startInbound: vi.fn(), stop: vi.fn() };
+    const notify = vi.fn(async () => {}); // base notify (mailbox) stub
+
+    const h = startCockpitd({ stateRoot, sockPath, sweepMs: 0, rotationIntervalMs: 0, notify, telegram });
+    // Drive one notify by handing the daemon a started+done lifecycle through notify directly:
+    await notify({ project: "cockpit", message: "CREW DONE", record: { id: "t1", project: "cockpit", name: "crew-1", provider: "claude", state: "done" } as any, event: { type: "task.done", id: "t1" } as any });
+    // The composed notify (telegram on top of base) is what the daemon uses; assert it via a direct push:
+    await expect(telegram.pushLifecycle({ project: "cockpit", message: "x", record: { id: "t1", project: "cockpit", state: "done" } as any })).resolves.toBeUndefined();
+    expect(telegram.startInbound).toHaveBeenCalled();
+
+    await h.stop();
+    expect(telegram.stop).toHaveBeenCalled();
+  });
+
+  it("does not start telegram when opts.telegram is absent and config has none", async () => {
+    const { stateRoot, sockPath } = tmpRoots();
+    const h = startCockpitd({ stateRoot, sockPath, sweepMs: 0, rotationIntervalMs: 0 });
+    // No throw, daemon boots fine without telegram.
+    await h.stop();
+    expect(true).toBe(true);
+  });
+});
+```
+
+Note: the first test asserts the *injected* subsystem is started/stopped and that its `pushLifecycle` is best-effort. The composition wiring (base-notify → telegram) is unit-tested in Task 6/7; this test guards the daemon-level lifecycle hooks.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/control/__tests__/cockpitd.telegram.test.ts`
+Expected: FAIL — `opts.telegram` is not accepted / `startInbound` never called.
+
+- [ ] **Step 3: Wire the daemon**
+
+In `src/control/cockpitd.ts`:
+
+(a) Add the import near the other control imports (~line 16):
+
+```typescript
+import { createTelegramSubsystem, type TelegramSubsystem } from "./telegram/index.js";
+import { appendCaptainMessage } from "./mailbox.js";
+```
+
+(`appendToMailbox`/`rotateIfNeeded` are already imported from `./mailbox.js`; add `appendCaptainMessage` to that existing import instead of a duplicate line.)
+
+(b) Add to `CockpitdOpts` (after `opencodeBridge`, ~line 73):
+
+```typescript
+  /** Inject a fake Telegram subsystem for tests. Absent + no config.telegram = feature off. */
+  telegram?: TelegramSubsystem;
+```
+
+(c) Read config once and build the subsystem. Replace the existing `taskTimeoutMs` line (~line 87):
+
+```typescript
+  const cfg = loadConfig();
+  const taskTimeoutMs = cfg.defaults.taskTimeoutMs;
+```
+
+(d) After `const notify = opts.notify ?? defaultNotify;` (~line 272), compose Telegram on top:
+
+```typescript
+  // #65 Telegram: opt-in, crash-contained. Built from config unless a test injects one.
+  let telegram: TelegramSubsystem | null = opts.telegram ?? null;
+  if (!telegram && cfg.telegram) {
+    try {
+      telegram = await createTelegramSubsystemFromConfig();
+    } catch (e) {
+      log(`telegram init failed (feature disabled this boot): ${(e as Error).message}`);
+      telegram = null;
+    }
+  }
+  const baseNotify = notify;
+  const composedNotify = telegram
+    ? async (args: { project: string; message: string; record: TaskRecord; event: ControlEvent }) => {
+        await baseNotify(args);
+        // best-effort, never blocks/throws into the daemon
+        void telegram!.pushLifecycle({ project: args.project, message: args.message, record: args.record });
+      }
+    : baseNotify;
+```
+
+`startCockpitd` must become `async` is **not** desired (it returns a handle synchronously). Instead, build the subsystem synchronously-then-async via a helper that does the await inside the existing boot IIFE. To keep `startCockpitd` synchronous, define the builder and start inbound inside the boot IIFE. Concretely:
+
+- Replace step (d)'s `await createTelegramSubsystemFromConfig()` approach with a deferred build. Declare `let telegram: TelegramSubsystem | null = opts.telegram ?? null;` and compose `composedNotify` to read `telegram` lazily (it already does via the closure variable). Then inside the boot IIFE (the existing `void (async () => { ... })()` near line 382), add at the end:
+
+```typescript
+    // #65 Telegram subsystem boot (after reconcile so the store is warm).
+    if (!telegram && cfg.telegram) {
+      try {
+        telegram = await createTelegramSubsystem({
+          client: createTelegramClient(cfg.telegram.botToken),
+          chats: cfg.telegram.chats,
+          stateRoot,
+          appendCaptainMessage,
+          resolveCrewName: (project, taskId) =>
+            store.listAll().find((r) => r.id === taskId)?.name,
+          log,
+        });
+      } catch (e) {
+        log(`telegram init failed (feature disabled this boot): ${(e as Error).message}`);
+        telegram = null;
+      }
+    }
+    telegram?.startInbound();
+```
+
+And add the import for `createTelegramClient` to the barrel import in step (a):
+
+```typescript
+import { createTelegramClient, createTelegramSubsystem, type TelegramSubsystem } from "./telegram/index.js";
+```
+
+Because `composedNotify` closes over the mutable `telegram` variable, the lazy build inside the IIFE is picked up by later events. Pass `composedNotify` (not `notify`) to `createDaemon`:
+
+```typescript
+  const d = createDaemon({
+    store, now: () => Date.now(), isPidAlive, notify: composedNotify, taskTimeoutMs,
+    // ...rest unchanged
+```
+
+When `opts.telegram` is injected (tests), `startInbound()` must still run — add `telegram?.startInbound();` is inside the IIFE which always runs, so injected subsystems are started too. Good.
+
+(e) In `stop()` (~line 556), add before `return new Promise(...)`:
+
+```typescript
+      telegram?.stop();
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/control/__tests__/cockpitd.telegram.test.ts`
+Expected: PASS (both cases).
+
+- [ ] **Step 5: Run the full daemon test suite for regressions**
+
+Run: `npx vitest run src/control/__tests__/`
+Expected: PASS — composing notify and the lazy telegram build do not change existing behavior when telegram is absent.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/control/cockpitd.ts src/control/__tests__/cockpitd.telegram.test.ts
+git commit -m "feat(telegram): wire crash-contained subsystem into cockpitd (#65)"
+```
+
+---
+
+## Task 9: `cockpit telegram link` + `status` CLI
+
+**Files:**
+- Create: `src/commands/telegram.ts`
+- Test: `src/commands/__tests__/telegram.test.ts`
+
+`telegram link <project>` captures the chat_id of the supergroup the bot was added to (from the most recent `my_chat_member` update via `getUpdates`) and writes `config.telegram.chats[project]`. `telegram status` prints linked projects and whether the token validates (`getMe`).
+
+The action logic is extracted into pure-ish injectable functions for testing (no real network / no real config writes in tests).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/commands/__tests__/telegram.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { resolveLinkChatId, buildStatusReport } from "../telegram.js";
+import type { TgUpdate } from "../../control/telegram/client.js";
+
+describe("telegram link", () => {
+  it("picks the chat_id from the most recent my_chat_member where the bot became admin/member", () => {
+    const updates: TgUpdate[] = [
+      { update_id: 1, my_chat_member: { chat: { id: -100, type: "supergroup", title: "cockpit" }, new_chat_member: { status: "administrator" } } },
+      { update_id: 2, message: { chat: { id: -100, type: "supergroup" }, text: "hi" } },
+    ];
+    expect(resolveLinkChatId(updates)).toBe(-100);
+  });
+
+  it("returns undefined when no my_chat_member update is present", () => {
+    expect(resolveLinkChatId([{ update_id: 1, message: { chat: { id: -100, type: "supergroup" }, text: "hi" } }])).toBeUndefined();
+  });
+});
+
+describe("telegram status", () => {
+  it("reports linked projects and token validity", () => {
+    const report = buildStatusReport({ tokenValid: true, chats: { cockpit: -100, brove: -200 } });
+    expect(report).toContain("token: valid");
+    expect(report).toContain("cockpit");
+    expect(report).toContain("-100");
+    expect(report).toContain("brove");
+  });
+
+  it("reports when telegram is not configured", () => {
+    expect(buildStatusReport({ tokenValid: false, chats: {} })).toContain("no projects linked");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/commands/__tests__/telegram.test.ts`
+Expected: FAIL — module `../telegram.js` not found.
+
+- [ ] **Step 3: Implement the command**
+
+```typescript
+// src/commands/telegram.ts
+import { Command } from "commander";
+import chalk from "chalk";
+import { loadConfig, saveConfig, type CockpitConfig } from "../config.js";
+import { createTelegramClient, type TgUpdate } from "../control/telegram/index.js";
+
+/** Pure: the chat_id of the most recent my_chat_member update (bot added to a group). */
+export function resolveLinkChatId(updates: TgUpdate[]): number | undefined {
+  for (let i = updates.length - 1; i >= 0; i--) {
+    const m = updates[i].my_chat_member;
+    if (m) return m.chat.id;
+  }
+  return undefined;
+}
+
+/** Pure: render `telegram status`. */
+export function buildStatusReport(args: { tokenValid: boolean; chats: Record<string, number> }): string {
+  const lines = [`token: ${args.tokenValid ? "valid" : "invalid/unset"}`];
+  const entries = Object.entries(args.chats);
+  if (entries.length === 0) lines.push("no projects linked");
+  else for (const [project, id] of entries) lines.push(`  ${project} → ${id}`);
+  return lines.join("\n");
+}
+
+async function runLink(project: string, configPath?: string): Promise<number> {
+  const config: CockpitConfig = loadConfig(configPath);
+  if (!config.telegram?.botToken) {
+    console.error(chalk.red("telegram link: set telegram.botToken in ~/.config/cockpit/config.json first"));
+    return 1;
+  }
+  if (!config.projects[project]) {
+    console.error(chalk.red(`telegram link: unknown project '${project}'`));
+    return 1;
+  }
+  const client = createTelegramClient(config.telegram.botToken);
+  const updates = await client.getUpdates(0, 0);
+  const chatId = resolveLinkChatId(updates);
+  if (chatId === undefined) {
+    console.error(chalk.yellow("telegram link: no group found. Add the bot to your project supergroup (as admin), then re-run."));
+    return 1;
+  }
+  config.telegram.chats = { ...config.telegram.chats, [project]: chatId };
+  saveConfig(config, configPath);
+  console.log(chalk.green(`✔ linked '${project}' → chat ${chatId}`));
+  return 0;
+}
+
+async function runStatus(configPath?: string): Promise<number> {
+  const config = loadConfig(configPath);
+  let tokenValid = false;
+  if (config.telegram?.botToken) {
+    try {
+      await createTelegramClient(config.telegram.botToken).getMe();
+      tokenValid = true;
+    } catch { tokenValid = false; }
+  }
+  console.log(buildStatusReport({ tokenValid, chats: config.telegram?.chats ?? {} }));
+  return 0;
+}
+
+export const telegramCommand = new Command("telegram")
+  .description("Configure Telegram remote control (#65)")
+  .addCommand(
+    new Command("link")
+      .description("Bind a project to the supergroup the bot was added to")
+      .argument("<project>", "project to link")
+      .action(async (project: string) => process.exit(await runLink(project))),
+  )
+  .addCommand(
+    new Command("status")
+      .description("Show token validity and linked projects")
+      .action(async () => process.exit(await runStatus())),
+  );
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/commands/__tests__/telegram.test.ts`
+Expected: PASS (4 cases).
+
+- [ ] **Step 5: Register the command**
+
+Find where commands are registered (search for `notifyCommand` or `.addCommand(` in `src/index.ts` or `src/cli.ts`):
+
+Run: `grep -rn "notifyRelayCommand\|notifyCommand" src/index.ts src/cli.ts 2>/dev/null`
+
+Add the import and registration next to the other commands:
+
+```typescript
+import { telegramCommand } from "./commands/telegram.js";
+// ...
+program.addCommand(telegramCommand);
+```
+
+- [ ] **Step 6: Build to verify registration compiles**
+
+Run: `npm run build`
+Expected: tsc exits 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/commands/telegram.ts src/commands/__tests__/telegram.test.ts src/index.ts
+git commit -m "feat(telegram): link + status CLI (#65)"
+```
+
+---
+
+## Task 10: Docs + setup guide
+
+**Files:**
+- Modify: `README.md` (add a "Telegram remote control" section)
+- Modify: `AGENTS.md` (one-line feature note under the relevant section)
+
+- [ ] **Step 1: Add the README section**
+
+Add under the features/usage area of `README.md`:
+
+```markdown
+## Telegram remote control (#65)
+
+Drive cockpit from your phone. Crew lifecycle events (done / blocked / idle) push
+to Telegram forum topics — one topic per session — and replies route back to the
+captain.
+
+### Setup
+
+1. Create a bot with [@BotFather](https://t.me/botfather); copy the token.
+2. Add the token to `~/.config/cockpit/config.json`:
+   ```json
+   { "telegram": { "botToken": "123456:ABC...", "chats": {} } }
+   ```
+3. Create a Telegram **supergroup with Topics enabled** for the project, and add
+   your bot as an **admin** (with "Manage topics").
+4. Run `cockpit telegram link <project>` — this binds the group to the project.
+5. Restart the daemon: `launchctl kickstart -kp gui/$(id -u)/com.cockpit.daemon`.
+
+Check status any time with `cockpit telegram status`.
+
+### How it works
+
+- **Outbound** rides the daemon's existing notification fan-out — Telegram is a
+  parallel consumer; your laptop notifications are unaffected if Telegram or the
+  network is down (best-effort).
+- **Inbound** replies are delivered to the captain (the coordinator), which routes
+  them onward to crews.
+- The feature is **opt-in**: with no `telegram` config, the daemon behaves exactly
+  as before.
+
+Deferred enhancements: inline approve/deny buttons (#309), webhook ingress (#310),
+direct-to-crew injection (#249).
+```
+
+- [ ] **Step 2: Add the AGENTS.md note**
+
+Add one bullet where cockpit's notification/remote surfaces are described in `AGENTS.md`:
+
+```markdown
+- **Telegram remote control** (opt-in, #65): push crew lifecycle to Telegram forum
+  topics (one per session) and reply back to the captain. Configure via
+  `cockpit telegram link <project>`. See README "Telegram remote control".
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md AGENTS.md
+git commit -m "docs(telegram): setup guide + AGENTS note (#65)"
+```
+
+---
+
+## Task 11: Full verification + integration smoke
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the whole suite**
+
+Run: `npm test`
+Expected: all tests PASS (new telegram suites + no regressions). If anything fails, fix before proceeding.
+
+- [ ] **Step 2: Type-check the build**
+
+Run: `npm run build`
+Expected: tsc exits 0.
+
+- [ ] **Step 3: CLI smoke (no live Telegram needed)**
+
+Run: `node dist/index.js telegram status`
+Expected: prints `token: invalid/unset` + `no projects linked` on a machine with no telegram config (or the configured state). No crash.
+
+- [ ] **Step 4: Commit (if any fixes were needed)**
+
+```bash
+git add -A
+git commit -m "test(telegram): full-suite verification fixes (#65)"
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:**
+- Outbound push (curated messages, topic auto-provision, best-effort) → Tasks 6, 8. ✅
+- Inbound reply → captain via mailbox → Tasks 5, 7, 8. ✅
+- Forum-topic mapping, one group per project → Tasks 3, 4, 6. ✅
+- Daemon-hosted, opt-in, crash-contained → Tasks 6 (best-effort push), 7 (loop backoff), 8 (injection + isolation test). ✅
+- Security: chat_id allowlist (derived from `chats`), no shell passthrough → Task 7 (allowlist), Task 5 (message-not-command). ✅
+- Setup `cockpit telegram link` + config → Tasks 1, 9. ✅
+- Isolation/failure matrix → Tasks 6, 7, 8 best-effort + backoff + daemon-isolation test. ✅
+- Non-goals (#249/#309/#310, no webhook, no token deltas) → out of scope; not built. ✅
+- Testing strategy (pure units, mocked HTTP, isolation) → every task is TDD with injected I/O. ✅
+
+**Type consistency:** `TelegramClient`, `TgUpdate`, `TelegramState`, `TelegramSubsystem`, `appendCaptainMessage`, `createTelegramSubsystem`, `processInboundUpdate` names are used identically across tasks. `MailboxEntry.kind` widening is the one shared-type change (Task 5), consumed in Task 8.
+
+**Open risk flagged for the executor:** Task 8 step 3 keeps `startCockpitd` synchronous by building the subsystem inside the existing boot IIFE while `composedNotify` closes over the mutable `telegram` variable. If the executor finds the closure timing awkward, the acceptable alternative is to construct the subsystem eagerly with a synchronous `loadTelegramState` variant — but do NOT make `startCockpitd` async (callers depend on the synchronous handle return). Verify the daemon-isolation test (Task 8) passes either way.
+```

--- a/docs/specs/2026-06-15-telegram-integration-design.md
+++ b/docs/specs/2026-06-15-telegram-integration-design.md
@@ -1,0 +1,233 @@
+# Telegram Integration — Design Spec
+
+**Issue:** #65 — Telegram integration for remote cockpit control
+**Date:** 2026-06-15
+**Status:** Approved design → ready for implementation plan
+**Target release:** v1.0.0 (bundled with the four pre-Telegram reliability fixes already on `develop`)
+
+## Goal
+
+Drive cockpit from a phone via Telegram:
+
+- **Outbound** — push curated lifecycle events (crew done, captain blocked, crew idle) to Telegram.
+- **Inbound** — reply from Telegram and have the message route to the right session.
+
+Success criteria (from #65 acceptance):
+
+1. Cockpit can push a message to the user on Telegram.
+2. The user replies from Telegram and it routes to the correct session.
+
+## Scope decisions (locked during brainstorm)
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Direction | **Full two-way** (push + reply) | #65 acceptance requires both. |
+| Transport reuse | **Reuse existing mailbox + cmux relay** | Proven path across the daemon→cmux lineage wall; just hardened (#240, #302). Avoids re-solving #249. |
+| Listener location | **Inside the daemon**, opt-in + crash-contained | Daemon is always-up, is the event hub, knows every project/task, survives captain restarts. |
+| Telegram structure | **Forum Topics**, one supergroup per project | `message_thread_id` is the routing key both directions; topic lifecycle mirrors tab lifecycle. |
+| Inbound delivery | **Through the captain** (not direct-to-crew) | Reuses relay with zero new cmux proxy; matches the coordinator model. |
+| Outbound granularity | **Curated mailbox messages only** (no token deltas) | Same `formatMessage` source of truth as the laptop; avoids phone spam. |
+| Ingress | **getUpdates long-poll** (no webhook) | Works behind home NAT; no public URL. Webhook deferred → #310. |
+
+### Explicit non-goals (deferred)
+
+- Direct-to-crew injection / daemon↔surface direct contract → **#249** (backlog).
+- Inline approve/deny buttons for BLOCKED events → **#309**.
+- Webhook ingress → **#310**.
+- Live token-delta streaming to the phone.
+
+## Architecture
+
+### Topology
+
+```
+┌─────────────────────────── cockpitd (daemon) ───────────────────────────┐
+│  event hub + mailbox + state-machine + watchdog   (UNCHANGED)            │
+│                                                                          │
+│  ┌─ Telegram subsystem (NEW, opt-in, crash-contained) ──────────────┐   │
+│  │   • outbound: reads mailbox messages → sendMessage(thread_id)     │   │
+│  │   • inbound:  getUpdates long-poll → {chat_id, thread_id, text}   │   │
+│  │   • topic registry: topic_id ↔ {project, task}                    │   │
+│  └──────────────────────────────────────────────────────────────────┘   │
+└──────────────────────────────────────────────────────────────────────────┘
+        ▲ outbound (best-effort)               │ inbound (via existing relay)
+        │                                       ▼
+   api.telegram.org                      captain surface (cmux)
+```
+
+### Components
+
+1. **`telegram` NotifierDriver** — fills the existing `config.notifier` slot
+   (`src/notifiers/`, interface `probe()` + `notify(message)`). Outbound only,
+   matching the existing interface. Registered in the `NotifierRegistry`
+   alongside `cmux`. The `notify(message)` call resolves the target topic from
+   the current task context and calls `sendMessage`.
+
+2. **Telegram inbound loop** — new daemon-resident subsystem. Runs a
+   `getUpdates` long-poll loop. Parses each update into
+   `{chat_id, message_thread_id, text, from}`. Enqueues an inbound command for
+   the relay to deliver to the captain.
+
+3. **Topic registry** — `topic_id ↔ {project, task}` map, persisted alongside
+   the daemon's task state. The daemon already owns the task registry; this is
+   an adjacent map. Used both directions:
+   - outbound: task → `message_thread_id` (create topic on first event).
+   - inbound: `message_thread_id` → `{project, task}`.
+
+4. **Telegram API client** — thin wrapper over the Bot API HTTP endpoints used:
+   `getUpdates`, `sendMessage`, `createForumTopic`, `closeForumTopic`,
+   `getMe` (probe), and capture of `my_chat_member` (for `link`). No third-party
+   SDK required; plain HTTPS calls.
+
+The cmux notify-relay and the daemon core are **untouched** for outbound.
+Telegram is a parallel consumer of the same mailbox messages.
+
+### Topic mapping
+
+```
+cmux                          Telegram
+────                          ────────
+captain-workspace      →      supergroup  "🚀 <project>"
+ ├─ captain tab        →       ├─ topic "⚓ captain"   (general topic)
+ ├─ crew-1 tab         →       ├─ topic "🔧 crew-1"
+ └─ crew-2 tab         →       └─ topic "🔧 crew-2"
+```
+
+Multiple projects = multiple supergroups (1:1 with the workspace model; allows
+per-project mute/archive).
+
+## Data flows
+
+### Outbound (push to phone)
+
+```
+crew event → state-machine → mailbox entry {message, project, task}
+                                   │
+              ┌────────────────────┴────────────────────┐
+              ▼ (existing)                                ▼ (NEW)
+        cmux relay → laptop surface          telegram subsystem:
+                                              1. resolve task → topic_id
+                                              2. topic missing? createForumTopic, store mapping
+                                              3. sendMessage(chat_id, thread_id, message)
+                                              4. on failure: log + drop (best-effort)
+```
+
+- Reuses the daemon's curated `message` string verbatim (same granularity as the
+  laptop relay). Entries the daemon chose not to surface (`message == null`) are
+  skipped, exactly as the relay does.
+- Topic auto-provisioning: first event for a task creates its topic; crew close
+  posts the final result, then `closeForumTopic`.
+- Best-effort: a failed Telegram send NEVER blocks or delays cmux relay delivery.
+
+### Inbound (reply from phone)
+
+```
+user types in "🔧 crew-2" topic → Telegram
+        │
+        ▼ getUpdates long-poll (daemon)
+  update: {chat_id, message_thread_id, text}
+        │
+   1. allowlist check: chat_id ∈ configured chats?  (else ignore + log)
+   2. map (chat_id, thread_id) → {project, task}
+   3. enqueue inbound command to mailbox/relay
+        │
+        ▼ existing relay (in captain's process tree)
+  delivered to CAPTAIN surface:
+     "📩 [from Telegram · crew-2] use lucia"
+        │
+        ▼ captain interprets & acts
+  captain → cockpit crew send <project> crew-2 "use lucia"
+```
+
+- **Through the captain**, not direct-to-crew. The relay already delivers
+  daemon→captain messages across the lineage wall; no new cmux proxy is built.
+- The inbound text is delivered as a **message**, not executed as a shell
+  command. The captain interprets it as a normal user turn under its existing
+  permission mode.
+- A reply in the captain topic is delivered to the captain plainly (no task tag).
+
+## Setup & provisioning
+
+One-time, manual:
+
+1. Create a bot via BotFather → obtain the bot token.
+2. Create a supergroup per project, **enable Topics**, add the bot as admin with
+   *manage topics* permission.
+3. Run `cockpit telegram link <project>` — the daemon captures the group's
+   `chat_id` from the `my_chat_member` update Telegram emits when the bot is
+   added, and binds it to the project.
+
+After linking, the daemon creates topics automatically as crews spawn.
+
+### Configuration
+
+Stored in `~/.config/cockpit` config (JSON, per repo convention):
+
+- `config.notifier = "telegram"` (or keep `cmux` and run Telegram in parallel —
+  see Open question O1).
+- Telegram block: bot token (secret, gitignored location), per-project
+  `chat_id` bindings, and the `chat_id` allowlist.
+
+The bot token must never be committed to the repo.
+
+## Security
+
+This is remote control of the user's machine; treated accordingly:
+
+- **chat_id allowlist** — the daemon only acts on updates from explicitly-linked
+  chats. Any other chat is ignored and logged. A stranger who discovers the bot
+  cannot route into a session.
+- **No shell passthrough** — inbound text becomes a captain *message*, never a
+  raw shell command. The captain runs under its normal permission mode; never
+  `--dangerously-skip-permissions`.
+- **Token isolation** — a leaked token allows messaging the bot, but the
+  allowlist still blocks routing into any session.
+
+## Isolation & failure behavior
+
+The Telegram subsystem is wrapped so nothing it does can throw into the daemon's
+event loop, mailbox, state-machine, or watchdog. It is modeled as a `liveness`
+component that may be `gone` without making the daemon `unhealthy`.
+
+| Condition | Daemon core | Outbound TG | Inbound TG | Laptop relay |
+|-----------|-------------|-------------|------------|--------------|
+| No `telegram` config | normal | off | off | normal |
+| Network down | normal | retries w/ backoff, drops | stalled, retries | normal |
+| Telegram API error / bad token | normal | logs + drops | logs + retries | normal |
+| Captain dead | normal | normal | queued, can't land | n/a |
+| TG loop crashes | unaffected | restarts in-loop | restarts in-loop | normal |
+
+## Testing strategy
+
+- **Pure units** (no network): topic-registry mapping (both directions),
+  inbound update parsing, allowlist enforcement, outbound message resolution
+  (task → thread_id, skip on `message == null`), failure containment (a thrown
+  send is caught and dropped).
+- **Telegram API client**: tested against a mocked HTTP layer — assert correct
+  endpoints/payloads for `sendMessage`, `createForumTopic`, `getUpdates`,
+  `my_chat_member` capture. No live Telegram calls in CI.
+- **Isolation guarantee**: a test that forces the TG loop to throw and asserts
+  the daemon core (mailbox append, state-machine step, watchdog) is unaffected.
+- **Inbound→captain routing**: assert an inbound update produces the correct
+  relay-delivered captain message with the right `{project, task}` tag.
+- Follows `superpowers:test-driven-development` and the Karpathy discipline
+  (surgical, goal-driven, no speculative abstraction).
+
+## Open questions (resolve during planning)
+
+- **O1 — Outbound parallelism.** Should `config.notifier = "telegram"` *replace*
+  the cmux notifier, or should Telegram run *in parallel* with cmux (laptop +
+  phone both get pushes)? The isolation design assumes parallel is desirable
+  (phone is additive, laptop unaffected). If the notifier slot is single-valued,
+  we may need a small multi-notifier list rather than a single `notifier` field.
+  Recommendation: parallel (additive), via a notifier list.
+- **O2 — Inbound queue mechanism.** Reuse the existing mailbox for inbound
+  commands, or a small dedicated inbound queue the relay drains? Prefer reusing
+  existing relay delivery machinery; confirm the relay can carry a
+  captain-directed message that originates from the daemon (not a task event).
+
+## Out of scope (tracked elsewhere)
+
+- #249 — daemon↔surface direct contract (non-cmux drivers).
+- #309 — inline approve/deny buttons.
+- #310 — webhook ingress.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-cockpit",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Multi-project agent orchestration for Claude Code",
   "type": "module",
   "bin": {

--- a/src/commands/__tests__/crew-attach.test.ts
+++ b/src/commands/__tests__/crew-attach.test.ts
@@ -7,6 +7,12 @@ import {
   formatApproval,
   formatDoneFollowup,
   formatGatePromoted,
+  formatConnectionLost,
+  formatReattachFailed,
+  computeBackoffDelay,
+  isConnectionStable,
+  STABLE_MS,
+  RETRY_BUDGET_MS,
 } from "../crew-attach.js";
 
 describe("crew-attach formatters", () => {
@@ -48,5 +54,96 @@ describe("crew-attach formatters", () => {
   it("dim helpers contain expected text", () => {
     expect(stripAnsi(formatDoneFollowup())).toContain("done — type a follow-up");
     expect(stripAnsi(formatGatePromoted("g-123"))).toContain("g-123");
+  });
+
+  it("formatConnectionLost contains retry message", () => {
+    const plain = stripAnsi(formatConnectionLost());
+    expect(plain).toContain("connection lost");
+    expect(plain).toContain("retrying");
+  });
+
+  it("formatReattachFailed contains task id and re-run command", () => {
+    const plain = stripAnsi(formatReattachFailed("task-abc-123"));
+    expect(plain).toContain("reattach failed");
+    expect(plain).toContain("cockpit crew attach task-abc-123");
+  });
+});
+
+describe("crew-attach backoff logic", () => {
+  it("computeBackoffDelay: attempt 0→1s, 1→2s, 2→4s, 3→8s, 4+→16s cap", () => {
+    expect(computeBackoffDelay(0)).toBe(1_000);
+    expect(computeBackoffDelay(1)).toBe(2_000);
+    expect(computeBackoffDelay(2)).toBe(4_000);
+    expect(computeBackoffDelay(3)).toBe(8_000);
+    expect(computeBackoffDelay(4)).toBe(16_000);
+    expect(computeBackoffDelay(5)).toBe(16_000);
+    expect(computeBackoffDelay(10)).toBe(16_000);
+  });
+
+  it("isConnectionStable: not stable before STABLE_MS with no frames", () => {
+    const t0 = 100_000;
+    expect(isConnectionStable(t0, 0, t0 + STABLE_MS - 1)).toBe(false);
+  });
+
+  it("isConnectionStable: stable at exactly STABLE_MS with no frames", () => {
+    const t0 = 100_000;
+    expect(isConnectionStable(t0, 0, t0 + STABLE_MS)).toBe(true);
+  });
+
+  it("isConnectionStable: stable immediately with >=1 frame, regardless of elapsed time", () => {
+    const t0 = 100_000;
+    expect(isConnectionStable(t0, 1, t0 + 10)).toBe(true);
+    expect(isConnectionStable(t0, 5, t0 + 1)).toBe(true);
+  });
+
+  it("flapping guard: 50ms immediate-close with no frames is NOT stable", () => {
+    const t0 = 100_000;
+    expect(isConnectionStable(t0, 0, t0 + 50)).toBe(false);
+  });
+
+  it("STABLE_MS is 5 seconds", () => {
+    expect(STABLE_MS).toBe(5_000);
+  });
+
+  it("RETRY_BUDGET_MS is 60 seconds", () => {
+    expect(RETRY_BUDGET_MS).toBe(60_000);
+  });
+
+  it("flapping: backoff grows on each unstable disconnect (no reset)", () => {
+    // Simulate flapping: each connect closes immediately (unstable)
+    // backoff should grow, not reset
+    let attempt = 0;
+    const delays: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      delays.push(computeBackoffDelay(attempt));
+      attempt += 1; // unstable → increment
+    }
+    expect(delays).toEqual([1_000, 2_000, 4_000, 8_000, 16_000]);
+  });
+
+  it("stable-reset: backoff resets to 0 after a stable connection", () => {
+    // Simulate: grow to attempt=3 via flapping, then get a stable connection
+    let attempt = 3;
+    // stable disconnect → reset to 0
+    attempt = 0;
+    // next flap → delay should be back to 1s
+    expect(computeBackoffDelay(attempt)).toBe(1_000);
+  });
+
+  it("budget exhaustion: flapping from attempt 0 exceeds budget after 7 close events", () => {
+    // Trace: delays are 1,2,4,8,16,16,16... (cap at 16s)
+    // cumulative: 1,3,7,15,31,47,63 → exceeds 60s on 7th
+    let attempt = 0;
+    let total = 0;
+    let closeCount = 0;
+    while (true) {
+      const delay = computeBackoffDelay(attempt);
+      total += delay;
+      closeCount += 1;
+      if (total > RETRY_BUDGET_MS) break;
+      attempt += 1; // unstable
+    }
+    expect(closeCount).toBe(7);
+    expect(total).toBeGreaterThan(RETRY_BUDGET_MS);
   });
 });

--- a/src/commands/__tests__/crew-attach.test.ts
+++ b/src/commands/__tests__/crew-attach.test.ts
@@ -101,6 +101,14 @@ describe("crew-attach backoff logic", () => {
     expect(isConnectionStable(t0, 0, t0 + 50)).toBe(false);
   });
 
+  it("daemon-down guard: connectTimeMs=0 (never established) is NOT stable, even with huge elapsed", () => {
+    // If 'connect' event never fires, connectTimeMs stays 0.
+    // Date.now() - 0 is ~1.7e12 >> STABLE_MS, so without the connectTimeMs>0 guard
+    // this would wrongly return true and reset backoff/budget every attempt.
+    expect(isConnectionStable(0, 0, Date.now())).toBe(false);
+    expect(isConnectionStable(0, 0, STABLE_MS * 1000)).toBe(false);
+  });
+
   it("STABLE_MS is 5 seconds", () => {
     expect(STABLE_MS).toBe(5_000);
   });

--- a/src/commands/__tests__/launch.test.ts
+++ b/src/commands/__tests__/launch.test.ts
@@ -21,7 +21,7 @@ vi.mock("../../lib/cmux-bin.js", () => ({
   resetCmuxBinCache: vi.fn(),
 }));
 
-import { cmuxLocal, buildRelaySupervisorCommand } from "../launch.js";
+import { cmuxLocal, buildRelaySupervisorCommand, deliverStartupPrompt } from "../launch.js";
 
 describe("cmuxLocal (launch.ts direct-cmux helper)", () => {
   beforeEach(() => {
@@ -77,5 +77,85 @@ describe("buildRelaySupervisorCommand (#186 self-healing relay)", () => {
     const cmd = buildRelaySupervisorCommand("brove");
     const body = cmd.replace(/^while .*?; do /, "").replace(/; done$/, "");
     expect(body).toContain("cockpit notify-relay brove --as captain");
+  });
+});
+
+// #292: the captain startup prompt was delivered on a fixed 8s setTimeout. CC
+// cold-init takes 5–15s, so on a slow boot the prompt landed on the splash screen
+// and was silently dropped (#235), so the captain never ran startup and the relay
+// never booted. deliverStartupPrompt replaces the magic delay with a deterministic
+// poll-send-confirm loop: wait for input-readiness, send, and bounded re-send if
+// the keystrokes were dropped — without ever re-sending a prompt that landed.
+describe("deliverStartupPrompt (#292 deterministic startup delivery)", () => {
+  // Real CC layouts the classifier keys on (see cmux.ts / 258 fixture).
+  const HR = "─".repeat(110);
+  const SPLASH = " ✻ Welcome to Claude Code\n   Loading…";
+  const IDLE = [HR, "❯ ", HR, "   Model: Opus 4.8  Ctx Used: 52.0%", "  ⏵⏵ auto mode on"].join("\n");
+  const WORKING = ["✢ Cerebrating… (4s · ↓ 1.2k tokens)", HR, "❯ ", HR, "  ⏵⏵ auto mode on"].join("\n");
+
+  const FAST = { readyTimeoutMs: 100, settleMs: 1, pollMs: 1, maxAttempts: 3 };
+
+  // A fake runtime whose read-screen returns scripted screens by call index
+  // (clamped to the last), recording every send for assertions.
+  function fakeRuntime(screens: string[]) {
+    let i = 0;
+    const sends: string[] = [];
+    return {
+      sends,
+      readScreen: vi.fn(async () => screens[Math.min(i++, screens.length - 1)]),
+      send: vi.fn(async (_ref: string, msg: string) => { sends.push(msg); }),
+    };
+  }
+
+  it("waits out the splash and sends only once the surface is input-ready", async () => {
+    // loading (initial) → idle (ready) → working (confirm: landed)
+    const rt = fakeRuntime([SPLASH, IDLE, WORKING]);
+    await deliverStartupPrompt(rt, "workspace:1", "GO", FAST);
+    expect(rt.sends).toEqual(["GO"]);
+    // It must NOT have sent while the screen was still the splash.
+    expect(rt.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT re-send when the first prompt landed (guards duplicate runs)", async () => {
+    // idle (ready) → working (confirm: landed) — exactly one send.
+    const rt = fakeRuntime([IDLE, WORKING]);
+    await deliverStartupPrompt(rt, "workspace:1", "GO", FAST);
+    expect(rt.sends).toEqual(["GO"]);
+  });
+
+  it("re-sends (bounded) when the first keystrokes were dropped", async () => {
+    // idle → (send) → still idle after settle (dropped) → idle → (send) → working.
+    const rt = fakeRuntime([IDLE, IDLE, IDLE, WORKING]);
+    await deliverStartupPrompt(rt, "workspace:1", "GO", FAST);
+    expect(rt.sends).toEqual(["GO", "GO"]);
+  });
+
+  it("never re-sends into an already-working session", async () => {
+    const rt = fakeRuntime([WORKING]);
+    await deliverStartupPrompt(rt, "workspace:1", "GO", FAST);
+    expect(rt.sends).toEqual([]);
+  });
+
+  it("falls back to a single best-effort send if readiness never appears (no hang)", async () => {
+    // Unrecognized chrome forever (e.g. a non-Claude agent): time out, send once.
+    const rt = fakeRuntime([SPLASH]);
+    await deliverStartupPrompt(rt, "workspace:1", "GO", FAST);
+    expect(rt.sends).toEqual(["GO"]);
+  });
+
+  it("stops re-sending after maxAttempts even if it never lands", async () => {
+    // Stuck idle forever (every keystroke dropped): bounded to maxAttempts sends.
+    const rt = fakeRuntime([IDLE]);
+    await deliverStartupPrompt(rt, "workspace:1", "GO", { ...FAST, maxAttempts: 3 });
+    expect(rt.sends).toEqual(["GO", "GO", "GO"]);
+  });
+
+  it("never throws even if readScreen rejects", async () => {
+    const rt = {
+      sends: [] as string[],
+      readScreen: vi.fn(async () => { throw new Error("surface gone"); }),
+      send: vi.fn(async () => {}),
+    };
+    await expect(deliverStartupPrompt(rt, "workspace:1", "GO", FAST)).resolves.toBeUndefined();
   });
 });

--- a/src/commands/__tests__/launch.test.ts
+++ b/src/commands/__tests__/launch.test.ts
@@ -150,6 +150,33 @@ describe("deliverStartupPrompt (#292 deterministic startup delivery)", () => {
     expect(rt.sends).toEqual(["GO", "GO", "GO"]);
   });
 
+  // DEBUG-REPRO (#292 follow-up): the captain startup checklist runs shell
+  // commands from its FIRST step (read-handoff.sh, wiki-query.sh, relay
+  // supervise). While a shell command is in flight, CC's spinner reads
+  // "✻ Crunched for 27s · 1 shell still running" — a WORKING screen that carries
+  // NO "↓ X.Xk tokens" counter (tokens only stream during generation, not tool
+  // waits) and no "esc to interrupt" (absent from this CC version's footer; 0
+  // hits in docs/reports/258-parse-bug-fixture.txt). CC_WORKING_RE therefore
+  // misses it and classifyStartupSurface returns "idle". The confirm/poll loop
+  // reads that working captain as "idle" on every settle sample, concludes the
+  // keystrokes were dropped, and re-sends — 3 duplicate startup runs.
+  // Source of truth: 258 fixture line 4 (working, no token counter).
+  it("FAILS PRE-FIX: a working-but-shell-waiting captain is misread as idle → 3 dupes", async () => {
+    const SHELL_WAITING = [
+      "✻ Crunched for 27s · 1 shell still running",
+      HR, "❯ ", HR,
+      "   Model: Opus 4.8  Ctx Used: 52.0%",
+      "  ⏵⏵ auto mode on · 1 shell",
+    ].join("\n");
+    // idle (ready) → send → captain is now WORKING on a shell cmd for the whole
+    // turn. Every confirm/poll sample returns SHELL_WAITING.
+    const rt = fakeRuntime([IDLE, SHELL_WAITING]);
+    await deliverStartupPrompt(rt, "workspace:1", "GO", FAST);
+    // Correct behavior: send exactly once — the prompt landed and the captain
+    // is working. Pre-fix this is ["GO","GO","GO"].
+    expect(rt.sends).toEqual(["GO"]);
+  });
+
   it("never throws even if readScreen rejects", async () => {
     const rt = {
       sends: [] as string[],

--- a/src/commands/__tests__/launch.test.ts
+++ b/src/commands/__tests__/launch.test.ts
@@ -161,7 +161,7 @@ describe("deliverStartupPrompt (#292 deterministic startup delivery)", () => {
   // reads that working captain as "idle" on every settle sample, concludes the
   // keystrokes were dropped, and re-sends — 3 duplicate startup runs.
   // Source of truth: 258 fixture line 4 (working, no token counter).
-  it("FAILS PRE-FIX: a working-but-shell-waiting captain is misread as idle → 3 dupes", async () => {
+  it("does NOT re-send when the captain is working on a shell command (no token counter)", async () => {
     const SHELL_WAITING = [
       "✻ Crunched for 27s · 1 shell still running",
       HR, "❯ ", HR,

--- a/src/commands/crew-attach.ts
+++ b/src/commands/crew-attach.ts
@@ -83,8 +83,45 @@ export function formatConnectionClosed(): string {
   return chalk.dim("(connection closed)");
 }
 
+export function formatConnectionLost(): string {
+  return chalk.dim("(connection lost — retrying...)");
+}
+
+export function formatReattachFailed(taskId: string): string {
+  return chalk.red(`(reattach failed — re-run: cockpit crew attach ${taskId})`);
+}
+
 export function formatGatePromoted(gateId: string): string {
   return chalk.dim(`(no client was attached; question promoted to gate ${gateId})`);
+}
+
+// --- Retry/backoff pure logic (exported for tests) ---
+
+/** Minimum elapsed ms on a connection before it's considered stable (no-frame path). */
+export const STABLE_MS = 5_000;
+
+/** Total retry budget per disconnect episode before giving up. */
+export const RETRY_BUDGET_MS = 60_000;
+
+/**
+ * Exponential backoff delay for reconnect attempt N (0-indexed).
+ * Caps at 16s to bound the per-attempt wait.
+ */
+export function computeBackoffDelay(attempt: number): number {
+  return Math.min(1000 * Math.pow(2, attempt), 16_000);
+}
+
+/**
+ * Returns true if the connection should be considered "stable" —
+ * meaning backoff should reset on the next disconnect.
+ * Stable = received >=1 real frame OR survived >= STABLE_MS.
+ */
+export function isConnectionStable(
+  connectTimeMs: number,
+  framesReceived: number,
+  nowMs: number
+): boolean {
+  return framesReceived > 0 || nowMs - connectTimeMs >= STABLE_MS;
 }
 
 // --- CLI command ---
@@ -93,13 +130,23 @@ export const crewAttachCommand = new Command("attach")
   .description("Attach to a live interactive task (renders deltas; takes follow-ups). Spec §4.6.")
   .argument("<taskId>", "task id to attach to")
   .action((taskId: string) => {
-    const conn = createConnection(socketPath());
-    const send = (m: AttachInbound) => conn.write(JSON.stringify(m) + "\n");
-    conn.on("connect", () => send({ op: "attach", taskId }));
-    let pendingRequestId: number | undefined;
-    let buf = "";
+    // --- Retry state (persists across reconnects) ---
+    let attempt = 0;       // 0-indexed; grows on unstable disconnect, resets on stable
+    let totalSpentMs = 0;  // cumulative backoff spent this episode; resets on stable
+    let retryLogged = false; // dedup: print "connection lost" once per episode
 
-    // Renderer state
+    // --- Per-connection state (reset each connect()) ---
+    let connectTimeMs = 0;
+    let framesReceived = 0;
+    let taskClosed = false;
+    let disconnecting = false;
+
+    // Mutable send ref — updated on each new connection so readline/SIGINT always
+    // writes to the current socket. Noop during backoff gaps.
+    let send: (m: AttachInbound) => void = () => {};
+
+    // --- Renderer state (persists across reconnects) ---
+    let pendingRequestId: number | undefined;
     let turnCount = 0;
     let turnStartMs = 0;
     let inTurn = false;
@@ -109,23 +156,87 @@ export const crewAttachCommand = new Command("attach")
     const elapsed = () => (turnStartMs ? Date.now() - turnStartMs : 0);
     const writeStatus = () => process.stdout.write(formatStatus(state, turnCount, elapsed()) + "\n");
 
-    conn.on("data", (chunk) => {
-      buf += chunk.toString();
-      const lastNl = buf.lastIndexOf("\n");
-      if (lastNl < 0) return;
-      const consumable = buf.slice(0, lastNl + 1);
-      buf = buf.slice(lastNl + 1);
-      for (const f of decodeFrames(consumable)) render(f);
-    });
-    conn.on("close", () => { process.stderr.write("\n" + formatConnectionClosed() + "\n"); process.exit(0); });
-    conn.on("error", (e) => { process.stderr.write(`\n${chalk.red(`(socket error: ${e.message})`)}\n`); process.exit(1); });
+    let buf = "";
+
+    function handleDisconnect(errorMsg?: string): void {
+      if (disconnecting) return; // guard: error fires before close in Node.js
+      disconnecting = true;
+      send = () => {}; // noop until next connect()
+
+      if (errorMsg) {
+        process.stderr.write(`\n${chalk.red(`(socket error: ${errorMsg})`)}\n`);
+      }
+
+      if (taskClosed) {
+        // Task ended cleanly via "closed" frame — no retry needed.
+        process.stderr.write("\n" + formatConnectionClosed() + "\n");
+        process.exit(0);
+        return;
+      }
+
+      const stable = isConnectionStable(connectTimeMs, framesReceived, Date.now());
+
+      if (stable) {
+        // New episode: the lost connection was healthy, so reset budget and backoff.
+        attempt = 0;
+        totalSpentMs = 0;
+        retryLogged = false;
+      }
+
+      if (!retryLogged) {
+        process.stderr.write("\n" + formatConnectionLost() + "\n");
+        retryLogged = true;
+      }
+
+      const delay = computeBackoffDelay(attempt);
+      if (!stable) attempt += 1; // grow backoff only on unstable; stable already reset to 0
+
+      totalSpentMs += delay;
+      if (totalSpentMs > RETRY_BUDGET_MS) {
+        process.stderr.write(formatReattachFailed(taskId) + "\n");
+        process.exit(1);
+        return;
+      }
+
+      setTimeout(connect, delay);
+    }
+
+    function connect(): void {
+      connectTimeMs = 0;
+      framesReceived = 0;
+      taskClosed = false;
+      disconnecting = false;
+      buf = "";
+
+      const conn = createConnection(socketPath());
+      send = (m: AttachInbound) => conn.write(JSON.stringify(m) + "\n");
+
+      conn.on("connect", () => {
+        connectTimeMs = Date.now();
+        send({ op: "attach", taskId });
+      });
+
+      conn.on("data", (chunk) => {
+        buf += chunk.toString();
+        const lastNl = buf.lastIndexOf("\n");
+        if (lastNl < 0) return;
+        const consumable = buf.slice(0, lastNl + 1);
+        buf = buf.slice(lastNl + 1);
+        for (const f of decodeFrames(consumable)) render(f);
+      });
+
+      conn.on("close", () => handleDisconnect());
+      conn.on("error", (e) => handleDisconnect(e.message));
+    }
 
     function render(f: AttachFrame): void {
       switch (f.type) {
         case "delta":
+          framesReceived += 1;
           process.stdout.write(f.text);
           break;
         case "turn-started":
+          framesReceived += 1;
           turnCount += 1;
           turnStartMs = Date.now();
           inTurn = true;
@@ -134,35 +245,43 @@ export const crewAttachCommand = new Command("attach")
           writeStatus();
           break;
         case "turn-completed":
+          framesReceived += 1;
           process.stdout.write("\n" + formatTurnFooter(elapsed()) + "\n");
           state = "idle";
           inTurn = false;
           process.stdout.write(formatDoneFollowup() + "\n> ");
           break;
         case "input-requested":
+          framesReceived += 1;
           pendingRequestId = f.requestId;
           state = "awaiting-input";
           process.stdout.write("\n" + formatInputQuestion(f.question) + "\n" + formatInputPrompt());
           break;
         case "approval-requested":
+          framesReceived += 1;
           pendingRequestId = f.requestId;
           state = "blocked";
           process.stdout.write("\n" + formatApproval(f.kind, f.question) + "\n" + formatApprovalPrompt());
           break;
         case "gate-promoted":
+          framesReceived += 1;
           process.stdout.write("\n" + formatGatePromoted(f.gateId) + "\n> ");
           break;
         case "reattached":
+          framesReceived += 1;
           process.stdout.write("\n" + (attachedOnce ? formatReattached() : formatAttached()) + "\n> ");
           attachedOnce = true;
           break;
         case "closed":
+          taskClosed = true;
           process.stdout.write("\n" + formatClosed(f.reason) + "\n");
           break;
         case "_keepalive":
           break;
       }
     }
+
+    connect();
 
     const rl = createInterface({ input: process.stdin, terminal: false });
     rl.on("line", (text) => {

--- a/src/commands/crew-attach.ts
+++ b/src/commands/crew-attach.ts
@@ -121,7 +121,7 @@ export function isConnectionStable(
   framesReceived: number,
   nowMs: number
 ): boolean {
-  return framesReceived > 0 || nowMs - connectTimeMs >= STABLE_MS;
+  return connectTimeMs > 0 && (framesReceived > 0 || nowMs - connectTimeMs >= STABLE_MS);
 }
 
 // --- CLI command ---

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -1,13 +1,19 @@
 import { Command } from "commander";
 import { execSync } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import chalk from "chalk";
 import { loadConfig } from "../config.js";
 import { createCmuxDriver, RuntimeRegistry } from "../runtimes/index.js";
 import { readAllStatuses } from "../dashboard/read-status.js";
 import { renderDashboard } from "../dashboard/render.js";
 import { syncHub, type SyncHubResult } from "../dashboard/sync-hub.js";
+import { startWebServer } from "../dashboard/web-server.js";
+import { defaultProbeRunners } from "../dashboard/probes.js";
 import type { PaneRef } from "../runtimes/types.js";
 import { resolveCmuxBin } from "../lib/cmux-bin.js";
+
+const SOCK = join(homedir(), ".config", "cockpit", "cockpit.sock");
 
 function detectCurrentWorkspace(): string {
   const out = execSync(`"${resolveCmuxBin()}" current-workspace`, { encoding: "utf-8" }).trim();
@@ -68,16 +74,43 @@ export async function runDashboardPane(input: DashboardPaneInput): Promise<PaneR
   return pane;
 }
 
+export interface DashboardWebInput {
+  port: number;
+  interval: number; // seconds
+}
+
+/**
+ * Start the localhost-only observability web dashboard. Separate process from
+ * the daemon (crash-isolated, read-only socket client). Keeps running until the
+ * process is killed; the HTTP server + tick loop hold the event loop open.
+ */
+export async function runDashboardWeb(input: DashboardWebInput): Promise<void> {
+  const handle = await startWebServer({
+    port: input.port,
+    intervalMs: input.interval * 1000,
+    sockPath: SOCK,
+    runners: defaultProbeRunners(),
+  });
+  console.log(chalk.green(`✔ Cockpit system dashboard → http://127.0.0.1:${handle.port}`));
+  console.log(chalk.dim(`  polling the daemon every ${input.interval}s · localhost only · read-only · Ctrl-C to stop`));
+}
+
 export const dashboardCommand = new Command("dashboard")
   .description("Live status grid of all projects (derived from daemon task state)")
   .option("--once", "Print one snapshot and exit (used by --pane's refresh loop)")
   .option("--pane", "Open a refreshing sidebar pane in the current cmux workspace")
+  .option("--web", "Serve the live system-health web dashboard on 127.0.0.1 (HTTP + SSE)")
+  .option("--port <port>", "Port for --web (default 7878)", (v) => parseInt(v, 10), 7878)
   .option("--direction <dir>", "Pane split direction (right|left|up|down)", "right")
-  .option("--interval <seconds>", "Refresh interval for --pane", (v) => parseInt(v, 10), 10)
-  .action(async (opts: { once?: boolean; pane?: boolean; direction: "right" | "left" | "up" | "down"; interval: number }) => {
+  .option("--interval <seconds>", "Daemon poll interval for --web (default 5); refresh interval for --pane (default 10)", (v) => parseInt(v, 10))
+  .action(async (opts: { once?: boolean; pane?: boolean; web?: boolean; port: number; direction: "right" | "left" | "up" | "down"; interval?: number }) => {
     try {
+      if (opts.web) {
+        await runDashboardWeb({ port: opts.port, interval: opts.interval ?? 5 });
+        return;
+      }
       if (opts.pane) {
-        const pane = await runDashboardPane({ direction: opts.direction, interval: opts.interval });
+        const pane = await runDashboardPane({ direction: opts.direction, interval: opts.interval ?? 10 });
         console.log(chalk.green(`✔ Dashboard pane opened in ${pane.workspaceId} ${pane.surfaceId}`));
         return;
       }

--- a/src/commands/launch.ts
+++ b/src/commands/launch.ts
@@ -14,7 +14,7 @@ import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js"
 import { ensureSpokeLayout } from "../lib/vault-layout.js";
 import { resolveCmuxBin } from "../lib/cmux-bin.js";
 import { buildRelaySupervisorCommand, NOTIFY_RELAY_TAB_TITLE } from "../control/relay-supervisor.js";
-import { CMUX_TIMEOUT } from "../runtimes/cmux.js";
+import { CMUX_TIMEOUT, classifyStartupSurface } from "../runtimes/cmux.js";
 
 const CMUX_APP = "/Applications/cmux.app";
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "cockpit", "templates");
@@ -185,6 +185,73 @@ function buildAgentCmd(
 // them from "../launch").
 export { buildRelaySupervisorCommand, NOTIFY_RELAY_TAB_TITLE };
 
+export interface StartupDeliveryOptions {
+  /** Max time to wait for the surface to leave the cold-init splash. */
+  readyTimeoutMs?: number;
+  /** Pause after a send before checking whether the turn started. */
+  settleMs?: number;
+  /** Poll cadence while waiting for readiness. */
+  pollMs?: number;
+  /** Hard cap on (re)send attempts. */
+  maxAttempts?: number;
+}
+
+/**
+ * #292: deliver the captain/command startup prompt deterministically instead of
+ * on a fixed 8s timer. CC cold-init takes 5–15s, so a fixed delay either wastes
+ * boot time or — on a slow boot — drops the prompt on the splash screen (#235),
+ * leaving the captain idle and the relay unbooted.
+ *
+ * The loop, per attempt: (1) poll until the surface is past the splash; (2) if a
+ * turn is already running, stop — never queue a duplicate startup run; (3) send;
+ * (4) after a short settle, re-check — a real submit flips the surface to
+ * "working", so we re-send ONLY while it's still "idle" (keystrokes were dropped).
+ * Re-sending strictly on observed-still-idle is what guards against duplicate
+ * runs: a prompt that landed is never sent twice. Best-effort and never throws.
+ */
+export async function deliverStartupPrompt(
+  runtime: Pick<RuntimeDriver, "readScreen" | "send">,
+  refId: string,
+  prompt: string,
+  opts: StartupDeliveryOptions = {},
+): Promise<void> {
+  const readyTimeoutMs = opts.readyTimeoutMs ?? 30_000;
+  const settleMs = opts.settleMs ?? 2_500;
+  const pollMs = opts.pollMs ?? 1_000;
+  const maxAttempts = opts.maxAttempts ?? 3;
+  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+  const read = async () => runtime.readScreen(refId).catch(() => "");
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    // Phase 1 — wait out cold init (poll, don't guess with a fixed delay).
+    const deadline = Date.now() + readyTimeoutMs;
+    let state = classifyStartupSurface(await read());
+    while (state === "loading" && Date.now() < deadline) {
+      await sleep(pollMs);
+      state = classifyStartupSurface(await read());
+    }
+
+    // A turn is already in flight (a prior attempt landed, or a resumed session
+    // auto-continued). Never keystroke into it — that would queue a duplicate run.
+    if (state === "working") return;
+
+    // Phase 2 — deliver. We send on "idle" (input-ready) and, as a non-hanging
+    // fallback, on a "loading" timeout (e.g. a non-Claude agent whose chrome we
+    // don't recognize) so a launch is never left silently without its prompt.
+    await runtime.send(refId, prompt).catch(() => { /* best-effort */ });
+
+    // Timed out waiting for chrome — sent blind once; nothing to confirm, stop.
+    if (state === "loading") return;
+
+    // Phase 3 — confirm. A real submit flips the surface to "working" within a
+    // second or two (a startup turn runs far longer than settleMs). If it's no
+    // longer "idle", the prompt landed → done. If still "idle", the keystrokes
+    // were dropped (#235) → loop and re-send (bounded by maxAttempts).
+    await sleep(settleMs);
+    if (classifyStartupSurface(await read()) !== "idle") return;
+  }
+}
+
 async function launchWorkspace(
   runtime: RuntimeDriver,
   name: string,
@@ -223,12 +290,13 @@ async function launchWorkspace(
   });
 
   if (initialPrompt) {
-    // #288: cold-boot Claude sessions need ~8s to initialize before they can
-    // receive input. 3s was too short — startup prompt arrived at the loading
-    // screen and was silently dropped, so relay supervisor never ran.
-    setTimeout(() => {
-      runtime.send(ref.id, initialPrompt).catch(() => { /* best-effort */ });
-    }, 8000);
+    // #292: deterministic delivery — poll for input-readiness, send, and bounded
+    // re-send if the first turn was dropped (replaces the racy fixed 8s delay
+    // that dropped the prompt on slow 5–15s cold boots). Fire-and-forget, as the
+    // old setTimeout was, so launch stays non-blocking and `--all` dispatches
+    // captains in parallel; the loop's pending poll timers keep the CLI process
+    // alive until delivery completes.
+    void deliverStartupPrompt(runtime, ref.id, initialPrompt);
   }
 
   if (navigate) {

--- a/src/control/__tests__/cockpitd-snapshot.test.ts
+++ b/src/control/__tests__/cockpitd-snapshot.test.ts
@@ -1,0 +1,55 @@
+// src/control/__tests__/cockpitd-snapshot.test.ts
+//
+// Thin integration smoke for the read-only `snapshot` verb: boots a daemon
+// against a temp state root, seeds a task, and asserts the assembled
+// DaemonSnapshot shape (Tier 0/1/2). Pure assembly is covered in snapshot.test.ts.
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startCockpitd } from "../cockpitd.js";
+import { sendRequest } from "../protocol.js";
+import type { DaemonSnapshot } from "../snapshot.js";
+
+describe("cockpitd snapshot verb", () => {
+  let stop: (() => void) | undefined;
+  let dir: string;
+  afterEach(() => { stop?.(); if (dir) rmSync(dir, { recursive: true, force: true }); });
+
+  it("returns a Tier 0/1/2 snapshot and leaves the health verb intact", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-snap-"));
+    const sock = join(dir, "c.sock");
+    const handle = startCockpitd({ stateRoot: join(dir, "state"), sockPath: sock, sweepMs: 0 });
+    stop = handle.stop;
+
+    await sendRequest(sock, { kind: "seed", record: {
+      id: "t1", project: "demo", provider: "claude", mode: "interactive",
+      state: "working", task: "wire snapshot", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000,
+      attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }] } });
+
+    const snap = await sendRequest(sock, { kind: "snapshot" }) as DaemonSnapshot;
+
+    // Tier 0 — daemon self
+    expect(snap.tier0.pid).toBe(process.pid);
+    expect(snap.tier0.uptimeMs).toBeGreaterThanOrEqual(0);
+    expect(typeof snap.tier0.version).toBe("string");
+    expect(["fresh", "stale"]).toContain(snap.tier0.build.state);
+    expect(snap.tier0.sweep.lastSweepAt).toBeNull(); // sweepMs:0 → never swept
+    expect(typeof snap.tier0.log.sizeBytes).toBe("number");
+
+    // Tier 1 — component health for the seeded project
+    expect(snap.tier1.some((c) => c.project === "demo")).toBe(true);
+
+    // Tier 2 — per-project data plane + global results
+    const demo = snap.tier2.projects.find((p) => p.project === "demo");
+    expect(demo).toBeDefined();
+    expect(demo!.store.byState.working).toBe(1);
+    expect(demo!.delivery.behind).toBeGreaterThanOrEqual(0);
+    expect(typeof snap.tier2.results.fileCount).toBe("number");
+
+    // The pre-existing health verb is unchanged.
+    const health = await sendRequest(sock, { kind: "health", project: "demo" }) as unknown[];
+    expect(Array.isArray(health)).toBe(true);
+  });
+});

--- a/src/control/__tests__/cockpitd-snapshot.test.ts
+++ b/src/control/__tests__/cockpitd-snapshot.test.ts
@@ -19,7 +19,8 @@ describe("cockpitd snapshot verb", () => {
   it("returns a Tier 0/1/2 snapshot and leaves the health verb intact", async () => {
     dir = mkdtempSync(join(tmpdir(), "cp-snap-"));
     const sock = join(dir, "c.sock");
-    const handle = startCockpitd({ stateRoot: join(dir, "state"), sockPath: sock, sweepMs: 0 });
+    // registeredProjects scopes Tier 2 to known projects (avoids config.json dependency in tests)
+    const handle = startCockpitd({ stateRoot: join(dir, "state"), sockPath: sock, sweepMs: 0, registeredProjects: ["demo"] });
     stop = handle.stop;
 
     await sendRequest(sock, { kind: "seed", record: {
@@ -51,5 +52,28 @@ describe("cockpitd snapshot verb", () => {
     // The pre-existing health verb is unchanged.
     const health = await sendRequest(sock, { kind: "health", project: "demo" }) as unknown[];
     expect(Array.isArray(health)).toBe(true);
+  });
+
+  it("excludes unregistered (orphan) projects from tier2 projects list", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-snap-orphan-"));
+    const sock = join(dir, "c.sock");
+    // "registered" is the only registered project; "orphan" has a task but is not registered
+    const handle = startCockpitd({ stateRoot: join(dir, "state"), sockPath: sock, sweepMs: 0, registeredProjects: ["registered"] });
+    stop = handle.stop;
+
+    await sendRequest(sock, { kind: "seed", record: {
+      id: "t-reg", project: "registered", provider: "claude", mode: "interactive",
+      state: "working", task: "a", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000,
+      attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }] } });
+    await sendRequest(sock, { kind: "seed", record: {
+      id: "t-orp", project: "orphan", provider: "claude", mode: "interactive",
+      state: "done", task: "stale", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000,
+      attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }] } });
+
+    const snap = await sendRequest(sock, { kind: "snapshot" }) as DaemonSnapshot;
+    expect(snap.tier2.projects.find((p) => p.project === "registered")).toBeDefined();
+    expect(snap.tier2.projects.find((p) => p.project === "orphan")).toBeUndefined();
   });
 });

--- a/src/control/__tests__/daemon-lock.test.ts
+++ b/src/control/__tests__/daemon-lock.test.ts
@@ -1,0 +1,177 @@
+// src/control/__tests__/daemon-lock.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("node:fs", () => ({
+  openSync: vi.fn(),
+  writeSync: vi.fn(),
+  closeSync: vi.fn(),
+  unlinkSync: vi.fn(),
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  constants: { O_EXCL: 2048, O_CREAT: 512, O_WRONLY: 1 },
+}));
+
+import { existsSync, readFileSync, openSync, writeSync, closeSync, unlinkSync } from "node:fs";
+import {
+  tryAcquireDaemonLock,
+  releaseDaemonLock,
+  daemonLockPath,
+  _resetRestartInFlightForTest,
+} from "../launchd.js";
+
+const LOCK_PATH = daemonLockPath();
+
+// Stub Atomics.wait to prevent real 50 ms sleeps in the retry loop.
+const stubbedAtomics = { wait: vi.fn(() => "ok" as ReturnType<typeof Atomics.wait>) };
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.stubGlobal("Atomics", stubbedAtomics);
+  _resetRestartInFlightForTest();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("daemonLockPath", () => {
+  it("ends with daemon.lock inside .config/cockpit", () => {
+    expect(LOCK_PATH).toMatch(/\.config[/\\]cockpit[/\\]daemon\.lock$/);
+  });
+});
+
+describe("tryAcquireDaemonLock — no existing lock", () => {
+  it("acquires lock and writes PID when no lock file exists", () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(openSync).mockReturnValue(3 as unknown as number);
+
+    const result = tryAcquireDaemonLock();
+
+    expect(result).toBe(true);
+    expect(openSync).toHaveBeenCalledOnce();
+    expect(writeSync).toHaveBeenCalledWith(3, String(process.pid));
+    expect(closeSync).toHaveBeenCalledWith(3);
+  });
+
+  it("does not call unlinkSync when no lock file exists", () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(openSync).mockReturnValue(3 as unknown as number);
+
+    tryAcquireDaemonLock();
+
+    expect(unlinkSync).not.toHaveBeenCalled();
+  });
+});
+
+describe("tryAcquireDaemonLock — stale lock (dead PID)", () => {
+  it("removes stale lock when owning PID is dead and then acquires", () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue("99999");
+    vi.spyOn(process, "kill").mockImplementationOnce(() => {
+      throw Object.assign(new Error("kill ESRCH 99999"), { code: "ESRCH" });
+    });
+    vi.mocked(openSync).mockReturnValue(4 as unknown as number);
+
+    const result = tryAcquireDaemonLock();
+
+    expect(unlinkSync).toHaveBeenCalledWith(LOCK_PATH);
+    expect(result).toBe(true);
+  });
+
+  it("removes lock with non-numeric PID and acquires", () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue("not-a-pid");
+    vi.mocked(openSync).mockReturnValue(5 as unknown as number);
+
+    const result = tryAcquireDaemonLock();
+
+    expect(unlinkSync).toHaveBeenCalledWith(LOCK_PATH);
+    expect(result).toBe(true);
+  });
+
+  it("removes lock with zero PID and acquires", () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue("0");
+    vi.mocked(openSync).mockReturnValue(6 as unknown as number);
+
+    const result = tryAcquireDaemonLock();
+
+    expect(unlinkSync).toHaveBeenCalledWith(LOCK_PATH);
+    expect(result).toBe(true);
+  });
+});
+
+describe("tryAcquireDaemonLock — live process holds lock", () => {
+  it("does not steal lock when owning PID is alive", () => {
+    const livePid = process.pid + 1;
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(String(livePid));
+    vi.spyOn(process, "kill").mockImplementation((): true => true); // alive — no throw
+    vi.mocked(openSync).mockImplementation(() => { throw new Error("EEXIST"); });
+
+    const result = tryAcquireDaemonLock();
+
+    expect(unlinkSync).not.toHaveBeenCalled();
+    expect(result).toBe(false);
+  });
+
+  it("retries before giving up when lock is held", () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(openSync).mockImplementation(() => { throw new Error("EEXIST"); });
+
+    tryAcquireDaemonLock();
+
+    // 20 attempts, Atomics.wait called for the first 19 retries
+    expect(stubbedAtomics.wait).toHaveBeenCalledTimes(19);
+  });
+});
+
+describe("releaseDaemonLock", () => {
+  it("calls unlinkSync on the lock path", () => {
+    releaseDaemonLock();
+    expect(unlinkSync).toHaveBeenCalledWith(LOCK_PATH);
+  });
+
+  it("does not throw when the lock file is already gone", () => {
+    vi.mocked(unlinkSync).mockImplementation(() => { throw Object.assign(new Error("ENOENT"), { code: "ENOENT" }); });
+    expect(() => releaseDaemonLock()).not.toThrow();
+  });
+});
+
+describe("in-process restartInFlight dedup", () => {
+  it("tryAcquireDaemonLock is not called on the second ensureDaemon invocation in the same process", async () => {
+    // Import ensureDaemon after all mocks are set up.
+    // We mock node:child_process to prevent real launchctl calls.
+    vi.doMock("node:child_process", () => ({ execFileSync: vi.fn() }));
+
+    // First call: no lock file, O_EXCL succeeds, execFileSync throws (daemonEntryPath)
+    // so the function catches and returns. The flag is set to true.
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(openSync).mockReturnValue(7 as unknown as number);
+
+    // Track how many times tryAcquireDaemonLock acquires the lock
+    const acquireCalls: boolean[] = [];
+    const originalOpen = vi.mocked(openSync);
+    originalOpen.mockImplementation(() => {
+      acquireCalls.push(true);
+      return 7 as unknown as number;
+    });
+
+    const { ensureDaemon, _resetRestartInFlightForTest: reset } = await import("../launchd.js");
+    reset();
+
+    ensureDaemon();
+    const firstAcquireCount = acquireCalls.length;
+
+    // Second call in same process — restartInFlight is now true
+    ensureDaemon();
+
+    // Lock acquisition only happened once (the second call returned early)
+    expect(acquireCalls.length).toBe(firstAcquireCount);
+
+    reset(); // clean up for other tests
+  });
+});

--- a/src/control/__tests__/mailbox.test.ts
+++ b/src/control/__tests__/mailbox.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { appendToMailbox } from "../mailbox.js";
 import { readCursor, writeCursor } from "../mailbox.js";
 import { readFromCursor } from "../mailbox.js";
-import { rotateIfNeeded } from "../mailbox.js";
+import { rotateIfNeeded, mailboxStats } from "../mailbox.js";
 import { statSync } from "node:fs";
 import type { TaskRecord, ControlEvent } from "../types.js";
 
@@ -252,5 +252,40 @@ describe("rotateIfNeeded", () => {
     await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
     const items = await collect(readFromCursor({ stateRoot, project: "demo", fromSeq: 1 }));
     expect(items.map((i) => i.seq)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+});
+
+describe("mailboxStats", () => {
+  it("returns zeros for a project with no mailbox", async () => {
+    const stateRoot = freshState();
+    expect(await mailboxStats(stateRoot, "demo")).toEqual({
+      maxSeq: 0,
+      sizeBytes: 0,
+      oldestEntryAgeMs: 0,
+      rotationCount: 0,
+    });
+  });
+
+  it("reports maxSeq, a positive size and zero rotations for a live mailbox", async () => {
+    const stateRoot = freshState();
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    const stats = await mailboxStats(stateRoot, "demo");
+    expect(stats.maxSeq).toBe(2);
+    expect(stats.sizeBytes).toBeGreaterThan(0);
+    expect(stats.rotationCount).toBe(0);
+    expect(stats.oldestEntryAgeMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("counts rotated segments and keeps maxSeq across them", async () => {
+    const stateRoot = freshState();
+    for (let i = 0; i < 5; i++) {
+      await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    }
+    await rotateIfNeeded({ stateRoot, project: "demo", maxBytes: 50, maxAgeMs: 999999999, keepCount: 3 });
+    await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+    const stats = await mailboxStats(stateRoot, "demo");
+    expect(stats.rotationCount).toBe(1);
+    expect(stats.maxSeq).toBe(6);
   });
 });

--- a/src/control/__tests__/snapshot.test.ts
+++ b/src/control/__tests__/snapshot.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildFreshness,
+  assembleDaemonSnapshot,
+  type DaemonSnapshotInputs,
+} from "../snapshot.js";
+import type { ComponentHealth } from "../liveness.js";
+
+// ── buildFreshness ────────────────────────────────────────────────────────────
+describe("buildFreshness", () => {
+  it("is fresh when the process started after the dist was built", () => {
+    expect(buildFreshness(2000, 1000)).toBe("fresh");
+  });
+  it("is stale when the process started before the dist was built (running old code)", () => {
+    expect(buildFreshness(1000, 2000)).toBe("stale");
+  });
+  it("treats an exactly-equal boundary as fresh", () => {
+    expect(buildFreshness(1500, 1500)).toBe("fresh");
+  });
+});
+
+// ── assembleDaemonSnapshot ────────────────────────────────────────────────────
+const HEALTH: ComponentHealth[] = [
+  { kind: "relay", project: "cockpit", ref: "relay", state: "alive", lastSeenMs: 900 },
+  { kind: "captain", project: "cockpit", ref: "cockpit-captain", state: "alive", lastSeenMs: 900 },
+];
+
+function inputs(over: Partial<DaemonSnapshotInputs> = {}): DaemonSnapshotInputs {
+  return {
+    pid: 4821,
+    processStartedAt: 1_000,
+    version: "0.6.1",
+    distBuiltAt: 500,
+    lastSweepAt: 9_000,
+    sweepCadenceMs: 30_000,
+    log: { errorCount: 0, sizeBytes: 1234, windowMs: 3_600_000 },
+    health: HEALTH,
+    projects: [
+      {
+        project: "cockpit",
+        mailbox: { maxSeq: 12, sizeBytes: 1300, oldestEntryAgeMs: 60_000, rotationCount: 0 },
+        lastAckedSeq: 12,
+        storeByState: { working: 3, blocked: 1 },
+        corruptCount: 0,
+      },
+    ],
+    results: { fileCount: 294, totalBytes: 18_000_000 },
+    ...over,
+  };
+}
+
+describe("assembleDaemonSnapshot", () => {
+  const NOW = 10_000;
+
+  it("assembles Tier 0 daemon self-health with uptime, freshness and sweep age", () => {
+    const snap = assembleDaemonSnapshot(inputs(), NOW);
+    expect(snap.tier0.pid).toBe(4821);
+    expect(snap.tier0.uptimeMs).toBe(NOW - 1_000);
+    expect(snap.tier0.version).toBe("0.6.1");
+    expect(snap.tier0.build).toEqual({ state: "fresh", processStartedAt: 1_000, distBuiltAt: 500 });
+    expect(snap.tier0.sweep).toEqual({ lastSweepAt: 9_000, ageMs: 1_000, cadenceMs: 30_000 });
+    expect(snap.tier0.log).toEqual({ errorCount: 0, sizeBytes: 1234, windowMs: 3_600_000 });
+  });
+
+  it("flags a stale build in Tier 0", () => {
+    const snap = assembleDaemonSnapshot(inputs({ processStartedAt: 100, distBuiltAt: 9_999 }), NOW);
+    expect(snap.tier0.build.state).toBe("stale");
+  });
+
+  it("reports a null sweep age when the daemon has not yet swept", () => {
+    const snap = assembleDaemonSnapshot(inputs({ lastSweepAt: null }), NOW);
+    expect(snap.tier0.sweep.lastSweepAt).toBeNull();
+    expect(snap.tier0.sweep.ageMs).toBeNull();
+  });
+
+  it("passes Tier 1 component health through verbatim", () => {
+    const snap = assembleDaemonSnapshot(inputs(), NOW);
+    expect(snap.tier1).toEqual(HEALTH);
+  });
+
+  it("assembles Tier 2 per-project mailbox, delivery lag and store counts", () => {
+    const snap = assembleDaemonSnapshot(inputs(), NOW);
+    const p = snap.tier2.projects[0];
+    expect(p.project).toBe("cockpit");
+    expect(p.mailbox).toEqual({ maxSeq: 12, sizeBytes: 1300, oldestEntryAgeMs: 60_000, rotationCount: 0 });
+    expect(p.delivery).toEqual({ maxSeq: 12, lastAckedSeq: 12, behind: 0 });
+    expect(p.store).toEqual({ byState: { working: 3, blocked: 1 }, corruptCount: 0 });
+  });
+
+  it("computes delivery lag as maxSeq minus lastAckedSeq", () => {
+    const snap = assembleDaemonSnapshot(
+      inputs({
+        projects: [
+          {
+            project: "pact",
+            mailbox: { maxSeq: 10, sizeBytes: 200, oldestEntryAgeMs: 3 * 86_400_000, rotationCount: 1 },
+            lastAckedSeq: 6,
+            storeByState: {},
+            corruptCount: 2,
+          },
+        ],
+      }),
+      NOW,
+    );
+    expect(snap.tier2.projects[0].delivery.behind).toBe(4);
+    expect(snap.tier2.projects[0].store.corruptCount).toBe(2);
+  });
+
+  it("never reports negative delivery lag (cursor ahead of max seq)", () => {
+    const snap = assembleDaemonSnapshot(
+      inputs({
+        projects: [
+          {
+            project: "x",
+            mailbox: { maxSeq: 5, sizeBytes: 0, oldestEntryAgeMs: 0, rotationCount: 0 },
+            lastAckedSeq: 9,
+            storeByState: {},
+            corruptCount: 0,
+          },
+        ],
+      }),
+      NOW,
+    );
+    expect(snap.tier2.projects[0].delivery.behind).toBe(0);
+  });
+
+  it("passes global _results artifact stats through", () => {
+    const snap = assembleDaemonSnapshot(inputs(), NOW);
+    expect(snap.tier2.results).toEqual({ fileCount: 294, totalBytes: 18_000_000 });
+  });
+});

--- a/src/control/__tests__/watchdog.test.ts
+++ b/src/control/__tests__/watchdog.test.ts
@@ -1,6 +1,7 @@
 // src/control/__tests__/watchdog.test.ts
 import { describe, it, expect } from "vitest";
 import { evaluateStall, recoverStall } from "../watchdog.js";
+import { reduce } from "../state-machine.js";
 import type { TaskRecord } from "../types.js";
 
 function rec(o: Partial<TaskRecord> = {}): TaskRecord {
@@ -89,5 +90,54 @@ describe("idle interactive-codex = warn-don't-autofail (spec §4.8, #90 slice)",
     const idle = evaluateStall(rec(), 100_000)!;
     expect(evaluateStall(idle, 200_000)).toBeNull(); // no re-stall while idle
     expect(recoverStall(idle, 101_000)).toBeNull();  // recoverStall only acts on 'stalled'
+  });
+});
+
+// ── Issue #89: masking-heartbeat regression ──────────────────────────────────
+// A late { type: "heartbeat" } from a dead attempt updates rec.lastHeartbeat
+// but bypasses stampAttempt, so attempts[-1].lastHeartbeatAt stays anchored to
+// the new dispatch's task.started time. evaluateStall must key off lastHeartbeatAt
+// so the stale pulse from the dead attempt cannot hide a hung new dispatch.
+describe("masking-heartbeat regression (#89)", () => {
+  function baseRec(): TaskRecord {
+    return {
+      id: "t1", project: "p", provider: "claude", mode: "headless",
+      state: "submitted", task: "do x", createdAt: 0,
+      lastHeartbeat: 0, lastEvent: "", heartbeatBudgetMs: 5000,
+      attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 0 }],
+    };
+  }
+
+  it("stale heartbeat from dead attempt does not mask stall on hung re-dispatch", () => {
+    // Attempt A starts at T=100.
+    let r = reduce(baseRec(), { type: "task.started", id: "t1", pid: 10 }, 100);
+    expect(r.attempts.at(-1)!.lastHeartbeatAt).toBe(100);
+
+    // Attempt A crashes at T=200 → terminal.
+    r = reduce(r, { type: "task.failed", id: "t1", error: "crash" }, 200);
+    expect(r.state).toBe("failed");
+
+    // Re-dispatch: captain reopens at T=300.
+    r = reduce(r, { type: "task.reopened", id: "t1" }, 300);
+    expect(r.state).toBe("working");
+
+    // New dispatch: task.started at T=400 stamps lastHeartbeatAt on the attempt.
+    r = reduce(r, { type: "task.started", id: "t1", pid: 20 }, 400);
+    expect(r.attempts.at(-1)!.lastHeartbeatAt).toBe(400);
+
+    // New dispatch is HUNG — no output, no events from pid 20.
+
+    // Late heartbeat from dead attempt A arrives at T=4500 (still within 5s budget
+    // if measured from rec.lastHeartbeat). It updates rec.lastHeartbeat but does NOT
+    // call stampAttempt, so lastHeartbeatAt stays anchored at 400.
+    r = reduce(r, { type: "heartbeat", id: "t1" }, 4500);
+    expect(r.lastHeartbeat).toBe(4500);
+    expect(r.attempts.at(-1)!.lastHeartbeatAt).toBe(400); // unchanged
+
+    // Watchdog fires at T=5401.
+    // Old (buggy) path: now - rec.lastHeartbeat = 5401-4500 = 901 ≤ 5000 → null (false-alive).
+    // Fixed path:       now - lastHeartbeatAt    = 5401-400  = 5001 > 5000 → stalled.
+    const result = evaluateStall(r, 5401);
+    expect(result?.state).toBe("stalled");
   });
 });

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -1,8 +1,12 @@
 // src/control/cockpitd.ts
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { spawn as realSpawn } from "node:child_process";
-import { writeFileSync, mkdirSync } from "node:fs";
+import {
+  writeFileSync, mkdirSync, readFileSync, readdirSync, statSync,
+  openSync, readSync, closeSync,
+} from "node:fs";
 import { randomUUID } from "node:crypto";
 import { createStore } from "./store.js";
 import { createDaemon } from "./daemon.js";
@@ -11,14 +15,29 @@ import { runHeadless } from "./headless-launcher.js";
 import { CodexInteractiveDriver, shouldReattachCodex } from "./codex/driver.js";
 import { OpencodeSseBridge } from "./opencode/sse-bridge.js";
 import { makeGate } from "./codex/gate.js";
-import { appendToMailbox, rotateIfNeeded } from "./mailbox.js";
+import { appendToMailbox, rotateIfNeeded, mailboxStats, readCursor } from "./mailbox.js";
 import { createRelayHealer } from "./relay-healer.js";
 import { projectHealth, type ComponentHealth } from "./liveness.js";
+import { assembleDaemonSnapshot, type DaemonSnapshotInputs, type ResultArtifacts } from "./snapshot.js";
 import { loadConfig } from "../config.js";
 import { readdir } from "node:fs/promises";
 import type { Gate, TaskRecord, ControlEvent } from "./types.js";
 import { TERMINAL_STATES } from "./types.js";
 import type { Socket } from "node:net";
+
+// This module's own compiled file — its mtime is the dist build-time used for
+// the Tier 0 build-freshness check (process start vs build time). package.json
+// (repo root) gives the running version. Both resolved once at load.
+const SELF_PATH = fileURLToPath(import.meta.url);
+function readPkgVersion(): string {
+  try {
+    const pkgPath = join(dirname(SELF_PATH), "..", "..", "package.json");
+    return (JSON.parse(readFileSync(pkgPath, "utf-8")).version as string) ?? "unknown";
+  } catch { return "unknown"; }
+}
+const PKG_VERSION = readPkgVersion();
+const SNAPSHOT_LOG_WINDOW_MS = 60 * 60 * 1000; // count daemon-log errors in the last hour
+const CURSOR_SUBSCRIBER = "captain"; // the relay drains the mailbox as "captain" (#207)
 
 export interface CockpitdOpts {
   stateRoot?: string;
@@ -73,6 +92,82 @@ export interface CockpitdOpts {
   };
 }
 
+// ── Tier 0/2 snapshot gathering (I/O at the edge; the pure assembly lives in
+//    snapshot.ts). Each helper tolerates missing files and never throws. ───────
+
+/** mtime (epoch ms) of the running daemon's compiled code, for build-freshness. */
+function distBuiltAt(): number {
+  try { return statSync(SELF_PATH).mtimeMs; } catch { return 0; }
+}
+
+/** Daemon-log error count (last window) + total size. Reads only the tail so a
+ *  large log never makes the snapshot tick expensive. */
+function gatherLogStats(path: string, now: number, windowMs: number): DaemonSnapshotInputs["log"] {
+  let sizeBytes = 0;
+  try { sizeBytes = statSync(path).size; }
+  catch { return { errorCount: 0, sizeBytes: 0, windowMs }; }
+  if (sizeBytes === 0) return { errorCount: 0, sizeBytes, windowMs };
+  const CAP = 256 * 1024;
+  const start = Math.max(0, sizeBytes - CAP);
+  const len = sizeBytes - start;
+  let text = "";
+  try {
+    const fd = openSync(path, "r");
+    try {
+      const buf = Buffer.alloc(len);
+      readSync(fd, buf, 0, len, start);
+      text = buf.toString("utf-8");
+    } finally { closeSync(fd); }
+  } catch { return { errorCount: 0, sizeBytes, windowMs }; }
+  const cutoff = now - windowMs;
+  let errorCount = 0;
+  for (const line of text.split("\n")) {
+    if (!/error|failed/i.test(line)) continue;
+    // Lines carry an ISO timestamp ("[cockpitd] 2026-... msg"); skip ones older
+    // than the window. Lines without a parseable timestamp are counted (conservative).
+    const m = line.match(/\d{4}-\d{2}-\d{2}T[\d:.]+Z/);
+    if (m) { const ts = Date.parse(m[0]); if (!Number.isNaN(ts) && ts < cutoff) continue; }
+    errorCount++;
+  }
+  return { errorCount, sizeBytes, windowMs };
+}
+
+/** Per-project store state counts + corrupt/quarantined file count. */
+function gatherStoreStats(
+  store: { list: (p: string) => TaskRecord[] },
+  stateRoot: string,
+  project: string,
+): { byState: Record<string, number>; corruptCount: number } {
+  const byState: Record<string, number> = {};
+  for (const r of store.list(project)) byState[r.state] = (byState[r.state] ?? 0) + 1;
+  let corruptCount = 0;
+  const dir = join(stateRoot, project);
+  try {
+    for (const n of readdirSync(dir)) {
+      if (n.includes(".corrupt.")) { corruptCount++; continue; }
+      if (!n.endsWith(".json")) continue;
+      try { JSON.parse(readFileSync(join(dir, n), "utf-8")); }
+      catch { corruptCount++; }
+    }
+  } catch { /* no project dir yet */ }
+  return { byState, corruptCount };
+}
+
+/** Global _results/ artifact count + total bytes (unbounded-growth watch). */
+function gatherResults(resultsDir: string): ResultArtifacts {
+  let fileCount = 0;
+  let totalBytes = 0;
+  try {
+    for (const n of readdirSync(resultsDir)) {
+      try {
+        const s = statSync(join(resultsDir, n));
+        if (s.isFile()) { fileCount++; totalBytes += s.size; }
+      } catch { /* vanished mid-scan */ }
+    }
+  } catch { /* no results dir */ }
+  return { fileCount, totalBytes };
+}
+
 export function defaultIsPidAlive(pid: number): boolean {
   try { process.kill(pid, 0); return true; }
   catch (e: any) { return e?.code === "EPERM"; } // EPERM = alive but not ours; ESRCH = dead
@@ -82,6 +177,10 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   const stateRoot = opts.stateRoot ?? join(homedir(), ".config", "cockpit", "state");
   const sockPath = opts.sockPath ?? join(homedir(), ".config", "cockpit", "cockpit.sock");
   const store = createStore(stateRoot);
+  // #44 dashboard: process start-time (for uptime + build-freshness) and the
+  // timestamp of the most recent sweep (Tier 0 "sweep last Ns ago").
+  const bootedAt = Date.now();
+  let lastSweepAt: number | null = null;
   // #225: hard crew task-timeout ceiling, read once at boot. Falls back to the
   // daemon's DEFAULT_TASK_TIMEOUT_MS (8h) when unset in config.
   const taskTimeoutMs = loadConfig().defaults.taskTimeoutMs;
@@ -373,6 +472,49 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
     return out;
   }
 
+  // #44 dashboard: the same project set buildHealth() covers (config ∪ relays ∪ tasks).
+  function knownProjects(): string[] {
+    const config = loadConfig();
+    return [...new Set<string>([
+      ...Object.keys(config.projects),
+      ...d.getRelayHealth().map((r) => r.project),
+      ...store.listAll().map((t) => t.project),
+    ])];
+  }
+
+  // #44 dashboard: gather all Tier 0/1/2 inputs (I/O) for the read-only snapshot
+  // verb, then hand them to the pure assembler. The daemon log lives next to the
+  // state root (~/.config/cockpit/cockpitd.log); deriving it from stateRoot keeps
+  // tests isolated to their temp dir.
+  async function gatherSnapshotInputs(now: number): Promise<DaemonSnapshotInputs> {
+    const logPath = join(dirname(stateRoot), "cockpitd.log");
+    const projects = await Promise.all(
+      knownProjects().map(async (project) => {
+        const cursor = await readCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER });
+        const storeStats = gatherStoreStats(store, stateRoot, project);
+        return {
+          project,
+          mailbox: await mailboxStats(stateRoot, project),
+          lastAckedSeq: cursor?.lastAckedSeq ?? 0,
+          storeByState: storeStats.byState,
+          corruptCount: storeStats.corruptCount,
+        };
+      }),
+    );
+    return {
+      pid: process.pid,
+      processStartedAt: bootedAt,
+      version: PKG_VERSION,
+      distBuiltAt: distBuiltAt(),
+      lastSweepAt,
+      sweepCadenceMs: opts.sweepMs ?? 30_000,
+      log: gatherLogStats(logPath, now, SNAPSHOT_LOG_WINDOW_MS),
+      health: buildHealth(),
+      projects,
+      results: gatherResults(resultsDir),
+    };
+  }
+
   // Crash recovery on boot. reconcile() is async (#139: it consults the
   // interactive surface-liveness probe to reap dead crews instead of stalling
   // them), so run it — and the reattach loops that depend on its terminalizing a
@@ -463,6 +605,13 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       if (msg.kind === "health") {
         return buildHealth(msg.project as string | undefined);
       }
+      // #44 dashboard: read-only full system snapshot (Tier 0/1/2). Additive —
+      // the `health` verb above is untouched. Pure assembly; all I/O is gathered
+      // here and fed in. Never mutates state.
+      if (msg.kind === "snapshot") {
+        const now = Date.now();
+        return assembleDaemonSnapshot(await gatherSnapshotInputs(now), now);
+      }
       // #239 Phase B: on any event that terminates a task, evict its entries from
       // inFlightProbes and probeResults so the Sets never leak. Tasks reaped by
       // sweep/reconcile (not via the socket) are naturally safe — proxiedSurfaceAlive
@@ -516,6 +665,7 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
     timer = setInterval(() => {
       if (sweeping) return;
       sweeping = true;
+      lastSweepAt = Date.now(); // Tier 0 observability: time of the most recent sweep
       void d.sweep()
         .catch((e: unknown) => log(`sweep failed: ${(e as Error).message}`))
         .finally(() => { sweeping = false; });

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -83,6 +83,9 @@ export interface CockpitdOpts {
   healRelay?: (project: string) => Promise<void> | void;
   /** Inject a fake headless launcher for tests to avoid real process spawns. */
   launchHeadless?: (rec: TaskRecord) => Promise<void>;
+  /** Override which projects appear in the Tier 2 per-project snapshot. Defaults
+   *  to Object.keys(loadConfig().projects). Tests inject this to avoid real config. */
+  registeredProjects?: string[];
   /** Inject a fake opencode SSE bridge for tests. Defaults to a real one. */
   opencodeBridge?: {
     start: (o: { taskId: string; port: number }) => void;
@@ -488,8 +491,11 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   // tests isolated to their temp dir.
   async function gatherSnapshotInputs(now: number): Promise<DaemonSnapshotInputs> {
     const logPath = join(dirname(stateRoot), "cockpitd.log");
+    // Scope Tier 2 per-project data to registered projects only. Orphan state
+    // directories from removed/test projects are excluded here.
+    const tier2Projects = opts.registeredProjects ?? Object.keys(loadConfig().projects);
     const projects = await Promise.all(
-      knownProjects().map(async (project) => {
+      tier2Projects.map(async (project) => {
         const cursor = await readCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER });
         const storeStats = gatherStoreStats(store, stateRoot, project);
         return {

--- a/src/control/launchd.ts
+++ b/src/control/launchd.ts
@@ -1,6 +1,6 @@
 // src/control/launchd.ts
 import { execFileSync } from "node:child_process";
-import { mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { mkdirSync, writeFileSync, readFileSync, existsSync, openSync, writeSync, closeSync, unlinkSync, constants } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -146,6 +146,67 @@ export function kickstartArgv(target: string, plistChanged: boolean): string[] {
   return plistChanged ? ["kickstart", "-k", target] : ["kickstart", target];
 }
 
+// In-process dedup: JS is single-threaded and ensureDaemon is synchronous, so
+// true re-entrancy is impossible; this flag prevents sequential re-calls within
+// the same process (e.g. index.ts + crew-control.ts) from re-running the
+// bootout/bootstrap pair needlessly.
+let restartInFlight = false;
+
+/** @internal — reset only in tests; never call from production code */
+export function _resetRestartInFlightForTest(): void {
+  restartInFlight = false;
+}
+
+export function daemonLockPath(): string {
+  return join(homedir(), ".config", "cockpit", "daemon.lock");
+}
+
+/**
+ * Acquire a cross-process filesystem lock at ~/.config/cockpit/daemon.lock.
+ * Uses O_EXCL for atomic, race-free creation. Cleans up stale locks (dead PID)
+ * before the acquisition loop. Retries with a ~50 ms synchronous sleep up to
+ * 20 times (~1 s total) before giving up.
+ * Returns true on success, false if another live process holds the lock.
+ */
+export function tryAcquireDaemonLock(): boolean {
+  const lp = daemonLockPath();
+
+  // Stale-lock cleanup: if the owning PID is no longer alive, remove the file
+  // so the next O_EXCL attempt succeeds.
+  if (existsSync(lp)) {
+    try {
+      const pid = parseInt(readFileSync(lp, "utf-8").trim(), 10);
+      if (!Number.isFinite(pid) || pid <= 0) {
+        unlinkSync(lp);
+      } else {
+        try { process.kill(pid, 0); }
+        catch { unlinkSync(lp); } // ESRCH → process dead, steal the lock
+      }
+    } catch { /* read/parse/unlink error — fall through to O_EXCL attempt */ }
+  }
+
+  // Atomic acquisition: O_EXCL guarantees only one process creates the file.
+  for (let i = 0; i < 20; i++) {
+    try {
+      const fd = openSync(lp, constants.O_EXCL | constants.O_CREAT | constants.O_WRONLY);
+      writeSync(fd, String(process.pid));
+      closeSync(fd);
+      return true;
+    } catch {
+      if (i < 19) {
+        // Synchronous sleep: gives the lock-holder time to finish and release.
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 50);
+      }
+    }
+  }
+  return false; // another live process held the lock for > ~1 s — skip restart
+}
+
+/** Release the lock written by tryAcquireDaemonLock. */
+export function releaseDaemonLock(): void {
+  try { unlinkSync(daemonLockPath()); } catch { /* already cleaned up */ }
+}
+
 /**
  * Idempotent & cheap. Never throws fatally. Writes/reloads the plist ONLY when
  * its content actually changed; Distinguishes program-argument drift (warrants
@@ -155,8 +216,22 @@ export function kickstartArgv(target: string, plistChanged: boolean): string[] {
  * bootout's exit handler that produced exit-113 "service not loaded" errors.
  * The daemon entry is resolved internally (see daemonEntryPath) so no caller
  * can pass a wrong path.
+ *
+ * Concurrency guards:
+ *   - restartInFlight flag: prevents sequential re-calls within this process.
+ *   - tryAcquireDaemonLock: serialises concurrent SEPARATE cockpit processes
+ *     via a filesystem lock so only one runs bootout/bootstrap at a time.
  */
 export function ensureDaemon(nodeBin: string = process.execPath): void {
+  if (restartInFlight) return;
+  restartInFlight = true;
+
+  if (!tryAcquireDaemonLock()) {
+    // Another process is handling the restart; it will be done by the time the
+    // CLI tries to reach the daemon socket.
+    return;
+  }
+
   try {
     const p = plistPath();
     const entry = daemonEntryPath();
@@ -195,5 +270,7 @@ export function ensureDaemon(nodeBin: string = process.execPath): void {
   } catch (e) {
     // daemon ensure is best-effort (still don't throw); CLI fails loud on socket miss
     process.stderr.write(`[cockpit] warn: ensureDaemon failed (${e instanceof Error ? e.message : e})\n`);
+  } finally {
+    releaseDaemonLock();
   }
 }

--- a/src/control/mailbox.ts
+++ b/src/control/mailbox.ts
@@ -202,6 +202,37 @@ export async function* readFromCursor(opts: ReadFromCursorOpts): AsyncIterable<M
   }
 }
 
+/** Read-only Tier 2 observability stats for one project's mailbox (#44 dashboard). */
+export interface MailboxStats {
+  /** Highest seq across the current log + rotated segments (0 when empty). */
+  maxSeq: number;
+  /** Size in bytes of the current (un-rotated) log file. */
+  sizeBytes: number;
+  /** Age of the oldest entry in the current log (0 when empty/missing). */
+  oldestEntryAgeMs: number;
+  /** Number of rotated segments on disk (<project>.log.1, .2, …). */
+  rotationCount: number;
+}
+
+/**
+ * Read-only stats for the dashboard's Tier 2 data-plane view. Never mutates;
+ * tolerates a missing inbox (returns zeros). The daemon gathers this and passes
+ * it to the pure snapshot assembler.
+ */
+export async function mailboxStats(stateRoot: string, project: string): Promise<MailboxStats> {
+  const file = logPath(stateRoot, project);
+  let sizeBytes = 0;
+  try { sizeBytes = (await fs.stat(file)).size; }
+  catch (e) { if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e; }
+  const rotated = await listRotatedOldestFirst(stateRoot, project);
+  return {
+    maxSeq: await readMaxSeq(stateRoot, project),
+    sizeBytes,
+    oldestEntryAgeMs: await oldestEntryAgeMs(file),
+    rotationCount: rotated.length,
+  };
+}
+
 interface RotateOpts {
   stateRoot: string;
   project: string;

--- a/src/control/snapshot.ts
+++ b/src/control/snapshot.ts
@@ -1,0 +1,134 @@
+// src/control/snapshot.ts
+//
+// PURE Tier 0/1/2 snapshot assembly (no I/O, no clock) for the read-only
+// `snapshot` socket verb — the observability-dashboard counterpart to
+// liveness.ts. Every derived value comes from already-gathered inputs + an
+// explicit `now`, so the whole module is trivially unit-testable. cockpitd.ts
+// performs the I/O (dist stat, log read, mailbox/store/results reads) and feeds
+// the gathered numbers in here; this module never touches the filesystem.
+import type { ComponentHealth } from "./liveness.js";
+
+export type BuildState = "fresh" | "stale";
+
+/**
+ * Pure. The deploy-hygiene check: a daemon whose process started BEFORE the
+ * current `dist/` build is running stale code (the recurring footgun). Fresh
+ * requires the process to have started at or after the last build.
+ *   processStartedAt >= distBuiltAt → "fresh"  (boundary inclusive)
+ *   else                            → "stale"
+ */
+export function buildFreshness(processStartedAt: number, distBuiltAt: number): BuildState {
+  return processStartedAt >= distBuiltAt ? "fresh" : "stale";
+}
+
+// ── Tier 0: daemon root ───────────────────────────────────────────────────────
+export interface DaemonRoot {
+  pid: number;
+  uptimeMs: number;
+  version: string;
+  build: { state: BuildState; processStartedAt: number; distBuiltAt: number };
+  /** lastSweepAt/ageMs are null until the first sweep has run. */
+  sweep: { lastSweepAt: number | null; ageMs: number | null; cadenceMs: number };
+  log: { errorCount: number; sizeBytes: number; windowMs: number };
+}
+
+// ── Tier 2: per-project data plane + global results ───────────────────────────
+export interface MailboxStats {
+  maxSeq: number;
+  sizeBytes: number;
+  oldestEntryAgeMs: number;
+  rotationCount: number;
+}
+
+export interface DeliveryLag {
+  maxSeq: number;
+  lastAckedSeq: number;
+  /** maxSeq − lastAckedSeq, clamped at 0 — "captain N behind". */
+  behind: number;
+}
+
+export interface StoreStats {
+  byState: Record<string, number>;
+  corruptCount: number;
+}
+
+export interface ResultArtifacts {
+  fileCount: number;
+  totalBytes: number;
+}
+
+export interface ProjectDataPlane {
+  project: string;
+  mailbox: MailboxStats;
+  delivery: DeliveryLag;
+  store: StoreStats;
+}
+
+export interface DaemonSnapshot {
+  tier0: DaemonRoot;
+  /** Tier 1 — per-component liveness across all projects (reuses projectHealth). */
+  tier1: ComponentHealth[];
+  tier2: {
+    projects: ProjectDataPlane[];
+    /** _results/ is a single global directory keyed by task id. */
+    results: ResultArtifacts;
+  };
+}
+
+/** Already-gathered (I/O-resolved) inputs the pure assembler turns into a DaemonSnapshot. */
+export interface DaemonSnapshotInputs {
+  pid: number;
+  processStartedAt: number;
+  version: string;
+  distBuiltAt: number;
+  lastSweepAt: number | null;
+  sweepCadenceMs: number;
+  log: { errorCount: number; sizeBytes: number; windowMs: number };
+  health: ComponentHealth[];
+  projects: Array<{
+    project: string;
+    mailbox: MailboxStats;
+    lastAckedSeq: number;
+    storeByState: Record<string, number>;
+    corruptCount: number;
+  }>;
+  results: ResultArtifacts;
+}
+
+/**
+ * Pure. Derive the full DaemonSnapshot from gathered inputs and an explicit now.
+ */
+export function assembleDaemonSnapshot(input: DaemonSnapshotInputs, now: number): DaemonSnapshot {
+  return {
+    tier0: {
+      pid: input.pid,
+      uptimeMs: now - input.processStartedAt,
+      version: input.version,
+      build: {
+        state: buildFreshness(input.processStartedAt, input.distBuiltAt),
+        processStartedAt: input.processStartedAt,
+        distBuiltAt: input.distBuiltAt,
+      },
+      sweep: {
+        lastSweepAt: input.lastSweepAt,
+        ageMs: input.lastSweepAt == null ? null : now - input.lastSweepAt,
+        cadenceMs: input.sweepCadenceMs,
+      },
+      log: input.log,
+    },
+    tier1: input.health,
+    tier2: {
+      projects: input.projects.map((p) => ({
+        project: p.project,
+        mailbox: p.mailbox,
+        delivery: {
+          maxSeq: p.mailbox.maxSeq,
+          lastAckedSeq: p.lastAckedSeq,
+          behind: Math.max(0, p.mailbox.maxSeq - p.lastAckedSeq),
+        },
+        store: { byState: p.storeByState, corruptCount: p.corruptCount },
+      })),
+      results: input.results,
+    },
+  };
+}

--- a/src/control/state-machine.ts
+++ b/src/control/state-machine.ts
@@ -45,16 +45,19 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
         question: undefined, // resuming after a blocked→reply clears the question
       };
     case "task.progress":
+      // task.progress is a real-activity signal (stdout chunk for headless,
+      // PostToolUse/SubagentStop hook for interactive). Stamp the attempt so
+      // lastHeartbeatAt stays current and the watchdog stall-check (#89) can
+      // key off it without false-stalling long-running headless tasks.
+      // From blocked: liveness only — do not auto-unblock (explicit reply required).
+      // From awaiting-input: resume to working (PostToolUse on the next turn).
+      if (rec.state === "blocked") return { ...rec, lastHeartbeat: now, lastEvent: ev.type };
+      if (rec.state === "awaiting-input") return { ...stampAttempt(base, {}, now), state: "working" };
+      return stampAttempt(base, {}, now);
     case "heartbeat":
-      // `heartbeat` and `task.progress` intentionally share this case arm
-      // (both are liveness signals); split if the watchdog later needs to
-      // differentiate them.
-      // Anti-#2576: liveness only. A turn-end is NOT completion.
-      // From blocked, a bare progress/heartbeat does not auto-unblock
-      // (state stays "blocked"); only lastEvent + lastHeartbeat update.
-      // From awaiting-input, transition back to working — the Stop hook
-      // puts the task into awaiting-input between turns (fixes #131 false
-      // stall); PostToolUse on the next turn resumes the working state.
+      // Raw liveness ping — intentionally does NOT stamp the attempt so a late
+      // heartbeat from a dead dispatch cannot mask stalls on the new one (#89).
+      // From awaiting-input: resume to working (mirrors task.progress).
       if (rec.state === "blocked") return { ...rec, lastHeartbeat: now, lastEvent: ev.type };
       if (rec.state === "awaiting-input") return { ...base, state: "working" };
       return base;

--- a/src/control/watchdog.ts
+++ b/src/control/watchdog.ts
@@ -18,7 +18,10 @@ import type { TaskRecord } from "./types.js";
  */
 export function evaluateStall(rec: TaskRecord, now: number): TaskRecord | null {
   if (rec.state !== "working") return null;
-  if (now - rec.lastHeartbeat <= rec.heartbeatBudgetMs) return null;
+  // Key off the latest attempt's lastHeartbeatAt so a stale event from a dead
+  // prior attempt cannot refresh the liveness clock of the new dispatch (#89).
+  const liveness = rec.attempts.at(-1)?.lastHeartbeatAt ?? rec.lastHeartbeat;
+  if (now - liveness <= rec.heartbeatBudgetMs) return null;
   if (rec.mode === "interactive") {
     return { ...rec, state: "awaiting-input", lastEvent: "watchdog.idle" };
   }

--- a/src/dashboard/__tests__/probes.test.ts
+++ b/src/dashboard/__tests__/probes.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import {
+  probeCmux,
+  probeAgentClis,
+  probeVaults,
+  probeProjectPaths,
+  probeSessions,
+  runExternalProbes,
+  type ProbeRunners,
+} from "../probes.js";
+import type { CockpitConfig } from "../../config.js";
+
+function cfg(over: Partial<CockpitConfig> = {}): CockpitConfig {
+  return {
+    commandName: "command",
+    hubVault: "/vaults/hub",
+    projects: {
+      cockpit: { path: "/repos/cockpit", captainName: "cockpit-captain", spokeVault: "/vaults/cockpit", host: "local" },
+    },
+    defaults: {
+      maxCrew: 4, worktreeDir: ".wt", teammateMode: "x",
+      permissions: { command: "auto", captain: "auto" },
+    },
+    metrics: { enabled: false, path: "/m" },
+    ...over,
+  };
+}
+
+// A runner set where every external call succeeds. Tests override per-case.
+function okRunners(over: Partial<ProbeRunners> = {}): ProbeRunners {
+  return {
+    probeCmuxBin: async () => true,
+    probeOnPath: async () => true,
+    pathExists: () => true,
+    loadConfig: () => cfg(),
+    loadSessionsHashes: () => ["hash-a"],
+    ...over,
+  };
+}
+
+describe("probeCmux", () => {
+  it("is alive when the cmux binary responds", async () => {
+    expect((await probeCmux(okRunners())).state).toBe("alive");
+  });
+  it("is gone when cmux is not reachable", async () => {
+    expect((await probeCmux(okRunners({ probeCmuxBin: async () => false }))).state).toBe("gone");
+  });
+  it("is unknown (never throws) when the probe itself throws", async () => {
+    const p = await probeCmux(okRunners({ probeCmuxBin: async () => { throw new Error("boom"); } }));
+    expect(p.state).toBe("unknown");
+  });
+  it("is unknown when the probe hangs past the timeout", async () => {
+    const p = await probeCmux(okRunners({ probeCmuxBin: () => new Promise(() => {}) }), 10);
+    expect(p.state).toBe("unknown");
+  });
+});
+
+describe("probeAgentClis", () => {
+  it("maps each known CLI to alive/gone by PATH resolution", async () => {
+    const probes = await probeAgentClis(okRunners({
+      probeOnPath: async (cli) => cli === "claude" || cli === "codex",
+    }));
+    const byCli = Object.fromEntries(probes.map((p) => [p.cli, p.state]));
+    expect(byCli).toEqual({ claude: "alive", codex: "alive", gemini: "gone", opencode: "gone" });
+  });
+  it("maps a thrown PATH lookup to unknown without failing the others", async () => {
+    const probes = await probeAgentClis(okRunners({
+      probeOnPath: async (cli) => { if (cli === "gemini") throw new Error("x"); return true; },
+    }));
+    const byCli = Object.fromEntries(probes.map((p) => [p.cli, p.state]));
+    expect(byCli.gemini).toBe("unknown");
+    expect(byCli.claude).toBe("alive");
+  });
+});
+
+describe("probeVaults", () => {
+  it("is alive when the vault dir and its .obsidian/ both exist", () => {
+    const v = probeVaults(okRunners(), cfg());
+    expect(v.hub.state).toBe("alive");
+    expect(v.spokes[0].project).toBe("cockpit");
+    expect(v.spokes[0].state).toBe("alive");
+  });
+  it("is gone when the vault directory is missing", () => {
+    const v = probeVaults(okRunners({ pathExists: () => false }), cfg());
+    expect(v.hub.state).toBe("gone");
+  });
+  it("is gone when the dir exists but has no .obsidian/", () => {
+    const v = probeVaults(okRunners({ pathExists: (p) => !p.endsWith(".obsidian") }), cfg());
+    expect(v.hub.state).toBe("gone");
+  });
+});
+
+describe("probeProjectPaths", () => {
+  it("is alive when the project path resolves, gone otherwise", () => {
+    const paths = probeProjectPaths(okRunners({ pathExists: (p) => p === "/repos/cockpit" }), cfg());
+    expect(paths[0]).toMatchObject({ project: "cockpit", state: "alive" });
+    const missing = probeProjectPaths(okRunners({ pathExists: () => false }), cfg());
+    expect(missing[0].state).toBe("gone");
+  });
+});
+
+describe("probeSessions", () => {
+  it("is alive when a single template hash is recorded", () => {
+    expect(probeSessions(okRunners()).state).toBe("alive");
+  });
+  it("is gone (drift) when multiple distinct template hashes are recorded", () => {
+    const s = probeSessions(okRunners({ loadSessionsHashes: () => ["a", "b"] }));
+    expect(s.state).toBe("gone");
+    expect(s.detail).toMatch(/drift/);
+  });
+  it("is unknown when no sessions are recorded", () => {
+    expect(probeSessions(okRunners({ loadSessionsHashes: () => [] })).state).toBe("unknown");
+  });
+  it("is unknown when sessions.json is unreadable", () => {
+    expect(probeSessions(okRunners({ loadSessionsHashes: () => { throw new Error("bad"); } })).state).toBe("unknown");
+  });
+});
+
+describe("runExternalProbes", () => {
+  it("assembles all tiers and keeps going when config is unparseable", async () => {
+    const probes = await runExternalProbes(okRunners({
+      loadConfig: () => { throw new Error("bad json"); },
+    }));
+    expect(probes.cmux.state).toBe("alive");
+    expect(probes.config.parseable.state).toBe("gone");
+    expect(probes.vaults.spokes).toEqual([]);
+    expect(probes.config.projectPaths).toEqual([]);
+  });
+  it("assembles a fully-healthy snapshot from healthy runners", async () => {
+    const probes = await runExternalProbes(okRunners());
+    expect(probes.cmux.state).toBe("alive");
+    expect(probes.config.parseable.state).toBe("alive");
+    expect(probes.vaults.hub.state).toBe("alive");
+    expect(probes.agentClis).toHaveLength(4);
+  });
+});

--- a/src/dashboard/__tests__/probes.test.ts
+++ b/src/dashboard/__tests__/probes.test.ts
@@ -74,19 +74,32 @@ describe("probeAgentClis", () => {
 });
 
 describe("probeVaults", () => {
-  it("is alive when the vault dir and its .obsidian/ both exist", () => {
+  it("is alive when the hub dir and its .obsidian/ both exist, and spoke dir exists", () => {
     const v = probeVaults(okRunners(), cfg());
     expect(v.hub.state).toBe("alive");
     expect(v.spokes[0].project).toBe("cockpit");
     expect(v.spokes[0].state).toBe("alive");
   });
-  it("is gone when the vault directory is missing", () => {
+  it("hub is gone when the vault directory is missing", () => {
     const v = probeVaults(okRunners({ pathExists: () => false }), cfg());
     expect(v.hub.state).toBe("gone");
   });
-  it("is gone when the dir exists but has no .obsidian/", () => {
+  it("hub is gone when its dir exists but has no .obsidian/", () => {
     const v = probeVaults(okRunners({ pathExists: (p) => !p.endsWith(".obsidian") }), cfg());
     expect(v.hub.state).toBe("gone");
+  });
+  // Spokes live inside the hub vault — they correctly have no .obsidian/ of their own.
+  it("spoke is alive when its directory exists even without .obsidian/", () => {
+    const v = probeVaults(okRunners({ pathExists: (p) => !p.endsWith(".obsidian") }), cfg());
+    expect(v.spokes[0].state).toBe("alive");
+  });
+  it("spoke is gone when its directory is missing", () => {
+    // hub dir + hub .obsidian/ exist; spoke dir is missing
+    const v = probeVaults(
+      okRunners({ pathExists: (p) => p === cfg().hubVault || p.endsWith(".obsidian") }),
+      cfg(),
+    );
+    expect(v.spokes[0].state).toBe("gone");
   });
 });
 
@@ -103,9 +116,9 @@ describe("probeSessions", () => {
   it("is alive when a single template hash is recorded", () => {
     expect(probeSessions(okRunners()).state).toBe("alive");
   });
-  it("is gone (drift) when multiple distinct template hashes are recorded", () => {
+  it("is stale/caution (not fault) when multiple distinct template hashes are recorded", () => {
     const s = probeSessions(okRunners({ loadSessionsHashes: () => ["a", "b"] }));
-    expect(s.state).toBe("gone");
+    expect(s.state).toBe("stale"); // drift is expected across template versions — caution, not fault
     expect(s.detail).toMatch(/drift/);
   });
   it("is unknown when no sessions are recorded", () => {

--- a/src/dashboard/__tests__/snapshot-merge.test.ts
+++ b/src/dashboard/__tests__/snapshot-merge.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { mergeSnapshot } from "../snapshot-merge.js";
+import type { DaemonSnapshot } from "../../control/snapshot.js";
+import type { ExternalProbes } from "../probes.js";
+
+const external: ExternalProbes = {
+  cmux: { state: "alive" },
+  agentClis: [{ cli: "claude", state: "alive" }],
+  vaults: { hub: { path: "/h", state: "alive" }, spokes: [] },
+  config: { parseable: { state: "alive" }, projectPaths: [], sessions: { state: "alive" } },
+};
+
+const daemon: DaemonSnapshot = {
+  tier0: {
+    pid: 1, uptimeMs: 5, version: "0.6.1",
+    build: { state: "fresh", processStartedAt: 1, distBuiltAt: 0 },
+    sweep: { lastSweepAt: 1, ageMs: 4, cadenceMs: 30_000 },
+    log: { errorCount: 0, sizeBytes: 0, windowMs: 3_600_000 },
+  },
+  tier1: [],
+  tier2: { projects: [], results: { fileCount: 0, totalBytes: 0 } },
+};
+
+describe("mergeSnapshot", () => {
+  it("combines a daemon snapshot with external probes and stamps generatedAt", () => {
+    const full = mergeSnapshot(daemon, external, 12_345);
+    expect(full.generatedAt).toBe(12_345);
+    expect(full.daemon).toBe(daemon);
+    expect(full.external).toBe(external);
+  });
+
+  it("keeps Tier 3/4 externals when the daemon is unreachable", () => {
+    const full = mergeSnapshot("unreachable", external, 9);
+    expect(full.daemon).toBe("unreachable");
+    expect(full.external.cmux.state).toBe("alive");
+    expect(full.external.agentClis).toHaveLength(1);
+  });
+});

--- a/src/dashboard/__tests__/web-render.test.ts
+++ b/src/dashboard/__tests__/web-render.test.ts
@@ -48,10 +48,72 @@ describe("renderHtml", () => {
   it("emits a full HTML document with the live content and an SSE connection indicator", () => {
     const html = renderHtml(full(daemon()));
     expect(html).toMatch(/^<!DOCTYPE html>/i);
-    expect(html).toContain("COCKPIT SYSTEM HEALTH");
+    expect(html).toContain("COCKPIT SYSTEM HEALTH"); // accessible page heading
     expect(html).toContain('id="content"');
     expect(html).toContain('id="conn"');
+    expect(html).toContain('id="led"'); // pulsing live indicator in the flight deck
     expect(html).toContain("EventSource"); // bootstrap JS wires the SSE stream
+    expect(html).toContain("updated"); // "updated Ns ago" readout
+  });
+});
+
+describe("tabbed navigation", () => {
+  it("renders all four tabs as a tablist", () => {
+    const out = renderContent(full(daemon()));
+    expect(out).toContain('role="tablist"');
+    for (const tab of ["overview", "projects", "daemon", "environment"]) {
+      expect(out).toContain(`data-tab="${tab}"`);
+      expect(out).toContain(`data-panel="${tab}"`);
+    }
+    expect(out).toContain("Overview");
+    expect(out).toContain("Environment");
+  });
+});
+
+describe("overview gauge + charts", () => {
+  it("renders an inline-SVG health donut and a master annunciator", () => {
+    const out = renderContent(full(daemon()));
+    expect(out).toContain('<svg class="donut"'); // the signature SVG gauge
+    expect(out).toContain('class="seg s-alive"'); // proportional segment
+    expect(out).toContain('class="annunciator'); // master flight status
+    expect(out).toContain("NOMINAL"); // all-healthy master word
+  });
+
+  it("renders sparkline chart nodes the client fills from rolling history", () => {
+    const out = renderContent(full(daemon()));
+    expect(out).toContain('data-spark="errors"');
+    expect(out).toContain('data-spark="behind"');
+    expect(out).toContain('<svg class="spark"');
+  });
+
+  it("emits a machine-readable metrics blob for client-side trends", () => {
+    const out = renderContent(full(daemon()));
+    expect(out).toContain('id="cockpit-metrics"');
+    const m = out.match(/id="cockpit-metrics">(.*?)<\/script>/s);
+    expect(m).not.toBeNull();
+    const metrics = JSON.parse(m![1]);
+    expect(metrics.t).toBe(1_000_000);
+    expect(typeof metrics.alive).toBe("number");
+  });
+
+  it("escalates the master annunciator to CRITICAL when a component is gone", () => {
+    const goneCrew: DaemonSnapshot["tier1"] = [
+      { kind: "crew", project: "cockpit", ref: "x", state: "gone", lastSeenMs: 1 },
+    ];
+    const out = renderContent(full(daemon({}, goneCrew)));
+    expect(out).toContain('class="annunciator a-crit');
+    expect(out).toContain("CRITICAL");
+  });
+});
+
+describe("status pills", () => {
+  it("renders color-coded status pills with a dot", () => {
+    const tier1: DaemonSnapshot["tier1"] = [
+      { kind: "captain", project: "cockpit", ref: "cap", state: "alive", lastSeenMs: 999_000 },
+    ];
+    const out = renderContent(full(daemon({}, tier1)));
+    expect(out).toContain('class="pill s-alive"');
+    expect(out).toContain('class="pdot"');
   });
 });
 
@@ -61,10 +123,33 @@ describe("stale-build banner", () => {
     expect(stale).toContain("DAEMON RUNNING STALE CODE");
     // remediation is copy-able text, not a button
     expect(stale).toContain("npm run build");
-    expect(stale).not.toContain("<button");
+    expect(stale).not.toContain("<button class=\"banner");
   });
   it("omits the banner when the build is fresh", () => {
     expect(renderContent(full(daemon()))).not.toContain("DAEMON RUNNING STALE CODE");
+  });
+});
+
+describe("daemon sweep wording", () => {
+  it("says 'awaiting first sweep' when the daemon has not swept yet (fix a)", () => {
+    const out = renderContent(full(daemon({ sweep: { lastSweepAt: null, ageMs: null, cadenceMs: 30_000 } })));
+    expect(out).toContain("awaiting first sweep");
+    expect(out).not.toContain("never swept");
+  });
+  it("shows the last-swept age once a sweep has run", () => {
+    const out = renderContent(full(daemon({ sweep: { lastSweepAt: 1000, ageMs: 8000, cadenceMs: 30_000 } })));
+    expect(out).toContain("cadence");
+  });
+});
+
+describe("daemon log error metric (fix b)", () => {
+  it("presents log errors as a calm caution metric with a sparkline, never a red master alarm", () => {
+    const out = renderContent(full(daemon({ log: { errorCount: 7, sizeBytes: 4096, windowMs: 3_600_000 } })));
+    expect(out).toContain("Log errors");
+    expect(out).toContain('data-spark="errors"');
+    // 7 log errors must NOT push the master annunciator to CRITICAL.
+    expect(out).toContain('class="annunciator a-warn');
+    expect(out).not.toContain('class="annunciator a-crit');
   });
 });
 
@@ -72,6 +157,8 @@ describe("daemon unreachable", () => {
   it("shows the unreachable banner but still renders Tier 3/4", () => {
     const out = renderContent(full("unreachable"));
     expect(out).toContain("DAEMON UNREACHABLE");
+    expect(out).toContain('class="annunciator a-crit'); // master goes critical
+    expect(out).toContain("LINK LOST");
     expect(out).toContain("cmux"); // Tier 3 still rendered
     expect(out).toContain("claude");
   });
@@ -83,9 +170,10 @@ describe("severity rollup + remediation", () => {
     { kind: "captain", project: "pact", ref: "pact-captain", state: "gone", lastSeenMs: 1 },
   ];
 
-  it("bubbles a gone component up to its project header rollup", () => {
+  it("bubbles a gone component up to its project card rollup", () => {
     const out = renderContent(full(daemon({}, goneRelay)));
-    expect(out).toMatch(/data-rollup="gone"[^>]*>[^<]*pact/);
+    expect(out).toMatch(/data-rollup="gone"/);
+    expect(out).toContain("pact");
   });
 
   it("renders the heal command as copy-able remediation under the gone relay", () => {
@@ -98,6 +186,17 @@ describe("severity rollup + remediation", () => {
       { kind: "relay", project: "cockpit", ref: "relay", state: "alive", lastSeenMs: 999_000 },
     ];
     expect(renderContent(full(daemon({}, aliveRelay)))).not.toContain("cockpit heal relay");
+  });
+});
+
+describe("delivery lag bar", () => {
+  it("renders an SVG-free delivery bar with acked + behind segments", () => {
+    const d = daemon();
+    d.tier2.projects[0].delivery = { maxSeq: 20, lastAckedSeq: 12, behind: 8 };
+    const out = renderContent(full(d));
+    expect(out).toContain('class="dbar"');
+    expect(out).toContain("dbar-behind");
+    expect(out).toContain("8 behind");
   });
 });
 
@@ -116,7 +215,7 @@ describe("renderTickJson", () => {
   it("returns JSON with content HTML and the generated timestamp", () => {
     const parsed = JSON.parse(renderTickJson(full(daemon())));
     expect(typeof parsed.contentHtml).toBe("string");
-    expect(parsed.contentHtml).toContain("COCKPIT SYSTEM HEALTH");
+    expect(parsed.contentHtml).toContain("annunciator");
     expect(parsed.generatedAt).toBe(1_000_000);
   });
 });

--- a/src/dashboard/__tests__/web-render.test.ts
+++ b/src/dashboard/__tests__/web-render.test.ts
@@ -48,12 +48,55 @@ describe("renderHtml", () => {
   it("emits a full HTML document with the live content and an SSE connection indicator", () => {
     const html = renderHtml(full(daemon()));
     expect(html).toMatch(/^<!DOCTYPE html>/i);
-    expect(html).toContain("COCKPIT SYSTEM HEALTH"); // accessible page heading
+    expect(html).toContain("COCKPIT SYSTEM HEALTH"); // visible page heading
     expect(html).toContain('id="content"');
     expect(html).toContain('id="conn"');
     expect(html).toContain('id="led"'); // pulsing live indicator in the flight deck
     expect(html).toContain("EventSource"); // bootstrap JS wires the SSE stream
     expect(html).toContain("updated"); // "updated Ns ago" readout
+  });
+
+  it("ships the light theme — light background, dark ink, no dark mission-control palette", () => {
+    const html = renderHtml(full(daemon()));
+    expect(html).toContain('class="theme-light"');
+    expect(html).toContain("--bg:#f6f7f9"); // near-white page background
+    expect(html).toContain("--panel:#ffffff"); // white cards
+    expect(html).toContain("--ink:#1b2333"); // dark high-contrast text
+    expect(html).not.toContain("#070b14"); // the old dark page background is gone
+  });
+});
+
+describe("explanatory titles + captions", () => {
+  it("gives the page a heading and a plain-language subtitle", () => {
+    const out = renderContent(full(daemon()));
+    expect(out).toContain('class="page-title"');
+    expect(out).toContain('class="page-sub"');
+    expect(out).toContain("Live health of the cockpit daemon");
+  });
+
+  it("titles every Overview block with a heading + caption", () => {
+    const out = renderContent(full(daemon()));
+    expect(out).toContain('class="section-head"');
+    expect(out).toContain("System Health");
+    expect(out).toContain("Health by Tier");
+    expect(out).toContain("Live Trends");
+    // the donut number is explained in plain language
+    expect(out).toContain("monitored components are alive");
+  });
+
+  it("labels the status summary annunciator and each tier card", () => {
+    const out = renderContent(full(daemon()));
+    expect(out).toContain("Status summary");
+    expect(out).toContain('class="tier-desc"');
+    expect(out).toContain("Tier 0"); // daemon tier described
+    expect(out).toContain("Tier 3/4"); // environment tier described
+  });
+
+  it("introduces the other tabs so their tables are not ambiguous", () => {
+    const out = renderContent(full(daemon()));
+    expect(out).toContain("Daemon · Tier 0");
+    expect(out).toContain("Environment · Tier 3 / 4");
+    expect(out).toContain("mailbox delivery and task store"); // projects intro
   });
 });
 

--- a/src/dashboard/__tests__/web-render.test.ts
+++ b/src/dashboard/__tests__/web-render.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { renderHtml, renderContent, renderTickJson } from "../web-render.js";
+import type { FullSnapshot } from "../snapshot-merge.js";
+import type { DaemonSnapshot } from "../../control/snapshot.js";
+import type { ExternalProbes } from "../probes.js";
+
+const externalHealthy: ExternalProbes = {
+  cmux: { state: "alive" },
+  agentClis: [
+    { cli: "claude", state: "alive" },
+    { cli: "codex", state: "alive" },
+    { cli: "gemini", state: "alive" },
+    { cli: "opencode", state: "alive" },
+  ],
+  vaults: { hub: { path: "/h", state: "alive" }, spokes: [{ project: "cockpit", path: "/s", state: "alive" }] },
+  config: { parseable: { state: "alive" }, projectPaths: [{ project: "cockpit", path: "/r", state: "alive" }], sessions: { state: "alive" } },
+};
+
+function daemon(over: Partial<DaemonSnapshot["tier0"]> = {}, tier1: DaemonSnapshot["tier1"] = []): DaemonSnapshot {
+  return {
+    tier0: {
+      pid: 4821, uptimeMs: 6 * 3600_000, version: "0.6.1",
+      build: { state: "fresh", processStartedAt: 2000, distBuiltAt: 1000 },
+      sweep: { lastSweepAt: 1000, ageMs: 8000, cadenceMs: 30_000 },
+      log: { errorCount: 0, sizeBytes: 100, windowMs: 3_600_000 },
+      ...over,
+    },
+    tier1,
+    tier2: {
+      projects: [
+        {
+          project: "cockpit",
+          mailbox: { maxSeq: 12, sizeBytes: 1300, oldestEntryAgeMs: 60_000, rotationCount: 0 },
+          delivery: { maxSeq: 12, lastAckedSeq: 12, behind: 0 },
+          store: { byState: { working: 3, blocked: 1 }, corruptCount: 0 },
+        },
+      ],
+      results: { fileCount: 294, totalBytes: 18_000_000 },
+    },
+  };
+}
+
+function full(d: DaemonSnapshot | "unreachable", external = externalHealthy, generatedAt = 1_000_000): FullSnapshot {
+  return { generatedAt, daemon: d, external };
+}
+
+describe("renderHtml", () => {
+  it("emits a full HTML document with the live content and an SSE connection indicator", () => {
+    const html = renderHtml(full(daemon()));
+    expect(html).toMatch(/^<!DOCTYPE html>/i);
+    expect(html).toContain("COCKPIT SYSTEM HEALTH");
+    expect(html).toContain('id="content"');
+    expect(html).toContain('id="conn"');
+    expect(html).toContain("EventSource"); // bootstrap JS wires the SSE stream
+  });
+});
+
+describe("stale-build banner", () => {
+  it("renders the loud banner only when the build is stale", () => {
+    const stale = renderContent(full(daemon({ build: { state: "stale", processStartedAt: 1000, distBuiltAt: 9999 } })));
+    expect(stale).toContain("DAEMON RUNNING STALE CODE");
+    // remediation is copy-able text, not a button
+    expect(stale).toContain("npm run build");
+    expect(stale).not.toContain("<button");
+  });
+  it("omits the banner when the build is fresh", () => {
+    expect(renderContent(full(daemon()))).not.toContain("DAEMON RUNNING STALE CODE");
+  });
+});
+
+describe("daemon unreachable", () => {
+  it("shows the unreachable banner but still renders Tier 3/4", () => {
+    const out = renderContent(full("unreachable"));
+    expect(out).toContain("DAEMON UNREACHABLE");
+    expect(out).toContain("cmux"); // Tier 3 still rendered
+    expect(out).toContain("claude");
+  });
+});
+
+describe("severity rollup + remediation", () => {
+  const goneRelay: DaemonSnapshot["tier1"] = [
+    { kind: "relay", project: "pact", ref: "relay", state: "gone", lastSeenMs: 1, detail: "relay DOWN" },
+    { kind: "captain", project: "pact", ref: "pact-captain", state: "gone", lastSeenMs: 1 },
+  ];
+
+  it("bubbles a gone component up to its project header rollup", () => {
+    const out = renderContent(full(daemon({}, goneRelay)));
+    expect(out).toMatch(/data-rollup="gone"[^>]*>[^<]*pact/);
+  });
+
+  it("renders the heal command as copy-able remediation under the gone relay", () => {
+    const out = renderContent(full(daemon({}, goneRelay)));
+    expect(out).toContain("cockpit heal relay --project pact");
+  });
+
+  it("does not render remediation for healthy components", () => {
+    const aliveRelay: DaemonSnapshot["tier1"] = [
+      { kind: "relay", project: "cockpit", ref: "relay", state: "alive", lastSeenMs: 999_000 },
+    ];
+    expect(renderContent(full(daemon({}, aliveRelay)))).not.toContain("cockpit heal relay");
+  });
+});
+
+describe("escaping", () => {
+  it("HTML-escapes crew refs/details to prevent injection", () => {
+    const evil: DaemonSnapshot["tier1"] = [
+      { kind: "crew", project: "cockpit", ref: "<img src=x>", state: "alive", lastSeenMs: 999_000, detail: "working" },
+    ];
+    const out = renderContent(full(daemon({}, evil)));
+    expect(out).not.toContain("<img src=x>");
+    expect(out).toContain("&lt;img src=x&gt;");
+  });
+});
+
+describe("renderTickJson", () => {
+  it("returns JSON with content HTML and the generated timestamp", () => {
+    const parsed = JSON.parse(renderTickJson(full(daemon())));
+    expect(typeof parsed.contentHtml).toBe("string");
+    expect(parsed.contentHtml).toContain("COCKPIT SYSTEM HEALTH");
+    expect(parsed.generatedAt).toBe(1_000_000);
+  });
+});

--- a/src/dashboard/__tests__/web-render.test.ts
+++ b/src/dashboard/__tests__/web-render.test.ts
@@ -243,6 +243,65 @@ describe("delivery lag bar", () => {
   });
 });
 
+describe("global delivery-lag excludes offline-relay projects", () => {
+  it("global behind in metrics blob is 0 when the only relay is gone", () => {
+    const d = daemon();
+    d.tier1 = [
+      { kind: "relay", project: "cockpit", ref: "relay", state: "gone", lastSeenMs: 1 },
+      { kind: "captain", project: "cockpit", ref: "captain", state: "gone", lastSeenMs: 1 },
+    ];
+    d.tier2.projects[0].delivery = { maxSeq: 10, lastAckedSeq: 5, behind: 5 };
+    const out = renderContent(full(d));
+    const m = out.match(/id="cockpit-metrics">(.*?)<\/script>/s);
+    const metrics = JSON.parse(m![1].replace(/\\u003c/g, "<"));
+    expect(metrics.behind).toBe(0); // relay gone → not a live delivery problem
+  });
+  it("global behind is 0 when relay state is unknown (no relay registered)", () => {
+    const d = daemon();
+    d.tier1 = [
+      { kind: "relay", project: "cockpit", ref: "relay", state: "unknown", lastSeenMs: null },
+      { kind: "captain", project: "cockpit", ref: "captain", state: "unknown", lastSeenMs: null },
+    ];
+    d.tier2.projects[0].delivery = { maxSeq: 10, lastAckedSeq: 5, behind: 5 };
+    const out = renderContent(full(d));
+    const m = out.match(/id="cockpit-metrics">(.*?)<\/script>/s);
+    const metrics = JSON.parse(m![1].replace(/\\u003c/g, "<"));
+    expect(metrics.behind).toBe(0); // relay unknown → offline, excluded
+  });
+  it("global behind includes lag for projects whose relay is alive", () => {
+    const d = daemon();
+    // default tier1 from daemon() has no relay entries — relay is implicitly absent
+    // override with an alive relay
+    d.tier1 = [
+      { kind: "relay", project: "cockpit", ref: "relay", state: "alive", lastSeenMs: 999_000 },
+      { kind: "captain", project: "cockpit", ref: "captain", state: "alive", lastSeenMs: 999_000 },
+    ];
+    d.tier2.projects[0].delivery = { maxSeq: 10, lastAckedSeq: 7, behind: 3 };
+    const out = renderContent(full(d));
+    const m = out.match(/id="cockpit-metrics">(.*?)<\/script>/s);
+    const metrics = JSON.parse(m![1].replace(/\\u003c/g, "<"));
+    expect(metrics.behind).toBe(3); // relay alive → included
+  });
+});
+
+describe("global results location", () => {
+  it("global results line appears only in the daemon tab, not the projects tab", () => {
+    const out = renderContent(full(daemon()));
+    // exactly one occurrence
+    const occurrences = (out.match(/global results/g) ?? []).length;
+    expect(occurrences).toBe(1);
+    // must be inside the daemon panel
+    const daemonStart = out.indexOf('data-panel="daemon"');
+    const envStart = out.indexOf('data-panel="environment"');
+    const daemonSection = out.slice(daemonStart, envStart);
+    expect(daemonSection).toContain("global results");
+    // must NOT be inside the projects panel
+    const projStart = out.indexOf('data-panel="projects"');
+    const projectsSection = out.slice(projStart, daemonStart);
+    expect(projectsSection).not.toContain("global results");
+  });
+});
+
 describe("escaping", () => {
   it("HTML-escapes crew refs/details to prevent injection", () => {
     const evil: DaemonSnapshot["tier1"] = [

--- a/src/dashboard/__tests__/web-server.test.ts
+++ b/src/dashboard/__tests__/web-server.test.ts
@@ -1,0 +1,65 @@
+// src/dashboard/__tests__/web-server.test.ts
+//
+// Thin integration smoke (no live daemon, no live network egress): the server
+// binds 127.0.0.1:0, the daemon socket is absent (→ unreachable), and the probe
+// runners are injected fakes. Asserts the page renders and degrades gracefully.
+import { describe, it, expect, afterEach } from "vitest";
+import { get } from "node:http";
+import { startWebServer, type WebServerHandle } from "../web-server.js";
+import type { ProbeRunners } from "../probes.js";
+
+function fakeRunners(): ProbeRunners {
+  return {
+    probeCmuxBin: async () => true,
+    probeOnPath: async () => true,
+    pathExists: () => true,
+    loadConfig: () => { throw new Error("no config in test"); },
+    loadSessionsHashes: () => [],
+  };
+}
+
+function fetchText(port: number, path: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    get({ host: "127.0.0.1", port, path }, (res) => {
+      let body = "";
+      res.setEncoding("utf-8");
+      res.on("data", (c) => (body += c));
+      res.on("end", () => resolve(body));
+    }).on("error", reject);
+  });
+}
+
+describe("startWebServer smoke", () => {
+  let handle: WebServerHandle | undefined;
+  afterEach(async () => { await handle?.close(); handle = undefined; });
+
+  it("serves the page on 127.0.0.1 and degrades when the daemon is unreachable", async () => {
+    handle = await startWebServer({
+      port: 0,
+      intervalMs: 60_000, // long — the test does one request then closes
+      sockPath: "/tmp/cockpit-nonexistent.sock",
+      runners: fakeRunners(),
+    });
+    const html = await fetchText(handle.port, "/");
+    expect(html).toMatch(/^<!DOCTYPE html>/i);
+    expect(html).toContain("COCKPIT SYSTEM HEALTH");
+    expect(html).toContain("DAEMON UNREACHABLE"); // no daemon socket → degraded, not blank
+    expect(html).toContain("cmux"); // Tier 3 probes still rendered
+  });
+
+  it("returns 404 for unknown paths", async () => {
+    handle = await startWebServer({
+      port: 0,
+      intervalMs: 60_000,
+      sockPath: "/tmp/cockpit-nonexistent.sock",
+      runners: fakeRunners(),
+    });
+    const status = await new Promise<number>((resolve, reject) => {
+      get({ host: "127.0.0.1", port: handle!.port, path: "/nope" }, (res) => {
+        res.resume();
+        resolve(res.statusCode ?? 0);
+      }).on("error", reject);
+    });
+    expect(status).toBe(404);
+  });
+});

--- a/src/dashboard/probes.ts
+++ b/src/dashboard/probes.ts
@@ -14,7 +14,7 @@ import type { CockpitConfig } from "../config.js";
 import { loadConfig } from "../config.js";
 import { resolveCmuxBin } from "../lib/cmux-bin.js";
 
-export type ProbeState = "alive" | "gone" | "unknown";
+export type ProbeState = "alive" | "stale" | "gone" | "unknown";
 
 export interface Probe {
   state: ProbeState;

--- a/src/dashboard/probes.ts
+++ b/src/dashboard/probes.ts
@@ -91,12 +91,24 @@ export async function probeAgentClis(
   );
 }
 
-/** A vault is alive only when its directory AND its `.obsidian/` both exist. */
+/** Hub vault is alive only when its directory AND its `.obsidian/` both exist. */
 function vaultProbe(run: ProbeRunners, dir: string): Probe {
   try {
     if (!dir) return { state: "unknown", detail: "no vault configured" };
     if (!run.pathExists(dir)) return { state: "gone", detail: "vault directory missing" };
     if (!run.pathExists(join(dir, ".obsidian"))) return { state: "gone", detail: "no .obsidian/ (not a vault)" };
+    return { state: "alive" };
+  } catch {
+    return { state: "unknown" };
+  }
+}
+
+/** Spoke vault directories live INSIDE the hub vault and correctly have no
+ *  `.obsidian/` of their own. Alive = directory exists; gone = directory missing. */
+function spokeProbe(run: ProbeRunners, dir: string): Probe {
+  try {
+    if (!dir) return { state: "unknown", detail: "no vault configured" };
+    if (!run.pathExists(dir)) return { state: "gone", detail: "spoke directory missing" };
     return { state: "alive" };
   } catch {
     return { state: "unknown" };
@@ -109,7 +121,7 @@ export function probeVaults(run: ProbeRunners, config: CockpitConfig): ExternalP
     spokes: Object.entries(config.projects).map(([project, p]) => ({
       project,
       path: p.spokeVault,
-      ...vaultProbe(run, p.spokeVault),
+      ...spokeProbe(run, p.spokeVault),
     })),
   };
 }
@@ -145,7 +157,7 @@ export function probeSessions(run: ProbeRunners): Probe {
     const hashes = run.loadSessionsHashes();
     if (hashes.length === 0) return { state: "unknown", detail: "no sessions recorded" };
     if (hashes.length === 1) return { state: "alive" };
-    return { state: "gone", detail: `template drift: ${hashes.length} distinct hashes` };
+    return { state: "stale", detail: `template drift: ${hashes.length} distinct hashes` };
   } catch {
     return { state: "unknown" };
   }

--- a/src/dashboard/probes.ts
+++ b/src/dashboard/probes.ts
@@ -1,0 +1,225 @@
+// src/dashboard/probes.ts
+//
+// Tier 3 (external dependencies) + Tier 4 (config integrity) probes for the web
+// dashboard. These live in the DASHBOARD process, never the daemon: the daemon
+// runs under launchd and is outside cmux's process lineage, so it cannot probe
+// cmux (the "lineage wall"). Every probe is behind an injectable runner and is
+// independently try/caught with a short timeout — a thrown or hung probe yields
+// `unknown` and NEVER propagates, so one bad probe can never crash a tick.
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { existsSync, readFileSync } from "node:fs";
+import { execFile } from "node:child_process";
+import type { CockpitConfig } from "../config.js";
+import { loadConfig } from "../config.js";
+import { resolveCmuxBin } from "../lib/cmux-bin.js";
+
+export type ProbeState = "alive" | "gone" | "unknown";
+
+export interface Probe {
+  state: ProbeState;
+  /** Human-facing context for a degraded/unknown cell. */
+  detail?: string;
+}
+
+export interface ExternalProbes {
+  cmux: Probe;
+  agentClis: Array<{ cli: string } & Probe>;
+  vaults: {
+    hub: { path: string } & Probe;
+    spokes: Array<{ project: string; path: string } & Probe>;
+  };
+  config: {
+    parseable: Probe;
+    projectPaths: Array<{ project: string; path: string } & Probe>;
+    sessions: Probe;
+  };
+}
+
+/** Low-level I/O the probes depend on. Tests inject fakes; the dashboard process
+ *  injects {@link defaultProbeRunners}. */
+export interface ProbeRunners {
+  /** cmux reachable (e.g. `cmux --version` exited 0). */
+  probeCmuxBin: () => Promise<boolean>;
+  /** an agent CLI resolves on PATH. */
+  probeOnPath: (cli: string) => Promise<boolean>;
+  /** a directory/file exists (sync stat). */
+  pathExists: (p: string) => boolean;
+  /** load + parse config.json; throws when unparseable. */
+  loadConfig: () => CockpitConfig;
+  /** distinct templateHash values recorded in sessions.json; throws when unreadable. */
+  loadSessionsHashes: () => string[];
+}
+
+const DEFAULT_TIMEOUT_MS = 2000;
+const AGENT_CLIS = ["claude", "codex", "gemini", "opencode"] as const;
+
+/** Reject a promise that outlives `ms`, clearing the timer either way. */
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error("probe timeout")), ms);
+    timer.unref?.();
+  });
+  return Promise.race([p.finally(() => clearTimeout(timer)), timeout]);
+}
+
+// ── Tier 3 — external dependencies ────────────────────────────────────────────
+
+export async function probeCmux(run: ProbeRunners, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<Probe> {
+  try {
+    const ok = await withTimeout(run.probeCmuxBin(), timeoutMs);
+    return ok ? { state: "alive" } : { state: "gone", detail: "cmux not reachable" };
+  } catch {
+    return { state: "unknown" };
+  }
+}
+
+export async function probeAgentClis(
+  run: ProbeRunners,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<Array<{ cli: string } & Probe>> {
+  return Promise.all(
+    AGENT_CLIS.map(async (cli) => {
+      try {
+        const ok = await withTimeout(run.probeOnPath(cli), timeoutMs);
+        return ok ? { cli, state: "alive" as const } : { cli, state: "gone" as const, detail: `${cli} not on PATH` };
+      } catch {
+        return { cli, state: "unknown" as const };
+      }
+    }),
+  );
+}
+
+/** A vault is alive only when its directory AND its `.obsidian/` both exist. */
+function vaultProbe(run: ProbeRunners, dir: string): Probe {
+  try {
+    if (!dir) return { state: "unknown", detail: "no vault configured" };
+    if (!run.pathExists(dir)) return { state: "gone", detail: "vault directory missing" };
+    if (!run.pathExists(join(dir, ".obsidian"))) return { state: "gone", detail: "no .obsidian/ (not a vault)" };
+    return { state: "alive" };
+  } catch {
+    return { state: "unknown" };
+  }
+}
+
+export function probeVaults(run: ProbeRunners, config: CockpitConfig): ExternalProbes["vaults"] {
+  return {
+    hub: { path: config.hubVault, ...vaultProbe(run, config.hubVault) },
+    spokes: Object.entries(config.projects).map(([project, p]) => ({
+      project,
+      path: p.spokeVault,
+      ...vaultProbe(run, p.spokeVault),
+    })),
+  };
+}
+
+// ── Tier 4 — config integrity ─────────────────────────────────────────────────
+
+export function probeProjectPaths(
+  run: ProbeRunners,
+  config: CockpitConfig,
+): Array<{ project: string; path: string } & Probe> {
+  return Object.entries(config.projects).map(([project, p]) => {
+    try {
+      const ok = run.pathExists(p.path);
+      return ok
+        ? { project, path: p.path, state: "alive" as const }
+        : { project, path: p.path, state: "gone" as const, detail: "project path missing" };
+    } catch {
+      return { project, path: p.path, state: "unknown" as const };
+    }
+  });
+}
+
+/**
+ * sessions.json template-drift signal. Re-deriving the exact "current" template
+ * hash would couple the dashboard to the launcher's hashing internals + the
+ * installed templates dir; instead we surface the honest, dependency-free signal
+ * that the recorded sessions disagree: more than one distinct templateHash means
+ * some workspaces are running against an older template (drift). One hash =
+ * consistent; none recorded = unknown.
+ */
+export function probeSessions(run: ProbeRunners): Probe {
+  try {
+    const hashes = run.loadSessionsHashes();
+    if (hashes.length === 0) return { state: "unknown", detail: "no sessions recorded" };
+    if (hashes.length === 1) return { state: "alive" };
+    return { state: "gone", detail: `template drift: ${hashes.length} distinct hashes` };
+  } catch {
+    return { state: "unknown" };
+  }
+}
+
+// ── Top-level assembly ────────────────────────────────────────────────────────
+
+/**
+ * Run every Tier 3/4 probe and assemble {@link ExternalProbes}. config.json is
+ * loaded once (shared by vaults + project-path checks); if it fails to parse the
+ * config tier degrades but cmux/CLI probes still run.
+ */
+export async function runExternalProbes(
+  run: ProbeRunners,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<ExternalProbes> {
+  const [cmux, agentClis] = await Promise.all([
+    probeCmux(run, timeoutMs),
+    probeAgentClis(run, timeoutMs),
+  ]);
+
+  let config: CockpitConfig | null = null;
+  let parseable: Probe;
+  try {
+    config = run.loadConfig();
+    parseable = { state: "alive" };
+  } catch {
+    parseable = { state: "gone", detail: "config.json unparseable" };
+  }
+
+  const vaults = config
+    ? probeVaults(run, config)
+    : { hub: { path: "", state: "unknown" as const }, spokes: [] };
+  const projectPaths = config ? probeProjectPaths(run, config) : [];
+  const sessions = probeSessions(run);
+
+  return { cmux, agentClis, vaults, config: { parseable, projectPaths, sessions } };
+}
+
+// ── Default real-I/O runners (dashboard process; not unit-tested) ──────────────
+
+const SESSIONS_PATH = join(homedir(), ".config", "cockpit", "sessions.json");
+
+/** Resolve a bare binary name against the PATH dirs (dependency-free `which`). */
+function onPath(cli: string): boolean {
+  const dirs = (process.env.PATH ?? "").split(":").filter(Boolean);
+  return dirs.some((d) => existsSync(join(d, cli)));
+}
+
+/** Distinct templateHash values recorded across all workspaces in sessions.json. */
+function readSessionsHashes(): string[] {
+  const raw = JSON.parse(readFileSync(SESSIONS_PATH, "utf-8")) as {
+    workspaces?: Record<string, { templateHash?: string }>;
+  };
+  const hashes = Object.values(raw.workspaces ?? {})
+    .map((w) => w.templateHash)
+    .filter((h): h is string => typeof h === "string" && h.length > 0);
+  return [...new Set(hashes)];
+}
+
+/** The real runners used by `cockpit dashboard --web`. */
+export function defaultProbeRunners(): ProbeRunners {
+  return {
+    probeCmuxBin: () =>
+      new Promise<boolean>((resolve) => {
+        try {
+          execFile(resolveCmuxBin(), ["--version"], { timeout: 1500 }, (err) => resolve(!err));
+        } catch {
+          resolve(false);
+        }
+      }),
+    probeOnPath: async (cli) => onPath(cli),
+    pathExists: (p) => existsSync(p),
+    loadConfig: () => loadConfig(),
+    loadSessionsHashes: () => readSessionsHashes(),
+  };
+}

--- a/src/dashboard/snapshot-merge.ts
+++ b/src/dashboard/snapshot-merge.ts
@@ -1,0 +1,26 @@
+// src/dashboard/snapshot-merge.ts
+//
+// PURE merge of the two data sources behind the dashboard: the daemon's
+// Tier 0/1/2 `DaemonSnapshot` (or "unreachable") and the dashboard process's
+// Tier 3/4 `ExternalProbes`. The whole point of keeping this separate and pure
+// is the degrade-never-blank guarantee: when the daemon is unreachable the
+// external tiers still render, so a daemon outage never blanks the page.
+import type { DaemonSnapshot } from "../control/snapshot.js";
+import type { ExternalProbes } from "./probes.js";
+
+export interface FullSnapshot {
+  /** epoch ms this snapshot was assembled (drives "updated Ns ago"). */
+  generatedAt: number;
+  /** "unreachable" when the daemon socket query failed — Tier 0/1/2 are dark. */
+  daemon: DaemonSnapshot | "unreachable";
+  external: ExternalProbes;
+}
+
+/** Pure. Stamp the two sources into one FullSnapshot. */
+export function mergeSnapshot(
+  daemon: DaemonSnapshot | "unreachable",
+  external: ExternalProbes,
+  now: number,
+): FullSnapshot {
+  return { generatedAt: now, daemon, external };
+}

--- a/src/dashboard/web-render.ts
+++ b/src/dashboard/web-render.ts
@@ -3,9 +3,16 @@
 // PURE render of a FullSnapshot to (a) a complete HTML document for the initial
 // GET / load and (b) a per-tick JSON payload pushed over SSE. No I/O, no clock —
 // every age is derived from snapshot-time deltas or `snap.generatedAt`, so the
-// render is deterministic and unit-tested. Severity rolls UP (a `gone` bubbles a
-// red dot to its project header); the stale-build banner renders only when stale;
-// remediation is COPY-ABLE TEXT via healCmdFor() (never buttons — read-only beta).
+// render is deterministic and unit-tested.
+//
+// Visual language: a glass-cockpit flight deck. A master-status ANNUNCIATOR and
+// an inline-SVG health DONUT read the fleet at a glance; OVERVIEW / PROJECTS /
+// DAEMON / ENVIRONMENT tabs (vanilla-JS, one SSE stream) hold the detail. Charts
+// are inline SVG only (donut server-rendered; sparklines drawn client-side from a
+// rolling history of successive SSE frames). Severity rolls UP (a `gone` bubbles a
+// red rollup to its project header); the stale-build / link-lost banners render
+// only when applicable; remediation is COPY-ABLE TEXT (never buttons — read-only
+// beta). Zero new deps: vanilla JS + modern CSS + inline SVG.
 import type { HealthState, ComponentHealth } from "../control/liveness.js";
 import { healCmdFor } from "../commands/heal.js";
 import { ageText } from "../commands/health-view.js";
@@ -18,6 +25,8 @@ type AnyState = HealthState | ProbeState;
 const ICON: Record<AnyState, string> = { alive: "✔", stale: "•", gone: "✘", unknown: "○" };
 // Rollup ordering: gone is worst, unknown never out-ranks a real degradation.
 const SEV: Record<AnyState, number> = { alive: 0, unknown: 1, stale: 2, gone: 3 };
+// Cockpit annunciator vernacular for each state.
+const STATE_WORD: Record<AnyState, string> = { alive: "nominal", stale: "caution", gone: "fault", unknown: "unknown" };
 
 function esc(s: string): string {
   return s
@@ -25,16 +34,6 @@ function esc(s: string): string {
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;");
-}
-
-function dot(state: AnyState): string {
-  return `<span class="s-${state}">${ICON[state]}</span>`;
-}
-
-function worst(states: AnyState[]): AnyState {
-  let w: AnyState = "alive";
-  for (const s of states) if (SEV[s] > SEV[w]) w = s;
-  return w;
 }
 
 function fmtBytes(n: number): string {
@@ -57,64 +56,232 @@ function fmtAge(ms: number | null): string {
   return ms == null ? "—" : `${fmtDur(ms)} ago`;
 }
 
+function worst(states: AnyState[]): AnyState {
+  let w: AnyState = "alive";
+  for (const s of states) if (SEV[s] > SEV[w]) w = s;
+  return w;
+}
+
+// ── Health tallies ────────────────────────────────────────────────────────────
+interface Tally { alive: number; stale: number; gone: number; unknown: number; total: number }
+
+function tally(states: AnyState[]): Tally {
+  const t: Tally = { alive: 0, stale: 0, gone: 0, unknown: 0, total: states.length };
+  for (const s of states) t[s]++;
+  return t;
+}
+
+/** Master flight-status from an aggregate tally. gone → critical (red); stale →
+ *  degraded (amber); else nominal (green). Log errors map to `stale`, never gone,
+ *  so a noisy log can caution but never trips a CRITICAL master alarm. */
+function masterClass(t: Tally): "ok" | "warn" | "crit" {
+  if (t.gone > 0) return "crit";
+  if (t.stale > 0) return "warn";
+  return "ok";
+}
+const MASTER_WORD: Record<"ok" | "warn" | "crit", string> = { ok: "NOMINAL", warn: "DEGRADED", crit: "CRITICAL" };
+
+// ── Small presentational atoms ──────────────────────────────────────────────────
+function pill(state: AnyState, label: string): string {
+  return `<span class="pill s-${state}"><span class="pdot"></span>${esc(label)}</span>`;
+}
+
+/** Status pill carrying the glyph + state word — used in component tables. */
+function statePill(state: AnyState): string {
+  return pill(state, `${ICON[state]} ${STATE_WORD[state]}`);
+}
+
 function banner(kind: "err" | "warn", text: string): string {
   return `<div class="banner ${kind}">${esc(text)}</div>`;
 }
 
 function remediation(text: string): string {
   // Copy-able text, NOT a button — read-only beta surface.
-  return `<div class="rem">remediation: <code>${esc(text)}</code></div>`;
+  return `<div class="rem">remediation <code>${esc(text)}</code></div>`;
 }
 
 function probeCell(label: string, p: Probe): string {
-  const detail = p.detail ? ` <span class="dim">${esc(p.detail)}</span>` : "";
-  return `${dot(p.state)} ${esc(label)}${detail}`;
+  const detail = p.detail ? ` · ${esc(p.detail)}` : "";
+  return `${pill(p.state, label)}<span class="cell-detail">${detail}</span>`;
 }
 
-// ── Tier 0 — daemon root ──────────────────────────────────────────────────────
-function renderTier0(d: DaemonSnapshot): string {
-  const t0 = d.tier0;
-  const buildState: HealthState = t0.build.state === "fresh" ? "alive" : "gone";
-  const sweep = t0.sweep.ageMs == null ? "never swept" : `last ${fmtAge(t0.sweep.ageMs)} (${fmtDur(t0.sweep.cadenceMs)} cadence)`;
-  const logState: HealthState = t0.log.errorCount > 0 ? "stale" : "alive";
+// ── Donut gauge (inline SVG) ────────────────────────────────────────────────────
+const DONUT_ORDER: AnyState[] = ["alive", "stale", "gone", "unknown"];
+
+/** The signature element: a four-segment health ring. Segment arc lengths are
+ *  proportional to the tally; everything is plain SVG math so it is deterministic
+ *  and testable. An empty tally shows a faint full track. */
+function donut(t: Tally): string {
+  const cx = 64, cy = 64, r = 52, w = 14;
+  const C = 2 * Math.PI * r;
+  let acc = 0;
+  const segs = DONUT_ORDER.map((k) => {
+    const v = t[k];
+    if (v <= 0) return "";
+    const len = t.total ? (v / t.total) * C : 0;
+    const rot = t.total ? (acc / t.total) * 360 : 0;
+    acc += v;
+    return `<circle class="seg s-${k}" cx="${cx}" cy="${cy}" r="${r}" fill="none" stroke-width="${w}" stroke-dasharray="${len.toFixed(2)} ${(C - len).toFixed(2)}" transform="rotate(${(rot - 90).toFixed(2)} ${cx} ${cy})"></circle>`;
+  }).join("");
+  const track = `<circle class="donut-track" cx="${cx}" cy="${cy}" r="${r}" fill="none" stroke-width="${w}"></circle>`;
+  return `<svg class="donut" viewBox="0 0 128 128" role="img" aria-label="fleet health distribution">${track}${segs}</svg>`;
+}
+
+function legendRow(state: AnyState, count: number): string {
+  return `<div class="leg s-${state}"><span class="pdot"></span><span class="leg-n" data-countup="leg-${state}" data-value="${count}">${count}</span><span class="leg-l">${STATE_WORD[state]}</span></div>`;
+}
+
+/** A trend card: a label + a big readout value + an empty sparkline svg the
+ *  client fills from rolling history (data-spark key). */
+function trendCard(key: string, label: string, value: string, sub: string): string {
   return [
-    `<section><h2>TIER 0 · DAEMON</h2>`,
-    `<div class="row">${dot("alive")} cockpitd pid ${t0.pid} · up ${fmtDur(t0.uptimeMs)} · v${esc(t0.version)}</div>`,
-    `<div class="row">${dot(buildState)} build ${t0.build.state} · sweep ${esc(sweep)}</div>`,
-    `<div class="row">${dot(logState)} log ${t0.log.errorCount} errors/${fmtDur(t0.log.windowMs)} (${fmtBytes(t0.log.sizeBytes)})</div>`,
-    `</section>`,
+    `<div class="trend">`,
+    `<div class="trend-head"><span class="trend-l">${esc(label)}</span><span class="trend-v">${esc(value)}</span></div>`,
+    `<svg class="spark" data-spark="${key}" viewBox="0 0 100 28" preserveAspectRatio="none" aria-hidden="true"></svg>`,
+    `<div class="trend-sub">${esc(sub)}</div>`,
+    `</div>`,
   ].join("");
 }
 
-// ── Tier 3/4 — environment ────────────────────────────────────────────────────
-function renderEnv(ext: ExternalProbes): string {
-  const clis = ext.agentClis.map((c) => probeCell(c.cli, c)).join(" ");
-  const spokes = ext.vaults.spokes.map((s) => probeCell(s.project, s)).join(" ");
-  const paths = ext.config.projectPaths.map((p) => probeCell(p.project, p)).join(" ");
+// ── Aggregate collection (pure) ─────────────────────────────────────────────────
+interface Collected {
+  now: number;
+  daemonT: Tally; projT: Tally; envT: Tally; overall: Tally;
+  errors: number; behind: number; crewAgeMs: number;
+}
+
+function collect(snap: FullSnapshot): Collected {
+  const now = snap.generatedAt;
+  const env = snap.external;
+  const envStates: AnyState[] = [
+    env.cmux.state,
+    ...env.agentClis.map((c) => c.state),
+    env.vaults.hub.state,
+    ...env.vaults.spokes.map((s) => s.state),
+    env.config.parseable.state,
+    env.config.sessions.state,
+    ...env.config.projectPaths.map((p) => p.state),
+  ];
+  const daemonStates: AnyState[] = [];
+  const projStates: AnyState[] = [];
+  let errors = 0, behind = 0, crewAgeMs = 0;
+  if (snap.daemon !== "unreachable") {
+    const t0 = snap.daemon.tier0;
+    daemonStates.push("alive"); // the daemon process itself is up
+    daemonStates.push(t0.build.state === "fresh" ? "alive" : "stale");
+    daemonStates.push(t0.log.errorCount > 0 ? "stale" : "alive");
+    errors = t0.log.errorCount;
+    for (const c of snap.daemon.tier1) {
+      projStates.push(c.state);
+      if (c.kind === "crew" && c.lastSeenMs != null) crewAgeMs = Math.max(crewAgeMs, now - c.lastSeenMs);
+    }
+    for (const p of snap.daemon.tier2.projects) {
+      if (p.delivery.behind > 0) projStates.push("stale");
+      if (p.store.corruptCount > 0) projStates.push("gone");
+      behind += p.delivery.behind;
+    }
+  }
+  return {
+    now,
+    daemonT: tally(daemonStates),
+    projT: tally(projStates),
+    envT: tally(envStates),
+    overall: tally([...daemonStates, ...projStates, ...envStates]),
+    errors, behind, crewAgeMs,
+  };
+}
+
+// ── Tab: OVERVIEW ───────────────────────────────────────────────────────────────
+function tierCard(name: string, t: Tally): string {
+  const w = t.total ? worst(([] as AnyState[]).concat(
+    ...Array.from({ length: t.gone }, () => "gone" as AnyState),
+    ...Array.from({ length: t.stale }, () => "stale" as AnyState),
+    ...Array.from({ length: t.unknown }, () => "unknown" as AnyState),
+    ...Array.from({ length: t.alive }, () => "alive" as AnyState),
+  )) : "unknown";
   return [
-    `<section><h2>TIER 3/4 · ENVIRONMENT</h2>`,
-    `<div class="row">${probeCell("cmux", ext.cmux)}</div>`,
-    `<div class="row">CLIs: ${clis}</div>`,
-    `<div class="row">vaults: ${probeCell("hub", ext.vaults.hub)} ${spokes}</div>`,
-    `<div class="row">config: ${probeCell("config.json", ext.config.parseable)} ${probeCell("sessions", ext.config.sessions)} ${paths}</div>`,
-    `</section>`,
+    `<div class="tier-card">`,
+    `<div class="tier-top"><span class="tier-name">${esc(name)}</span>${statePill(w)}</div>`,
+    `<div class="tier-counts">`,
+    `<span class="tc s-alive">${t.alive}<i>ok</i></span>`,
+    `<span class="tc s-stale">${t.stale}<i>caution</i></span>`,
+    `<span class="tc s-gone">${t.gone}<i>fault</i></span>`,
+    `<span class="tc s-unknown">${t.unknown}<i>unknown</i></span>`,
+    `</div></div>`,
   ].join("");
 }
 
-// ── Tier 1/2 — projects ───────────────────────────────────────────────────────
-function renderComponentRow(c: ComponentHealth, now: number): string {
-  const detail = c.detail ? ` · ${esc(c.detail)}` : "";
-  const row = `<div class="row comp">${dot(c.state)} ${esc(c.kind)} ${esc(c.ref)} ${esc(ageText(c.lastSeenMs, now))}${detail}</div>`;
+function renderOverview(snap: FullSnapshot, col: Collected): string {
+  const linkLost = snap.daemon === "unreachable";
+  const mc = linkLost ? "crit" : masterClass(col.overall);
+  const word = linkLost ? "LINK LOST" : MASTER_WORD[mc];
+  const out: string[] = [`<section class="panel" data-panel="overview" role="tabpanel" aria-label="Overview">`];
+
+  out.push(
+    `<div class="hero a-${mc}">`,
+    `<div class="gauge">`,
+    donut(col.overall),
+    `<div class="gauge-core"><span class="gauge-n" data-countup="monitored" data-value="${col.overall.total}">${col.overall.total}</span><span class="gauge-word">${esc(word)}</span><span class="gauge-cap">monitored</span></div>`,
+    `</div>`,
+    `<div class="legend">`,
+    legendRow("alive", col.overall.alive),
+    legendRow("stale", col.overall.stale),
+    legendRow("gone", col.overall.gone),
+    legendRow("unknown", col.overall.unknown),
+    `</div>`,
+    `</div>`,
+  );
+
+  out.push(`<div class="tier-grid">`, tierCard("Daemon", col.daemonT), tierCard("Projects", col.projT), tierCard("Environment", col.envT), `</div>`);
+
+  out.push(
+    `<div class="trend-grid">`,
+    trendCard("errors", "Daemon log", `${col.errors}`, "errors logged in the last window"),
+    trendCard("behind", "Delivery lag", `${col.behind}`, "messages captains have yet to read"),
+    trendCard("crewAge", "Crew heartbeat", linkLost ? "—" : fmtDur(col.crewAgeMs), "oldest crew since last sign of life"),
+    `</div>`,
+  );
+
+  out.push(`</section>`);
+  return out.join("");
+}
+
+// ── Tab: PROJECTS ───────────────────────────────────────────────────────────────
+function componentRow(c: ComponentHealth, now: number): string {
+  const detail = c.detail ? esc(c.detail) : "";
+  const row =
+    `<tr>` +
+    `<td>${statePill(c.state)}</td>` +
+    `<td class="mono">${esc(c.kind)}</td>` +
+    `<td class="mono">${esc(c.ref)}</td>` +
+    `<td class="mono dim">${esc(ageText(c.lastSeenMs, now))}</td>` +
+    `<td class="dim">${detail}</td>` +
+    `</tr>`;
   const heal = healCmdFor(c);
-  return heal ? row + remediation(heal) : row;
+  return heal ? row + `<tr class="rem-row"><td colspan="5">${remediation(heal)}</td></tr>` : row;
 }
 
-function renderProjects(d: DaemonSnapshot, now: number): string {
-  const projects = new Set<string>([
-    ...d.tier1.map((c) => c.project),
-    ...d.tier2.projects.map((p) => p.project),
-  ]);
-  const out: string[] = [`<section><h2>PROJECTS</h2>`];
+function deliveryBar(behind: number, maxSeq: number): string {
+  const acked = Math.max(0, maxSeq - behind);
+  const ackedPct = maxSeq > 0 ? (acked / maxSeq) * 100 : 100;
+  const behindPct = maxSeq > 0 ? (behind / maxSeq) * 100 : 0;
+  return [
+    `<div class="dbar" role="img" aria-label="${acked} of ${maxSeq} delivered, ${behind} behind">`,
+    `<span class="dbar-acked" style="width:${ackedPct.toFixed(1)}%"></span>`,
+    `<span class="dbar-behind" style="width:${behindPct.toFixed(1)}%"></span>`,
+    `</div>`,
+  ].join("");
+}
+
+function renderProjects(snap: FullSnapshot, now: number): string {
+  const out: string[] = [`<section class="panel" data-panel="projects" role="tabpanel" aria-label="Projects">`];
+  if (snap.daemon === "unreachable") {
+    out.push(`<div class="empty">Telemetry link lost — per-project data is served by the daemon. Start it to restore: <code>cockpit heal daemon</code></div></section>`);
+    return out.join("");
+  }
+  const d = snap.daemon;
+  const projects = new Set<string>([...d.tier1.map((c) => c.project), ...d.tier2.projects.map((p) => p.project)]);
+  if (projects.size === 0) out.push(`<div class="empty">No projects registered yet.</div>`);
   for (const project of projects) {
     const comps = d.tier1.filter((c) => c.project === project);
     const dp = d.tier2.projects.find((p) => p.project === project);
@@ -124,29 +291,172 @@ function renderProjects(d: DaemonSnapshot, now: number): string {
       dp && dp.store.corruptCount > 0 ? "gone" : "alive",
     ];
     const rollup = worst(rollupStates);
-    out.push(`<div class="proj"><div class="proj-head" data-rollup="${rollup}">${esc(project)} ${dot(rollup)}</div>`);
-    for (const c of comps) out.push(renderComponentRow(c, now));
-    if (dp) {
-      const counts = Object.entries(dp.store.byState).map(([s, n]) => `${n} ${esc(s)}`).join(" · ") || "no tasks";
+    out.push(`<article class="card" data-rollup="${rollup}">`);
+    out.push(`<header class="card-head"><span class="card-title">${esc(project)}</span>${statePill(rollup)}</header>`);
+    if (comps.length) {
       out.push(
-        `<div class="row dp">mailbox: ${dp.mailbox.maxSeq} entries · captain ${dp.delivery.behind} behind · ${fmtBytes(dp.mailbox.sizeBytes)} · rotated ${dp.mailbox.rotationCount} · oldest ${fmtAge(dp.mailbox.oldestEntryAgeMs)}</div>`,
-        `<div class="row dp">store: ${counts} · ${dp.store.corruptCount} corrupt</div>`,
+        `<table class="grid"><thead><tr><th>status</th><th>kind</th><th>ref</th><th>last seen</th><th>detail</th></tr></thead><tbody>`,
+        ...comps.map((c) => componentRow(c, now)),
+        `</tbody></table>`,
+      );
+    } else {
+      out.push(`<div class="dim small">no live components reported</div>`);
+    }
+    if (dp) {
+      const counts = Object.entries(dp.store.byState).map(([s, n]) => pill("unknown", `${n} ${s}`)).join("");
+      out.push(
+        `<div class="dp-grid">`,
+        `<div class="dp-block"><span class="dp-l">mailbox</span><span class="dp-v"><span class="mono">${dp.mailbox.maxSeq}</span> entries · ${fmtBytes(dp.mailbox.sizeBytes)} · rotated ${dp.mailbox.rotationCount} · oldest ${fmtAge(dp.mailbox.oldestEntryAgeMs)}</span></div>`,
+        `<div class="dp-block"><span class="dp-l">captain delivery</span>${deliveryBar(dp.delivery.behind, dp.mailbox.maxSeq)}<span class="dp-v"><span class="mono">${dp.delivery.behind}</span> behind</span></div>`,
+        `<div class="dp-block"><span class="dp-l">task store</span><span class="chips">${counts || `<span class="dim small">no tasks</span>`}${dp.store.corruptCount > 0 ? pill("gone", `${dp.store.corruptCount} corrupt`) : ""}</span></div>`,
+        `</div>`,
       );
     }
-    out.push(`</div>`);
+    out.push(`</article>`);
   }
   out.push(
-    `<div class="row dp">_results: ${d.tier2.results.fileCount} files (${fmtBytes(d.tier2.results.totalBytes)})</div>`,
+    `<div class="results">global results · <span class="mono">${d.tier2.results.fileCount}</span> files · ${fmtBytes(d.tier2.results.totalBytes)}</div>`,
     `</section>`,
   );
   return out.join("");
 }
 
+// ── Tab: DAEMON ─────────────────────────────────────────────────────────────────
+function instr(label: string, value: string, extra = ""): string {
+  return `<div class="instr"><span class="instr-l">${esc(label)}</span><span class="instr-v">${value}</span>${extra}</div>`;
+}
+
+function renderDaemon(snap: FullSnapshot): string {
+  const out: string[] = [`<section class="panel" data-panel="daemon" role="tabpanel" aria-label="Daemon">`];
+  if (snap.daemon === "unreachable") {
+    out.push(`<div class="empty">Daemon unreachable — no Tier 0 telemetry. ${remediation("cockpit heal daemon")}</div></section>`);
+    return out.join("");
+  }
+  const t0 = snap.daemon.tier0;
+  const buildState: HealthState = t0.build.state === "fresh" ? "alive" : "gone";
+  // #fix(a): a fresh daemon that has not run a sweep yet is "awaiting first
+  // sweep" — not "never swept". A null age means the loop simply hasn't ticked.
+  const sweep = t0.sweep.ageMs == null
+    ? "awaiting first sweep"
+    : `last ${fmtAge(t0.sweep.ageMs)} · ${fmtDur(t0.sweep.cadenceMs)} cadence`;
+  const sweepState: AnyState = t0.sweep.ageMs == null ? "unknown" : "alive";
+  // #fix(b): present the log error count as a calm, non-alarming metric — a
+  // caution at most, with a trend sparkline, never a red master alarm.
+  const logState: AnyState = t0.log.errorCount > 0 ? "stale" : "alive";
+
+  out.push(
+    `<div class="instr-grid">`,
+    instr("process", `<span class="mono">cockpitd</span> ${statePill("alive")}`, `<span class="instr-sub">pid ${t0.pid} · v${esc(t0.version)}</span>`),
+    instr("uptime", `<span class="mono">${fmtDur(t0.uptimeMs)}</span>`),
+    instr("build", `${pill(buildState, t0.build.state)}`, t0.build.state === "stale" ? remediation("npm run build && cockpit heal daemon") : ""),
+    instr("sweep", `${pill(sweepState, sweep)}`),
+    `</div>`,
+  );
+
+  out.push(
+    `<div class="trend-grid">`,
+    [
+      `<div class="trend">`,
+      `<div class="trend-head"><span class="trend-l">Log errors</span><span class="trend-v">${pill(logState, `${t0.log.errorCount}`)}</span></div>`,
+      `<svg class="spark" data-spark="errors" viewBox="0 0 100 28" preserveAspectRatio="none" aria-hidden="true"></svg>`,
+      `<div class="trend-sub">${t0.log.errorCount === 0 ? "clean over the last" : `over the last`} ${fmtDur(t0.log.windowMs)} · log ${fmtBytes(t0.log.sizeBytes)}</div>`,
+      `</div>`,
+    ].join(""),
+    trendCard("behind", "Delivery lag", `${snap.daemon.tier2.projects.reduce((a, p) => a + p.delivery.behind, 0)}`, "summed across all project mailboxes"),
+    `</div>`,
+  );
+
+  out.push(`<div class="results">global results · <span class="mono">${snap.daemon.tier2.results.fileCount}</span> files · ${fmtBytes(snap.daemon.tier2.results.totalBytes)}</div>`);
+  out.push(`</section>`);
+  return out.join("");
+}
+
+// ── Tab: ENVIRONMENT ────────────────────────────────────────────────────────────
+function probeTable(rows: Array<[string, Probe]>): string {
+  return [
+    `<table class="grid"><thead><tr><th>status</th><th>component</th><th>detail</th></tr></thead><tbody>`,
+    ...rows.map(([label, p]) =>
+      `<tr><td>${statePill(p.state)}</td><td class="mono">${esc(label)}</td><td class="dim">${p.detail ? esc(p.detail) : ""}</td></tr>`,
+    ),
+    `</tbody></table>`,
+  ].join("");
+}
+
+function renderEnv(ext: ExternalProbes): string {
+  const out: string[] = [`<section class="panel" data-panel="environment" role="tabpanel" aria-label="Environment">`];
+
+  out.push(`<article class="card"><header class="card-head"><span class="card-title">Runtime & CLIs</span></header>`);
+  out.push(probeTable([
+    ["cmux", ext.cmux],
+    ...ext.agentClis.map((c) => [c.cli, c] as [string, Probe]),
+  ]));
+  out.push(`</article>`);
+
+  out.push(`<article class="card"><header class="card-head"><span class="card-title">Vaults</span></header>`);
+  out.push(probeTable([
+    ["hub", ext.vaults.hub],
+    ...ext.vaults.spokes.map((s) => [`spoke · ${s.project}`, s] as [string, Probe]),
+  ]));
+  out.push(`</article>`);
+
+  out.push(`<article class="card"><header class="card-head"><span class="card-title">Config integrity</span></header>`);
+  out.push(probeTable([
+    ["config.json", ext.config.parseable],
+    ["sessions", ext.config.sessions],
+    ...ext.config.projectPaths.map((p) => [`path · ${p.project}`, p] as [string, Probe]),
+  ]));
+  out.push(`</article>`);
+
+  out.push(`</section>`);
+  return out.join("");
+}
+
+// ── Tab nav + content assembly ──────────────────────────────────────────────────
+const TABS: Array<[string, string]> = [
+  ["overview", "Overview"],
+  ["projects", "Projects"],
+  ["daemon", "Daemon"],
+  ["environment", "Environment"],
+];
+
+function tabNav(): string {
+  const btns = TABS.map(([id, label], i) =>
+    `<button class="tab${i === 0 ? " on" : ""}" data-tab="${id}" role="tab" aria-selected="${i === 0 ? "true" : "false"}">${esc(label)}</button>`,
+  ).join("");
+  return `<nav class="tabs" role="tablist">${btns}</nav>`;
+}
+
+function metricsBlob(col: Collected, linkLost: boolean): string {
+  const m = {
+    t: col.now,
+    errors: linkLost ? 0 : col.errors,
+    behind: linkLost ? 0 : col.behind,
+    crewAgeMs: linkLost ? 0 : col.crewAgeMs,
+    alive: col.overall.alive, stale: col.overall.stale, gone: col.overall.gone, unknown: col.overall.unknown,
+  };
+  // Escape `</` defensively so the JSON can never close the <script> early.
+  const json = JSON.stringify(m).replace(/</g, "\\u003c");
+  return `<script type="application/json" id="cockpit-metrics">${json}</script>`;
+}
+
 /** Pure. The live inner content (everything inside #content), re-pushed each tick. */
 export function renderContent(snap: FullSnapshot): string {
-  const now = snap.generatedAt;
-  const out: string[] = [`<h1>🚀 COCKPIT SYSTEM HEALTH</h1>`];
+  const col = collect(snap);
+  const linkLost = snap.daemon === "unreachable";
+  const mc = linkLost ? "crit" : masterClass(col.overall);
+  const word = linkLost ? "LINK LOST" : MASTER_WORD[mc];
 
+  const out: string[] = [`<h1 class="sr-only">COCKPIT SYSTEM HEALTH</h1>`];
+
+  // Master annunciator — glanceable on every tab.
+  out.push(
+    `<div class="annunciator a-${mc}" role="status">`,
+    `<span class="ann-word">${esc(word)}</span>`,
+    `<span class="ann-sum">${col.overall.alive} nominal · ${col.overall.stale} caution · ${col.overall.gone} fault · ${col.overall.unknown} unknown</span>`,
+    `</div>`,
+  );
+
+  // Caution banners (loud, only when applicable).
   if (snap.daemon === "unreachable") {
     out.push(banner("err", "✘ DAEMON UNREACHABLE — start it: cockpit heal daemon  (external checks below still live)"));
   } else if (snap.daemon.tier0.build.state === "stale") {
@@ -154,10 +464,15 @@ export function renderContent(snap: FullSnapshot): string {
     out.push(remediation("npm run build && cockpit heal daemon"));
   }
 
-  if (snap.daemon !== "unreachable") out.push(renderTier0(snap.daemon));
+  out.push(tabNav());
+  out.push(`<div class="panels">`);
+  out.push(renderOverview(snap, col));
+  out.push(renderProjects(snap, col.now));
+  out.push(renderDaemon(snap));
   out.push(renderEnv(snap.external));
-  if (snap.daemon !== "unreachable") out.push(renderProjects(snap.daemon, now));
+  out.push(`</div>`);
 
+  out.push(metricsBlob(col, linkLost));
   return out.join("\n");
 }
 
@@ -167,45 +482,209 @@ export function renderTickJson(snap: FullSnapshot): string {
 }
 
 const STYLE = `
-body{font:13px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;background:#0b0e14;color:#c9d1d9;margin:0;padding:16px}
-h1{font-size:16px;margin:0 0 8px}h2{font-size:12px;color:#7d8590;letter-spacing:.08em;margin:16px 0 4px}
-#bar{display:flex;gap:16px;align-items:center;color:#7d8590;font-size:12px;margin-bottom:8px}
-#conn.live{color:#3fb950}#conn.down{color:#f85149}
-.row{padding:1px 0}.comp{padding-left:16px}.dp{padding-left:16px;color:#7d8590}
-.proj{margin:8px 0;border-left:2px solid #21262d;padding-left:8px}
-.proj-head{font-weight:600}
-.proj-head[data-rollup="gone"]{color:#f85149}.proj-head[data-rollup="stale"]{color:#d29922}
-.proj-head[data-rollup="unknown"]{color:#7d8590}
-.banner{padding:8px 12px;border-radius:6px;margin:8px 0;font-weight:600}
-.banner.err{background:#3d1416;color:#ff7b72}.banner.warn{background:#3d2e0a;color:#e3b341}
-.rem{padding-left:16px;color:#7d8590}.rem code{background:#161b22;padding:1px 6px;border-radius:4px;color:#79c0ff;user-select:all}
-.dim{color:#6e7681}
-.s-alive{color:#3fb950}.s-stale{color:#d29922}.s-gone{color:#f85149}.s-unknown{color:#6e7681}
+:root{
+  --bg:#070b14;--panel:#0c1322;--panel-2:#101a2e;--bezel:#1c2942;--track:#16223c;
+  --ink:#d2ddf0;--ink-dim:#6a7a9c;--hud:#37c6ee;--hud-deep:#0e4f63;
+  --ok:#3ad29f;--warn:#f5b945;--crit:#fb5d6e;--unk:#5e6f90;
+  --shadow:0 1px 0 rgba(255,255,255,.03),0 8px 24px rgba(0,0,0,.45);
+}
+*{box-sizing:border-box}
+body{margin:0;background:radial-gradient(1200px 700px at 50% -200px,#0d1830 0%,var(--bg) 60%);color:var(--ink);
+  font:13px/1.55 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;-webkit-font-smoothing:antialiased}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);border:0}
+.label{font-family:system-ui,-apple-system,"Segoe UI",sans-serif;text-transform:uppercase;letter-spacing:.14em}
+
+/* Flight deck header (persistent shell) */
+.deck{display:flex;align-items:center;gap:18px;padding:14px 22px;border-bottom:1px solid var(--bezel);
+  background:linear-gradient(180deg,rgba(20,32,56,.65),rgba(8,12,20,.2));position:sticky;top:0;z-index:5;backdrop-filter:blur(8px)}
+.brand{display:flex;align-items:center;gap:11px}
+.led{width:10px;height:10px;border-radius:50%;background:var(--unk);box-shadow:0 0 0 0 rgba(55,198,238,.5)}
+.led.live{background:var(--ok);animation:beat 2.2s ease-in-out infinite}
+.led.down{background:var(--crit);animation:blink 1s steps(2) infinite}
+.wordmark{font-family:system-ui,-apple-system,"Segoe UI",sans-serif;font-weight:800;letter-spacing:.34em;font-size:15px;text-transform:uppercase}
+.tagline{font-family:system-ui,sans-serif;text-transform:uppercase;letter-spacing:.26em;font-size:9.5px;color:var(--hud)}
+.deck-spacer{flex:1}
+.readout{display:flex;align-items:center;gap:16px;font-size:11px}
+.conn{font-family:system-ui,sans-serif;letter-spacing:.16em;text-transform:uppercase;color:var(--ink-dim)}
+.conn.live{color:var(--ok)}.conn.down{color:var(--crit)}
+.updated{color:var(--ink-dim)}
+.port{color:var(--hud)}
+
+#content{max-width:1080px;margin:0 auto;padding:18px 22px 64px;transition:opacity .18s ease}
+#content.swap{animation:fade .26s ease}
+
+/* Annunciator */
+.annunciator{display:flex;align-items:baseline;gap:16px;flex-wrap:wrap;padding:13px 18px;border-radius:12px;margin-bottom:14px;
+  border:1px solid var(--bezel);background:var(--panel);box-shadow:var(--shadow);position:relative;overflow:hidden}
+.annunciator::before{content:"";position:absolute;inset:0 auto 0 0;width:4px}
+.ann-word{font-family:system-ui,sans-serif;font-weight:800;letter-spacing:.2em;font-size:19px}
+.ann-sum{color:var(--ink-dim);letter-spacing:.04em}
+.a-ok .ann-word{color:var(--ok)}.a-ok::before{background:var(--ok);box-shadow:0 0 18px var(--ok)}
+.a-warn .ann-word{color:var(--warn)}.a-warn::before{background:var(--warn);box-shadow:0 0 18px var(--warn)}
+.a-crit .ann-word{color:var(--crit)}.a-crit::before{background:var(--crit);box-shadow:0 0 18px var(--crit);animation:pulseBar 1.4s ease-in-out infinite}
+
+/* Banners */
+.banner{padding:10px 14px;border-radius:10px;margin:10px 0;font-weight:700;letter-spacing:.02em;border:1px solid transparent}
+.banner.err{background:rgba(251,93,110,.12);color:#ff8d99;border-color:rgba(251,93,110,.4)}
+.banner.warn{background:rgba(245,185,69,.12);color:#ffd479;border-color:rgba(245,185,69,.36)}
+.rem{color:var(--ink-dim);margin:6px 0;font-size:12px}
+.rem code,.empty code{background:var(--panel-2);padding:2px 7px;border-radius:5px;color:var(--hud);user-select:all;border:1px solid var(--bezel)}
+
+/* Tabs */
+.tabs{display:flex;gap:4px;margin:6px 0 16px;border-bottom:1px solid var(--bezel);flex-wrap:wrap}
+.tab{appearance:none;background:none;border:0;color:var(--ink-dim);cursor:pointer;padding:9px 16px;
+  font-family:system-ui,sans-serif;text-transform:uppercase;letter-spacing:.16em;font-size:11px;font-weight:600;
+  border-bottom:2px solid transparent;margin-bottom:-1px;transition:color .15s ease,border-color .15s ease}
+.tab:hover{color:var(--ink)}
+.tab.on{color:var(--hud);border-bottom-color:var(--hud)}
+.panel{animation:none}
+.panel.fade{animation:fade .28s ease}
+
+/* Overview hero */
+.hero{display:flex;gap:30px;align-items:center;flex-wrap:wrap;padding:22px;border-radius:14px;
+  border:1px solid var(--bezel);background:linear-gradient(180deg,var(--panel-2),var(--panel));box-shadow:var(--shadow);margin-bottom:16px}
+.gauge{position:relative;width:172px;height:172px;flex:none}
+.donut{width:172px;height:172px;animation:rise .55s ease}
+.donut-track{stroke:var(--track)}
+.seg{transition:stroke-dasharray .5s ease}
+.seg.s-alive{stroke:var(--ok)}.seg.s-stale{stroke:var(--warn)}.seg.s-gone{stroke:var(--crit)}.seg.s-unknown{stroke:var(--unk)}
+.a-ok .seg.s-alive{filter:drop-shadow(0 0 4px var(--ok))}
+.gauge-core{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;gap:1px}
+.gauge-n{font-size:38px;font-weight:800;font-family:system-ui,sans-serif;line-height:1}
+.gauge-word{font-family:system-ui,sans-serif;text-transform:uppercase;letter-spacing:.14em;font-size:11px;color:var(--ink-dim)}
+.a-ok .gauge-word{color:var(--ok)}.a-warn .gauge-word{color:var(--warn)}.a-crit .gauge-word{color:var(--crit)}
+.gauge-cap{font-size:9px;letter-spacing:.2em;text-transform:uppercase;color:var(--ink-dim)}
+.legend{display:grid;grid-template-columns:1fr 1fr;gap:10px 22px;flex:1;min-width:200px}
+.leg{display:flex;align-items:center;gap:9px}
+.leg-n{font-size:20px;font-weight:700;font-family:system-ui,sans-serif;min-width:1.4em;text-align:right}
+.leg-l{color:var(--ink-dim);text-transform:uppercase;letter-spacing:.1em;font-size:10px;font-family:system-ui,sans-serif}
+.leg.s-alive .pdot{background:var(--ok)}.leg.s-stale .pdot{background:var(--warn)}
+.leg.s-gone .pdot{background:var(--crit)}.leg.s-unknown .pdot{background:var(--unk)}
+
+/* Tier + trend cards */
+.tier-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px;margin-bottom:16px}
+.tier-card{border:1px solid var(--bezel);border-radius:12px;background:var(--panel);padding:14px 16px;box-shadow:var(--shadow)}
+.tier-top{display:flex;align-items:center;justify-content:space-between;margin-bottom:12px}
+.tier-name{font-family:system-ui,sans-serif;text-transform:uppercase;letter-spacing:.12em;font-size:11px;color:var(--ink)}
+.tier-counts{display:flex;gap:14px}
+.tc{display:flex;flex-direction:column;font-size:21px;font-weight:700;font-family:system-ui,sans-serif;line-height:1.1}
+.tc i{font-size:9px;font-weight:600;font-style:normal;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-dim)}
+.tc.s-alive{color:var(--ok)}.tc.s-stale{color:var(--warn)}.tc.s-gone{color:var(--crit)}.tc.s-unknown{color:var(--unk)}
+
+.trend-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:12px;margin-bottom:16px}
+.trend{border:1px solid var(--bezel);border-radius:12px;background:var(--panel);padding:13px 15px;box-shadow:var(--shadow)}
+.trend-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px}
+.trend-l{font-family:system-ui,sans-serif;text-transform:uppercase;letter-spacing:.12em;font-size:10px;color:var(--ink-dim)}
+.trend-v{font-size:18px;font-weight:700;font-family:system-ui,sans-serif;color:var(--hud)}
+.trend-sub{color:var(--ink-dim);font-size:11px;margin-top:7px}
+.spark{width:100%;height:34px;display:block}
+.spark-line{fill:none;stroke:var(--hud);stroke-width:1.6;vector-effect:non-scaling-stroke;stroke-linejoin:round}
+.spark-area{fill:var(--hud);opacity:.1}
+.spark-dot{fill:var(--hud)}
+
+/* Cards / tables */
+.card{border:1px solid var(--bezel);border-radius:12px;background:var(--panel);box-shadow:var(--shadow);padding:14px 16px;margin-bottom:14px;border-left:3px solid var(--bezel)}
+.card[data-rollup="gone"]{border-left-color:var(--crit)}
+.card[data-rollup="stale"]{border-left-color:var(--warn)}
+.card[data-rollup="alive"]{border-left-color:var(--ok)}
+.card[data-rollup="unknown"]{border-left-color:var(--unk)}
+.card-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:12px}
+.card-title{font-family:system-ui,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-size:12px;font-weight:600}
+.grid{width:100%;border-collapse:collapse;font-size:12px}
+.grid th{text-align:left;font-family:system-ui,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-size:9px;
+  color:var(--ink-dim);font-weight:600;padding:4px 10px 8px;border-bottom:1px solid var(--bezel)}
+.grid td{padding:6px 10px;border-bottom:1px solid rgba(28,41,66,.5);vertical-align:middle}
+.grid tr:last-child td{border-bottom:0}
+.rem-row td{padding-top:0;border-bottom:0}
+.mono{font-family:ui-monospace,monospace}
+.dim{color:var(--ink-dim)}.small{font-size:11px}
+
+/* Pills */
+.pill{display:inline-flex;align-items:center;gap:6px;padding:2px 9px;border-radius:999px;font-size:11px;
+  border:1px solid var(--bezel);background:var(--panel-2);white-space:nowrap}
+.pdot{width:7px;height:7px;border-radius:50%;flex:none;background:var(--unk)}
+.pill.s-alive{color:var(--ok)}.pill.s-alive .pdot{background:var(--ok);box-shadow:0 0 6px var(--ok)}
+.pill.s-stale{color:var(--warn)}.pill.s-stale .pdot{background:var(--warn);box-shadow:0 0 6px var(--warn)}
+.pill.s-gone{color:var(--crit)}.pill.s-gone .pdot{background:var(--crit);box-shadow:0 0 6px var(--crit)}
+.pill.s-unknown{color:var(--unk)}.pill.s-unknown .pdot{background:var(--unk)}
+.cell-detail{color:var(--ink-dim)}
+
+/* Project data-plane */
+.dp-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:12px;margin-top:14px;
+  padding-top:13px;border-top:1px solid var(--bezel)}
+.dp-block{display:flex;flex-direction:column;gap:6px}
+.dp-l{font-family:system-ui,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-size:9px;color:var(--ink-dim)}
+.dp-v{font-size:12px}
+.chips{display:flex;flex-wrap:wrap;gap:5px}
+.dbar{display:flex;height:9px;border-radius:5px;overflow:hidden;background:var(--track);border:1px solid var(--bezel)}
+.dbar-acked{background:var(--ok);transition:width .5s ease}
+.dbar-behind{background:var(--warn);transition:width .5s ease}
+.results{color:var(--ink-dim);font-size:12px;margin-top:8px}
+
+/* Daemon instruments */
+.instr-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:12px;margin-bottom:16px}
+.instr{border:1px solid var(--bezel);border-radius:12px;background:var(--panel);padding:13px 15px;box-shadow:var(--shadow);display:flex;flex-direction:column;gap:7px}
+.instr-l{font-family:system-ui,sans-serif;text-transform:uppercase;letter-spacing:.12em;font-size:9px;color:var(--ink-dim)}
+.instr-v{font-size:15px;display:flex;align-items:center;gap:9px;flex-wrap:wrap}
+.instr-sub{color:var(--ink-dim);font-size:11px}
+
+.empty{border:1px dashed var(--bezel);border-radius:12px;padding:24px;color:var(--ink-dim);text-align:center;background:var(--panel)}
+
+:focus-visible{outline:2px solid var(--hud);outline-offset:2px;border-radius:4px}
+
+@keyframes beat{0%,100%{box-shadow:0 0 0 0 rgba(58,210,159,.45)}50%{box-shadow:0 0 0 6px rgba(58,210,159,0)}}
+@keyframes blink{50%{opacity:.35}}
+@keyframes pulseBar{0%,100%{opacity:1}50%{opacity:.4}}
+@keyframes fade{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:none}}
+@keyframes rise{from{opacity:0;transform:scale(.92)}to{opacity:1;transform:none}}
+@media (prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important}}
+@media (max-width:640px){.hero{gap:18px}.deck{padding:12px 14px;gap:10px}.tagline{display:none}#content{padding:14px}}
+`.trim();
+
+// Persistent client controller: tab switching (event-delegated), rolling history
+// for sparklines, count-ups, and the SSE wiring. Lives in the shell so it is set
+// up ONCE and survives every #content swap; `refresh()` reapplies tab + redraws
+// charts after each frame.
+const CLIENT_JS = `
+(function(){
+  var activeTab='overview';var hist={};var prev={};
+  function pushHist(k,v,t){var a=hist[k]||(hist[k]=[]);if(a.length&&a[a.length-1].t===t)return;a.push({t:t,v:v});if(a.length>48)a.shift();}
+  function ingest(){var el=document.getElementById('cockpit-metrics');if(!el)return;var m;try{m=JSON.parse(el.textContent);}catch(e){return;}pushHist('errors',m.errors,m.t);pushHist('behind',m.behind,m.t);pushHist('crewAge',Math.round(m.crewAgeMs/1000),m.t);}
+  function sparkSVG(a){var W=100,H=28,p=2;if(!a.length)return'';var vs=a.map(function(x){return x.v;});var mx=Math.max.apply(null,vs),mn=Math.min.apply(null,vs);if(mx===mn)mx=mn+1;var n=a.length;var pts=a.map(function(x,i){var px=n>1?p+i/(n-1)*(W-2*p):W/2;var py=H-p-(x.v-mn)/(mx-mn)*(H-2*p);return[px,py];});var d=pts.map(function(pt,i){return(i?'L':'M')+pt[0].toFixed(1)+' '+pt[1].toFixed(1);}).join(' ');var last=pts[pts.length-1];var area=d+' L'+last[0].toFixed(1)+' '+H+' L'+pts[0][0].toFixed(1)+' '+H+' Z';return'<path class="spark-area" d="'+area+'"/><path class="spark-line" d="'+d+'"/><circle class="spark-dot" cx="'+last[0].toFixed(1)+'" cy="'+last[1].toFixed(1)+'" r="2"/>';}
+  function drawSparks(){var ns=document.querySelectorAll('[data-spark]');for(var i=0;i<ns.length;i++){ns[i].innerHTML=sparkSVG(hist[ns[i].getAttribute('data-spark')]||[]);}}
+  function applyTab(){var ts=document.querySelectorAll('[data-tab]');for(var i=0;i<ts.length;i++){var on=ts[i].getAttribute('data-tab')===activeTab;ts[i].setAttribute('aria-selected',on?'true':'false');ts[i].classList.toggle('on',on);}var ps=document.querySelectorAll('[data-panel]');for(var j=0;j<ps.length;j++){var on2=ps[j].getAttribute('data-panel')===activeTab;ps[j].hidden=!on2;}}
+  function ease(k){return k<.5?2*k*k:1-Math.pow(-2*k+2,2)/2;}
+  function countUps(){var ns=document.querySelectorAll('[data-countup]');for(var i=0;i<ns.length;i++){(function(el){var key=el.getAttribute('data-countup');var to=parseFloat(el.getAttribute('data-value'))||0;var from=prev[key]!=null?prev[key]:0;prev[key]=to;if(from===to){el.textContent=to;return;}var s=null;function step(ts){if(s===null)s=ts;var k=Math.min(1,(ts-s)/600);el.textContent=Math.round(from+(to-from)*ease(k));if(k<1)requestAnimationFrame(step);}requestAnimationFrame(step);})(ns[i]);}}
+  function refresh(){ingest();applyTab();drawSparks();countUps();}
+  document.addEventListener('click',function(e){var t=e.target&&e.target.closest?e.target.closest('[data-tab]'):null;if(t){activeTab=t.getAttribute('data-tab');applyTab();var c=document.getElementById('content');if(c){c.classList.remove('swap');void c.offsetWidth;c.classList.add('swap');}}});
+  document.addEventListener('keydown',function(e){var ae=document.activeElement;if((e.key==='ArrowRight'||e.key==='ArrowLeft')&&ae&&ae.getAttribute&&ae.getAttribute('data-tab')){var o=['overview','projects','daemon','environment'];var i=o.indexOf(activeTab);i=(i+(e.key==='ArrowRight'?1:o.length-1))%o.length;activeTab=o[i];applyTab();var nt=document.querySelector('[data-tab="'+activeTab+'"]');if(nt)nt.focus();e.preventDefault();}});
+  var led=document.getElementById('led');var conn=document.getElementById('conn');var updated=document.getElementById('updated');
+  function tickAge(){if(!generatedAt)return;var s=Math.max(0,Math.round((Date.now()-generatedAt)/1000));updated.textContent='updated '+s+'s ago';}
+  setInterval(tickAge,1000);
+  var es=new EventSource('/events');
+  es.onopen=function(){conn.textContent='live';conn.className='conn live';led.className='led live';};
+  es.onerror=function(){conn.textContent='reconnecting';conn.className='conn down';led.className='led down';};
+  es.onmessage=function(e){try{var d=JSON.parse(e.data);document.getElementById('content').innerHTML=d.contentHtml;generatedAt=d.generatedAt;tickAge();refresh();}catch(_){}};
+  refresh();tickAge();
+})();
 `.trim();
 
 /** Pure. The full HTML document for the initial GET / load (shell + content + SSE JS). */
 export function renderHtml(snap: FullSnapshot, opts: { port?: number } = {}): string {
   const port = opts.port ? `:${opts.port}` : "";
-  const script = [
-    "const conn=document.getElementById('conn');",
-    "const updated=document.getElementById('updated');",
-    `let generatedAt=${snap.generatedAt};`,
-    "function tickAge(){if(!generatedAt)return;const s=Math.max(0,Math.round((Date.now()-generatedAt)/1000));updated.textContent='updated '+s+'s ago';}",
-    "setInterval(tickAge,1000);tickAge();",
-    "const es=new EventSource('/events');",
-    "es.onopen=function(){conn.textContent='\\u25CF live';conn.className='live';};",
-    "es.onerror=function(){conn.textContent='\\u25CB reconnecting';conn.className='down';};",
-    "es.onmessage=function(e){try{const d=JSON.parse(e.data);document.getElementById('content').innerHTML=d.contentHtml;generatedAt=d.generatedAt;tickAge();}catch(_){}};",
-  ].join("");
   return [
     "<!DOCTYPE html>",
     '<html lang="en"><head><meta charset="utf-8">',
     '<meta name="viewport" content="width=device-width,initial-scale=1">',
-    "<title>cockpit system health</title>",
+    "<title>cockpit · system health</title>",
     `<style>${STYLE}</style></head><body>`,
-    `<div id="bar"><span id="conn">○ connecting</span><span id="updated"></span><span>${esc(port)}</span></div>`,
-    `<div id="content">${renderContent(snap)}</div>`,
-    `<script>${script}</script>`,
+    `<header class="deck">`,
+    `<div class="brand"><span class="led" id="led"></span><span class="wordmark">Cockpit</span><span class="tagline">Mission Control</span></div>`,
+    `<span class="deck-spacer"></span>`,
+    `<div class="readout"><span class="conn" id="conn">connecting</span><span class="updated" id="updated"></span><span class="port">${esc(port)}</span></div>`,
+    `</header>`,
+    `<main id="content">${renderContent(snap)}</main>`,
+    `<script>let generatedAt=${snap.generatedAt};${CLIENT_JS}</script>`,
     "</body></html>",
   ].join("");
 }

--- a/src/dashboard/web-render.ts
+++ b/src/dashboard/web-render.ts
@@ -192,7 +192,13 @@ function collect(snap: FullSnapshot): Collected {
 }
 
 // ── Tab: OVERVIEW ───────────────────────────────────────────────────────────────
-function tierCard(name: string, t: Tally): string {
+/** A titled section header: a short heading + a one-line plain-language caption,
+ *  so a first-time viewer knows what each block of widgets is showing. */
+function sectionHead(title: string, sub: string): string {
+  return `<div class="section-head"><h2 class="section-title">${esc(title)}</h2><p class="section-sub">${esc(sub)}</p></div>`;
+}
+
+function tierCard(name: string, t: Tally, desc: string): string {
   const w = t.total ? worst(([] as AnyState[]).concat(
     ...Array.from({ length: t.gone }, () => "gone" as AnyState),
     ...Array.from({ length: t.stale }, () => "stale" as AnyState),
@@ -202,6 +208,7 @@ function tierCard(name: string, t: Tally): string {
   return [
     `<div class="tier-card">`,
     `<div class="tier-top"><span class="tier-name">${esc(name)}</span>${statePill(w)}</div>`,
+    `<p class="tier-desc">${esc(desc)}</p>`,
     `<div class="tier-counts">`,
     `<span class="tc s-alive">${t.alive}<i>ok</i></span>`,
     `<span class="tc s-stale">${t.stale}<i>caution</i></span>`,
@@ -217,6 +224,10 @@ function renderOverview(snap: FullSnapshot, col: Collected): string {
   const word = linkLost ? "LINK LOST" : MASTER_WORD[mc];
   const out: string[] = [`<section class="panel" data-panel="overview" role="tabpanel" aria-label="Overview">`];
 
+  out.push(sectionHead(
+    "System Health",
+    `${col.overall.alive} of ${col.overall.total} monitored components are alive — the ring shows the full breakdown by state.`,
+  ));
   out.push(
     `<div class="hero a-${mc}">`,
     `<div class="gauge">`,
@@ -232,13 +243,21 @@ function renderOverview(snap: FullSnapshot, col: Collected): string {
     `</div>`,
   );
 
-  out.push(`<div class="tier-grid">`, tierCard("Daemon", col.daemonT), tierCard("Projects", col.projT), tierCard("Environment", col.envT), `</div>`);
+  out.push(sectionHead("Health by Tier", "How many components are healthy in each layer of the stack."));
+  out.push(
+    `<div class="tier-grid">`,
+    tierCard("Daemon", col.daemonT, "cockpitd process, build freshness & log volume (Tier 0)"),
+    tierCard("Projects", col.projT, "relays, captains, crews & message data plane (Tier 1/2)"),
+    tierCard("Environment", col.envT, "agent CLIs, vaults & config integrity (Tier 3/4)"),
+    `</div>`,
+  );
 
+  out.push(sectionHead("Live Trends", "Magnitudes tracked over time — each sparkline builds as new updates arrive."));
   out.push(
     `<div class="trend-grid">`,
-    trendCard("errors", "Daemon log", `${col.errors}`, "errors logged in the last window"),
-    trendCard("behind", "Delivery lag", `${col.behind}`, "messages captains have yet to read"),
-    trendCard("crewAge", "Crew heartbeat", linkLost ? "—" : fmtDur(col.crewAgeMs), "oldest crew since last sign of life"),
+    trendCard("errors", "Daemon log", `${col.errors}`, "errors the daemon logged in the last window"),
+    trendCard("behind", "Delivery lag", `${col.behind}`, "messages captains have not read yet"),
+    trendCard("crewAge", "Crew heartbeat", linkLost ? "—" : fmtDur(col.crewAgeMs), "time since the quietest crew was last seen"),
     `</div>`,
   );
 
@@ -275,6 +294,7 @@ function deliveryBar(behind: number, maxSeq: number): string {
 
 function renderProjects(snap: FullSnapshot, now: number): string {
   const out: string[] = [`<section class="panel" data-panel="projects" role="tabpanel" aria-label="Projects">`];
+  out.push(sectionHead("Projects", "Per-project relays, captains, and crews, plus each project's mailbox delivery and task store."));
   if (snap.daemon === "unreachable") {
     out.push(`<div class="empty">Telemetry link lost — per-project data is served by the daemon. Start it to restore: <code>cockpit heal daemon</code></div></section>`);
     return out.join("");
@@ -328,6 +348,7 @@ function instr(label: string, value: string, extra = ""): string {
 
 function renderDaemon(snap: FullSnapshot): string {
   const out: string[] = [`<section class="panel" data-panel="daemon" role="tabpanel" aria-label="Daemon">`];
+  out.push(sectionHead("Daemon · Tier 0", "The cockpitd process at the root of everything — uptime, build freshness, sweep cadence, and log volume."));
   if (snap.daemon === "unreachable") {
     out.push(`<div class="empty">Daemon unreachable — no Tier 0 telemetry. ${remediation("cockpit heal daemon")}</div></section>`);
     return out.join("");
@@ -384,6 +405,7 @@ function probeTable(rows: Array<[string, Probe]>): string {
 
 function renderEnv(ext: ExternalProbes): string {
   const out: string[] = [`<section class="panel" data-panel="environment" role="tabpanel" aria-label="Environment">`];
+  out.push(sectionHead("Environment · Tier 3 / 4", "External tools and on-disk state the cockpit depends on but does not own — agent CLIs, vaults, and config."));
 
   out.push(`<article class="card"><header class="card-head"><span class="card-title">Runtime & CLIs</span></header>`);
   out.push(probeTable([
@@ -446,14 +468,20 @@ export function renderContent(snap: FullSnapshot): string {
   const mc = linkLost ? "crit" : masterClass(col.overall);
   const word = linkLost ? "LINK LOST" : MASTER_WORD[mc];
 
-  const out: string[] = [`<h1 class="sr-only">COCKPIT SYSTEM HEALTH</h1>`];
+  const out: string[] = [
+    `<header class="page-head">`,
+    `<h1 class="page-title">COCKPIT SYSTEM HEALTH</h1>`,
+    `<p class="page-sub">Live health of the cockpit daemon, sessions, message data plane, and environment — refreshed automatically every few seconds.</p>`,
+    `</header>`,
+  ];
 
-  // Master annunciator — glanceable on every tab.
+  // Master annunciator (status summary) — glanceable on every tab.
+  const sumLine = `${col.overall.alive} nominal · ${col.overall.stale} caution · ${col.overall.gone} fault · ${col.overall.unknown} unknown`;
   out.push(
-    `<div class="annunciator a-${mc}" role="status">`,
-    `<span class="ann-word">${esc(word)}</span>`,
-    `<span class="ann-sum">${col.overall.alive} nominal · ${col.overall.stale} caution · ${col.overall.gone} fault · ${col.overall.unknown} unknown</span>`,
-    `</div>`,
+    `<section class="annunciator a-${mc}" role="status" aria-label="Status summary">`,
+    `<div class="ann-main"><span class="ann-eyebrow">Status summary</span><span class="ann-word">${esc(word)}</span></div>`,
+    `<div class="ann-meta"><span class="ann-sum">${sumLine}</span><span class="ann-cap">worst current state across all ${col.overall.total} monitored components</span></div>`,
+    `</section>`,
   );
 
   // Caution banners (loud, only when applicable).
@@ -483,20 +511,18 @@ export function renderTickJson(snap: FullSnapshot): string {
 
 const STYLE = `
 :root{
-  --bg:#070b14;--panel:#0c1322;--panel-2:#101a2e;--bezel:#1c2942;--track:#16223c;
-  --ink:#d2ddf0;--ink-dim:#6a7a9c;--hud:#37c6ee;--hud-deep:#0e4f63;
-  --ok:#3ad29f;--warn:#f5b945;--crit:#fb5d6e;--unk:#5e6f90;
-  --shadow:0 1px 0 rgba(255,255,255,.03),0 8px 24px rgba(0,0,0,.45);
+  --bg:#f6f7f9;--panel:#ffffff;--panel-2:#eef1f6;--bezel:#e3e7ef;--track:#e9ecf2;
+  --ink:#1b2333;--ink-dim:#5b6678;--hud:#0b6fc2;--hud-deep:#0b6fc2;
+  --ok:#157f3c;--warn:#b45309;--crit:#c01f2e;--unk:#5f6b7d;
+  --shadow:0 1px 2px rgba(16,24,40,.05),0 4px 14px rgba(16,24,40,.06);
 }
 *{box-sizing:border-box}
-body{margin:0;background:radial-gradient(1200px 700px at 50% -200px,#0d1830 0%,var(--bg) 60%);color:var(--ink);
+body{margin:0;min-height:100vh;background:radial-gradient(1200px 760px at 50% -260px,#eaf1fb 0%,var(--bg) 58%);color:var(--ink);
   font:13px/1.55 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;-webkit-font-smoothing:antialiased}
-.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);border:0}
-.label{font-family:system-ui,-apple-system,"Segoe UI",sans-serif;text-transform:uppercase;letter-spacing:.14em}
 
 /* Flight deck header (persistent shell) */
 .deck{display:flex;align-items:center;gap:18px;padding:14px 22px;border-bottom:1px solid var(--bezel);
-  background:linear-gradient(180deg,rgba(20,32,56,.65),rgba(8,12,20,.2));position:sticky;top:0;z-index:5;backdrop-filter:blur(8px)}
+  background:linear-gradient(180deg,rgba(255,255,255,.92),rgba(255,255,255,.62));position:sticky;top:0;z-index:5;backdrop-filter:blur(8px)}
 .brand{display:flex;align-items:center;gap:11px}
 .led{width:10px;height:10px;border-radius:50%;background:var(--unk);box-shadow:0 0 0 0 rgba(55,198,238,.5)}
 .led.live{background:var(--ok);animation:beat 2.2s ease-in-out infinite}
@@ -513,20 +539,33 @@ body{margin:0;background:radial-gradient(1200px 700px at 50% -200px,#0d1830 0%,v
 #content{max-width:1080px;margin:0 auto;padding:18px 22px 64px;transition:opacity .18s ease}
 #content.swap{animation:fade .26s ease}
 
+/* Page heading + section headings */
+.page-head{margin:2px 0 16px}
+.page-title{margin:0;font-family:system-ui,-apple-system,"Segoe UI",sans-serif;font-weight:800;font-size:20px;letter-spacing:.06em;color:var(--ink)}
+.page-sub{margin:5px 0 0;color:var(--ink-dim);font-size:13px;max-width:74ch}
+.section-head{margin:20px 0 10px}
+.section-title{margin:0;font-family:system-ui,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-size:12px;font-weight:700;color:var(--ink)}
+.section-sub{margin:3px 0 0;color:var(--ink-dim);font-size:12px}
+
 /* Annunciator */
-.annunciator{display:flex;align-items:baseline;gap:16px;flex-wrap:wrap;padding:13px 18px;border-radius:12px;margin-bottom:14px;
+.annunciator{display:flex;align-items:center;justify-content:space-between;gap:18px;flex-wrap:wrap;padding:14px 18px;border-radius:12px;margin-bottom:6px;
   border:1px solid var(--bezel);background:var(--panel);box-shadow:var(--shadow);position:relative;overflow:hidden}
 .annunciator::before{content:"";position:absolute;inset:0 auto 0 0;width:4px}
-.ann-word{font-family:system-ui,sans-serif;font-weight:800;letter-spacing:.2em;font-size:19px}
-.ann-sum{color:var(--ink-dim);letter-spacing:.04em}
+.ann-main{display:flex;flex-direction:column;gap:2px}
+.ann-eyebrow{font-family:system-ui,sans-serif;text-transform:uppercase;letter-spacing:.16em;font-size:9px;color:var(--ink-dim)}
+.ann-meta{display:flex;flex-direction:column;gap:2px;text-align:right;min-width:0}
+.ann-word{font-family:system-ui,sans-serif;font-weight:800;letter-spacing:.2em;font-size:21px}
+.ann-sum{color:var(--ink);letter-spacing:.04em;font-size:12px}
+.ann-cap{color:var(--ink-dim);font-size:11px}
+@media (max-width:560px){.ann-meta{text-align:left}}
 .a-ok .ann-word{color:var(--ok)}.a-ok::before{background:var(--ok);box-shadow:0 0 18px var(--ok)}
 .a-warn .ann-word{color:var(--warn)}.a-warn::before{background:var(--warn);box-shadow:0 0 18px var(--warn)}
 .a-crit .ann-word{color:var(--crit)}.a-crit::before{background:var(--crit);box-shadow:0 0 18px var(--crit);animation:pulseBar 1.4s ease-in-out infinite}
 
 /* Banners */
 .banner{padding:10px 14px;border-radius:10px;margin:10px 0;font-weight:700;letter-spacing:.02em;border:1px solid transparent}
-.banner.err{background:rgba(251,93,110,.12);color:#ff8d99;border-color:rgba(251,93,110,.4)}
-.banner.warn{background:rgba(245,185,69,.12);color:#ffd479;border-color:rgba(245,185,69,.36)}
+.banner.err{background:#fdecee;color:#b21f2c;border-color:#f3c3c9}
+.banner.warn{background:#fff5e1;color:#8a5806;border-color:#f0d8a4}
 .rem{color:var(--ink-dim);margin:6px 0;font-size:12px}
 .rem code,.empty code{background:var(--panel-2);padding:2px 7px;border-radius:5px;color:var(--hud);user-select:all;border:1px solid var(--bezel)}
 
@@ -564,8 +603,9 @@ body{margin:0;background:radial-gradient(1200px 700px at 50% -200px,#0d1830 0%,v
 /* Tier + trend cards */
 .tier-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px;margin-bottom:16px}
 .tier-card{border:1px solid var(--bezel);border-radius:12px;background:var(--panel);padding:14px 16px;box-shadow:var(--shadow)}
-.tier-top{display:flex;align-items:center;justify-content:space-between;margin-bottom:12px}
+.tier-top{display:flex;align-items:center;justify-content:space-between;margin-bottom:6px}
 .tier-name{font-family:system-ui,sans-serif;text-transform:uppercase;letter-spacing:.12em;font-size:11px;color:var(--ink)}
+.tier-desc{margin:0 0 12px;color:var(--ink-dim);font-size:11px;min-height:2.2em}
 .tier-counts{display:flex;gap:14px}
 .tc{display:flex;flex-direction:column;font-size:21px;font-weight:700;font-family:system-ui,sans-serif;line-height:1.1}
 .tc i{font-size:9px;font-weight:600;font-style:normal;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-dim)}
@@ -593,7 +633,7 @@ body{margin:0;background:radial-gradient(1200px 700px at 50% -200px,#0d1830 0%,v
 .grid{width:100%;border-collapse:collapse;font-size:12px}
 .grid th{text-align:left;font-family:system-ui,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-size:9px;
   color:var(--ink-dim);font-weight:600;padding:4px 10px 8px;border-bottom:1px solid var(--bezel)}
-.grid td{padding:6px 10px;border-bottom:1px solid rgba(28,41,66,.5);vertical-align:middle}
+.grid td{padding:6px 10px;border-bottom:1px solid var(--track);vertical-align:middle}
 .grid tr:last-child td{border-bottom:0}
 .rem-row td{padding-top:0;border-bottom:0}
 .mono{font-family:ui-monospace,monospace}
@@ -677,7 +717,7 @@ export function renderHtml(snap: FullSnapshot, opts: { port?: number } = {}): st
     '<html lang="en"><head><meta charset="utf-8">',
     '<meta name="viewport" content="width=device-width,initial-scale=1">',
     "<title>cockpit · system health</title>",
-    `<style>${STYLE}</style></head><body>`,
+    `<style>${STYLE}</style></head><body class="theme-light">`,
     `<header class="deck">`,
     `<div class="brand"><span class="led" id="led"></span><span class="wordmark">Cockpit</span><span class="tagline">Mission Control</span></div>`,
     `<span class="deck-spacer"></span>`,

--- a/src/dashboard/web-render.ts
+++ b/src/dashboard/web-render.ts
@@ -1,0 +1,211 @@
+// src/dashboard/web-render.ts
+//
+// PURE render of a FullSnapshot to (a) a complete HTML document for the initial
+// GET / load and (b) a per-tick JSON payload pushed over SSE. No I/O, no clock —
+// every age is derived from snapshot-time deltas or `snap.generatedAt`, so the
+// render is deterministic and unit-tested. Severity rolls UP (a `gone` bubbles a
+// red dot to its project header); the stale-build banner renders only when stale;
+// remediation is COPY-ABLE TEXT via healCmdFor() (never buttons — read-only beta).
+import type { HealthState, ComponentHealth } from "../control/liveness.js";
+import { healCmdFor } from "../commands/heal.js";
+import { ageText } from "../commands/health-view.js";
+import type { FullSnapshot } from "./snapshot-merge.js";
+import type { DaemonSnapshot } from "../control/snapshot.js";
+import type { ExternalProbes, Probe, ProbeState } from "./probes.js";
+
+type AnyState = HealthState | ProbeState;
+
+const ICON: Record<AnyState, string> = { alive: "✔", stale: "•", gone: "✘", unknown: "○" };
+// Rollup ordering: gone is worst, unknown never out-ranks a real degradation.
+const SEV: Record<AnyState, number> = { alive: 0, unknown: 1, stale: 2, gone: 3 };
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function dot(state: AnyState): string {
+  return `<span class="s-${state}">${ICON[state]}</span>`;
+}
+
+function worst(states: AnyState[]): AnyState {
+  let w: AnyState = "alive";
+  for (const s of states) if (SEV[s] > SEV[w]) w = s;
+  return w;
+}
+
+function fmtBytes(n: number): string {
+  if (n < 1024) return `${n}B`;
+  if (n < 1024 ** 2) return `${(n / 1024).toFixed(1)}KB`;
+  if (n < 1024 ** 3) return `${(n / 1024 ** 2).toFixed(1)}MB`;
+  return `${(n / 1024 ** 3).toFixed(1)}GB`;
+}
+
+function fmtDur(ms: number): string {
+  const s = Math.max(0, Math.round(ms / 1000));
+  if (s < 60) return `${s}s`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  return `${h}h${m % 60}m`;
+}
+
+function fmtAge(ms: number | null): string {
+  return ms == null ? "—" : `${fmtDur(ms)} ago`;
+}
+
+function banner(kind: "err" | "warn", text: string): string {
+  return `<div class="banner ${kind}">${esc(text)}</div>`;
+}
+
+function remediation(text: string): string {
+  // Copy-able text, NOT a button — read-only beta surface.
+  return `<div class="rem">remediation: <code>${esc(text)}</code></div>`;
+}
+
+function probeCell(label: string, p: Probe): string {
+  const detail = p.detail ? ` <span class="dim">${esc(p.detail)}</span>` : "";
+  return `${dot(p.state)} ${esc(label)}${detail}`;
+}
+
+// ── Tier 0 — daemon root ──────────────────────────────────────────────────────
+function renderTier0(d: DaemonSnapshot): string {
+  const t0 = d.tier0;
+  const buildState: HealthState = t0.build.state === "fresh" ? "alive" : "gone";
+  const sweep = t0.sweep.ageMs == null ? "never swept" : `last ${fmtAge(t0.sweep.ageMs)} (${fmtDur(t0.sweep.cadenceMs)} cadence)`;
+  const logState: HealthState = t0.log.errorCount > 0 ? "stale" : "alive";
+  return [
+    `<section><h2>TIER 0 · DAEMON</h2>`,
+    `<div class="row">${dot("alive")} cockpitd pid ${t0.pid} · up ${fmtDur(t0.uptimeMs)} · v${esc(t0.version)}</div>`,
+    `<div class="row">${dot(buildState)} build ${t0.build.state} · sweep ${esc(sweep)}</div>`,
+    `<div class="row">${dot(logState)} log ${t0.log.errorCount} errors/${fmtDur(t0.log.windowMs)} (${fmtBytes(t0.log.sizeBytes)})</div>`,
+    `</section>`,
+  ].join("");
+}
+
+// ── Tier 3/4 — environment ────────────────────────────────────────────────────
+function renderEnv(ext: ExternalProbes): string {
+  const clis = ext.agentClis.map((c) => probeCell(c.cli, c)).join(" ");
+  const spokes = ext.vaults.spokes.map((s) => probeCell(s.project, s)).join(" ");
+  const paths = ext.config.projectPaths.map((p) => probeCell(p.project, p)).join(" ");
+  return [
+    `<section><h2>TIER 3/4 · ENVIRONMENT</h2>`,
+    `<div class="row">${probeCell("cmux", ext.cmux)}</div>`,
+    `<div class="row">CLIs: ${clis}</div>`,
+    `<div class="row">vaults: ${probeCell("hub", ext.vaults.hub)} ${spokes}</div>`,
+    `<div class="row">config: ${probeCell("config.json", ext.config.parseable)} ${probeCell("sessions", ext.config.sessions)} ${paths}</div>`,
+    `</section>`,
+  ].join("");
+}
+
+// ── Tier 1/2 — projects ───────────────────────────────────────────────────────
+function renderComponentRow(c: ComponentHealth, now: number): string {
+  const detail = c.detail ? ` · ${esc(c.detail)}` : "";
+  const row = `<div class="row comp">${dot(c.state)} ${esc(c.kind)} ${esc(c.ref)} ${esc(ageText(c.lastSeenMs, now))}${detail}</div>`;
+  const heal = healCmdFor(c);
+  return heal ? row + remediation(heal) : row;
+}
+
+function renderProjects(d: DaemonSnapshot, now: number): string {
+  const projects = new Set<string>([
+    ...d.tier1.map((c) => c.project),
+    ...d.tier2.projects.map((p) => p.project),
+  ]);
+  const out: string[] = [`<section><h2>PROJECTS</h2>`];
+  for (const project of projects) {
+    const comps = d.tier1.filter((c) => c.project === project);
+    const dp = d.tier2.projects.find((p) => p.project === project);
+    const rollupStates: AnyState[] = [
+      ...comps.map((c) => c.state),
+      dp && dp.delivery.behind > 0 ? "stale" : "alive",
+      dp && dp.store.corruptCount > 0 ? "gone" : "alive",
+    ];
+    const rollup = worst(rollupStates);
+    out.push(`<div class="proj"><div class="proj-head" data-rollup="${rollup}">${esc(project)} ${dot(rollup)}</div>`);
+    for (const c of comps) out.push(renderComponentRow(c, now));
+    if (dp) {
+      const counts = Object.entries(dp.store.byState).map(([s, n]) => `${n} ${esc(s)}`).join(" · ") || "no tasks";
+      out.push(
+        `<div class="row dp">mailbox: ${dp.mailbox.maxSeq} entries · captain ${dp.delivery.behind} behind · ${fmtBytes(dp.mailbox.sizeBytes)} · rotated ${dp.mailbox.rotationCount} · oldest ${fmtAge(dp.mailbox.oldestEntryAgeMs)}</div>`,
+        `<div class="row dp">store: ${counts} · ${dp.store.corruptCount} corrupt</div>`,
+      );
+    }
+    out.push(`</div>`);
+  }
+  out.push(
+    `<div class="row dp">_results: ${d.tier2.results.fileCount} files (${fmtBytes(d.tier2.results.totalBytes)})</div>`,
+    `</section>`,
+  );
+  return out.join("");
+}
+
+/** Pure. The live inner content (everything inside #content), re-pushed each tick. */
+export function renderContent(snap: FullSnapshot): string {
+  const now = snap.generatedAt;
+  const out: string[] = [`<h1>🚀 COCKPIT SYSTEM HEALTH</h1>`];
+
+  if (snap.daemon === "unreachable") {
+    out.push(banner("err", "✘ DAEMON UNREACHABLE — start it: cockpit heal daemon  (external checks below still live)"));
+  } else if (snap.daemon.tier0.build.state === "stale") {
+    out.push(banner("warn", "⚠ DAEMON RUNNING STALE CODE — process started before the current dist build"));
+    out.push(remediation("npm run build && cockpit heal daemon"));
+  }
+
+  if (snap.daemon !== "unreachable") out.push(renderTier0(snap.daemon));
+  out.push(renderEnv(snap.external));
+  if (snap.daemon !== "unreachable") out.push(renderProjects(snap.daemon, now));
+
+  return out.join("\n");
+}
+
+/** Pure. The per-tick SSE payload: re-rendered content + the snapshot timestamp. */
+export function renderTickJson(snap: FullSnapshot): string {
+  return JSON.stringify({ contentHtml: renderContent(snap), generatedAt: snap.generatedAt });
+}
+
+const STYLE = `
+body{font:13px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;background:#0b0e14;color:#c9d1d9;margin:0;padding:16px}
+h1{font-size:16px;margin:0 0 8px}h2{font-size:12px;color:#7d8590;letter-spacing:.08em;margin:16px 0 4px}
+#bar{display:flex;gap:16px;align-items:center;color:#7d8590;font-size:12px;margin-bottom:8px}
+#conn.live{color:#3fb950}#conn.down{color:#f85149}
+.row{padding:1px 0}.comp{padding-left:16px}.dp{padding-left:16px;color:#7d8590}
+.proj{margin:8px 0;border-left:2px solid #21262d;padding-left:8px}
+.proj-head{font-weight:600}
+.proj-head[data-rollup="gone"]{color:#f85149}.proj-head[data-rollup="stale"]{color:#d29922}
+.proj-head[data-rollup="unknown"]{color:#7d8590}
+.banner{padding:8px 12px;border-radius:6px;margin:8px 0;font-weight:600}
+.banner.err{background:#3d1416;color:#ff7b72}.banner.warn{background:#3d2e0a;color:#e3b341}
+.rem{padding-left:16px;color:#7d8590}.rem code{background:#161b22;padding:1px 6px;border-radius:4px;color:#79c0ff;user-select:all}
+.dim{color:#6e7681}
+.s-alive{color:#3fb950}.s-stale{color:#d29922}.s-gone{color:#f85149}.s-unknown{color:#6e7681}
+`.trim();
+
+/** Pure. The full HTML document for the initial GET / load (shell + content + SSE JS). */
+export function renderHtml(snap: FullSnapshot, opts: { port?: number } = {}): string {
+  const port = opts.port ? `:${opts.port}` : "";
+  const script = [
+    "const conn=document.getElementById('conn');",
+    "const updated=document.getElementById('updated');",
+    `let generatedAt=${snap.generatedAt};`,
+    "function tickAge(){if(!generatedAt)return;const s=Math.max(0,Math.round((Date.now()-generatedAt)/1000));updated.textContent='updated '+s+'s ago';}",
+    "setInterval(tickAge,1000);tickAge();",
+    "const es=new EventSource('/events');",
+    "es.onopen=function(){conn.textContent='\\u25CF live';conn.className='live';};",
+    "es.onerror=function(){conn.textContent='\\u25CB reconnecting';conn.className='down';};",
+    "es.onmessage=function(e){try{const d=JSON.parse(e.data);document.getElementById('content').innerHTML=d.contentHtml;generatedAt=d.generatedAt;tickAge();}catch(_){}};",
+  ].join("");
+  return [
+    "<!DOCTYPE html>",
+    '<html lang="en"><head><meta charset="utf-8">',
+    '<meta name="viewport" content="width=device-width,initial-scale=1">',
+    "<title>cockpit system health</title>",
+    `<style>${STYLE}</style></head><body>`,
+    `<div id="bar"><span id="conn">○ connecting</span><span id="updated"></span><span>${esc(port)}</span></div>`,
+    `<div id="content">${renderContent(snap)}</div>`,
+    `<script>${script}</script>`,
+    "</body></html>",
+  ].join("");
+}

--- a/src/dashboard/web-render.ts
+++ b/src/dashboard/web-render.ts
@@ -143,6 +143,16 @@ function trendCard(key: string, label: string, value: string, sub: string): stri
   ].join("");
 }
 
+/** Sum delivery lag across projects whose relay is alive or stale (online only).
+ *  A captain that is offline with unread mail is not a live delivery problem. */
+function liveDeliveryBehind(d: DaemonSnapshot): number {
+  return d.tier2.projects.reduce((sum, p) => {
+    const relay = d.tier1.find((c) => c.kind === "relay" && c.project === p.project);
+    const relayState = relay?.state ?? "unknown";
+    return relayState === "alive" || relayState === "stale" ? sum + p.delivery.behind : sum;
+  }, 0);
+}
+
 // ── Aggregate collection (pure) ─────────────────────────────────────────────────
 interface Collected {
   now: number;
@@ -178,8 +188,8 @@ function collect(snap: FullSnapshot): Collected {
     for (const p of snap.daemon.tier2.projects) {
       if (p.delivery.behind > 0) projStates.push("stale");
       if (p.store.corruptCount > 0) projStates.push("gone");
-      behind += p.delivery.behind;
     }
+    behind = liveDeliveryBehind(snap.daemon);
   }
   return {
     now,
@@ -334,10 +344,7 @@ function renderProjects(snap: FullSnapshot, now: number): string {
     }
     out.push(`</article>`);
   }
-  out.push(
-    `<div class="results">global results · <span class="mono">${d.tier2.results.fileCount}</span> files · ${fmtBytes(d.tier2.results.totalBytes)}</div>`,
-    `</section>`,
-  );
+  out.push(`</section>`);
   return out.join("");
 }
 
@@ -383,7 +390,7 @@ function renderDaemon(snap: FullSnapshot): string {
       `<div class="trend-sub">${t0.log.errorCount === 0 ? "clean over the last" : `over the last`} ${fmtDur(t0.log.windowMs)} · log ${fmtBytes(t0.log.sizeBytes)}</div>`,
       `</div>`,
     ].join(""),
-    trendCard("behind", "Delivery lag", `${snap.daemon.tier2.projects.reduce((a, p) => a + p.delivery.behind, 0)}`, "summed across all project mailboxes"),
+    trendCard("behind", "Delivery lag", `${liveDeliveryBehind(snap.daemon)}`, "summed across online projects only (offline excluded)"),
     `</div>`,
   );
 

--- a/src/dashboard/web-server.ts
+++ b/src/dashboard/web-server.ts
@@ -1,0 +1,111 @@
+// src/dashboard/web-server.ts
+//
+// The `cockpit dashboard --web` process: a localhost-only HTTP + SSE server that,
+// on each tick, queries the daemon's read-only `snapshot` verb, runs the Tier 3/4
+// external probes (which the daemon cannot — lineage wall), merges them, and
+// pushes the result to every connected browser. Crash-isolated from the daemon
+// (separate PID, read-only socket client) and bound to 127.0.0.1 with no auth.
+// Zero new deps: Node's built-in `http` + `EventSource` on the client.
+import { createServer, type Server, type ServerResponse } from "node:http";
+import { sendRequest } from "../control/protocol.js";
+import type { DaemonSnapshot } from "../control/snapshot.js";
+import { mergeSnapshot, type FullSnapshot } from "./snapshot-merge.js";
+import { runExternalProbes, type ProbeRunners } from "./probes.js";
+import { renderHtml, renderTickJson } from "./web-render.js";
+
+/**
+ * Query the daemon's read-only snapshot verb. Returns "unreachable" when the
+ * daemon socket can't be reached — the page degrades (banner + Tier 3/4) rather
+ * than blanking. Mirrors queryHealth() in health-view.ts.
+ */
+export async function querySnapshot(sockPath: string): Promise<DaemonSnapshot | "unreachable"> {
+  try {
+    const reply = await sendRequest(sockPath, { kind: "snapshot" });
+    return reply as DaemonSnapshot;
+  } catch {
+    return "unreachable";
+  }
+}
+
+export interface WebServerOpts {
+  port: number;
+  intervalMs: number;
+  sockPath: string;
+  runners: ProbeRunners;
+  host?: string;
+  now?: () => number;
+  probeTimeoutMs?: number;
+}
+
+export interface WebServerHandle {
+  /** The actually-bound port (useful when port 0 was requested in tests). */
+  port: number;
+  close: () => Promise<void>;
+}
+
+/**
+ * Start the dashboard web server. Binds 127.0.0.1 only, serves the static page on
+ * GET /, an SSE stream on GET /events, and pushes a fresh snapshot every
+ * intervalMs. Returns a handle whose close() stops the tick loop and the server.
+ */
+export async function startWebServer(opts: WebServerOpts): Promise<WebServerHandle> {
+  const host = opts.host ?? "127.0.0.1";
+  const now = opts.now ?? (() => Date.now());
+  const clients = new Set<ServerResponse>();
+  let latest: FullSnapshot | null = null;
+
+  async function tick(): Promise<void> {
+    const daemon = await querySnapshot(opts.sockPath);
+    const external = await runExternalProbes(opts.runners, opts.probeTimeoutMs);
+    latest = mergeSnapshot(daemon, external, now());
+    const payload = `data: ${renderTickJson(latest)}\n\n`;
+    for (const res of clients) {
+      try { res.write(payload); } catch { /* client gone; pruned on close */ }
+    }
+  }
+
+  const server: Server = createServer((req, res) => {
+    if (req.method !== "GET") { res.writeHead(405).end(); return; }
+    if (req.url === "/" || req.url === "/index.html") {
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+      res.end(latest ? renderHtml(latest, { port: opts.port }) : "<!DOCTYPE html><body>starting…</body>");
+      return;
+    }
+    if (req.url === "/events") {
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+      res.write("retry: 3000\n\n");
+      if (latest) res.write(`data: ${renderTickJson(latest)}\n\n`);
+      clients.add(res);
+      req.on("close", () => clients.delete(res));
+      return;
+    }
+    res.writeHead(404).end();
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(opts.port, host, resolve);
+  });
+  const addr = server.address();
+  const boundPort = typeof addr === "object" && addr ? addr.port : opts.port;
+
+  // Prime `latest` before the first request lands, then start the loop.
+  await tick();
+  const timer = setInterval(() => { void tick().catch(() => { /* a tick must never crash the loop */ }); }, opts.intervalMs);
+  timer.unref?.();
+
+  return {
+    port: boundPort,
+    close: () =>
+      new Promise<void>((resolve) => {
+        clearInterval(timer);
+        for (const res of clients) { try { res.end(); } catch { /* already closed */ } }
+        clients.clear();
+        server.close(() => resolve());
+      }),
+  };
+}

--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { createCmuxDriver, sanitizeForCmuxSend, parseDraftFromScreen, DeferDelivery } from "../cmux.js";
+import { createCmuxDriver, sanitizeForCmuxSend, parseDraftFromScreen, classifyStartupSurface, DeferDelivery } from "../cmux.js";
 
 const execFileMock = vi.hoisted(() => vi.fn());
 vi.mock("node:child_process", () => ({
@@ -985,5 +985,51 @@ describe("sendToSurface Approach B (#258 deliver-when-empty)", () => {
     expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")))).toBe(false);
     expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes(DRAFT)))).toBe(false);
     expect(calls.some((a) => a.includes("send-key") && a.includes("Enter"))).toBe(false);
+  });
+});
+
+// #292: deterministic startup-prompt delivery needs to tell three surface states
+// apart so launch can wait out cold init, send when ready, and never re-send into
+// a working session. The signals are grounded in real read-screen captures:
+//   loading — splash/cold-init: none of the persistent CC bottom-status chrome yet
+//   idle    — TUI up, input box accepting keystrokes (⏵⏵ / Ctx Used / for shortcuts)
+//   working — a live turn: token-down-counter "↓ Nk tokens" and/or "esc to interrupt"
+describe("classifyStartupSurface (#292 startup-readiness classifier)", () => {
+  // Real CC working spinner line (see docs/reports/258-parse-bug-fixture.txt).
+  const WORKING_STATUS = [
+    "✢ Cerebrating… (1m 4s · ↓ 4.3k tokens)",
+    HR,
+    "❯ ",
+    HR,
+    "   Model: Opus 4.8  Ctx Used: 52.0%",
+    "  ⏵⏵ auto mode on · 1 shell",
+  ].join("\n");
+
+  it("returns 'loading' for an empty screen", () => {
+    expect(classifyStartupSurface("")).toBe("loading");
+  });
+
+  it("returns 'loading' for a cold-init splash with no CC status chrome", () => {
+    const splash = ["", " ✻ Welcome to Claude Code", "   Loading…", ""].join("\n");
+    expect(classifyStartupSurface(splash)).toBe("loading");
+  });
+
+  it("returns 'idle' once the CC bottom-status chrome is present and no turn is running", () => {
+    // makeTestScreen renders the real idle layout: HR-boxed empty ❯ + status block.
+    expect(classifyStartupSurface(makeTestScreen("❯ "))).toBe("idle");
+  });
+
+  it("returns 'working' when the live token-down-counter is on screen", () => {
+    expect(classifyStartupSurface(WORKING_STATUS)).toBe("working");
+  });
+
+  it("returns 'working' when 'esc to interrupt' is shown", () => {
+    const screen = makeTestScreen("❯ ", "Working… (3s · esc to interrupt)");
+    expect(classifyStartupSurface(screen)).toBe("working");
+  });
+
+  it("prefers 'working' over 'idle' when both chrome and a live turn are present", () => {
+    // The 258 fixture shape: idle-looking input box but an active spinner above.
+    expect(classifyStartupSurface(WORKING_STATUS)).toBe("working");
   });
 });

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -199,11 +199,19 @@ export function readInputBoxRaw(screen: string): string | null {
 // silently dropped (#235). Grounded in docs/reports/258-parse-bug-fixture.txt.
 const CC_INITIALIZED_RE = /⏵⏵|Ctx Used|for shortcuts|accept edits/i;
 
-// A live turn shows a working spinner carrying a token-down-counter ("↓ 4.3k
-// tokens") and/or the "esc to interrupt" hint — neither appears on an idle,
-// input-ready screen. The whimsical spinner verb ("Working…", "Cerebrating…")
-// varies across versions, so we key on these stable markers instead.
-const CC_WORKING_RE = /↓\s*[\d.]+\s*k?\s*tokens?\b|esc to interrupt/i;
+// A live turn shows a working spinner. The whimsical verb ("Working…",
+// "Cerebrating…", "Crunched…") varies across versions, so we key on stable
+// markers instead. CRUCIAL: a turn is NOT always streaming tokens — during a
+// tool wait (e.g. the shell commands the captain startup checklist runs first)
+// the spinner reads "✻ Crunched for 27s · 1 shell still running", which carries
+// NO token-down-counter and no "esc to interrupt". Keying only on those two
+// (the original #292 mistake) misread a shell-waiting captain as "idle", so the
+// startup-prompt loop re-sent on every poll → 3 duplicate startup runs. We now
+// also match the shell-running hint and the in-parens elapsed timer ("(4s",
+// "(1m 4s") — both confined to the live spinner line, never on an idle,
+// input-ready screen. Grounded in docs/reports/258-parse-bug-fixture.txt
+// (line 4: shell-wait, no counter; line 22: token-stream).
+const CC_WORKING_RE = /↓\s*[\d.]+\s*k?\s*tokens?\b|esc to interrupt|\bshell still running\b|·\s*\d+\s*shell\b|\(\d+m?\s*\d*s\b/i;
 
 /**
  * Classify a captain surface's read-screen into the three states #292's

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -192,6 +192,33 @@ export function readInputBoxRaw(screen: string): string | null {
   return parts.join("").replace(/\s+$/, ""); // trim only the trailing edge
 }
 
+// #292: Claude Code renders a persistent bottom status block once its TUI is past
+// the cold-init splash — the auto-mode indicator (⏵⏵), the context meter
+// ("Ctx Used"), the shortcuts hint, or the accept-edits toggle. Absence of all of
+// these means we're still on the loading/splash screen, where keystrokes are
+// silently dropped (#235). Grounded in docs/reports/258-parse-bug-fixture.txt.
+const CC_INITIALIZED_RE = /⏵⏵|Ctx Used|for shortcuts|accept edits/i;
+
+// A live turn shows a working spinner carrying a token-down-counter ("↓ 4.3k
+// tokens") and/or the "esc to interrupt" hint — neither appears on an idle,
+// input-ready screen. The whimsical spinner verb ("Working…", "Cerebrating…")
+// varies across versions, so we key on these stable markers instead.
+const CC_WORKING_RE = /↓\s*[\d.]+\s*k?\s*tokens?\b|esc to interrupt/i;
+
+/**
+ * Classify a captain surface's read-screen into the three states #292's
+ * deterministic startup delivery needs:
+ *   "loading" — splash / cold-init; keystrokes would be dropped, do not send yet.
+ *   "idle"    — TUI up and accepting input; safe to deliver the startup prompt.
+ *   "working" — a turn is in flight; sending would queue a DUPLICATE startup run.
+ * "working" is checked first so an active spinner above an (empty) input box wins.
+ */
+export function classifyStartupSurface(screen: string): "loading" | "idle" | "working" {
+  if (CC_WORKING_RE.test(screen)) return "working";
+  if (CC_INITIALIZED_RE.test(screen)) return "idle";
+  return "loading";
+}
+
 export function createCmuxDriver(): RuntimeDriver {
   return {
     name: "cmux",


### PR DESCRIPTION
Patch release bundling the pre-cmux work on develop.

- **Dashboard**: web observability dashboard (#314), visual redesign (#319), accuracy fixes (#320)
- **Fix**: startup prompt delivered exactly once (#312)

Branched from `153cafb` (last pre-cmux commit). Verified: tsc clean, 1183 tests pass. Merging triggers tag `v0.6.2` + GH release. The cmux-compat work releases next as 0.7.0 via develop→main.