### PR TITLE
feat(#348): cmux socket auto-config for daemon-direct delivery

### DIFF
--- a/docs/specs/2026-06-16-cmux-socket-auth-daemon-direct-design.md
+++ b/docs/specs/2026-06-16-cmux-socket-auth-daemon-direct-design.md
@@ -1,0 +1,189 @@
+# cmux Socket Auth for Daemon-Direct Delivery — Design
+
+**Issue:** #348 (part of #332)
+**Status:** Implemented (this PR delivers the autoconfig; #332 delivery wiring is opt-in / follow-up)
+**Date:** 2026-06-16 (reconstructed 2026-06-17 — the original doc was written but never committed and was lost; this REPLACES it)
+
+> This document reconstructs the lost #348 design from recovered research
+> (claude-mem session S5306/S5307, observations 18379–18395) plus live
+> verification against `~/.config/cmux/cmux.json` on the dev machine.
+
+---
+
+## 1. Problem
+
+Daemon-direct notification delivery (`defaults.daemonDirectCmux`) lets the
+launchd-managed cockpit daemon (`cockpitd`) drive cmux **directly** — shelling
+out to the `cmux` CLI to send notifications into crew/captain surfaces — instead
+of routing through the captain-owned notify-relay.
+
+This **only works today because the dev machine carries a MANUAL config block**:
+
+```jsonc
+// ~/.config/cmux/cmux.json   [cockpit-dbg] block
+"automation": {
+  "socketControlMode": "automation"
+}
+```
+
+On a **clean install** that block does not exist, so daemon-direct **silently
+fails**: the cmux control socket rejects the daemon's connection. #348 makes
+cockpit write that config itself.
+
+---
+
+## 2. Root Cause
+
+The cmux control socket reads `automation.socketControlMode` to decide who may
+connect:
+
+- **`cmuxOnly`** (the default): at `accept()` the socket performs a
+  **peer-credential / process-parentage check** — it walks the connecting
+  process's parent chain and rejects any peer that is **not descended from the
+  cmux app**. `cockpitd` runs under launchd (PPID ⇒ 1), is NOT a cmux
+  descendant, and is therefore **rejected** ("Access denied — only processes
+  started inside cmux").
+- **`automation`**: no parentage check. Any same-user process may connect.
+
+**Fix:** set `socketControlMode = "automation"`.
+
+### Security note
+
+`automation` carries **no password**, but for a **same-user threat model** the
+security is **equivalent to password mode**: any same-user process can already
+invoke the `cmux` CLI, which implicit-loads a saved password. A local attacker
+who can run our probe can already run `cmux` directly. We therefore choose the
+no-password `automation` mode rather than managing a secret.
+
+---
+
+## 3. Verified cmux Config Model
+
+Established by live inspection (do not re-derive — these are load-bearing):
+
+1. **The socket reads its mode from cmux *defaults* (`com.cmuxterm.app`) at
+   LAUNCH only.** Changing the mode requires a **cmux restart** to take effect
+   *on the socket*.
+2. **cmux watches `~/.config/cmux/cmux.json` LIVE** and syncs file-managed keys
+   into defaults **immediately** while running. (So writing the file updates
+   defaults at once — but per (1), the *already-bound socket* keeps its old mode
+   until restart.)
+3. **cmux does NOT rewrite `cmux.json` on launch** — comments and formatting are
+   preserved. Our writer must do the same (comment-preserving JSONC merge).
+4. **If cmux is NOT running at write time**, the live watcher will not sync. The
+   value still applies on the *next* cmux launch (file-managed keys load at
+   boot), and our daemon-start re-check re-probes to recover.
+
+### ⚠️ Contaminated prior research
+
+Earlier research claimed the cmux socket is reachable from **any** process. That
+test was **contaminated**: it ran inside a cmux pane, so the probe kept cmux
+ancestry even under `env -i`. **Do not trust it.** A faithful probe MUST run
+from a process with **no cmux ancestor** (PPID ⇒ 1, launchd-reparented).
+
+---
+
+## 4. Implementation
+
+### 4.1 Comment-preserving JSONC merge — `src/lib/cmux-config.ts`
+
+Use **`jsonc-parser`** (`modify` + `applyEdits`) to write **only**
+`automation.socketControlMode = "automation"` into `~/.config/cmux/cmux.json`,
+preserving every existing comment and key.
+
+- **Idempotent**: if the key is already `"automation"`, it's a no-op
+  (`changed: false`).
+- **Missing file**: write a minimal cockpit-managed JSONC template carrying just
+  the automation block, so a clean install works before cmux ever creates its
+  own template. (cmux merges its template keys on next launch; ours is a strict
+  subset, so there is no conflict.)
+- Returns `{ changed, alreadySet, path }`.
+
+### 4.2 Idempotent non-cmux probe — `src/lib/cmux-probe.ts`
+
+`probeCmuxDaemonDirect()` answers: *can a non-cmux process reach the cmux control
+socket right now?* — the **hybrid gate** for choosing daemon-direct vs relay.
+
+Faithfulness requires escaping cmux ancestry (§3). Mechanism:
+
+1. Spawn a detached **launcher** that spawns a detached **worker** and exits
+   immediately → the worker is **orphaned and reparented to launchd**
+   (`process.ppid ⇒ 1`).
+2. The worker **waits until `process.ppid === 1`** (bounded poll), then runs a
+   cheap read-only cmux command (`workspace list --json`).
+3. The worker writes `{ code, stderr }` to a temp file; the caller reads it.
+
+`classifyProbe({ ok, stderr })` (pure, unit-tested) maps the result:
+
+- success ⇒ `"reachable"` (daemon-direct viable)
+- stderr matches access-denied / "only processes started inside cmux" ⇒
+  `"denied"` (still `cmuxOnly` on the live socket — restart needed)
+- anything else (cmux missing, timeout) ⇒ `"unknown"` (fail soft → stay on relay)
+
+The spawn runner is injectable so unit tests never spawn a real process; the
+classifier is tested in isolation.
+
+> **Production note:** `cockpitd` itself already runs PPID ⇒ 1 under launchd, so
+> the daemon can probe by simply attempting a cmux call (`DaemonCmux.isAvailable`)
+> — it does not need the orphan trick. The orphan-escape exists for the
+> **setup-time CLI** (`cockpit cmux autoconfig`), which may be invoked from
+> inside a cmux pane and would otherwise report a contaminated result.
+
+### 4.3 Semi-automatic, one-time restart prompt — `src/lib/cmux-autoconfig.ts`
+
+`ensureCmuxAutoConfig()` ties it together:
+
+1. `ensureSocketAutomation()` — write config if needed (§4.1).
+2. `probeCmuxDaemonDirect()` — check the live socket (§4.2).
+3. If the probe is `"denied"` (config written but socket still on the old mode),
+   surface a **one-time** prompt: *"Restart cmux to enable daemon-direct
+   delivery."* A state marker (`~/.config/cockpit/cmux-autoconfig.state.json`,
+   `{ promptedRestart: true }`) ensures we **do not nag** on subsequent runs.
+4. Return a structured result so the caller (CLI prints it; daemon logs it once).
+
+Per the "semi-automatic over fully-automatic" and "prefer permanent rules over
+temp fixes" principles, cockpit **never restarts cmux for the user** — restarting
+cmux disrupts live sessions. We write config + prompt; the user restarts.
+
+### 4.4 Daemon-start re-check + recovery — `src/control/cockpitd.ts`
+
+On daemon start, **when `daemonDirectCmux` is opt-in ON**, run
+`ensureCmuxAutoConfig()` (idempotent). This:
+
+- writes the config if a clean install never had it,
+- recovers the §3.4 edge case (cmux not running at first write): because the
+  check re-runs every daemon start, the next start re-probes and the value is
+  already file-managed, so daemon-direct activates once cmux is (re)launched.
+
+The re-check is **gated on the existing `daemonDirectCmux` flag** — a no-op when
+the flag is OFF (relay default). It changes no `startCockpitd` signature; the
+blast radius is LOW (verified via gitnexus_impact: 4 direct callers, 0 processes,
+0 modules).
+
+---
+
+## 5. #332 Re-scope (documented here; delivery wiring may be a follow-up)
+
+- **Relay = zero-setup default.** Works on any clean install with no cmux config
+  changes. **Do NOT delete the relay.**
+- **Daemon-direct = opt-in**, viable only once the non-cmux probe (§4.2) succeeds.
+- **Hybrid selection**: the non-cmux probe is the gate. Daemon-direct is selected
+  only when the probe returns `"reachable"`; otherwise cockpit stays on the relay.
+
+This PR delivers the autoconfig primitives (config writer, probe, orchestrator,
+CLI, gated daemon re-check). The full hybrid *delivery-path selection* in the
+daemon (auto-switching relay ⇄ daemon-direct based on the probe) is the #332
+follow-up.
+
+---
+
+## 6. Files
+
+| File | Role |
+|------|------|
+| `src/lib/cmux-config.ts` | Comment-preserving JSONC merge (§4.1) |
+| `src/lib/cmux-probe.ts` | Non-cmux orphan probe + classifier (§4.2) |
+| `src/lib/cmux-autoconfig.ts` | Orchestrator: write → probe → one-time prompt (§4.3) |
+| `src/commands/cmux.ts` | `cockpit cmux autoconfig` user-facing surface |
+| `src/control/cockpitd.ts` | Gated daemon-start re-check / recovery (§4.4) |
+| `docs/specs/2026-06-16-cmux-socket-auth-daemon-direct-design.md` | This doc |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "claude-cockpit",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-cockpit",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.0",
         "commander": "^13.0.0",
-        "gray-matter": "^4.0.3"
+        "gray-matter": "^4.0.3",
+        "jsonc-parser": "^3.3.1"
       },
       "bin": {
         "cockpit": "dist/index.js"
@@ -1248,6 +1249,12 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "license": "MIT"
     },
     "node_modules/kind-of": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "dependencies": {
     "chalk": "^5.4.0",
     "commander": "^13.0.0",
-    "gray-matter": "^4.0.3"
+    "gray-matter": "^4.0.3",
+    "jsonc-parser": "^3.3.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/src/commands/__tests__/cmux.test.ts
+++ b/src/commands/__tests__/cmux.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { Writable } from "node:stream";
+import { runCmuxAutoconfig } from "../cmux.js";
+import type { AutoConfigResult } from "../../lib/cmux-autoconfig.js";
+
+function sink() {
+  let buf = "";
+  const s = new Writable({
+    write(c, _e, cb) {
+      buf += c.toString();
+      cb();
+    },
+  });
+  return { s, text: () => buf };
+}
+
+function result(over: Partial<AutoConfigResult>): AutoConfigResult {
+  return {
+    configPath: "/tmp/cmux.json",
+    configChanged: false,
+    configAlreadySet: true,
+    verdict: "reachable",
+    needsRestart: false,
+    promptedThisRun: false,
+    ...over,
+  };
+}
+
+describe("runCmuxAutoconfig", () => {
+  it("reachable → exit 0 with a success line", async () => {
+    const out = sink();
+    const err = sink();
+    const code = await runCmuxAutoconfig({
+      json: false,
+      stdout: out.s,
+      stderr: err.s,
+      run: async () => result({ verdict: "reachable" }),
+    });
+    expect(code).toBe(0);
+    expect(out.text().toLowerCase()).toContain("reachable");
+  });
+
+  it("denied → exit 2 and tells the user to restart cmux", async () => {
+    const out = sink();
+    const err = sink();
+    const code = await runCmuxAutoconfig({
+      json: false,
+      stdout: out.s,
+      stderr: err.s,
+      run: async () => result({ configChanged: true, configAlreadySet: false, verdict: "denied", needsRestart: true }),
+    });
+    expect(code).toBe(2);
+    expect(out.text().toLowerCase()).toContain("restart cmux");
+  });
+
+  it("unknown → exit 1 (fail-soft, stay on relay)", async () => {
+    const out = sink();
+    const err = sink();
+    const code = await runCmuxAutoconfig({
+      json: false,
+      stdout: out.s,
+      stderr: err.s,
+      run: async () => result({ verdict: "unknown" }),
+    });
+    expect(code).toBe(1);
+    expect((out.text() + err.text()).toLowerCase()).toContain("relay");
+  });
+
+  it("--json emits the machine-readable result", async () => {
+    const out = sink();
+    const err = sink();
+    const code = await runCmuxAutoconfig({
+      json: true,
+      stdout: out.s,
+      stderr: err.s,
+      run: async () => result({ verdict: "denied", needsRestart: true }),
+    });
+    expect(code).toBe(2);
+    const parsed = JSON.parse(out.text());
+    expect(parsed.verdict).toBe("denied");
+    expect(parsed.needsRestart).toBe(true);
+  });
+});

--- a/src/commands/cmux.ts
+++ b/src/commands/cmux.ts
@@ -1,0 +1,82 @@
+// src/commands/cmux.ts
+//
+// cockpit cmux autoconfig — #348 (part of #332). User-facing surface for the
+// cmux socket auto-config: write the comment-preserving automation config, probe
+// the live socket from a non-cmux process, and tell the user whether a cmux
+// restart is needed to enable daemon-direct delivery.
+//
+// See docs/specs/2026-06-16-cmux-socket-auth-daemon-direct-design.md §4.
+import { Command } from "commander";
+import chalk from "chalk";
+import { ensureCmuxAutoConfig, type AutoConfigResult } from "../lib/cmux-autoconfig.js";
+
+export interface CmuxAutoconfigOpts {
+  json: boolean;
+  stdout: NodeJS.WritableStream;
+  stderr: NodeJS.WritableStream;
+  /** Injectable for tests. Default = ensureCmuxAutoConfig (real I/O). */
+  run?: () => Promise<AutoConfigResult>;
+}
+
+/** Returns exit code: 0=reachable, 1=unknown/error, 2=restart needed. */
+export async function runCmuxAutoconfig(opts: CmuxAutoconfigOpts): Promise<number> {
+  const { json, stdout, stderr } = opts;
+  let r: AutoConfigResult;
+  try {
+    r = await (opts.run ?? ensureCmuxAutoConfig)();
+  } catch (e) {
+    stderr.write(`cmux autoconfig failed: ${(e as Error).message}\n`);
+    return 1;
+  }
+
+  if (json) {
+    stdout.write(JSON.stringify(r) + "\n");
+    return r.verdict === "reachable" ? 0 : r.needsRestart ? 2 : 1;
+  }
+
+  if (r.configChanged) {
+    stdout.write(`wrote cmux automation config → ${r.configPath}\n`);
+  } else {
+    stdout.write(chalk.dim(`cmux automation config already in place (${r.configPath})\n`));
+  }
+
+  if (r.verdict === "reachable") {
+    stdout.write(chalk.green("✔ daemon-direct delivery is reachable — cmux control socket accepts the daemon\n"));
+    return 0;
+  }
+
+  if (r.needsRestart) {
+    stdout.write(
+      chalk.yellow("⚠ cmux is still on the old socket mode — restart cmux to enable daemon-direct delivery.\n"),
+    );
+    if (r.promptedThisRun) {
+      stdout.write(chalk.dim("  (one-time prompt — you won't be nagged again)\n"));
+    }
+    return 2;
+  }
+
+  // unknown — fail soft.
+  stderr.write(
+    "could not reach the cmux control socket (is cmux installed and running?) — staying on the relay.\n",
+  );
+  return 1;
+}
+
+export const cmuxCommand = new Command("cmux")
+  .description("cmux integration helpers")
+  .addCommand(
+    new Command("autoconfig")
+      .description(
+        "Write the cmux automation socket config and probe whether daemon-direct\n" +
+        "delivery is reachable. Idempotent; prompts once if a cmux restart is needed.",
+      )
+      .option("--json", "output machine-readable JSON (exit 0=reachable, 1=unknown, 2=restart-needed)")
+      .action(async (opts: { json?: boolean }) => {
+        const code = await runCmuxAutoconfig({
+          json: opts.json ?? false,
+          stdout: process.stdout,
+          stderr: process.stderr,
+        });
+        process.exit(code);
+      }),
+  );

--- a/src/control/__tests__/cockpitd-cmux-autoconfig.test.ts
+++ b/src/control/__tests__/cockpitd-cmux-autoconfig.test.ts
@@ -1,0 +1,58 @@
+// src/control/__tests__/cockpitd-cmux-autoconfig.test.ts
+//
+// #348: the daemon runs the cmux socket auto-config re-check on boot ONLY when
+// daemon-direct is opt-in ON. With the relay default (flag OFF) it must be a
+// no-op — it must never touch the user's cmux.json or spawn the orphan probe.
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startCockpitd } from "../cockpitd.js";
+import type { AutoConfigResult } from "../../lib/cmux-autoconfig.js";
+
+const okResult: AutoConfigResult = {
+  configPath: "/tmp/cmux.json",
+  configChanged: false,
+  configAlreadySet: true,
+  verdict: "reachable",
+  needsRestart: false,
+  promptedThisRun: false,
+};
+
+describe("cockpitd cmux autoconfig re-check (#348)", () => {
+  let stop: (() => void) | undefined;
+  let dir: string;
+  afterEach(async () => { await stop?.(); if (dir) rmSync(dir, { recursive: true, force: true }); });
+
+  it("runs the re-check on boot when daemonDirectCmux is ON", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-autoconf-on-"));
+    const runCmuxAutoConfig = vi.fn(async () => okResult);
+    const handle = startCockpitd({
+      stateRoot: join(dir, "state"),
+      sockPath: join(dir, "c.sock"),
+      sweepMs: 0,
+      daemonDirectCmux: true,
+      daemonCmux: { isAvailable: async () => false, listSurfaces: async () => [] } as any,
+      makeDaemonCmux: () => ({ isAvailable: async () => false, listSurfaces: async () => [] }) as any,
+      runCmuxAutoConfig,
+    });
+    stop = handle.stop;
+    await new Promise((r) => setTimeout(r, 50));
+    expect(runCmuxAutoConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT run the re-check when daemonDirectCmux is OFF (relay default)", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-autoconf-off-"));
+    const runCmuxAutoConfig = vi.fn(async () => okResult);
+    const handle = startCockpitd({
+      stateRoot: join(dir, "state"),
+      sockPath: join(dir, "c.sock"),
+      sweepMs: 0,
+      daemonDirectCmux: false,
+      runCmuxAutoConfig,
+    });
+    stop = handle.stop;
+    await new Promise((r) => setTimeout(r, 50));
+    expect(runCmuxAutoConfig).not.toHaveBeenCalled();
+  });
+});

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -30,6 +30,7 @@ import { TERMINAL_STATES } from "./types.js";
 import type { Socket } from "node:net";
 import type { PaneRef } from "../runtimes/types.js";
 import { DaemonCmux } from "./cmux/daemon-cmux.js";
