### PR TITLE
Release v0.7.0 — cmux 0.64.16 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-16
+
+A compatibility release aligning cockpit with **cmux 0.64.16**, headlined by a fix for `cockpit launch --fresh` (broken by cmux's new pinned-workspace protection) and the elimination of cmux's deprecation noise. Introduces an **external-tool compatibility manifest** so dependency drift is caught early, plus first steps toward driver-agnostic crew-lifecycle detection via cmux's native event stream.
+
+### Added
+
+- **External-tool compatibility manifest + `doctor` drift check.** New `src/lib/compat-manifest.ts` pins the supported version of every external component cockpit depends on — `cmux` (min 0.64.0, last-verified 0.64.16), `claude` (min 2.1.32), `node` (min 18, last-verified 24.6.0), and presence-checked `codex` 0.139.0 / `gemini` 0.38.2 / `opencode` 1.17.4. `cockpit doctor` now warns (non-blocking) when an installed tool is below its floor or newer than the last-verified version, surfacing a future breaking update early instead of letting it fail silently. (#325)
+
+- **cmux native event stream for crew-idle detection (B1).** The daemon consumes cmux's `agent.hook.Stop` events as an additional crew-idle signal, keeping the screen-scrape as fallback. (#328)
+
+- **Agent-hook working-state to suppress false stalls (B4/A3).** `agent.hook.PreToolUse`/`UserPromptSubmit` derive a "working" state so a crew mid-tool-call is no longer misreported as stalled (the #292 class). Additive and gated; the delicate draft scraper is untouched. (#331)
+
+### Fixed
+
+- **`cockpit launch --fresh` works again on pinned workspaces.** cmux 0.64.16 refuses to close a pinned workspace; the driver's `stop()` now unpins before closing, so `--fresh` replaces the captain workspace instead of leaving a stale duplicate. (#325)
+
+- **cmux deprecation noise eliminated.** Migrated the driver to cmux's canonical noun-verb commands (`workspace list/create/rename/close`) and set `CMUX_QUIET=1` in the cmux subprocess env, removing the per-call "legacy alias" notices. Read commands also lock `--id-format refs` to stay robust against a future default change. (#325, #327)
+
+- **Focus-neutral crew spawn (A1/B3).** cmux's new freeform-canvas layout broke the index-based focus-restore dance; the driver now passes `--focus false` (cmux's new default) and drops the dance entirely, preventing keystroke leakage into a crew's launch line. (#327)
+
+- **`--json` parsing for `workspace list` / `tree`.** Replaces brittle regex parsing of cmux text output with structured JSON. (#327)
+
+- **Relay-health log noise pruned.** The daemon no longer floods `not_found: Workspace not found` every sweep on stale closed-crew refs — stale records are pruned and logged once. (#329)
+
+### Changed
+
+- **Agent Hibernation evaluated, gated off.** cmux's agent-hibernation is global-only and would hibernate the captain/relay, so it ships behind `defaults.cmuxAgentHibernation` (default `false`) with documented rationale rather than enabled. (#329)
+
+### Docs
+
+- cmux 0.62→0.64 compatibility audit, the agent-lifecycle + daemon-architecture research dossier, and a workspace-groups (audit C1) deferral note — backing follow-up issues #326 (compat backlog), #332 (deprecate relay → daemon-direct cmux), #333 (driver-agnostic `LifecycleSource`), and #114 (native codex TUI via hooks). (#327, #330, #334)
+
 ## [0.6.2] - 2026-06-16
 
 A patch release bundling the **web observability dashboard** and a **startup-delivery fix** — the work that accumulated on `develop` after 0.6.1, ahead of the cmux-compat changes that land in 0.7.0.

--- a/docs/reports/2026-06-15-cmux-compat-audit-0.62-0.64.md
+++ b/docs/reports/2026-06-15-cmux-compat-audit-0.62-0.64.md
@@ -1,0 +1,108 @@
+# cmux Compatibility & Opportunity Audit — 0.62.0 → 0.64.16
+
+**Date:** 2026-06-15
+**cmux window audited:** 0.62.0 (2026-03-12) → 0.64.16 (2026-06-15) — 24 releases, ~3 months
+**Sources:** `manaflow-ai/cmux` `CHANGELOG.md` + `docs/cli-contract.md` (raw from `main`)
+**Trigger:** user updated cmux to 0.64.16; deprecation spam + broken `--fresh` surfaced. Cockpit's code last referenced cmux ~0.62.2, so this audit covers the drift since then.
+**Method:** cross-referenced every cmux invocation / output-assumption across cockpit's integration surface — `src/runtimes/cmux.ts`, `src/notifiers/cmux.ts`, `src/commands/launch.ts`, `src/commands/notify-relay.ts`, `src/control/interactive/pane-classifier.ts`, `src/control/liveness.ts`, `src/control/cockpitd.ts`.
+
+---
+
+## Executive summary
+
+- **No hard breaks** beyond the two already fixed in-flight (workspace-verb migration + pinned-workspace close). cmux's contract keeps the text output cockpit pins to stable.
+- **Category A (must-adapt): 4 findings** — 1 correctness regression risk (A1 focus-restore), 1 already-folded defensive item (A4 id-format), 2 cosmetic/latent (A2, A3).
+- **Category B (simplify integration): 4 findings** — biggest lever is **B1 `cmux events` JSON stream**, which can retire the daemon's relay-proxy cmux-blindness workaround. **B3 focus-neutral spawn is the same fix as A1.**
+- **Category C (adopt new capability): 5 findings** — workspace groups, agent hibernation, per-workspace env lead.
+- **Single most important architecture finding:** `cmux events` (reconnectable JSON event bus) — replaces screen-scraping for liveness/focus/surface enumeration.
+
+### Disposition (2026-06-15 decisions)
+| Item | Disposition |
+|------|-------------|
+| Verb migration + `CMUX_QUIET=1` + pinned-close unpin | **In-flight crew** `cmux-compat` (branch `fix/cmux-0.64-compat`) |
+| A4 `--id-format refs` hardening | **Folded into in-flight crew** |
+| A1 + B3 (focus-neutral spawn) | **Pre-release crew — gates v1.0.0** |
+| A2 (OSC sanitizer) | Confirm no-op in pre-release crew |
+| A3, B1, B2, B4, C1–C5 | **This audit + single tracking GH issue** → carve sub-issues later |
+
+---
+
+## Category A — Behavioral changes cockpit must adapt to
+
+### A1. Focus-restore `move-surface --index --focus` dance is now fragile — **DEGRADES (correctness)**
+- **cmux:** 0.64.16 "Freeform 2D canvas layout for workspace panes" (#5987) + "Stagger restored terminal surface spawns" (#6149).
+- **cockpit:** `src/runtimes/cmux.ts:331-360` (`newPane`), `:402-425` (`spawnInjector`), `parseSurfaceOrder` `:60-69`. Records the `[selected]` surface's **array index** from `cmux tree`, then `move-surface --surface <prior> --index <priorIndex> --focus true`.
+- **Why:** the new canvas layout + staggered restore weaken the "tree order == linear tab-strip index" invariant. During staggered restore the tree can be transiently incomplete → `priorIndex` points at the wrong surface; under canvas layout "index" is no longer a 1-D strip position. Already best-effort (`try/catch`), so failure mode is **silent loss of focus restoration** = regression of the #295 focus-steal (captain keystrokes land in the fresh crew's launch line).
+- **Fix:** move off index-based refocus → focus-neutral spawn (see **B3** — same work). Gates v1.0.0.
+
+### A2. `cmux send` OSC fix — **COSMETIC (no change)**
+- **cmux:** 0.64.14 "Fix OSC control sequences printed as literal text when sent via `cmux send`" (#5509).
+- **cockpit:** `sanitizeForCmuxSend` `cmux.ts:75-81` only collapses `\n\r\t` (newline→Enter protection), never relied on OSC passthrough. No conflict. Confirm + move on.
+
+### A3. `read-screen` chrome-scraping is version-drifting — **DEGRADES (latent)**
+- **cmux:** TUI-chrome-adjacent changes — 0.64.0 "Auto-hide terminal scroll bar on alt-screen", 0.64.13 "Anchor textbox autocomplete to cursor", 0.64.15 React/Solid agent-session panels (#4429).
+- **cockpit:** `CC_INITIALIZED_RE`/`CC_WORKING_RE` `cmux.ts:200,214`; `parseDraftFromScreen` `:97-161`; `classifyPaneTail` `pane-classifier.ts:93-113` — all pinned to specific glyphs (`⏵⏵`, `❯`, `─{10,}` HR, `▌█`) and English spinner phrases.
+- **Why:** every cmux/CC chrome change is a silent breakage risk. This is the structural fragility the whole report flags.
+- **Fix:** no forced change now; durable answer is **B4** (structured agent state), which cmux has not yet exposed over the socket. **Tracked in the GH issue.**
+
+### A4. `--id-format` default assumption — **COSMETIC (folded into in-flight crew)**
+- **cmux:** global `--id-format refs|uuids|both`.
+- **cockpit:** every parser assumes `workspace:N`/`surface:N` ref form — `parseList` `:45`, `parseSurfaceOrder` `:64`, `listSurfaces` `:491`, spawn id-extraction `:261`. If the default ever changes, all silently return empty.
+- **Fix:** pass `--id-format refs` explicitly on read commands (`workspace list`, `tree`). **Folded into crew `cmux-compat`.**
+
+---
+
+## Category B — New cmux APIs that could reduce/simplify cockpit integration
+
+### B1. ⭐ Reconnectable JSON event stream (`cmux events` / `events.jsonl`)
+- **cmux:** CLI contract §Events; `capabilities` advertises `events.stream`; `~/.cmuxterm/events.jsonl` emits surface selection/focus/creation/closure + workspace selection; cursor-file + `--after-seq` resume. 0.64.10 reorder events; 0.64.15 event-stream allocation fix (#5664) → load-bearing, maintained.
+- **Replaces:** the surface-liveness reaper's per-sweep `tree` scrape (`crew-pane-reader.ts`), and **the entire relay-proxy cmux-blindness workaround** (`relay-proxy-poll`/`result` in `notify-relay.ts:331-365`, `cockpitd.ts:208-217,590-608`) that exists only because the launchd daemon can't poll cmux. A daemon-side subscriber gives authoritative surface-create/close/select events with built-in resume.
+- **Value:** HIGH (biggest architectural simplification). Prototype a daemon `cmux events --reconnect --cursor-file … --category surface,workspace` consumer; map `surface.closed`→reaper, `surface.selected`→focus tracking. Keep scrape path as fallback during migration.
+
+### B2. `--json` output on `tree`/list
+- **cmux:** global `--json`; 0.64.16 "Expose each workspace's custom title to the control socket" (#6013).
+- **Replaces:** the four hand-rolled regex parsers (`parseList`, `parseSurfaceOrder`, `listSurfaces`, stdout id-extraction). Custom titles become first-class instead of quoted-substring matching (`send` routing `:293-305`).
+- **Value:** MEDIUM-HIGH. Eliminates ~5 brittle regexes + the A4 risk in one move.
+
+### B3. Focus-neutral spawn (`split-off`, `workspace.create --layout`)
+- **cmux:** 0.64.0 "Focus-neutral split-off layout command" (#3484) + "`--layout` on `workspace.create`" (#2916); contract: `split-off` "Move a surface into a new split without changing focus by default".
+- **Replaces:** the snapshot-index-then-`move-surface --focus` logic in `newPane`/`spawnInjector` (`cmux.ts:331-360`, `402-425`) — i.e. **the A1 fix.** `split-off` exists specifically to not steal focus, which is the #295 problem hand-rolled around.
+- **Value:** MEDIUM-HIGH. **Bundled with A1, gates v1.0.0.**
+
+### B4. Hook-less live-agent / fork detection + agent-session panels
+- **cmux:** 0.64.16 "Detect live claude/codex processes so hook-less agent sessions stay fork-able" (#6133); 0.64.15 agent-session panels (#4429); 0.64.3 live status driving the tab status bar (#5235).
+- **Replaces (eventually):** the CC-chrome heuristics (`classifyStartupSurface`, `CC_WORKING_RE`/`CC_INITIALIZED_RE`, parts of `classifyPaneTail`) — cmux now tracks agent run-state internally.
+- **Value:** MEDIUM (watch-and-adopt; not yet socket-exposed). Long-term answer to A3. **Tracked.**
+
+> The #302 buffer-liveness backspace probe in `sendToSurface` (`cmux.ts:429-479`) protects the captain's *own* draft and has **no cmux-side equivalent** in this window — keep it.
+
+---
+
+## Category C — New cmux features worth integrating (ranked)
+
+### C1. Workspace groups CLI (`cmux workspace-group`) — HIGH
+- **cmux:** 0.64.11 (#5018) create/remove/set-color/set-icon/move/focus groups + per-group new-workspace placement; 0.64.15 group commands in cloud relay (#5856).
+- **For cockpit:** maps 1:1 onto captain + N crews per project. Replaces ad-hoc `pinToTop` (`cmux.ts:276-285`) + `🔧 project:name` title convention with a first-class colored/iconed container; per-group placement lands new crews in the right group automatically. Aligns with the "sibling projects aware of each other" goal.
+
+### C2. Agent Hibernation — HIGH (targets the RAM-flood pain)
+- **cmux:** 0.64.11 (#4165) pauses idle agent sessions, restore-on-demand; 0.64.14 5s idle default (#5449); `agent-hibernation <on|off>`.
+- **For cockpit:** directly addresses the documented RAM-flood / orphaned-headless-session theme and the 24h idle crew budget (`liveness.ts:48-49`). Enable in launch defaults; **verify a hibernated crew reads as "alive" to the reaper, not "gone".**
+
+### C3. Per-workspace environment variables (`workspace env` / `--env` / `--env-file`) — MEDIUM-HIGH
+- **cmux:** 0.64.16 (#6116) per-workspace env inherited by every shell, re-applied on restore, protected `CMUX_*` keys.
+- **For cockpit:** replaces the `envPrefix` string concatenation (`crew.ts:399,449`); survives restore; cleaner shell-safety (#118). Could finally give **codex crews a stable `COCKPIT_CREW_TASK_ID`** (the known codex-signal gap).
+
+### C4. Detachable SSH PTY daemon + `workspace reconnect/disconnect` — MEDIUM (future remote crews)
+- **cmux:** 0.64.11 (#4807) detachable SSH PTY; 0.64.13 SSH agent forwarding (#5301).
+- **For cockpit:** dropped connection wouldn't kill an in-flight remote crew turn. Roadmap note for remote/cloud crews; no action now.
+
+### C5. `--window` routing — MEDIUM-LOW
+- **cmux:** 0.64.8 (#4211) `--window` for window-scoped commands.
+- **For cockpit:** scope `list`/`tree` to the captain's window to avoid multi-window collisions when resolving a captain by name. Low priority until a collision is reported.
+
+---
+
+## Explicitly NOT a concern (so the release doesn't chase them)
+- **Notification CLI** (0.64.5/0.64.11 panel parity, redesign, dismiss/mark-read/jump-to-unread): cockpit uses its own mailbox + notify-relay; never calls `cmux notify`/`set-status`/`list-notifications`. Optional only.
+- **Browser automation suite** (0.64.13–16): cockpit doesn't drive cmux's browser.
+- **GUI-only** (iOS app, themes, sidebar font, markdown/diff viewers, minimap): no CLI/socket dependency — except the freeform **canvas** (A1).

--- a/docs/research/2026-06-16-cmux-agent-lifecycle-and-daemon-architecture.md
+++ b/docs/research/2026-06-16-cmux-agent-lifecycle-and-daemon-architecture.md
@@ -1,0 +1,142 @@
+# cmux agent-lifecycle detection & cockpit daemon architecture — research dossier
+
+**Date:** 2026-06-16
+**Purpose:** Brainstorm reference. Captures everything researched about (1) cmux socket reachability, (2) how cmux detects agent lifecycle, (3) implications for cockpit's relay + event-bridge, (4) a driver-agnostic `LifecycleSource` design, (5) running codex interactively via hooks instead of the app-server.
+**Sources:** live probes on this machine (cmux 0.64.16, codex-cli 0.139.0), cmux docs (`docs/agent-hooks.md`, `notifications.md`, `feed.md`), and a source-level dive of `github.com/manaflow-ai/cmux@main` (Swift macOS monorepo). Related: issues #326 (compat backlog), #332 (deprecate relay), #114 (native codex TUI + hooks), #201 (codex first-turn hang).
+
+---
+
+## 1. cmux socket is now reachable from ANY process (relay no longer must live in cmux)
+
+**Live-verified.** Running cmux with every cmux env var scrubbed (`env -i HOME PATH only` — simulates the launchd daemon, a non-cmux-descendant):
+```
+$ env -i HOME=$HOME PATH=$PATH cmux ping            -> PONG
+$ env -i HOME=$HOME PATH=$PATH cmux workspace list  -> * workspace:3  ⚓ cockpit-captain ...
+```
+cmux auto-discovers a **canonical socket** at `~/.local/state/cmux/cmux.sock` (`CMUX_SOCKET_PATH`; moved out of Application Support in cmux #5176) and authenticates without inherited env/password.
+
+**Consequence:** the premise behind cockpit's relay-proxy architecture — *"process-lineage denies all daemon-originated cmux calls"* — is **false** on 0.64.16. The daemon can call `cmux send/read-screen/workspace …` directly. → **#332** (deprecate notify-relay → daemon-direct). Closes the old #249 ("future non-cmux direct path") whose premise is now disproven.
+
+---
+
+## 2. How cmux detects agent lifecycle (the mechanism to learn)
+
+cmux tracks a 4-state lifecycle per agent session: **`running | idle | needsInput | unknown`** (`Sources/AgentHibernation/AgentHibernationLifecycleState.swift`, `allowsHibernation = (state == .idle)`).
+
+### 2a. Primary signal = HOOKS (source of truth)
+
+cmux installs a hook into each agent's **native config**, fired by the agent on lifecycle transitions, routed **over the socket**:
+```sh
+"$cmux_cli" --socket "$CMUX_SOCKET_PATH" hooks <agent> <sub>   # || echo '{}'  (never blocks the agent)
+```
+Canonical event → state map (`CLI/CMUXCLI+AgentHookDefinitions.swift`, `subcommandActions`):
+
+| Hook subcommand | Lifecycle | Trigger examples |
+|---|---|---|
+| `session-start`, `prompt-submit`, `shell-exec` | **running** | session begins / user prompt / tool starts |
+| `stop`, `agent-response` | **idle** | turn ended |
+| `notification`, `PermissionRequest` (feed, 120–125s sync) | **needsInput** | permission / blocking decision |
+| `session-end`, `session-finalize` | teardown | process exit |
+
+Hard rule (`Sources/Feed/FeedCoordinator.swift`): *an explicit running/idle/needsInput update from the agent always wins over any inferred state.* `needsInput` only relaxes to `running` on the next `prompt-submit`.
+
+**Per-agent native install** (`cmux hooks setup <agent>` — 16 agents: codex, grok, opencode, pi, omp, amp, cursor, gemini, kiro, rovodev, copilot, codebuddy, factory, qoder, antigravity, hermes):
+
+| Agent | Native file written | Events | Disable / config-dir env |
+|---|---|---|---|
+| **Claude Code** | *no persistent file* — per-launch PATH shim → `cmux-claude-wrapper` injects `--settings` hooks | SessionStart/UserPromptSubmit/PreToolUse/PermissionRequest/Notification/Stop/SessionEnd | `CMUX_CLAUDE_HOOKS_DISABLED=1` |
+| **Codex** | `~/.codex/hooks.json` + `~/.codex/config.toml` (`codex_hooks=true`) | SessionStart→running, UserPromptSubmit→running, Stop→idle; feed: PreToolUse, PermissionRequest | `CMUX_CODEX_HOOKS_DISABLED=1`, `CODEX_HOME` |
+| **Gemini** | `~/.gemini/settings.json` | SessionStart→running, BeforeAgent→running, AfterAgent→idle, SessionEnd | `CMUX_GEMINI_HOOKS_DISABLED=1` |
+| **OpenCode** | `~/.config/opencode/plugins/cmux-session.js` (+ `cmux-feed.js`) | SDK plugin event bus (self-registered) | `CMUX_OPENCODE_HOOKS_DISABLED=1`, `OPENCODE_CONFIG_DIR` |
+
+### 2b. Persistence: `~/.cmuxterm/<agent>-hook-sessions.json`
+
+The same hook write mirrors to a durable JSON store (`Sources/RestorableAgentTypes.swift` `hookStoreFileURL`; override `CMUX_AGENT_HOOK_STATE_DIR`). Live schema captured on this machine (`claude-hook-sessions.json`):
+```jsonc
+{
+  "activeSessionsBySurface": { "<SURFACE_UUID>": { "sessionId", "updatedAt" } },
+  "activeSessionsByWorkspace": { "<WORKSPACE_UUID>": { ... } },
+  "sessions": { "<sessionId>": {
+      "agentLifecycle": "running|idle|needsInput|unknown",
+      "cwd", "pid", "sessionId", "transcriptPath", "isRestorable",
+      "lastBody": "Claude needs your permission", "lastSubtitle": "Permission",
+      "launchCommand": { "launcher","executablePath","arguments","workingDirectory","environment","source" },
+      "updatedAt"
+  } }
+}
+```
+**Source of truth = live socket events (`agent.hook.*`); the JSON store is the durable mirror** (same write produces both; they don't diverge by design). For an external daemon the **file is the more stable contract** (`version:1`), the socket stream is lower-latency but internal/less-stable.
+
+### 2c. Hook-LESS fallback = liveness only, NOT lifecycle
+
+When no hook is installed (`Sources/VaultAgentProcessScanner.swift`, `CmuxTopSnapshot.swift`):
+- **libproc process scan** + `sysctl(KERN_PROCARGS2)` reads each PID's argv+env; binds process↔panel by matching `CMUX_WORKSPACE_ID`/`CMUX_SURFACE_ID` in its env; classifies claude/codex/opencode by binary basename/argv. → yields **liveness + identity only**; a purely process-detected entry gets `lifecycle: nil`.
+- **tail + PID fingerprint** (last 12 lines + sorted PID set, stable across `confirmationSeconds`) → quiescence test for hibernation (`Sources/App/AgentHibernationController.swift`).
+- **OSC 133** → shell command-block segmentation only. **OSC 9/99/777** → desktop notifications only. **Neither drives `agentLifecycle`** (the wrapper even disables Claude's OSC notif channel so hooks are the sole signal).
+
+→ **`needsInput`/`running`/`idle` are hook-only.** Hook-less gives you "alive + quiescent", never "waiting for a human".
+
+---
+
+## 3. Implication for what cockpit shipped (#328 B1 / #331 B4)
+
+- #328/#331 consume cmux's `agent.hook.*` socket events. Per §2a this **only fires for claude crews today** (claude auto-wraps; codex/gemini/opencode are NOT `cmux hooks setup`-installed on this machine → no events). Verified live: only `~/.cmuxterm/claude-hook-sessions.json` exists.
+- This is **option (b)** in §4 — the most cmux-coupled, least-stable-wire path. Treat #328/#331 as a **claude stopgap**, not the durable design.
+
+---
+
+## 4. Driver-agnostic design: a `LifecycleSource` port
+
+cockpit's stated goal: support multiple terminal drivers (cmux today, others later) without lifecycle detection dying on a driver swap. The user built the daemon precisely to avoid hard cmux-coupling — that concern is **validated** (cmux lifecycle = cmux hooks + cmux socket + cmux file).
+
+Define a `LifecycleSource` port in cockpitd, two implementations behind it:
+
+| Option | What | Pro | Con |
+|---|---|---|---|
+| **(A) CmuxStoreSource** *(ship now, as adapter)* | watch `~/.cmuxterm/<agent>-hook-sessions.json`, read `agentLifecycle`, verify `pid` liveness yourself | simplest; **16 agents free**; stable `version:1` schema; matches live reality | cmux-coupled (file vanishes if cmux swapped) |
+| **(B) Socket `agent.hook.*`** | subscribe to cmux event bus | push, low-latency | most coupled + least-stable wire; **avoid as primary** |
+| **(C) NativeHookSource** *(build incrementally, = the core)* | cockpit installs its OWN hooks into each agent native config (mirror `AgentHookDef`) → `cockpitd hooks <agent> <sub>`; + own `KERN_PROCARGS2` scan keyed on `COCKPIT_CREW_TASK_ID`/`COCKPIT_SURFACE`; + OSC 9/777 as universal turn-end hint | fully portable; survives cmux swap | reimplements cmux's installer + per-agent template matrix; risk of double-hook collision with cmux |
+
+**Recommendation: hybrid (A)+(C) behind the port.** Ship (A) as the cmux *driver adapter* now (cheapest accurate lifecycle for 16 agents). Build (C) as the driver-agnostic core. Both feed ONE normalized reducer using cmux's exact event→state map (§2a), honoring "explicit agent update wins". Process-scan + fingerprint = liveness/quiescence layer only, never a substitute for hook-only `needsInput`. This also folds into #332 (daemon-direct): the same daemon that drops the relay-proxy can read `~/.cmuxterm` + drop screen-scraping in one refactor.
+
+---
+
+## 5. Codex: run interactively via hooks instead of the app-server (big gap)
+
+### Today
+cockpit runs codex **not interactively**: `codex exec --json --skip-git-repo-check --sandbox workspace-write [task]` (one-shot/print, `src/control/headless/codex.ts`) plus an **app-server JSON-RPC client** (`src/control/codex/app-server-client.ts`). Code comment: *"until the interactive-wiring spec lands."* This is why codex crews can't take `cockpit crew send` follow-ups and why lifecycle/signal was fragile. Original blocker (memory): *"codex PARKED — signal lifecycle blocked by its workspace-write sandbox"* — `cockpit crew signal` (a shell call from inside the sandboxed codex) was denied.
+
+### What changed
+- **codex-cli 0.139.0 has a native hooks system** — verified live: `--dangerously-bypass-hook-trust` ("run enabled hooks without requiring persisted hook trust"), i.e. hooks + a **trust** model. This is the API cmux uses (`~/.codex/hooks.json` + `config.toml codex_hooks=true`).
+- cmux runs **bare interactive `codex` (TUI)** and gets lifecycle from these hooks — **no app-server, no JSON-RPC**.
+
+### The unlock
+cockpit can adopt cmux's pattern: **interactive `codex` TUI in a cmux surface + install `~/.codex/hooks.json`** (SessionStart→running, Stop→idle, PreToolUse/PermissionRequest→needsInput). Crucially this **sidesteps the original sandbox blocker**: lifecycle now comes from codex's own (trusted) hook process reporting out, NOT from a `cockpit crew signal` shell call the sandbox blocks. → drop the app-server complexity, gain multi-turn `crew send`, unify codex with the claude/opencode lifecycle model. This is exactly **issue #114** ("Hybrid: native codex TUI + hook-based daemon tracking, replaces #102").
+
+### Caveats to brainstorm
+- **Hook trust:** codex requires persisted hook trust (or the `--dangerously-bypass-hook-trust` flag — avoid; the user rejects "dangerously" flags). Need to find how codex persists hook trust and trust cockpit's hook once at setup.
+- **First-turn hang #201** must be handled in interactive mode.
+- **Collision:** if both cmux and cockpit install codex hooks, dedupe (cmux uses `~/.codex/hooks.json`; cockpit's NativeHookSource (§4C) could reuse or namespace).
+- Decide: cockpit installs its OWN codex hooks (option C, portable) vs relies on `cmux hooks setup codex` + reads `~/.cmuxterm/codex-hook-sessions.json` (option A, coupled).
+
+---
+
+## 6. Open questions for the brainstorm
+1. Port boundary: what's the minimal `LifecycleSource` interface (events? poll? both)? How does the reducer reconcile A vs C when both report?
+2. Migration: do #328/#331 get refactored behind the port, or kept as the cmux adapter and wrapped?
+3. Relay (#332): fully retire, or keep a thin in-process notification-delivery piece? Daemon-direct `cmux send` must re-home the #258/#302 defer-while-typing logic.
+4. Codex (#114): cockpit-owned hooks (portable) vs lean on cmux's codex hooks (coupled)? Trust handling without dangerous flags?
+5. Hibernation (C2, #329): if cockpit reads `~/.cmuxterm`, a hibernated crew must read as alive — reconcile with cmux's `allowsHibernation == idle`.
+6. Driver abstraction (#31): does the `LifecycleSource` port slot under the existing runtime/workspace/notifier plugin model?
+
+---
+
+## Key cmux source files (manaflow-ai/cmux@main)
+- `Resources/bin/cmux-claude-wrapper` — claude PATH-shim hook injection
+- `CLI/CMUXCLI+AgentHookDefinitions.swift` — per-agent native templates, event→subcommand map, socket-routed hook command
+- `Sources/RestorableAgentTypes.swift` / `RestorableAgentSession.swift` — `~/.cmuxterm/<agent>-hook-sessions.json` path + record schema + live-PID filter + process-detected merge
+- `Sources/AgentHibernation/AgentHibernationLifecycleState.swift` — the 4-state enum
+- `Sources/Feed/FeedCoordinator.swift` — socket-event reducer / needsInput attention / "explicit update wins"
+- `Sources/VaultAgentProcessScanner.swift`, `Sources/CmuxTopSnapshot.swift` — hook-less process scan (liveness/identity only)
+- `Sources/App/AgentHibernationController.swift` — tail+PID fingerprint quiescence
+- `Sources/CmuxEventPublishing.swift` (+ `docs/events.md`) — `agent.hook.*` socket bus (option B)

--- a/docs/research/2026-06-16-cmux-events-stream.md
+++ b/docs/research/2026-06-16-cmux-events-stream.md
@@ -1,0 +1,108 @@
+# cmux native event stream — investigation (audit item B1)
+
+**Date:** 2026-06-16 · **Branch:** `feat/cmux-events-stream` · **cmux:** 0.64.16 (96)
+
+Goal: reduce cockpit's fragile screen-scraping by consuming cmux's native event
+stream. **Additive & safe** — the events consumer runs alongside the existing
+relay-proxy / pane-reader path, which stays as the fallback during migration.
+
+## STEP 0 — does `cmux events` exist? YES.
+
+`cmux events` streams **newline-delimited JSON** over the cmux Unix socket.
+
+```
+cmux events [--after <seq>] [--cursor-file <path>] [--name <event>]
+            [--category <category>] [--reconnect] [--limit <n>]
+            [--no-ack] [--no-heartbeat]
+```
+
+- `--reconnect` — reconnect forever, resume from last received seq (in-process).
+- `--cursor-file <path>` — read the starting seq from a file, update it after
+  each event. **Durable resume across daemon restarts.**
+- `--after <seq>` — replay retained events after a sequence.
+- `--category` / `--name` — server-side filters, repeatable.
+- `--no-heartbeat` — suppress the 15s heartbeat frames.
+
+### Frame shapes (live-captured)
+
+**Ack** (first frame; suppress with `--no-ack`):
+```json
+{"type":"ack","protocol":"cmux-events","version":1,"boot_id":"…",
+ "subscription_id":"…","heartbeat_interval_seconds":15,"replay_count":0,
+ "resume":{"after_seq":null,"gap":false,"latest_seq":1434,"next_seq":1435,
+           "oldest_seq":1,"requested_after_seq":1434},
+ "filters":{"categories":[],"names":[]}}
+```
+`resume.gap:true` signals retained-buffer overflow (events were dropped).
+
+**Event**:
+```json
+{"type":"event","protocol":"cmux-events","version":1,"seq":1435,
+ "boot_id":"…","id":"…-1435","category":"agent",
+ "name":"agent.hook.PreToolUse","occurred_at":"2026-06-15T17:02:17.362Z",
+ "source":"claude","workspace_id":"2AED…","surface_id":null,"pane_id":null,
+ "window_id":null,
+ "payload":{ "_source":"claude","session_id":"claude-7ba3…","_ppid":70993,
+   "cwd":"/Users/q3labsadmin/me/claude-cockpit",
+   "hook_event_name":"PreToolUse","phase":"received|completed",
+   "tool_name":"Bash","workspace_id":"2AED…", … }}
+```
+
+### Categories / names observed live
+
+| category       | names                                                                  |
+|----------------|------------------------------------------------------------------------|
+| `agent`        | `agent.hook.PreToolUse`, `agent.hook.Stop`, `agent.hook.SubagentStop`  |
+| `feed`         | `feed.item.received`, `feed.item.completed`                             |
+| `notification` | `notification.created/requested/cleared/clear_requested`               |
+| `sidebar`      | `sidebar.metadata.updated`                                              |
+
+The `agent` category is what we want: it mirrors Claude Code hook events
+(`PreToolUse`, `Stop`, `SubagentStop`, etc.) with `payload.cwd`,
+`payload.session_id`, `payload._source` (agent kind), and `workspace_id`.
+
+## Key architectural difference vs the opencode SSE bridge
+
+`OpencodeSseBridge` subscribes **per-crew** to that crew's `opencode --port N`
+HTTP server. `cmux events` is a **single global stream** for the whole cmux app,
+carrying every agent's hook events. So the cmux bridge is **one** long-lived
+subscription owned by the daemon, and each frame is **correlated** to a crew
+TaskRecord rather than arriving pre-addressed.
+
+### Correlation key: `payload.cwd` → `TaskRecord.cwd`
+
+Interactive crews run in an **isolated worktree** whose path becomes the record's
+`cwd` (`crew.ts` sets `cwd: spawnCwd`). Each worktree path is unique, so
+`payload.cwd === rec.cwd` cleanly maps a hook event to its crew. We only consider
+**non-terminal interactive** records, matching `_source` to the record provider.
+
+Limitation (prototype): a `--shared` crew runs with `cwd === projRoot`, which
+collides with the captain's cwd — those fall back to the existing scrape path.
+This is acceptable: scrape remains the fallback by design.
+
+## Mapping (minimal, idempotent)
+
+| cmux event                         | ControlEvent emitted      | effect                         |
+|------------------------------------|---------------------------|--------------------------------|
+| `agent.hook.Stop` (main session)   | `task.turn.completed`     | working → awaiting-input       |
+| `agent.hook.SubagentStop`          | *(ignored)*               | subagent end ≠ turn end        |
+
+`Stop` is the high-value signal: it's exactly the "turn ended / crew idle" state
+the pane-reader currently infers by scraping the screen. `task.turn.completed` is
+**liveness, not completion** (anti-#2576): terminal state still comes from the
+explicit `cockpit crew signal done`. The state-machine reducer already absorbs
+duplicate/late `task.turn.completed`, so feeding it from BOTH the events bridge
+and the existing path is harmless — the core property that makes this additive.
+
+## Lifecycle
+
+- Started once in the daemon boot IIFE (next to opencode re-subscribe).
+- Durable resume via `--cursor-file <stateRoot>/cmux-events.seq` + `--reconnect`.
+- Stopped in the daemon's returned `stop()` (kill the child).
+- Gated behind `defaults.cmuxEventsBridge` (default **on**); set false to fall
+  back to scrape-only.
+
+## Conclusion
+
+`cmux events` exists, is stable JSON, exposes the agent hook surface we need, and
+resumes durably. Safe to prototype a consumer alongside the scrape fallback.

--- a/docs/research/2026-06-16-cmux-events-stream.md
+++ b/docs/research/2026-06-16-cmux-events-stream.md
@@ -145,3 +145,38 @@ in the relay/probe path and not unblocked by any event here.
 resumes durably. It does **not** expose surface lifecycle events, so the
 event-driven reaper/prune the audit hypothesized is not possible on this version.
 Safe to prototype the agent-hook consumer alongside the scrape fallback — done.
+
+## STEP 3 follow-up — relay stale-ref noise, fixed the polled way
+
+Implemented in `feat/lifecycle-hardening`. The observed per-cycle noise was the
+daemon sweep re-healing relay records for projects whose **captain workspace is
+permanently gone** (live `cockpitd.log` showed `relay heal pact-network: captain
+workspace not present` every cycle for `pact-network`/`oneplan`). Mechanism: a
+failing/absent cmux lookup degrades gracefully in code, but cmux's CLI **stderr
+is inherited** by the daemon (`execFileSync` default), so each retry also echoes
+cmux's own `Error: not_found …` to our stderr.
+
+Fix (polled, no surface events needed): `createRelayHealer` now returns
+`"captain-absent"` when the captain workspace no longer resolves; the sweep
+prunes that relay-health record (and its debounce) so the heal/log fires **once**
+then goes quiet. A captain restart re-registers a fresh relay, so recovery is
+unaffected. The crew-surface probe poll set was already pruned of terminal crews
+(`cockpitd` evicts `inFlightProbes`/`probeResults` on terminal state, and
+`proxiedSurfaceAlive` only enqueues non-terminal records), so no change there.
+
+## C2 — agent hibernation: investigated, deferred (global-only, unsafe)
+
+`cmux agent-hibernation --help` in 0.64.16 is `cmux agent-hibernation <on|off>`
+— a **GLOBAL, app-wide** toggle with no per-session or per-workspace argument
+("Configure idle and live-terminal limits from Settings"). Enabling it would
+hibernate **every** agent/terminal session, including the **captain** and the
+**notify-relay** — both must stay responsive to deliver notifications — which
+would break orchestration. Idle trigger is configured globally (Settings/JSON),
+not scopeable to crews.
+
+**Decision: do NOT enable.** Wired a documented OFF flag
+`defaults.cmuxAgentHibernation` (default `false`) in `src/config.ts` as a
+decision record + forward hook for if/when cmux adds crew-only scoping. Because
+it is global-only, the surface-liveness reaper needs no "hibernated = alive"
+change in this PR (nothing is hibernated). Revisit if cmux exposes per-session
+hibernation.

--- a/docs/research/2026-06-16-cmux-events-stream.md
+++ b/docs/research/2026-06-16-cmux-events-stream.md
@@ -119,6 +119,23 @@ PreToolUse→working / Stop→idle to replace the spinner scrape entirely. This 
 already consumes `Stop`; extending to PreToolUse-as-working is the natural next
 step. (Reporting only, per the task — not implemented here.)
 
+**STATUS — IMPLEMENTED (B4/A3, branch `feat/agent-hook-runstate`).** The
+working-state half now ships, but as a *false-stall suppressor*, not a spinner
+replacement. `deriveRunState()` classifies `PreToolUse`/`UserPromptSubmit` →
+`working` and `Stop` → `idle`. The bridge feeds a `working` hook into the
+liveness path **additively** as `task.progress` (the reducer's documented
+real-activity signal, state-machine.ts), which refreshes `lastHeartbeatAt` — the
+exact clock `evaluateStall` keys off — so a crew mid long, screen-quiet tool call
+is **not** false-idled (#292), and a crew the scrape path wrongly idled resumes
+to `working`. No change to `liveness.ts`/`watchdog.ts` was needed: suppression is
+achieved through the heartbeat clock they already consult. Screen-scraping stays
+as the fallback; the whole path is gated by `defaults.cmuxEventsBridge`.
+Re-verified live on 2026-06-16 that `agent.hook.PreToolUse` reaches
+`cmux events --category agent`. `UserPromptSubmit` is mapped opportunistically
+(not observed in 0.64.16 captures; harmless if it never fires). The spinner-scrape
+*replacement* (dropping `classifyStartupSurface`/`CC_WORKING_RE`) remains future
+work and is explicitly out of scope — that path is the most bug-fixed in the repo.
+
 ## Surface lifecycle events — audit premise does NOT match cmux 0.64.16
 
 The audit assumed the stream emits `surface.created/closed/selected` +

--- a/docs/research/2026-06-16-cmux-events-stream.md
+++ b/docs/research/2026-06-16-cmux-events-stream.md
@@ -102,7 +102,46 @@ and the existing path is harmless — the core property that makes this additive
 - Gated behind `defaults.cmuxEventsBridge` (default **on**); set false to fall
   back to scrape-only.
 
+## B4 check — does the stream carry agent run-state? YES, via agent hooks.
+
+The audit asked whether the stream exposes claude/codex **working vs idle** so
+cockpit could drop the read-screen spinner heuristics
+(`classifyStartupSurface` / `CC_WORKING_RE`). There is **no dedicated
+"agent.status" query method** (`cmux capabilities` has no agent run-state
+method; the closest is `surface.report_shell_state`). But run-state **is**
+derivable from the `agent` event category itself:
+
+- `agent.hook.PreToolUse` / `UserPromptSubmit` → the agent is **working**.
+- `agent.hook.Stop` → the agent is **idle** (turn ended).
+
+So B4 is feasible **on top of this same stream**: a future PR could map
+PreToolUse→working / Stop→idle to replace the spinner scrape entirely. This PR
+already consumes `Stop`; extending to PreToolUse-as-working is the natural next
+step. (Reporting only, per the task — not implemented here.)
+
+## Surface lifecycle events — audit premise does NOT match cmux 0.64.16
+
+The audit assumed the stream emits `surface.created/closed/selected` +
+`workspace.selected` (for an event-driven crew-surface reaper — STEP 2 — and an
+authoritative stale-ref prune — STEP 3). **Live verification contradicts this.**
+Creating and then closing a workspace while subscribed with
+`--category surface` produced only `surface.input_sent` / `surface.key_sent`
+(keystroke echoes) — **no** `surface.created` / `surface.closed` /
+`surface.selected` frame fired. There is also no `~/.cmuxterm/events.jsonl`
+file; the stream is socket-based (`cmux events`).
+
+**Implication:** an event-driven surface reaper / stale-ref prune cannot be built
+on `surface.closed` in cmux 0.64.16 — that event does not exist. The
+**agent-hook** approach this PR ships (`agent.hook.Stop` → turn-end / idle) is
+the achievable B1 win. STEP 3's relay "Workspace not found" noise must be fixed
+the polled way (a per-sweep workspace-list guard + prune-once log), independent
+of the event stream — flagged to the captain as a separate follow-up, since it's
+in the relay/probe path and not unblocked by any event here.
+
 ## Conclusion
 
-`cmux events` exists, is stable JSON, exposes the agent hook surface we need, and
-resumes durably. Safe to prototype a consumer alongside the scrape fallback.
+`cmux events` exists, is stable JSON, exposes the **agent hook** surface we need
+(idle via `Stop`, working via `PreToolUse` — enough for B1 and a future B4), and
+resumes durably. It does **not** expose surface lifecycle events, so the
+event-driven reaper/prune the audit hypothesized is not possible on this version.
+Safe to prototype the agent-hook consumer alongside the scrape fallback — done.

--- a/docs/research/2026-06-16-cmux-workspace-groups-audit-C1.md
+++ b/docs/research/2026-06-16-cmux-workspace-groups-audit-C1.md
@@ -1,0 +1,114 @@
+# cmux workspace groups — investigation & disposition (audit item C1)
+
+**Date:** 2026-06-16 · **Branch:** `feat/workspace-groups` · **cmux:** 0.64.16 (96)
+
+**Disposition: DEFER.** Investigated all three proposed mappings live. None map
+cleanly onto cockpit's surface-based crew model + existing launch flow without
+either spawning phantom workspaces or an architectural redesign. No runtime code
+was added — this is an "investigated, dispositioned" outcome.
+
+## The proposal
+
+The audit suggested mapping **captain → group anchor, crews → group members**
+using `cmux workspace-group` (0.64.x: `create`/`add`/`remove`/`set-color`/
+`set-icon`/`move`/`focus`/`new-workspace` + per-group placement). Three concrete
+options were on the table:
+
+- **(a)** Per-project visual identity — give each captain workspace a colored/
+  iconed group header so projects are distinguishable at a glance.
+- **(b)** Cross-project sibling grouping — group the captain workspaces of
+  projects sharing a cockpit `group` (e.g. all `scaffold-*`) under one cmux
+  group. Aligns with the "sibling projects aware of each other" goal.
+- **(c)** The original captain+crews framing.
+
+## STEP 0 — what does `workspace-group` actually operate on?
+
+`cmux workspace-group --help` is unambiguous:
+
+> Each group is owned by an **"anchor" workspace**; the group header IS the
+> anchor's sidebar representation. Closing the anchor dissolves the group while
+> preserving its other members as ungrouped workspaces.
+
+**Groups group whole _workspaces_, not _surfaces_.** Live-captured shape:
+
+```json
+{ "groups": [ {
+    "anchor_workspace_ref": "workspace:4",
+    "custom_color": null, "icon_symbol": null,
+    "is_collapsed": false, "is_pinned": false,
+    "member_count": 2,
+    "member_workspace_refs": ["workspace:4", "workspace:1"],
+    "name": "cockpit-shape-probe",
+    "ref": "workspace_group:1"
+} ], "window_ref": "window:1" }
+```
+
+## Cockpit reality (confirmed live)
+
+Cockpit creates **one workspace per project** — the captain — via
+`cmux workspace create --command <agentCmd>` (`src/runtimes/cmux.ts` `spawn()`).
+**Crews spawn as `new-surface` tabs _inside_ the captain's workspace**
+(`cmux.ts` `newPane()` / `spawnInjector()`), not as separate workspaces. The
+separate-workspace-per-crew redesign was rejected in #117.
+
+Directly confirmed while investigating: this crew's own CLI ran as
+`surface:18` inside `workspace:3` titled `⚓ cockpit-captain` — i.e. a surface
+in the captain workspace, exactly the model above.
+
+## Why each option does not map cleanly
+
+### (c) captain + crews → **hard mismatch**
+Crews are _surfaces_; `workspace-group` can only contain _workspaces_. There is
+exactly one workspace per project (the captain's). "Captain + its crew tabs as a
+group" has no representation. Dead, as the prior crew predicted.
+
+### (a) / (b) workspace-level grouping → **not clean: phantom workspaces**
+Both (a) and (b) operate at the right altitude (workspace↔workspace), so they
+_look_ viable. They are not, because of how a group comes into existence:
+
+- **`create` spawns a phantom anchor.** Live test:
+  `workspace-group create --name X --from workspace:1` produced a **brand-new**
+  `workspace:4` as the anchor and added `workspace:1` as a member
+  (`member_count: 2`). It did **not** simply wrap the existing workspace. So
+  forming a group around already-running captain workspaces leaves a stray,
+  empty anchor workspace behind.
+- **No `--command` genesis path.** Neither `workspace-group create` nor
+  `workspace-group new-workspace` accepts `--command`, so a captain — which
+  must be born with its agent CLI via `cmux workspace create --command …` —
+  cannot be created _inside_ a group through the group CLI. The captain can only
+  be `add`-ed to a group _after_ it already exists as a standalone workspace.
+- **Genesis therefore requires `create` → phantom**, then `add` the real
+  captains, then `set-anchor` to a real captain, then close the phantom. That is
+  multi-step driver-fighting, not a clean wiring — precisely what the task
+  warned against ("coordinate via config, don't fight the driver"). It even trips
+  cockpit's own workspace-protection guard: the auto-mode classifier denied
+  closing the phantom workspace ("user's own workspaces untouched").
+
+Making the phantom _useful_ (a dedicated always-present "group home" workspace
+per group) would be a new architectural element — out of scope for a
+conservative release and explicitly a "defer on architectural redesign" case.
+
+## Decision
+
+**DEFER.** No runtime code added. Per the audit's decision rule, a clean
+investigated-and-dispositioned outcome is the deliverable here.
+
+Re-open if **either** upstream change lands in cmux:
+
+1. A phantom-free way to form a group from an existing workspace (e.g.
+   `workspace-group create --anchor <existingWs>` that promotes it in place), **or**
+2. `--command` support on `workspace-group new-workspace` / `create`, letting a
+   captain be born directly inside a group through the normal spawn path.
+
+With either, **option (b)** (cross-project sibling grouping keyed off the
+existing `ProjectConfig.group` field) becomes the clean, valuable target, with
+(a)'s per-project color as a deterministic side-benefit. Until then, projects
+remain visually distinguished by their captain workspace emoji/title (e.g.
+`⚓ cockpit-captain`), which already covers the bulk of (a)'s value with zero
+risk.
+
+## Verification artifacts cleaned up
+
+The probe created `workspace:4` (`cockpit-shape-probe`); it was ungrouped and
+closed, and the sidebar was confirmed restored to its pre-probe state
+(captain + user home, 0 groups).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-cockpit",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "Multi-project agent orchestration for Claude Code",
   "type": "module",
   "bin": {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -5,6 +5,7 @@ import { stat } from "node:fs/promises";
 import path from "node:path";
 import chalk from "chalk";
 import { loadConfig } from "../config.js";
+import { compatManifest } from "../lib/compat-manifest.js";
 import { createCmuxDriver, RuntimeRegistry } from "../runtimes/index.js";
 import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
 import { createCmuxNotifier, NotifierRegistry } from "../notifiers/index.js";
@@ -31,11 +32,12 @@ function claudeVersionOk(): boolean {
     const version = execSync("claude --version", { encoding: "utf-8" }).trim();
     const match = version.match(/(\d+)\.(\d+)\.(\d+)/);
     if (!match) return false;
-    const [, major, minor, patch] = match.map(Number);
+    const [major, minor, patch] = match.slice(1).map(Number);
+    const [minMajor, minMinor, minPatch] = compatManifest.tools.claude.min.split(".").map(Number);
     return (
-      major > 2 ||
-      (major === 2 && minor > 1) ||
-      (major === 2 && minor === 1 && patch >= 32)
+      major > minMajor ||
+      (major === minMajor && minor > minMinor) ||
+      (major === minMajor && minor === minMinor && patch >= minPatch)
     );
   } catch {
     return false;
@@ -89,7 +91,7 @@ export const doctorCommand = new Command("doctor")
     const results: boolean[] = [];
 
     results.push(check("Claude Code installed", commandExists("claude")));
-    results.push(check("Claude Code version >= 2.1.32", claudeVersionOk()));
+    results.push(check(`Claude Code version >= ${compatManifest.tools.claude.min}`, claudeVersionOk()));
     results.push(check("Obsidian installed", commandExists("obsidian") || fs.existsSync("/Applications/Obsidian.app")));
     results.push(check("Node.js >= 18", nodeVersionOk()));
     results.push(

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -5,7 +5,8 @@ import { stat } from "node:fs/promises";
 import path from "node:path";
 import chalk from "chalk";
 import { loadConfig } from "../config.js";
-import { compatManifest } from "../lib/compat-manifest.js";
+import { compatManifest, type ToolEntry } from "../lib/compat-manifest.js";
+import { checkToolCompat } from "../lib/tool-compat.js";
 import { createCmuxDriver, RuntimeRegistry } from "../runtimes/index.js";
 import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js";
 import { createCmuxNotifier, NotifierRegistry } from "../notifiers/index.js";
@@ -72,9 +73,17 @@ function pluginInstalled(pluginKey: string): boolean {
 }
 
 function nodeVersionOk(): boolean {
-  const version = process.versions.node;
-  const major = parseInt(version.split(".")[0], 10);
-  return major >= 18;
+  const major = parseInt(process.versions.node.split(".")[0], 10);
+  const [minMajor] = compatManifest.tools.node.min.split(".").map(Number);
+  return major >= minMajor;
+}
+
+function tryGetVersion(cmd: string): string {
+  try {
+    return execSync(`${cmd} --version`, { encoding: "utf-8" }).trim();
+  } catch {
+    return "";
+  }
 }
 
 function check(label: string, pass: boolean): boolean {
@@ -209,6 +218,29 @@ export const doctorCommand = new Command("doctor")
     // #77 service-health: live per-component liveness from the daemon. Printed
     // before the prereq-fail exit so a degraded install still shows what is up.
     printServiceHealth(await queryHealth());
+
+    // Non-blocking version compat drift for every tool in the manifest.
+    // Tools not installed are skipped silently; only drift (below min / above
+    // lastVerified) produces a warning line — nothing here causes an exit.
+    console.log(chalk.bold("\nTool Version Compat\n"));
+    const toolVersionMap: Record<string, string> = {
+      cmux:     probeResults["cmux"]?.version ?? "",
+      claude:   tryGetVersion("claude"),
+      node:     process.versions.node,
+      codex:    tryGetVersion("codex"),
+      gemini:   tryGetVersion("gemini"),
+      opencode: tryGetVersion("opencode"),
+    };
+    for (const [name, entry] of Object.entries(compatManifest.tools) as [string, ToolEntry][]) {
+      const version = toolVersionMap[name] ?? "";
+      if (!version) continue;
+      const warn = checkToolCompat(name, version, entry);
+      if (warn) {
+        console.log(`  ${chalk.yellow("⚠ WARN")}  ${name}: ${warn}`);
+      } else {
+        console.log(`  ${chalk.green("✔ OK  ")}  ${name}: ${version}`);
+      }
+    }
 
     if (results.some((r) => !r)) {
       process.exit(1);

--- a/src/commands/heal.ts
+++ b/src/commands/heal.ts
@@ -14,6 +14,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { queryHealth } from "./health-view.js";
 import { createRelayHealer } from "../control/relay-healer.js";
+import type { RelayHealOutcome } from "../control/daemon.js";
 import { ensureDaemon as _ensureDaemon } from "../control/launchd.js";
 import type { ComponentHealth, HealthState } from "../control/liveness.js";
 
@@ -124,7 +125,7 @@ export async function runHealStatus(opts: HealStatusOpts): Promise<number> {
 export interface HealRelayOpts {
   project: string;
   queryHealth: typeof queryHealth;
-  relayHealer: (project: string) => Promise<void>;
+  relayHealer: (project: string) => Promise<RelayHealOutcome | void>;
   stdout: NodeJS.WritableStream;
   stderr: NodeJS.WritableStream;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -89,6 +89,9 @@ export interface CockpitConfig {
     taskTimeoutMs?: number;
     /** #275 rule-based crew routing: keyword rules map task text to {agent, model}. Optional — absent = fall through to defaults.roles.crew. */
     crewRouting?: CrewRoutingConfig;
+    /** B1: consume cmux's native event stream for crew turn-end (idle) detection
+     *  alongside the scrape fallback. Default true; set false for scrape-only. */
+    cmuxEventsBridge?: boolean;
   };
   metrics: {
     enabled: boolean;
@@ -131,6 +134,7 @@ export function getDefaultConfig(): CockpitConfig {
         side: { agent: "claude", model: "opus" },
       },
       taskTimeoutMs: 8 * 60 * 60 * 1000,
+      cmuxEventsBridge: true,
       crewRouting: {
         rules: [
           { tier: "extreme", match: "redesign|architect|rewrite|from scratch|deep reasoning", agent: "claude", model: "opus" },

--- a/src/config.ts
+++ b/src/config.ts
@@ -92,6 +92,17 @@ export interface CockpitConfig {
     /** B1: consume cmux's native event stream for crew turn-end (idle) detection
      *  alongside the scrape fallback. Default true; set false for scrape-only. */
     cmuxEventsBridge?: boolean;
+    /**
+     * Audit C2 — agent hibernation (reclaim idle-crew RAM). INTENTIONALLY OFF and
+     * INERT: cmux 0.64.16's `cmux agent-hibernation <on|off>` is GLOBAL (app-wide,
+     * no per-session/per-workspace scope), so enabling it would also hibernate the
+     * CAPTAIN and the notify-relay — both must stay responsive to deliver
+     * notifications — breaking orchestration. We do NOT call `agent-hibernation on`
+     * anywhere; this flag is a documented decision record + a forward hook for when
+     * cmux gains crew-only scoping. Until then leave false.
+     * See docs/research/2026-06-16-cmux-events-stream.md (C2 finding).
+     */
+    cmuxAgentHibernation?: boolean;
   };
   metrics: {
     enabled: boolean;
@@ -135,6 +146,9 @@ export function getDefaultConfig(): CockpitConfig {
       },
       taskTimeoutMs: 8 * 60 * 60 * 1000,
       cmuxEventsBridge: true,
+      // Audit C2: OFF by design — cmux hibernation is global-only and would
+      // hibernate the captain/relay. See the field doc above.
+      cmuxAgentHibernation: false,
       crewRouting: {
         rules: [
           { tier: "extreme", match: "redesign|architect|rewrite|from scratch|deep reasoning", agent: "claude", model: "opus" },

--- a/src/control/__tests__/cockpitd-cmux-events.test.ts
+++ b/src/control/__tests__/cockpitd-cmux-events.test.ts
@@ -1,0 +1,35 @@
+// src/control/__tests__/cockpitd-cmux-events.test.ts
+//
+// B1: the daemon wires the cmux native-events bridge additively — it starts on
+// boot and stops on daemon shutdown. An injected fake keeps this off the real
+// `cmux events` process (the real default is skipped under vitest).
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startCockpitd } from "../cockpitd.js";
+
+describe("cockpitd cmux events bridge wiring", () => {
+  let stop: (() => void) | undefined;
+  let dir: string;
+  afterEach(() => { stop?.(); if (dir) rmSync(dir, { recursive: true, force: true }); });
+
+  it("starts the injected bridge on boot and stops it on shutdown", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-cmuxev-"));
+    const bridge = { start: vi.fn(), stop: vi.fn() };
+    const handle = startCockpitd({
+      stateRoot: join(dir, "state"),
+      sockPath: join(dir, "c.sock"),
+      sweepMs: 0,
+      cmuxEventsBridge: bridge,
+    });
+    stop = handle.stop;
+    // Boot work runs in an async IIFE; let it flush.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(bridge.start).toHaveBeenCalledTimes(1);
+
+    await handle.stop();
+    stop = undefined;
+    expect(bridge.stop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/control/__tests__/daemon-relay-health.test.ts
+++ b/src/control/__tests__/daemon-relay-health.test.ts
@@ -93,6 +93,60 @@ describe("daemon relay health (#207)", () => {
     expect(healed).toEqual([]);
   });
 
+  it("prunes a relay whose captain workspace is gone — heals + logs ONCE (audit STEP 3)", async () => {
+    let t = 1000;
+    const healed: string[] = [];
+    const store = createStore(dir);
+    // Fixture: a stale relay ref whose captain workspace no longer resolves.
+    const d = createDaemon({
+      store,
+      now: () => t,
+      healRelay: (p) => { healed.push(p); return "captain-absent"; },
+    });
+    d.registerRelay({ project: "dead-proj", pid: 42, startedAt: 900 });
+
+    // Gone past the window → heal fires once and reports the captain absent.
+    t = 1000 + RELAY_GONE_MS + 1;
+    await d.sweep();
+    expect(healed).toEqual(["dead-proj"]);
+    // The stale record is pruned, so the liveness surface no longer carries it…
+    expect(d.getRelayHealth()).toEqual([]);
+
+    // …and every subsequent sweep is quiet: no re-heal, no per-cycle spam.
+    for (let i = 0; i < 3; i++) {
+      t += RELAY_GONE_MS + 1;
+      await d.sweep();
+    }
+    expect(healed).toEqual(["dead-proj"]);
+  });
+
+  it("a captain that restarts after a prune re-registers and heals again", async () => {
+    let t = 1000;
+    const healed: string[] = [];
+    const store = createStore(dir);
+    let captainPresent = false;
+    const d = createDaemon({
+      store,
+      now: () => t,
+      healRelay: (p) => { healed.push(p); return captainPresent ? "healed" : "captain-absent"; },
+    });
+    d.registerRelay({ project: "p", pid: 42, startedAt: 900 });
+
+    // Captain gone → first sweep heals once and prunes.
+    t = 1000 + RELAY_GONE_MS + 1;
+    await d.sweep();
+    expect(healed).toEqual(["p"]);
+    expect(d.getRelayHealth()).toEqual([]);
+
+    // Captain comes back: a fresh relay registers, then goes dark again later.
+    captainPresent = true;
+    t += 1000;
+    d.registerRelay({ project: "p", pid: 99, startedAt: t });
+    t += RELAY_GONE_MS + 1;
+    await d.sweep();
+    expect(healed).toEqual(["p", "p"]); // heals again — the prune did not blacklist it
+  });
+
   it("a throwing healRelay never breaks the sweep", async () => {
     let t = 1000;
     const store = createStore(dir);

--- a/src/control/cmux/__tests__/events-bridge.test.ts
+++ b/src/control/cmux/__tests__/events-bridge.test.ts
@@ -1,0 +1,161 @@
+// Tests for the cmux native-events → ControlEvent bridge (audit B1).
+// The bridge subscribes ONCE to `cmux events` (a single global newline-delimited
+// JSON stream over the cmux socket) and correlates each agent hook frame to a
+// crew TaskRecord by cwd, mapping `agent.hook.Stop` → `task.turn.completed`.
+// This is the events-stream alternative to scraping a crew's pane for idle.
+import { describe, it, expect, vi } from "vitest";
+import { Readable } from "node:stream";
+import { EventEmitter } from "node:events";
+import { CmuxEventsBridge } from "../events-bridge.js";
+import type { ControlEvent } from "../../types.js";
+
+/** A fake `cmux events` child: stdout streams the given lines, then exits. */
+function fakeChild(lines: string[]) {
+  const stdout = Readable.from(lines.map((l) => Buffer.from(l)));
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: Readable;
+    kill: () => void;
+  };
+  child.stdout = stdout;
+  child.kill = vi.fn(() => stdout.destroy());
+  // Emit "exit" once stdout drains, mirroring a real child whose stream ended.
+  stdout.on("end", () => child.emit("exit", 0, null));
+  return child;
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+const ack =
+  '{"type":"ack","protocol":"cmux-events","resume":{"latest_seq":1,"gap":false}}\n';
+
+function stopFrame(cwd: string, phase = "completed", name = "agent.hook.Stop") {
+  return (
+    JSON.stringify({
+      type: "event",
+      category: "agent",
+      name,
+      seq: 2,
+      source: "claude",
+      workspace_id: "ws1",
+      payload: { _source: "claude", session_id: "claude-abc", cwd, phase },
+    }) + "\n"
+  );
+}
+
+describe("CmuxEventsBridge", () => {
+  it("maps agent.hook.Stop → task.turn.completed for the matching crew cwd", async () => {
+    const events: ControlEvent[] = [];
+    const resolve = (e: { cwd?: string }) =>
+      e.cwd === "/wt/crew-a" ? { id: "task-a" } : undefined;
+    const spawnImpl = vi.fn((_bin: string, _args: string[]) =>
+      fakeChild([ack, stopFrame("/wt/crew-a")]),
+    );
+
+    const bridge = new CmuxEventsBridge({
+      emit: (e) => events.push(e),
+      resolve,
+      cursorFile: "/tmp/seq",
+      spawnImpl: spawnImpl as never,
+      stopAfterFirstRun: true,
+    });
+    bridge.start();
+    await flush();
+    await flush();
+
+    // It invoked `cmux events` with reconnect + cursor-file + agent category.
+    const args = spawnImpl.mock.calls[0][1];
+    expect(args).toContain("events");
+    expect(args).toContain("--reconnect");
+    expect(args).toContain("--cursor-file");
+    expect(args).toContain("/tmp/seq");
+    expect(args).toEqual(expect.arrayContaining(["--category", "agent"]));
+
+    expect(events).toEqual([
+      { type: "task.turn.completed", id: "task-a", turnId: "claude-abc" },
+    ]);
+    bridge.stop();
+  });
+
+  it("ignores frames with no matching crew, the ack, and SubagentStop", async () => {
+    const events: ControlEvent[] = [];
+    const resolve = (e: { cwd?: string }) =>
+      e.cwd === "/wt/known" ? { id: "t" } : undefined;
+    const lines = [
+      ack,
+      stopFrame("/wt/unknown"), // no matching record
+      stopFrame("/wt/known", "completed", "agent.hook.SubagentStop"), // subagent ≠ turn
+      stopFrame("/wt/known"), // the only one that should fire
+    ];
+    const bridge = new CmuxEventsBridge({
+      emit: (e) => events.push(e),
+      resolve,
+      cursorFile: "/tmp/seq",
+      spawnImpl: (() => fakeChild(lines)) as never,
+      stopAfterFirstRun: true,
+    });
+    bridge.start();
+    await flush();
+    await flush();
+    expect(events).toEqual([
+      { type: "task.turn.completed", id: "t", turnId: "claude-abc" },
+    ]);
+    bridge.stop();
+  });
+
+  it("emits once per Stop, ignoring the received-phase duplicate", async () => {
+    const events: ControlEvent[] = [];
+    const lines = [
+      ack,
+      stopFrame("/wt/x", "received"), // the paired received frame — must NOT fire
+      stopFrame("/wt/x", "completed"),
+    ];
+    const bridge = new CmuxEventsBridge({
+      emit: (e) => events.push(e),
+      resolve: () => ({ id: "x" }),
+      cursorFile: "/tmp/seq",
+      spawnImpl: (() => fakeChild(lines)) as never,
+      stopAfterFirstRun: true,
+    });
+    bridge.start();
+    await flush();
+    await flush();
+    expect(events.filter((e) => e.type === "task.turn.completed")).toHaveLength(1);
+    bridge.stop();
+  });
+
+  it("survives a malformed line without emitting", async () => {
+    const events: ControlEvent[] = [];
+    const bridge = new CmuxEventsBridge({
+      emit: (e) => events.push(e),
+      resolve: () => ({ id: "x" }),
+      cursorFile: "/tmp/seq",
+      spawnImpl: (() => fakeChild([ack, "not json\n", stopFrame("/wt/x")])) as never,
+      stopAfterFirstRun: true,
+    });
+    bridge.start();
+    await flush();
+    await flush();
+    expect(events).toHaveLength(1);
+    bridge.stop();
+  });
+
+  it("buffers partial lines across chunk boundaries", async () => {
+    const events: ControlEvent[] = [];
+    const full = stopFrame("/wt/x");
+    const mid = Math.floor(full.length / 2);
+    // Split one JSON frame across two stdout chunks.
+    const bridge = new CmuxEventsBridge({
+      emit: (e) => events.push(e),
+      resolve: () => ({ id: "x" }),
+      cursorFile: "/tmp/seq",
+      spawnImpl: (() =>
+        fakeChild([ack, full.slice(0, mid), full.slice(mid)])) as never,
+      stopAfterFirstRun: true,
+    });
+    bridge.start();
+    await flush();
+    await flush();
+    expect(events).toHaveLength(1);
+    bridge.stop();
+  });
+});

--- a/src/control/cmux/__tests__/events-bridge.test.ts
+++ b/src/control/cmux/__tests__/events-bridge.test.ts
@@ -6,8 +6,10 @@
 import { describe, it, expect, vi } from "vitest";
 import { Readable } from "node:stream";
 import { EventEmitter } from "node:events";
-import { CmuxEventsBridge } from "../events-bridge.js";
-import type { ControlEvent } from "../../types.js";
+import { CmuxEventsBridge, deriveRunState } from "../events-bridge.js";
+import { reduce } from "../../state-machine.js";
+import { evaluateStall } from "../../watchdog.js";
+import type { ControlEvent, TaskRecord } from "../../types.js";
 
 /** A fake `cmux events` child: stdout streams the given lines, then exits. */
 function fakeChild(lines: string[]) {
@@ -40,6 +42,11 @@ function stopFrame(cwd: string, phase = "completed", name = "agent.hook.Stop") {
       payload: { _source: "claude", session_id: "claude-abc", cwd, phase },
     }) + "\n"
   );
+}
+
+/** A "working" agent hook frame (PreToolUse / UserPromptSubmit). */
+function workingFrame(cwd: string, name = "agent.hook.PreToolUse", phase = "completed") {
+  return stopFrame(cwd, phase, name);
 }
 
 describe("CmuxEventsBridge", () => {
@@ -157,5 +164,128 @@ describe("CmuxEventsBridge", () => {
     await flush();
     expect(events).toHaveLength(1);
     bridge.stop();
+  });
+});
+
+// B4/A3 — run-state derivation: PreToolUse/UserPromptSubmit → working, Stop → idle.
+describe("deriveRunState", () => {
+  it("maps PreToolUse and UserPromptSubmit to working", () => {
+    expect(deriveRunState("agent.hook.PreToolUse")).toBe("working");
+    expect(deriveRunState("agent.hook.UserPromptSubmit")).toBe("working");
+  });
+  it("maps Stop to idle", () => {
+    expect(deriveRunState("agent.hook.Stop")).toBe("idle");
+  });
+  it("ignores SubagentStop and unknown names (subagent end ≠ turn end)", () => {
+    expect(deriveRunState("agent.hook.SubagentStop")).toBeNull();
+    expect(deriveRunState("agent.hook.PostToolUse")).toBeNull();
+    expect(deriveRunState("")).toBeNull();
+  });
+});
+
+// B4/A3 — the bridge emits task.progress for a working hook so the crew's
+// liveness clock stays fresh while a turn is live (false-stall suppression).
+describe("CmuxEventsBridge working hooks → task.progress", () => {
+  it("maps agent.hook.PreToolUse → task.progress for the matching crew cwd", async () => {
+    const events: ControlEvent[] = [];
+    const bridge = new CmuxEventsBridge({
+      emit: (e) => events.push(e),
+      resolve: (h) => (h.cwd === "/wt/crew-a" ? { id: "task-a" } : undefined),
+      cursorFile: "/tmp/seq",
+      spawnImpl: (() => fakeChild([ack, workingFrame("/wt/crew-a")])) as never,
+      stopAfterFirstRun: true,
+    });
+    bridge.start();
+    await flush();
+    await flush();
+    expect(events).toEqual([{ type: "task.progress", id: "task-a", note: "agent.hook.PreToolUse" }]);
+    bridge.stop();
+  });
+
+  it("maps agent.hook.UserPromptSubmit → task.progress", async () => {
+    const events: ControlEvent[] = [];
+    const bridge = new CmuxEventsBridge({
+      emit: (e) => events.push(e),
+      resolve: () => ({ id: "t" }),
+      cursorFile: "/tmp/seq",
+      spawnImpl: (() =>
+        fakeChild([ack, workingFrame("/wt/x", "agent.hook.UserPromptSubmit")])) as never,
+      stopAfterFirstRun: true,
+    });
+    bridge.start();
+    await flush();
+    await flush();
+    expect(events).toEqual([{ type: "task.progress", id: "t", note: "agent.hook.UserPromptSubmit" }]);
+    bridge.stop();
+  });
+
+  it("ignores the received-phase duplicate of a working hook (emits once)", async () => {
+    const events: ControlEvent[] = [];
+    const bridge = new CmuxEventsBridge({
+      emit: (e) => events.push(e),
+      resolve: () => ({ id: "x" }),
+      cursorFile: "/tmp/seq",
+      spawnImpl: (() =>
+        fakeChild([ack, workingFrame("/wt/x", "agent.hook.PreToolUse", "received"), workingFrame("/wt/x")])) as never,
+      stopAfterFirstRun: true,
+    });
+    bridge.start();
+    await flush();
+    await flush();
+    expect(events.filter((e) => e.type === "task.progress")).toHaveLength(1);
+    bridge.stop();
+  });
+
+  it("does not emit for a working hook whose cwd matches no crew", async () => {
+    const events: ControlEvent[] = [];
+    const bridge = new CmuxEventsBridge({
+      emit: (e) => events.push(e),
+      resolve: () => undefined,
+      cursorFile: "/tmp/seq",
+      spawnImpl: (() => fakeChild([ack, workingFrame("/wt/unknown")])) as never,
+      stopAfterFirstRun: true,
+    });
+    bridge.start();
+    await flush();
+    await flush();
+    expect(events).toHaveLength(0);
+    bridge.stop();
+  });
+});
+
+// B4/A3 — end-to-end suppression: a working hook's task.progress refreshes the
+// liveness clock the watchdog keys off, so evaluateStall stops false-idling a
+// crew that is mid long tool-call but quiet on screen (#292 false-stalled).
+describe("working-hook run-state suppresses false-stall (#292)", () => {
+  function workingCrew(lastHeartbeatAt: number): TaskRecord {
+    return {
+      id: "task-a",
+      name: "crew-a",
+      project: "cockpit",
+      provider: "claude",
+      mode: "interactive",
+      state: "working",
+      task: "do a thing",
+      createdAt: 0,
+      lastHeartbeat: lastHeartbeatAt,
+      lastEvent: "task.started",
+      heartbeatBudgetMs: 60_000,
+      attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt }],
+    };
+  }
+
+  it("without a working hook, a quiet crew past budget false-idles", () => {
+    const now = 100_000; // 100s since the last heartbeat at t=0, budget 60s
+    const idle = evaluateStall(workingCrew(0), now);
+    expect(idle?.state).toBe("awaiting-input");
+  });
+
+  it("a PreToolUse-derived task.progress refreshes liveness so the crew does NOT idle", () => {
+    const now = 100_000;
+    // The bridge's working-hook event lands as task.progress just before the sweep.
+    const progressed = reduce(workingCrew(0), { type: "task.progress", id: "task-a", note: "agent.hook.PreToolUse" }, now);
+    // evaluateStall now keys off the refreshed lastHeartbeatAt → no false idle.
+    expect(evaluateStall(progressed, now)).toBeNull();
+    expect(progressed.state).toBe("working");
   });
 });

--- a/src/control/cmux/events-bridge.ts
+++ b/src/control/cmux/events-bridge.ts
@@ -1,0 +1,189 @@
+// src/control/cmux/events-bridge.ts
+// Daemon-side bridge from cmux's native event stream to cockpit ControlEvents
+// (audit item B1 — reduce fragile screen-scraping).
+//
+// Unlike the per-crew OpencodeSseBridge, `cmux events` is a SINGLE global stream
+// for the whole cmux app: one newline-delimited JSON frame per cmux event,
+// carrying every agent's hook events. So this bridge is ONE long-lived
+// subscription owned by the daemon. Each `agent` frame is correlated back to a
+// crew TaskRecord by cwd (each interactive crew runs in a unique worktree path),
+// and `agent.hook.Stop` — the "turn ended / crew idle" signal the pane reader
+// currently infers by scraping — is mapped to `task.turn.completed`.
+//
+// ADDITIVE & SAFE: this runs ALONGSIDE the existing relay-proxy/pane-reader path,
+// which stays as the fallback. `task.turn.completed` is liveness, NOT completion
+// (anti-#2576): terminal state still comes from the explicit `cockpit crew signal
+// done`. The state-machine reducer already absorbs duplicate/late
+// task.turn.completed, so feeding it from BOTH paths is harmless.
+import type { ChildProcess } from "node:child_process";
+import { spawn as nodeSpawn } from "node:child_process";
+import { resolveCmuxBin } from "../../lib/cmux-bin.js";
+import type { ControlEvent } from "../types.js";
+
+/** Minimal subset of ChildProcess this bridge needs (injectable for tests). */
+export interface CmuxEventsChild {
+  stdout: NodeJS.ReadableStream | null;
+  kill(signal?: NodeJS.Signals): boolean | void;
+  on(event: "exit", cb: (code: number | null) => void): unknown;
+  on(event: "error", cb: (err: Error) => void): unknown;
+}
+
+/** A correlated hook frame, passed to the caller's record resolver. */
+export interface CmuxAgentHook {
+  cwd?: string;
+  /** The emitting agent kind (`payload._source`, e.g. "claude"). */
+  source?: string;
+  /** The agent session id (`payload.session_id`). */
+  sessionId?: string;
+}
+
+export interface CmuxEventsBridgeDeps {
+  /** Ingress into the daemon's event pipeline (resolves project + handles). */
+  emit: (ev: ControlEvent) => void;
+  /**
+   * Map an agent hook frame to its owning crew record, or undefined if none.
+   * The daemon supplies this from the store (non-terminal interactive records
+   * matched by cwd). Keeping it injected keeps the bridge pure and testable.
+   */
+  resolve: (hook: CmuxAgentHook) => { id: string } | undefined;
+  /** Durable resume cursor passed to `cmux events --cursor-file`. */
+  cursorFile: string;
+  /** Injectable spawn for tests; defaults to spawning the real cmux binary. */
+  spawnImpl?: (bin: string, args: string[]) => CmuxEventsChild;
+  /** Injectable cmux binary path; defaults to resolveCmuxBin(). */
+  cmuxBin?: string;
+  /** Injectable backoff for tests; defaults to setTimeout. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Backoff between respawn attempts after the child exits (ms, default 1000). */
+  reconnectMs?: number;
+  log?: (msg: string) => void;
+  /** Test-only: stop after the first child exits (don't respawn). */
+  stopAfterFirstRun?: boolean;
+}
+
+/**
+ * One long-lived `cmux events` subscription for the whole daemon. The CLI's
+ * `--reconnect` resumes the socket in-process; `--cursor-file` makes resume
+ * durable across daemon (and child) restarts. If the child process itself dies,
+ * we respawn with backoff so the consumer self-heals.
+ */
+export class CmuxEventsBridge {
+  private child: CmuxEventsChild | null = null;
+  private stopped = false;
+  private buf = "";
+  private deps: CmuxEventsBridgeDeps;
+
+  constructor(deps: CmuxEventsBridgeDeps) {
+    this.deps = deps;
+  }
+
+  /** Begin the subscription. Idempotent. */
+  start(): void {
+    if (this.child || this.stopped) return;
+    void this.run();
+  }
+
+  /** Stop the subscription and kill the child (daemon shutdown). */
+  stop(): void {
+    this.stopped = true;
+    const c = this.child;
+    this.child = null;
+    if (c) {
+      try { c.kill(); } catch { /* already gone */ }
+    }
+  }
+
+  private async run(): Promise<void> {
+    const spawnImpl =
+      this.deps.spawnImpl ??
+      ((bin, args) => nodeSpawn(bin, args, { stdio: ["ignore", "pipe", "ignore"] }) as ChildProcess as unknown as CmuxEventsChild);
+    const bin = this.deps.cmuxBin ?? resolveCmuxBin();
+    const sleep = this.deps.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+    const reconnectMs = this.deps.reconnectMs ?? 1000;
+    const args = [
+      "events",
+      "--reconnect",
+      "--cursor-file", this.deps.cursorFile,
+      "--category", "agent",
+      "--no-heartbeat",
+    ];
+
+    while (!this.stopped) {
+      this.buf = "";
+      let child: CmuxEventsChild;
+      try {
+        child = spawnImpl(bin, args);
+      } catch (e) {
+        this.deps.log?.(`cmux events spawn failed: ${(e as Error).message}`);
+        if (this.deps.stopAfterFirstRun) return;
+        await sleep(reconnectMs);
+        continue;
+      }
+      this.child = child;
+      await new Promise<void>((resolve) => {
+        let settled = false;
+        const done = () => { if (!settled) { settled = true; resolve(); } };
+        child.stdout?.on("data", (b: Buffer | string) => this.onData(b));
+        child.stdout?.on("end", done);
+        child.on("exit", done);
+        child.on("error", (err) => {
+          this.deps.log?.(`cmux events child error: ${err.message}`);
+          done();
+        });
+      });
+      this.child = null;
+      if (this.stopped || this.deps.stopAfterFirstRun) break;
+      // Child died (cmux app restart, binary error): resume from the cursor.
+      await sleep(reconnectMs);
+    }
+  }
+
+  private onData(chunk: Buffer | string): void {
+    this.buf += typeof chunk === "string" ? chunk : chunk.toString("utf-8");
+    let nl: number;
+    while ((nl = this.buf.indexOf("\n")) >= 0) {
+      const line = this.buf.slice(0, nl);
+      this.buf = this.buf.slice(nl + 1);
+      this.handleLine(line);
+    }
+  }
+
+  private handleLine(rawLine: string): void {
+    const line = rawLine.trim();
+    if (!line || line[0] !== "{") return;
+    let f:
+      | {
+          type?: string;
+          category?: string;
+          name?: string;
+          source?: string;
+          payload?: { _source?: string; session_id?: string; cwd?: string; phase?: string };
+        }
+      | undefined;
+    try {
+      f = JSON.parse(line);
+    } catch {
+      return; // partial/non-JSON keepalive or ack we don't parse
+    }
+    // Only agent hook events; ignore ack/heartbeat and other categories.
+    if (f?.type !== "event" || f.category !== "agent") return;
+    // `Stop` is the main-session turn-end; `SubagentStop` is a nested agent
+    // finishing (NOT a turn end) — only Stop maps to task.turn.completed.
+    if (f.name !== "agent.hook.Stop") return;
+    const p = f.payload ?? {};
+    // Each hook fires a "received" then "completed" phase frame; act on the
+    // settled one so we emit exactly once per Stop.
+    if (p.phase === "received") return;
+    const rec = this.deps.resolve({
+      cwd: p.cwd,
+      source: p._source ?? f.source,
+      sessionId: p.session_id,
+    });
+    if (!rec) return;
+    this.deps.emit({
+      type: "task.turn.completed",
+      id: rec.id,
+      turnId: p.session_id ?? "cmux",
+    });
+  }
+}

--- a/src/control/cmux/events-bridge.ts
+++ b/src/control/cmux/events-bridge.ts
@@ -6,15 +6,21 @@
 // for the whole cmux app: one newline-delimited JSON frame per cmux event,
 // carrying every agent's hook events. So this bridge is ONE long-lived
 // subscription owned by the daemon. Each `agent` frame is correlated back to a
-// crew TaskRecord by cwd (each interactive crew runs in a unique worktree path),
-// and `agent.hook.Stop` — the "turn ended / crew idle" signal the pane reader
-// currently infers by scraping — is mapped to `task.turn.completed`.
+// crew TaskRecord by cwd (each interactive crew runs in a unique worktree path)
+// and classified into a run-state (deriveRunState):
+//   - `agent.hook.Stop` — the "turn ended / crew idle" signal the pane reader
+//     infers by scraping — → `task.turn.completed`.
+//   - `agent.hook.PreToolUse` / `UserPromptSubmit` (a turn is live) →
+//     `task.progress` (B4/A3): a real-activity signal that refreshes the crew's
+//     liveness clock so the watchdog does not false-stall a crew mid long,
+//     screen-quiet tool call (#292).
 //
 // ADDITIVE & SAFE: this runs ALONGSIDE the existing relay-proxy/pane-reader path,
-// which stays as the fallback. `task.turn.completed` is liveness, NOT completion
+// which stays as the fallback. Both emissions are liveness, NOT completion
 // (anti-#2576): terminal state still comes from the explicit `cockpit crew signal
 // done`. The state-machine reducer already absorbs duplicate/late
-// task.turn.completed, so feeding it from BOTH paths is harmless.
+// task.turn.completed and task.progress (a blocked crew stays blocked), so
+// feeding them from BOTH paths is harmless.
 import type { ChildProcess } from "node:child_process";
 import { spawn as nodeSpawn } from "node:child_process";
 import { resolveCmuxBin } from "../../lib/cmux-bin.js";
@@ -26,6 +32,35 @@ export interface CmuxEventsChild {
   kill(signal?: NodeJS.Signals): boolean | void;
   on(event: "exit", cb: (code: number | null) => void): unknown;
   on(event: "error", cb: (err: Error) => void): unknown;
+}
+
+/** Per-surface agent run-state derived from the hook stream (B4/A3). */
+export type RunState = "working" | "idle";
+
+/**
+ * Pure. Classify an `agent.hook.*` event name into the crew's run-state, or
+ * null for hooks that carry no run-state signal.
+ *
+ *   PreToolUse / UserPromptSubmit → "working"  (a turn is live)
+ *   Stop                          → "idle"     (turn ended)
+ *   SubagentStop / anything else  → null       (subagent end ≠ turn end)
+ *
+ * `Stop` is the existing turn-end signal (→ task.turn.completed). The "working"
+ * hooks are the B4/A3 addition: they let the daemon keep a crew's liveness clock
+ * fresh while it is mid (possibly long, screen-quiet) tool call, so the watchdog
+ * does not false-stall it (#292). Only `PreToolUse` is live-confirmed in cmux
+ * 0.64.16; `UserPromptSubmit` is mapped opportunistically (harmless if absent).
+ */
+export function deriveRunState(eventName: string): RunState | null {
+  switch (eventName) {
+    case "agent.hook.PreToolUse":
+    case "agent.hook.UserPromptSubmit":
+      return "working";
+    case "agent.hook.Stop":
+      return "idle";
+    default:
+      return null;
+  }
 }
 
 /** A correlated hook frame, passed to the caller's record resolver. */
@@ -167,12 +202,14 @@ export class CmuxEventsBridge {
     }
     // Only agent hook events; ignore ack/heartbeat and other categories.
     if (f?.type !== "event" || f.category !== "agent") return;
-    // `Stop` is the main-session turn-end; `SubagentStop` is a nested agent
-    // finishing (NOT a turn end) — only Stop maps to task.turn.completed.
-    if (f.name !== "agent.hook.Stop") return;
+    // Classify the hook into a run-state. `Stop` is the main-session turn-end;
+    // PreToolUse/UserPromptSubmit mean a turn is live; SubagentStop and any
+    // other hook carry no turn-level run-state and are ignored.
+    const runState = f.name ? deriveRunState(f.name) : null;
+    if (!runState) return;
     const p = f.payload ?? {};
     // Each hook fires a "received" then "completed" phase frame; act on the
-    // settled one so we emit exactly once per Stop.
+    // settled one so we emit exactly once per hook.
     if (p.phase === "received") return;
     const rec = this.deps.resolve({
       cwd: p.cwd,
@@ -180,10 +217,20 @@ export class CmuxEventsBridge {
       sessionId: p.session_id,
     });
     if (!rec) return;
-    this.deps.emit({
-      type: "task.turn.completed",
-      id: rec.id,
-      turnId: p.session_id ?? "cmux",
-    });
+    if (runState === "idle") {
+      // Turn-end / idle — the signal the pane reader infers by scraping.
+      this.deps.emit({
+        type: "task.turn.completed",
+        id: rec.id,
+        turnId: p.session_id ?? "cmux",
+      });
+      return;
+    }
+    // working: feed a real-activity signal into the liveness path. task.progress
+    // refreshes lastHeartbeatAt (the clock evaluateStall keys off), so a crew
+    // that is mid long tool-call but screen-quiet is NOT false-stalled (#292),
+    // and a crew the scrape path wrongly idled resumes to 'working'. ADDITIVE:
+    // the reducer absorbs this idempotently, and a blocked crew stays blocked.
+    this.deps.emit({ type: "task.progress", id: rec.id, note: f.name });
   }
 }

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -14,6 +14,7 @@ import { startServer, encodeFrame, type AttachFrame, type AttachInbound } from "
 import { runHeadless } from "./headless-launcher.js";
 import { CodexInteractiveDriver, shouldReattachCodex } from "./codex/driver.js";
 import { OpencodeSseBridge } from "./opencode/sse-bridge.js";
+import { CmuxEventsBridge } from "./cmux/events-bridge.js";
 import { makeGate } from "./codex/gate.js";
 import { appendToMailbox, rotateIfNeeded, mailboxStats, readCursor } from "./mailbox.js";
 import { createRelayHealer } from "./relay-healer.js";
@@ -93,6 +94,9 @@ export interface CockpitdOpts {
     /** CP3: POST the captain's approve/deny decision to the crew's server. */
     answer: (taskId: string, decision: "approve" | "deny") => Promise<boolean>;
   };
+  /** B1: inject a fake cmux events bridge for tests. Defaults to a real one
+   *  (gated on defaults.cmuxEventsBridge). */
+  cmuxEventsBridge?: { start: () => void; stop: () => void };
 }
 
 // ── Tier 0/2 snapshot gathering (I/O at the edge; the pure assembly lives in
@@ -342,6 +346,35 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
     log,
   });
 
+  // B1: cmux native-events bridge. ADDITIVE — runs alongside the relay-proxy /
+  // pane-reader scrape path, which stays as the fallback. A single global
+  // `cmux events` subscription maps each crew's `agent.hook.Stop` (turn-end /
+  // idle) to task.turn.completed, correlating the frame's cwd to a non-terminal
+  // interactive record (each crew runs in a unique worktree path). The reducer
+  // absorbs duplicate/late turn.completed, so feeding it from both paths is safe.
+  const cmuxEventsBridge =
+    opts.cmuxEventsBridge ??
+    new CmuxEventsBridge({
+      emit: (ev) => {
+        const found = store.listAll().find((r) => r.id === ev.id);
+        if (!found) return;
+        void d.handle({ kind: "event", project: found.project, event: ev });
+      },
+      resolve: (hook) => {
+        if (!hook.cwd) return undefined;
+        return store
+          .listAll()
+          .find(
+            (r) =>
+              r.mode === "interactive" &&
+              !TERMINAL_STATES.has(r.state) &&
+              r.cwd === hook.cwd,
+          );
+      },
+      cursorFile: join(stateRoot, "cmux-events.seq"),
+      log,
+    });
+
   const ingest = (project: string) => (e: import("./types.js").ControlEvent) =>
     void d.handle({ kind: "event", project, event: e });
 
@@ -563,6 +596,17 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       if (!rec.serverPort) continue;
       opencodeBridge.start({ taskId: rec.id, port: rec.serverPort });
     }
+
+    // B1: start the single cmux native-events subscription (additive; the scrape
+    // fallback is unaffected). Opt out via defaults.cmuxEventsBridge:false. The
+    // REAL (non-injected) bridge is skipped under vitest so daemon tests never
+    // spawn a real `cmux events` child; an injected fake always starts so the
+    // wiring stays testable.
+    const enableCmuxEvents = loadConfig().defaults.cmuxEventsBridge !== false;
+    const cmuxEventsSafe = !!opts.cmuxEventsBridge || !process.env.VITEST;
+    if (enableCmuxEvents && cmuxEventsSafe) {
+      try { cmuxEventsBridge.start(); } catch (e) { log(`cmux events bridge start failed: ${(e as Error).message}`); }
+    }
   })();
 
   const server = startServer(sockPath, {
@@ -712,6 +756,7 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
     stop(): Promise<void> {
       if (timer) clearInterval(timer);
       if (rotationTimer) clearInterval(rotationTimer);
+      try { cmuxEventsBridge.stop(); } catch { /* best-effort */ }
       for (const kill of activeHeadlessKills) kill();
       return new Promise<void>((resolve) => server.close(() => { log("stopped"); resolve(); }));
     },

--- a/src/control/daemon.ts
+++ b/src/control/daemon.ts
@@ -6,6 +6,15 @@ import { reduce } from "./state-machine.js";
 import { evaluateStall, recoverStall } from "./watchdog.js";
 import { classifyHealth, RELAY_STALE_MS, RELAY_GONE_MS, type RelayHealth } from "./liveness.js";
 
+/**
+ * Result of a relay-heal attempt (audit STEP 3). "captain-absent" tells the
+ * sweep the captain workspace is permanently gone — the relay can never be
+ * healed, so its health record is pruned to stop per-cycle "captain workspace
+ * not present" log spam. Any other value (or void, for legacy impls) leaves the
+ * record in place so the liveness surface keeps reporting it.
+ */
+export type RelayHealOutcome = "captain-absent" | "healed" | "skipped";
+
 export interface DaemonDeps {
   store: Store;
   now: () => number;
@@ -66,7 +75,7 @@ export interface DaemonDeps {
    * getRelayHealth() + the liveness surface, not by this hook. Errors are
    * swallowed by the sweep so a refused cmux write never trips the daemon.
    */
-  healRelay?: (project: string) => Promise<void> | void;
+  healRelay?: (project: string) => Promise<RelayHealOutcome | void> | RelayHealOutcome | void;
   /**
    * #225 hard crew task-timeout: wall-clock ceiling in ms. When a non-terminal
    * task's age (now - createdAt) exceeds this, the sweep fires a CREW TIMEOUT
@@ -434,15 +443,22 @@ export function createDaemon(deps: DaemonDeps) {
       // surface (getRelayHealth) already exposes the "gone" state regardless —
       // that is the never-silently-blind guarantee; heal is the secondary try.
       if (deps.healRelay) {
-        for (const rh of relayHealth.values()) {
+        // Snapshot first: a "captain-absent" prune deletes from relayHealth mid-loop.
+        for (const rh of [...relayHealth.values()]) {
           if (classifyHealth(rh.lastSeenMs, t, RELAY_STALE_MS, RELAY_GONE_MS) !== "gone") continue;
           const last = lastHealAttempt.get(rh.project);
           if (last != null && t - last <= RELAY_GONE_MS) continue; // debounce
           lastHealAttempt.set(rh.project, t);
           try {
-            const r = deps.healRelay(rh.project);
-            if (r && typeof (r as Promise<void>).catch === "function") {
-              (r as Promise<void>).catch(() => {});
+            const outcome = await deps.healRelay(rh.project);
+            // audit STEP 3 stale-ref prune: the captain workspace is permanently
+            // gone, so this relay can never be healed and re-probing it every
+            // sweep just spams "captain workspace not present". Drop the record
+            // (and its debounce) so the loop goes quiet after a single attempt; a
+            // captain restart re-registers a fresh relay via registerRelay.
+            if (outcome === "captain-absent") {
+              relayHealth.delete(rh.project);
+              lastHealAttempt.delete(rh.project);
             }
           } catch {
             // best-effort — a refused cmux write (lineage) must not trip the sweep

--- a/src/control/relay-healer.ts
+++ b/src/control/relay-healer.ts
@@ -7,6 +7,7 @@
 import { loadConfig } from "../config.js";
 import { createCmuxDriver, RuntimeRegistry } from "../runtimes/index.js";
 import { buildRelaySupervisorCommand, NOTIFY_RELAY_TAB_TITLE } from "./relay-supervisor.js";
+import type { RelayHealOutcome } from "./daemon.js";
 
 /**
  * Best-effort relay heal (#207, SECONDARY). Re-spawns the notify-relay tab in
@@ -19,17 +20,19 @@ import { buildRelaySupervisorCommand, NOTIFY_RELAY_TAB_TITLE } from "./relay-sup
  */
 export function createRelayHealer(
   log: (m: string) => void = () => {},
-): (project: string) => Promise<void> {
+): (project: string) => Promise<RelayHealOutcome> {
   return async (project) => {
     try {
       const config = loadConfig();
       const proj = config.projects[project];
-      if (!proj) return;
+      if (!proj) return "skipped";
       const runtime = new RuntimeRegistry({ cmux: createCmuxDriver() }).forProject(project, config);
       const ws = await runtime.status(proj.captainName);
       if (!ws) {
-        log(`relay heal ${project}: captain workspace not present; nothing to heal into`);
-        return;
+        // Captain workspace gone for good — signal the sweep to prune this relay
+        // record so this log fires ONCE, not every cycle (audit STEP 3).
+        log(`relay heal ${project}: captain workspace not present; pruning stale relay record`);
+        return "captain-absent";
       }
       // Dedup: close any pre-existing relay tab before respawning fresh.
       try {
@@ -47,10 +50,14 @@ export function createRelayHealer(
         placement: "background",
       });
       log(`relay heal ${project}: re-spawned notify-relay tab`);
+      return "healed";
     } catch (e) {
       // Expected under launchd (cmux lineage refusal). The surface still shows
-      // the relay down with its actionable; this is the secondary path.
+      // the relay down with its actionable; this is the secondary path. Captain
+      // workspace WAS resolvable here (status succeeded), so do not prune —
+      // return "skipped" so the record stays and the surface keeps reporting it.
       log(`relay heal ${project} failed (expected under launchd lineage): ${(e as Error).message}`);
+      return "skipped";
     }
   };
 }

--- a/src/lib/__tests__/tool-compat.test.ts
+++ b/src/lib/__tests__/tool-compat.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { checkToolCompat } from "../tool-compat.js";
+
+describe("checkToolCompat", () => {
+  it("returns null when version is within range", () => {
+    expect(checkToolCompat("cmux", "cmux 0.64.8", { min: "0.64.0", lastVerified: "0.64.16" })).toBeNull();
+  });
+
+  it("returns null when version equals min exactly", () => {
+    expect(checkToolCompat("cmux", "cmux 0.64.0", { min: "0.64.0", lastVerified: "0.64.16" })).toBeNull();
+  });
+
+  it("returns null when version equals lastVerified exactly", () => {
+    expect(checkToolCompat("cmux", "cmux 0.64.16", { min: "0.64.0", lastVerified: "0.64.16" })).toBeNull();
+  });
+
+  it("warns when version is below min", () => {
+    const warn = checkToolCompat("cmux", "cmux 0.63.5", { min: "0.64.0", lastVerified: "0.64.16" });
+    expect(warn).not.toBeNull();
+    expect(warn).toMatch(/< min/);
+    expect(warn).toMatch(/0\.64\.0/);
+    expect(warn).toMatch(/upgrade/i);
+  });
+
+  it("warn message includes tool name and installed version when below min", () => {
+    const warn = checkToolCompat("cmux", "cmux 0.63.5", { min: "0.64.0" });
+    expect(warn).toMatch(/^cmux cmux 0\.63\.5 </);
+  });
+
+  it("warns when installed version exceeds lastVerified (drift signal)", () => {
+    const warn = checkToolCompat("cmux", "cmux 0.65.0", { min: "0.64.0", lastVerified: "0.64.16" });
+    expect(warn).not.toBeNull();
+    expect(warn).toMatch(/last-verified/);
+    expect(warn).toMatch(/0\.64\.16/);
+    expect(warn).toMatch(/compat audit/i);
+  });
+
+  it("warn message includes tool name and installed version when above lastVerified", () => {
+    const warn = checkToolCompat("cmux", "cmux 0.65.0", { min: "0.64.0", lastVerified: "0.64.16" });
+    expect(warn).toMatch(/cmux 0\.65\.0 > last-verified 0\.64\.16/);
+  });
+
+  it("returns null when no lastVerified and version is above min", () => {
+    expect(checkToolCompat("claude", "claude 2.2.0", { min: "2.1.32" })).toBeNull();
+  });
+
+  it("returns null when version string has no parseable semver", () => {
+    expect(checkToolCompat("cmux", "unknown build", { min: "0.64.0" })).toBeNull();
+  });
+
+  it("returns null for empty version string", () => {
+    expect(checkToolCompat("cmux", "", { min: "0.64.0" })).toBeNull();
+  });
+
+  it("works with just a bare semver string (no tool name prefix)", () => {
+    expect(checkToolCompat("claude", "2.1.32", { min: "2.1.32" })).toBeNull();
+    const warn = checkToolCompat("claude", "2.1.31", { min: "2.1.32" });
+    expect(warn).toMatch(/< min/);
+  });
+
+  it("compares patch level correctly (minor ok, patch below min)", () => {
+    const warn = checkToolCompat("cmux", "cmux 0.64.15", { min: "0.64.16", lastVerified: "0.64.20" });
+    expect(warn).toMatch(/< min/);
+  });
+
+  it("compares major version correctly (major above min → in range without lastVerified)", () => {
+    expect(checkToolCompat("claude", "claude 3.0.0", { min: "2.1.32" })).toBeNull();
+  });
+});

--- a/src/lib/__tests__/tool-compat.test.ts
+++ b/src/lib/__tests__/tool-compat.test.ts
@@ -66,4 +66,26 @@ describe("checkToolCompat", () => {
   it("compares major version correctly (major above min → in range without lastVerified)", () => {
     expect(checkToolCompat("claude", "claude 3.0.0", { min: "2.1.32" })).toBeNull();
   });
+
+  // Optional-min entries (codex/gemini/opencode — presence-checked, no floor enforced yet)
+  it("returns null when min is absent and version is below lastVerified", () => {
+    expect(checkToolCompat("codex", "codex-cli 0.100.0", { lastVerified: "0.139.0" })).toBeNull();
+  });
+
+  it("warns when min is absent but version is above lastVerified (drift)", () => {
+    const warn = checkToolCompat("codex", "codex-cli 0.200.0", { lastVerified: "0.139.0" });
+    expect(warn).not.toBeNull();
+    expect(warn).toMatch(/last-verified/);
+  });
+
+  it("returns null when only lastVerified is set and version matches it exactly", () => {
+    expect(checkToolCompat("opencode", "1.17.4", { lastVerified: "1.17.4" })).toBeNull();
+  });
+
+  // Manifest shape: all six tools should produce a null when version is in-range
+  it("manifest tool entries for cmux/claude/node each have a min and are checkable", () => {
+    expect(checkToolCompat("cmux",  "cmux 0.64.16", { min: "0.64.0",  lastVerified: "0.64.16" })).toBeNull();
+    expect(checkToolCompat("claude","claude 2.1.32", { min: "2.1.32" })).toBeNull();
+    expect(checkToolCompat("node",  "22.0.0",        { min: "18.0.0", lastVerified: "24.6.0" })).toBeNull();
+  });
 });

--- a/src/lib/compat-manifest.ts
+++ b/src/lib/compat-manifest.ts
@@ -1,0 +1,6 @@
+export const compatManifest = {
+  tools: {
+    cmux: { min: "0.64.0", lastVerified: "0.64.16" },
+    claude: { min: "2.1.32" },
+  },
+} as const;

--- a/src/lib/compat-manifest.ts
+++ b/src/lib/compat-manifest.ts
@@ -1,6 +1,13 @@
+export type ToolEntry = { min?: string; lastVerified?: string };
+
 export const compatManifest = {
   tools: {
-    cmux: { min: "0.64.0", lastVerified: "0.64.16" },
-    claude: { min: "2.1.32" },
+    cmux:     { min: "0.64.0",  lastVerified: "0.64.16" } satisfies ToolEntry,
+    claude:   { min: "2.1.32" }                           satisfies ToolEntry,
+    node:     { min: "18.0.0",  lastVerified: "24.6.0"  } satisfies ToolEntry,
+    // presence-checked; no floor enforced yet
+    codex:    { lastVerified: "0.139.0" }                 satisfies ToolEntry,
+    gemini:   { lastVerified: "0.38.2"  }                 satisfies ToolEntry,
+    opencode: { lastVerified: "1.17.4"  }                 satisfies ToolEntry,
   },
 } as const;

--- a/src/lib/tool-compat.ts
+++ b/src/lib/tool-compat.ts
@@ -1,0 +1,42 @@
+type SemVer = [number, number, number];
+
+function parseSemVer(v: string): SemVer | null {
+  const m = v.match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!m) return null;
+  return [parseInt(m[1], 10), parseInt(m[2], 10), parseInt(m[3], 10)];
+}
+
+function cmpSemVer(a: SemVer, b: SemVer): number {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+/**
+ * Compare an installed tool version against the compat manifest entry.
+ * Returns a warning string when the version is below min or above lastVerified,
+ * or null when the version is in-range or unparseable (non-blocking).
+ */
+export function checkToolCompat(
+  name: string,
+  rawVersion: string,
+  entry: { min: string; lastVerified?: string },
+): string | null {
+  const installed = parseSemVer(rawVersion);
+  if (!installed) return null;
+
+  const min = parseSemVer(entry.min);
+  if (min && cmpSemVer(installed, min) < 0) {
+    return `${name} ${rawVersion} < min ${entry.min} — upgrade to ${entry.min}+`;
+  }
+
+  if (entry.lastVerified) {
+    const lastVerified = parseSemVer(entry.lastVerified);
+    if (lastVerified && cmpSemVer(installed, lastVerified) > 0) {
+      return `${name} ${rawVersion} > last-verified ${entry.lastVerified} — re-run compat audit`;
+    }
+  }
+
+  return null;
+}

--- a/src/lib/tool-compat.ts
+++ b/src/lib/tool-compat.ts
@@ -17,16 +17,17 @@ function cmpSemVer(a: SemVer, b: SemVer): number {
  * Compare an installed tool version against the compat manifest entry.
  * Returns a warning string when the version is below min or above lastVerified,
  * or null when the version is in-range or unparseable (non-blocking).
+ * `min` is optional — entries without a floor are only drift-checked against lastVerified.
  */
 export function checkToolCompat(
   name: string,
   rawVersion: string,
-  entry: { min: string; lastVerified?: string },
+  entry: { min?: string; lastVerified?: string },
 ): string | null {
   const installed = parseSemVer(rawVersion);
   if (!installed) return null;
 
-  const min = parseSemVer(entry.min);
+  const min = entry.min ? parseSemVer(entry.min) : null;
   if (min && cmpSemVer(installed, min) < 0) {
     return `${name} ${rawVersion} < min ${entry.min} — upgrade to ${entry.min}+`;
   }

--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -15,6 +15,34 @@ vi.mock("node:child_process", () => ({
 const argvOf = (call: unknown[]): string[] => call[1] as string[];
 const cmdOf = (call: unknown[]): string => (call[1] as string[]).join(" ");
 
+// Build a `cmux workspace list --json` payload for list()/status() tests (B2).
+function wsListJson(...wss: { ref: string; title?: string; cwd?: string }[]): string {
+  return JSON.stringify({
+    window_ref: "window:1",
+    workspaces: wss.map((w, i) => ({
+      ref: w.ref,
+      custom_title: w.title ?? null,
+      has_custom_title: w.title != null,
+      current_directory: w.cwd ?? "/home/u",
+      index: i,
+    })),
+  });
+}
+
+// Build a `cmux tree --json` payload (one window/workspace/pane) for
+// listSurfaces()/send() tests (B2).
+function treeJson(workspaceRef: string, ...surfaces: { ref: string; title: string }[]): string {
+  return JSON.stringify({
+    windows: [{
+      ref: "window:1",
+      workspaces: [{
+        ref: workspaceRef,
+        panes: [{ ref: "pane:1", surfaces: surfaces.map((s, i) => ({ ref: s.ref, title: s.title, index: i })) }],
+      }],
+    }],
+  });
+}
+
 // Build a minimal screen in the real Claude Code format for parseDraftFromScreen tests.
 // Layout: optional transcript lines, then top-HR, then inputLine, then bottom-HR, then
 // a two-line status block. The HR lines use U+2500 ─ (110 chars) matching a real screen.
@@ -97,14 +125,14 @@ describe("cmux driver", () => {
     expect(result.version).toBe("");
   });
 
-  it("list calls 'workspace list' (migrated from list-workspaces) and parses output", async () => {
+  it("list parses `workspace list --json` into WorkspaceRefs (B2)", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      if (args[0] === "workspace" && args[1] === "list") {
-        return [
-          "workspace:1  🏛️ command  (running)",
-          "workspace:2  brove-captain  [selected]",
-          "workspace:3  ⚡ reactor  (running)",
-        ].join("\n");
+      if (args.includes("list") && args.includes("--json")) {
+        return wsListJson(
+          { ref: "workspace:1", title: "🏛️ command" },
+          { ref: "workspace:2", title: "brove-captain" },
+          { ref: "workspace:3", title: "⚡ reactor" },
+        );
       }
       return "";
     });
@@ -116,9 +144,28 @@ describe("cmux driver", () => {
     expect(cmds.every((c) => !c.includes("list-workspaces"))).toBe(true);
   });
 
+  it("list falls back to cwd as the name for an untitled workspace", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("list") && args.includes("--json")) {
+        return wsListJson({ ref: "workspace:1", cwd: "/Users/u" });
+      }
+      return "";
+    });
+    const refs = await driver.list();
+    expect(refs).toEqual([{ id: "workspace:1", name: "/Users/u", status: "running" }]);
+  });
+
+  it("list returns [] when the JSON payload is malformed", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("list") && args.includes("--json")) return "not json";
+      return "";
+    });
+    expect(await driver.list()).toEqual([]);
+  });
+
   it("status returns null when name not in list", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      if (args[0] === "workspace" && args[1] === "list") return "workspace:1  other-ws  (running)";
+      if (args.includes("list") && args.includes("--json")) return wsListJson({ ref: "workspace:1", title: "other-ws" });
       return "";
     });
     const ref = await driver.status("brove-captain");
@@ -127,7 +174,7 @@ describe("cmux driver", () => {
 
   it("status returns WorkspaceRef when name matches", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      if (args[0] === "workspace" && args[1] === "list") return "workspace:5  brove-captain  (running)";
+      if (args.includes("list") && args.includes("--json")) return wsListJson({ ref: "workspace:5", title: "brove-captain" });
       return "";
     });
     const ref = await driver.status("brove-captain");
@@ -144,26 +191,24 @@ describe("cmux driver", () => {
 
   it("send routes to surface named after workspace when one exists", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      const cmd = args.join(" ");
-      if (args[0] === "workspace" && args[1] === "list") return "workspace:2  test-ws  (running)";
-      if (cmd.includes("tree"))           return '  └── surface surface:5 [terminal] "test-ws"';
+      if (args.includes("list") && args.includes("--json")) return wsListJson({ ref: "workspace:2", title: "test-ws" });
+      if (args.includes("tree"))                            return treeJson("workspace:2", { ref: "surface:5", title: "test-ws" });
       return "";
     });
     await driver.send("workspace:2", "hello tab");
-    const cmds = execFileMock.mock.calls.map(cmdOf).filter((c) => !c.includes("list-workspaces") && !c.includes("tree"));
+    const cmds = execFileMock.mock.calls.map(cmdOf).filter((c) => !c.includes("list") && !c.includes("tree"));
     expect(cmds.some((c) => c.includes("send ") && c.includes("--surface surface:5") && c.includes("hello tab") && !c.includes("send-key"))).toBe(true);
     expect(cmds.some((c) => c.includes("send-key") && c.includes("--surface surface:5") && c.includes("Enter"))).toBe(true);
   });
 
   it("send falls back to workspace-level when no surface matches workspace name", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      const cmd = args.join(" ");
-      if (args[0] === "workspace" && args[1] === "list") return "workspace:2  test-ws  (running)";
-      if (cmd.includes("tree"))           return '  └── surface surface:5 [terminal] "crew-1"';
+      if (args.includes("list") && args.includes("--json")) return wsListJson({ ref: "workspace:2", title: "test-ws" });
+      if (args.includes("tree"))                            return treeJson("workspace:2", { ref: "surface:5", title: "crew-1" });
       return "";
     });
     await driver.send("workspace:2", "fallback message");
-    const cmds = execFileMock.mock.calls.map(cmdOf).filter((c) => !c.includes("list-workspaces") && !c.includes("tree"));
+    const cmds = execFileMock.mock.calls.map(cmdOf).filter((c) => !c.includes("list") && !c.includes("tree"));
     expect(cmds.some((c) => c.includes("send ") && !c.includes("--surface") && c.includes("fallback message"))).toBe(true);
     expect(cmds.some((c) => c.includes("send-key") && c.includes("Enter") && !c.includes("--surface"))).toBe(true);
   });
@@ -535,17 +580,15 @@ describe("cmux driver", () => {
     })).rejects.toThrow(/did not return a surface/);
   });
 
-  it("listSurfaces parses cmux tree output and returns surfaces with titles", async () => {
+  it("listSurfaces parses `tree --json` and returns surfaces with titles (B2)", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
       if (args.includes("tree")) {
-        return [
-          'window window:1 [current] ◀ active',
-          '└── workspace workspace:10 "⚓ pact-network-captain"',
-          '    └── pane pane:29 [focused]',
-          '        ├── surface surface:29 [terminal] "✳ Run startup checklist" [selected]',
-          '        ├── surface surface:30 [terminal] "🔧 pact-network:crew-1"',
-          '        └── surface surface:31 [terminal] "🔧 pact-network:crew-2"',
-        ].join("\n");
+        return treeJson(
+          "workspace:10",
+          { ref: "surface:29", title: "✳ Run startup checklist" },
+          { ref: "surface:30", title: "🔧 pact-network:crew-1" },
+          { ref: "surface:31", title: "🔧 pact-network:crew-2" },
+        );
       }
       return "";
     });
@@ -555,15 +598,43 @@ describe("cmux driver", () => {
       { workspaceId: "workspace:10", surfaceId: "surface:30", title: "🔧 pact-network:crew-1" },
       { workspaceId: "workspace:10", surfaceId: "surface:31", title: "🔧 pact-network:crew-2" },
     ]);
-    // Verify --id-format refs is passed to lock in the refs default
+    // The tree read must request both JSON (B2) and refs id-format (#325).
     const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.includes("tree") && c.includes("--json"))).toBe(true);
     expect(cmds.some((c) => c.includes("tree") && c.includes("--id-format refs"))).toBe(true);
+  });
+
+  it("listSurfaces only returns surfaces of the requested workspace", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("tree")) {
+        return JSON.stringify({
+          windows: [{
+            ref: "window:1",
+            workspaces: [
+              { ref: "workspace:10", panes: [{ surfaces: [{ ref: "surface:1", title: "keep" }] }] },
+              { ref: "workspace:99", panes: [{ surfaces: [{ ref: "surface:2", title: "skip" }] }] },
+            ],
+          }],
+        });
+      }
+      return "";
+    });
+    const surfaces = await driver.listSurfaces("workspace:10");
+    expect(surfaces).toEqual([{ workspaceId: "workspace:10", surfaceId: "surface:1", title: "keep" }]);
   });
 
   it("listSurfaces returns empty array when cmux throws", async () => {
     execFileMock.mockImplementation(() => { throw new Error("workspace not found"); });
     const surfaces = await driver.listSurfaces("workspace:99");
     expect(surfaces).toEqual([]);
+  });
+
+  it("listSurfaces returns empty array when the JSON payload is malformed", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("tree")) return "not json";
+      return "";
+    });
+    expect(await driver.listSurfaces("workspace:10")).toEqual([]);
   });
 });
 

--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -86,9 +86,9 @@ describe("cmux driver", () => {
     expect(result.version).toBe("");
   });
 
-  it("list parses list-workspaces output into WorkspaceRefs", async () => {
+  it("list calls 'workspace list' (migrated from list-workspaces) and parses output", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      if (args.includes("list-workspaces")) {
+      if (args[0] === "workspace" && args[1] === "list") {
         return [
           "workspace:1  🏛️ command  (running)",
           "workspace:2  brove-captain  [selected]",
@@ -100,11 +100,14 @@ describe("cmux driver", () => {
     const refs = await driver.list();
     expect(refs).toHaveLength(3);
     expect(refs[1]).toEqual({ id: "workspace:2", name: "brove-captain", status: "running" });
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.startsWith("workspace list"))).toBe(true);
+    expect(cmds.every((c) => !c.includes("list-workspaces"))).toBe(true);
   });
 
   it("status returns null when name not in list", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      if (args.includes("list-workspaces")) return "workspace:1  other-ws  (running)";
+      if (args[0] === "workspace" && args[1] === "list") return "workspace:1  other-ws  (running)";
       return "";
     });
     const ref = await driver.status("brove-captain");
@@ -113,7 +116,7 @@ describe("cmux driver", () => {
 
   it("status returns WorkspaceRef when name matches", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      if (args.includes("list-workspaces")) return "workspace:5  brove-captain  (running)";
+      if (args[0] === "workspace" && args[1] === "list") return "workspace:5  brove-captain  (running)";
       return "";
     });
     const ref = await driver.status("brove-captain");
@@ -131,7 +134,7 @@ describe("cmux driver", () => {
   it("send routes to surface named after workspace when one exists", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
       const cmd = args.join(" ");
-      if (cmd.includes("list-workspaces")) return "workspace:2  test-ws  (running)";
+      if (args[0] === "workspace" && args[1] === "list") return "workspace:2  test-ws  (running)";
       if (cmd.includes("tree"))           return '  └── surface surface:5 [terminal] "test-ws"';
       return "";
     });
@@ -144,7 +147,7 @@ describe("cmux driver", () => {
   it("send falls back to workspace-level when no surface matches workspace name", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
       const cmd = args.join(" ");
-      if (cmd.includes("list-workspaces")) return "workspace:2  test-ws  (running)";
+      if (args[0] === "workspace" && args[1] === "list") return "workspace:2  test-ws  (running)";
       if (cmd.includes("tree"))           return '  └── surface surface:5 [terminal] "crew-1"';
       return "";
     });
@@ -171,12 +174,26 @@ describe("cmux driver", () => {
     expect(cmds[0]).toContain("Escape");
   });
 
-  it("stop calls close-workspace", async () => {
+  it("stop unpins workspace then closes it ('workspace close' migrated from 'close-workspace')", async () => {
     execFileMock.mockReturnValue("");
     await driver.stop("workspace:2");
     const cmds = execFileMock.mock.calls.map(cmdOf);
-    expect(cmds[0]).toContain("close-workspace");
-    expect(cmds[0]).toContain("workspace:2");
+    const unpinIdx = cmds.findIndex((c) => c.includes("workspace-action") && c.includes("--action unpin") && c.includes("workspace:2"));
+    const closeIdx = cmds.findIndex((c) => c.startsWith("workspace close") && c.includes("workspace:2"));
+    expect(unpinIdx, "unpin call must exist").toBeGreaterThanOrEqual(0);
+    expect(closeIdx, "close call must exist").toBeGreaterThanOrEqual(0);
+    expect(unpinIdx, "unpin must precede close").toBeLessThan(closeIdx);
+    expect(cmds.every((c) => !c.includes("close-workspace"))).toBe(true);
+  });
+
+  it("stop proceeds to close even when unpin throws (workspace may not be pinned)", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("workspace-action")) throw new Error("cannot unpin");
+      return "";
+    });
+    await driver.stop("workspace:2");
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.startsWith("workspace close") && c.includes("workspace:2"))).toBe(true);
   });
 
   it("readScreen calls read-screen and returns output", async () => {
@@ -188,10 +205,10 @@ describe("cmux driver", () => {
     expect(out).toBe("screen contents");
   });
 
-  it("spawn creates workspace, renames it, pins it, renames and pins its initial tab", async () => {
+  it("spawn calls 'workspace create' + 'workspace rename' (migrated verbs) and pins workspace and initial tab", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
       const cmd = args.join(" ");
-      if (cmd.includes("new-workspace")) return "Created workspace:7\n";
+      if (args[0] === "workspace" && args[1] === "create") return "Created workspace:7\n";
       if (cmd.includes("tree"))        return '  └── surface surface:1 [terminal] ""';
       return "";
     });
@@ -199,8 +216,13 @@ describe("cmux driver", () => {
     expect(ref.id).toBe("workspace:7");
     expect(ref.name).toBe("test-ws");
     const cmds = execFileMock.mock.calls.map(cmdOf);
-    expect(cmds.some((c) => c.includes("new-workspace"))).toBe(true);
-    expect(cmds.some((c) => c.includes("rename-workspace") && c.includes("test-ws"))).toBe(true);
+    // Migrated: 'workspace create' not 'new-workspace'
+    expect(cmds.some((c) => c.startsWith("workspace create"))).toBe(true);
+    expect(cmds.every((c) => !c.includes("new-workspace"))).toBe(true);
+    // Migrated: 'workspace rename id --title name' not 'rename-workspace --workspace id name'
+    expect(cmds.some((c) => c.startsWith("workspace rename") && c.includes("--title") && c.includes("test-ws"))).toBe(true);
+    expect(cmds.every((c) => !c.includes("rename-workspace"))).toBe(true);
+    // Tab rename and pin unchanged
     expect(cmds.some((c) => c.includes("rename-tab") && c.includes("surface:1") && c.includes("test-ws"))).toBe(true);
     expect(cmds.some((c) => c.includes("workspace-action") && c.includes("--action pin"))).toBe(true);
     expect(cmds.some((c) => c.includes("tab-action") && c.includes("--surface surface:1") && c.includes("--action pin"))).toBe(true);

--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -101,7 +101,7 @@ describe("cmux driver", () => {
     expect(refs).toHaveLength(3);
     expect(refs[1]).toEqual({ id: "workspace:2", name: "brove-captain", status: "running" });
     const cmds = execFileMock.mock.calls.map(cmdOf);
-    expect(cmds.some((c) => c.startsWith("workspace list"))).toBe(true);
+    expect(cmds.some((c) => c.startsWith("workspace list") && c.includes("--id-format refs"))).toBe(true);
     expect(cmds.every((c) => !c.includes("list-workspaces"))).toBe(true);
   });
 
@@ -575,6 +575,9 @@ describe("cmux driver", () => {
       { workspaceId: "workspace:10", surfaceId: "surface:30", title: "🔧 pact-network:crew-1" },
       { workspaceId: "workspace:10", surfaceId: "surface:31", title: "🔧 pact-network:crew-2" },
     ]);
+    // Verify --id-format refs is passed to lock in the refs default
+    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.includes("tree") && c.includes("--id-format refs"))).toBe(true);
   });
 
   it("listSurfaces returns empty array when cmux throws", async () => {

--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -263,49 +263,32 @@ describe("cmux driver", () => {
     expect(cmds.every((c) => !c.includes("--direction"))).toBe(true);
   });
 
-  // #295: new tab steals cmux focus, leaking user keystrokes into crew launch command.
-  // Fix: snapshot selected surface before new-surface, restore focus after creation.
-  it("newPane with direction=tab restores focus to the previously-selected surface (#295)", async () => {
+  // audit A1+B3: a crew tab must be created focus-neutrally. cmux 0.64.16's
+  // new-surface defaults to --focus false; we pass it explicitly and NO LONGER
+  // snapshot the tree or move-surface to restore focus (the old #295 dance,
+  // which the 0.64 freeform canvas broke).
+  it("newPane with direction=tab creates the surface with --focus false and no refocus dance", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      const cmd = args.join(" ");
-      if (cmd.includes("tree")) {
-        return [
-          'surface surface:5 [terminal] "captain" [selected]',
-          'surface surface:6 [terminal] "crew-1"',
-        ].join("\n");
-      }
-      if (cmd.includes("new-surface")) return "OK surface:8 workspace:1";
+      if (args.includes("new-surface")) return "OK surface:8 workspace:1";
       return "";
     });
     await driver.newPane({ workspaceId: "workspace:1", direction: "tab" });
     const cmds = execFileMock.mock.calls.map(cmdOf);
-    expect(cmds.some((c) =>
-      c.includes("move-surface") &&
-      c.includes("--surface surface:5") &&
-      c.includes("--index 0") &&
-      c.includes("--focus true"))).toBe(true);
-  });
-
-  it("newPane with direction=tab skips focus restore gracefully when tree is unreadable (#295)", async () => {
-    execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      const cmd = args.join(" ");
-      if (cmd.includes("tree")) throw new Error("tree unreadable");
-      if (cmd.includes("new-surface")) return "OK surface:8 workspace:1";
-      return "";
-    });
-    const pane = await driver.newPane({ workspaceId: "workspace:1", direction: "tab" });
-    expect(pane.surfaceId).toBe("surface:8");
-    const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.includes("new-surface") && c.includes("--focus false"))).toBe(true);
+    // No tree snapshot, no move-surface, never asks for focus true.
+    expect(cmds.every((c) => !c.includes("tree"))).toBe(true);
     expect(cmds.every((c) => !c.includes("move-surface"))).toBe(true);
+    expect(cmds.every((c) => !c.includes("--focus true"))).toBe(true);
   });
 
-  it("newPane with split direction does NOT query tree or restore focus (#295)", async () => {
+  it("newPane with split direction creates the pane with --focus false and queries nothing", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
       if (args.includes("new-pane")) return "OK surface:27 pane:25 workspace:1";
       return "";
     });
     await driver.newPane({ workspaceId: "workspace:1", direction: "right" });
     const cmds = execFileMock.mock.calls.map(cmdOf);
+    expect(cmds.some((c) => c.includes("new-pane") && c.includes("--focus false"))).toBe(true);
     expect(cmds.every((c) => !c.includes("tree"))).toBe(true);
     expect(cmds.every((c) => !c.includes("move-surface"))).toBe(true);
   });
@@ -473,9 +456,7 @@ describe("cmux driver", () => {
   // (new-surface) keeps the captain pane full-height with no split.
   it("spawnInjector background uses new-surface (no split-pane, no resize-pane)", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      const cmd = args.join(" ");
-      if (cmd.includes("tree")) return 'surface surface:5 [terminal] "cap" [selected]';
-      if (cmd.includes("new-surface")) return "OK surface:8 pane:2 workspace:1";
+      if (args.includes("new-surface")) return "OK surface:8 pane:2 workspace:1";
       return "";
     });
     const pane = await driver.spawnInjector({
@@ -494,9 +475,7 @@ describe("cmux driver", () => {
 
   it("spawnInjector background sends the command + Enter to the new surface", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      const cmd = args.join(" ");
-      if (cmd.includes("tree")) return 'surface surface:5 [terminal] "cap" [selected]';
-      if (cmd.includes("new-surface")) return "OK surface:8 pane:2 workspace:1";
+      if (args.includes("new-surface")) return "OK surface:8 pane:2 workspace:1";
       return "";
     });
     await driver.spawnInjector({
@@ -509,19 +488,12 @@ describe("cmux driver", () => {
     expect(cmds.some((c) => c.includes("send-key") && c.includes("--surface surface:8") && c.includes("Enter"))).toBe(true);
   });
 
-  // The background relay tab must never steal focus from the captain: after
-  // spawning it we re-select whichever surface was selected before, in its
-  // original position.
-  it("spawnInjector background restores focus to the previously-selected surface", async () => {
+  // audit A1+B3: the background relay tab must never steal focus from the
+  // captain. cmux 0.64.16's new-surface defaults to --focus false, so we pass it
+  // explicitly and DROP the old snapshot-then-move-surface refocus dance.
+  it("spawnInjector background creates the surface with --focus false and no refocus dance", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      const cmd = args.join(" ");
-      if (cmd.includes("tree")) {
-        return [
-          'surface surface:5 [terminal] "cap" [selected]',
-          'surface surface:6 [terminal] "crew-1"',
-        ].join("\n");
-      }
-      if (cmd.includes("new-surface")) return "OK surface:8 pane:2 workspace:1";
+      if (args.includes("new-surface")) return "OK surface:8 pane:2 workspace:1";
       return "";
     });
     await driver.spawnInjector({
@@ -530,18 +502,15 @@ describe("cmux driver", () => {
       placement: "background",
     });
     const cmds = execFileMock.mock.calls.map(cmdOf);
-    expect(cmds.some((c) =>
-      c.includes("move-surface") &&
-      c.includes("--surface surface:5") &&
-      c.includes("--index 0") &&
-      c.includes("--focus true"))).toBe(true);
+    expect(cmds.some((c) => c.includes("new-surface") && c.includes("--focus false"))).toBe(true);
+    expect(cmds.every((c) => !c.includes("tree"))).toBe(true);
+    expect(cmds.every((c) => !c.includes("move-surface"))).toBe(true);
+    expect(cmds.every((c) => !c.includes("--focus true"))).toBe(true);
   });
 
-  it("spawnInjector visible uses new-surface and leaves the new tab focused (no refocus)", async () => {
+  it("spawnInjector visible creates the surface with --focus true and no refocus dance", async () => {
     execFileMock.mockImplementation((_bin: string, args: string[]) => {
-      const cmd = args.join(" ");
-      if (cmd.includes("tree")) return 'surface surface:5 [terminal] "cap" [selected]';
-      if (cmd.includes("new-surface")) return "OK surface:8 pane:2 workspace:1";
+      if (args.includes("new-surface")) return "OK surface:8 pane:2 workspace:1";
       return "";
     });
     await driver.spawnInjector({
@@ -550,7 +519,7 @@ describe("cmux driver", () => {
       placement: "visible",
     });
     const cmds = execFileMock.mock.calls.map(cmdOf);
-    expect(cmds.some((c) => c.includes("new-surface"))).toBe(true);
+    expect(cmds.some((c) => c.includes("new-surface") && c.includes("--focus true"))).toBe(true);
     expect(cmds.every((c) => !c.includes("move-surface"))).toBe(true);
   });
 

--- a/src/runtimes/__tests__/cmux.test.ts
+++ b/src/runtimes/__tests__/cmux.test.ts
@@ -52,6 +52,17 @@ describe("cmux driver", () => {
       expect(((cmuxCall as unknown[])[2] as Record<string, unknown>).timeout).toBeGreaterThan(0);
     });
 
+    it("passes CMUX_QUIET=1 in the subprocess env to silence deprecation notices", async () => {
+      execFileMock.mockReturnValue("");
+      await driver.probe();
+      const cmuxCall = execFileMock.mock.calls.find((c: unknown[]) =>
+        (c[1] as string[]).includes("--version"),
+      );
+      expect(cmuxCall).toBeDefined();
+      const env = (optsOf(cmuxCall as unknown[]).env) as Record<string, string>;
+      expect(env.CMUX_QUIET).toBe("1");
+    });
+
     it("throws a clean CmuxTimeoutError when execFileSync times out (unwrapped caller)", async () => {
       execFileMock.mockImplementation(() => {
         const err = new Error("cmux hung");

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -49,17 +49,50 @@ function cmux(args: string[]): string {
   }
 }
 
+// Shape of `cmux workspace list --json` (cmux 0.64.16). Only the fields we
+// consume are typed; everything else in the payload is ignored.
+interface CmuxWorkspaceListJson {
+  workspaces?: Array<{
+    ref?: string;
+    custom_title?: string | null;
+    has_custom_title?: boolean;
+    current_directory?: string | null;
+  }>;
+}
+
+// Shape of `cmux tree --json` (cmux 0.64.16). Surfaces nest as
+// windows[].workspaces[].panes[].surfaces[]; only consumed fields are typed.
+interface CmuxTreeJson {
+  windows?: Array<{
+    workspaces?: Array<{
+      ref?: string;
+      panes?: Array<{
+        surfaces?: Array<{ ref?: string; surface_ref?: string; title?: string | null }>;
+      }>;
+    }>;
+  }>;
+}
+
+// Parse `cmux workspace list --json` into WorkspaceRefs. Replaces the old
+// regex over the human-readable `list-workspaces` text (audit B2). The display
+// name is the workspace's custom title when set (byte-identical to what the
+// text form showed, e.g. "⚓ cockpit-captain" — this is what cockpit matches
+// captains by), falling back to the cwd for untitled workspaces.
 function parseList(output: string): WorkspaceRef[] {
+  let parsed: CmuxWorkspaceListJson;
+  try {
+    parsed = JSON.parse(output) as CmuxWorkspaceListJson;
+  } catch {
+    return [];
+  }
   const refs: WorkspaceRef[] = [];
-  for (const line of output.split("\n")) {
-    const match = line.match(/(workspace:\d+)\s+(.+?)(?:\s+\(.*\))?(?:\s+\[selected\])?$/);
-    if (match) {
-      refs.push({
-        id: match[1],
-        name: match[2].trim(),
-        status: "running",
-      });
-    }
+  for (const ws of parsed.workspaces ?? []) {
+    if (!ws.ref) continue;
+    refs.push({
+      id: ws.ref,
+      name: (ws.has_custom_title && ws.custom_title) ? ws.custom_title : (ws.current_directory ?? ws.ref),
+      status: "running",
+    });
   }
   return refs;
 }
@@ -240,7 +273,9 @@ export function createCmuxDriver(): RuntimeDriver {
 
     async list(): Promise<WorkspaceRef[]> {
       try {
-        return parseList(cmux(["workspace", "list", "--id-format", "refs"]));
+        // --json: structured output (B2); --id-format refs: ids as
+        // workspace:N refs, not numeric (from #325). Both are required.
+        return parseList(cmux(["workspace", "list", "--json", "--id-format", "refs"]));
       } catch {
         return [];
       }
@@ -463,18 +498,32 @@ export function createCmuxDriver(): RuntimeDriver {
     async listSurfaces(workspaceId: string): Promise<PaneRef[]> {
       let output: string;
       try {
-        output = cmux(["tree", "--workspace", workspaceId, "--id-format", "refs"]);
+        // --json: structured output (B2); --id-format refs: surface ids as
+        // surface:N refs, not numeric (from #325). Both are required.
+        output = cmux(["tree", "--workspace", workspaceId, "--json", "--id-format", "refs"]);
       } catch {
         return [];
       }
+      let parsed: CmuxTreeJson;
+      try {
+        parsed = JSON.parse(output) as CmuxTreeJson;
+      } catch {
+        return [];
+      }
+      // Navigate windows[].workspaces[].panes[].surfaces[], collecting every
+      // surface that belongs to the requested workspace. Replaces the old regex
+      // over `cmux tree` text (audit B2). Surface refs are globally unique, so
+      // filtering by the parent workspace ref is sufficient.
       const surfaces: PaneRef[] = [];
-      // tree output line example:
-      //     ├── surface surface:30 [terminal] "🔧 pact-network:crew-1" [selected]
-      const re = /surface\s+(surface:\d+)\s+\[\w+\]\s+"([^"]*)"/;
-      for (const line of output.split("\n")) {
-        const match = line.match(re);
-        if (match) {
-          surfaces.push({ workspaceId, surfaceId: match[1], title: match[2] });
+      for (const win of parsed.windows ?? []) {
+        for (const ws of win.workspaces ?? []) {
+          if (ws.ref !== workspaceId) continue;
+          for (const pane of ws.panes ?? []) {
+            for (const sf of pane.surfaces ?? []) {
+              const ref = sf.ref ?? sf.surface_ref;
+              if (ref) surfaces.push({ workspaceId, surfaceId: ref, title: sf.title ?? "" });
+            }
+          }
         }
       }
       return surfaces;

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -1,6 +1,8 @@
 import { execFileSync } from "node:child_process";
 import type { RuntimeDriver, RuntimeProbeResult, RuntimeSpawnOptions, WorkspaceRef, PaneRef, RuntimePaneOptions } from "./types.js";
 import { resolveCmuxBin } from "../lib/cmux-bin.js";
+import { checkToolCompat } from "../lib/tool-compat.js";
+import { compatManifest } from "../lib/compat-manifest.js";
 
 // 15s — cmux operations are local IPC (sub-50ms normally). 15s covers unusual
 // system load or a momentarily stuck cmux server without causing the captain
@@ -234,6 +236,8 @@ export function createCmuxDriver(): RuntimeDriver {
     async probe(): Promise<RuntimeProbeResult> {
       try {
         const version = cmux(["--version"]);
+        const warn = checkToolCompat("cmux", version, compatManifest.tools.cmux);
+        if (warn) process.stderr.write(`[cockpit] ${warn}\n`);
         return { installed: true, version };
       } catch {
         return { installed: false, version: "" };
@@ -242,7 +246,7 @@ export function createCmuxDriver(): RuntimeDriver {
 
     async list(): Promise<WorkspaceRef[]> {
       try {
-        return parseList(cmux(["list-workspaces"]));
+        return parseList(cmux(["workspace", "list"]));
       } catch {
         return [];
       }
@@ -255,14 +259,14 @@ export function createCmuxDriver(): RuntimeDriver {
     },
 
     async spawn(opts: RuntimeSpawnOptions): Promise<WorkspaceRef> {
-      const newWorkspaceArgs = ["new-workspace", "--command", opts.command];
+      const newWorkspaceArgs = ["workspace", "create", "--command", opts.command];
       if (opts.workdir) newWorkspaceArgs.push("--cwd", opts.workdir);
       const output = cmux(newWorkspaceArgs);
       const id = output.match(/workspace:\d+/)?.[0] || output.split(/\s+/).pop() || "";
       if (!id) {
         throw new Error(`cmux spawn did not return a workspace id: ${output}`);
       }
-      cmux(["rename-workspace", "--workspace", id, opts.name]);
+      cmux(["workspace", "rename", id, "--title", opts.name]);
       // Rename the initial tab to the workspace name so send() can route to it
       let initialSurface: string | undefined;
       try {
@@ -320,8 +324,13 @@ export function createCmuxDriver(): RuntimeDriver {
     },
 
     async stop(ref: string): Promise<void> {
+      // cmux 0.64.16 refuses to close a pinned workspace. Unpin first so that
+      // cockpit launch --fresh works even when the captain workspace is pinned.
       try {
-        cmux(["close-workspace", "--workspace", ref]);
+        cmux(["workspace-action", "--workspace", ref, "--action", "unpin"]);
+      } catch { /* workspace may not be pinned — proceed to close regardless */ }
+      try {
+        cmux(["workspace", "close", ref]);
       } catch { /* may already be closed */ }
     },
 

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -64,20 +64,6 @@ function parseList(output: string): WorkspaceRef[] {
   return refs;
 }
 
-// Parse `cmux tree` into the ordered list of surfaces in a workspace, marking
-// which one is currently selected. Order matches the tab strip, so the array
-// index doubles as the surface's position for move-surface --index.
-function parseSurfaceOrder(tree: string): { id: string; selected: boolean }[] {
-  const surfaces: { id: string; selected: boolean }[] = [];
-  for (const line of tree.split("\n")) {
-    const match = line.match(/surface\s+(surface:\d+)/);
-    if (match) {
-      surfaces.push({ id: match[1], selected: line.includes("[selected]") });
-    }
-  }
-  return surfaces;
-}
-
 // cmux `send` treats \n, \r (and \t) as Enter/Tab keystrokes, so any newline in a
 // multi-line message would submit it line-by-line. Collapse all newline/CR/tab
 // (real bytes AND literal backslash-escapes) to single spaces so the whole message
@@ -343,22 +329,16 @@ export function createCmuxDriver(): RuntimeDriver {
     },
 
     async newPane(opts: RuntimePaneOptions): Promise<PaneRef> {
-      // #295: snapshot the focused surface before creating a new tab so we can
-      // restore focus afterward. new-surface steals focus; the captain's
-      // keystrokes would otherwise land in the crew's launch command line.
-      // Applies only to tabs (new-surface); split-panes keep cmux default focus.
-      let priorSurface: string | undefined;
-      let priorIndex = -1;
-      if (opts.direction === "tab") {
-        try {
-          const before = parseSurfaceOrder(cmux(["tree", "--workspace", opts.workspaceId, "--id-format", "refs"]));
-          priorIndex = before.findIndex((s) => s.selected);
-          if (priorIndex >= 0) priorSurface = before[priorIndex].id;
-        } catch { /* best-effort: if we can't read the tree, skip refocus */ }
-      }
+      // #295 / audit A1+B3: a crew tab must never steal focus from the captain.
+      // cmux 0.64.16's new-surface and new-pane both DEFAULT to --focus false,
+      // so we pass it explicitly (intent + resilience if the default changes)
+      // and create the surface focus-neutrally. This REPLACES the old
+      // snapshot-then-move-surface refocus dance, which depended on the fragile
+      // "tree order == array index" invariant that the 0.64 freeform canvas +
+      // staggered restore broke — risking a focus-steal regression.
       const cmd = opts.direction === "tab"
-        ? ["new-surface", "--type", "terminal", "--workspace", opts.workspaceId]
-        : ["new-pane", "--type", "terminal", "--direction", opts.direction, "--workspace", opts.workspaceId];
+        ? ["new-surface", "--type", "terminal", "--workspace", opts.workspaceId, "--focus", "false"]
+        : ["new-pane", "--type", "terminal", "--direction", opts.direction, "--workspace", opts.workspaceId, "--focus", "false"];
       const output = cmux(cmd);
       const surfaceId = output.match(/surface:\d+/)?.[0];
       if (!surfaceId) {
@@ -369,11 +349,6 @@ export function createCmuxDriver(): RuntimeDriver {
         try {
           cmux(["rename-tab", "--workspace", opts.workspaceId, "--surface", surfaceId, "--title", opts.title]);
         } catch { /* rename is best-effort */ }
-      }
-      if (opts.direction === "tab" && priorSurface) {
-        try {
-          cmux(["move-surface", "--surface", priorSurface, "--index", String(priorIndex), "--focus", "true"]);
-        } catch { /* refocus is best-effort */ }
       }
       return { workspaceId: opts.workspaceId, surfaceId };
     },
@@ -410,20 +385,15 @@ export function createCmuxDriver(): RuntimeDriver {
       // relay still runs as a cmux descendant in the same workspace, preserving
       // the in-cmux delivery requirement (#112).
       //
-      // "background" then re-selects whatever surface was focused before, in its
-      // original position, so the relay tab never steals focus from the
-      // captain. "visible" leaves the new tab focused for debug ergonomics.
+      // cmux 0.64.16's new-surface DEFAULTS to --focus false, so "background"
+      // passes --focus false and the relay tab is created without ever stealing
+      // focus from the captain — no snapshot-then-move-surface refocus dance
+      // (audit A1+B3; the 0.64 freeform canvas broke the old tree-order==index
+      // assumption it relied on). "visible" passes --focus true to leave the
+      // debug tab focused for ergonomics.
       const wsId = opts.captainWorkspace.id;
-      let priorSurface: string | undefined;
-      let priorIndex = -1;
-      if (opts.placement === "background") {
-        try {
-          const before = parseSurfaceOrder(cmux(["tree", "--workspace", wsId, "--id-format", "refs"]));
-          priorIndex = before.findIndex((s) => s.selected);
-          if (priorIndex >= 0) priorSurface = before[priorIndex].id;
-        } catch { /* best-effort: if we can't read the tree, skip refocus */ }
-      }
-      const output = cmux(["new-surface", "--type", "terminal", "--workspace", wsId]);
+      const focus = opts.placement === "visible" ? "true" : "false";
+      const output = cmux(["new-surface", "--type", "terminal", "--workspace", wsId, "--focus", focus]);
       const surfaceId = output.match(/surface:\d+/)?.[0];
       if (!surfaceId) {
         throw new Error(`cmux spawnInjector did not return a surface id: ${output}`);
@@ -435,11 +405,6 @@ export function createCmuxDriver(): RuntimeDriver {
       }
       cmux(["send", "--workspace", wsId, "--surface", surfaceId, opts.command]);
       cmux(["send-key", "--workspace", wsId, "--surface", surfaceId, "Enter"]);
-      if (opts.placement === "background" && priorSurface) {
-        try {
-          cmux(["move-surface", "--surface", priorSurface, "--index", String(priorIndex), "--focus", "true"]);
-        } catch { /* refocus is best-effort */ }
-      }
       return { workspaceId: wsId, surfaceId, title: opts.title };
     },
 

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -32,7 +32,15 @@ export class DeferDelivery extends Error {
 // literal argument — backticks, $(), quotes are never parsed. See #118.
 function cmux(args: string[]): string {
   try {
-    return execFileSync(resolveCmuxBin(), args, { encoding: "utf-8", timeout: CMUX_TIMEOUT }).trim();
+    // CMUX_QUIET=1 silences cmux 0.64's one-time deprecation hints (e.g. the
+    // "list-workspaces is now an alias for cmux workspace list" notice). Those
+    // notices print to the command's stdout and would otherwise pollute the
+    // output we parse. Inherit the rest of the environment unchanged.
+    return execFileSync(resolveCmuxBin(), args, {
+      encoding: "utf-8",
+      timeout: CMUX_TIMEOUT,
+      env: { ...process.env, CMUX_QUIET: "1" },
+    }).trim();
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ETIMEDOUT") {
       throw new CmuxTimeoutError(args.join(" "));

--- a/src/runtimes/cmux.ts
+++ b/src/runtimes/cmux.ts
@@ -246,7 +246,7 @@ export function createCmuxDriver(): RuntimeDriver {
 
     async list(): Promise<WorkspaceRef[]> {
       try {
-        return parseList(cmux(["workspace", "list"]));
+        return parseList(cmux(["workspace", "list", "--id-format", "refs"]));
       } catch {
         return [];
       }
@@ -270,7 +270,7 @@ export function createCmuxDriver(): RuntimeDriver {
       // Rename the initial tab to the workspace name so send() can route to it
       let initialSurface: string | undefined;
       try {
-        const tree = cmux(["tree", "--workspace", id]);
+        const tree = cmux(["tree", "--workspace", id, "--id-format", "refs"]);
         const m = tree.match(/surface\s+(surface:\d+)\s+\[\w+\]\s+"([^"]*)"/);
         if (m) {
           initialSurface = m[1];
@@ -343,7 +343,7 @@ export function createCmuxDriver(): RuntimeDriver {
       let priorIndex = -1;
       if (opts.direction === "tab") {
         try {
-          const before = parseSurfaceOrder(cmux(["tree", "--workspace", opts.workspaceId]));
+          const before = parseSurfaceOrder(cmux(["tree", "--workspace", opts.workspaceId, "--id-format", "refs"]));
           priorIndex = before.findIndex((s) => s.selected);
           if (priorIndex >= 0) priorSurface = before[priorIndex].id;
         } catch { /* best-effort: if we can't read the tree, skip refocus */ }
@@ -410,7 +410,7 @@ export function createCmuxDriver(): RuntimeDriver {
       let priorIndex = -1;
       if (opts.placement === "background") {
         try {
-          const before = parseSurfaceOrder(cmux(["tree", "--workspace", wsId]));
+          const before = parseSurfaceOrder(cmux(["tree", "--workspace", wsId, "--id-format", "refs"]));
           priorIndex = before.findIndex((s) => s.selected);
           if (priorIndex >= 0) priorSurface = before[priorIndex].id;
         } catch { /* best-effort: if we can't read the tree, skip refocus */ }
@@ -490,7 +490,7 @@ export function createCmuxDriver(): RuntimeDriver {
     async listSurfaces(workspaceId: string): Promise<PaneRef[]> {
       let output: string;
       try {
-        output = cmux(["tree", "--workspace", workspaceId]);
+        output = cmux(["tree", "--workspace", workspaceId, "--id-format", "refs"]);
       } catch {
         return [];
       }


### PR DESCRIPTION
Minor release aligning cockpit with cmux 0.64.16.

**Headline:** `cockpit launch --fresh` fixed (cmux now refuses to close pinned workspaces → unpin-then-close); cmux deprecation noise eliminated.

**New:** external-tool **compat manifest** (`src/lib/compat-manifest.ts`: cmux/claude/node/codex/gemini/opencode version pins) + `doctor` drift check; cmux events-bridge for crew idle (B1); agent-hook working-state to suppress false-stalls (B4/A3).

**Also:** focus-neutral spawn (A1/B3), `--json` parsing, relay-health prune, hibernation gated-off (#329).

Verified: tsc clean, 1222 tests pass. Merging triggers tag `v0.7.0` + GH release. Follow-ups: #326 #332 #333 #114.