### PR TITLE
fix(launch): confirm startup send by surface-change, not spinner-match (cmux 0.64.16 double-run)

### DIFF
--- a/docs/reports/2026-06-16-dbg-cmux-double-startup-and-enter-newline.md
+++ b/docs/reports/2026-06-16-dbg-cmux-double-startup-and-enter-newline.md
@@ -55,22 +55,32 @@ cockpit `send`+`send-key Enter` pattern, captured the surface every 0.25s from a
 frame. Result above: the agent is misclassified "idle" for the majority of an
 active working turn, including the `settleMs` window.
 
-### Draft fix (on scratch — `src/commands/launch.ts` Phase 3)
-Confirm via the **input box**, not the spinner. A landed prompt leaves the box
-empty; dropped keystrokes leave the prompt sitting in it.
+### Fix (applied — `src/commands/launch.ts` Phase 3, `deliverStartupPrompt`)
+Confirm by whether the surface **changed**, not by re-matching the spinner.
+Snapshot the screen just before the send; after `settleMs`, re-send **only if the
+screen is byte-identical** to that baseline.
 
 ```ts
+// Phase 1 keeps the last read as `preSend`.
 await sleep(settleMs);
-const draft = parseDraftFromScreen(await read());
-if (draft === "" || draft === null) return;   // box empty / not visible → landed
-// else: real draft still present → keystrokes dropped → loop & re-send (#235)
+const after = await read();
+if (after !== preSend) return;   // landed (transcript/spinner changed); no re-send
+// identical → keystrokes dropped (#235) → loop & re-send (bounded by maxAttempts)
 ```
 