+import { ensureCmuxAutoConfig, type AutoConfigResult } from "../lib/cmux-autoconfig.js";
 import { createCmuxDriver } from "../runtimes/index.js";
 
 // This module's own compiled file — its mtime is the dist build-time used for
@@ -118,6 +119,10 @@ export interface CockpitdOpts {
    *  daemon-direct delivery loop. Used as fallback when real discovery (Task 5)
    *  returns no surface (e.g. cmux not reachable or captain not yet running). */
   captainSurfaces?: Record<string, PaneRef>;
+  /** #348: override the cmux socket auto-config re-check (write+probe). Tests
+   *  inject a fake; in production it runs only when daemonDirectCmux is ON and
+   *  not under vitest. See cmux-autoconfig.ts. */
+  runCmuxAutoConfig?: () => Promise<AutoConfigResult>;
 }
 
 // ── Tier 0/2 snapshot gathering (I/O at the edge; the pure assembly lives in
@@ -660,6 +665,25 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
     const cmuxEventsSafe = !!opts.cmuxEventsBridge || !process.env.VITEST;
     if (enableCmuxEvents && cmuxEventsSafe) {
       try { cmuxEventsBridge.start(); } catch (e) { log(`cmux events bridge start failed: ${(e as Error).message}`); }
+    }
+
+    // #348: when daemon-direct is opt-in ON, ensure the cmux socket auto-config
+    // (comment-preserving write + non-cmux probe) on every boot. Idempotent, and
+    // it recovers the "cmux not running at first write" edge case (§3.4 / §4.4):
+    // the next boot re-probes once cmux is (re)launched. Gated on the flag so it's
+    // a no-op under the relay default; skipped under vitest unless injected so
+    // daemon tests never touch the real cmux.json or spawn the orphan probe.
+    const autoConfigSafe = !!opts.runCmuxAutoConfig || !process.env.VITEST;
+    if (daemonDirectCmux && autoConfigSafe) {
+      try {
+        const r = await (opts.runCmuxAutoConfig ?? ensureCmuxAutoConfig)();
+        if (r.configChanged) log(`cmux autoconfig: wrote automation socket mode to ${r.configPath}`);
+        if (r.needsRestart && r.promptedThisRun) {
+          log("cmux autoconfig: socket still rejects the daemon — restart cmux to enable daemon-direct delivery");
+        }
+      } catch (e) {
+        log(`cmux autoconfig failed: ${(e as Error).message}`);
+      }
     }
   })();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import { codexChatSmokeCommand } from "./commands/codex-chat-smoke.js";
 import { configCommand } from "./commands/config.js";
 import { healCommand } from "./commands/heal.js";
 import { groupCommand } from "./commands/group.js";
