### PR TITLE
feat(#332): daemon-direct cmux behind daemonDirectCmux flag (transport-only)

### DIFF
--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -28,7 +28,7 @@ The handoff file is auto-deleted after reading. Use this as your primary context
 ~/.config/cockpit/scripts/wiki-query.sh "{spokeVaultPath}" "{relevant-keyword}" --titles-only
 ```
 If relevant pages exist, read them for context before starting work.
-8. **Own your relay (#240):** Launch the notify-relay supervisor as a `run_in_background` process on session start:
+8. **Own your relay (#240):** If `defaults.daemonDirectCmux` is ON in cockpit config, skip `relay supervise` — the daemon owns notification delivery directly (#332). Otherwise, launch the notify-relay supervisor as a `run_in_background` process on session start:
    ```bash
    cockpit relay supervise <project> --as captain
    ```

--- a/src/commands/__tests__/relay.test.ts
+++ b/src/commands/__tests__/relay.test.ts
@@ -1,9 +1,29 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createServer } from "node:net";
 import { existsSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildRelaySuperviseArgs, readRelayLogs } from "../relay.js";
+
+const loadConfigMock = vi.hoisted(() => vi.fn());
+vi.mock("../../config.js", () => ({ loadConfig: loadConfigMock, resolveHome: (p: string) => p }));
+
+const runRelaySupervisorMock = vi.hoisted(() => vi.fn());
+vi.mock("../../control/relay-supervisor-loop.js", () => ({ runRelaySupervisor: runRelaySupervisorMock }));
+
+const createRelayLogBroadcasterMock = vi.hoisted(() => vi.fn());
+vi.mock("../../control/relay-log-broadcaster.js", () => ({
+  createRelayLogBroadcaster: createRelayLogBroadcasterMock,
+  relayLogSockPath: vi.fn(),
+}));
+
+const forProjectMock = vi.hoisted(() => vi.fn());
+const RuntimeRegistryMock = vi.hoisted(() => vi.fn().mockImplementation(() => ({ forProject: forProjectMock })));
+vi.mock("../../runtimes/index.js", () => ({
+  createCmuxDriver: () => ({}),
+  RuntimeRegistry: RuntimeRegistryMock,
+}));
+
+import { buildRelaySuperviseArgs, readRelayLogs, relayCommand } from "../relay.js";
 
 function cleanSock(path: string) {
   if (existsSync(path)) try { unlinkSync(path); } catch { /* ignore */ }
@@ -62,6 +82,23 @@ describe("relay supervise", () => {
         stateRoot: "/tmp/state",
       }),
     ).toThrow(/unknown project/);
+  });
+
+  it("relay supervise no-ops when daemonDirectCmux is ON", async () => {
+    loadConfigMock.mockReturnValue({
+      projects: { test: { captainName: "test-captain", path: "/test" } },
+      defaults: { daemonDirectCmux: true },
+    });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await relayCommand.parseAsync(["node", "relay", "supervise", "test"]);
+
+    expect(runRelaySupervisorMock).not.toHaveBeenCalled();
+    expect(createRelayLogBroadcasterMock).not.toHaveBeenCalled();
+    expect(forProjectMock).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("daemon-direct active"));
+
+    logSpy.mockRestore();
   });
 });
 

--- a/src/commands/notify-relay.ts
+++ b/src/commands/notify-relay.ts
@@ -266,7 +266,7 @@ export async function runNotifyRelay(opts: RunOpts): Promise<() => void> {
               sendToSurface: (s: unknown, m: string, o?: { probe?: boolean }) => Promise<void>;
             }).sendToSurface(captainSurface, text, sendOpts),
           );
-          if (!result.delivered) {
+          if ("deferred" in result) {
             log(`deferred: captain typing (seq=${entry.seq})`);
             return;
           }

--- a/src/commands/notify-relay.ts
+++ b/src/commands/notify-relay.ts
@@ -13,14 +13,13 @@ import { join } from "node:path";
 import chalk from "chalk";
 import { loadConfig } from "../config.js";
 import { RuntimeRegistry, createCmuxDriver } from "../runtimes/index.js";
-import { DeferDelivery } from "../runtimes/cmux.js";
 import type { RuntimeDriver } from "../runtimes/types.js";
 import {
   readCursor,
   writeCursor,
   readFromCursor,
-  type MailboxEntry,
 } from "../control/mailbox.js";
+import { CaptainDelivery, deliverable } from "../control/delivery/captain-delivery.js";
 import { sendRequest } from "../control/protocol.js";
 import { classifyPaneTail } from "../control/interactive/pane-classifier.js";
 import { createCrewPaneReader, surfaceVerdict, crewPaneTitle } from "../control/crew-pane-reader.js";
@@ -55,19 +54,9 @@ export const PROBE_QUIET_MS = 20_000;
 // RELAY_STALE_MS/RELAY_GONE_MS windows are sized as multiples of this.
 export const RELAY_REGISTER_HEARTBEAT_MS = 10_000;
 
-// Unified-formatter (#214/#210): the daemon's formatMessage is the single
-// source of truth for the captain-facing message and stores it on the mailbox
-// entry. The relay is a dumb pipe — it delivers entry.message verbatim and
-// skips entries the daemon chose not to surface (null/empty). The old
-// formatEntry switch re-derived the message from the raw event kind and had
-// drifted (no case for task.approval.requested / task.idle), silently dropping
-// those events. It is retired; deliverable() is the whole policy now.
-export function deliverable(entry: MailboxEntry): string | null {
-  const msg = entry.message;
-  if (msg == null) return null;
-  const trimmed = msg.trim();
-  return trimmed.length > 0 ? msg : null;
-}
+// deliverable() is defined in captain-delivery.ts (Task 3) — imported above.
+// Both the relay (flag OFF) and the daemon (flag ON) use the SAME module,
+// so flag-OFF parity is guaranteed.
 
 // ── Phase 2b: in-cmux interactive-block probe ───────────────────────────────
 // A claude/opencode crew parked at a permission prompt (or ending a turn with a
@@ -212,16 +201,14 @@ export async function runNotifyRelay(opts: RunOpts): Promise<() => void> {
   if (!captainSurface) throw new Error("no surfaces in captain workspace");
 
   const sessionStartMs = (opts.now ?? (() => Date.now()))();
-  const maxDefers = opts.maxDeferDeliveries ?? DEFAULT_MAX_DEFERS;
-  const stableProbePolls = opts.stableProbePolls ?? DEFAULT_STABLE_PROBE_POLLS;
 
-  // #258 idle-defer: consecutive defer counts per mailbox seq.
-  // Keyed by entry.seq; deleted on successful delivery.
-  const deferCounts = new Map<number, number>();
-  // #302 stability tracking: last observed draft content + how many consecutive
-  // polls it stayed byte-identical. Stable non-empty content → safe to probe.
-  const lastContent = new Map<number, string | null>();
-  const stableCounts = new Map<number, number>();
+  // #332: CaptainDelivery (imported from captain-delivery.ts) handles defer-
+  // while-typing (#258) and stability-probe (#302) identically for both the
+  // relay (flag OFF) and the daemon (flag ON).
+  const captainDelivery = new CaptainDelivery({
+    maxDefers: opts.maxDeferDeliveries ?? DEFAULT_MAX_DEFERS,
+    stableProbePolls: opts.stableProbePolls ?? DEFAULT_STABLE_PROBE_POLLS,
+  });
 
   const cursor = await readCursor({
     stateRoot: opts.stateRoot,
@@ -274,37 +261,13 @@ export async function runNotifyRelay(opts: RunOpts): Promise<() => void> {
         }
         const msg = deliverable(entry);
         if (msg) {
-          try {
-            const deferCount = deferCounts.get(entry.seq) ?? 0;
-            // #302: probe early once content has been stable for stableProbePolls
-            // polls (captain not typing) — kills the ~5min stall; the 300-defer
-            // backstop still guarantees delivery never hangs forever.
-            const stable = (stableCounts.get(entry.seq) ?? 0) >= stableProbePolls;
-            const probe = stable || deferCount >= maxDefers;
-            await (opts.runtime as RuntimeDriver & {
+          const result = await captainDelivery.deliver(entry, (text, sendOpts) =>
+            (opts.runtime as RuntimeDriver & {
               sendToSurface: (s: unknown, m: string, o?: { probe?: boolean }) => Promise<void>;
-            }).sendToSurface(captainSurface, msg, probe ? { probe: true } : undefined);
-            deferCounts.delete(entry.seq);
-            stableCounts.delete(entry.seq);
-            lastContent.delete(entry.seq);
-          } catch (e) {
-            if (e instanceof DeferDelivery) {
-              deferCounts.set(entry.seq, (deferCounts.get(entry.seq) ?? 0) + 1);
-              // Track content stability: byte-identical non-empty draft across
-              // consecutive polls means the captain isn't actively typing (#302).
-              const content = e.draft;
-              if (content && content === lastContent.get(entry.seq)) {
-                stableCounts.set(entry.seq, (stableCounts.get(entry.seq) ?? 0) + 1);
-              } else {
-                stableCounts.set(entry.seq, 0);
-              }
-              lastContent.set(entry.seq, content);
-              log(`deferred: captain typing (seq=${entry.seq})`);
-              // Don't advance cursor; the next poll will retry from the same seq.
-              return;
-            }
-            log(`sendToSurface failed seq=${entry.seq}: ${(e as Error).message}`);
-            // Don't advance cursor; the next poll will retry from the same seq.
+            }).sendToSurface(captainSurface, text, sendOpts),
+          );
+          if (!result.delivered) {
+            log(`deferred: captain typing (seq=${entry.seq})`);
             return;
           }
           log(`deliver seq=${entry.seq} -> ${opts.subscriber}: ${msg}`);

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -110,6 +110,10 @@ export const relayCommand = new Command("relay")
       .action(async (project: string, opts: { as: string; stateRoot: string }) => {
         try {
           const config = loadConfig();
+          if (config.defaults?.daemonDirectCmux) {
+            console.log(chalk.blue("daemon-direct active; relay disabled (#332)"));
+            return;
+          }
           const relayArgs = buildRelaySuperviseArgs({
             project,
             subscriber: opts.as,

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -22,6 +22,11 @@ describe("config", () => {
     expect(config.metrics.enabled).toBe(true);
   });
 
+  it("daemonDirectCmux defaults to false", () => {
+    const cfg = getDefaultConfig();
+    expect(cfg.defaults?.daemonDirectCmux).toBe(false);
+  });
+
   it("saves and loads config", () => {
     const config = getDefaultConfig();
     config.projects.brove = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -90,8 +90,12 @@ export interface CockpitConfig {
     /** #275 rule-based crew routing: keyword rules map task text to {agent, model}. Optional — absent = fall through to defaults.roles.crew. */
     crewRouting?: CrewRoutingConfig;
     /** B1: consume cmux's native event stream for crew turn-end (idle) detection
-     *  alongside the scrape fallback. Default true; set false for scrape-only. */
+      *  alongside the scrape fallback. Default true; set false for scrape-only. */
     cmuxEventsBridge?: boolean;
+    /** #332: daemon calls cmux directly (bypass notify-relay).
+     *  TRANSPORT ONLY — does not change lifecycle source-of-truth.
+     *  Default false for safe rollout; set true to retire the relay process. */
+    daemonDirectCmux?: boolean;
     /**
      * Audit C2 — agent hibernation (reclaim idle-crew RAM). INTENTIONALLY OFF and
      * INERT: cmux 0.64.16's `cmux agent-hibernation <on|off>` is GLOBAL (app-wide,
@@ -149,6 +153,8 @@ export function getDefaultConfig(): CockpitConfig {
       // Audit C2: OFF by design — cmux hibernation is global-only and would
       // hibernate the captain/relay. See the field doc above.
       cmuxAgentHibernation: false,
+      // #332: daemon-direct cmux — OFF for safe rollout; set true to retire the relay.
+      daemonDirectCmux: false,
       crewRouting: {
         rules: [
           { tier: "extreme", match: "redesign|architect|rewrite|from scratch|deep reasoning", agent: "claude", model: "opus" },

--- a/src/config.ts
+++ b/src/config.ts
@@ -90,7 +90,7 @@ export interface CockpitConfig {
     /** #275 rule-based crew routing: keyword rules map task text to {agent, model}. Optional — absent = fall through to defaults.roles.crew. */
     crewRouting?: CrewRoutingConfig;
     /** B1: consume cmux's native event stream for crew turn-end (idle) detection
-      *  alongside the scrape fallback. Default true; set false for scrape-only. */
+     *  alongside the scrape fallback. Default true; set false for scrape-only. */
     cmuxEventsBridge?: boolean;
     /** #332: daemon calls cmux directly (bypass notify-relay).
      *  TRANSPORT ONLY — does not change lifecycle source-of-truth.

--- a/src/control/__tests__/cockpitd-daemon-direct.test.ts
+++ b/src/control/__tests__/cockpitd-daemon-direct.test.ts
@@ -78,22 +78,21 @@ describe("cockpitd daemon-direct (#332)", () => {
     const stateRoot = join(dir, "state");
     mkdirSync(join(stateRoot, "inbox"), { recursive: true });
 
-    // Seed a message for delivery on the first tick. Also seed a store task so
-    // project "p" appears in the delivery tick's project iteration.
-    await appendToMailbox({ stateRoot, project: "p", taskRecord: TASK, event: EVENT, message: "CREW DONE" });
+    // Seed first message (delivered on tick 1). A second message is appended
+    // after the reap (before tick 5) to prove delivery resumes.
+    await appendToMailbox({ stateRoot, project: "p", taskRecord: TASK, event: EVENT, message: "CREW DONE #1" });
     await writeCursor({ stateRoot, project: "p", subscriber: "captain", lastAckedSeq: 0 });
     mkdirSync(join(stateRoot, "p"), { recursive: true });
     writeFileSync(join(stateRoot, "p", `${TASK.id}.json`), JSON.stringify(TASK));
 
     const captainTitle = "p-captain";
-    // Mock: first tick → captain present; subsequent ticks → captain absent (gone)
     let surfCall = 0;
     const surfResults: PaneRef[][] = [
-      [{ workspaceId: "ws:1", surfaceId: "s1", title: captainTitle }],    // tick 1: found
+      [{ workspaceId: "ws:1", surfaceId: "s1", title: captainTitle }],    // tick 1: found → deliver #1
       [{ workspaceId: "ws:1", surfaceId: "s2", title: "some-other-pane" }], // tick 2: gone
       [{ workspaceId: "ws:1", surfaceId: "s2", title: "some-other-pane" }], // tick 3: gone
       [{ workspaceId: "ws:1", surfaceId: "s2", title: "some-other-pane" }], // tick 4: gone → reap
-      [{ workspaceId: "ws:1", surfaceId: "s1", title: captainTitle }],      // tick 5: would resume but reaped
+      [{ workspaceId: "ws:1", surfaceId: "s1", title: captainTitle }],      // tick 5: un-reap + deliver #2
     ];
     const cmux = {
       sent: [] as Array<{ text: string }>,
@@ -123,9 +122,76 @@ describe("cockpitd daemon-direct (#332)", () => {
     if (handle.tickDelivery) await handle.tickDelivery(); // streak=3 → reaped
     expect(cmux.sent.length).toBe(1);
 
-    // Tick 5: captain surface reappears but project is reaped → no delivery.
-    if (handle.tickDelivery) await handle.tickDelivery();
+    // Append a second message to prove delivery resumes.
+    await appendToMailbox({ stateRoot, project: "p", taskRecord: TASK, event: EVENT, message: "CREW DONE #2" });
+    if (handle.tickDelivery) await handle.tickDelivery(); // tick 5: deliver #2
+    expect(cmux.sent.length).toBe(2);
+  });
+
+  it("reap is NON-terminal: resume on reappearance, re-enter after K on fresh cycle", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-dd-reap2-"));
+    const sock = join(dir, "c.sock");
+    const stateRoot = join(dir, "state");
+    mkdirSync(join(stateRoot, "inbox"), { recursive: true });
+
+    // Seed first message (delivered on tick 1). Second message appended after
+    // reap (before tick 5) to prove delivery resumes.
+    await appendToMailbox({ stateRoot, project: "p", taskRecord: TASK, event: EVENT, message: "CREW DONE #1" });
+    await writeCursor({ stateRoot, project: "p", subscriber: "captain", lastAckedSeq: 0 });
+    mkdirSync(join(stateRoot, "p"), { recursive: true });
+    writeFileSync(join(stateRoot, "p", `${TASK.id}.json`), JSON.stringify(TASK));
+
+    const captainTitle = "p-captain";
+    let surfCall = 0;
+    const surfResults: PaneRef[][] = [
+      [{ workspaceId: "ws:1", surfaceId: "s1", title: captainTitle }],    // tick 1: found → deliver
+      [{ workspaceId: "ws:1", surfaceId: "s2", title: "other" }],          // tick 2: gone    streak=1
+      [{ workspaceId: "ws:1", surfaceId: "s2", title: "other" }],          // tick 3: gone    streak=2
+      [{ workspaceId: "ws:1", surfaceId: "s2", title: "other" }],          // tick 4: gone    streak=3 → reap fires (once)
+      [{ workspaceId: "ws:1", surfaceId: "s1", title: captainTitle }],    // tick 5: found   → un-reap + deliver
+      [{ workspaceId: "ws:1", surfaceId: "s2", title: "other" }],          // tick 6: gone    streak=1 (fresh cycle)
+      [{ workspaceId: "ws:1", surfaceId: "s2", title: "other" }],          // tick 7: gone    streak=2
+      [{ workspaceId: "ws:1", surfaceId: "s2", title: "other" }],          // tick 8: gone    streak=3 → reap fires again
+    ];
+    const cmux = {
+      sent: [] as Array<{ text: string }>,
+      send: async (_surface: PaneRef, text: string) => { (cmux as any).sent.push({ text }); },
+      listSurfaces: async () => surfResults[surfCall++],
+      readScreen: async () => null,
+      isAvailable: async () => true,
+      findWorkspaceId: async (name: string) => name === captainTitle ? "ws:1" : null,
+    } as unknown as DaemonCmux & { sent: Array<{ text: string }> };
+
+    const handle = startCockpitd({
+      stateRoot, sockPath: sock, sweepMs: 0,
+      daemonCmux: cmux,
+      daemonDirectCmux: true,
+    });
+    stop = handle.stop;
+
+    // Phase 1: present → absent → reap.
+    if (handle.tickDelivery) await handle.tickDelivery(); // tick 1: deliver
     expect(cmux.sent.length).toBe(1);
+    if (handle.tickDelivery) await handle.tickDelivery(); // tick 2: streak=1
+    expect(cmux.sent.length).toBe(1);
+    if (handle.tickDelivery) await handle.tickDelivery(); // tick 3: streak=2
+    expect(cmux.sent.length).toBe(1);
+    if (handle.tickDelivery) await handle.tickDelivery(); // tick 4: streak=3 → reap
+    expect(cmux.sent.length).toBe(1);
+
+    // Phase 2: append second message, then reappear → resume delivery.
+    await appendToMailbox({ stateRoot, project: "p", taskRecord: TASK, event: EVENT, message: "CREW DONE #2" });
+    if (handle.tickDelivery) await handle.tickDelivery(); // tick 5: deliver #2
+    expect(cmux.sent.length).toBe(2);
+
+    // Phase 3: absent again → fresh streak → reap again.
+    if (handle.tickDelivery) await handle.tickDelivery(); // tick 6: streak=1
+    expect(cmux.sent.length).toBe(2);
+    if (handle.tickDelivery) await handle.tickDelivery(); // tick 7: streak=2
+    expect(cmux.sent.length).toBe(2);
+    if (handle.tickDelivery) await handle.tickDelivery(); // tick 8: streak=3 → reap again
+    expect(cmux.sent.length).toBe(2);
+    // If tick 9 had captain found, delivery would resume to 3.
   });
 
   it("does NOT reap on a single transient empty sweep (K>1)", async () => {

--- a/src/control/__tests__/cockpitd-daemon-direct.test.ts
+++ b/src/control/__tests__/cockpitd-daemon-direct.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { startCockpitd, discoverCaptainSurface } from "../cockpitd.js";
 import { appendToMailbox, writeCursor } from "../mailbox.js";
+import { sendRequest } from "../protocol.js";
+import { crewPaneTitle } from "../crew-pane-reader.js";
 import type { DaemonCmux } from "../cmux/daemon-cmux.js";
 import type { PaneRef } from "../../runtimes/types.js";
 import type { TaskRecord, ControlEvent } from "../types.js";
@@ -29,6 +31,18 @@ function fakeCmux(): DaemonCmux & { sent: Array<{ text: string }> } {
     findWorkspaceId: async () => null, // cmux workspaces not available in test
   } as unknown as DaemonCmux & { sent: Array<{ text: string }> };
 }
+
+// A claude permission dialog (box-drawing chrome included) — classifyPaneTail
+// recognises this as an approval wait. Copied from notify-relay-probe.test.ts.
+const APPROVAL_TAIL = [
+  "● I'll create the file now.",
+  "╭──────────────────────────────────────────────────────╮",
+  "│ Do you want to create newfile.txt?                     │",
+  "│ ❯ 1. Yes                                               │",
+  "│   2. No, and tell Claude what to do differently        │",
+  "╰──────────────────────────────────────────────────────╯",
+  "  accept edits on (shift+tab to cycle)                    ",
+].join("\n");
 
 describe("cockpitd daemon-direct (#332)", () => {
   let stop: (() => void) | undefined;
@@ -87,7 +101,10 @@ describe("cockpitd daemon-direct (#332)", () => {
 
     const captainTitle = "p-captain";
     let surfCall = 0;
+    // Index 0 is consumed by d.reconcile() on boot (checks surface liveness).
+    // Then tick 1 uses index 1, tick 2 uses index 2, etc.
     const surfResults: PaneRef[][] = [
+      [{ workspaceId: "ws:1", surfaceId: "s0", title: captainTitle }],     // reconcile (boot): found
       [{ workspaceId: "ws:1", surfaceId: "s1", title: captainTitle }],    // tick 1: found → deliver #1
       [{ workspaceId: "ws:1", surfaceId: "s2", title: "some-other-pane" }], // tick 2: gone
       [{ workspaceId: "ws:1", surfaceId: "s2", title: "some-other-pane" }], // tick 3: gone
@@ -143,7 +160,9 @@ describe("cockpitd daemon-direct (#332)", () => {
 
     const captainTitle = "p-captain";
     let surfCall = 0;
+    // Index 0 is consumed by d.reconcile() on boot. Then tick 1 uses index 1, etc.
     const surfResults: PaneRef[][] = [
+      [{ workspaceId: "ws:1", surfaceId: "s0", title: captainTitle }],     // reconcile (boot): found
       [{ workspaceId: "ws:1", surfaceId: "s1", title: captainTitle }],    // tick 1: found → deliver
       [{ workspaceId: "ws:1", surfaceId: "s2", title: "other" }],          // tick 2: gone    streak=1
       [{ workspaceId: "ws:1", surfaceId: "s2", title: "other" }],          // tick 3: gone    streak=2
@@ -205,11 +224,12 @@ describe("cockpitd daemon-direct (#332)", () => {
     mkdirSync(join(stateRoot, "p"), { recursive: true });
     writeFileSync(join(stateRoot, "p", `${TASK.id}.json`), JSON.stringify(TASK));
 
-    // Mock: first tick → gone (wrong title), second tick → captain found
+    // Mock: reconcile consumes index 0, then tick 1 uses index 1, tick 2 uses index 2
     let callIdx = 0;
     const results: PaneRef[][] = [
+      [{ workspaceId: "ws:1", surfaceId: "s0", title: "p-captain" }],      // reconcile (boot): found
       [{ workspaceId: "ws:1", surfaceId: "s2", title: "some-other-pane" }], // tick 1: gone
-      [{ workspaceId: "ws:1", surfaceId: "s1", title: "p-captain" }], // tick 2: found
+      [{ workspaceId: "ws:1", surfaceId: "s1", title: "p-captain" }],       // tick 2: found
     ];
     const captainTitle = "p-captain";
     const cmux = {
@@ -259,5 +279,51 @@ describe("cockpitd daemon-direct (#332)", () => {
 
     expect((handle as any).tickDelivery).toBeUndefined();
     expect(cmux.sent).toEqual([]);
+  });
+
+  it("flag ON: daemon-direct probe emits task.blocked when interactive crew pane shows a permission prompt", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-dd-probe-"));
+    const sock = join(dir, "c.sock");
+    const stateRoot = join(dir, "state");
+    mkdirSync(join(stateRoot, "inbox"), { recursive: true });
+
+    // Seed a working interactive task that is quiet enough to be probed.
+    const worker: TaskRecord = {
+      id: "probe-1", project: "p", provider: "claude", mode: "interactive",
+      state: "working", task: "x", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000,
+      name: "worker",
+      attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }],
+    };
+
+    const cmux = {
+      sent: [] as Array<{ text: string }>,
+      send: async () => {},
+      listSurfaces: async () => [
+        { workspaceId: "ws:1", surfaceId: "s1", title: crewPaneTitle("p", "worker") },
+      ],
+      readScreen: async () => APPROVAL_TAIL,
+      isAvailable: async () => true,
+      findWorkspaceId: async () => "ws:1",
+    } as unknown as DaemonCmux & { sent: Array<{ text: string }> };
+
+    const handle = startCockpitd({
+      stateRoot, sockPath: sock, sweepMs: 0,
+      daemonCmux: cmux,
+      daemonDirectCmux: true,
+    });
+    stop = handle.stop;
+
+    // Seed the task into the daemon's store.
+    await sendRequest(sock, { kind: "seed", record: worker });
+
+    // Wait for boot reconcile to settle, then trigger the probe tick.
+    await new Promise((r) => setTimeout(r, 20));
+    if ((handle as any).tickProbe) await (handle as any).tickProbe();
+
+    // Verify task transitioned to blocked. lastEvent is "task.blocked"
+    // (the event type); reason is protocol/logging-only per state-machine.ts.
+    const updated = await sendRequest(sock, { kind: "status", project: "p", id: "probe-1" }) as TaskRecord;
+    expect(updated.state).toBe("blocked");
   });
 });

--- a/src/control/__tests__/cockpitd-daemon-direct.test.ts
+++ b/src/control/__tests__/cockpitd-daemon-direct.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { startCockpitd } from "../cockpitd.js";
+import { startCockpitd, discoverCaptainSurface } from "../cockpitd.js";
 import { appendToMailbox, writeCursor } from "../mailbox.js";
 import type { DaemonCmux } from "../cmux/daemon-cmux.js";
 import type { PaneRef } from "../../runtimes/types.js";
@@ -26,6 +26,7 @@ function fakeCmux(): DaemonCmux & { sent: Array<{ text: string }> } {
     listSurfaces: async () => [],
     readScreen: async () => null,
     isAvailable: async () => true,
+    findWorkspaceId: async () => null, // cmux workspaces not available in test
   } as unknown as DaemonCmux & { sent: Array<{ text: string }> };
 }
 
@@ -60,6 +61,114 @@ describe("cockpitd daemon-direct (#332)", () => {
 
     expect(cmux.sent.length).toBe(1);
     expect(cmux.sent[0].text).toMatch(/CREW DONE/);
+  });
+
+  it("discoverCaptainSurface finds the matching captain pane by title", () => {
+    const surfaces: PaneRef[] = [
+      { workspaceId: "ws:1", surfaceId: "s9", title: "⚓ cockpit-captain" },
+      { workspaceId: "ws:1", surfaceId: "s10", title: "🔧 cockpit:crew-1" },
+    ];
+    expect(discoverCaptainSurface(surfaces, "⚓ cockpit-captain")?.surfaceId).toBe("s9");
+    expect(discoverCaptainSurface(surfaces, "nonexistent")).toBeNull();
+  });
+
+  it("reaps the captain as closed after K consecutive sweeps with no captain surface", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-dd-reap-"));
+    const sock = join(dir, "c.sock");
+    const stateRoot = join(dir, "state");
+    mkdirSync(join(stateRoot, "inbox"), { recursive: true });
+
+    // Seed a message for delivery on the first tick. Also seed a store task so
+    // project "p" appears in the delivery tick's project iteration.
+    await appendToMailbox({ stateRoot, project: "p", taskRecord: TASK, event: EVENT, message: "CREW DONE" });
+    await writeCursor({ stateRoot, project: "p", subscriber: "captain", lastAckedSeq: 0 });
+    mkdirSync(join(stateRoot, "p"), { recursive: true });
+    writeFileSync(join(stateRoot, "p", `${TASK.id}.json`), JSON.stringify(TASK));
+
+    const captainTitle = "p-captain";
+    // Mock: first tick → captain present; subsequent ticks → captain absent (gone)
+    let surfCall = 0;
+    const surfResults: PaneRef[][] = [
+      [{ workspaceId: "ws:1", surfaceId: "s1", title: captainTitle }],    // tick 1: found
+      [{ workspaceId: "ws:1", surfaceId: "s2", title: "some-other-pane" }], // tick 2: gone
+      [{ workspaceId: "ws:1", surfaceId: "s2", title: "some-other-pane" }], // tick 3: gone
+      [{ workspaceId: "ws:1", surfaceId: "s2", title: "some-other-pane" }], // tick 4: gone → reap
+      [{ workspaceId: "ws:1", surfaceId: "s1", title: captainTitle }],      // tick 5: would resume but reaped
+    ];
+    const cmux = {
+      sent: [] as Array<{ text: string }>,
+      send: async (_surface: PaneRef, text: string) => { (cmux as any).sent.push({ text }); },
+      listSurfaces: async () => surfResults[surfCall++],
+      readScreen: async () => null,
+      isAvailable: async () => true,
+      findWorkspaceId: async (name: string) => name === captainTitle ? "ws:1" : null,
+    } as unknown as DaemonCmux & { sent: Array<{ text: string }> };
+
+    const handle = startCockpitd({
+      stateRoot, sockPath: sock, sweepMs: 0,
+      daemonCmux: cmux,
+      daemonDirectCmux: true,
+    });
+    stop = handle.stop;
+
+    // Tick 1: captain found → message delivered.
+    if (handle.tickDelivery) await handle.tickDelivery();
+    expect(cmux.sent.length).toBe(1);
+
+    // Tick 2-4: captain gone → streak builds to K=3 → project reaped.
+    if (handle.tickDelivery) await handle.tickDelivery(); // streak=1
+    expect(cmux.sent.length).toBe(1);
+    if (handle.tickDelivery) await handle.tickDelivery(); // streak=2
+    expect(cmux.sent.length).toBe(1);
+    if (handle.tickDelivery) await handle.tickDelivery(); // streak=3 → reaped
+    expect(cmux.sent.length).toBe(1);
+
+    // Tick 5: captain surface reappears but project is reaped → no delivery.
+    if (handle.tickDelivery) await handle.tickDelivery();
+    expect(cmux.sent.length).toBe(1);
+  });
+
+  it("does NOT reap on a single transient empty sweep (K>1)", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-dd-transient-"));
+    const sock = join(dir, "c.sock");
+    const stateRoot = join(dir, "state");
+    mkdirSync(join(stateRoot, "inbox"), { recursive: true });
+
+    await appendToMailbox({ stateRoot, project: "p", taskRecord: TASK, event: EVENT, message: "CREW DONE [claude/t1]" });
+    await writeCursor({ stateRoot, project: "p", subscriber: "captain", lastAckedSeq: 0 });
+    mkdirSync(join(stateRoot, "p"), { recursive: true });
+    writeFileSync(join(stateRoot, "p", `${TASK.id}.json`), JSON.stringify(TASK));
+
+    // Mock: first tick → gone (wrong title), second tick → captain found
+    let callIdx = 0;
+    const results: PaneRef[][] = [
+      [{ workspaceId: "ws:1", surfaceId: "s2", title: "some-other-pane" }], // tick 1: gone
+      [{ workspaceId: "ws:1", surfaceId: "s1", title: "p-captain" }], // tick 2: found
+    ];
+    const captainTitle = "p-captain";
+    const cmux = {
+      sent: [] as Array<{ text: string }>,
+      send: async (_surface: PaneRef, text: string) => { (cmux as any).sent.push({ text }); },
+      listSurfaces: async () => results[callIdx++],
+      readScreen: async () => null,
+      isAvailable: async () => true,
+      findWorkspaceId: async (name: string) => name === captainTitle ? "ws:1" : null,
+    } as unknown as DaemonCmux & { sent: Array<{ text: string }> };
+
+    const handle = startCockpitd({
+      stateRoot, sockPath: sock, sweepMs: 0,
+      daemonCmux: cmux,
+      daemonDirectCmux: true,
+    });
+    stop = handle.stop;
+
+    // Tick 1: transient absence → streak=1, no delivery.
+    if (handle.tickDelivery) await handle.tickDelivery();
+    expect(cmux.sent.length).toBe(0);
+
+    // Tick 2: captain found → message delivered, streak reset.
+    if (handle.tickDelivery) await handle.tickDelivery();
+    expect(cmux.sent.length).toBe(1);
   });
 
   it("flag OFF: daemon does NOT run the delivery loop (relay path owns it)", async () => {

--- a/src/control/__tests__/cockpitd-daemon-direct.test.ts
+++ b/src/control/__tests__/cockpitd-daemon-direct.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startCockpitd } from "../cockpitd.js";
+import { appendToMailbox, writeCursor } from "../mailbox.js";
+import type { DaemonCmux } from "../cmux/daemon-cmux.js";
+import type { PaneRef } from "../../runtimes/types.js";
+import type { TaskRecord, ControlEvent } from "../types.js";
+
+const TASK: TaskRecord = {
+  id: "t1", project: "p", provider: "claude", mode: "interactive",
+  state: "submitted", task: "x", createdAt: 1, lastHeartbeat: 1,
+  lastEvent: "", heartbeatBudgetMs: 1000,
+  name: "test-crew",
+  attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }],
+};
+
+const EVENT: ControlEvent = { type: "task.done", id: "t1", resultRef: "/tmp/x" };
+
+function fakeCmux(): DaemonCmux & { sent: Array<{ text: string }> } {
+  const sent: Array<{ text: string }> = [];
+  return {
+    sent,
+    send: async (_surface: PaneRef, text: string) => { sent.push({ text }); },
+    listSurfaces: async () => [],
+    readScreen: async () => null,
+    isAvailable: async () => true,
+  } as unknown as DaemonCmux & { sent: Array<{ text: string }> };
+}
+
+describe("cockpitd daemon-direct (#332)", () => {
+  let stop: (() => void) | undefined;
+  let dir: string;
+  afterEach(() => { stop?.(); if (dir) rmSync(dir, { recursive: true, force: true }); });
+
+  it("flag ON: daemon delivers queued captain messages via DaemonCmux + CaptainDelivery", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-dd-"));
+    const sock = join(dir, "c.sock");
+    const stateRoot = join(dir, "state");
+    mkdirSync(join(stateRoot, "inbox"), { recursive: true });
+
+    // Seed the mailbox directly.
+    await appendToMailbox({ stateRoot, project: "p", taskRecord: TASK, event: EVENT, message: "CREW DONE [claude/t1] — build the widget" });
+    // Write cursor for the "captain" subscriber starting at seq 0.
+    await writeCursor({ stateRoot, project: "p", subscriber: "captain", lastAckedSeq: 0 });
+
+    const cmux = fakeCmux();
+    const handle = startCockpitd({
+      stateRoot,
+      sockPath: sock,
+      sweepMs: 0,
+      daemonCmux: cmux,
+      daemonDirectCmux: true,
+      captainSurfaces: { p: { workspaceId: "ws:1", surfaceId: "surface:1", title: "captain" } },
+    });
+    stop = handle.stop;
+
+    if (handle.tickDelivery) await handle.tickDelivery();
+
+    expect(cmux.sent.length).toBe(1);
+    expect(cmux.sent[0].text).toMatch(/CREW DONE/);
+  });
+
+  it("flag OFF: daemon does NOT run the delivery loop (relay path owns it)", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-dd-off-"));
+    const sock = join(dir, "c.sock");
+    const stateRoot = join(dir, "state");
+    mkdirSync(join(stateRoot, "inbox"), { recursive: true });
+
+    await appendToMailbox({ stateRoot, project: "p", taskRecord: TASK, event: EVENT, message: "CREW DONE [claude/t1]" });
+    await writeCursor({ stateRoot, project: "p", subscriber: "captain", lastAckedSeq: 0 });
+
+    const cmux = fakeCmux();
+    const handle = startCockpitd({
+      stateRoot,
+      sockPath: sock,
+      sweepMs: 0,
+      daemonCmux: cmux,
+      daemonDirectCmux: false,
+      captainSurfaces: { p: { workspaceId: "ws:1", surfaceId: "surface:1", title: "captain" } },
+    });
+    stop = handle.stop;
+
+    expect((handle as any).tickDelivery).toBeUndefined();
+    expect(cmux.sent).toEqual([]);
+  });
+});

--- a/src/control/__tests__/cockpitd-daemon-direct.test.ts
+++ b/src/control/__tests__/cockpitd-daemon-direct.test.ts
@@ -303,6 +303,7 @@ describe("cockpitd daemon-direct (#332)", () => {
         { workspaceId: "ws:1", surfaceId: "s1", title: crewPaneTitle("p", "worker") },
       ],
       readScreen: async () => APPROVAL_TAIL,
+      readPaneScreen: async () => APPROVAL_TAIL,
       isAvailable: async () => true,
       findWorkspaceId: async () => "ws:1",
     } as unknown as DaemonCmux & { sent: Array<{ text: string }> };

--- a/src/control/__tests__/crew-pane-reader-direct.test.ts
+++ b/src/control/__tests__/crew-pane-reader-direct.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { createDirectSurfaceLivenessProbe, crewPaneTitle } from "../crew-pane-reader.js";
+import type { DaemonCmux } from "../cmux/daemon-cmux.js";
+import type { TaskRecord } from "../types.js";
+
+function mockCmux(overrides?: Partial<DaemonCmux>): DaemonCmux {
+  return {
+    send: async () => {},
+    listSurfaces: async () => [],
+    readScreen: async () => null,
+    isAvailable: async () => true,
+    findWorkspaceId: async () => null,
+    ...overrides,
+  } as unknown as DaemonCmux;
+}
+
+const TASK: TaskRecord = {
+  id: "t1", project: "p", provider: "claude", mode: "interactive",
+  state: "working", task: "test", createdAt: 1, lastHeartbeat: 1,
+  lastEvent: "", heartbeatBudgetMs: 1000,
+  name: "crew-1",
+  attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }],
+};
+
+describe("createDirectSurfaceLivenessProbe (#332)", () => {
+  it("returns alive when captain workspace surfaces contain the crew pane", async () => {
+    const wantTitle = crewPaneTitle("p", "crew-1");
+    const cmux = mockCmux({
+      findWorkspaceId: async () => "ws:1",
+      listSurfaces: async () => [
+        { workspaceId: "ws:1", surfaceId: "s1", title: "⚓ p-captain" },
+        { workspaceId: "ws:1", surfaceId: "s2", title: wantTitle },
+      ],
+    });
+    const probe = createDirectSurfaceLivenessProbe(cmux, () => "p-captain");
+    await expect(probe(TASK)).resolves.toBe("alive");
+  });
+
+  it("returns gone when surfaces are non-empty but lack the crew pane", async () => {
+    const cmux = mockCmux({
+      findWorkspaceId: async () => "ws:1",
+      listSurfaces: async () => [
+        { workspaceId: "ws:1", surfaceId: "s1", title: "⚓ p-captain" },
+        { workspaceId: "ws:1", surfaceId: "s2", title: "🔧 p:other-crew" },
+      ],
+    });
+    const probe = createDirectSurfaceLivenessProbe(cmux, () => "p-captain");
+    await expect(probe(TASK)).resolves.toBe("gone");
+  });
+
+  it("returns unknown when listSurfaces returns empty (fail-soft)", async () => {
+    const cmux = mockCmux({
+      findWorkspaceId: async () => "ws:1",
+      listSurfaces: async () => [],
+    });
+    const probe = createDirectSurfaceLivenessProbe(cmux, () => "p-captain");
+    await expect(probe(TASK)).resolves.toBe("unknown");
+  });
+
+  it("returns unknown when findWorkspaceId returns null (cmux unreachable)", async () => {
+    const cmux = mockCmux({
+      findWorkspaceId: async () => null,
+    });
+    const probe = createDirectSurfaceLivenessProbe(cmux, () => "p-captain");
+    await expect(probe(TASK)).resolves.toBe("unknown");
+  });
+
+  it("returns unknown for non-interactive task", async () => {
+    const probe = createDirectSurfaceLivenessProbe(mockCmux(), () => "p-captain");
+    await expect(probe({ ...TASK, mode: "headless" })).resolves.toBe("unknown");
+  });
+
+  it("returns unknown for unnamed task", async () => {
+    const probe = createDirectSurfaceLivenessProbe(mockCmux(), () => "p-captain");
+    await expect(probe({ ...TASK, name: undefined })).resolves.toBe("unknown");
+  });
+
+  it("returns unknown on exception from any cmux method", async () => {
+    const cmux = mockCmux({
+      findWorkspaceId: async () => { throw new Error("cmux boom"); },
+    });
+    const probe = createDirectSurfaceLivenessProbe(cmux, () => "p-captain");
+    await expect(probe(TASK)).resolves.toBe("unknown");
+  });
+});

--- a/src/control/__tests__/daemon-cmux.test.ts
+++ b/src/control/__tests__/daemon-cmux.test.ts
@@ -26,4 +26,15 @@ describe("DaemonCmux", () => {
     expect(await new DaemonCmux({ listSurfaces: async () => [] } as any).isAvailable()).toBe(true);
     expect(await new DaemonCmux({ listSurfaces: async () => { throw new Error(); } } as any).isAvailable()).toBe(false);
   });
+
+  it("findWorkspaceId returns workspace ID when found, null when not found or error", async () => {
+    const found = await new DaemonCmux({ status: async () => ({ id: "ws:42" }) } as any).findWorkspaceId("captain");
+    expect(found).toBe("ws:42");
+
+    const miss = await new DaemonCmux({ status: async () => null } as any).findWorkspaceId("ghost");
+    expect(miss).toBeNull();
+
+    const err = await new DaemonCmux({ status: async () => { throw new Error("gone"); } } as any).findWorkspaceId("err");
+    expect(err).toBeNull();
+  });
 });

--- a/src/control/__tests__/daemon-cmux.test.ts
+++ b/src/control/__tests__/daemon-cmux.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { DaemonCmux } from "../cmux/daemon-cmux.js";
+import { DeferDelivery } from "../../runtimes/cmux.js";
+
+describe("DaemonCmux", () => {
+  it("listSurfaces failure returns [] (never throws into the caller)", async () => {
+    const driver = { listSurfaces: async () => { throw new Error("socket down"); } } as any;
+    const dc = new DaemonCmux(driver);
+    await expect(dc.listSurfaces("ws1")).resolves.toEqual([]);
+  });
+
+  it("readScreen failure returns null", async () => {
+    const driver = { readScreen: async () => { throw new Error("nope"); } } as any;
+    const dc = new DaemonCmux(driver);
+    await expect(dc.readScreen("surface:1")).resolves.toBeNull();
+  });
+
+  it("send re-throws DeferDelivery (so the delivery loop can defer), swallows other errors", async () => {
+    const deferDriver = { sendToSurface: async () => { throw new DeferDelivery("draft"); } } as any;
+    await expect(new DaemonCmux(deferDriver).send({ ref: "s" } as any, "hi")).rejects.toBeInstanceOf(DeferDelivery);
+    const errDriver = { sendToSurface: async () => { throw new Error("boom"); } } as any;
+    await expect(new DaemonCmux(errDriver).send({ ref: "s" } as any, "hi")).resolves.toBeUndefined();
+  });
+
+  it("isAvailable() is true when listSurfaces resolves, false when it throws", async () => {
+    expect(await new DaemonCmux({ listSurfaces: async () => [] } as any).isAvailable()).toBe(true);
+    expect(await new DaemonCmux({ listSurfaces: async () => { throw new Error(); } } as any).isAvailable()).toBe(false);
+  });
+});

--- a/src/control/cmux/daemon-cmux.ts
+++ b/src/control/cmux/daemon-cmux.ts
@@ -34,6 +34,15 @@ export class DaemonCmux {
     catch { return null; }
   }
 
+  async findWorkspaceId(name: string): Promise<string | null> {
+    try {
+      const ref = await this.driver.status(name);
+      return ref?.id ?? null;
+    } catch {
+      return null;
+    }
+  }
+
   async isAvailable(): Promise<boolean> {
     try { await this.driver.listSurfaces(""); return true; }
     catch { return false; }

--- a/src/control/cmux/daemon-cmux.ts
+++ b/src/control/cmux/daemon-cmux.ts
@@ -34,6 +34,11 @@ export class DaemonCmux {
     catch { return null; }
   }
 
+  async readPaneScreen(pane: PaneRef): Promise<string | null> {
+    try { return await this.driver.readPaneScreen(pane); }
+    catch { return null; }
+  }
+
   async findWorkspaceId(name: string): Promise<string | null> {
     try {
       const ref = await this.driver.status(name);

--- a/src/control/cmux/daemon-cmux.ts
+++ b/src/control/cmux/daemon-cmux.ts
@@ -1,0 +1,41 @@
+import type { RuntimeDriver, PaneRef } from "../../runtimes/types";
+import { DeferDelivery } from "../../runtimes/cmux";
+
+/**
+ * #332: daemon-side cmux access. The daemon (a launchd process, NOT a cmux
+ * descendant) can now drive cmux directly because the CLI auto-discovers its
+ * canonical socket (~/.local/state/cmux/cmux.sock) from any process.
+ *
+ * Every method is FAIL-SOFT: a cmux/socket error degrades to a safe sentinel
+ * ([] / null / no-op) so a transient failure NEVER false-reaps a live crew.
+ * The ONE exception is DeferDelivery, which `send` re-throws so the delivery
+ * loop can defer-while-typing (#258/#302).
+ *
+ * This is the seam #333's LifecycleSource port sits beside.
+ */
+export class DaemonCmux {
+  constructor(private readonly driver: RuntimeDriver) {}
+
+  async send(surface: PaneRef, text: string, opts?: { probe?: boolean }): Promise<void> {
+    try {
+      await this.driver.sendToSurface(surface, text, opts);
+    } catch (e) {
+      if (e instanceof DeferDelivery) throw e;
+    }
+  }
+
+  async listSurfaces(workspaceId: string): Promise<PaneRef[]> {
+    try { return await this.driver.listSurfaces(workspaceId); }
+    catch { return []; }
+  }
+
+  async readScreen(ref: string): Promise<string | null> {
+    try { return await this.driver.readScreen(ref); }
+    catch { return null; }
+  }
+
+  async isAvailable(): Promise<boolean> {
+    try { await this.driver.listSurfaces(""); return true; }
+    catch { return false; }
+  }
+}

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -18,6 +18,8 @@ import { CmuxEventsBridge } from "./cmux/events-bridge.js";
 import { makeGate } from "./codex/gate.js";
 import { appendToMailbox, rotateIfNeeded, mailboxStats, readCursor, writeCursor, readFromCursor } from "./mailbox.js";
 import { createRelayHealer } from "./relay-healer.js";
+import { createDirectSurfaceLivenessProbe, createDirectCrewPaneReader } from "./crew-pane-reader.js";
+import { createInteractiveProbe } from "../commands/notify-relay.js";
 import { CaptainDelivery } from "./delivery/captain-delivery.js";
 import { projectHealth, type ComponentHealth } from "./liveness.js";
 import { assembleDaemonSnapshot, type DaemonSnapshotInputs, type ResultArtifacts } from "./snapshot.js";
@@ -431,11 +433,28 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   };
   const notify = opts.notify ?? defaultNotify;
 
+  // #332: daemon-direct flag resolved here so both the surface-liveness probe
+  // (below) and the delivery loop (further down) agree on the same value.
+  const daemonDirectCmux = opts.daemonDirectCmux ?? loadConfig().defaults?.daemonDirectCmux ?? false;
+
+  // #332: daemon-direct mode replaces the proxy-based surface liveness probe
+  // with a direct cmux probe (DaemonCmux.listSurfaces + surfaceVerdict).
+  const surfaceProbe = opts.isSurfaceAlive
+    ?? (daemonDirectCmux && opts.daemonCmux
+      ? createDirectSurfaceLivenessProbe(
+          opts.daemonCmux,
+          (project) => {
+            const cfg = loadConfig();
+            return cfg.projects?.[project]?.captainName ?? `${project}-captain`;
+          },
+        )
+      : proxiedSurfaceAlive);
+
   const d = createDaemon({
     store, now: () => Date.now(), isPidAlive, notify, taskTimeoutMs,
     // #139 backstop: terminalize interactive crews whose cmux pane is provably
     // gone (sweep/reconcile reaper). Three-valued; "unknown" never reaps.
-    isSurfaceAlive: opts.isSurfaceAlive ?? proxiedSurfaceAlive,
+    isSurfaceAlive: surfaceProbe,
     // #207 best-effort relay heal on the sweep (secondary — surface is primary).
     healRelay: opts.healRelay ?? createRelayHealer(log),
     launchHeadless: opts.launchHeadless ?? (async (rec) => {
@@ -737,10 +756,10 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   // it manually; in production the caller sets up an interval (or the CLU
   // entrypoint below adds one).
   let deliveryTick: (() => Promise<void>) | undefined;
+  let probeTick: (() => Promise<void>) | undefined;
   const captainMissingStreak = new Map<string, number>();
   const stoppedProjects = new Set<string>();
 
-  const daemonDirectCmux = opts.daemonDirectCmux ?? loadConfig().defaults?.daemonDirectCmux ?? false;
   if (daemonDirectCmux && opts.daemonCmux) {
     const cmux = opts.daemonCmux;
     const cfg = loadConfig();
@@ -822,6 +841,29 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
         }
       }
     };
+
+    // #332: daemon-direct blocked-crew detection. Reuses createInteractiveProbe
+    // (from notify-relay.ts) with a direct cmux pane reader injected as the
+    // readPaneTail dep. Matches the relay's PROBE_INTERVAL_MS (10s).
+    const directPaneReader = createDirectCrewPaneReader(cmux, (project) => {
+      const cfg2 = loadConfig();
+      return cfg2.projects?.[project]?.captainName ?? `${project}-captain`;
+    });
+
+    const interactiveProbe = createInteractiveProbe({
+      project: "_all_",
+      listTasks: async () => store.listAll(),
+      readPaneTail: directPaneReader,
+      sendEvent: async (event) => {
+        const rec = store.listAll().find((r) => r.id === event.id);
+        if (rec) {
+          await d.handle({ kind: "event", project: rec.project, event });
+        }
+      },
+      now: () => Date.now(),
+      log,
+    });
+    probeTick = interactiveProbe.tick;
   }
 
   // #332: production delivery interval (1s poll). Gated on sweepMs so tests
@@ -833,6 +875,15 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       void deliveryTick!().catch((e: unknown) => log(`delivery tick error: ${(e as Error).message}`));
     }, 1000);
     deliveryTimer.unref?.();
+  }
+
+  // #332: blocked-crew probe interval (10s). Same gate as delivery interval.
+  let probeTimer: NodeJS.Timeout | undefined;
+  if (daemonDirectCmux && opts.daemonCmux && opts.sweepMs && opts.sweepMs > 0) {
+    probeTimer = setInterval(() => {
+      void probeTick!().catch((e: unknown) => log(`probe tick error: ${(e as Error).message}`));
+    }, 10_000);
+    probeTimer.unref?.();
   }
 
   let timer: NodeJS.Timeout | undefined;
@@ -884,6 +935,7 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   return {
     stop(): Promise<void> {
       if (deliveryTimer) clearInterval(deliveryTimer);
+      if (probeTimer) clearInterval(probeTimer);
       if (timer) clearInterval(timer);
       if (rotationTimer) clearInterval(rotationTimer);
       try { cmuxEventsBridge.stop(); } catch { /* best-effort */ }
@@ -891,6 +943,7 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       return new Promise<void>((resolve) => server.close(() => { log("stopped"); resolve(); }));
     },
     tickDelivery: deliveryTick,
+    tickProbe: probeTick,
   };
 }
 

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -755,8 +755,6 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       ])];
 
       for (const project of allProjects) {
-        if (stoppedProjects.has(project)) continue;
-
         const projCfg = cfg.projects?.[project];
         const captainTitle = projCfg?.captainName ?? `${project}-captain`;
 
@@ -774,7 +772,15 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
         // Fall back to injected surface (tests / config-less projects).
         if (!surface) surface = injectedSurfaces[project] ?? null;
 
-        if (!surface) {
+        if (surface) {
+          // Captain found — if previously reaped, un-reap and reset streak so
+          // delivery resumes (a relaunched captain creates a new pane).
+          if (stoppedProjects.has(project)) {
+            stoppedProjects.delete(project);
+            captainMissingStreak.set(project, 0);
+          }
+          captainMissingStreak.set(project, 0);
+        } else {
           // Streak tracking: surfaces.length > 0 means cmux is reachable but the
           // captain's pane is provably absent. surfaces.length === 0 means cmux
           // was unreachable (fail-soft → []), which we treat as "unknown" — never
@@ -783,15 +789,16 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
             const streak = (captainMissingStreak.get(project) ?? 0) + 1;
             captainMissingStreak.set(project, streak);
             if (streak >= CAPTAIN_GONE_STREAK_K) {
-              stoppedProjects.add(project);
-              log(`captain ${captainTitle}: surface gone for ${CAPTAIN_GONE_STREAK_K} sweeps — stopping delivery`);
+              // Fire the reap log exactly ONCE on the transition (only the first
+              // absent sweep past K). Do NOT re-fire on subsequent sweeps.
+              if (!stoppedProjects.has(project)) {
+                stoppedProjects.add(project);
+                log(`captain ${captainTitle}: surface gone for ${CAPTAIN_GONE_STREAK_K} sweeps — stopping delivery`);
+              }
             }
           }
           continue;
         }
-
-        // Captain found — reset streak.
-        captainMissingStreak.set(project, 0);
 
         const cursor = await readCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER });
         const lastAcked = cursor?.lastAckedSeq ?? 0;

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -108,7 +108,8 @@ export interface CockpitdOpts {
    *  delivery loop instead of relying on the notify-relay. */
   daemonDirectCmux?: boolean;
   /** #332: injected captain-surface mapping (project → PaneRef) for the
-   *  daemon-direct delivery loop. Task 5 replaces this with real discovery. */
+   *  daemon-direct delivery loop. Used as fallback when real discovery (Task 5)
+   *  returns no surface (e.g. cmux not reachable or captain not yet running). */
   captainSurfaces?: Record<string, PaneRef>;
 }
 
@@ -186,6 +187,17 @@ function gatherResults(resultsDir: string): ResultArtifacts {
     }
   } catch { /* no results dir */ }
   return { fileCount, totalBytes };
+}
+
+const CAPTAIN_GONE_STREAK_K = 3;
+export type ListSurfacesFn = (wsId: string) => Promise<PaneRef[]>;
+
+/**
+ * Pure: search a list of surfaces for one whose title matches the captain name.
+ * Part of #332 daemon-direct captain-surface discovery (Task 5).
+ */
+export function discoverCaptainSurface(surfaces: PaneRef[], captainTitle: string): PaneRef | null {
+  return surfaces.find((s) => s.title === captainTitle) ?? null;
 }
 
 export function defaultIsPidAlive(pid: number): boolean {
@@ -725,6 +737,8 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   // it manually; in production the caller sets up an interval (or the CLU
   // entrypoint below adds one).
   let deliveryTick: (() => Promise<void>) | undefined;
+  const captainMissingStreak = new Map<string, number>();
+  const stoppedProjects = new Set<string>();
 
   const daemonDirectCmux = opts.daemonDirectCmux ?? loadConfig().defaults?.daemonDirectCmux ?? false;
   if (daemonDirectCmux && opts.daemonCmux) {
@@ -733,8 +747,52 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
     const deliveries = new Map<string, CaptainDelivery>();
 
     deliveryTick = async () => {
-      const surfaces = opts.captainSurfaces ?? {};
-      for (const [project, surface] of Object.entries(surfaces)) {
+      const injectedSurfaces = opts.captainSurfaces ?? {};
+      const allProjects = [...new Set([
+        ...Object.keys(cfg.projects ?? {}),
+        ...Object.keys(injectedSurfaces),
+        ...store.listAll().map((t) => t.project),
+      ])];
+
+      for (const project of allProjects) {
+        if (stoppedProjects.has(project)) continue;
+
+        const projCfg = cfg.projects?.[project];
+        const captainTitle = projCfg?.captainName ?? `${project}-captain`;
+
+        // Try real discovery from cmux.
+        const wsId = cmux.findWorkspaceId ? await cmux.findWorkspaceId(captainTitle) : null;
+        let surface: PaneRef | null = null;
+        let surfacesLength = 0;
+
+        if (wsId) {
+          const surfaces = await cmux.listSurfaces(wsId);
+          surfacesLength = surfaces.length;
+          surface = discoverCaptainSurface(surfaces, captainTitle);
+        }
+
+        // Fall back to injected surface (tests / config-less projects).
+        if (!surface) surface = injectedSurfaces[project] ?? null;
+
+        if (!surface) {
+          // Streak tracking: surfaces.length > 0 means cmux is reachable but the
+          // captain's pane is provably absent. surfaces.length === 0 means cmux
+          // was unreachable (fail-soft → []), which we treat as "unknown" — never
+          // increment the streak (no false reaping on transient outages).
+          if (surfacesLength > 0) {
+            const streak = (captainMissingStreak.get(project) ?? 0) + 1;
+            captainMissingStreak.set(project, streak);
+            if (streak >= CAPTAIN_GONE_STREAK_K) {
+              stoppedProjects.add(project);
+              log(`captain ${captainTitle}: surface gone for ${CAPTAIN_GONE_STREAK_K} sweeps — stopping delivery`);
+            }
+          }
+          continue;
+        }
+
+        // Captain found — reset streak.
+        captainMissingStreak.set(project, 0);
+
         const cursor = await readCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER });
         const lastAcked = cursor?.lastAckedSeq ?? 0;
         let d = deliveries.get(project);
@@ -747,7 +805,7 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
         }
         for await (const entry of readFromCursor({ stateRoot, project, fromSeq: lastAcked + 1 })) {
           const result = await d.deliver(entry, (text, sendOpts) =>
-            cmux.send(surface, text, sendOpts),
+            cmux.send(surface!, text, sendOpts),
           );
           if (result.delivered) {
             await writeCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER, lastAckedSeq: entry.seq });
@@ -757,6 +815,17 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
         }
       }
     };
+  }
+
+  // #332: production delivery interval (1s poll). Gated on sweepMs so tests
+  // with sweepMs:0 avoid a real timer. The interval is always fire-and-forget so
+  // a slow tick never stacks.
+  let deliveryTimer: NodeJS.Timeout | undefined;
+  if (daemonDirectCmux && opts.daemonCmux && opts.sweepMs && opts.sweepMs > 0) {
+    deliveryTimer = setInterval(() => {
+      void deliveryTick!().catch((e: unknown) => log(`delivery tick error: ${(e as Error).message}`));
+    }, 1000);
+    deliveryTimer.unref?.();
   }
 
   let timer: NodeJS.Timeout | undefined;
@@ -807,6 +876,7 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
 
   return {
     stop(): Promise<void> {
+      if (deliveryTimer) clearInterval(deliveryTimer);
       if (timer) clearInterval(timer);
       if (rotationTimer) clearInterval(rotationTimer);
       try { cmuxEventsBridge.stop(); } catch { /* best-effort */ }

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -16,8 +16,9 @@ import { CodexInteractiveDriver, shouldReattachCodex } from "./codex/driver.js";
 import { OpencodeSseBridge } from "./opencode/sse-bridge.js";
 import { CmuxEventsBridge } from "./cmux/events-bridge.js";
 import { makeGate } from "./codex/gate.js";
-import { appendToMailbox, rotateIfNeeded, mailboxStats, readCursor } from "./mailbox.js";
+import { appendToMailbox, rotateIfNeeded, mailboxStats, readCursor, writeCursor, readFromCursor } from "./mailbox.js";
 import { createRelayHealer } from "./relay-healer.js";
+import { CaptainDelivery } from "./delivery/captain-delivery.js";
 import { projectHealth, type ComponentHealth } from "./liveness.js";
 import { assembleDaemonSnapshot, type DaemonSnapshotInputs, type ResultArtifacts } from "./snapshot.js";
 import { loadConfig } from "../config.js";
@@ -25,6 +26,8 @@ import { readdir } from "node:fs/promises";
 import type { Gate, TaskRecord, ControlEvent } from "./types.js";
 import { TERMINAL_STATES } from "./types.js";
 import type { Socket } from "node:net";
+import type { PaneRef } from "../runtimes/types.js";
+import type { DaemonCmux } from "./cmux/daemon-cmux.js";
 
 // This module's own compiled file — its mtime is the dist build-time used for
 // the Tier 0 build-freshness check (process start vs build time). package.json
@@ -97,6 +100,16 @@ export interface CockpitdOpts {
   /** B1: inject a fake cmux events bridge for tests. Defaults to a real one
    *  (gated on defaults.cmuxEventsBridge). */
   cmuxEventsBridge?: { start: () => void; stop: () => void };
+  /** #332: inject a fake DaemonCmux for testing daemon-direct delivery. When
+   *  absent and daemonDirectCmux is ON, a real cmux driver is created. */
+  daemonCmux?: DaemonCmux;
+  /** #332: override for daemonDirectCmux flag (bypasses config file load).
+   *  When true and daemonCmux is provided/injected, runs the daemon-direct
+   *  delivery loop instead of relying on the notify-relay. */
+  daemonDirectCmux?: boolean;
+  /** #332: injected captain-surface mapping (project → PaneRef) for the
+   *  daemon-direct delivery loop. Task 5 replaces this with real discovery. */
+  captainSurfaces?: Record<string, PaneRef>;
 }
 
 // ── Tier 0/2 snapshot gathering (I/O at the edge; the pure assembly lives in
@@ -706,6 +719,46 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   });
   log(`started pid=${process.pid} sock=${sockPath} stateRoot=${stateRoot}`);
 
+  // #332: daemon-direct delivery loop — replaces relay EGRESS when flag ON.
+  // Each tick reads from the project's mailbox cursor and delivers via
+  // DaemonCmux + CaptainDelivery. Returns `tickDelivery` so tests can trigger
+  // it manually; in production the caller sets up an interval (or the CLU
+  // entrypoint below adds one).
+  let deliveryTick: (() => Promise<void>) | undefined;
+
+  const daemonDirectCmux = opts.daemonDirectCmux ?? loadConfig().defaults?.daemonDirectCmux ?? false;
+  if (daemonDirectCmux && opts.daemonCmux) {
+    const cmux = opts.daemonCmux;
+    const cfg = loadConfig();
+    const deliveries = new Map<string, CaptainDelivery>();
+
+    deliveryTick = async () => {
+      const surfaces = opts.captainSurfaces ?? {};
+      for (const [project, surface] of Object.entries(surfaces)) {
+        const cursor = await readCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER });
+        const lastAcked = cursor?.lastAckedSeq ?? 0;
+        let d = deliveries.get(project);
+        if (!d) {
+          d = new CaptainDelivery({
+            maxDefers: cfg.relay?.maxDeferDeliveries ?? 300,
+            stableProbePolls: cfg.relay?.stableProbePolls ?? 3,
+          });
+          deliveries.set(project, d);
+        }
+        for await (const entry of readFromCursor({ stateRoot, project, fromSeq: lastAcked + 1 })) {
+          const result = await d.deliver(entry, (text, sendOpts) =>
+            cmux.send(surface, text, sendOpts),
+          );
+          if (result.delivered) {
+            await writeCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER, lastAckedSeq: entry.seq });
+          } else {
+            break;
+          }
+        }
+      }
+    };
+  }
+
   let timer: NodeJS.Timeout | undefined;
   if (opts.sweepMs && opts.sweepMs > 0) {
     // sweep() is async (#139: it probes cmux surface liveness). Guard against an
@@ -760,6 +813,7 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       for (const kill of activeHeadlessKills) kill();
       return new Promise<void>((resolve) => server.close(() => { log("stopped"); resolve(); }));
     },
+    tickDelivery: deliveryTick,
   };
 }
 

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -833,7 +833,7 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
           const result = await d.deliver(entry, (text, sendOpts) =>
             cmux.send(surface!, text, sendOpts),
           );
-          if (result.delivered) {
+          if ("delivered" in result) {
             await writeCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER, lastAckedSeq: entry.seq });
           } else {
             break;

--- a/src/control/crew-pane-reader.ts
+++ b/src/control/crew-pane-reader.ts
@@ -1,5 +1,6 @@
 import { loadConfig } from "../config.js";
 import { createCmuxDriver, RuntimeRegistry } from "../runtimes/index.js";
+import type { DaemonCmux } from "./cmux/daemon-cmux.js";
 import type { TaskRecord } from "./types.js";
 
 const TAIL_LINES = 25;
@@ -84,6 +85,62 @@ export function createCrewPaneReader(): (rec: TaskRecord) => Promise<string | nu
       const pane = surfaces.find((s) => s.title === want);
       if (!pane) return null;
       const screen = await runtime.readPaneScreen(pane);
+      if (!screen) return null;
+      return screen.split(/\r?\n/).slice(-TAIL_LINES).join("\n");
+    } catch {
+      return null;
+    }
+  };
+}
+
+/**
+ * Build a direct surface-liveness probe for daemon-direct mode (#332).
+ * Uses DaemonCmux to list surfaces directly (bypassing the relay/proxy).
+ * Fail-soft: `listSurfaces` returning `[]` (error or empty) → "unknown"
+ * so a transient cmux outage never false-reaps a live crew. Non-empty list
+ * without the wanted pane → "gone". Never throws.
+ */
+export function createDirectSurfaceLivenessProbe(
+  cmux: DaemonCmux,
+  getCaptainTitle: (project: string) => string,
+): (rec: TaskRecord) => Promise<SurfaceLiveness> {
+  return async (rec) => {
+    try {
+      if (rec.mode !== "interactive" || !rec.name) return "unknown";
+      const wsId = await cmux.findWorkspaceId(getCaptainTitle(rec.project));
+      if (!wsId) return "unknown";
+      const surfaces = await cmux.listSurfaces(wsId);
+      if (surfaces.length === 0) return "unknown";
+      return surfaceVerdict(
+        surfaces.map((s) => s.title ?? ""),
+        crewPaneTitle(rec.project, rec.name),
+      );
+    } catch {
+      return "unknown";
+    }
+  };
+}
+
+/**
+ * Build a direct crew-pane reader for daemon-direct mode (#332).
+ * Uses DaemonCmux.readScreen directly instead of the RuntimeRegistry path
+ * (which relies on relay-proxy). Returns the last ~25 lines of the crew's
+ * cmux pane, or null on any failure. Never throws.
+ */
+export function createDirectCrewPaneReader(
+  cmux: DaemonCmux,
+  getCaptainTitle: (project: string) => string,
+): (rec: TaskRecord) => Promise<string | null> {
+  return async (rec) => {
+    try {
+      if (!rec.name) return null;
+      const wsId = await cmux.findWorkspaceId(getCaptainTitle(rec.project));
+      if (!wsId) return null;
+      const surfaces = await cmux.listSurfaces(wsId);
+      const want = crewPaneTitle(rec.project, rec.name);
+      const pane = surfaces.find((s) => s.title === want);
+      if (!pane) return null;
+      const screen = await cmux.readScreen(pane);
       if (!screen) return null;
       return screen.split(/\r?\n/).slice(-TAIL_LINES).join("\n");
     } catch {

--- a/src/control/crew-pane-reader.ts
+++ b/src/control/crew-pane-reader.ts
@@ -140,7 +140,7 @@ export function createDirectCrewPaneReader(
       const want = crewPaneTitle(rec.project, rec.name);
       const pane = surfaces.find((s) => s.title === want);
       if (!pane) return null;
-      const screen = await cmux.readScreen(pane);
+      const screen = await cmux.readPaneScreen(pane);
       if (!screen) return null;
       return screen.split(/\r?\n/).slice(-TAIL_LINES).join("\n");
     } catch {

--- a/src/control/delivery/__tests__/captain-delivery.test.ts
+++ b/src/control/delivery/__tests__/captain-delivery.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { CaptainDelivery } from "../captain-delivery.js";
+import { DeferDelivery } from "../../../runtimes/cmux.js";
+
+describe("CaptainDelivery defer-while-typing (#258/#302)", () => {
+  it("defers while the captain is typing, delivers once clear", async () => {
+    let typing = true;
+    const sent: string[] = [];
+    const d = new CaptainDelivery({ maxDefers: 300, stableProbePolls: 3 });
+    const send = async (text: string) => { if (typing) throw new DeferDelivery("draft"); sent.push(text); };
+    await d.deliver({ seq: 1, message: "hello" }, send);
+    expect(sent).toEqual([]);
+    typing = false;
+    await d.deliver({ seq: 1, message: "hello" }, send);
+    expect(sent).toEqual(["hello"]);
+  });
+
+  it("escalates to a probe send after stableProbePolls of byte-identical draft", async () => {
+    const probes: boolean[] = [];
+    const d = new CaptainDelivery({ maxDefers: 300, stableProbePolls: 3 });
+    const send = async (_t: string, opts?: { probe?: boolean }) => {
+      probes.push(!!opts?.probe);
+      if (!opts?.probe) throw new DeferDelivery("same-draft");
+    };
+    for (let i = 0; i < 5; i++) await d.deliver({ seq: 7, message: "x" }, send);
+    expect(probes[probes.length - 1]).toBe(true);
+  });
+
+  it("force-delivers (probe) after maxDefers regardless of stability", async () => {
+    const probes: boolean[] = [];
+    const d = new CaptainDelivery({ maxDefers: 2, stableProbePolls: 999 });
+    let n = 0;
+    const send = async (_t: string, opts?: { probe?: boolean }) => {
+      probes.push(!!opts?.probe);
+      if (!opts?.probe && n++ < 5) throw new DeferDelivery(`draft-${n}`);
+    };
+    for (let i = 0; i < 4; i++) await d.deliver({ seq: 9, message: "x" }, send);
+    expect(probes.includes(true)).toBe(true);
+  });
+
+  it("returns { delivered: true } for null message (nothing to deliver)", async () => {
+    const sent: string[] = [];
+    const d = new CaptainDelivery({ maxDefers: 300, stableProbePolls: 3 });
+    const result = await d.deliver({ seq: 99, message: null }, async (t) => { sent.push(t); });
+    expect(result).toEqual({ delivered: true });
+    expect(sent).toEqual([]);
+  });
+});

--- a/src/control/delivery/captain-delivery.ts
+++ b/src/control/delivery/captain-delivery.ts
@@ -1,0 +1,86 @@
+import { DeferDelivery } from "../../runtimes/cmux";
+
+/**
+ * #332: extracted defer-while-typing state machine (#258/#302).
+ *
+ * Behaviour is ported VERBATIM from notify-relay.ts drain() (lines 276-309):
+ *   - per-seq deferCounts / stableCounts / lastContent maps
+ *   - maxDefers / stableProbePolls thresholds
+ *   - stable-content probe escalation (#302)
+ *
+ * Both the relay (flag OFF) and the daemon (flag ON) consume this same module
+ * so flag-OFF parity is guaranteed.
+ */
+export interface CaptainDeliveryOptions {
+  maxDefers: number;
+  stableProbePolls: number;
+}
+
+export type SendFn = (text: string, opts?: { probe?: boolean }) => Promise<void>;
+export type DeliverResult = { delivered: true } | { deferred: true };
+
+/**
+ * Unified-formatter helper (#214/#210): the daemon's formatMessage is the single
+ * source of truth for the captain-facing message. Returns null for entries the
+ * daemon chose not to surface (null/empty message fields).
+ */
+export function deliverable(entry: { message?: string | null }): string | null {
+  const msg = entry.message;
+  if (msg == null) return null;
+  const trimmed = msg.trim();
+  return trimmed.length > 0 ? msg : null;
+}
+
+export class CaptainDelivery {
+  private deferCounts = new Map<number, number>();
+  private lastContent = new Map<number, string | null>();
+  private stableCounts = new Map<number, number>();
+
+  constructor(private readonly opts: CaptainDeliveryOptions) {}
+
+  /**
+   * Attempt to deliver one mailbox entry to the captain. Calls `send(text, opts)`
+   * and, if the send throws DeferDelivery, tracks defer/stable counts for the
+   * entry's seq and returns {deferred: true} (caller should NOT advance cursor).
+   * On success or null message returns {delivered: true} (caller SHOULD advance).
+   */
+  async deliver(
+    entry: { seq: number; message?: string | null },
+    send: SendFn,
+  ): Promise<DeliverResult> {
+    const msg = deliverable(entry);
+    if (!msg) return { delivered: true };
+
+    const seq = entry.seq;
+    const deferCount = this.deferCounts.get(seq) ?? 0;
+    // #302: probe early once content has been stable for stableProbePolls
+    // polls (captain not typing) — kills the ~5min stall; the 300-defer
+    // backstop still guarantees delivery never hangs forever.
+    const stable = (this.stableCounts.get(seq) ?? 0) >= this.opts.stableProbePolls;
+    const probe = stable || deferCount >= this.opts.maxDefers;
+
+    try {
+      await send(msg, probe ? { probe: true } : undefined);
+      this.deferCounts.delete(seq);
+      this.stableCounts.delete(seq);
+      this.lastContent.delete(seq);
+      return { delivered: true };
+    } catch (e) {
+      if (e instanceof DeferDelivery) {
+        this.deferCounts.set(seq, deferCount + 1);
+        // Track content stability: byte-identical non-empty draft across
+        // consecutive polls means the captain isn't actively typing (#302).
+        const content = e.draft;
+        if (content && content === this.lastContent.get(seq)) {
+          this.stableCounts.set(seq, (this.stableCounts.get(seq) ?? 0) + 1);
+        } else {
+          this.stableCounts.set(seq, 0);
+        }
+        this.lastContent.set(seq, content);
+        return { deferred: true };
+      }
+      // Non-DeferDelivery errors: don't advance cursor, retry next poll.
+      return { deferred: true };
+    }
+  }
+}


### PR DESCRIPTION
Implements [#332](https://github.com/tu11aa/claude-cockpit/issues/332) per spec/plan (merged in #341). **Transport-only, flag-gated** — daemon calls cmux directly instead of proxying through the notify-relay, behind `defaults.daemonDirectCmux` (default **false** → byte-identical to today).

## What changed (8 TDD tasks)
1. `daemonDirectCmux` config flag (default false)
2. `DaemonCmux` — fail-soft daemon-side cmux accessor (error → []/null/no-op; re-throws only `DeferDelivery`)
3. `CaptainDelivery` — defer-while-typing (#258/#302) extracted into a **shared module** that BOTH the relay (flag OFF) and the daemon (flag ON) consume → parity guaranteed
4. Daemon-direct **EGRESS** notify delivery loop (flag-gated); same `"captain"` cursor subscriber as the relay (no double-delivery on flip)
5. Captain-surface discovery + **non-terminal** captain-close reap (#324): reaps once on absence, resumes when the captain pane reappears (matches relay re-registration)
6. Daemon-direct **INGEST** probes — surface-liveness (`surfaceVerdict` kept byte-for-byte) + blocked-crew via **reused** `createInteractiveProbe` with a direct pane reader; both flag-gated (no double-run with relay)
7. Relay spawn gated off when flag ON; `drain()` rewired onto `CaptainDelivery`; `deliverable()` consolidated to one source of truth; captain-ops SKILL.md step 8 updated
8. Verification

## Verification
- `tsc --noEmit` clean.
- Full suite **1248/1248 pass** (107 files; +25 new tests over the 1223 baseline).
- Flag-OFF parity: the #258/#302 defer/stable/maxDefers tests (notify-relay 16) + relay-proxy (13) pass **unchanged** after consolidating onto `CaptainDelivery`.
- All daemon→cmux calls fail-soft (unit-tested → never false-reap).

## Deliberately deferred
- **Live flag-ON smoke** (plan §8 steps 2-3): not run because the captain is live on this machine and flipping the flag mid-session could disrupt notifications. Flag defaults OFF → safe to merge; live verification happens in the controlled "verify N days" rollout phase.
- Relay code deletion → follow-on PR once flag-ON is proven (per the flag-gated cutover plan).

## Minor / known (non-blocking)
- `DaemonCmux.readScreen(ref)` is now unused (the pane reader uses `readPaneScreen(pane)`) — candidate for removal.
- Production delivery interval is hardcoded 1s (matches the relay's poll default).

Spec: `docs/superpowers/specs/2026-06-16-332-daemon-direct-cmux-design.md` · Plan: `docs/superpowers/plans/2026-06-16-332-daemon-direct-cmux.md`. Sets up the `DaemonCmux` seam for #333 (NativeHookSource).