### PR TITLE
fix(#332): re-entrancy guard on daemon-direct delivery + probe loops (storm-2)

### DIFF
--- a/src/control/__tests__/cockpitd-daemon-direct.test.ts
+++ b/src/control/__tests__/cockpitd-daemon-direct.test.ts
@@ -360,6 +360,68 @@ describe("cockpitd daemon-direct (#332)", () => {
     expect(cmux.sent).toEqual([]);
   });
 
+  // #332 storm BUG (re-entrancy): each deliveryTick does multiple slow cmux
+  // subprocess calls and can exceed the 1s interval. Without a re-entrancy guard,
+  // the interval fires again while the previous tick is still mid-flight; both
+  // ticks read the SAME cursor seq and both deliver the entries after it →
+  // duplicate/storm delivery. The guard must skip an overlapping tick so every
+  // mailbox entry is delivered EXACTLY ONCE even when ticks overlap.
+  it("flag ON: overlapping delivery ticks deliver each entry exactly once (re-entrancy guard)", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-dd-reentrancy-"));
+    const sock = join(dir, "c.sock");
+    const stateRoot = join(dir, "state");
+    mkdirSync(join(stateRoot, "inbox"), { recursive: true });
+
+    // One fresh mailbox entry. Both ticks would (without a guard) read cursor=0
+    // and deliver this same seq.
+    await appendToMailbox({ stateRoot, project: "p", taskRecord: TASK, event: EVENT, message: "CREW DONE [claude/t1] — only once" });
+    await writeCursor({ stateRoot, project: "p", subscriber: "captain", lastAckedSeq: 0 });
+
+    // A send that blocks on a controllable gate, so tick #1 is still in-flight
+    // (cursor not yet advanced) when we fire tick #2.
+    let releaseSend!: () => void;
+    const sendGate = new Promise<void>((resolve) => { releaseSend = resolve; });
+    const sent: Array<{ text: string }> = [];
+    const cmux = {
+      sent,
+      send: async (_surface: PaneRef, text: string) => { sent.push({ text }); await sendGate; },
+      listSurfaces: async () => [],
+      readScreen: async () => null,
+      isAvailable: async () => true,
+      findWorkspaceId: async () => null,
+    } as unknown as DaemonCmux & { sent: Array<{ text: string }> };
+
+    const handle = startCockpitd({
+      stateRoot, sockPath: sock, sweepMs: 0,
+      daemonCmux: cmux,
+      daemonDirectCmux: true,
+      captainSurfaces: { p: { workspaceId: "ws:1", surfaceId: "surface:1", title: "captain" } },
+    });
+    stop = handle.stop;
+
+    // Fire tick #1 (does not resolve — blocked inside send awaiting the gate).
+    const tick1 = handle.tickDelivery!();
+    // Let tick #1 reach the blocked send.
+    await new Promise((r) => setTimeout(r, 10));
+    // Fire tick #2 while tick #1 is still in-flight → guard must skip it.
+    await handle.tickDelivery!();
+    // tick #2 returned immediately (skipped); only tick #1's send is pending.
+    expect(sent.length).toBe(1);
+
+    // Release the gate and let tick #1 finish + advance the cursor.
+    releaseSend();
+    await tick1;
+
+    // Exactly one delivery total, cursor advanced once.
+    expect(sent.length).toBe(1);
+    const c = await readCursor({ stateRoot, project: "p", subscriber: "captain" });
+    expect(c?.lastAckedSeq).toBe(1);
+
+    // A subsequent (non-overlapping) tick must NOT re-deliver the already-acked entry.
+    await handle.tickDelivery!();
+    expect(sent.length).toBe(1);
+  });
+
   it("flag ON: daemon-direct probe emits task.blocked when interactive crew pane shows a permission prompt", async () => {
     dir = mkdtempSync(join(tmpdir(), "cp-dd-probe-"));
     const sock = join(dir, "c.sock");

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -780,7 +780,15 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
     // cursor from re-delivering the entire historical backlog.
     const sessionStartMs = Date.now();
 
-    deliveryTick = async () => {
+    // #332 storm BUG (re-entrancy): each tick does multiple slow cmux subprocess
+    // calls and can exceed the 1s interval, so the interval can fire again while
+    // the previous tick is still in-flight. Two overlapping ticks read the SAME
+    // cursor seq and both deliver the entries after it → duplicate/storm
+    // delivery. Mirror the relay's drain() `draining` guard: set on entry, clear
+    // in a finally, skip overlapping fires.
+    let delivering = false;
+
+    const deliveryCore = async () => {
       const injectedSurfaces = opts.captainSurfaces ?? {};
       const allProjects = [...new Set([
         ...Object.keys(cfg.projects ?? {}),
@@ -865,6 +873,16 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       }
     };
 
+    deliveryTick = async () => {
+      if (delivering) return;
+      delivering = true;
+      try {
+        await deliveryCore();
+      } finally {
+        delivering = false;
+      }
+    };
+
     // #332: daemon-direct blocked-crew detection. Reuses createInteractiveProbe
     // (from notify-relay.ts) with a direct cmux pane reader injected as the
     // readPaneTail dep. Matches the relay's PROBE_INTERVAL_MS (10s).
@@ -886,7 +904,20 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       now: () => Date.now(),
       log,
     });
-    probeTick = interactiveProbe.tick;
+    // #332 storm BUG (re-entrancy): the probe reads crew panes via slow cmux
+    // subprocess calls and can exceed its 10s interval. Give it its own
+    // independent guard (separate from `delivering`) so an overlapping probe
+    // fire is skipped rather than stacking back-to-back cmux reads.
+    let probing = false;
+    probeTick = async () => {
+      if (probing) return;
+      probing = true;
+      try {
+        await interactiveProbe.tick();
+      } finally {
+        probing = false;
+      }
+    };
   }
 
   // #332: production delivery interval (1s poll). Gated on sweepMs so tests


### PR DESCRIPTION
Fixes a SECOND notification storm found when live-testing daemon-direct (#332), plus the related control-plane-timeout.

**Root cause:** the daemon-direct delivery loop was `setInterval(() => deliveryTick(), 1000)` with NO re-entrancy guard. Each tick does slow cmux subprocess calls (findWorkspaceId + listSurfaces per project) and can exceed 1s, so the next interval fires while the previous tick is mid-flight → overlapping ticks read the same cursor seq and both deliver the entries after it → duplicate/storm. It also saturated the daemon event loop (back-to-back cmux spawns), which is why a crew's `cockpit crew signal done` timed out 3x.

**Fix:** closure-scoped re-entrancy guards (`delivering` / `probing`, set on entry, cleared in `finally`) on both the delivery loop and the blocked-crew probe loop — mirrors the relay `drain()`'s `draining` guard.

**Parity audit:** compared the daemon-direct delivery loop against the battle-tested relay `drain()` for ALL safeguards (we'd already hit 4 storm bugs that were each a drain() safeguard the daemon loop lacked). Re-entrancy was the last missing one; everything else (stale-skip, per-seq defer via CaptainDelivery, advance-only-on-delivered, null-message gate) is at parity. `break`-vs-`return` and the deliverable-gate location are correct multi-project adaptations, not bugs.

**Test:** overlapping-tick test (gate-blocked send; tick #2 fires while tick #1 in-flight) asserts each entry delivered EXACTLY ONCE — RED before, GREEN after. Verification: build clean, `node dist/index.js --help` loads, tsc clean, 39 tests pass (cockpitd-daemon-direct + relay-proxy + notify-relay, flag-OFF parity green).

This is the 4th and (per the drain-parity audit) final storm safeguard. Daemon-direct still ships flag-OFF (relay = default per the re-scope); this hardens it for opt-in.