+import { cmuxCommand } from "./commands/cmux.js";
 import { detectDrift } from "./lib/config-drift.js";
 import { needsCheck, withStamp } from "./lib/config-version.js";
 import { getDefaultConfig } from "./config.js";
@@ -112,6 +113,7 @@ program.addCommand(codexChatSmokeCommand);
 program.addCommand(configCommand);
 program.addCommand(healCommand);
 program.addCommand(groupCommand);
+program.addCommand(cmuxCommand);
 
 program.parseAsync().catch((e) => {
   process.stderr.write(`error: ${e instanceof Error ? e.message : String(e)}\n`);

--- a/src/lib/__tests__/cmux-autoconfig.test.ts
+++ b/src/lib/__tests__/cmux-autoconfig.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ensureCmuxAutoConfig } from "../cmux-autoconfig.js";
+
+let dir: string;
+let configPath: string;
+let statePath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "cmux-auto-"));
+  configPath = join(dir, "cmux.json");
+  statePath = join(dir, "cmux-autoconfig.json");
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("ensureCmuxAutoConfig", () => {
+  it("writes config and reports reachable without a restart prompt", async () => {
+    const r = await ensureCmuxAutoConfig({
+      configPath,
+      statePath,
+      probe: async () => "reachable",
+    });
+    expect(r.configChanged).toBe(true);
+    expect(r.verdict).toBe("reachable");
+    expect(r.needsRestart).toBe(false);
+    expect(r.promptedThisRun).toBe(false);
+    expect(existsSync(statePath)).toBe(false); // no marker when nothing to prompt
+  });
+
+  it("prompts once when the socket is still denied (config written, restart needed)", async () => {
+    const first = await ensureCmuxAutoConfig({
+      configPath,
+      statePath,
+      probe: async () => "denied",
+    });
+    expect(first.needsRestart).toBe(true);
+    expect(first.promptedThisRun).toBe(true);
+    expect(existsSync(statePath)).toBe(true);
+
+    // Second run, still denied → must NOT nag again.
+    const second = await ensureCmuxAutoConfig({
+      configPath,
+      statePath,
+      probe: async () => "denied",
+    });
+    expect(second.needsRestart).toBe(true);
+    expect(second.promptedThisRun).toBe(false);
+  });
+
+  it("clears the prompt marker once the socket becomes reachable", async () => {
+    await ensureCmuxAutoConfig({ configPath, statePath, probe: async () => "denied" });
+    expect(existsSync(statePath)).toBe(true);
+
+    const r = await ensureCmuxAutoConfig({ configPath, statePath, probe: async () => "reachable" });
+    expect(r.promptedThisRun).toBe(false);
+    expect(existsSync(statePath)).toBe(false); // marker reset so a future regression re-prompts
+  });
+
+  it("does not prompt on an unknown verdict (fail-soft, no nag)", async () => {
+    const r = await ensureCmuxAutoConfig({ configPath, statePath, probe: async () => "unknown" });
+    expect(r.verdict).toBe("unknown");
+    expect(r.needsRestart).toBe(false);
+    expect(r.promptedThisRun).toBe(false);
+    expect(existsSync(statePath)).toBe(false);
+  });
+
+  it("is idempotent on config (no re-write when already set)", async () => {
+    writeFileSync(configPath, `{ "automation": { "socketControlMode": "automation" } }\n`);
+    const r = await ensureCmuxAutoConfig({ configPath, statePath, probe: async () => "reachable" });
+    expect(r.configChanged).toBe(false);
+    expect(r.configAlreadySet).toBe(true);
+  });
+});

