### PR TITLE
docs: cockpit architecture diagrams (overview EN+VI, notification flow, cockpitd structure)

### DIFF
--- a/docs/diagrams/2026-06-17-cockpit-architecture-overview.html
+++ b/docs/diagrams/2026-06-17-cockpit-architecture-overview.html
@@ -1,0 +1,193 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Cockpit — Architecture Overview · where daemon &amp; cockpitd live</title>
+<style>
+  :root{
+    --bg:#0d1117; --panel:#161b22; --panel2:#1b2230; --line:#30363d; --ink:#e6edf3; --dim:#9aa4b0;
+    --cli:#58a6ff; --roles:#3fb950; --control:#d29922; --adapt:#bc8cff; --persist:#39c5cf; --hot:#f85149;
+    --mono:'SF Mono',ui-monospace,Menlo,Consolas,monospace; --sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;height:100%;background:var(--bg);color:var(--ink);font-family:var(--sans)}
+  #deck{height:100vh;display:flex;flex-direction:column}
+  header{padding:14px 28px;border-bottom:1px solid var(--line);display:flex;align-items:center;gap:14px;flex:0 0 auto}
+  header h1{font-size:15px;margin:0;font-weight:600}
+  header .tag{font-family:var(--mono);font-size:11px;color:var(--dim);border:1px solid var(--line);padding:2px 8px;border-radius:20px}
+  header .spacer{flex:1}
+  .slide{flex:1;display:none;padding:20px 44px 6px;overflow:auto}
+  .slide.active{display:flex;flex-direction:column;animation:fade .4s ease}
+  @keyframes fade{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:none}}
+  .slide h2{margin:0 0 6px;font-size:22px}
+  .slide .sub{color:var(--dim);font-size:14px;margin:0;max-width:1040px;line-height:1.5}
+  .stage{flex:1;display:grid;place-items:center;padding:8px 0}
+  svg{width:100%;height:auto;max-height:68vh;display:block}
+  .bt{font-family:var(--sans);font-weight:600;font-size:14px;fill:var(--ink)}
+  .bs{font-family:var(--mono);font-size:11px;fill:var(--dim)}
+  .band-l{font-family:var(--sans);font-weight:700;font-size:13px}
+  .chip{font-family:var(--mono);font-size:11.5px;fill:var(--ink)}
+  .edge{stroke:#52606d;stroke-width:2;fill:none;marker-end:url(#ar)}
+  .elabel{font-family:var(--mono);font-size:11.5px;fill:var(--dim)}
+  .pulse{stroke-dasharray:5 7;animation:dash 1.1s linear infinite} @keyframes dash{to{stroke-dashoffset:-24}}
+  .legend{display:flex;gap:16px;flex-wrap:wrap;font-size:12px;color:var(--dim);padding:6px 0 2px}
+  .legend b{display:inline-block;width:10px;height:10px;border-radius:2px;margin-right:5px;vertical-align:middle}
+  footer{flex:0 0 auto;border-top:1px solid var(--line);padding:10px 28px;display:flex;align-items:center;gap:16px}
+  button{background:var(--panel);color:var(--ink);border:1px solid var(--line);border-radius:8px;padding:7px 14px;font-size:13px;cursor:pointer;font-family:var(--sans)}
+  button:hover{border-color:var(--cli)}
+  .dots{display:flex;gap:7px;flex:1;justify-content:center}
+  .dots i{width:9px;height:9px;border-radius:50%;background:var(--line);cursor:pointer} .dots i.on{background:var(--cli);transform:scale(1.25)}
+  .num{font-family:var(--mono);font-size:12px;color:var(--dim);min-width:54px;text-align:right}
+  code{font-family:var(--mono);background:#1f2530;padding:1px 5px;border-radius:4px;font-size:.9em}
+  table{border-collapse:collapse;width:100%;max-width:1100px;font-size:13.5px}
+  td,th{border:1px solid var(--line);padding:9px 14px;text-align:left;vertical-align:top}
+  th{background:var(--panel);color:var(--dim);font-weight:600}
+  td code{font-size:.92em}
+</style>
+</head>
+<body>
+<div id="deck">
+  <header>
+    <h1>⚓ Cockpit — Architecture Overview</h1>
+    <span class="tag">where daemon &amp; cockpitd live</span>
+    <div class="spacer"></div>
+    <span class="tag">space / → · A = autoplay</span>
+  </header>
+
+  <!-- SLIDE 1: the layer cake -->
+  <section class="slide active">
+    <h2>1 · Cockpit in 5 layers</h2>
+    <p class="sub">Cockpit is a <b>multi-agent orchestration layer</b>. Read top→down: the user types a CLI command → the CLI spawns <b style="color:var(--roles)">role-sessions</b> + talks to the <b style="color:var(--control)">control plane (the daemon)</b> → the daemon drives agents &amp; the terminal through <b style="color:var(--adapt)">adapters</b> → everything persists to <b style="color:var(--persist)">storage</b>.</p>
+    <div class="stage">
+      <svg viewBox="0 0 1180 600">
+        <defs><marker id="ar" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#52606d"/></marker></defs>
+
+        <!-- L1 CLI -->
+        <rect x="40" y="30" width="1100" height="84" rx="12" fill="var(--panel)" stroke="var(--cli)" stroke-width="1.6"/>
+        <text class="band-l" x="60" y="58" fill="var(--cli)">① CLI — the ignition key</text><text class="bs" x="60" y="78">src/index.ts · src/commands/</text>
+        <text class="chip" x="360" y="62">cockpit launch</text><text class="chip" x="500" y="62">crew</text><text class="chip" x="580" y="62">side</text><text class="chip" x="660" y="62">relay</text><text class="chip" x="760" y="62">command</text><text class="chip" x="900" y="62">dashboard</text>
+        <text class="bs" x="360" y="92">"bootstraps &amp; delegates — not the brain" · talks to the daemon over a unix socket</text>
+
+        <!-- L2 roles -->
+        <rect x="40" y="134" width="1100" height="84" rx="12" fill="var(--panel)" stroke="var(--roles)" stroke-width="1.6"/>
+        <text class="band-l" x="60" y="162" fill="var(--roles)">② Roles — SESSIONS (not code)</text><text class="bs" x="60" y="182">agent sessions inside cmux surfaces + templates/skills</text>
+        <text class="chip" x="540" y="166">🎛 Command</text><text class="elabel" x="660" y="166">→</text><text class="chip" x="690" y="166">⚓ Captain</text><text class="elabel" x="800" y="166">→</text><text class="chip" x="830" y="166">🔧 Crew</text>
+        <text class="bs" x="540" y="198">core loop = Captain → Crew (Command is optional / on-demand)</text>
+
+        <!-- L3 control plane (highlight) -->
+        <rect x="40" y="238" width="1100" height="150" rx="12" fill="var(--panel2)" stroke="var(--control)" stroke-width="2.4"/>
+        <text class="band-l" x="60" y="266" fill="var(--control)">③ Control plane — THE DAEMON  ← daemon &amp; cockpitd LIVE HERE</text><text class="bs" x="60" y="286">src/control/ · long-lived launchd service</text>
+        <rect x="60" y="300" width="250" height="72" rx="10" fill="var(--bg)" stroke="var(--control)"/><text class="bt" x="78" y="326" fill="var(--control)">cockpitd.ts — HOST</text><text class="bs" x="78" y="346">startCockpitd() · socket+timers</text><text class="bs" x="78" y="362">1008 LOC · wiring</text>
+        <rect x="330" y="300" width="230" height="72" rx="10" fill="var(--bg)" stroke="var(--roles)"/><text class="bt" x="348" y="326" fill="var(--roles)">daemon.ts — CORE</text><text class="bs" x="348" y="346">createDaemon() · state machine</text><text class="bs" x="348" y="362">503 LOC · pure-ish</text>
+        <rect x="580" y="300" width="250" height="72" rx="10" fill="var(--bg)" stroke="var(--line)"/><text class="bt" x="598" y="326">store · mailbox · cursor</text><text class="bs" x="598" y="346">ledger + append-only queue</text><text class="bs" x="598" y="362">state-machine · watchdog</text>
+        <rect x="850" y="300" width="270" height="72" rx="10" fill="var(--bg)" stroke="var(--line)"/><text class="bt" x="868" y="326">delivery + bridges</text><text class="bs" x="868" y="346">relay / daemon-direct (#332)</text><text class="bs" x="868" y="362">codex · opencode · cmux-events</text>
+
+        <!-- L4 adapters -->
+        <rect x="40" y="408" width="1100" height="96" rx="12" fill="var(--panel)" stroke="var(--adapt)" stroke-width="1.6"/>
+        <text class="band-l" x="60" y="436" fill="var(--adapt)">④ Adapters — registry-based plugin slots</text>
+        <rect x="60" y="448" width="200" height="46" rx="8" fill="var(--bg)" stroke="var(--adapt)"/><text class="chip" x="76" y="476" fill="var(--adapt)">drivers/ · agents</text>
+        <rect x="276" y="448" width="200" height="46" rx="8" fill="var(--bg)" stroke="var(--adapt)"/><text class="chip" x="292" y="476" fill="var(--adapt)">runtimes/ · cmux</text>
+        <rect x="492" y="448" width="200" height="46" rx="8" fill="var(--bg)" stroke="var(--adapt)"/><text class="chip" x="508" y="476" fill="var(--adapt)">notifiers/ · push</text>
+        <rect x="708" y="448" width="200" height="46" rx="8" fill="var(--bg)" stroke="var(--adapt)"/><text class="chip" x="724" y="476" fill="var(--adapt)">workspaces/ · vault</text>
+        <rect x="924" y="448" width="196" height="46" rx="8" fill="var(--bg)" stroke="var(--adapt)"/><text class="chip" x="940" y="476" fill="var(--adapt)">projection/ · #31</text>
+
+        <!-- L5 persistence -->
+        <rect x="40" y="524" width="1100" height="66" rx="12" fill="var(--panel)" stroke="var(--persist)" stroke-width="1.6"/>
+        <text class="band-l" x="60" y="552" fill="var(--persist)">⑤ Persistence / external</text>
+        <text class="chip" x="320" y="556">~/.config/cockpit (config · state · mailbox)</text><text class="chip" x="720" y="556">cockpit-hub (vault)</text><text class="chip" x="960" y="556">cmux.app · agent CLIs</text>
+
+        <!-- vertical flow arrows -->
+        <path class="edge pulse" d="M590 114 L590 132" stroke="var(--cli)"/>
+        <path class="edge pulse" d="M590 218 L590 236" stroke="var(--roles)"/>
+        <path class="edge pulse" d="M590 388 L590 406" stroke="var(--control)"/>
+        <path class="edge pulse" d="M590 504 L590 522" stroke="var(--adapt)"/>
+      </svg>
+    </div>
+    <div class="legend"><span><b style="background:var(--control)"></b>③ control plane = where daemon &amp; cockpitd live — between the roles (above) and the adapters (below)</span></div>
+  </section>
+
+  <!-- SLIDE 2: request path -->
+  <section class="slide">
+    <h2>2 · One command travels through the stack</h2>
+    <p class="sub">Example <code>cockpit crew spawn …</code>: CLI → daemon (writes the ledger) → cmux adapter (creates a surface, spawns the agent) → crew runs → on finish, daemon → mailbox → delivery → captain. daemon/cockpitd is the relay station in the middle.</p>
+    <div class="stage">
+      <svg viewBox="0 0 1180 420">
+        <defs><marker id="ar2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#52606d"/></marker></defs>
+        <rect x="30" y="180" width="150" height="64" rx="10" fill="var(--panel)" stroke="var(--cli)"/><text class="bt" x="48" y="208" fill="var(--cli)">CLI</text><text class="bs" x="48" y="228">cockpit crew</text>
+        <rect x="250" y="170" width="190" height="84" rx="10" fill="var(--panel2)" stroke="var(--control)"/><text class="bt" x="268" y="198" fill="var(--control)">cockpitd</text><text class="bs" x="268" y="220">socket · ledger</text><text class="bs" x="268" y="238">→ createDaemon</text>
+        <rect x="510" y="180" width="170" height="64" rx="10" fill="var(--panel)" stroke="var(--adapt)"/><text class="bt" x="528" y="208" fill="var(--adapt)">cmux runtime</text><text class="bs" x="528" y="228">spawn surface</text>
+        <rect x="750" y="60" width="170" height="64" rx="10" fill="var(--panel)" stroke="var(--roles)"/><text class="bt" x="768" y="88" fill="var(--roles)">🔧 Crew</text><text class="bs" x="768" y="108">runs · signals done</text>
+        <rect x="750" y="300" width="190" height="64" rx="10" fill="var(--panel)" stroke="var(--persist)"/><text class="bt" x="768" y="328" fill="var(--persist)">mailbox + cursor</text><text class="bs" x="768" y="348">append-only</text>
+        <rect x="990" y="180" width="160" height="64" rx="10" fill="var(--panel)" stroke="var(--cli)"/><text class="bt" x="1008" y="208" fill="var(--cli)">⚓ Captain</text><text class="bs" x="1008" y="228">notified</text>
+
+        <path class="edge" marker-end="url(#ar2)" d="M180 212 L248 212"/><text class="elabel" x="188" y="200">socket</text>
+        <path class="edge" marker-end="url(#ar2)" d="M440 210 L508 210"/><text class="elabel" x="446" y="200">spawn</text>
+        <path class="edge" marker-end="url(#ar2)" d="M680 196 L748 110"/>
+        <path class="edge pulse" marker-end="url(#ar2)" d="M820 124 C 600 160, 480 300, 748 326" stroke="var(--control)"/><text class="elabel" x="470" y="280" fill="var(--control)">done → daemon → append</text>
+        <path class="edge pulse" marker-end="url(#ar2)" d="M940 320 C 1040 300, 1060 270, 1055 246" stroke="var(--persist)"/><text class="elabel" x="980" y="295">delivery (relay/direct)</text>
+      </svg>
+    </div>
+    <div class="legend"><span>For the "done → mailbox → captain" leg in detail, see the deck <code>2026-06-16-daemon-architecture-and-flow.html</code>.</span></div>
+  </section>
+
+  <!-- SLIDE 3: folder → layer map -->
+  <section class="slide">
+    <h2>3 · src/ folder → which layer</h2>
+    <p class="sub">A map to locate any file in the project.</p>
+    <div class="stage">
+      <table>
+        <tr><th>Layer</th><th>Folder</th><th>Role</th></tr>
+        <tr><td style="color:var(--cli)">① CLI</td><td><code>src/index.ts</code> · <code>src/commands/</code> · <code>src/config.ts</code></td><td>Entry + every command (launch/crew/side/relay/command/dashboard/group/…). Bootstrap only — no orchestration logic.</td></tr>
+        <tr><td style="color:var(--roles)">② Roles</td><td><code>plugin/skills/</code> · templates</td><td>Command/Captain/Crew are <b>sessions</b> running in cmux, loaded with a template + skills. Not code modules.</td></tr>
+        <tr><td style="color:var(--control);font-weight:700">③ Control plane</td><td><code>src/control/</code> — <code>cockpitd.ts</code>, <code>daemon.ts</code>, <code>store</code>, <code>mailbox</code>, <code>state-machine</code>, <code>watchdog</code>, <code>liveness</code>, <code>snapshot</code>, <code>protocol</code>, <code>codex/ opencode/ cmux/ interactive/ delivery/</code></td><td><b>The brain.</b> daemon = cockpitd (host) + createDaemon (core). Tracks task lifecycle, delivers notifications.</td></tr>
+        <tr><td style="color:var(--adapt)">④ Adapters</td><td><code>drivers/</code> (agents) · <code>runtimes/</code> (cmux) · <code>notifiers/</code> · <code>workspaces/</code> · <code>projection/</code></td><td>Each = a registry + types = a plugin slot. Swap cmux→another driver, add an agent… without touching the control plane.</td></tr>
+        <tr><td style="color:var(--persist)">⑤ Persistence</td><td><code>~/.config/cockpit/</code> · <code>cockpit-hub/</code> · <code>src/lib/</code></td><td>config.json, state (ledger/mailbox/cursor), hub-spoke vault; lib = shared (cmux-bin…).</td></tr>
+      </table>
+    </div>
+    <div class="legend"><span>Zoom-in: control-plane internals + split proposal → <code>2026-06-16-cockpitd-structure.html</code>.</span></div>
+  </section>
+
+  <!-- SLIDE 4: daemon vs cockpitd recap -->
+  <section class="slide">
+    <h2>4 · The recap: daemon vs cockpitd</h2>
+    <p class="sub">The two most confusing names — here is the definitive distinction.</p>
+    <div class="stage">
+      <table>
+        <tr><th></th><th style="color:var(--roles)">daemon.ts</th><th style="color:var(--control)">cockpitd.ts</th></tr>
+        <tr><td>Function</td><td><code>createDaemon()</code></td><td><code>startCockpitd()</code></td></tr>
+        <tr><td>What it is</td><td>CORE — pure-ish logic</td><td>HOST — the process</td></tr>
+        <tr><td>Holds</td><td>state machine, reaping, push policy (firePush/formatMessage), relay-health</td><td>socket server, 4 timers, 9 handlers, drivers/bridges, delivery loop, probes, gates, attach</td></tr>
+        <tr><td>I/O</td><td>NONE — injected via <code>DaemonDeps</code></td><td>ALL real I/O (socket/spawn/cmux/fs)</td></tr>
+        <tr><td>LOC</td><td>503 · cohesive</td><td>1008 · heavy (≈10 concerns)</td></tr>
+        <tr><td>Relationship</td><td colspan="2"><code>startCockpitd</code> builds the deps → calls <code>createDaemon(deps)</code> → mounts the socket + timers around it. They talk via <code>daemon.handle(req)</code> + the <code>deps.notify/launch*</code> callbacks.</td></tr>
+        <tr><td>Proposal</td><td>leave it (rename → <code>core.ts</code> to kill the confusion?)</td><td>split into <code>daemon/{server,attach,delivery,probes,drivers,gates}.ts</code> → a ~150-LOC composition root</td></tr>
+      </table>
+    </div>
+    <div class="legend"><span>Mnemonic: <b style="color:var(--control)">cockpitd</b> = "the daemon <b>process</b>" (the <b>d</b> = daemon/launchd). <b style="color:var(--roles)">daemon.ts</b> = "the daemon's <b>brain</b>". Same name, different roles.</span></div>
+  </section>
+
+  <footer>
+    <button id="prev">← Prev</button>
+    <div class="dots" id="dots"></div>
+    <button id="auto">▶ Autoplay</button>
+    <button id="next">Next →</button>
+    <span class="num" id="counter">1 / 4</span>
+  </footer>
+</div>
+<script>
+  const slides=[...document.querySelectorAll('.slide')];
+  const dotsBox=document.getElementById('dots');
+  let i=0, timer=null;
+  slides.forEach((_,n)=>{const d=document.createElement('i');d.onclick=()=>go(n);dotsBox.appendChild(d);});
+  const dots=[...dotsBox.children];
+  function go(n){i=(n+slides.length)%slides.length;slides.forEach((s,k)=>s.classList.toggle('active',k===i));dots.forEach((d,k)=>d.classList.toggle('on',k===i));document.getElementById('counter').textContent=(i+1)+' / '+slides.length;}
+  const next=()=>go(i+1), prev=()=>go(i-1);
+  document.getElementById('next').onclick=next; document.getElementById('prev').onclick=prev;
+  function toggleAuto(){const b=document.getElementById('auto');if(timer){clearInterval(timer);timer=null;b.textContent='▶ Autoplay';}else{timer=setInterval(next,6000);b.textContent='⏸ Pause';}}
+  document.getElementById('auto').onclick=toggleAuto;
+  addEventListener('keydown',e=>{if(e.key==='ArrowRight'||e.key===' '){e.preventDefault();next();}else if(e.key==='ArrowLeft')prev();else if(e.key.toLowerCase()==='a')toggleAuto();});
+  go(0);
+</script>
+</body>
+</html>

--- a/docs/diagrams/2026-06-17-cockpit-architecture-overview.vi.html
+++ b/docs/diagrams/2026-06-17-cockpit-architecture-overview.vi.html
@@ -1,0 +1,193 @@
+<!doctype html>
+<html lang="vi">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Cockpit — Toàn cảnh kiến trúc · daemon &amp; cockpitd ở đâu</title>
+<style>
+  :root{
+    --bg:#0d1117; --panel:#161b22; --panel2:#1b2230; --line:#30363d; --ink:#e6edf3; --dim:#9aa4b0;
+    --cli:#58a6ff; --roles:#3fb950; --control:#d29922; --adapt:#bc8cff; --persist:#39c5cf; --hot:#f85149;
+    --mono:'SF Mono',ui-monospace,Menlo,Consolas,monospace; --sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;height:100%;background:var(--bg);color:var(--ink);font-family:var(--sans)}
+  #deck{height:100vh;display:flex;flex-direction:column}
+  header{padding:14px 28px;border-bottom:1px solid var(--line);display:flex;align-items:center;gap:14px;flex:0 0 auto}
+  header h1{font-size:15px;margin:0;font-weight:600}
+  header .tag{font-family:var(--mono);font-size:11px;color:var(--dim);border:1px solid var(--line);padding:2px 8px;border-radius:20px}
+  header .spacer{flex:1}
+  .slide{flex:1;display:none;padding:20px 44px 6px;overflow:auto}
+  .slide.active{display:flex;flex-direction:column;animation:fade .4s ease}
+  @keyframes fade{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:none}}
+  .slide h2{margin:0 0 6px;font-size:22px}
+  .slide .sub{color:var(--dim);font-size:14px;margin:0;max-width:1040px;line-height:1.5}
+  .stage{flex:1;display:grid;place-items:center;padding:8px 0}
+  svg{width:100%;height:auto;max-height:68vh;display:block}
+  .bt{font-family:var(--sans);font-weight:600;font-size:14px;fill:var(--ink)}
+  .bs{font-family:var(--mono);font-size:11px;fill:var(--dim)}
+  .band-l{font-family:var(--sans);font-weight:700;font-size:13px}
+  .chip{font-family:var(--mono);font-size:11.5px;fill:var(--ink)}
+  .edge{stroke:#52606d;stroke-width:2;fill:none;marker-end:url(#ar)}
+  .elabel{font-family:var(--mono);font-size:11.5px;fill:var(--dim)}
+  .pulse{stroke-dasharray:5 7;animation:dash 1.1s linear infinite} @keyframes dash{to{stroke-dashoffset:-24}}
+  .legend{display:flex;gap:16px;flex-wrap:wrap;font-size:12px;color:var(--dim);padding:6px 0 2px}
+  .legend b{display:inline-block;width:10px;height:10px;border-radius:2px;margin-right:5px;vertical-align:middle}
+  footer{flex:0 0 auto;border-top:1px solid var(--line);padding:10px 28px;display:flex;align-items:center;gap:16px}
+  button{background:var(--panel);color:var(--ink);border:1px solid var(--line);border-radius:8px;padding:7px 14px;font-size:13px;cursor:pointer;font-family:var(--sans)}
+  button:hover{border-color:var(--cli)}
+  .dots{display:flex;gap:7px;flex:1;justify-content:center}
+  .dots i{width:9px;height:9px;border-radius:50%;background:var(--line);cursor:pointer} .dots i.on{background:var(--cli);transform:scale(1.25)}
+  .num{font-family:var(--mono);font-size:12px;color:var(--dim);min-width:54px;text-align:right}
+  code{font-family:var(--mono);background:#1f2530;padding:1px 5px;border-radius:4px;font-size:.9em}
+  table{border-collapse:collapse;width:100%;max-width:1100px;font-size:13.5px}
+  td,th{border:1px solid var(--line);padding:9px 14px;text-align:left;vertical-align:top}
+  th{background:var(--panel);color:var(--dim);font-weight:600}
+  td code{font-size:.92em}
+</style>
+</head>
+<body>
+<div id="deck">
+  <header>
+    <h1>⚓ Cockpit — Toàn cảnh kiến trúc</h1>
+    <span class="tag">daemon &amp; cockpitd ở đâu</span>
+    <div class="spacer"></div>
+    <span class="tag">space / → · A = autoplay</span>
+  </header>
+
+  <!-- SLIDE 1: the layer cake -->
+  <section class="slide active">
+    <h2>1 · 5 tầng của cockpit</h2>
+    <p class="sub">Cockpit là <b>lớp điều phối đa-agent</b>. Đọc từ trên xuống: người dùng gõ CLI → CLI spawn các <b style="color:var(--roles)">role-session</b> + nói chuyện với <b style="color:var(--control)">control plane (daemon)</b> → daemon dùng các <b style="color:var(--adapt)">adapter</b> để điều khiển agent &amp; terminal → mọi thứ ghi xuống <b style="color:var(--persist)">persistence</b>.</p>
+    <div class="stage">
+      <svg viewBox="0 0 1180 600">
+        <defs><marker id="ar" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#52606d"/></marker></defs>
+
+        <!-- L1 CLI -->
+        <rect x="40" y="30" width="1100" height="84" rx="12" fill="var(--panel)" stroke="var(--cli)" stroke-width="1.6"/>
+        <text class="band-l" x="60" y="58" fill="var(--cli)">① CLI — ignition</text><text class="bs" x="60" y="78">src/index.ts · src/commands/</text>
+        <text class="chip" x="360" y="62">cockpit launch</text><text class="chip" x="500" y="62">crew</text><text class="chip" x="580" y="62">side</text><text class="chip" x="660" y="62">relay</text><text class="chip" x="760" y="62">command</text><text class="chip" x="900" y="62">dashboard</text>
+        <text class="bs" x="360" y="92">"khởi động & ủy thác — không phải bộ não" · talks to daemon via unix socket</text>
+
+        <!-- L2 roles -->
+        <rect x="40" y="134" width="1100" height="84" rx="12" fill="var(--panel)" stroke="var(--roles)" stroke-width="1.6"/>
+        <text class="band-l" x="60" y="162" fill="var(--roles)">② Roles — SESSION (không phải code)</text><text class="bs" x="60" y="182">agent sessions trong cmux surface + templates/skills</text>
+        <text class="chip" x="540" y="166">🎛 Command</text><text class="elabel" x="660" y="166">→</text><text class="chip" x="690" y="166">⚓ Captain</text><text class="elabel" x="800" y="166">→</text><text class="chip" x="830" y="166">🔧 Crew</text>
+        <text class="bs" x="540" y="198">core loop = Captain → Crew (Command optional/on-demand)</text>
+
+        <!-- L3 control plane (highlight) -->
+        <rect x="40" y="238" width="1100" height="150" rx="12" fill="var(--panel2)" stroke="var(--control)" stroke-width="2.4"/>
+        <text class="band-l" x="60" y="266" fill="var(--control)">③ Control plane — THE DAEMON  ← daemon &amp; cockpitd Ở ĐÂY</text><text class="bs" x="60" y="286">src/control/ · long-lived launchd service</text>
+        <rect x="60" y="300" width="250" height="72" rx="10" fill="var(--bg)" stroke="var(--control)"/><text class="bt" x="78" y="326" fill="var(--control)">cockpitd.ts — HOST</text><text class="bs" x="78" y="346">startCockpitd() · socket+timers</text><text class="bs" x="78" y="362">1008 LOC · wiring</text>
+        <rect x="330" y="300" width="230" height="72" rx="10" fill="var(--bg)" stroke="var(--roles)"/><text class="bt" x="348" y="326" fill="var(--roles)">daemon.ts — CORE</text><text class="bs" x="348" y="346">createDaemon() · state machine</text><text class="bs" x="348" y="362">503 LOC · pure-ish</text>
+        <rect x="580" y="300" width="250" height="72" rx="10" fill="var(--bg)" stroke="var(--line)"/><text class="bt" x="598" y="326">store · mailbox · cursor</text><text class="bs" x="598" y="346">ledger + append-only queue</text><text class="bs" x="598" y="362">state-machine · watchdog</text>
+        <rect x="850" y="300" width="270" height="72" rx="10" fill="var(--bg)" stroke="var(--line)"/><text class="bt" x="868" y="326">delivery + bridges</text><text class="bs" x="868" y="346">relay / daemon-direct (#332)</text><text class="bs" x="868" y="362">codex · opencode · cmux-events</text>
+
+        <!-- L4 adapters -->
+        <rect x="40" y="408" width="1100" height="96" rx="12" fill="var(--panel)" stroke="var(--adapt)" stroke-width="1.6"/>
+        <text class="band-l" x="60" y="436" fill="var(--adapt)">④ Adapters — registry-based plugin slots</text>
+        <rect x="60" y="448" width="200" height="46" rx="8" fill="var(--bg)" stroke="var(--adapt)"/><text class="chip" x="76" y="476" fill="var(--adapt)">drivers/ · agents</text>
+        <rect x="276" y="448" width="200" height="46" rx="8" fill="var(--bg)" stroke="var(--adapt)"/><text class="chip" x="292" y="476" fill="var(--adapt)">runtimes/ · cmux</text>
+        <rect x="492" y="448" width="200" height="46" rx="8" fill="var(--bg)" stroke="var(--adapt)"/><text class="chip" x="508" y="476" fill="var(--adapt)">notifiers/ · push</text>
+        <rect x="708" y="448" width="200" height="46" rx="8" fill="var(--bg)" stroke="var(--adapt)"/><text class="chip" x="724" y="476" fill="var(--adapt)">workspaces/ · vault</text>
+        <rect x="924" y="448" width="196" height="46" rx="8" fill="var(--bg)" stroke="var(--adapt)"/><text class="chip" x="940" y="476" fill="var(--adapt)">projection/ · #31</text>
+
+        <!-- L5 persistence -->
+        <rect x="40" y="524" width="1100" height="66" rx="12" fill="var(--panel)" stroke="var(--persist)" stroke-width="1.6"/>
+        <text class="band-l" x="60" y="552" fill="var(--persist)">⑤ Persistence / external</text>
+        <text class="chip" x="320" y="556">~/.config/cockpit (config · state · mailbox)</text><text class="chip" x="720" y="556">cockpit-hub (vault)</text><text class="chip" x="960" y="556">cmux.app · agent CLIs</text>
+
+        <!-- vertical flow arrows -->
+        <path class="edge pulse" d="M590 114 L590 132" stroke="var(--cli)"/>
+        <path class="edge pulse" d="M590 218 L590 236" stroke="var(--roles)"/>
+        <path class="edge pulse" d="M590 388 L590 406" stroke="var(--control)"/>
+        <path class="edge pulse" d="M590 504 L590 522" stroke="var(--adapt)"/>
+      </svg>
+    </div>
+    <div class="legend"><span><b style="background:var(--control)"></b>③ control plane = nơi daemon &amp; cockpitd sống — giữa roles (trên) và adapters (dưới)</span></div>
+  </section>
+
+  <!-- SLIDE 2: request path -->
+  <section class="slide">
+    <h2>2 · Một lệnh đi xuyên kiến trúc</h2>
+    <p class="sub">Ví dụ <code>cockpit crew spawn …</code>: CLI → daemon (ghi ledger) → adapter cmux (tạo surface, spawn agent) → crew chạy → khi xong, daemon → mailbox → delivery → captain. daemon/cockpitd là trạm trung chuyển ở giữa.</p>
+    <div class="stage">
+      <svg viewBox="0 0 1180 420">
+        <defs><marker id="ar2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#52606d"/></marker></defs>
+        <rect x="30" y="180" width="150" height="64" rx="10" fill="var(--panel)" stroke="var(--cli)"/><text class="bt" x="48" y="208" fill="var(--cli)">CLI</text><text class="bs" x="48" y="228">cockpit crew</text>
+        <rect x="250" y="170" width="190" height="84" rx="10" fill="var(--panel2)" stroke="var(--control)"/><text class="bt" x="268" y="198" fill="var(--control)">cockpitd</text><text class="bs" x="268" y="220">socket · ledger</text><text class="bs" x="268" y="238">→ createDaemon</text>
+        <rect x="510" y="180" width="170" height="64" rx="10" fill="var(--panel)" stroke="var(--adapt)"/><text class="bt" x="528" y="208" fill="var(--adapt)">cmux runtime</text><text class="bs" x="528" y="228">spawn surface</text>
+        <rect x="750" y="60" width="170" height="64" rx="10" fill="var(--panel)" stroke="var(--roles)"/><text class="bt" x="768" y="88" fill="var(--roles)">🔧 Crew</text><text class="bs" x="768" y="108">runs · signals done</text>
+        <rect x="750" y="300" width="190" height="64" rx="10" fill="var(--panel)" stroke="var(--persist)"/><text class="bt" x="768" y="328" fill="var(--persist)">mailbox + cursor</text><text class="bs" x="768" y="348">append-only</text>
+        <rect x="990" y="180" width="160" height="64" rx="10" fill="var(--panel)" stroke="var(--cli)"/><text class="bt" x="1008" y="208" fill="var(--cli)">⚓ Captain</text><text class="bs" x="1008" y="228">notified</text>
+
+        <path class="edge" marker-end="url(#ar2)" d="M180 212 L248 212"/><text class="elabel" x="188" y="200">socket</text>
+        <path class="edge" marker-end="url(#ar2)" d="M440 210 L508 210"/><text class="elabel" x="446" y="200">spawn</text>
+        <path class="edge" marker-end="url(#ar2)" d="M680 196 L748 110"/>
+        <path class="edge pulse" marker-end="url(#ar2)" d="M820 124 C 600 160, 480 300, 748 326" stroke="var(--control)"/><text class="elabel" x="470" y="280" fill="var(--control)">done → daemon → append</text>
+        <path class="edge pulse" marker-end="url(#ar2)" d="M940 320 C 1040 300, 1060 270, 1055 246" stroke="var(--persist)"/><text class="elabel" x="980" y="295">delivery (relay/direct)</text>
+      </svg>
+    </div>
+    <div class="legend"><span>Chi tiết khúc "done → mailbox → captain": xem deck <code>2026-06-16-daemon-architecture-and-flow.html</code>.</span></div>
+  </section>
+
+  <!-- SLIDE 3: folder → layer map -->
+  <section class="slide">
+    <h2>3 · src/ folder → tầng nào</h2>
+    <p class="sub">Bản đồ để định vị bất kỳ file nào trong dự án.</p>
+    <div class="stage">
+      <table>
+        <tr><th>Tầng</th><th>Thư mục</th><th>Vai trò</th></tr>
+        <tr><td style="color:var(--cli)">① CLI</td><td><code>src/index.ts</code> · <code>src/commands/</code> · <code>src/config.ts</code></td><td>Entry + tất cả lệnh (launch/crew/side/relay/command/dashboard/group/…). Bootstrap, không chứa orchestration logic.</td></tr>
+        <tr><td style="color:var(--roles)">② Roles</td><td><code>plugin/skills/</code> · templates</td><td>Command/Captain/Crew là <b>session</b> chạy trong cmux, nạp template + skill. Không phải module code.</td></tr>
+        <tr><td style="color:var(--control);font-weight:700">③ Control plane</td><td><code>src/control/</code> — <code>cockpitd.ts</code>, <code>daemon.ts</code>, <code>store</code>, <code>mailbox</code>, <code>state-machine</code>, <code>watchdog</code>, <code>liveness</code>, <code>snapshot</code>, <code>protocol</code>, <code>codex/ opencode/ cmux/ interactive/ delivery/</code></td><td><b>Bộ não.</b> daemon = cockpitd (host) + createDaemon (core). Theo dõi vòng đời task, gửi notification.</td></tr>
+        <tr><td style="color:var(--adapt)">④ Adapters</td><td><code>drivers/</code> (agents) · <code>runtimes/</code> (cmux) · <code>notifiers/</code> · <code>workspaces/</code> · <code>projection/</code></td><td>Mỗi cái 1 registry + types = plugin slot. Đổi cmux→driver khác, thêm agent… không đụng control plane.</td></tr>
+        <tr><td style="color:var(--persist)">⑤ Persistence</td><td><code>~/.config/cockpit/</code> · <code>cockpit-hub/</code> · <code>src/lib/</code></td><td>config.json, state (ledger/mailbox/cursor), vault hub-spoke; lib = shared (cmux-bin…).</td></tr>
+      </table>
+    </div>
+    <div class="legend"><span>Zoom-in: cấu trúc nội bộ control plane + đề xuất tách → <code>2026-06-16-cockpitd-structure.html</code>.</span></div>
+  </section>
+
+  <!-- SLIDE 4: daemon vs cockpitd recap -->
+  <section class="slide">
+    <h2>4 · Chốt lại: daemon vs cockpitd</h2>
+    <p class="sub">Hai cái tên gây rối nhất — đây là phân biệt dứt khoát.</p>
+    <div class="stage">
+      <table>
+        <tr><th></th><th style="color:var(--roles)">daemon.ts</th><th style="color:var(--control)">cockpitd.ts</th></tr>
+        <tr><td>Hàm</td><td><code>createDaemon()</code></td><td><code>startCockpitd()</code></td></tr>
+        <tr><td>Là gì</td><td>LÕI — logic thuần</td><td>VỎ — process host</td></tr>
+        <tr><td>Chứa</td><td>state machine, reap, push-policy (firePush/formatMessage), relay-health</td><td>socket server, 4 timer, 9 handler, drivers/bridges, delivery loop, probes, gates, attach</td></tr>
+        <tr><td>I/O</td><td>KHÔNG — inject qua <code>DaemonDeps</code></td><td>TẤT CẢ I/O thật (socket/spawn/cmux/fs)</td></tr>
+        <tr><td>LOC</td><td>503 · cohesive</td><td>1008 · nặng (≈10 concern)</td></tr>
+        <tr><td>Quan hệ</td><td colspan="2"><code>startCockpitd</code> dựng deps → gọi <code>createDaemon(deps)</code> → mount socket+timers quanh nó. Giao tiếp qua <code>daemon.handle(req)</code> + callbacks <code>deps.notify/launch*</code>.</td></tr>
+        <tr><td>Đề xuất</td><td>để yên (rename → <code>core.ts</code> cho đỡ nhầm?)</td><td>tách ra <code>daemon/{server,attach,delivery,probes,drivers,gates}.ts</code> → còn ~150 LOC composition root</td></tr>
+      </table>
+    </div>
+    <div class="legend"><span>Mẹo nhớ: <b style="color:var(--control)">cockpitd</b> = "the <b>d</b>aemon process" (chữ d = daemon/launchd). <b style="color:var(--roles)">daemon.ts</b> = "the daemon's <b>brain</b>". Tên trùng nhưng vai khác.</span></div>
+  </section>
+
+  <footer>
+    <button id="prev">← Prev</button>
+    <div class="dots" id="dots"></div>
+    <button id="auto">▶ Autoplay</button>
+    <button id="next">Next →</button>
+    <span class="num" id="counter">1 / 4</span>
+  </footer>
+</div>
+<script>
+  const slides=[...document.querySelectorAll('.slide')];
+  const dotsBox=document.getElementById('dots');
+  let i=0, timer=null;
+  slides.forEach((_,n)=>{const d=document.createElement('i');d.onclick=()=>go(n);dotsBox.appendChild(d);});
+  const dots=[...dotsBox.children];
+  function go(n){i=(n+slides.length)%slides.length;slides.forEach((s,k)=>s.classList.toggle('active',k===i));dots.forEach((d,k)=>d.classList.toggle('on',k===i));document.getElementById('counter').textContent=(i+1)+' / '+slides.length;}
+  const next=()=>go(i+1), prev=()=>go(i-1);
+  document.getElementById('next').onclick=next; document.getElementById('prev').onclick=prev;
+  function toggleAuto(){const b=document.getElementById('auto');if(timer){clearInterval(timer);timer=null;b.textContent='▶ Autoplay';}else{timer=setInterval(next,6000);b.textContent='⏸ Pause';}}
+  document.getElementById('auto').onclick=toggleAuto;
+  addEventListener('keydown',e=>{if(e.key==='ArrowRight'||e.key===' '){e.preventDefault();next();}else if(e.key==='ArrowLeft')prev();else if(e.key.toLowerCase()==='a')toggleAuto();});
+  go(0);
+</script>
+</body>
+</html>

--- a/docs/reports/2026-06-16-cockpitd-structure.html
+++ b/docs/reports/2026-06-16-cockpitd-structure.html
@@ -1,0 +1,216 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Cockpit — Daemon Structure (core vs host) &amp; Split Proposal</title>
+<style>
+  :root{
+    --bg:#0d1117; --panel:#161b22; --panel2:#1b2230; --line:#30363d; --ink:#e6edf3; --dim:#9aa4b0;
+    --core:#3fb950; --host:#d29922; --rpc:#58a6ff; --deliver:#bc8cff; --probe:#39c5cf;
+    --driver:#f778ba; --gate:#e3b341; --attach:#79c0ff; --bad:#f85149;
+    --mono:'SF Mono',ui-monospace,Menlo,Consolas,monospace; --sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;height:100%;background:var(--bg);color:var(--ink);font-family:var(--sans)}
+  #deck{height:100vh;display:flex;flex-direction:column}
+  header{padding:14px 28px;border-bottom:1px solid var(--line);display:flex;align-items:center;gap:14px;flex:0 0 auto}
+  header h1{font-size:15px;margin:0;font-weight:600}
+  header .tag{font-family:var(--mono);font-size:11px;color:var(--dim);border:1px solid var(--line);padding:2px 8px;border-radius:20px}
+  header .spacer{flex:1}
+  .slide{flex:1;display:none;padding:22px 44px 6px;overflow:auto}
+  .slide.active{display:flex;flex-direction:column;animation:fade .4s ease}
+  @keyframes fade{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:none}}
+  .slide h2{margin:0 0 6px;font-size:23px}
+  .slide .sub{color:var(--dim);font-size:14px;margin:0;max-width:1000px;line-height:1.5}
+  .stage{flex:1;display:grid;place-items:center;padding:8px 0}
+  svg{width:100%;height:auto;max-height:66vh;display:block}
+  .bt{font-family:var(--sans);font-weight:600;font-size:14.5px;fill:var(--ink)}
+  .bs{font-family:var(--mono);font-size:11.5px;fill:var(--dim)}
+  .edge{stroke:#52606d;stroke-width:1.8;fill:none}
+  .elabel{font-family:var(--mono);font-size:11.5px;fill:var(--dim)}
+  .loc{font-family:var(--mono);font-size:11px;fill:var(--dim)}
+  .legend{display:flex;gap:16px;flex-wrap:wrap;font-size:12px;color:var(--dim);padding:6px 0 2px}
+  .legend b{display:inline-block;width:10px;height:10px;border-radius:2px;margin-right:5px;vertical-align:middle}
+  footer{flex:0 0 auto;border-top:1px solid var(--line);padding:10px 28px;display:flex;align-items:center;gap:16px}
+  button{background:var(--panel);color:var(--ink);border:1px solid var(--line);border-radius:8px;padding:7px 14px;font-size:13px;cursor:pointer;font-family:var(--sans)}
+  button:hover{border-color:var(--rpc)}
+  .dots{display:flex;gap:7px;flex:1;justify-content:center}
+  .dots i{width:9px;height:9px;border-radius:50%;background:var(--line);cursor:pointer;transition:.2s}
+  .dots i.on{background:var(--rpc);transform:scale(1.25)}
+  .num{font-family:var(--mono);font-size:12px;color:var(--dim);min-width:54px;text-align:right}
+  code{font-family:var(--mono);background:#1f2530;padding:1px 5px;border-radius:4px;font-size:.9em}
+  .pulse{stroke-dasharray:5 7;animation:dash 1.1s linear infinite}
+  @keyframes dash{to{stroke-dashoffset:-24}}
+  .twocol{display:grid;grid-template-columns:1fr 1fr;gap:26px;width:100%;max-width:1200px}
+  .card{border:1px solid var(--line);border-radius:14px;padding:22px 26px;background:var(--panel);min-height:48vh}
+  .card h3{margin:0 0 14px;font-size:17px}
+  .card ul{margin:0;padding-left:20px;font-size:14px;color:var(--ink);line-height:1.8}
+  .card ul li{margin-bottom:6px} .card ul li small{color:var(--dim)}
+</style>
+</head>
+<body>
+<div id="deck">
+  <header>
+    <h1>⚙ Cockpit — Daemon Structure &amp; Split Proposal</h1>
+    <span class="tag">core vs host</span>
+    <div class="spacer"></div>
+    <span class="tag">space / → · A = autoplay</span>
+  </header>
+
+  <!-- SLIDE 1: two layers -->
+  <section class="slide active">
+    <h2>1 · Two layers (the seam already exists)</h2>
+    <p class="sub"><code>cockpitd.ts</code> is NOT the brain — it's the <b style="color:var(--host)">host process</b> (I/O, sockets, timers, drivers). The brain is <code>daemon.ts</code> = <b style="color:var(--core)">createDaemon()</b>, a near-pure core with all I/O <b>injected</b>. They talk through one function: <code>daemon.handle(req)</code>.</p>
+    <div class="stage">
+      <svg viewBox="0 0 1180 460">
+        <rect x="60" y="70" width="470" height="320" rx="16" fill="none" stroke="var(--host)" stroke-width="1.6" stroke-dasharray="6 5"/>
+        <text x="84" y="104" class="bs" fill="var(--host)">cockpitd.ts · startCockpitd()  — HOST (1008 LOC)</text>
+        <rect x="92" y="130" width="180" height="58" rx="10" fill="var(--panel)" stroke="var(--line)"/><text class="bt" x="112" y="156">socket server</text><text class="bs" x="112" y="176">+ 4 timers</text>
+        <rect x="320" y="130" width="170" height="58" rx="10" fill="var(--panel)" stroke="var(--line)"/><text class="bt" x="340" y="156">real I/O wiring</text><text class="bs" x="340" y="176">spawn · cmux · fs</text>
+        <rect x="92" y="300" width="180" height="58" rx="10" fill="var(--panel)" stroke="var(--driver)"/><text class="bt" x="112" y="326" fill="var(--driver)">drivers/bridges</text><text class="bs" x="112" y="346">codex·opencode·cmux</text>
+        <rect x="320" y="300" width="170" height="58" rx="10" fill="var(--panel)" stroke="var(--deliver)"/><text class="bt" x="340" y="326" fill="var(--deliver)">delivery·probes</text><text class="bs" x="340" y="346">loops + reap</text>
+
+        <rect x="700" y="150" width="400" height="170" rx="16" fill="var(--panel2)" stroke="var(--core)" stroke-width="1.8"/>
+        <text x="724" y="186" class="bs" fill="var(--core)">daemon.ts · createDaemon()  — CORE (503 LOC)</text>
+        <text class="bt" x="724" y="220">state machine · reaping · push policy</text>
+        <text class="bs" x="724" y="246">all I/O injected via DaemonDeps</text>
+        <text class="bs" x="724" y="268">{ store, now, isPidAlive, notify,</text>
+        <text class="bs" x="724" y="288">  launchHeadless, launchInteractive, … }</text>
+
+        <path class="edge pulse" d="M530 235 L698 235" stroke="var(--core)" marker-end="url(#a)"/>
+        <defs><marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="var(--core)"/></marker></defs>
+        <text class="elabel" x="556" y="222" fill="var(--core)">daemon.handle(req)</text>
+        <text class="elabel" x="556" y="258">deps.notify / launch* (callbacks back)</text>
+      </svg>
+    </div>
+    <div class="legend"><span>The split is healthy in principle — but the host (left) has accreted ~10 concerns into one 1008-line function. That's the weight.</span></div>
+  </section>
+
+  <!-- SLIDE 2: daemon.ts core -->
+  <section class="slide">
+    <h2>2 · <code style="font-size:.8em">daemon.ts</code> — the core (createDaemon)</h2>
+    <p class="sub">Near-pure. Owns task lifecycle + the "when do we notify the captain" policy. Depends only on small pure modules. This part is <b style="color:var(--core)">already clean</b> — leave it.</p>
+    <div class="stage">
+      <svg viewBox="0 0 1180 470">
+        <defs><marker id="ad" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#52606d"/></marker></defs>
+        <!-- center -->
+        <rect x="430" y="190" width="320" height="92" rx="14" fill="var(--panel2)" stroke="var(--core)" stroke-width="1.8"/>
+        <text class="bt" x="456" y="226" fill="var(--core)">createDaemon().handle(req)</text>
+        <text class="bs" x="456" y="252">dispatch · event  → reduce() + firePush()</text>
+        <text class="bs" x="456" y="272">+ relay-health tracking</text>
+
+        <!-- internal helpers (top) -->
+        <rect x="120" y="60" width="220" height="60" rx="10" fill="var(--panel)" stroke="var(--line)"/><text class="bt" x="140" y="86">firePush()</text><text class="bs" x="140" y="106">notify + IDLE debounce</text>
+        <rect x="370" y="60" width="220" height="60" rx="10" fill="var(--panel)" stroke="var(--line)"/><text class="bt" x="390" y="86">formatMessage()</text><text class="bs" x="390" y="106">event → captain text</text>
+        <rect x="620" y="60" width="240" height="60" rx="10" fill="var(--panel)" stroke="var(--line)"/><text class="bt" x="640" y="86">formatDelegationReport()</text><text class="bs" x="640" y="106">cross-project report</text>
+
+        <!-- pure deps (bottom) -->
+        <rect x="120" y="350" width="190" height="60" rx="10" fill="var(--panel)" stroke="var(--rpc)"/><text class="bt" x="140" y="376" fill="var(--rpc)">state-machine.ts</text><text class="bs" x="140" y="396">reduce() · 118 LOC</text>
+        <rect x="340" y="350" width="170" height="60" rx="10" fill="var(--panel)" stroke="var(--rpc)"/><text class="bt" x="360" y="376" fill="var(--rpc)">watchdog.ts</text><text class="bs" x="360" y="396">stall detect</text>
+        <rect x="540" y="350" width="170" height="60" rx="10" fill="var(--panel)" stroke="var(--rpc)"/><text class="bt" x="560" y="376" fill="var(--rpc)">liveness.ts</text><text class="bs" x="560" y="396">relay health</text>
+        <rect x="740" y="350" width="160" height="60" rx="10" fill="var(--panel)" stroke="var(--rpc)"/><text class="bt" x="760" y="376" fill="var(--rpc)">store.ts</text><text class="bs" x="760" y="396">task records</text>
+
+        <path class="edge" marker-end="url(#ad)" d="M230 120 L520 188"/>
+        <path class="edge" marker-end="url(#ad)" d="M480 120 L560 188"/>
+        <path class="edge" marker-end="url(#ad)" d="M740 120 L640 188"/>
+        <path class="edge" marker-end="url(#ad)" d="M300 350 L500 284"/>
+        <path class="edge" marker-end="url(#ad)" d="M430 350 L560 284"/>
+        <path class="edge" marker-end="url(#ad)" d="M610 350 L600 284"/>
+        <path class="edge" marker-end="url(#ad)" d="M790 350 L680 284"/>
+      </svg>
+    </div>
+    <div class="legend"><span><b style="background:var(--core)"></b>core logic</span><span><b style="background:var(--rpc)"></b>small pure deps</span><span>No sockets, no timers, no cmux — testable by injecting fakes. ~503 LOC, cohesive.</span></div>
+  </section>
+
+  <!-- SLIDE 3: cockpitd.ts host -->
+  <section class="slide">
+    <h2>3 · <code style="font-size:.8em">cockpitd.ts</code> — the host (startCockpitd) · the heavy one</h2>
+    <p class="sub">One 1008-line function wires ~10 distinct concerns + 20 imports + 9 socket handlers + 4 timers. Everything below lives inside a single closure — that's why it feels heavy.</p>
+    <div class="stage">
+      <svg viewBox="0 0 1180 480">
+        <ellipse cx="590" cy="240" rx="150" ry="64" fill="var(--panel2)" stroke="var(--host)" stroke-width="2"/>
+        <text class="bt" x="590" y="234" text-anchor="middle" fill="var(--host)">startCockpitd()</text>
+        <text class="bs" x="590" y="256" text-anchor="middle">1008 LOC · one closure</text>
+
+        <!-- concern satellites -->
+        <g font-family="var(--sans)">
+        <rect x="60"  y="40"  width="210" height="56" rx="10" fill="var(--panel)" stroke="var(--rpc)"/><text class="bt" x="78" y="64" fill="var(--rpc)">9 socket handlers</text><text class="bs" x="78" y="84">seed·codex-close·relay-*·health·snapshot·event</text>
+        <rect x="910" y="40"  width="210" height="56" rx="10" fill="var(--panel)" stroke="var(--attach)"/><text class="bt" x="928" y="64" fill="var(--attach)">attach fan-out</text><text class="bs" x="928" y="84">broadcast AttachFrames</text>
+        <rect x="60"  y="130" width="210" height="56" rx="10" fill="var(--panel)" stroke="var(--gate)"/><text class="bt" x="78" y="154" fill="var(--gate)">gate promotion</text><text class="bs" x="78" y="174">schedule/cancel timers</text>
+        <rect x="910" y="130" width="210" height="56" rx="10" fill="var(--panel)" stroke="var(--driver)"/><text class="bt" x="928" y="154" fill="var(--driver)">codex driver</text><text class="bs" x="928" y="174">CodexInteractiveDriver</text>
+        <rect x="60"  y="330" width="210" height="56" rx="10" fill="var(--panel)" stroke="var(--deliver)"/><text class="bt" x="78" y="354" fill="var(--deliver)">delivery loop</text><text class="bs" x="78" y="374">+ captain-close reap</text>
+        <rect x="910" y="330" width="210" height="56" rx="10" fill="var(--panel)" stroke="var(--probe)"/><text class="bt" x="928" y="354" fill="var(--probe)">probes</text><text class="bs" x="928" y="374">surface-live + blocked</text>
+        <rect x="60"  y="410" width="210" height="52" rx="10" fill="var(--panel)" stroke="var(--driver)"/><text class="bt" x="78" y="434" fill="var(--driver)">opencode + cmux bridges</text><text class="bs" x="78" y="452">SSE · events-bridge</text>
+        <rect x="910" y="410" width="210" height="52" rx="10" fill="var(--panel)" stroke="var(--line)"/><text class="bt" x="928" y="434">4 timers + mailbox notify</text><text class="bs" x="928" y="452">sweep·rotate·deliver·probe</text>
+        <rect x="430" y="400" width="320" height="56" rx="10" fill="var(--panel)" stroke="var(--bad)"/><text class="bt" x="448" y="424" fill="var(--bad)">relay-proxy queues (legacy)</text><text class="bs" x="448" y="444">pendingProbes·probeResults — delete w/ #332</text>
+        </g>
+
+        <path class="edge" d="M270 70 L450 210"/>
+        <path class="edge" d="M910 70 L730 210"/>
+        <path class="edge" d="M270 158 L444 218"/>
+        <path class="edge" d="M910 158 L736 218"/>
+        <path class="edge" d="M270 356 L450 270"/>
+        <path class="edge" d="M910 356 L730 270"/>
+        <path class="edge" d="M270 432 L448 280"/>
+        <path class="edge" d="M910 432 L734 282"/>
+        <path class="edge" d="M590 400 L590 306"/>
+      </svg>
+    </div>
+    <div class="legend"><span>Each colour = a concern that could become its own module. They share little state — mostly the <code>store</code>, the <code>daemon</code> handle, and a few maps.</span></div>
+  </section>
+
+  <!-- SLIDE 4: split proposal -->
+  <section class="slide">
+    <h2>4 · Proposed split — shrink the host to a wiring file</h2>
+    <p class="sub">Extract each concern into a focused module under <code>src/control/daemon/</code>. <code>startCockpitd</code> becomes a thin <b>composition root</b>: build deps → <code>createDaemon</code> → mount modules → start timers. Target: ~150 LOC.</p>
+    <div class="stage"><div class="twocol">
+      <div class="card">
+        <h3 style="color:var(--host)">Extract from cockpitd.ts →</h3>
+        <ul>
+          <li><code>daemon/server.ts</code> — socket + the 9 handlers (request router) <small>· ~rpc</small></li>
+          <li><code>daemon/attach.ts</code> — attach fan-out / AttachFrame broadcast</li>
+          <li><code>daemon/delivery.ts</code> — daemon-direct loop + captain discovery + close-reap</li>
+          <li><code>daemon/probes.ts</code> — surface-liveness + blocked probe wiring</li>
+          <li><code>daemon/drivers.ts</code> — codex / opencode / cmux-events bootstrap</li>
+          <li><code>daemon/gates.ts</code> — gate promotion timers</li>
+          <li><b>delete</b> relay-proxy queues (with #332 relay removal)</li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3 style="color:var(--core)">Leave alone (already cohesive)</h3>
+        <ul>
+          <li><code>daemon.ts</code> — the core. Maybe rename → <code>core.ts</code> to end the daemon.ts/cockpitd.ts confusion.</li>
+          <li><code>state-machine.ts</code>, <code>watchdog.ts</code>, <code>liveness.ts</code>, <code>store.ts</code></li>
+          <li><code>mailbox.ts</code>, <code>delivery/captain-delivery.ts</code></li>
+          <li><small>Pre-req: a thin <code>DaemonContext</code> ({store, daemon, log, cmux, cfg}) passed to each mounted module so they don't re-close over startCockpitd's locals.</small></li>
+        </ul>
+      </div>
+    </div></div>
+    <div class="legend"><span>Result: 1008-LOC closure → ~150-LOC composition root + 6 focused modules (~80-150 LOC each). Each independently testable. Lower risk for #332/#333 work.</span></div>
+  </section>
+
+  <footer>
+    <button id="prev">← Prev</button>
+    <div class="dots" id="dots"></div>
+    <button id="auto">▶ Autoplay</button>
+    <button id="next">Next →</button>
+    <span class="num" id="counter">1 / 4</span>
+  </footer>
+</div>
+<script>
+  const slides=[...document.querySelectorAll('.slide')];
+  const dotsBox=document.getElementById('dots');
+  let i=0, timer=null;
+  slides.forEach((_,n)=>{const d=document.createElement('i');d.onclick=()=>go(n);dotsBox.appendChild(d);});
+  const dots=[...dotsBox.children];
+  function go(n){i=(n+slides.length)%slides.length;slides.forEach((s,k)=>s.classList.toggle('active',k===i));dots.forEach((d,k)=>d.classList.toggle('on',k===i));document.getElementById('counter').textContent=(i+1)+' / '+slides.length;}
+  const next=()=>go(i+1), prev=()=>go(i-1);
+  document.getElementById('next').onclick=next; document.getElementById('prev').onclick=prev;
+  function toggleAuto(){const b=document.getElementById('auto');if(timer){clearInterval(timer);timer=null;b.textContent='▶ Autoplay';}else{timer=setInterval(next,5500);b.textContent='⏸ Pause';}}
+  document.getElementById('auto').onclick=toggleAuto;
+  addEventListener('keydown',e=>{if(e.key==='ArrowRight'||e.key===' '){e.preventDefault();next();}else if(e.key==='ArrowLeft')prev();else if(e.key.toLowerCase()==='a')toggleAuto();});
+  go(0);
+</script>
+</body>
+</html>

--- a/docs/reports/2026-06-16-daemon-architecture-and-flow.html
+++ b/docs/reports/2026-06-16-daemon-architecture-and-flow.html
@@ -1,0 +1,329 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Cockpit Daemon — Architecture &amp; Notification Flow</title>
+<style>
+  :root{
+    --bg:#0d1117; --panel:#161b22; --line:#30363d; --ink:#e6edf3; --dim:#9aa4b0;
+    --crew:#3fb950; --captain:#58a6ff; --daemon:#d29922; --mailbox:#bc8cff;
+    --relay:#f778ba; --cmux:#39c5cf; --bad:#f85149; --good:#3fb950;
+    --mono:'SF Mono',ui-monospace,'Cascadia Code',Menlo,Consolas,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;height:100%;background:var(--bg);color:var(--ink);font-family:var(--sans)}
+  #deck{height:100vh;display:flex;flex-direction:column}
+  header{padding:14px 28px;border-bottom:1px solid var(--line);display:flex;align-items:center;gap:14px;flex:0 0 auto}
+  header h1{font-size:15px;margin:0;font-weight:600;letter-spacing:.2px}
+  header .tag{font-family:var(--mono);font-size:11px;color:var(--dim);border:1px solid var(--line);padding:2px 8px;border-radius:20px}
+  header .spacer{flex:1}
+  .slide{flex:1;display:none;padding:22px 44px 6px;overflow:auto}
+  .slide.active{display:flex;flex-direction:column;animation:fade .4s ease}
+  @keyframes fade{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:none}}
+  .slide h2{margin:0 0 6px;font-size:23px}
+  .slide .sub{color:var(--dim);font-size:14px;margin:0;max-width:980px;line-height:1.5}
+  .stage{flex:1;display:grid;place-items:center;padding:10px 0}
+  svg{width:100%;height:auto;max-height:64vh;display:block}
+  .legend{display:flex;gap:18px;flex-wrap:wrap;font-size:12px;color:var(--dim);padding:6px 0 2px}
+  .legend b{display:inline-block;width:10px;height:10px;border-radius:2px;margin-right:5px;vertical-align:middle}
+  footer{flex:0 0 auto;border-top:1px solid var(--line);padding:10px 28px;display:flex;align-items:center;gap:16px}
+  button{background:var(--panel);color:var(--ink);border:1px solid var(--line);border-radius:8px;padding:7px 14px;font-size:13px;cursor:pointer;font-family:var(--sans)}
+  button:hover{border-color:var(--captain)}
+  .dots{display:flex;gap:7px;flex:1;justify-content:center}
+  .dots i{width:9px;height:9px;border-radius:50%;background:var(--line);cursor:pointer;transition:.2s}
+  .dots i.on{background:var(--captain);transform:scale(1.25)}
+  .num{font-family:var(--mono);font-size:12px;color:var(--dim);min-width:54px;text-align:right}
+  .box-t{font-family:var(--sans);font-weight:600;font-size:15px;fill:var(--ink)}
+  .box-s{font-family:var(--mono);font-size:12px;fill:var(--dim)}
+  .edge{stroke:#52606d;stroke-width:2;fill:none;marker-end:url(#arrow)}
+  .edge.hot{stroke:var(--daemon);stroke-width:2.5}
+  .elabel{font-family:var(--mono);font-size:12px;fill:var(--dim)}
+  .elabel.c{text-anchor:middle}
+  .pkt{fill:var(--daemon)}
+  .note{font-family:var(--mono);font-size:12.5px;fill:var(--dim)}
+  .ok{fill:var(--good)} .no{fill:var(--bad)}
+  code{font-family:var(--mono);background:#1f2530;padding:1px 5px;border-radius:4px;font-size:.9em}
+  .twocol{display:grid;grid-template-columns:1fr 1fr;gap:28px;width:100%;max-width:1180px}
+  .card{border:1px solid var(--line);border-radius:14px;padding:24px 28px;background:var(--panel);min-height:46vh}
+  .card h3{margin:0 0 14px;font-size:18px}
+  .card.def h3{color:var(--relay)} .card.dd h3{color:var(--daemon)}
+  .card ul{margin:0;padding-left:20px;font-size:14.5px;color:var(--ink);line-height:1.85}
+  .card ul li{margin-bottom:6px}
+  .card ul li b{color:var(--ink)}
+  .pill{font-family:var(--mono);font-size:11px;padding:2px 8px;border-radius:20px;border:1px solid var(--line);vertical-align:middle}
+  .pill.on{color:var(--good);border-color:var(--good)} .pill.off{color:var(--bad);border-color:var(--bad)}
+</style>
+</head>
+<body>
+<div id="deck">
+  <header>
+    <h1>⚓ Cockpit — Daemon Architecture &amp; Notification Flow</h1>
+    <span class="tag">#332</span>
+    <div class="spacer"></div>
+    <span class="tag">space / → advance · A = autoplay</span>
+  </header>
+
+  <!-- ===== SLIDE 1 ===== -->
+  <section class="slide active">
+    <h2>1 · The pieces</h2>
+    <p class="sub">The <b style="color:var(--daemon)">daemon (cockpitd)</b> is the brain — a long-lived launchd service that owns the <b style="color:var(--mailbox)">task ledger</b> + <b style="color:var(--mailbox)">mailbox</b>. <b style="color:var(--cmux)">cmux</b> hosts every <b style="color:var(--crew)">crew</b> and the <b style="color:var(--captain)">captain</b> as surfaces.</p>
+    <div class="stage">
+      <svg viewBox="0 0 1180 560">
+        <defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#52606d"/></marker></defs>
+
+        <rect x="30" y="40" width="520" height="500" rx="16" fill="none" stroke="var(--cmux)" stroke-dasharray="6 5" stroke-width="1.5"/>
+        <text x="52" y="74" class="box-s" fill="var(--cmux)">cmux.app · terminal multiplexer (one process tree)</text>
+
+        <rect x="70" y="100" width="220" height="86" rx="12" fill="var(--panel)" stroke="var(--crew)" stroke-width="1.5"/>
+        <text class="box-t" x="92" y="136" fill="var(--crew)">🔧 Crew</text><text class="box-s" x="92" y="162">cmux surface · claude/codex</text>
+
+        <rect x="70" y="237" width="220" height="86" rx="12" fill="var(--panel)" stroke="var(--captain)" stroke-width="1.5"/>
+        <text class="box-t" x="92" y="273" fill="var(--captain)">⚓ Captain</text><text class="box-s" x="92" y="299">cmux surface (you)</text>
+
+        <rect x="70" y="374" width="220" height="98" rx="12" fill="var(--panel)" stroke="var(--relay)" stroke-width="1.5"/>
+        <text class="box-t" x="92" y="410" fill="var(--relay)">✉ notify-relay</text><text class="box-s" x="92" y="436">cmux-descended helper</text><text class="box-s" x="92" y="456">(default delivery path)</text>
+
+        <rect x="350" y="210" width="180" height="140" rx="12" fill="var(--panel)" stroke="var(--cmux)" stroke-width="1.5"/>
+        <text class="box-t" x="372" y="246" fill="var(--cmux)">cmux control</text><text class="box-s" x="372" y="274">socket</text><text class="box-s" x="372" y="296">~/.local/state/</text><text class="box-s" x="372" y="316">cmux/cmux.sock</text>
+
+        <rect x="650" y="90" width="490" height="150" rx="14" fill="var(--panel)" stroke="var(--daemon)" stroke-width="1.5"/>
+        <text class="box-t" x="676" y="128" fill="var(--daemon)">cockpitd — launchd daemon</text><text class="box-s" x="676" y="156">com.cockpit.daemon · NOT a cmux descendant</text><text class="box-s" x="676" y="180">socket: ~/.config/cockpit/cockpit.sock</text><text class="box-s" x="676" y="204">owns: task-state ledger · sweep · delivery</text>
+
+        <rect x="650" y="300" width="490" height="150" rx="14" fill="var(--panel)" stroke="var(--mailbox)" stroke-width="1.5"/>
+        <text class="box-t" x="676" y="338" fill="var(--mailbox)">Mailbox (append-only)</text><text class="box-s" x="676" y="366">state/inbox/&lt;project&gt;.log · entries w/ seq</text><text class="box-s" x="676" y="390">state/inbox/&lt;project&gt;.captain.cursor</text><text class="box-s" x="676" y="414">cursor = lastAckedSeq (read position)</text>
+
+        <!-- edges with labels in clear space -->
+        <path class="edge" d="M290 150 L348 240"/>
+        <path class="edge" d="M290 416 L348 320"/>
+        <path class="edge" d="M530 270 L648 200"/>
+        <text class="elabel c" x="585" y="250">socket calls</text>
+        <path class="edge" d="M895 240 L895 298"/>
+        <text class="elabel" x="908" y="276">read / append</text>
+      </svg>
+    </div>
+    <div class="legend">
+      <span><b style="background:var(--crew)"></b>Crew</span><span><b style="background:var(--captain)"></b>Captain</span>
+      <span><b style="background:var(--daemon)"></b>Daemon</span><span><b style="background:var(--mailbox)"></b>Mailbox</span>
+      <span><b style="background:var(--relay)"></b>Relay</span><span><b style="background:var(--cmux)"></b>cmux</span>
+    </div>
+  </section>
+
+  <!-- ===== SLIDE 2 ===== -->
+  <section class="slide">
+    <h2>2 · A crew finishes → daemon writes the mailbox</h2>
+    <p class="sub"><code>cockpit crew signal done</code> hits the daemon socket. The daemon does two things: updates the <b style="color:var(--daemon)">ledger</b> (state → done) and <b style="color:var(--mailbox)">appends one entry</b> with the next monotonic <code>seq</code>.</p>
+    <div class="stage">
+      <svg viewBox="0 0 1180 460">
+        <defs><marker id="arrow2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#52606d"/></marker></defs>
+        <rect x="40" y="180" width="200" height="100" rx="12" fill="var(--panel)" stroke="var(--crew)" stroke-width="1.5"/>
+        <text class="box-t" x="62" y="226" fill="var(--crew)">🔧 Crew</text><text class="box-s" x="62" y="252">cockpit crew signal done</text>
+
+        <rect x="430" y="140" width="300" height="180" rx="14" fill="var(--panel)" stroke="var(--daemon)" stroke-width="1.5"/>
+        <text class="box-t" x="456" y="180" fill="var(--daemon)">cockpitd.handle()</text>
+        <text class="box-s" x="456" y="214">1 · ledger: state = done</text>
+        <text class="box-s" x="456" y="244">2 · appendToMailbox()</text>
+        <text class="box-s" x="456" y="270">     seq = lastSeq + 1</text>
+
+        <rect x="900" y="140" width="240" height="180" rx="14" fill="var(--panel)" stroke="var(--mailbox)" stroke-width="1.5"/>
+        <text class="box-t" x="924" y="180" fill="var(--mailbox)">&lt;project&gt;.log</text>
+        <text class="box-s" x="924" y="214">{ seq: 1008,</text><text class="box-s" x="924" y="238">  kind: "task.done",</text><text class="box-s" x="924" y="262">  name, ts }</text>
+        <text class="box-s" x="924" y="294">appended · never edited</text>
+
+        <path class="edge hot" marker-end="url(#arrow2)" id="p2a" d="M240 230 L428 230"/>
+        <text class="elabel c" x="334" y="216">unix socket</text>
+        <path class="edge hot" marker-end="url(#arrow2)" id="p2b" d="M730 230 L898 230"/>
+        <circle class="pkt" r="7"><animateMotion dur="1.7s" repeatCount="indefinite"><mpath href="#p2a"/></animateMotion></circle>
+        <circle class="pkt" r="7"><animateMotion dur="1.7s" begin="0.85s" repeatCount="indefinite"><mpath href="#p2b"/></animateMotion></circle>
+
+        <text class="note" x="40" y="384">The ledger is the source of truth for state. The mailbox is the outbound queue of things the captain should be told.</text>
+      </svg>
+    </div>
+  </section>
+
+  <!-- ===== SLIDE 3 ===== -->
+  <section class="slide">
+    <h2>3 · Delivery — two interchangeable modes</h2>
+    <p class="sub">A mailbox entry isn't a notification until something reads the cursor and pushes it to the captain's pane. Exactly ONE of these runs at a time (both = double-delivery).</p>
+    <div class="stage"><div class="twocol">
+      <div class="card def">
+        <h3>A · Relay &nbsp;<span class="pill on">DEFAULT</span></h3>
+        <ul>
+          <li><b>notify-relay</b> runs <em>inside the cmux tree</em> (a cmux-descended helper).</li>
+          <li>Tails the mailbox from the <code>captain</code> cursor every ~1s (<code>drain()</code>).</li>
+          <li>Each new entry → <code>cmux send</code> to the captain surface → advance cursor.</li>
+          <li>Works out-of-the-box: cmux trusts its own descendants.</li>
+          <li>Zero setup — captain runs <code>cockpit relay supervise</code>.</li>
+        </ul>
+      </div>
+      <div class="card dd">
+        <h3>B · Daemon-direct &nbsp;<span class="pill off">OPT-IN · #332</span></h3>
+        <ul>
+          <li>The <b>daemon itself</b> reads the cursor &amp; calls <code>cmux send</code> — no relay tab.</li>
+          <li>Gated by config <code>daemonDirectCmux: true</code>.</li>
+          <li>Same <code>CaptainDelivery</code> module as the relay → identical behaviour.</li>
+          <li><b>Requires</b> cmux <code>socketControlMode: automation</code> (slide 5) — the daemon is not a cmux descendant.</li>
+          <li>Re-entrancy + stale-skip guards mirror the relay's <code>drain()</code>.</li>
+        </ul>
+      </div>
+    </div></div>
+    <div class="legend"><span>HYBRID goal: probe cmux → use B if configured, else fall back to A. The relay is never deleted.</span></div>
+  </section>
+
+  <!-- ===== SLIDE 4 ===== -->
+  <section class="slide">
+    <h2>4 · The full path of one notification</h2>
+    <p class="sub">A <span style="color:var(--daemon)">●</span> packet travels crew → daemon → mailbox → delivery → captain. Top lane = relay (default), bottom lane = daemon-direct.</p>
+    <div class="stage">
+      <svg viewBox="0 0 1180 480">
+        <defs><marker id="arrow4" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#52606d"/></marker></defs>
+        <rect x="30" y="205" width="140" height="70" rx="12" fill="var(--panel)" stroke="var(--crew)" stroke-width="1.5"/><text class="box-t" x="50" y="238" fill="var(--crew)">🔧 Crew</text><text class="box-s" x="50" y="260">done</text>
+        <rect x="290" y="205" width="170" height="70" rx="12" fill="var(--panel)" stroke="var(--daemon)" stroke-width="1.5"/><text class="box-t" x="310" y="238" fill="var(--daemon)">cockpitd</text><text class="box-s" x="310" y="260">ledger + append</text>
+        <rect x="560" y="205" width="170" height="70" rx="12" fill="var(--panel)" stroke="var(--mailbox)" stroke-width="1.5"/><text class="box-t" x="580" y="238" fill="var(--mailbox)">mailbox</text><text class="box-s" x="580" y="260">seq · cursor</text>
+        <rect x="880" y="60" width="200" height="68" rx="12" fill="var(--panel)" stroke="var(--relay)" stroke-width="1.5"/><text class="box-t" x="900" y="92" fill="var(--relay)">✉ relay drain()</text><text class="box-s" x="900" y="114">in-cmux</text>
+        <rect x="880" y="356" width="200" height="68" rx="12" fill="var(--panel)" stroke="var(--daemon)" stroke-width="1.5"/><text class="box-t" x="900" y="388" fill="var(--daemon)">cockpitd loop</text><text class="box-s" x="900" y="410">daemon-direct</text>
+        <rect x="880" y="206" width="200" height="70" rx="12" fill="var(--panel)" stroke="var(--captain)" stroke-width="1.5"/><text class="box-t" x="900" y="239" fill="var(--captain)">⚓ Captain pane</text><text class="box-s" x="900" y="261">notification shown</text>
+
+        <path class="edge hot" marker-end="url(#arrow4)" id="f1" d="M170 240 L288 240"/>
+        <path class="edge hot" marker-end="url(#arrow4)" id="f2" d="M460 240 L558 240"/>
+        <path class="edge" marker-end="url(#arrow4)" id="f3" d="M720 220 C 800 150, 820 110, 878 100" stroke="var(--relay)"/>
+        <path class="edge" marker-end="url(#arrow4)" id="f5" d="M720 260 C 800 330, 820 372, 878 384" stroke="var(--daemon)"/>
+        <path class="edge" marker-end="url(#arrow4)" id="f4" d="M980 128 C 980 160, 982 178, 982 204" stroke="var(--relay)"/>
+        <path class="edge" marker-end="url(#arrow4)" id="f6" d="M980 356 C 980 324, 982 300, 982 278" stroke="var(--daemon)"/>
+        <text class="elabel" x="746" y="150" fill="var(--relay)">cursor read</text>
+        <text class="elabel" x="746" y="338" fill="var(--daemon)">cursor read</text>
+        <text class="elabel" x="996" y="170">cmux send</text>
+
+        <circle class="pkt" r="7"><animateMotion dur="5s" repeatCount="indefinite"><mpath href="#f1"/></animateMotion></circle>
+        <circle class="pkt" r="7"><animateMotion dur="5s" begin="1s" repeatCount="indefinite"><mpath href="#f2"/></animateMotion></circle>
+        <circle r="7" fill="var(--relay)"><animateMotion dur="5s" begin="2s" repeatCount="indefinite"><mpath href="#f3"/></animateMotion></circle>
+        <circle r="7" fill="var(--relay)"><animateMotion dur="5s" begin="3s" repeatCount="indefinite"><mpath href="#f4"/></animateMotion></circle>
+        <circle r="7" fill="var(--daemon)"><animateMotion dur="5s" begin="2s" repeatCount="indefinite"><mpath href="#f5"/></animateMotion></circle>
+        <circle r="7" fill="var(--daemon)"><animateMotion dur="5s" begin="3s" repeatCount="indefinite"><mpath href="#f6"/></animateMotion></circle>
+      </svg>
+    </div>
+    <div class="legend"><span><b style="background:var(--relay)"></b>relay lane (default)</span><span><b style="background:var(--daemon)"></b>daemon-direct lane (opt-in)</span><span>cursor advances only after a successful send → in-order, at-least-once.</span></div>
+  </section>
+
+  <!-- ===== SLIDE 5 ===== -->
+  <section class="slide">
+    <h2>5 · Why daemon-direct needs a cmux switch</h2>
+    <p class="sub">cmux's control socket checks the <b>caller's process ancestry</b> at <code>accept()</code>, governed by <code>automation.socketControlMode</code>. This gate is the entire reason the relay exists.</p>
+    <div class="stage">
+      <svg viewBox="0 0 1180 440">
+        <defs><marker id="arrowG" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#52606d"/></marker></defs>
+
+        <rect x="40" y="60" width="520" height="320" rx="16" fill="var(--panel)" stroke="var(--bad)" stroke-width="1.5"/>
+        <text class="box-t" x="68" y="104">socketControlMode: <tspan class="no" font-family="var(--mono)">cmuxOnly</tspan> <tspan class="box-s">(default)</tspan></text>
+        <rect x="80" y="150" width="180" height="64" rx="10" fill="#1b2230" stroke="var(--relay)" stroke-width="1.5"/><text class="box-s" x="100" y="188" fill="var(--relay)">✉ relay (in cmux)</text>
+        <rect x="80" y="270" width="180" height="64" rx="10" fill="#1b2230" stroke="var(--daemon)" stroke-width="1.5"/><text class="box-s" x="100" y="308" fill="var(--daemon)">cockpitd (launchd)</text>
+        <rect x="400" y="200" width="120" height="84" rx="10" fill="#1b2230" stroke="var(--cmux)" stroke-width="1.5"/><text class="box-s" x="424" y="248" fill="var(--cmux)">socket</text>
+        <path class="edge" marker-end="url(#arrowG)" d="M260 182 L398 226" stroke="var(--good)"/><text x="300" y="180" class="ok" font-family="var(--mono)" font-size="16">✓</text>
+        <path class="edge" marker-end="url(#arrowG)" d="M260 302 L398 262" stroke="var(--bad)"/><text x="284" y="312" class="no" font-family="var(--mono)" font-size="13">✗ broken pipe</text>
+
+        <rect x="620" y="60" width="520" height="320" rx="16" fill="var(--panel)" stroke="var(--good)" stroke-width="1.5"/>
+        <text class="box-t" x="648" y="104">socketControlMode: <tspan class="ok" font-family="var(--mono)">automation</tspan></text>
+        <rect x="660" y="150" width="180" height="64" rx="10" fill="#1b2230" stroke="var(--relay)" stroke-width="1.5"/><text class="box-s" x="680" y="188" fill="var(--relay)">✉ relay (in cmux)</text>
+        <rect x="660" y="270" width="180" height="64" rx="10" fill="#1b2230" stroke="var(--daemon)" stroke-width="1.5"/><text class="box-s" x="680" y="308" fill="var(--daemon)">cockpitd (launchd)</text>
+        <rect x="980" y="200" width="120" height="84" rx="10" fill="#1b2230" stroke="var(--cmux)" stroke-width="1.5"/><text class="box-s" x="1004" y="248" fill="var(--cmux)">socket</text>
+        <path class="edge" marker-end="url(#arrowG)" d="M840 182 L978 226" stroke="var(--good)"/><text x="880" y="180" class="ok" font-family="var(--mono)" font-size="16">✓</text>
+        <path class="edge" marker-end="url(#arrowG)" d="M840 302 L978 262" stroke="var(--good)"/><text x="864" y="312" class="ok" font-family="var(--mono)" font-size="13">✓ PONG</text>
+      </svg>
+    </div>
+    <div class="legend"><span>Set via ~/.config/cmux/cmux.json (file-managed, JSONC) + one cmux restart. Same-user threat model → no password needed.</span></div>
+  </section>
+
+  <!-- ===== SLIDE 6 ===== -->
+  <section class="slide">
+    <h2>6 · Mailbox mechanics &amp; the storm guards</h2>
+    <p class="sub">The mailbox is dead simple — an append-only log + a read cursor — but delivery needs four safeguards (the relay had them; daemon-direct had to learn them, via two storms 🌩).</p>
+    <div class="stage"><div class="twocol">
+      <div class="card">
+        <h3 style="color:var(--mailbox)">The data</h3>
+        <ul>
+          <li><code>&lt;project&gt;.log</code> — append-only; each line <code>{seq, ts, taskId, name, kind}</code>; rotated to <code>.log.1/.2</code>. <b>Nothing is ever deleted</b> → full audit trail.</li>
+          <li><code>&lt;project&gt;.captain.cursor</code> — <code>{lastAckedSeq}</code>. Read from <code>lastAcked+1</code>; advance only after a successful send.</li>
+          <li>Empty / corrupt cursor ⇒ treated as "start fresh" (never throws).</li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3 style="color:var(--daemon)">The 4 delivery guards</h3>
+        <ul>
+          <li><b>defer-while-typing</b> — hold a send while the captain is mid-keystroke (#258/#302).</li>
+          <li><b>stale-skip</b> — silently ack entries older than session start, so a reset cursor never re-floods the backlog.</li>
+          <li><b>re-entrancy guard</b> — a slow tick must not overlap the next (else the same entry delivers twice → storm).</li>
+          <li><b>atomic cursor write</b> — unique tmp + rename; concurrent writes never corrupt it.</li>
+        </ul>
+      </div>
+    </div></div>
+    <div class="legend"><span>Both modes share one <code>CaptainDelivery</code> module → relay and daemon-direct behave identically. Flip the flag, behaviour is unchanged.</span></div>
+  </section>
+
+  <!-- ===== SLIDE 7 ===== -->
+  <section class="slide">
+    <h2>7 · Where it stands</h2>
+    <p class="sub">Status of the #332 daemon-direct work after this session.</p>
+    <div class="stage"><div class="twocol">
+      <div class="card">
+        <h3 class="ok" style="color:var(--good)">✓ Done &amp; verified</h3>
+        <ul>
+          <li>Daemon-direct delivers cleanly (1 crew → 1 notification, no storm).</li>
+          <li>Root cause solved: cmux <code>socketControlMode</code> gate.</li>
+          <li>4 delivery bugs fixed + drain()-parity audited (#345 / #346 / #347).</li>
+          <li>Relay path hardened too (empty-cursor guard).</li>
+          <li>Mailbox preserved — append-only, traceable.</li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3 style="color:var(--daemon)">⏭ Next session</h3>
+        <ul>
+          <li><b>#348</b> auto-config cmux.json (clean install) + restart prompt + hybrid probe.</li>
+          <li><b>#332</b> re-scope: daemon-direct opt-in / relay default / hybrid.</li>
+          <li><b>#349</b> update docs: this diagram, README, CLI help.</li>
+          <li>Merge socket-auth design doc (branch <code>crew/dbg-socket-auth</code>).</li>
+          <li><b>#333</b> NativeHookSource — now that delivery is solid.</li>
+        </ul>
+      </div>
+    </div></div>
+    <div class="legend"><span>⚠ Today it works only because the machine is in cmux <b style="color:var(--good)">automation</b> debug mode. Clean-install support = #348.</span></div>
+  </section>
+
+  <footer>
+    <button id="prev">← Prev</button>
+    <div class="dots" id="dots"></div>
+    <button id="auto">▶ Autoplay</button>
+    <button id="next">Next →</button>
+    <span class="num" id="counter">1 / 7</span>
+  </footer>
+</div>
+<script>
+  const slides=[...document.querySelectorAll('.slide')];
+  const dotsBox=document.getElementById('dots');
+  let i=0, timer=null;
+  slides.forEach((_,n)=>{const d=document.createElement('i');d.onclick=()=>go(n);dotsBox.appendChild(d);});
+  const dots=[...dotsBox.children];
+  function go(n){
+    i=(n+slides.length)%slides.length;
+    slides.forEach((s,k)=>s.classList.toggle('active',k===i));
+    dots.forEach((d,k)=>d.classList.toggle('on',k===i));
+    document.getElementById('counter').textContent=(i+1)+' / '+slides.length;
+  }
+  const next=()=>go(i+1), prev=()=>go(i-1);
+  document.getElementById('next').onclick=next;
+  document.getElementById('prev').onclick=prev;
+  function toggleAuto(){
+    const b=document.getElementById('auto');
+    if(timer){clearInterval(timer);timer=null;b.textContent='▶ Autoplay';}
+    else{timer=setInterval(next,5000);b.textContent='⏸ Pause';}
+  }
+  document.getElementById('auto').onclick=toggleAuto;
+  addEventListener('keydown',e=>{
+    if(e.key==='ArrowRight'||e.key===' '){e.preventDefault();next();}
+    else if(e.key==='ArrowLeft')prev();
+    else if(e.key.toLowerCase()==='a')toggleAuto();
+  });
+  go(0);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Self-contained animated HTML decks produced while mapping the daemon for #332/#349.

- **docs/diagrams/2026-06-17-cockpit-architecture-overview.html** (+ `.vi.html`) — whole-project 5-layer view (CLI → roles → control plane → adapters → persistence); pins where **daemon (core)** vs **cockpitd (host)** live + a folder→layer map.
- **docs/reports/2026-06-16-daemon-architecture-and-flow.html** — one notification's path: crew → daemon → mailbox → delivery → captain; relay vs daemon-direct; the cmux socketControlMode gate; mailbox mechanics + the 4 storm guards.
- **docs/reports/2026-06-16-cockpitd-structure.html** — control-plane internals + proposed split of the 1008-LOC `startCockpitd` host into `daemon/{server,attach,delivery,probes,drivers,gates}.ts`.

Docs only. Relates #349 (docs update), #332.