### PR TITLE
fix(#332): 3 daemon-direct storm bugs (cursor corrupt-guard, writeCursor race, stale-skip)

### DIFF
--- a/src/control/__tests__/cockpitd-daemon-direct.test.ts
+++ b/src/control/__tests__/cockpitd-daemon-direct.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, appendFileSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { startCockpitd, discoverCaptainSurface } from "../cockpitd.js";
-import { appendToMailbox, writeCursor } from "../mailbox.js";
+import { appendToMailbox, writeCursor, readCursor } from "../mailbox.js";
+import { STALE_THRESHOLD_MS } from "../../commands/notify-relay.js";
 import { sendRequest } from "../protocol.js";
 import { crewPaneTitle } from "../crew-pane-reader.js";
 import type { DaemonCmux } from "../cmux/daemon-cmux.js";
@@ -75,6 +76,52 @@ describe("cockpitd daemon-direct (#332)", () => {
 
     expect(cmux.sent.length).toBe(1);
     expect(cmux.sent[0].text).toMatch(/CREW DONE/);
+  });
+
+  // BUG 3 (#332 storm): the daemon-direct delivery loop lacked the relay's
+  // STALE_THRESHOLD_MS silent-ack, so a fresh/empty cursor re-delivered the
+  // entire historical backlog (the same CREW DONE events fired dozens of times).
+  // Entries older than sessionStart - STALE_THRESHOLD_MS must be silently acked
+  // (cursor advanced) WITHOUT being delivered.
+  it("flag ON: daemon silently acks stale backlog entries without delivering them", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-dd-stale-"));
+    const sock = join(dir, "c.sock");
+    const stateRoot = join(dir, "state");
+    const inbox = join(stateRoot, "inbox");
+    mkdirSync(inbox, { recursive: true });
+
+    // Seed two STALE entries (older than STALE_THRESHOLD_MS) followed by one
+    // FRESH entry, all written directly so we control the timestamps.
+    const staleTs = new Date(Date.now() - STALE_THRESHOLD_MS - 60_000).toISOString();
+    const freshTs = new Date().toISOString();
+    const line = (seq: number, ts: string, message: string) =>
+      JSON.stringify({ seq, ts, taskId: "t1", name: "test-crew", kind: "task.done", provider: "claude", payload: {}, message }) + "\n";
+    appendFileSync(join(inbox, "p.log"),
+      line(1, staleTs, "CREW DONE stale-1") +
+      line(2, staleTs, "CREW DONE stale-2") +
+      line(3, freshTs, "CREW DONE fresh-3"),
+      "utf-8");
+    await writeCursor({ stateRoot, project: "p", subscriber: "captain", lastAckedSeq: 0 });
+
+    const cmux = fakeCmux();
+    const handle = startCockpitd({
+      stateRoot,
+      sockPath: sock,
+      sweepMs: 0,
+      daemonCmux: cmux,
+      daemonDirectCmux: true,
+      captainSurfaces: { p: { workspaceId: "ws:1", surfaceId: "surface:1", title: "captain" } },
+    });
+    stop = handle.stop;
+
+    if (handle.tickDelivery) await handle.tickDelivery();
+
+    // Only the fresh entry is delivered; the two stale ones are skipped.
+    expect(cmux.sent.length).toBe(1);
+    expect(cmux.sent[0].text).toMatch(/fresh-3/);
+    // The cursor advanced past all three (stale ones silently acked).
+    const c = await readCursor({ stateRoot, project: "p", subscriber: "captain" });
+    expect(c?.lastAckedSeq).toBe(3);
   });
 
   it("discoverCaptainSurface finds the matching captain pane by title", () => {

--- a/src/control/__tests__/mailbox.test.ts
+++ b/src/control/__tests__/mailbox.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { mkdtempSync, readFileSync, existsSync } from "node:fs";
+import { mkdtempSync, readFileSync, existsSync, writeFileSync, mkdirSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { appendToMailbox } from "../mailbox.js";
@@ -157,6 +157,46 @@ describe("cursor read/write", () => {
     const tg = await readCursor({ stateRoot, project: "demo", subscriber: "telegram" });
     expect(cap?.lastAckedSeq).toBe(10);
     expect(tg?.lastAckedSeq).toBe(5);
+  });
+
+  // BUG 1 (#332 storm): a 0-byte or corrupt cursor file must not throw — it
+  // would crash the relay boot / delivery loop. Treat it like a missing file.
+  it("readCursor returns null on an empty (0-byte) cursor file instead of throwing", async () => {
+    const stateRoot = freshState();
+    const inbox = join(stateRoot, "inbox");
+    mkdirSync(inbox, { recursive: true });
+    writeFileSync(join(inbox, "demo.captain.cursor"), "");
+    const c = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    expect(c).toBeNull();
+  });
+
+  it("readCursor returns null on a corrupt (unparseable) cursor file instead of throwing", async () => {
+    const stateRoot = freshState();
+    const inbox = join(stateRoot, "inbox");
+    mkdirSync(inbox, { recursive: true });
+    writeFileSync(join(inbox, "demo.captain.cursor"), "{not valid json");
+    const c = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    expect(c).toBeNull();
+  });
+
+  // BUG 2 (#332 storm): overlapping writeCursor calls used a SHARED tmp path,
+  // so one rename consumed the tmp the other expected → ENOENT, leaving a
+  // 0-byte/corrupt cursor. Concurrent writes must all succeed and leave a
+  // valid cursor with no leftover tmp files.
+  it("writeCursor survives concurrent overlapping writes (no shared-tmp rename race)", async () => {
+    const stateRoot = freshState();
+    await Promise.all(
+      Array.from({ length: 25 }, (_, i) =>
+        writeCursor({ stateRoot, project: "demo", subscriber: "captain", lastAckedSeq: i + 1 })
+      )
+    );
+    const c = await readCursor({ stateRoot, project: "demo", subscriber: "captain" });
+    expect(c).not.toBeNull();
+    expect(c!.lastAckedSeq).toBeGreaterThanOrEqual(1);
+    // No leftover unique-tmp files accumulated.
+    const inbox = join(stateRoot, "inbox");
+    const leftovers = readdirSync(inbox).filter((f) => f.includes(".tmp"));
+    expect(leftovers).toEqual([]);
   });
 });
 

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -19,7 +19,7 @@ import { makeGate } from "./codex/gate.js";
 import { appendToMailbox, rotateIfNeeded, mailboxStats, readCursor, writeCursor, readFromCursor } from "./mailbox.js";
 import { createRelayHealer } from "./relay-healer.js";
 import { createDirectSurfaceLivenessProbe, createDirectCrewPaneReader } from "./crew-pane-reader.js";
-import { createInteractiveProbe } from "../commands/notify-relay.js";
+import { createInteractiveProbe, STALE_THRESHOLD_MS } from "../commands/notify-relay.js";
 import { CaptainDelivery } from "./delivery/captain-delivery.js";
 import { projectHealth, type ComponentHealth } from "./liveness.js";
 import { assembleDaemonSnapshot, type DaemonSnapshotInputs, type ResultArtifacts } from "./snapshot.js";
@@ -774,6 +774,11 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
     const cmux = daemonCmux;
     const cfg = loadConfig();
     const deliveries = new Map<string, CaptainDelivery>();
+    // #332 storm BUG 3: captured once at delivery-loop setup. Entries older than
+    // sessionStartMs - STALE_THRESHOLD_MS are silently acked (cursor advanced)
+    // without delivery, mirroring the relay's drain(). This stops a fresh/empty
+    // cursor from re-delivering the entire historical backlog.
+    const sessionStartMs = Date.now();
 
     deliveryTick = async () => {
       const injectedSurfaces = opts.captainSurfaces ?? {};
@@ -840,6 +845,14 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
           deliveries.set(project, d);
         }
         for await (const entry of readFromCursor({ stateRoot, project, fromSeq: lastAcked + 1 })) {
+          // #332 storm BUG 3: silently ack entries that pre-date this daemon
+          // session by more than STALE_THRESHOLD_MS — leftovers from dead crews
+          // or a prior captain session. Mirrors the relay's drain() skip so a
+          // fresh/empty cursor never re-delivers the historical backlog.
+          if (new Date(entry.ts).getTime() < sessionStartMs - STALE_THRESHOLD_MS) {
+            await writeCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER, lastAckedSeq: entry.seq });
+            continue;
+          }
           const result = await d.deliver(entry, (text, sendOpts) =>
             cmux.send(surface!, text, sendOpts),
           );