--- a/src/lib/__tests__/cmux-config.test.ts
+++ b/src/lib/__tests__/cmux-config.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parse } from "jsonc-parser";
+import { ensureSocketAutomation } from "../cmux-config.js";
+
+let dir: string;
+let path: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "cmux-cfg-"));
+  path = join(dir, "cmux.json");
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("ensureSocketAutomation", () => {
+  it("creates a minimal cockpit-managed file when none exists", () => {
+    const r = ensureSocketAutomation({ path });
+    expect(r.changed).toBe(true);
+    expect(r.alreadySet).toBe(false);
+    expect(existsSync(path)).toBe(true);
+    expect(parse(readFileSync(path, "utf-8")).automation.socketControlMode).toBe("automation");
+  });
+
+  it("is a no-op when already set to automation", () => {
+    writeFileSync(
+      path,
+      `{\n  // keep me\n  "automation": { "socketControlMode": "automation" }\n}\n`,
+    );
+    const before = readFileSync(path, "utf-8");
+    const r = ensureSocketAutomation({ path });
+    expect(r.changed).toBe(false);
+    expect(r.alreadySet).toBe(true);
+    expect(readFileSync(path, "utf-8")).toBe(before); // byte-identical, untouched
+  });
+
+  it("preserves comments and existing keys when adding the automation key", () => {
+    const original = [
+      `{`,
+      `  "$schema": "https://example/cmux.schema.json",`,
+      `  // a leading comment that MUST survive`,
+      `  "schemaVersion": 1,`,
+      ``,
+      `  // a trailing comment`,
+      `}`,
+      ``,
+    ].join("\n");
+    writeFileSync(path, original);
+
+    const r = ensureSocketAutomation({ path });
+    expect(r.changed).toBe(true);
+    expect(r.alreadySet).toBe(false);
+
+    const after = readFileSync(path, "utf-8");
+    expect(after).toContain("// a leading comment that MUST survive");
+    expect(after).toContain("// a trailing comment");
+    expect(after).toContain(`"$schema"`);
+    const parsed = parse(after);
+    expect(parsed.schemaVersion).toBe(1);
+    expect(parsed.automation.socketControlMode).toBe("automation");
+  });
+
+  it("overwrites a non-automation mode (e.g. cmuxOnly) and preserves siblings", () => {
+    writeFileSync(
+      path,
+      `{\n  // hi\n  "automation": { "socketControlMode": "cmuxOnly", "other": true }\n}\n`,
+    );
+    const r = ensureSocketAutomation({ path });
+    expect(r.changed).toBe(true);
+    expect(r.alreadySet).toBe(false);
+    const parsed = parse(readFileSync(path, "utf-8"));
+    expect(parsed.automation.socketControlMode).toBe("automation");
+    expect(parsed.automation.other).toBe(true);
+    expect(readFileSync(path, "utf-8")).toContain("// hi");
+  });
+
+  it("is idempotent across repeated calls", () => {
+    ensureSocketAutomation({ path });
+    const first = readFileSync(path, "utf-8");
+    const r2 = ensureSocketAutomation({ path });
+    expect(r2.changed).toBe(false);
+    expect(r2.alreadySet).toBe(true);
+    expect(readFileSync(path, "utf-8")).toBe(first);
+  });
+});