-**Verified:** `parseDraftFromScreen` returns `""` for **all 9/9** working frames
-the current code misreads as "idle" → zero false re-sends, while a genuinely
-unsubmitted prompt (non-empty draft) still triggers the legitimate #235 retry.
-`parseDraftFromScreen` already strips `Press … to …` ghosts (#294) so a working
-ghost line cannot be mistaken for a remaining draft.
+**Why not the input box:** box-emptiness can't distinguish a *landed+working*
+captain (box empty) from a *#235 splash-drop* (box also empty — the prompt never
+arrived). Change-detection separates them: a landed prompt **always** mutates the
+surface (the submitted message echoes into the transcript and the turn begins),
+while a dropped send leaves it identical. This is also what the sibling crew path
+(`sendFirstTurnWhenReady`, #168) already does.
+
+**Verified:**
+- Hand-traced against all 8 existing `deliverStartupPrompt` tests — all map cleanly
+  (landed = screen changes to WORKING; dropped = screen stays IDLE).
+- Added regression test `does NOT re-send when the captain is thinking with an
+  unrecognized spinner` using the real captured `✽ Synthesizing…` frame.
+- `tsc --noEmit` clean; **full suite 1223/1223 pass** (15/15 in launch.test.ts).
 
 > Note: the crew first-turn path (`sendFirstTurnWhenReady`, `src/commands/crew.ts:152`)
 > uses a different but related confirmation (`isTurnAccepted` over a pre-send
@@ -137,7 +147,14 @@ cause of either bug. Capture live surfaces from a *different* surface only.
 ---
 
 ## Artifacts
-- Draft patch: `src/commands/launch.ts` (Phase 3 box-confirmation) on branch `crew/dbg-cmux`.
+- **Fix (applied):** `src/commands/launch.ts` Phase 3 change-detection +
+  regression test in `src/commands/__tests__/launch.test.ts`, on branch
+  `crew/dbg-cmux`. tsc clean, 1223/1223 tests pass.
 - This report: `docs/reports/2026-06-16-dbg-cmux-double-startup-and-enter-newline.md`.
 - Repro harness (ephemeral, /tmp/dbg): verbatim `classifyStartupSurface` /
   `parseDraftFromScreen` classifiers + captured CC turn frames.
+
+## Still open for a crew (BUG 2)
+BUG 2 (Enter→newline on crew DONE) is **not fixed** — not reproduced. Recommend
+adding the relay `sendToSurface` delivery instrumentation described above to catch
+it in the wild before attempting a fix.

--- a/docs/reports/2026-06-16-dbg-cmux-double-startup-and-enter-newline.md
+++ b/docs/reports/2026-06-16-dbg-cmux-double-startup-and-enter-newline.md
@@ -1,0 +1,143 @@
+# Debug side-session: cmux-0.64.16 double-startup + Enter→newline
+
+**Date:** 2026-06-16
+**Role:** debug side-session (scratch worktree `cockpit-dbg-cmux`, branch `crew/dbg-cmux`)
+**Scope:** root-cause only — draft patch on scratch, no ship.
+**Context:** cmux upgraded to 0.64.16; cockpit shipped v0.7.0 cmux-compat (verb migration, `CMUX_QUIET`, focus-neutral spawn, events-bridge, agent-hook run-state).
+
+---
+
+## BUG 1 — Double startup run — ROOT CAUSE PROVEN ✅
+
+### Symptom
+On captain/crew session start the startup-checklist prompt is submitted **twice**:
+the agent answers + loads the skill, then the same prompt appears and runs again.
+
+### Root cause
+`deliverStartupPrompt` (`src/commands/launch.ts:212`) confirms a startup send by
+re-reading the surface and re-sending **only while it still classifies "idle"**
+(Phase 3). The classification comes from `classifyStartupSurface`
+(`src/runtimes/cmux.ts:253`):
+
+```
+working  iff CC_WORKING_RE matches the live spinner
+idle     iff CC_INITIALIZED_RE matches (⏵⏵ / "Ctx Used") and not working
+loading  otherwise
+```
+
+`CC_WORKING_RE` keys on `↓ N tokens` / `esc to interrupt` / `shell still running` /
+`· N shell` / `(Ns` timer. **The new CC (Opus 4.8) renders the early working phase
+with NONE of these markers**:
+
+| frame (live capture, 0.25s apart) | spinner line | CC_WORKING_RE | classify |
+|---|---|---|---|
+| g01–g11 (~0–2.75s) | `✽ Synthesizing…` (bare, no timer) | **no match** | **idle (BUG)** |
+| g12–g14 (~3s) | `✽ Synthesizing… (2s · thinking with high effort)` | match (`(2s`) | working |
+| g15–g30, g45–g60 | `⏺ Thinking about …:` (streaming, no spinner line) | **no match** | **idle (BUG)** |
+
+`CC_INITIALIZED_RE` matches the persistent status block (`⏵⏵`, `Ctx Used`) which is
+**always present post-splash**, so any working frame without a `CC_WORKING_RE`
+marker falls through to **"idle"**.
+
+`deliverStartupPrompt` checks at `settleMs = 2500ms` — which lands squarely in the
+`g01–g11` "Synthesizing…" stretch → reads "idle" → concludes keystrokes were
+dropped → **re-sends → double startup run.**
+
+`src/commands/launch.ts` and the `CC_*` regexes are **unchanged since v0.6.2**
+(`git log v0.6.2..HEAD`), so this is **cmux/CC render drift** — exactly audit
+finding **A3** in `docs/reports/2026-06-15-cmux-compat-audit-0.62-0.64.md`, not a
+cockpit-code regression. (Earlier incarnation: #292, mem obs 17216 "delivered 3x".)
+
+### Evidence (reproduction)
+Spawned a throwaway `claude` surface, sent a think-then-tool prompt via the exact
+cockpit `send`+`send-key Enter` pattern, captured the surface every 0.25s from a
+*different* surface, and ran the **verbatim** `classifyStartupSurface` against each
+frame. Result above: the agent is misclassified "idle" for the majority of an
+active working turn, including the `settleMs` window.
+
+### Draft fix (on scratch — `src/commands/launch.ts` Phase 3)
+Confirm via the **input box**, not the spinner. A landed prompt leaves the box
+empty; dropped keystrokes leave the prompt sitting in it.
+
+```ts
+await sleep(settleMs);
+const draft = parseDraftFromScreen(await read());
+if (draft === "" || draft === null) return;   // box empty / not visible → landed
+// else: real draft still present → keystrokes dropped → loop & re-send (#235)
+```
+
+**Verified:** `parseDraftFromScreen` returns `""` for **all 9/9** working frames
+the current code misreads as "idle" → zero false re-sends, while a genuinely
+unsubmitted prompt (non-empty draft) still triggers the legitimate #235 retry.
+`parseDraftFromScreen` already strips `Press … to …` ghosts (#294) so a working
+ghost line cannot be mistaken for a remaining draft.
+
+> Note: the crew first-turn path (`sendFirstTurnWhenReady`, `src/commands/crew.ts:152`)
+> uses a different but related confirmation (`isTurnAccepted` over a pre-send
+> snapshot). It is **also vulnerable** to the same chrome drift if its
+> `splashMarker`/acceptance heuristic keys on now-absent markers — worth the crew
+> auditing it against the same captured frames. (The captain path is the one in
+> the report; crew path not separately reproduced here.)
+
+---
+
+## BUG 2 — Enter→newline on crew DONE — NOT REPRODUCED ⚠️ (obvious causes ruled out)
+
+### Symptom (as reported)
+When a crew reports DONE, pressing Enter **sometimes** inserts a newline in the
+captain input box instead of submitting.
+
+### What was ruled out (with evidence)
+1. **Message content newlines** — the DONE message (`formatMessage`,
+   `daemon.ts:117`) is a single line (`CREW DONE [prov/name]: <first-line, ≤200ch>`),
+   and `sanitizeForCmuxSend` (`cmux.ts:104`) collapses `\n\r\t` *and* literal
+   `\n`. Delivered via `sendToSurface` → `cmux send` + separate `cmux send-key Enter`.
+2. **Non-atomic `send` + `send-key Enter` race** — `cmux send` delivers a **raw
+   character burst, no bracketed-paste wrapper, no trailing newline** (verified
+   against a `cat -v` surface); `send-key Enter` is a separate CR ~100ms later.
+   Driving a real CC surface: **15/15 clean submits** on an idle empty box
+   (including 135-char messages, 0/0.3/0.8/1.5s gaps). Does **not** reproduce.
+3. **Delivery while CC is working** — message is **queued** by CC ("Press up to
+   edit queued messages"), not stranded as a newline.
+4. **#302 buffer-liveness probe** (`backspace`+restore into a live draft) — the
+   draft is preserved intact and the subsequent Enter submits. No corruption.
+
+> Methodology caveat: an early "12/12 not submitted" reading was a **false
+> positive** — it grepped the whole screen, and a *submitted* message also renders
+> in the transcript with `❯`/`│`. Correct detection isolates the input box between
+> the last two `─` HR lines (mirrors `parseDraftFromScreen`). After correction:
+> 15/15 submit.
+
+### Remaining hypotheses for the crew (need real-relay / concurrency repro)
+The intermittency was not reproducible in an isolated harness. Most plausible
+remaining vectors, in order:
+- **Working↔idle transition race at delivery time** — crew-DONE often lands exactly
+  as the captain's own turn ends; the `send` may land mid-transition (queued) and
+  the `send-key Enter` after the box re-renders. Needs the real relay + a captain
+  toggling state under load.
+- **cmux socket pressure** — under concurrent socket clients the 0.64.16 socket can
+  drop writes (see "Red herring" below); a dropped `send-key Enter` would leave the
+  text unsubmitted. Could not be reproduced for a non-self surface in isolation.
+- **Recommended next step:** instrument the relay's `sendToSurface` to log, per
+  delivery: the pre-send box state, the message, and a post-send box read-back
+  (submitted vs. still-present). This catches it in the wild where the timing
+  actually occurs, instead of guessing the trigger.
+
+---
+
+## Red herring (documented so it doesn't mislead) — self-surface read = broken pipe
+`cmux read-screen` of the surface you are *currently executing in* fails
+deterministically with `Error: Failed to write to socket (Broken pipe, errno 32)`
+(5/5 on self-surface; 5/5 OK on any other surface; ping/list/tree always OK).
+This wrecked the first capture attempts. **Cockpit never reads its own surface**
+(launch reads the captain from the launch process; the relay reads the captain
+from the relay tab) — so this is an instrumentation artifact, **NOT** a production
+cause of either bug. Capture live surfaces from a *different* surface only.
+
+---
+
+## Artifacts
+- Draft patch: `src/commands/launch.ts` (Phase 3 box-confirmation) on branch `crew/dbg-cmux`.
+- This report: `docs/reports/2026-06-16-dbg-cmux-double-startup-and-enter-newline.md`.
+- Repro harness (ephemeral, /tmp/dbg): verbatim `classifyStartupSurface` /
+  `parseDraftFromScreen` classifiers + captured CC turn frames.

--- a/src/commands/__tests__/launch.test.ts
+++ b/src/commands/__tests__/launch.test.ts
@@ -177,6 +177,34 @@ describe("deliverStartupPrompt (#292 deterministic startup delivery)", () => {
     expect(rt.sends).toEqual(["GO"]);
   });
 
+  // REGRESSION (cmux 0.64.16 / new CC render drift, audit A3): the captain's
+  // first working frames render as a BARE "✽ Synthesizing…" spinner — NO token
+  // counter, NO "(Ns" timer, NO "esc to interrupt", NO shell hint — and then
+  // stream "⏺ Thinking…" with no spinner line at all. CC_WORKING_RE matches none
+  // of these, so classifyStartupSurface returns "idle" for a captain that has
+  // ALREADY accepted the prompt and is thinking. The pre-fix confirm guard
+  // ("re-send while still idle") therefore re-sent → duplicate startup run.
+  // The fix confirms by surface CHANGE: a landed prompt mutates the screen
+  // (transcript + spinner) even when the spinner is unrecognized.
+  // Source of truth: live capture of an Opus 4.8 startup turn (frames g01–g11).
+  it("does NOT re-send when the captain is thinking with an unrecognized spinner", async () => {
+    const SYNTHESIZING = [
+      "❯ Run your startup checklist: use the cockpit:captain-ops skill",
+      "⏺ Thinking about the startup checklist:",
+      "✽ Synthesizing… ",
+      HR, "❯ ", HR,
+      "   Model: Opus 4.8  Ctx Used: 0.0%  Cost: $0.00",
+      "  ⏵⏵ auto mode on",
+    ].join("\n");
+    // idle (ready) → send → captain accepted it and is thinking (unrecognized
+    // spinner) for the whole turn. classifyStartupSurface(SYNTHESIZING) === "idle",
+    // but the surface DIFFERS from the pre-send idle baseline → landed.
+    const rt = fakeRuntime([IDLE, SYNTHESIZING]);
+    await deliverStartupPrompt(rt, "workspace:1", "GO", FAST);
+    // Exactly one send. Pre-fix this was ["GO", "GO", "GO"].
+    expect(rt.sends).toEqual(["GO"]);
+  });
+
   it("never throws even if readScreen rejects", async () => {
     const rt = {
       sends: [] as string[],

--- a/src/commands/launch.ts
+++ b/src/commands/launch.ts
@@ -14,7 +14,7 @@ import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js"
 import { ensureSpokeLayout } from "../lib/vault-layout.js";
 import { resolveCmuxBin } from "../lib/cmux-bin.js";
 import { buildRelaySupervisorCommand, NOTIFY_RELAY_TAB_TITLE } from "../control/relay-supervisor.js";
-import { CMUX_TIMEOUT, classifyStartupSurface, parseDraftFromScreen } from "../runtimes/cmux.js";
+import { CMUX_TIMEOUT, classifyStartupSurface } from "../runtimes/cmux.js";
 
 const CMUX_APP = "/Applications/cmux.app";
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "cockpit", "templates");
@@ -224,11 +224,14 @@ export async function deliverStartupPrompt(
 
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     // Phase 1 — wait out cold init (poll, don't guess with a fixed delay).
+    // Keep the last-read screen as the pre-send baseline for the Phase-3 check.
     const deadline = Date.now() + readyTimeoutMs;
-    let state = classifyStartupSurface(await read());
+    let preSend = await read();
+    let state = classifyStartupSurface(preSend);
     while (state === "loading" && Date.now() < deadline) {
       await sleep(pollMs);
-      state = classifyStartupSurface(await read());
+      preSend = await read();
+      state = classifyStartupSurface(preSend);
     }
 
     // A turn is already in flight (a prior attempt landed, or a resumed session
@@ -243,29 +246,21 @@ export async function deliverStartupPrompt(
     // Timed out waiting for chrome — sent blind once; nothing to confirm, stop.
     if (state === "loading") return;
 
-    // Phase 3 — confirm via the INPUT BOX, not the working-spinner.
-    //
-    // DRAFT FIX (debug side-session, cmux 0.64.16 double-startup bug): the old
-    // guard "re-send only if NOT working" relied on classifyStartupSurface →
-    // CC_WORKING_RE matching the live spinner. The new CC (Opus 4.8) renders the
-    // early thinking phase as a BARE "✽ Synthesizing…" (no timer/token/shell
-    // marker) and then streams "⏺ Thinking about …" with no spinner line at all —
-    // none of which CC_WORKING_RE matches. So a captain that has ALREADY accepted
-    // the prompt and is busy thinking reads as "idle" at the +settleMs check, and
-    // the loop re-sends → DOUBLE startup run (verified: 9/9 working frames of a
-    // real startup turn classified "idle"). classifyStartupSurface is unchanged
-    // since v0.6.2 — this is a cmux/CC render drift (audit finding A3), not a
-    // cockpit-code regression.
-    //
-    // Robust signal: a LANDED prompt leaves the input box empty; DROPPED
-    // keystrokes leave the prompt sitting unsubmitted in the box. parseDraftFromScreen
-    // returns "" for an empty box, null when the box isn't visible (working render),
-    // and the draft text only when real content remains. Re-send ONLY on a real
-    // remaining draft — proven to suppress every false re-send across the whole
-    // working turn while still catching genuinely-dropped keystrokes (#235).
+    // Phase 3 — confirm by whether the surface CHANGED, not by re-matching a
+    // working-spinner. The old guard re-sent "while still idle", relying on
+    // classifyStartupSurface → CC_WORKING_RE matching the live spinner. The newer
+    // CC renders the early turn as a bare "✽ Synthesizing…" (no timer/token/shell
+    // marker) and streams "⏺ Thinking…" with no spinner line at all — none of
+    // which CC_WORKING_RE matches — so a captain that ALREADY accepted the prompt
+    // and is busy thinking reads as "idle" at the +settleMs sample, and the loop
+    // re-sends → duplicate startup run (cmux/CC render drift, audit A3; the code
+    // is unchanged since v0.6.2). A LANDED prompt always mutates the surface (the
+    // submitted message echoes into the transcript and the turn begins); DROPPED
+    // keystrokes (#235) leave the surface byte-identical to the pre-send baseline.
+    // Re-send only on no-change — robust to whatever the spinner renders as.
     await sleep(settleMs);
-    const draft = parseDraftFromScreen(await read());
-    if (draft === "" || draft === null) return;
+    const after = await read();
+    if (after !== preSend) return;
   }
 }
 

--- a/src/commands/launch.ts
+++ b/src/commands/launch.ts
@@ -14,7 +14,7 @@ import { createObsidianDriver, WorkspaceRegistry } from "../workspaces/index.js"
 import { ensureSpokeLayout } from "../lib/vault-layout.js";
 import { resolveCmuxBin } from "../lib/cmux-bin.js";
 import { buildRelaySupervisorCommand, NOTIFY_RELAY_TAB_TITLE } from "../control/relay-supervisor.js";
-import { CMUX_TIMEOUT, classifyStartupSurface } from "../runtimes/cmux.js";
+import { CMUX_TIMEOUT, classifyStartupSurface, parseDraftFromScreen } from "../runtimes/cmux.js";
 
 const CMUX_APP = "/Applications/cmux.app";
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "cockpit", "templates");
@@ -243,12 +243,29 @@ export async function deliverStartupPrompt(
     // Timed out waiting for chrome — sent blind once; nothing to confirm, stop.
     if (state === "loading") return;
 
-    // Phase 3 — confirm. A real submit flips the surface to "working" within a
-    // second or two (a startup turn runs far longer than settleMs). If it's no
-    // longer "idle", the prompt landed → done. If still "idle", the keystrokes
-    // were dropped (#235) → loop and re-send (bounded by maxAttempts).
+    // Phase 3 — confirm via the INPUT BOX, not the working-spinner.
+    //
+    // DRAFT FIX (debug side-session, cmux 0.64.16 double-startup bug): the old
+    // guard "re-send only if NOT working" relied on classifyStartupSurface →
+    // CC_WORKING_RE matching the live spinner. The new CC (Opus 4.8) renders the
+    // early thinking phase as a BARE "✽ Synthesizing…" (no timer/token/shell
+    // marker) and then streams "⏺ Thinking about …" with no spinner line at all —
+    // none of which CC_WORKING_RE matches. So a captain that has ALREADY accepted
+    // the prompt and is busy thinking reads as "idle" at the +settleMs check, and
+    // the loop re-sends → DOUBLE startup run (verified: 9/9 working frames of a
+    // real startup turn classified "idle"). classifyStartupSurface is unchanged
+    // since v0.6.2 — this is a cmux/CC render drift (audit finding A3), not a
+    // cockpit-code regression.
+    //
+    // Robust signal: a LANDED prompt leaves the input box empty; DROPPED
+    // keystrokes leave the prompt sitting unsubmitted in the box. parseDraftFromScreen
+    // returns "" for an empty box, null when the box isn't visible (working render),
+    // and the draft text only when real content remains. Re-send ONLY on a real
+    // remaining draft — proven to suppress every false re-send across the whole
+    // working turn while still catching genuinely-dropped keystrokes (#235).
     await sleep(settleMs);
-    if (classifyStartupSurface(await read()) !== "idle") return;
+    const draft = parseDraftFromScreen(await read());
+    if (draft === "" || draft === null) return;
   }
 }
 


### PR DESCRIPTION
## Bug
After the cmux 0.64.16 / Opus 4.8 update, the captain/crew **startup prompt runs twice** — the checklist prompt is re-sent even though the first one already landed.

## Root cause (proven, live evidence)
`deliverStartupPrompt` confirmed a landed prompt via `classifyStartupSurface` → `CC_WORKING_RE`. The newer CC renders the early turn as a bare `✽ Synthesizing…` (no timer/token/shell marker) then streams `⏺ Thinking…` with no spinner line — **none** of which `CC_WORKING_RE` matches. So a captain that ALREADY accepted the prompt reads as `idle` at the +settleMs sample → the confirm guard re-sends → duplicate startup run. Pure cmux/CC **render drift** (audit A3); launch code unchanged since v0.6.2.

## Fix
Confirm by whether the surface **CHANGED**, not by re-matching a working-spinner. A landed prompt always mutates the surface (echoed message + turn begins) regardless of how the spinner renders; **dropped** keystrokes (#235) leave the surface byte-identical to the pre-send baseline → re-send only on no-change. Mirrors the crew-path fix #168.

## Tests
- New regression test using a **real captured Opus 4.8 startup frame** — asserts exactly one send (pre-fix: three).
- `tsc` clean, full suite 1223/1223 pass.

## Scope
3 files: `src/commands/launch.ts` (fix), `src/commands/__tests__/launch.test.ts` (regression), `docs/reports/2026-06-16-dbg-cmux-double-startup-and-enter-newline.md` (triage report — also covers BUG 2 → #339).

Closes the double-startup regression. BUG 2 (Enter→newline) was NOT reproduced → tracked in #339.