--- a/src/control/mailbox.ts
+++ b/src/control/mailbox.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
+import { randomUUID } from "node:crypto";
 import type { TaskRecord, ControlEvent } from "./types.js";
 
 export interface MailboxEntry {
@@ -143,19 +144,31 @@ export interface CursorState {
 }
 
 export async function readCursor(opts: CursorOpts): Promise<CursorState | null> {
+  let buf: string;
   try {
-    const buf = await fs.readFile(cursorPath(opts.stateRoot, opts.project, opts.subscriber), "utf-8");
-    return JSON.parse(buf) as CursorState;
+    buf = await fs.readFile(cursorPath(opts.stateRoot, opts.project, opts.subscriber), "utf-8");
   } catch (e) {
     if ((e as NodeJS.ErrnoException).code === "ENOENT") return null;
     throw e;
+  }
+  // A 0-byte or corrupt cursor (e.g. an interrupted write) must be treated the
+  // same as a missing one — return null so the caller starts fresh from seq 0
+  // rather than crashing the relay boot / delivery loop (#332 storm BUG 1).
+  if (!buf.trim()) return null;
+  try {
+    return JSON.parse(buf) as CursorState;
+  } catch {
+    return null;
   }
 }
 
 export async function writeCursor(opts: CursorOpts & { lastAckedSeq: number }): Promise<void> {
   await fs.mkdir(inboxDir(opts.stateRoot), { recursive: true });
   const dest = cursorPath(opts.stateRoot, opts.project, opts.subscriber);
-  const tmp = dest + ".tmp";
+  // Unique tmp per call so overlapping writes never share a tmp path. A shared
+  // `dest + ".tmp"` let one rename consume the tmp the other expected → ENOENT
+  // on rename, leaving a 0-byte/corrupt cursor (#332 storm BUG 2).
+  const tmp = `${dest}.${process.pid}.${randomUUID()}.tmp`;
   const data: CursorState = {
     lastAckedSeq: opts.lastAckedSeq,
     subscriber: opts.subscriber,
@@ -168,7 +181,13 @@ export async function writeCursor(opts: CursorOpts & { lastAckedSeq: number }): 
   } finally {
     await handle.close();
   }
-  await fs.rename(tmp, dest);
+  try {
+    await fs.rename(tmp, dest);
+  } catch (e) {
+    // Best-effort cleanup so a failed rename doesn't leave the unique tmp behind.
+    await fs.unlink(tmp).catch(() => {});
+    throw e;
+  }
 }
 
 interface ReadFromCursorOpts {


### PR DESCRIPTION
Fixes the notification-storm + relay-boot-failure found while live-testing daemon-direct (#332). Three related bugs:

1. **readCursor throws on empty/corrupt cursor** (`mailbox.ts`) → a 0-byte cursor (from bug 2) made `JSON.parse('')` throw, which broke notify-relay boot entirely. Now empty/unparseable → `null` (start fresh), same as ENOENT.
2. **writeCursor shared-tmp rename race** (`mailbox.ts`) → overlapping daemon-direct delivery ticks shared `dest+'.tmp'`; one rename consumed the other's tmp → `ENOENT` on rename → 0-byte cursor. Now uses a unique tmp `${dest}.${pid}.${randomUUID()}.tmp` + cleanup on failure.
3. **daemon-direct delivery loop missing STALE_THRESHOLD skip** (`cockpitd.ts`) → on a fresh/empty cursor it re-delivered the ENTIRE mailbox backlog (the storm: same CREW DONE fired dozens of times). Now mirrors the relay's `drain()` silent-ack of entries older than `sessionStartMs - STALE_THRESHOLD_MS` (imports the SAME exported constant — one source of truth).

TDD: each bug had a failing test first (empty+corrupt cursor; 25 concurrent overlapping writes; 2 stale + 1 fresh backlog). Verification: build clean, `node dist/index.js --help` loads (ESM gate), tsc clean, 64 tests pass across cockpitd-daemon-direct + mailbox + notify-relay + relay-proxy (flag-OFF parity green).

These were latent under the relay path; they only fired once daemon-direct delivery was exercised. Prereq for safely re-enabling `daemonDirectCmux`.