--- a/src/lib/__tests__/cmux-probe.test.ts
+++ b/src/lib/__tests__/cmux-probe.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { classifyProbe, probeCmuxDaemonDirect } from "../cmux-probe.js";
+
+describe("classifyProbe", () => {
+  it("ok=true → reachable", () => {
+    expect(classifyProbe({ ok: true })).toBe("reachable");
+  });
+
+  it("access-denied stderr → denied", () => {
+    expect(classifyProbe({ ok: false, stderr: "Access denied" })).toBe("denied");
+    expect(
+      classifyProbe({ ok: false, stderr: "only processes started inside cmux may connect" }),
+    ).toBe("denied");
+    expect(classifyProbe({ ok: false, stderr: "permission denied (socket)" })).toBe("denied");
+  });
+
+  it("other failures → unknown (fail-soft, stay on relay)", () => {
+    expect(classifyProbe({ ok: false, stderr: "cmux: command not found" })).toBe("unknown");
+    expect(classifyProbe({ ok: false, stderr: "orphan-timeout" })).toBe("unknown");
+    expect(classifyProbe({ ok: false })).toBe("unknown");
+  });
+});
+
+describe("probeCmuxDaemonDirect", () => {
+  it("returns the classified verdict from the injected runner", async () => {
+    expect(await probeCmuxDaemonDirect({ run: async () => ({ ok: true }) })).toBe("reachable");
+    expect(
+      await probeCmuxDaemonDirect({ run: async () => ({ ok: false, stderr: "Access denied" }) }),
+    ).toBe("denied");
+    expect(
+      await probeCmuxDaemonDirect({ run: async () => ({ ok: false, stderr: "boom" }) }),
+    ).toBe("unknown");
+  });
+
+  it("maps a thrown runner to unknown (never throws to the caller)", async () => {
+    const verdict = await probeCmuxDaemonDirect({
+      run: async () => {
+        throw new Error("spawn failed");
+      },
+    });
+    expect(verdict).toBe("unknown");
+  });
+});

