### PR TITLE
fix(#332): add .js extensions to ESM imports (runtime ERR_MODULE_NOT_FOUND)

### DIFF
--- a/src/control/cmux/daemon-cmux.ts
+++ b/src/control/cmux/daemon-cmux.ts
@@ -1,5 +1,5 @@
-import type { RuntimeDriver, PaneRef } from "../../runtimes/types";
-import { DeferDelivery } from "../../runtimes/cmux";
+import type { RuntimeDriver, PaneRef } from "../../runtimes/types.js";
+import { DeferDelivery } from "../../runtimes/cmux.js";
 
 /**
  * #332: daemon-side cmux access. The daemon (a launchd process, NOT a cmux

--- a/src/control/delivery/captain-delivery.ts
+++ b/src/control/delivery/captain-delivery.ts
@@ -1,4 +1,4 @@
-import { DeferDelivery } from "../../runtimes/cmux";
+import { DeferDelivery } from "../../runtimes/cmux.js";
 
 /**
  * #332: extracted defer-while-typing state machine (#258/#302).


### PR DESCRIPTION
## Hotfix
After #342 merged, `node dist/index.js <anything>` crashed at module load with:
```
ERR_MODULE_NOT_FOUND: Cannot find module '.../dist/runtimes/cmux' imported from .../dist/control/delivery/captain-delivery.js
```
Two value imports of `DeferDelivery` omitted the `.js` extension NodeNext requires at runtime (`captain-delivery.ts`, `daemon-cmux.ts`). `captain-delivery` is imported top-level by `cockpitd.ts` + `notify-relay.ts`, so the **entire cockpit CLI failed to load** — including `cockpit crew spawn`.

## Why CI/tsc missed it
`tsc` and vitest both resolve TS modules with a lenient resolver that doesn't require the `.js` extension; only Node's ESM loader enforces it at runtime. **Follow-up: CI should run a runtime smoke (`node dist/index.js --help`) — filed separately.**

## Fix
3 import lines get `.js` (2 value imports were the crash; the `types` one is type-only, fixed for consistency). Verified: `npm run build` clean + `node dist/index.js daemon --help` loads OK + delivery/cmux tests green.