--- a/src/lib/cmux-autoconfig.ts
+++ b/src/lib/cmux-autoconfig.ts
@@ -1,0 +1,98 @@
+// src/lib/cmux-autoconfig.ts
+//
+// #348 (part of #332): orchestrator for cmux socket auto-config. Ties together
+// the comment-preserving config write, the non-cmux probe, and a SEMI-AUTOMATIC,
+// one-time restart prompt.
+//
+// See docs/specs/2026-06-16-cmux-socket-auth-daemon-direct-design.md §4.3–§4.4.
+//
+// This module decides WHAT to surface (configChanged / verdict / one-time
+// prompt); it does not print or log. The caller — the `cockpit cmux autoconfig`
+// CLI or the daemon-start re-check — renders the result. cockpit NEVER restarts
+// cmux for the user (that disrupts live sessions); we write config and prompt.
+import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { ensureSocketAutomation } from "./cmux-config.js";
+import { probeCmuxDaemonDirect, type ProbeVerdict } from "./cmux-probe.js";
+
+/** One-time prompt marker, alongside the daemon state. */
+export function defaultStatePath(): string {
+  return join(homedir(), ".config", "cockpit", "state", "cmux-autoconfig.json");
+}
+
+export interface AutoConfigResult {
+  /** Path of the cmux config inspected/written. */
+  configPath: string;
+  /** True when the cmux config was written this run. */
+  configChanged: boolean;
+  /** True when socketControlMode was already "automation". */
+  configAlreadySet: boolean;
+  /** Live socket reachability from a non-cmux process. */
+  verdict: ProbeVerdict;
+  /** Config is in place but the live socket still rejects (cmux restart needed). */
+  needsRestart: boolean;
+  /** The one-time restart prompt fired this run (false on repeats — no nag). */
+  promptedThisRun: boolean;
+}
+
+export interface AutoConfigOpts {
+  configPath?: string;
+  statePath?: string;
+  /** Injectable for tests. Default = ensureSocketAutomation. */
+  ensureConfig?: typeof ensureSocketAutomation;
+  /** Injectable for tests. Default = the real orphan probe. */
+  probe?: () => Promise<ProbeVerdict>;
+}
+
+interface PromptState {
+  promptedRestart?: boolean;
+}
+
+function readState(path: string): PromptState {
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as PromptState;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Idempotent: write the cmux automation config (if needed), probe the live
+ * socket, and fire a one-time restart prompt when the socket still rejects.
+ *
+ * Safe to call on every daemon start — it recovers the "cmux not running at
+ * first write" edge case (§3.4): the value is already file-managed, so the next
+ * start re-probes and daemon-direct activates once cmux is (re)launched.
+ */
+export async function ensureCmuxAutoConfig(opts: AutoConfigOpts = {}): Promise<AutoConfigResult> {
+  const statePath = opts.statePath ?? defaultStatePath();
+  const ensureConfig = opts.ensureConfig ?? ensureSocketAutomation;
+  const probe = opts.probe ?? probeCmuxDaemonDirect;
+
+  const cfg = ensureConfig({ path: opts.configPath });
+  const verdict = await probe();
+  const needsRestart = verdict === "denied";
+
+  let promptedThisRun = false;
+  if (needsRestart) {
+    const already = readState(statePath).promptedRestart === true;
+    if (!already) {
+      mkdirSync(dirname(statePath), { recursive: true });
+      writeFileSync(statePath, JSON.stringify({ promptedRestart: true }));
+      promptedThisRun = true;
+    }
+  } else if (verdict === "reachable") {
+    // Reset the marker so a future regression (e.g. cmux config wiped) re-prompts.
+    if (existsSync(statePath)) rmSync(statePath, { force: true });
+  }
+
+  return {
+    configPath: cfg.path,
+    configChanged: cfg.changed,
+    configAlreadySet: cfg.alreadySet,
+    verdict,
+    needsRestart,
+    promptedThisRun,
+  };
+}

--- a/src/lib/cmux-config.ts
+++ b/src/lib/cmux-config.ts
@@ -1,0 +1,79 @@
+// src/lib/cmux-config.ts
+//
+// #348 (part of #332): comment-preserving JSONC merge for the cmux control
+// socket auth mode. Writes ONLY `automation.socketControlMode = "automation"`
+// into ~/.config/cmux/cmux.json so the launchd cockpit daemon (NOT a cmux
+// descendant) may connect to the cmux control socket for daemon-direct delivery.
+//
+// See docs/specs/2026-06-16-cmux-socket-auth-daemon-direct-design.md §2–§4.1.
+//
+// We use jsonc-parser (modify + applyEdits) rather than JSON.parse/stringify so
+// every existing comment and key in the user's cmux.json survives — cmux itself
+// preserves comments and we must not clobber them.
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { parse, modify, applyEdits } from "jsonc-parser";
+
+/** Canonical cmux config path. cmux watches this file live (§3.2). */
+export function defaultCmuxConfigPath(): string {
+  return join(homedir(), ".config", "cmux", "cmux.json");
+}
+
+export const SOCKET_CONTROL_MODE_PATH = ["automation", "socketControlMode"] as const;
+export const AUTOMATION_MODE = "automation";
+
+export interface EnsureSocketAutomationResult {
+  /** Absolute path written/inspected. */
+  path: string;
+  /** True when the file was written this call. */
+  changed: boolean;
+  /** True when socketControlMode was ALREADY "automation" (no write needed). */
+  alreadySet: boolean;
+}
+
+// Minimal cockpit-managed template used only when cmux.json does not yet exist
+// (clean install before cmux has created its own template). It is a strict
+// subset of cmux's schema, so cmux merges its full template keys on next launch
+// without conflict.
+const MINIMAL_TEMPLATE = [
+  `{`,
+  `  // [cockpit] file-managed: allow the launchd cockpit daemon to reach the cmux`,
+  `  // control socket for daemon-direct notification delivery (#348/#332).`,
+  `  "automation": {`,
+  `    "socketControlMode": "${AUTOMATION_MODE}"`,
+  `  }`,
+  `}`,
+  ``,
+].join("\n");
+
+/**
+ * Ensure `automation.socketControlMode = "automation"` in the cmux config.
+ *
+ * Idempotent: a no-op (changed=false) when already set. Comment- and
+ * formatting-preserving when adding/overwriting an existing file. Creates a
+ * minimal cockpit-managed file when none exists.
+ */
+export function ensureSocketAutomation(
+  opts: { path?: string } = {},
+): EnsureSocketAutomationResult {
+  const path = opts.path ?? defaultCmuxConfigPath();
+
+  if (!existsSync(path)) {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, MINIMAL_TEMPLATE);
+    return { path, changed: true, alreadySet: false };
+  }
+
+  const text = readFileSync(path, "utf-8");
+  const current = parse(text)?.automation?.socketControlMode;
+  if (current === AUTOMATION_MODE) {
+    return { path, changed: false, alreadySet: true };
+  }
+
+  const edits = modify(text, [...SOCKET_CONTROL_MODE_PATH], AUTOMATION_MODE, {
+    formattingOptions: { insertSpaces: true, tabSize: 2 },
+  });
+  writeFileSync(path, applyEdits(text, edits));
+  return { path, changed: true, alreadySet: false };
+}

--- a/src/lib/cmux-probe.ts
+++ b/src/lib/cmux-probe.ts
@@ -1,0 +1,136 @@
+// src/lib/cmux-probe.ts
+//
+// #348 (part of #332): the hybrid gate. Answer "can a NON-cmux process reach the
+// cmux control socket right now?" — i.e. is daemon-direct delivery viable?
+//
+// See docs/specs/2026-06-16-cmux-socket-auth-daemon-direct-design.md §4.2.
+//
+// FAITHFULNESS: cmuxOnly mode checks the connecting process's parent chain and
+// rejects anything not descended from the cmux app. Prior research was
+// CONTAMINATED because it ran inside a cmux pane and kept cmux ancestry even
+// under `env -i`. A faithful probe MUST run from a process reparented to launchd
+// (PPID ⇒ 1). We achieve that with a launcher→worker double-fork: the launcher
+// exits immediately, orphaning the worker, which waits until process.ppid === 1
+// before touching the socket.
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveCmuxBin } from "./cmux-bin.js";
+
+export type ProbeVerdict = "reachable" | "denied" | "unknown";
+
+export interface ProbeRawResult {
+  ok: boolean;
+  stderr?: string;
+}
+
+// cmux's parentage rejection message (and generic socket permission errors).
+const DENIED_RE = /access denied|only processes started inside cmux|permission denied/i;
+
+/**
+ * Pure. Map a raw probe result to a verdict.
+ * - ok ⇒ reachable (daemon-direct viable)
+ * - access-denied stderr ⇒ denied (socket still cmuxOnly — restart needed)
+ * - anything else ⇒ unknown (fail soft → stay on relay)
+ */
+export function classifyProbe(r: ProbeRawResult): ProbeVerdict {
+  if (r.ok) return "reachable";
+  if (r.stderr && DENIED_RE.test(r.stderr)) return "denied";
+  return "unknown";
+}
+
+export interface ProbeOpts {
+  /** Injectable runner (tests). Default = orphan-escape spawn of a cmux read. */
+  run?: () => Promise<ProbeRawResult>;
+  /** Overall budget for the orphan probe (default 8s). */
+  timeoutMs?: number;
+}
+
+/**
+ * Probe whether a non-cmux process can reach the cmux control socket. Never
+ * throws — a failed/timed-out probe degrades to "unknown" so the caller stays on
+ * the zero-setup relay.
+ */
+export async function probeCmuxDaemonDirect(opts: ProbeOpts = {}): Promise<ProbeVerdict> {
+  const run = opts.run ?? (() => orphanProbe(opts.timeoutMs ?? 8000));
+  try {
+    return classifyProbe(await run());
+  } catch {
+    return "unknown";
+  }
+}
+
+// The worker script, run via `node`. Two modes in one file:
+//   launch: spawn the worker detached, then exit → worker is orphaned to launchd
+//   work:   wait until PPID===1 (no cmux ancestor), run the cmux read, write JSON
+// argv: [node, script, mode, resultFile, cmuxBin]
+const WORKER_SRC = `
+import { spawn, execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+const [mode, resultFile, cmuxBin] = process.argv.slice(2);
+if (mode === "launch") {
+  const child = spawn(process.execPath, [process.argv[1], "work", resultFile, cmuxBin], {
+    detached: true, stdio: "ignore",
+  });
+  child.unref();
+  process.exit(0);
+}
+// work mode: wait to be reparented to launchd (PPID 1), then probe.
+const deadline = Date.now() + 3000;
+while (process.ppid !== 1 && Date.now() < deadline) {
+  const until = Date.now() + 25;
+  while (Date.now() < until) { /* tiny busy wait — no timers in a dying orphan */ }
+}
+let result;
+if (process.ppid !== 1) {
+  result = { ok: false, stderr: "orphan-timeout" };
+} else {
+  try {
+    execFileSync(cmuxBin, ["workspace", "list", "--json"], {
+      encoding: "utf-8", timeout: 10000, env: { ...process.env, CMUX_QUIET: "1" },
+    });
+    result = { ok: true };
+  } catch (e) {
+    const stderr = (e && (e.stderr?.toString?.() || e.message)) || "probe failed";
+    result = { ok: false, stderr };
+  }
+}
+writeFileSync(resultFile, JSON.stringify(result));
+`;
+
+// Default runner: double-fork to a launchd-reparented worker, poll its result.
+async function orphanProbe(timeoutMs: number): Promise<ProbeRawResult> {
+  const dir = mkdtempSync(join(tmpdir(), "cmux-probe-"));
+  const scriptFile = join(dir, "probe-worker.mjs");
+  const resultFile = join(dir, "result.json");
+  writeFileSync(scriptFile, WORKER_SRC);
+
+  try {
+    const launcher = spawn(
+      process.execPath,
+      [scriptFile, "launch", resultFile, resolveCmuxBin()],
+      { detached: true, stdio: "ignore" },
+    );
+    launcher.unref();
+
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (existsSync(resultFile)) {
+        try {
+          return JSON.parse(readFileSync(resultFile, "utf-8")) as ProbeRawResult;
+        } catch {
+          // partial write — fall through and retry
+        }
+      }
+      await sleep(100);
+    }
+    return { ok: false, stderr: "probe-timeout" };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}


### PR DESCRIPTION
Closes #348 (part of #332).

## Problem
Daemon-direct notification delivery (`defaults.daemonDirectCmux`) only works today because this dev machine carries a **manual** `[cockpit-dbg]` block in `~/.config/cmux/cmux.json` setting `automation.socketControlMode = "automation"`. On a **clean install** it does NOT work: the cmux control socket defaults to `cmuxOnly`, which peer-credential-rejects the launchd cockpit daemon (not cmux-descended). This makes cockpit write that config itself.

> The original #348 design doc was written but never committed and was **lost**. This PR **reconstructs** it from recovered research + live verification and re-commits it at `docs/specs/2026-06-16-cmux-socket-auth-daemon-direct-design.md`.

## What's here
- **`src/lib/cmux-config.ts`** — comment-preserving JSONC merge (`jsonc-parser` `modify`+`applyEdits`). Writes **only** `automation.socketControlMode="automation"`, idempotent (no-op when set), creates a minimal cockpit-managed file when none exists. All comments/keys preserved.
- **`src/lib/cmux-probe.ts`** — the hybrid gate. A launcher→worker **double-fork orphans the worker to launchd (PPID=1)** so it has **no cmux ancestor** before pinging the socket — faithful, unlike the *contaminated* prior research (which ran inside a cmux pane). Pure classifier → `reachable` / `denied` / `unknown`; injectable runner so tests never spawn.
- **`src/lib/cmux-autoconfig.ts`** — orchestrator: write → probe → **semi-automatic one-time restart prompt** (state marker, no nag; resets once reachable).
- **`src/commands/cmux.ts`** — `cockpit cmux autoconfig` user-facing surface (`--json`, exit 0/1/2).
- **`src/control/cockpitd.ts`** — **gated** daemon-start re-check. Runs only when `daemonDirectCmux` is opt-in ON; recovers the "cmux not running at write time" edge case on the next boot. **Additive** — `startCockpitd` signature unchanged.

## #332 re-scope (documented in the spec)
- **Relay = zero-setup default** — NOT deleted.
- **Daemon-direct = opt-in**, viable only when the non-cmux probe returns `reachable`.
- Full hybrid relay⇄daemon-direct *delivery selection* in the daemon is the #332 follow-up; this PR delivers the autoconfig primitives.

## Safety / discipline
- cockpit **never restarts cmux** for the user (disrupts live sessions) — it writes config + prompts.
- The **live `daemonDirectCmux` flag is untouched (OFF)**; this code is dormant until the next daemon restart. I did **not** flip the flag, modify the live `cmux.json`, or restart the live daemon/cmux.
- **gitnexus impact** on `startCockpitd`: **LOW** (4 direct callers, 0 processes, 0 modules). `detect_changes`: no existing-symbol changes (purely additive).
- **TDD: 21 new tests**, all green. Build + `node dist/index.js cmux --help` runtime gate pass.

## Note
`src/control/__tests__/relay-proxy.test.ts` fails 3/13 — **verified pre-existing on `develop`** (timing-flaky, unrelated to this change; left untouched per surgical-changes discipline).