### PR TITLE
Reorg 4a: restructure cockpitd.ts into daemon/* (host + startDaemon)

### DIFF
--- a/docs/superpowers/plans/2026-06-17-reorg-step4a-restructure-cockpitd.md
+++ b/docs/superpowers/plans/2026-06-17-reorg-step4a-restructure-cockpitd.md
@@ -1,0 +1,221 @@
+# Reorg Step 4a — Restructure `cockpitd.ts` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. This is a large multi-file restructure — use `/gsd:plan-phase` + `/gsd:execute-phase` for wave-based execution with fresh context per task.
+
+**Goal:** Carve the driver-agnostic daemon core out of the 1032-LOC `src/control/cockpitd.ts` into focused `src/control/daemon/*` modules, leaving `cockpitd.ts` as a thin host that constructs concrete drivers and calls `startDaemon(deps)`. Behavior-preserving; **no package created yet** (that is Step 4b).
+
+**Architecture:** Each `daemon/*.ts` exports a `createX(ctx)` factory over a shared `DaemonContext`. `cockpitd.ts` stays the bin/launchd entrypoint filename (so `dist/cockpitd.js`, the launchd plist, and the tsup entry are all unchanged) but becomes the host: it builds the concrete drivers and the `deps` object, then calls `startDaemon(deps)` exported from `daemon/start.ts`.
+
+**Tech Stack:** TypeScript (NodeNext ESM), vitest, pnpm + tsup build, git.
+
+## Global Constraints
+
+- Platform: macOS-only. No cross-platform shims.
+- NodeNext ESM: relative imports need `.js` extensions. **The real runtime gate is `node dist/cockpitd.js` booting + serving the socket AND `node dist/index.js --help`** — not just tests (tsc + vitest miss missing-extension breakage).
+- **Behavior-preserving refactor only.** No logic changes, no feature work, no signature changes to public daemon behavior. The existing test suite is the characterization safety net — every task ends with the **full suite green** (minus the known pre-existing #353 relay-proxy flakes) and the daemon booting.
+- **No package move in 4a.** Everything stays in the root `src/` tree. `packages/core` is created in 4b.
+- **Daemon-boot smoke must override `sockPath`** (temp path), never bind the real `~/.config/cockpit/cockpit.sock` — the Step-3 gotcha that disrupted the live daemon.
+- Branch off `develop`. Open a PR to `develop`; do not self-merge (captain reviews).
+- Do NOT touch the live daemon, live `~/.config/cockpit/config.json`, or restart cmux during dev.
+
+**Source-of-truth line map (verified 2026-06-17 against `cockpitd.ts`, 1032 LOC):**
+
+| Concern | Current location in `cockpitd.ts` | Target module |
+|---|---|---|
+| Inline structural driver types (`codexDriver`/`opencodeBridge`/`cmuxEventsBridge`/`daemonCmux` shapes) | `CockpitdOpts` lines 80–125 | `interfaces.ts` (named interfaces) |
+| `distBuiltAt` (132), `gatherLogStats` (138), `gatherStoreStats` (169), `gatherResults` (190) | module-level helpers | `daemon/snapshot-gather.ts` |
+| `buildHealth` (540), `knownProjects` (571), `gatherSnapshotInputs` (584) | inside `startCockpitd` | `daemon/snapshot-gather.ts` (as `createSnapshotGather(ctx)`) |
+| state setup (221–262): `store`, `bootedAt`, `lastSweepAt`, `taskTimeoutMs`, `isPidAlive`, `spawn`, `resultsDir`, `writeResult`, `log`, `attachConns`, probe maps, in-flight sets | inside `startCockpitd` | `daemon/context.ts` (`DaemonContext` + `buildContext`) |
+| `proxiedSurfaceAlive` (267) | inside `startCockpitd` | `daemon/probes.ts` |
+| `broadcast` (280), `schedulePromotion` (295), `cancelPromotionsFor` (324) | inside `startCockpitd` | `daemon/attach.ts` |
+| event-ingestion / cmux-events subscriptions + `ingest` (336–415) | inside `startCockpitd` | `daemon/start.ts` (composition) |
+| `defaultNotify` (424–540) | inside `startCockpitd` | `daemon/delivery.ts` |
+| boot-recovery IIFE: reconcile + codex reattach + opencode re-subscribe + cmux-events start + #348 autoconfig (622–688) | inside `startCockpitd` | `daemon/start.ts` (boot sequence; drivers via `deps`) |
+| `server = startServer(...)` + message-router handler (690–~790) | inside `startCockpitd` | `daemon/server.ts` |
+| daemon-direct delivery setup: `deliveryCore`/`deliveryTick`/`directPaneReader`/`interactiveProbe`/`probeTick` (790–945) | inside `startCockpitd` | `daemon/delivery.ts` + `daemon/probes.ts` |
+| approval-gate wiring (`makeGate`, decision routing ~527) | inside the handler | `daemon/gates.ts` |
+| timers (delivery/probe/sweep/rotation, 947–1011) + return handle (1013–1025) | inside `startCockpitd` | `daemon/start.ts` |
+| launchd entry guard (1028–1031) | bottom of file | `cockpitd.ts` host |
+
+---
+
+### Task 1: Extract driver-seam interfaces (`interfaces.ts`)
+
+**Files:**
+- Create: `src/control/interfaces.ts`
+- Modify: `src/control/cockpitd.ts` (`CockpitdOpts` — replace inline structural types with the named interfaces)
+
+**Interfaces:**
+- Produces: `AgentDriver` (`{ dispatch, reattach, say, steer, interrupt, answer, close }`), `OpencodeBridge` (`{ start, stop, answer }`), `CmuxEventsBridge` (`{ start, stop }`), `DaemonSurfaceDriver` (the `DaemonCmux` surface used by delivery: `findWorkspaceId?`, `listSurfaces`, `send`). Each copied verbatim from the inline shapes currently in `CockpitdOpts` (lines 80–125) so the structural contract is identical.
+- Consumes: nothing (pure type module, no runtime imports).
+
+- [ ] **Step 1:** Create `src/control/interfaces.ts` with the four interfaces above, lifting each member signature **verbatim** from the inline `CockpitdOpts` types (lines 80–88 for `AgentDriver`, 98–103 for `OpencodeBridge`, 106 for `CmuxEventsBridge`, the `DaemonCmux` usage in `deliveryCore` for `DaemonSurfaceDriver`). Add a one-line doc comment per interface naming the seam it represents.
+- [ ] **Step 2:** In `cockpitd.ts`, change the `CockpitdOpts` fields to reference the named interfaces (`codexDriver?: AgentDriver`, `opencodeBridge?: OpencodeBridge`, `cmuxEventsBridge?: CmuxEventsBridge`, `daemonCmux?: DaemonSurfaceDriver | DaemonCmux`). Keep `DaemonCmux` import for now (it's the concrete default's type).
+- [ ] **Step 3:** Type-check + full suite: `pnpm run lint && npm test`. Expected: `tsc -b` clean (structural types match, no behavior change), suite green.
+- [ ] **Step 4:** Boot smoke: `pnpm run build && node dist/cockpitd.js & sleep 2; <verify socket on a TEMP sockPath via a scratch invocation>; kill %1`. Expected: daemon boots. (Use a temp `sockPath` — never the real socket.)
+- [ ] **Step 5:** Commit: `git commit -am "refactor(4a): extract driver-seam interfaces into interfaces.ts"`.
+
+---
+
+### Task 2: Extract `daemon/snapshot-gather.ts`
+
+**Files:**
+- Create: `src/control/daemon/snapshot-gather.ts`
+- Modify: `src/control/cockpitd.ts`
+
+**Interfaces:**
+- Produces: pure helpers `distBuiltAt()`, `gatherLogStats(path, now, windowMs)`, `gatherStoreStats(store, stateRoot, project)`, `gatherResults(resultsDir)` (moved verbatim with their existing signatures); and `createSnapshotGather(ctx)` returning `{ buildHealth, knownProjects, gatherSnapshotInputs }` (the three closure fns, now reading `store`/`d`/`stateRoot`/`bootedAt`/`resultsDir` from `ctx`).
+- Consumes: `DaemonContext` (Task 3 defines it — for ordering, do Task 3 first if the crew prefers; this plan lists snapshot first because the pure helpers move cleanly, then the `createSnapshotGather` factory is added once `ctx` exists). If executed before Task 3, move only the 4 pure helpers in this task and defer `createSnapshotGather` to a follow-up step after `context.ts` lands.
+
+- [ ] **Step 1:** Move `distBuiltAt`, `gatherLogStats`, `gatherStoreStats`, `gatherResults` verbatim into `snapshot-gather.ts`; export each. Repoint their imports (`DaemonSnapshotInputs`, `ResultArtifacts` from `./snapshot.js`, `readCursor`/`mailboxStats` as needed). Import them back into `cockpitd.ts`.
+- [ ] **Step 2:** Full suite + boot smoke (as Task 1 Steps 3–4). Expected: green; daemon boots.
+- [ ] **Step 3:** Commit: `git commit -am "refactor(4a): move snapshot I/O helpers to daemon/snapshot-gather.ts"`.
+
+---
+
+### Task 3: Define `DaemonContext` + `buildContext` (`daemon/context.ts`)
+
+**Files:**
+- Create: `src/control/daemon/context.ts`
+- Modify: `src/control/cockpitd.ts`
+
+**Interfaces:**
+- Produces: `interface DaemonContext` holding the shared state currently set up in lines 221–262 — `stateRoot`, `sockPath`, `store`, `bootedAt`, `lastSweepAt` (mutable — expose as a getter/setter or a `{ value }` box so the sweep timer can update it), `taskTimeoutMs`, `isPidAlive`, `spawn`, `resultsDir`, `writeResult`, `log`, `attachConns`, `pendingProbes`, `probeResults`, `inFlightProbes`, `inFlightHeadlessIds`, `activeHeadlessKills`, `d` (the `Daemon` from `createDaemon`), and the `deps` (drivers + notify + config injectors). Plus `buildContext(deps): DaemonContext`.
+- Consumes: `interfaces.ts` types; `createStore`, `createDaemon`.
+
+- [ ] **Step 1:** Define `DaemonContext` and `buildContext(deps)` in `context.ts`, moving the state-setup block (221–262) into `buildContext`. `lastSweepAt` becomes a mutable box on the context so timers can update it. `d` (daemon) is constructed here or passed in — keep `createDaemon` wiring where it currently is and store the result on `ctx`.
+- [ ] **Step 2:** In `cockpitd.ts`/`start.ts`, replace the inline state setup with `const ctx = buildContext(deps)`.
+- [ ] **Step 3:** Full suite + boot smoke. Expected: green; daemon boots.
+- [ ] **Step 4:** Commit: `git commit -am "refactor(4a): introduce DaemonContext + buildContext"`.
+
+---
+
+### Task 4: Extract `daemon/attach.ts`
+
+**Files:**
+- Create: `src/control/daemon/attach.ts`
+- Modify: `src/control/cockpitd.ts` / `daemon/start.ts`
+
+**Interfaces:**
+- Produces: `createAttach(ctx)` returning `{ broadcast(taskId, frame), schedulePromotion(...), cancelPromotionsFor(taskId) }` (moved verbatim from lines 280–336, reading `attachConns` from `ctx`).
+- Consumes: `DaemonContext`; `AttachFrame`/`encodeFrame` from `./protocol.js`.
+
+- [ ] **Step 1:** Move `broadcast`, `schedulePromotion`, `cancelPromotionsFor` into `createAttach(ctx)`; wire callers in `start.ts` to the returned handlers.
+- [ ] **Step 2:** Full suite + boot smoke. Expected: green; daemon boots.
+- [ ] **Step 3:** Commit: `git commit -am "refactor(4a): extract attach fan-out to daemon/attach.ts"`.
+
+---
+
+### Task 5: Extract `daemon/probes.ts`
+
+**Files:**
+- Create: `src/control/daemon/probes.ts`
+- Modify: `src/control/cockpitd.ts` / `daemon/start.ts`
+
+**Interfaces:**
+- Produces: `createProbes(ctx)` returning `{ proxiedSurfaceAlive(rec), buildInteractiveProbe(deliverDeps), captainMissingStreak, stoppedProjects }` — the `proxiedSurfaceAlive` closure (267–278) plus the `createInteractiveProbe`/`createDirectCrewPaneReader` wiring (910–944, the `probeTick` guard). `captainMissingStreak`/`stoppedProjects` maps move here (shared with delivery via `ctx` if delivery also needs them — keep them on `ctx`).
+- Consumes: `DaemonContext`; `createInteractiveProbe`/`STALE_THRESHOLD_MS` (still from `../commands/notify-relay.js` in 4a — the back-edge is fixed in 4b), `createDirectCrewPaneReader`/`createDirectSurfaceLivenessProbe` from `./crew-pane-reader.js`.
+
+- [ ] **Step 1:** Move `proxiedSurfaceAlive` + the interactive-probe setup + `probeTick` guard into `createProbes(ctx)`. Keep `captainMissingStreak`/`stoppedProjects` on `ctx` (delivery reads them).
+- [ ] **Step 2:** Full suite + boot smoke. Expected: green; daemon boots.
+- [ ] **Step 3:** Commit: `git commit -am "refactor(4a): extract liveness probes to daemon/probes.ts"`.
+
+---
+
+### Task 6: Extract `daemon/delivery.ts`
+
+**Files:**
+- Create: `src/control/daemon/delivery.ts`
+- Modify: `src/control/cockpitd.ts` / `daemon/start.ts`
+
+**Interfaces:**
+- Produces: `createDelivery(ctx)` returning `{ defaultNotify(args), deliveryTick }` — `defaultNotify` (424–540) and the daemon-direct delivery block (790–908: `deliveryCore` + `deliveryTick` re-entrancy guard, using `ctx.deps.daemonCmux` as the `DaemonSurfaceDriver`, `CaptainDelivery`, `discoverCaptainSurface`, cursor read/write, `sessionStartMs`, `STALE_THRESHOLD_MS`).
+- Consumes: `DaemonContext`; `CaptainDelivery` from `./delivery/captain-delivery.js`; `discoverCaptainSurface` (keep exported from where tests import it — verify the test import path; re-export if it moves).
+
+- [ ] **Step 1:** Move `defaultNotify` + `deliveryCore`/`deliveryTick` into `createDelivery(ctx)`. The `notify` used by the daemon = `ctx.deps.notify ?? defaultNotify`. Preserve all #332 storm guards (re-entrancy `delivering`, stale-skip, streak) byte-for-byte.
+- [ ] **Step 2:** Verify `discoverCaptainSurface`'s test import still resolves (it is currently `export`ed from `cockpitd.ts`). If a test imports it from `cockpitd.ts`, re-export it from `cockpitd.ts` (`export { discoverCaptainSurface } from "./daemon/delivery.js"`) to avoid touching tests in 4a.
+- [ ] **Step 3:** Full suite + boot smoke + **daemon-direct delivery check** (boot with a temp `sockPath` + injected fake `daemonCmux` + `sweepMs>0`, assert `tickDelivery` advances a cursor). Expected: green; daemon boots; delivery ticks.
+- [ ] **Step 4:** Commit: `git commit -am "refactor(4a): extract delivery loop to daemon/delivery.ts"`.
+
+---
+
+### Task 7: Extract `daemon/gates.ts` + `daemon/server.ts`
+
+**Files:**
+- Create: `src/control/daemon/gates.ts`, `src/control/daemon/server.ts`
+- Modify: `src/control/cockpitd.ts` / `daemon/start.ts`
+
+**Interfaces:**
+- Produces:
+  - `createGates(ctx)` → `{ gate }` (the `makeGate` wiring + approve/deny decision routing, ~527).
+  - `createServer(ctx, handlers)` → the `startServer(sockPath, { handler })` wiring + the message router (690–~790: `seed`, `codex-close`, `relay-register`, `relay-heartbeat`, `relay-proxy-poll`, `relay-proxy-result`, and the `d.handle(msg)` fallthrough). `handlers` carries the `broadcast`/driver hooks the router calls (e.g. `ctx.deps.codexDriver.close`).
+- Consumes: `DaemonContext`; `startServer`/`encodeFrame` from `./protocol.js`; `makeGate` from `./codex/gate.js` (stays in root in 4a).
+
+- [ ] **Step 1:** Move the gate wiring into `createGates(ctx)`.
+- [ ] **Step 2:** Move `startServer` + the message router into `createServer(ctx, handlers)`. The router calls into `attach`/`delivery`/`probes`/`gates` via the passed `handlers` object — no direct closure refs.
+- [ ] **Step 3:** Full suite + boot smoke. Expected: green; daemon boots; a `seed`/`relay-register` round-trips.
+- [ ] **Step 4:** Commit: `git commit -am "refactor(4a): extract gates + socket server to daemon/{gates,server}.ts"`.
+
+---
+
+### Task 8: Assemble `daemon/start.ts` + reduce `cockpitd.ts` to the host
+
+**Files:**
+- Create: `src/control/daemon/start.ts`
+- Modify: `src/control/cockpitd.ts`
+
+**Interfaces:**
+- Produces:
+  - `startDaemon(deps: DaemonDeps): DaemonHandle` in `start.ts` — builds `ctx`, constructs the factories (`createAttach`, `createProbes`, `createDelivery`, `createGates`, `createServer`, `createSnapshotGather`), runs the boot-recovery sequence (reconcile + codex reattach + opencode re-subscribe + cmux-events start + #348 autoconfig — all via `deps` drivers), starts the timers (delivery/probe/sweep/rotation, 947–1011), and returns the `{ stop, tickDelivery, tickProbe }` handle (1013–1025). `DaemonDeps` = `CockpitdOpts` minus the inline driver defaults, **plus required driver fields** (`codexDriver`, `opencodeBridge`, `cmuxEventsBridge`, `launchHeadless`, `healRelay`; `daemonCmux`/`makeDaemonCmux` stay optional, gated by `daemonDirectCmux`).
+  - `cockpitd.ts` host: `readPkgVersion`/`PKG_VERSION` stay; constructs the concrete drivers (`new CodexInteractiveDriver()`, real `OpencodeSseBridge`, `new CmuxEventsBridge(...)`, `() => new DaemonCmux(createCmuxDriver())`, `runHeadless`, real `healRelay`), assembles `deps`, calls `startDaemon(deps)`. Keep the `startCockpitd(opts)` exported name as a thin shim over `startDaemon` (host supplies defaults) so existing test imports of `startCockpitd` keep working in 4a.
+- Consumes: everything above; the concrete driver classes (the only file still importing them).
+
+- [ ] **Step 1:** Create `start.ts` with `startDaemon(deps)` assembling the factories + boot sequence + timers + handle.
+- [ ] **Step 2:** Rewrite `cockpitd.ts` as the host: construct concrete drivers, build `deps`, and export `startCockpitd(opts)` as a shim that fills driver defaults from the concrete classes then calls `startDaemon`. Keep the launchd entry guard (1028–1031) calling `startCockpitd({ sweepMs: 30000 })`.
+- [ ] **Step 3:** Confirm `cockpitd.ts` no longer contains daemon logic — only driver construction + the shim + the entry guard (target ≤ ~120 LOC). Grep it for the moved function names; expect none remain defined here.
+- [ ] **Step 4:** Full suite + **both** runtime gates: `pnpm run build && node dist/index.js --help && node dist/cockpitd.js` (temp sockPath) boots + serves. Expected: all green.
+- [ ] **Step 5:** Commit: `git commit -am "refactor(4a): reduce cockpitd.ts to host; add daemon/start.ts (startDaemon)"`.
+
+---
+
+### Task 9: Verify, document, open PR
+
+**Files:**
+- Create: `src/control/daemon/README.md` (≈15 lines: Purpose / Owns / Public interface (`startDaemon`) / Depends on / Doesn't belong here — concrete drivers).
+- Modify: none.
+
+- [ ] **Step 1:** Confirm no concrete-driver imports remain in any `daemon/*.ts`: `git grep -nE "codex/driver|opencode/sse-bridge|cmux/events-bridge|cmux/daemon-cmux|runtimes/index|headless-launcher" -- src/control/daemon`. Expected: **no output** (those live only in the host `cockpitd.ts`). The one allowed root-edge — `createInteractiveProbe` from `commands/notify-relay.js` in `daemon/probes.ts` — is the documented 4b back-edge; note it but do not fix it here.
+- [ ] **Step 2:** Clean-room CI gate (the Step-3 lesson — run the exact CI command, do not pre-build by hand): from a clean `git stash`-free checkout, `pnpm i --frozen-lockfile && pnpm run build && pnpm test`. Expected: build + suite green.
+- [ ] **Step 3:** Write `daemon/README.md`.
+- [ ] **Step 4:** Push + open PR to `develop`:
+```bash
+git push -u origin HEAD
+gh pr create --base develop --title "Reorg 4a: restructure cockpitd.ts into daemon/* (host + startDaemon)" \
+  --body "Part of the monorepo reorg (docs/superpowers/specs/2026-06-17-monorepo-reorg-step4-extract-core-design.md), rollout step 4a.
+
+- Carve driver-agnostic core out of cockpitd.ts (1032 LOC) into daemon/{start,context,server,attach,delivery,probes,gates,snapshot-gather}.ts + interfaces.ts.
+- cockpitd.ts becomes the thin host (constructs concrete drivers, calls startDaemon). Entrypoint filename unchanged -> dist/cockpitd.js, launchd plist, tsup entry untouched.
+- No package move (that is 4b). No behavior change.
+
+Verified: pnpm build + pnpm test green; node dist/cockpitd.js boots (temp sockPath); node dist/index.js --help works; daemon-direct delivery ticks."
+```
+- [ ] **Step 5:** `cockpit crew signal done`.
+
+---
+
+## Self-Review
+
+**Spec coverage** (against the Step-4 4a section of `2026-06-17-monorepo-reorg-step4-extract-core-design.md`):
+- `cockpitd.ts` stays entry, becomes thin host → Task 8. ✓
+- Split into `daemon/{start,context,server,attach,delivery,probes,gates,snapshot-gather}.ts` → Tasks 2–8. ✓
+- Promote inline driver types to named interfaces → Task 1. ✓
+- `core` depends on nobody (seam interfaces) → Task 1 + Task 9 Step 1 grep. ✓
+- Entry/launchd/tsup untouched → Task 8 keeps `cockpitd.ts` filename + entry guard. ✓
+- Daemon-boot test overrides `sockPath` → Global Constraints + Task 6 Step 3. ✓
+- 4b back-edge (`notify-relay`) noted not fixed → Task 5 + Task 9 Step 1. ✓
+
+**Placeholder scan:** No TBD/TODO; every task names exact functions + line ranges + verification commands. The one deliberate ordering note (Task 2 vs Task 3) is called out explicitly, not left vague. ✓
+
+**Type consistency:** `DaemonContext` (Task 3) is the single shared bag consumed by Tasks 4–8; `DaemonDeps` (Task 8) = `CockpitdOpts` minus inline driver defaults + required driver fields; `startDaemon`/`startCockpitd`-shim names are consistent across Tasks 8–9. Seam interface names (`AgentDriver`/`OpencodeBridge`/`CmuxEventsBridge`/`DaemonSurfaceDriver`) match between Task 1 and their consumers. ✓
+
+**Out of scope (correctly deferred to 4b):** creating `packages/core`, moving the modules, fixing the `notify-relay` back-edge, project-reference enforcement. None ride along here.

--- a/docs/superpowers/specs/2026-06-17-monorepo-reorg-step4-extract-core-design.md
+++ b/docs/superpowers/specs/2026-06-17-monorepo-reorg-step4-extract-core-design.md
@@ -1,0 +1,157 @@
+# Design: Monorepo reorg — Step 4 (extract `core` + split `cockpitd.ts`)
+
+**Date:** 2026-06-17
+**Status:** Design — approved in brainstorming; pending spec-review → writing-plans
+**Parent spec:** `docs/superpowers/specs/2026-06-17-monorepo-reorg-design.md` (rollout step 4)
+**Predecessor:** Step 3 (`@cockpit/shared` extracted, pnpm workspaces + tsup) — merged as PR #355.
+
+## Goal
+
+Extract the daemon / control-plane core into a new private package **`@cockpit/core`**, and in
+the process split the 1032-LOC `cockpitd.ts` host into focused `daemon/*` modules. `core` must
+depend on **`@cockpit/shared` only** — never on a concrete agent/workspace driver, never on the
+`cli`. Concrete drivers (`codex/`, `opencode/`, `cmux/`, `headless`, `runtimes/`) stay in the root
+package this step and move to `agents`/`workspaces` in Step 5.
+
+No behavior change. This is structure + boundary enforcement only.
+
+## Key design decision: `cockpitd.ts` stays the host entrypoint
+
+The launchd daemon and the tsup bundle target `dist/cockpitd.js`. To avoid re-firing parent-spec
+**landmine #1** (entrypoint relocation), we keep `src/control/cockpitd.ts` as the **host
+entrypoint filename** and extract the driver-agnostic core *out of* it:
+
+- `cockpitd.ts` (root) **becomes the host** — it constructs the concrete drivers and calls
+  `startDaemon(deps)`. It is the **only** daemon file that imports concrete driver classes.
+- The driver-agnostic logic moves into a new `daemon/` folder (root in 4a, then `packages/core`
+  in 4b).
+
+Because the entrypoint filename never changes, **`dist/cockpitd.js` is unchanged**, so the
+launchd plist and the tsup `cockpitd` entry are untouched in both sub-PRs. Landmine #1 does not
+fire in Step 4 (it was already resolved in Step 3's tsup scaffold).
+
+## Decomposition: two sub-PRs
+
+Driver injection **already exists** — every concrete driver is already an injectable field on
+`CockpitdOpts` (`codexDriver?`, `opencodeBridge?`, `cmuxEventsBridge?`, `daemonCmux?` /
+`makeDaemonCmux?`, `launchHeadless?`, `healRelay?`). The concrete driver *imports* in `cockpitd.ts`
+exist solely to build the **inline defaults**. So "invert the DI" is not an API redesign — it is
+lifting those default constructions into the host and making the deps required at the `startDaemon`
+boundary. That makes the only high-risk piece the **physical move** into `packages/core`, which we
+isolate in its own sub-PR.
+
+### Sub-PR 4a — in-root restructure (no package move)
+
+Carve the driver-agnostic core out of `cockpitd.ts` into `src/control/daemon/`, leaving
+`cockpitd.ts` as a thin host. Everything stays in the root package; same test surface; daemon boots.
+
+```
+src/control/
+  cockpitd.ts          HOST (~80 LOC) — bin/launchd ENTRY (filename unchanged).
+                       Constructs concrete drivers (Codex, Opencode, cmux-events,
+                       DaemonCmux, headless, healRelay) and calls startDaemon(deps).
+                       The ONLY daemon file importing concrete drivers.
+  daemon/              NEW — driver-agnostic core carved from the 1032-LOC closure:
+    start.ts             startDaemon(deps): build context, wire factories, own timers
+    context.ts           DaemonContext type + shared mutable state
+                         (store, daemon, log, attachConns, probe queues, …)
+    server.ts            startServer + socket message routing
+                         (relay-register, heartbeat, relay-proxy-poll/result, d.handle)
+    attach.ts            attach fan-out (attachConns, broadcast, schedule/cancelPromotion)
+    delivery.ts          deliveryCore loop + defaultNotify + daemon-direct + CaptainDelivery
+    probes.ts            proxiedSurfaceAlive, probe queues, buildHealth, captain streak, timers
+    gates.ts             makeGate wiring + approval decision routing
+    snapshot-gather.ts   gatherLog/Store/Results/SnapshotInputs + distBuiltAt (I/O edge)
+  interfaces.ts        NEW — driver-seam interfaces (see below)
+```
+
+Each `daemon/*.ts` exports a `createX(ctx: DaemonContext)` factory; `start.ts` builds the context
+and wires them — the existing `daemon.ts`-core / `cockpitd.ts`-host pattern extended inward.
+
+**Driver-seam interfaces.** The inline structural driver types already in `CockpitdOpts`
+(lines 80–88: `{ dispatch, reattach, say, steer, interrupt, answer, close }`; the opencode bridge
+shape; the cmux-events shape; the `DaemonCmux` surface used by delivery) are **promoted to named
+interfaces** (`AgentDriver`, `OpencodeBridge`, `CmuxEventsBridge`, `DaemonSurfaceDriver`). These are
+the seam interfaces `core` will own. Concrete drivers (still in root) implement them structurally.
+This is what lets `core` depend on nobody but `shared`.
+
+`startDaemon(deps)` takes the drivers as **required** fields of `deps` (the host always supplies
+them; tests supply fakes). Test-only behavioral injectors that are not drivers (`spawn?`,
+`isPidAlive?`, `sweepMs?`, `notify?`, `rotationIntervalMs?`, …) keep their optional-with-default
+shape.
+
+**4a is done when:** `npm test` green (same pass set), `node dist/cockpitd.js` boots and serves the
+socket, daemon-direct delivery still advances the cursor. No package created yet.
+
+### Sub-PR 4b — create `packages/core` + move
+
+```
+packages/core/
+  package.json         private: true, name @cockpit/core, dep: @cockpit/shared
+  tsconfig.json        composite: true; references: [../shared]
+  README.md            Purpose / Owns / Public interface / Depends on / Doesn't belong here
+  src/
+    daemon/            the 4a split, moved verbatim
+    interfaces.ts      the driver-seam interfaces from 4a
+    daemon.ts mailbox.ts protocol.ts state-machine.ts liveness.ts watchdog.ts
+    store.ts snapshot.ts launchd.ts relay-healer.ts relay-* crew-pane-reader.ts
+    delivery/          (captain-delivery.ts)
+    notifiers/ projection/
+```
+
+- **Stays in the root package** (moves to `agents`/`workspaces` in Step 5): `cockpitd.ts` (host),
+  `codex/`, `opencode/`, `cmux/`, `headless-launcher.ts`, `runtimes/`. The host repoints its core
+  imports to `@cockpit/core`.
+- **Entry path unchanged:** host `cockpitd.ts` keeps its filename → `dist/cockpitd.js` →
+  **launchd plist + tsup `cockpitd` entry untouched**.
+- **Boundary enforced by TS project references:** `core`'s tsconfig references only `shared`; any
+  `core → root` import fails `tsc -b`.
+
+**Back-edge to resolve in 4b.** `cockpitd.ts` currently imports `createInteractiveProbe` and
+`STALE_THRESHOLD_MS` from `../commands/notify-relay.ts` — a *command* (cli layer) exporting daemon
+logic, which `core` cannot import. Fix: move `createInteractiveProbe` (+ `STALE_THRESHOLD_MS`) into
+`core` (it belongs with `daemon/probes.ts`); the `notify-relay` command imports it **back from
+`@cockpit/core`**. Verify no other `core → commands/` or `core → drivers/` edges remain (grep the
+moved files' imports before finalizing).
+
+## Landmines & mitigations (step-4 specific)
+
+1. **Daemon-boot test must override `sockPath`, not just `stateRoot`** (Step-3 lesson). `cockpitd`
+   ignores `COCKPIT_STATE_ROOT`; a state-root-only test binds the **real** socket and disrupts the
+   live daemon (it self-heals via launchd KeepAlive, but it's a live-system disruption). Every
+   boot/integration test in this step passes an explicit temp `sockPath`.
+2. **`pkgRoot`-relative reads** (parent landmine #2). `canonical-source.ts` / `runtime-sync.ts`
+   already moved to `@cockpit/shared` in Step 3 and are **not** touched here. No action — but the
+   4b tarball gate (below) re-proves them end-to-end.
+3. **Hidden `core → root` back-edges.** Beyond the known `notify-relay` one, the move can surface
+   others (e.g. a type imported from `runtimes/types.ts`). Mitigation: `tsc -b` is the hard gate;
+   anything it flags either moves into `core` (if it's core-owned) or becomes a seam interface.
+4. **Shared mutable closure state.** The 1032-LOC `startCockpitd` is one closure; the pieces share
+   `store`, `d`, `log`, `attachConns`, the probe maps, the in-flight sets. The split threads these
+   through an explicit `DaemonContext` object rather than module globals, so behavior is identical
+   and the pieces stay unit-reachable.
+
+## Success criteria
+
+- `packages/core` exists with `package.json`, `tsconfig.json` (composite, references `shared`),
+  and `README.md`.
+- `cockpitd.ts` is a thin host (~80 LOC) that constructs concrete drivers and calls `startDaemon`;
+  it is the only daemon file importing concrete driver classes.
+- `cockpitd.ts` (1032 LOC) is split into `daemon/{start,context,server,attach,delivery,probes,gates,
+  snapshot-gather}.ts` + `interfaces.ts`, each a focused module (no gratuitous <50-LOC fragments).
+- `tsc -b` passes; `@cockpit/core` cannot import from the root package, `commands/`, or any concrete
+  driver (project-reference enforced).
+- `npm test` green (same pass set as before, minus the known pre-existing #353 relay-proxy flakes).
+- `node dist/cockpitd.js` boots + serves the socket; daemon-direct delivery advances the cursor.
+- A packed tarball (`pnpm pack`) installs and runs `cockpit --help` + completes a `runtime-sync`.
+- `packages/core/README.md` present (Purpose / Owns / Public interface / Depends on / Doesn't
+  belong here).
+
+## Out of scope
+
+- Moving `codex/` / `opencode/` / `cmux/` / `headless` / `runtimes/` into `agents` / `workspaces`
+  (Step 5).
+- Moving `dashboard/` into `web` (Step 6); grouping `commands/` (Step 7).
+- Rewriting `daemon.ts` core logic — only the *host* file (`cockpitd.ts`) is decomposed; `daemon.ts`
+  (clean core, 5 imports) stays as-is.
+- Any behavior change. No feature work rides along.

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -2,9 +2,9 @@
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { readFileSync } from "node:fs";
-import { randomUUID } from "node:crypto";
 import { createDaemon } from "./daemon.js";
 import { buildContext } from "./daemon/context.js";
+import { createAttach } from "./daemon/attach.js";
 export type { CockpitdOpts } from "./daemon/context.js";
 export { defaultIsPidAlive } from "./daemon/context.js";
 import { startServer, encodeFrame, type AttachFrame, type AttachInbound } from "./protocol.js";
@@ -12,7 +12,6 @@ import { runHeadless } from "./headless-launcher.js";
 import { CodexInteractiveDriver, shouldReattachCodex } from "./codex/driver.js";
 import { OpencodeSseBridge } from "./opencode/sse-bridge.js";
 import { CmuxEventsBridge } from "./cmux/events-bridge.js";
-import { makeGate } from "./codex/gate.js";
 import { appendToMailbox, rotateIfNeeded, mailboxStats, readCursor, writeCursor, readFromCursor } from "./mailbox.js";
 import { createRelayHealer } from "./relay-healer.js";
 import { createDirectSurfaceLivenessProbe, createDirectCrewPaneReader } from "./crew-pane-reader.js";
@@ -22,7 +21,7 @@ import { projectHealth, type ComponentHealth } from "./liveness.js";
 import { assembleDaemonSnapshot, type DaemonSnapshotInputs } from "./snapshot.js";
 import { loadConfig } from "@cockpit/shared";
 import { readdir } from "node:fs/promises";
-import type { Gate, TaskRecord, ControlEvent } from "@cockpit/shared";
+import type { TaskRecord, ControlEvent } from "@cockpit/shared";
 import { TERMINAL_STATES } from "@cockpit/shared";
 import type { Socket } from "node:net";
 import type { PaneRef } from "../runtimes/types.js";
@@ -80,58 +79,10 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
     return probeResults.get(rec.id) ?? "unknown";
   };
 
-  function broadcast(taskId: string, f: AttachFrame): void {
-    const conns = attachConns.get(taskId);
-    if (!conns) return;
-    const wire = encodeFrame(f);
-    for (const conn of conns) {
-      try { conn.write(wire); } catch { /* client gone; onAttachClose will clean up */ }
-    }
-  }
-
-  // ── Gate promotion (spec §4.9) ────────────────────────────────────────────
-  // When a server-request event fires and no client is attached, start a 5s
-  // timer. If still unattached at fire time, promote to a Gate in the store
-  // and broadcast gate-promoted so any later-attaching client can offer takeover.
-  const pendingGateTimers = new Map<string, { taskId: string; timer: NodeJS.Timeout }>();
-
-  function schedulePromotion(
-    taskId: string,
-    requestId: number,
-    kind: "input" | "approval",
-    question: string,
-  ): void {
-    // If a client is already attached for this task, no promotion needed.
-    const conns = attachConns.get(taskId);
-    if (conns && conns.size > 0) return;
-    const key = `${taskId}#${requestId}`;
-    // Clear any prior timer for the same (taskId, requestId).
-    const prior = pendingGateTimers.get(key);
-    if (prior) clearTimeout(prior.timer);
-    const timer = setTimeout(() => {
-      pendingGateTimers.delete(key);
-      // Re-check at fire time — a client may have attached in the 5s window.
-      if (attachConns.get(taskId)?.size) return;
-      const rec = store.listAll().find((r) => r.id === taskId);
-      if (!rec) return;
-      const gate: Gate = makeGate({ taskId, kind, question, now: Date.now(), mkId: () => randomUUID() });
-      const gates = [...(rec.gates ?? []), gate];
-      store.put({ ...rec, gates });
-      broadcast(taskId, { type: "gate-promoted", taskId, gateId: gate.gateId });
-      log(`gate promoted gateId=${gate.gateId} taskId=${taskId} kind=${kind}`);
-    }, 5_000);
-    timer.unref?.();
-    pendingGateTimers.set(key, { taskId, timer });
-  }
-
-  function cancelPromotionsFor(taskId: string): void {
-    for (const [key, slot] of pendingGateTimers.entries()) {
-      if (slot.taskId === taskId) {
-        clearTimeout(slot.timer);
-        pendingGateTimers.delete(key);
-      }
-    }
-  }
+  const { broadcast, schedulePromotion, cancelPromotionsFor } = createAttach(ctx);
+  ctx.broadcast = broadcast;
+  ctx.schedulePromotion = schedulePromotion;
+  ctx.cancelPromotionsFor = cancelPromotionsFor;
 
   // ── CodexInteractiveDriver singleton ─────────────────────────────────────
   // The driver holds the single AppServerClient child. Each task maps to a

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -6,6 +6,7 @@ import { createDaemon } from "./daemon.js";
 import { buildContext } from "./daemon/context.js";
 import { createAttach } from "./daemon/attach.js";
 import { createProbes, buildSurfaceProbe } from "./daemon/probes.js";
+import { createDelivery } from "./daemon/delivery.js";
 export type { CockpitdOpts } from "./daemon/context.js";
 export { defaultIsPidAlive } from "./daemon/context.js";
 import { startServer, encodeFrame, type AttachFrame, type AttachInbound } from "./protocol.js";
@@ -13,10 +14,9 @@ import { runHeadless } from "./headless-launcher.js";
 import { CodexInteractiveDriver, shouldReattachCodex } from "./codex/driver.js";
 import { OpencodeSseBridge } from "./opencode/sse-bridge.js";
 import { CmuxEventsBridge } from "./cmux/events-bridge.js";
-import { appendToMailbox, rotateIfNeeded, mailboxStats, readCursor, writeCursor, readFromCursor } from "./mailbox.js";
+import { rotateIfNeeded, mailboxStats, readCursor } from "./mailbox.js";
 import { createRelayHealer } from "./relay-healer.js";
 import { STALE_THRESHOLD_MS } from "../commands/notify-relay.js";
-import { CaptainDelivery } from "./delivery/captain-delivery.js";
 import { projectHealth, type ComponentHealth } from "./liveness.js";
 import { assembleDaemonSnapshot, type DaemonSnapshotInputs } from "./snapshot.js";
 import { loadConfig } from "@cockpit/shared";
@@ -43,7 +43,6 @@ const PKG_VERSION = readPkgVersion();
 const SNAPSHOT_LOG_WINDOW_MS = 60 * 60 * 1000; // count daemon-log errors in the last hour
 const CURSOR_SUBSCRIBER = "captain"; // the relay drains the mailbox as "captain" (#207)
 
-const CAPTAIN_GONE_STREAK_K = 3;
 export type ListSurfacesFn = (wsId: string) => Promise<PaneRef[]>;
 
 /**
@@ -155,42 +154,21 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   const ingest = (project: string) => (e: import("@cockpit/shared").ControlEvent) =>
     void d.handle({ kind: "event", project, event: e });
 
-  // Default push-notification wiring (mailbox-injector spec): the daemon
-  // appends a JSON entry to <stateRoot>/inbox/<project>.log. An injector
-  // process running inside the captain workspace tails the file from its
-  // cursor and delivers each entry to the captain pane. The daemon never
-  // shells out to cmux; the captain owns delivery. Tests inject a fake
-  // `notify` to assert call shape without exercising the mailbox path.
-  const defaultNotify = async (args: {
-    project: string;
-    message: string;
-    record: TaskRecord;
-    event: ControlEvent;
-  }): Promise<void> => {
-    try {
-      await appendToMailbox({
-        stateRoot,
-        project: args.project,
-        taskRecord: args.record,
-        event: args.event,
-        // Persist the daemon-rendered message (#214/#210): the relay delivers it
-        // verbatim instead of re-deriving from the raw event (which drifted).
-        message: args.message,
-      });
-    } catch (e) {
-      log(`mailbox append failed project=${args.project}: ${(e as Error).message}`);
-    }
-  };
-  const notify = opts.notify ?? defaultNotify;
-
   // #332: daemon-direct flag resolved here so both the surface-liveness probe
-  // (below) and the delivery loop (further down) agree on the same value.
+  // and the delivery loop agree on the same value.
   const daemonDirectCmux = opts.daemonDirectCmux ?? loadConfig().defaults?.daemonDirectCmux ?? false;
 
   // #332: construct DaemonCmux in production when the flag is ON but no
   // injectable was provided. The factory is overridable for tests.
   const daemonCmux = opts.daemonCmux
     ?? (daemonDirectCmux ? (opts.makeDaemonCmux ?? (() => new DaemonCmux(createCmuxDriver())))() : undefined);
+
+  // Set late-bound driver fields on ctx before createDelivery reads them.
+  ctx.daemonDirectCmux = daemonDirectCmux;
+  ctx.daemonCmux = daemonCmux;
+
+  const { defaultNotify, deliveryTick: initialDeliveryTick } = createDelivery(ctx, daemonCmux, daemonDirectCmux);
+  const notify = opts.notify ?? defaultNotify;
 
   const surfaceProbe = buildSurfaceProbe(ctx, probes, daemonDirectCmux, daemonCmux);
 
@@ -515,130 +493,14 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   });
   log(`started pid=${process.pid} sock=${sockPath} stateRoot=${stateRoot}`);
 
-  // #332: daemon-direct delivery loop — replaces relay EGRESS when flag ON.
-  // Each tick reads from the project's mailbox cursor and delivers via
-  // DaemonCmux + CaptainDelivery. Returns `tickDelivery` so tests can trigger
-  // it manually; in production the caller sets up an interval (or the CLU
-  // entrypoint below adds one).
-  let deliveryTick: (() => Promise<void>) | undefined;
+  // #332: daemon-direct delivery loop — see daemon/delivery.ts.
+  let deliveryTick: (() => Promise<void>) | undefined = initialDeliveryTick;
   let probeTick: (() => Promise<void>) | undefined;
 
   if (daemonDirectCmux && daemonCmux) {
-    const cmux = daemonCmux;
-    const cfg = loadConfig();
-    const deliveries = new Map<string, CaptainDelivery>();
-    // #332 storm BUG 3: captured once at delivery-loop setup. Entries older than
-    // sessionStartMs - STALE_THRESHOLD_MS are silently acked (cursor advanced)
-    // without delivery, mirroring the relay's drain(). This stops a fresh/empty
-    // cursor from re-delivering the entire historical backlog.
-    const sessionStartMs = Date.now();
-
-    // #332 storm BUG (re-entrancy): each tick does multiple slow cmux subprocess
-    // calls and can exceed the 1s interval, so the interval can fire again while
-    // the previous tick is still in-flight. Two overlapping ticks read the SAME
-    // cursor seq and both deliver the entries after it → duplicate/storm
-    // delivery. Mirror the relay's drain() `draining` guard: set on entry, clear
-    // in a finally, skip overlapping fires.
-    let delivering = false;
-
-    const deliveryCore = async () => {
-      const injectedSurfaces = opts.captainSurfaces ?? {};
-      const allProjects = [...new Set([
-        ...Object.keys(cfg.projects ?? {}),
-        ...Object.keys(injectedSurfaces),
-        ...store.listAll().map((t) => t.project),
-      ])];
-
-      for (const project of allProjects) {
-        const projCfg = cfg.projects?.[project];
-        const captainTitle = projCfg?.captainName ?? `${project}-captain`;
-
-        // Try real discovery from cmux.
-        const wsId = cmux.findWorkspaceId ? await cmux.findWorkspaceId(captainTitle) : null;
-        let surface: PaneRef | null = null;
-        let surfacesLength = 0;
-
-        if (wsId) {
-          const surfaces = await cmux.listSurfaces(wsId);
-          surfacesLength = surfaces.length;
-          surface = discoverCaptainSurface(surfaces, captainTitle);
-        }
-
-        // Fall back to injected surface (tests / config-less projects).
-        if (!surface) surface = injectedSurfaces[project] ?? null;
-
-        if (surface) {
-          // Captain found — if previously reaped, un-reap and reset streak so
-          // delivery resumes (a relaunched captain creates a new pane).
-          if (stoppedProjects.has(project)) {
-            stoppedProjects.delete(project);
-            captainMissingStreak.set(project, 0);
-          }
-          captainMissingStreak.set(project, 0);
-        } else {
-          // Streak tracking: surfaces.length > 0 means cmux is reachable but the
-          // captain's pane is provably absent. surfaces.length === 0 means cmux
-          // was unreachable (fail-soft → []), which we treat as "unknown" — never
-          // increment the streak (no false reaping on transient outages).
-          if (surfacesLength > 0) {
-            const streak = (captainMissingStreak.get(project) ?? 0) + 1;
-            captainMissingStreak.set(project, streak);
-            if (streak >= CAPTAIN_GONE_STREAK_K) {
-              // Fire the reap log exactly ONCE on the transition (only the first
-              // absent sweep past K). Do NOT re-fire on subsequent sweeps.
-              if (!stoppedProjects.has(project)) {
-                stoppedProjects.add(project);
-                log(`captain ${captainTitle}: surface gone for ${CAPTAIN_GONE_STREAK_K} sweeps — stopping delivery`);
-              }
-            }
-          }
-          continue;
-        }
-
-        const cursor = await readCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER });
-        const lastAcked = cursor?.lastAckedSeq ?? 0;
-        let d = deliveries.get(project);
-        if (!d) {
-          d = new CaptainDelivery({
-            maxDefers: cfg.relay?.maxDeferDeliveries ?? 300,
-            stableProbePolls: cfg.relay?.stableProbePolls ?? 3,
-          });
-          deliveries.set(project, d);
-        }
-        for await (const entry of readFromCursor({ stateRoot, project, fromSeq: lastAcked + 1 })) {
-          // #332 storm BUG 3: silently ack entries that pre-date this daemon
-          // session by more than STALE_THRESHOLD_MS — leftovers from dead crews
-          // or a prior captain session. Mirrors the relay's drain() skip so a
-          // fresh/empty cursor never re-delivers the historical backlog.
-          if (new Date(entry.ts).getTime() < sessionStartMs - STALE_THRESHOLD_MS) {
-            await writeCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER, lastAckedSeq: entry.seq });
-            continue;
-          }
-          const result = await d.deliver(entry, (text, sendOpts) =>
-            cmux.send(surface!, text, sendOpts),
-          );
-          if ("delivered" in result) {
-            await writeCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER, lastAckedSeq: entry.seq });
-          } else {
-            break;
-          }
-        }
-      }
-    };
-
-    deliveryTick = async () => {
-      if (delivering) return;
-      delivering = true;
-      try {
-        await deliveryCore();
-      } finally {
-        delivering = false;
-      }
-    };
-
     // #332: daemon-direct blocked-crew detection (probe-tick guard is inside
     // createProbes.buildInteractiveProbe so re-entrancy is handled there).
-    probeTick = probes.buildInteractiveProbe({ cmux });
+    probeTick = probes.buildInteractiveProbe({ cmux: daemonCmux });
   }
 
   // #332: production delivery interval (1s poll). Gated on sweepMs so tests

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -3,10 +3,7 @@ import { homedir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawn as realSpawn } from "node:child_process";
-import {
-  writeFileSync, mkdirSync, readFileSync, readdirSync, statSync,
-  openSync, readSync, closeSync,
-} from "node:fs";
+import { writeFileSync, mkdirSync, readFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { createStore } from "./store.js";
 import { createDaemon } from "./daemon.js";
@@ -22,7 +19,7 @@ import { createDirectSurfaceLivenessProbe, createDirectCrewPaneReader } from "./
 import { createInteractiveProbe, STALE_THRESHOLD_MS } from "../commands/notify-relay.js";
 import { CaptainDelivery } from "./delivery/captain-delivery.js";
 import { projectHealth, type ComponentHealth } from "./liveness.js";
-import { assembleDaemonSnapshot, type DaemonSnapshotInputs, type ResultArtifacts } from "./snapshot.js";
+import { assembleDaemonSnapshot, type DaemonSnapshotInputs } from "./snapshot.js";
 import { loadConfig } from "@cockpit/shared";
 import { readdir } from "node:fs/promises";
 import type { Gate, TaskRecord, ControlEvent } from "@cockpit/shared";
@@ -33,10 +30,10 @@ import { DaemonCmux } from "./cmux/daemon-cmux.js";
 import { ensureCmuxAutoConfig, type AutoConfigResult } from "@cockpit/shared";
 import { createCmuxDriver } from "../runtimes/index.js";
 import type { AgentDriver, OpencodeBridge, CmuxEventsBridge, DaemonSurfaceDriver } from "./interfaces.js";
+import { distBuiltAt, gatherLogStats, gatherStoreStats, gatherResults } from "./daemon/snapshot-gather.js";
 
-// This module's own compiled file — its mtime is the dist build-time used for
-// the Tier 0 build-freshness check (process start vs build time). package.json
-// (repo root) gives the running version. Both resolved once at load.
+// This module's own compiled file — its mtime is used in readPkgVersion() only.
+// distBuiltAt() now lives in daemon/snapshot-gather.ts.
 const SELF_PATH = fileURLToPath(import.meta.url);
 function readPkgVersion(): string {
   try {
@@ -111,82 +108,6 @@ export interface CockpitdOpts {
    *  inject a fake; in production it runs only when daemonDirectCmux is ON and
    *  not under vitest. See cmux-autoconfig.ts. */
   runCmuxAutoConfig?: () => Promise<AutoConfigResult>;
-}
-
-// ── Tier 0/2 snapshot gathering (I/O at the edge; the pure assembly lives in
-//    snapshot.ts). Each helper tolerates missing files and never throws. ───────
-
-/** mtime (epoch ms) of the running daemon's compiled code, for build-freshness. */
-function distBuiltAt(): number {
-  try { return statSync(SELF_PATH).mtimeMs; } catch { return 0; }
-}
-
-/** Daemon-log error count (last window) + total size. Reads only the tail so a
- *  large log never makes the snapshot tick expensive. */
-function gatherLogStats(path: string, now: number, windowMs: number): DaemonSnapshotInputs["log"] {
-  let sizeBytes = 0;
-  try { sizeBytes = statSync(path).size; }
-  catch { return { errorCount: 0, sizeBytes: 0, windowMs }; }
-  if (sizeBytes === 0) return { errorCount: 0, sizeBytes, windowMs };
-  const CAP = 256 * 1024;
-  const start = Math.max(0, sizeBytes - CAP);
-  const len = sizeBytes - start;
-  let text = "";
-  try {
-    const fd = openSync(path, "r");
-    try {
-      const buf = Buffer.alloc(len);
-      readSync(fd, buf, 0, len, start);
-      text = buf.toString("utf-8");
-    } finally { closeSync(fd); }
-  } catch { return { errorCount: 0, sizeBytes, windowMs }; }
-  const cutoff = now - windowMs;
-  let errorCount = 0;
-  for (const line of text.split("\n")) {
-    if (!/error|failed/i.test(line)) continue;
-    // Lines carry an ISO timestamp ("[cockpitd] 2026-... msg"); skip ones older
-    // than the window. Lines without a parseable timestamp are counted (conservative).
-    const m = line.match(/\d{4}-\d{2}-\d{2}T[\d:.]+Z/);
-    if (m) { const ts = Date.parse(m[0]); if (!Number.isNaN(ts) && ts < cutoff) continue; }
-    errorCount++;
-  }
-  return { errorCount, sizeBytes, windowMs };
-}
-
-/** Per-project store state counts + corrupt/quarantined file count. */
-function gatherStoreStats(
-  store: { list: (p: string) => TaskRecord[] },
-  stateRoot: string,
-  project: string,
-): { byState: Record<string, number>; corruptCount: number } {
-  const byState: Record<string, number> = {};
-  for (const r of store.list(project)) byState[r.state] = (byState[r.state] ?? 0) + 1;
-  let corruptCount = 0;
-  const dir = join(stateRoot, project);
-  try {
-    for (const n of readdirSync(dir)) {
-      if (n.includes(".corrupt.")) { corruptCount++; continue; }
-      if (!n.endsWith(".json")) continue;
-      try { JSON.parse(readFileSync(join(dir, n), "utf-8")); }
-      catch { corruptCount++; }
-    }
-  } catch { /* no project dir yet */ }
-  return { byState, corruptCount };
-}
-
-/** Global _results/ artifact count + total bytes (unbounded-growth watch). */
-function gatherResults(resultsDir: string): ResultArtifacts {
-  let fileCount = 0;
-  let totalBytes = 0;
-  try {
-    for (const n of readdirSync(resultsDir)) {
-      try {
-        const s = statSync(join(resultsDir, n));
-        if (s.isFile()) { fileCount++; totalBytes += s.size; }
-      } catch { /* vanished mid-scan */ }
-    }
-  } catch { /* no results dir */ }
-  return { fileCount, totalBytes };
 }
 
 const CAPTAIN_GONE_STREAK_K = 3;

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -1,39 +1,25 @@
-// src/control/cockpitd.ts
+// src/control/cockpitd.ts — host: constructs concrete drivers + thin shim.
+// All daemon logic lives in daemon/start.ts; this file owns only the
+// concrete class instantiation and the launchd entry guard.
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { readFileSync } from "node:fs";
-import { createDaemon } from "./daemon.js";
 import { buildContext } from "./daemon/context.js";
 import { createAttach } from "./daemon/attach.js";
-import { createProbes, buildSurfaceProbe } from "./daemon/probes.js";
-import { createDelivery } from "./daemon/delivery.js";
-import { createGateResolver } from "./daemon/gates.js";
-import { createServer } from "./daemon/server.js";
+import { startDaemon } from "./daemon/start.js";
 export type { CockpitdOpts } from "./daemon/context.js";
 export { defaultIsPidAlive } from "./daemon/context.js";
 import type { AttachFrame } from "./protocol.js";
 import { runHeadless } from "./headless-launcher.js";
-import { CodexInteractiveDriver, shouldReattachCodex } from "./codex/driver.js";
+import { CodexInteractiveDriver } from "./codex/driver.js";
 import { OpencodeSseBridge } from "./opencode/sse-bridge.js";
 import { CmuxEventsBridge } from "./cmux/events-bridge.js";
-import { rotateIfNeeded, mailboxStats, readCursor } from "./mailbox.js";
 import { createRelayHealer } from "./relay-healer.js";
-import { STALE_THRESHOLD_MS } from "../commands/notify-relay.js";
-import { projectHealth, type ComponentHealth } from "./liveness.js";
-import type { DaemonSnapshotInputs } from "./snapshot.js";
-import { loadConfig } from "@cockpit/shared";
-import { readdir } from "node:fs/promises";
-import type { TaskRecord, ControlEvent } from "@cockpit/shared";
-import { TERMINAL_STATES } from "@cockpit/shared";
-import type { Socket } from "node:net";
+import { loadConfig, TERMINAL_STATES } from "@cockpit/shared";
 import type { PaneRef } from "../runtimes/types.js";
 import { DaemonCmux } from "./cmux/daemon-cmux.js";
-import { ensureCmuxAutoConfig, type AutoConfigResult } from "@cockpit/shared";
 import { createCmuxDriver } from "../runtimes/index.js";
-import { distBuiltAt, gatherLogStats, gatherStoreStats, gatherResults } from "./daemon/snapshot-gather.js";
 
-// This module's own compiled file — its mtime is used in readPkgVersion() only.
-// distBuiltAt() now lives in daemon/snapshot-gather.ts.
 const SELF_PATH = fileURLToPath(import.meta.url);
 function readPkgVersion(): string {
   try {
@@ -42,450 +28,108 @@ function readPkgVersion(): string {
   } catch { return "unknown"; }
 }
 const PKG_VERSION = readPkgVersion();
-const SNAPSHOT_LOG_WINDOW_MS = 60 * 60 * 1000; // count daemon-log errors in the last hour
-const CURSOR_SUBSCRIBER = "captain"; // the relay drains the mailbox as "captain" (#207)
 
 export type ListSurfacesFn = (wsId: string) => Promise<PaneRef[]>;
 
 /**
  * Pure: search a list of surfaces for one whose title matches the captain name.
- * Part of #332 daemon-direct captain-surface discovery (Task 5).
+ * Part of #332 daemon-direct captain-surface discovery.
  */
 export function discoverCaptainSurface(surfaces: PaneRef[], captainTitle: string): PaneRef | null {
   return surfaces.find((s) => s.title === captainTitle) ?? null;
 }
 
-export function startCockpitd(opts: CockpitdOpts = {}) {
+export function startCockpitd(opts: import("./daemon/context.js").CockpitdOpts = {}) {
   const ctx = buildContext(opts);
-  const {
-    stateRoot, sockPath, store, log, isPidAlive, spawn, resultsDir, writeResult,
-    taskTimeoutMs, attachConns, pendingProbes, probeResults, inFlightProbes,
-    inFlightHeadlessIds, activeHeadlessKills, captainMissingStreak, stoppedProjects,
-  } = ctx;
-  const bootedAt = ctx.bootedAt;
-
-  const probes = createProbes(ctx);
+  const { stateRoot, store, log, spawn, writeResult, inFlightHeadlessIds, activeHeadlessKills } = ctx;
 
   const { broadcast, schedulePromotion, cancelPromotionsFor } = createAttach(ctx);
   ctx.broadcast = broadcast;
   ctx.schedulePromotion = schedulePromotion;
   ctx.cancelPromotionsFor = cancelPromotionsFor;
 
-  // ── CodexInteractiveDriver singleton ─────────────────────────────────────
-  // The driver holds the single AppServerClient child. Each task maps to a
-  // thread inside that child. Events emitted here (a) update the state-machine
-  // via daemon.handle and (b) broadcast streaming AttachFrames to cmux clients.
+  // ── Concrete driver construction ──────────────────────────────────────────
+  // Emit callbacks close over ctx lazily: ctx.d, ctx.broadcast, and
+  // ctx.schedulePromotion are late-bound by startDaemon before any emit fires.
+
   const codexDriver = opts.codexDriver ?? new CodexInteractiveDriver({
     emit: (ev) => {
-      // Resolve the project so we can call daemon.handle with {kind:"event"}.
-      // store.listAll() is O(tasks) but tasks are few; acceptable for events.
-      const found = store.listAll().find((r) => r.id === ev.id);
+      const found = ctx.store.listAll().find((r) => r.id === ev.id);
       if (!found) return;
-      void d.handle({ kind: "event", project: found.project, event: ev });
-
-      // Map ControlEvent → AttachFrame and broadcast to any attached cmux clients.
+      void ctx.d.handle({ kind: "event", project: found.project, event: ev });
       if (ev.type === "task.delta")
-        broadcast(ev.id, { type: "delta", taskId: ev.id, text: ev.chunk });
+        ctx.broadcast(ev.id, { type: "delta", taskId: ev.id, text: ev.chunk } as AttachFrame);
       else if (ev.type === "task.turn.started")
-        broadcast(ev.id, { type: "turn-started", taskId: ev.id });
+        ctx.broadcast(ev.id, { type: "turn-started", taskId: ev.id } as AttachFrame);
       else if (ev.type === "task.turn.completed")
-        broadcast(ev.id, { type: "turn-completed", taskId: ev.id });
+        ctx.broadcast(ev.id, { type: "turn-completed", taskId: ev.id } as AttachFrame);
       else if (ev.type === "task.input.requested") {
-        broadcast(ev.id, { type: "input-requested", taskId: ev.id, requestId: ev.requestId, question: ev.question });
-        schedulePromotion(ev.id, ev.requestId, "input", ev.question);
+        ctx.broadcast(ev.id, { type: "input-requested", taskId: ev.id, requestId: ev.requestId, question: ev.question } as AttachFrame);
+        ctx.schedulePromotion(ev.id, ev.requestId, "input", ev.question);
       } else if (ev.type === "task.approval.requested") {
-        broadcast(ev.id, { type: "approval-requested", taskId: ev.id, requestId: ev.requestId, question: ev.question, kind: ev.kind });
-        schedulePromotion(ev.id, ev.requestId, "approval", ev.question);
-      }
-      else if (ev.type === "task.reattached")
-        broadcast(ev.id, { type: "reattached", taskId: ev.id });
+        ctx.broadcast(ev.id, { type: "approval-requested", taskId: ev.id, requestId: ev.requestId, question: ev.question, kind: ev.kind } as AttachFrame);
+        ctx.schedulePromotion(ev.id, ev.requestId, "approval", ev.question);
+      } else if (ev.type === "task.reattached")
+        ctx.broadcast(ev.id, { type: "reattached", taskId: ev.id } as AttachFrame);
     },
   });
 
-  // ── Opencode SSE bridge ───────────────────────────────────────────────────
-  // Interactive opencode crews launch as `opencode --port <N>`; this bridge
-  // subscribes to each crew's /event stream and maps `session.idle` →
-  // task.turn.completed so the daemon learns turn-end without the crew shelling
-  // out to cockpit. emit resolves the project from the store (events carry only
-  // the task id), mirroring the codexDriver emit above.
   const opencodeBridge = opts.opencodeBridge ?? new OpencodeSseBridge({
     emit: (ev) => {
       const found = store.listAll().find((r) => r.id === ev.id);
       if (!found) return;
-      void d.handle({ kind: "event", project: found.project, event: ev });
-      // CP3: a gated permission must become a resolvable gate so the captain can
-      // approve/deny via `crew reply --gate`. Opencode crews never attach a
-      // renderer (no `crew attach`), so schedulePromotion always fires after the
-      // grace window — mirroring the codex emit hook below.
-      if (ev.type === "task.approval.requested") {
-        schedulePromotion(ev.id, ev.requestId, "approval", ev.question);
-      }
+      void ctx.d.handle({ kind: "event", project: found.project, event: ev });
+      if (ev.type === "task.approval.requested")
+        ctx.schedulePromotion(ev.id, ev.requestId, "approval", ev.question);
     },
     log,
   });
 
-  // B1: cmux native-events bridge. ADDITIVE — runs alongside the relay-proxy /
-  // pane-reader scrape path, which stays as the fallback. A single global
-  // `cmux events` subscription maps each crew's `agent.hook.Stop` (turn-end /
-  // idle) to task.turn.completed, correlating the frame's cwd to a non-terminal
-  // interactive record (each crew runs in a unique worktree path). The reducer
-  // absorbs duplicate/late turn.completed, so feeding it from both paths is safe.
-  const cmuxEventsBridge =
-    opts.cmuxEventsBridge ??
-    new CmuxEventsBridge({
-      emit: (ev) => {
-        const found = store.listAll().find((r) => r.id === ev.id);
-        if (!found) return;
-        void d.handle({ kind: "event", project: found.project, event: ev });
-      },
-      resolve: (hook) => {
-        if (!hook.cwd) return undefined;
-        return store
-          .listAll()
-          .find(
-            (r) =>
-              r.mode === "interactive" &&
-              !TERMINAL_STATES.has(r.state) &&
-              r.cwd === hook.cwd,
-          );
-      },
-      cursorFile: join(stateRoot, "cmux-events.seq"),
-      log,
-    });
+  const cmuxEventsBridge = opts.cmuxEventsBridge ?? new CmuxEventsBridge({
+    emit: (ev) => {
+      const found = store.listAll().find((r) => r.id === ev.id);
+      if (!found) return;
+      void ctx.d.handle({ kind: "event", project: found.project, event: ev });
+    },
+    resolve: (hook) => {
+      if (!hook.cwd) return undefined;
+      return store.listAll().find(
+        (r) => r.mode === "interactive" && !TERMINAL_STATES.has(r.state) && r.cwd === hook.cwd,
+      );
+    },
+    cursorFile: join(stateRoot, "cmux-events.seq"),
+    log,
+  });
 
-  // Set late-bound driver fields so daemon/* modules (gates.ts, server.ts) can
-  // reference them lazily via ctx at call time.
   ctx.codexDriver = codexDriver;
   ctx.opencodeBridge = opencodeBridge;
   ctx.cmuxEventsBridge = cmuxEventsBridge;
 
-  const ingest = (project: string) => (e: import("@cockpit/shared").ControlEvent) =>
-    void d.handle({ kind: "event", project, event: e });
-
-  // #332: daemon-direct flag resolved here so both the surface-liveness probe
-  // and the delivery loop agree on the same value.
+  // ── daemonCmux resolution ─────────────────────────────────────────────────
   const daemonDirectCmux = opts.daemonDirectCmux ?? loadConfig().defaults?.daemonDirectCmux ?? false;
-
-  // #332: construct DaemonCmux in production when the flag is ON but no
-  // injectable was provided. The factory is overridable for tests.
   const daemonCmux = opts.daemonCmux
     ?? (daemonDirectCmux ? (opts.makeDaemonCmux ?? (() => new DaemonCmux(createCmuxDriver())))() : undefined);
-
-  // Set late-bound driver fields on ctx before createDelivery reads them.
   ctx.daemonDirectCmux = daemonDirectCmux;
   ctx.daemonCmux = daemonCmux;
 
-  const { defaultNotify, deliveryTick: initialDeliveryTick } = createDelivery(ctx, daemonCmux, daemonDirectCmux);
-  const notify = opts.notify ?? defaultNotify;
-
-  const surfaceProbe = buildSurfaceProbe(ctx, probes, daemonDirectCmux, daemonCmux);
-
-  const d = createDaemon({
-    store, now: () => Date.now(), isPidAlive, notify, taskTimeoutMs,
-    // #139 backstop: terminalize interactive crews whose cmux pane is provably
-    // gone (sweep/reconcile reaper). Three-valued; "unknown" never reaps.
-    isSurfaceAlive: surfaceProbe,
-    // #207 best-effort relay heal on the sweep (secondary — surface is primary).
-    healRelay: opts.healRelay ?? createRelayHealer(log),
-    launchHeadless: opts.launchHeadless ?? (async (rec) => {
-      const handle = runHeadless({
-        provider: rec.provider, task: rec.task, id: rec.id, sessionId: rec.sessionId,
-        cwd: rec.cwd, spawn, emit: ingest(rec.project), writeResult,
-      });
-      inFlightHeadlessIds.add(rec.id); // #259: mark in-flight before pid is set
-      activeHeadlessKills.add(handle.kill);
-      try { await handle.result; } finally {
-        inFlightHeadlessIds.delete(rec.id);
-        activeHeadlessKills.delete(handle.kill);
-      }
-    }),
-    isHeadlessInFlight: (id) => inFlightHeadlessIds.has(id),
-    launchInteractive: async (rec) => {
-      if (rec.provider === "codex") {
-        await codexDriver.dispatch(rec as any);
-        return;
-      }
-      if (rec.provider === "claude") {
-        // Claude interactive crews run in a cmux tab — the daemon does NOT
-        // own a Claude process. The tab does the actual launch. The daemon's
-        // only role for Claude is the state ledger: emit task.started so the
-        // record transitions submitted → working, then wait for task.progress
-        // / task.done events from the injected hook bridge + explicit
-        // `cockpit crew signal` (see claude-interactive spec, §4.4).
-        ingest(rec.project)({ type: "task.started", id: rec.id });
-        return;
-      }
-      if (rec.provider === "opencode") {
-        // Opencode interactive crews run in a cmux tab — same approach as
-        // claude. The daemon owns the state ledger, not the process. Emit
-        // task.started so the record transitions submitted → working. Terminal
-        // state still comes from explicit `cockpit crew signal` in the template;
-        // the SSE bridge (when serverPort is set) adds reliable turn-end
-        // (idle) detection on top so the daemon isn't stuck at "working".
-        ingest(rec.project)({ type: "task.started", id: rec.id });
-        if (rec.serverPort) opencodeBridge.start({ taskId: rec.id, port: rec.serverPort });
-        return;
-      }
-      throw new Error(
-        `interactive mode is not yet implemented for provider '${rec.provider}'; only 'codex', 'claude', and 'opencode' are supported`,
-      );
-    },
-    resolveInteractiveGate: createGateResolver(ctx),
+  // ── launchHeadless default ────────────────────────────────────────────────
+  // Kept here so this file is the sole importer of headless-launcher (daemon/* can't).
+  const launchHeadless = opts.launchHeadless ?? (async (rec) => {
+    const ingest = (e: import("@cockpit/shared").ControlEvent) =>
+      void ctx.d.handle({ kind: "event", project: rec.project, event: e });
+    const handle = runHeadless({
+      provider: rec.provider, task: rec.task, id: rec.id, sessionId: rec.sessionId,
+      cwd: rec.cwd, spawn, emit: ingest, writeResult,
+    });
+    inFlightHeadlessIds.add(rec.id);
+    activeHeadlessKills.add(handle.kill);
+    try { await handle.result; } finally {
+      inFlightHeadlessIds.delete(rec.id);
+      activeHeadlessKills.delete(handle.kill);
+    }
   });
 
-  ctx.d = d; // late-bind so daemon/* closures that reference ctx.d resolve correctly
-
-  // #77 service-health surface. Assembles per-component liveness for the health
-  // socket verb: relay map from the daemon, captain liveness from relay heartbeat
-  // (#239 Phase A — cmux probe removed; launchd lineage denies it), crews from
-  // the store — all fed into the pure projectHealth().
-  function buildHealth(only?: string): ComponentHealth[] {
-    const config = loadConfig();
-    const relays = d.getRelayHealth();
-    const now = Date.now();
-    // Projects known from config ∪ relay registrations ∪ active tasks, so a
-    // registered-but-unconfigured relay (or a crew) still surfaces.
-    const known = new Set<string>([
-      ...Object.keys(config.projects),
-      ...relays.map((r) => r.project),
-      ...store.listAll().map((t) => t.project),
-    ]);
-    const names = only ? [only] : [...known];
-    const out: ComponentHealth[] = [];
-    for (const project of names) {
-      const proj = config.projects[project];
-      const captainName = proj?.captainName ?? `${project}-captain`;
-      out.push(
-        ...projectHealth({
-          project,
-          now,
-          captainName,
-          relay: relays.find((r) => r.project === project) ?? null,
-          commandPresent: null, // command is on-demand; not tracked in this cut
-          crews: store.list(project),
-        }),
-      );
-    }
-    return out;
-  }
-
-  // #44 dashboard: the same project set buildHealth() covers (config ∪ relays ∪ tasks).
-  function knownProjects(): string[] {
-    const config = loadConfig();
-    return [...new Set<string>([
-      ...Object.keys(config.projects),
-      ...d.getRelayHealth().map((r) => r.project),
-      ...store.listAll().map((t) => t.project),
-    ])];
-  }
-
-  // #44 dashboard: gather all Tier 0/1/2 inputs (I/O) for the read-only snapshot
-  // verb, then hand them to the pure assembler. The daemon log lives next to the
-  // state root (~/.config/cockpit/cockpitd.log); deriving it from stateRoot keeps
-  // tests isolated to their temp dir.
-  async function gatherSnapshotInputs(now: number): Promise<DaemonSnapshotInputs> {
-    const logPath = join(dirname(stateRoot), "cockpitd.log");
-    // Scope Tier 2 per-project data to registered projects only. Orphan state
-    // directories from removed/test projects are excluded here.
-    const tier2Projects = opts.registeredProjects ?? Object.keys(loadConfig().projects);
-    const projects = await Promise.all(
-      tier2Projects.map(async (project) => {
-        const cursor = await readCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER });
-        const storeStats = gatherStoreStats(store, stateRoot, project);
-        return {
-          project,
-          mailbox: await mailboxStats(stateRoot, project),
-          lastAckedSeq: cursor?.lastAckedSeq ?? 0,
-          storeByState: storeStats.byState,
-          corruptCount: storeStats.corruptCount,
-        };
-      }),
-    );
-    return {
-      pid: process.pid,
-      processStartedAt: bootedAt,
-      version: PKG_VERSION,
-      distBuiltAt: distBuiltAt(),
-      lastSweepAt: ctx.lastSweepAt.value,
-      sweepCadenceMs: opts.sweepMs ?? 30_000,
-      log: gatherLogStats(logPath, now, SNAPSHOT_LOG_WINDOW_MS),
-      health: buildHealth(),
-      projects,
-      results: gatherResults(resultsDir),
-    };
-  }
-
-  // Crash recovery on boot. reconcile() is async (#139: it consults the
-  // interactive surface-liveness probe to reap dead crews instead of stalling
-  // them), so run it — and the reattach loops that depend on its terminalizing a
-  // dead crew before we re-subscribe it — inside an async IIFE. startCockpitd
-  // stays synchronous (returns the handle immediately); boot recovery settles
-  // shortly after. Errors are swallowed: a flaky probe must not crash boot.
-  void (async () => {
-    try {
-      await d.reconcile();
-    } catch (e) {
-      log(`reconcile on boot failed: ${(e as Error).message}`);
-    }
-
-    // Restart-reattach (spec §5; closes interactive slice of #86):
-    // For each LIVE interactive-codex task that has a resumeRef, fire reattach()
-    // against the driver. Fire-and-forget; failures are logged only.
-    //
-    // Guard against the reattach storm: resuming a thread re-spawns its per-thread
-    // MCP servers (gitnexus/pay), so blindly reattaching every non-terminal codex
-    // task means each daemon restart re-spawns one MCP set per HISTORICAL crew —
-    // which exhausted RAM (22 zombie tasks → 22 gitnexus servers on one boot).
-    // Skip terminal tasks (done/failed/cancelled — incl. crews closed via the new
-    // codex-close archive AND #139's surface-reaped crews) AND stale tasks whose
-    // crew pane is long gone (no heartbeat within the staleness window).
-    const bootNow = Date.now();
-    const REATTACH_STALE_MS = 10 * 60_000;
-    for (const rec of store.listAll()) {
-      if (!shouldReattachCodex(rec, bootNow, REATTACH_STALE_MS)) continue;
-      codexDriver.reattach(rec).catch((e: unknown) => {
-        log(`reattach failed for ${rec.id}: ${(e as Error).message}`);
-      });
-    }
-
-    // Re-subscribe the opencode SSE bridge after a daemon bounce: the crew's
-    // cmux pane (and its `opencode --port <N>` server) survives a daemon restart,
-    // so a non-terminal opencode crew with a known serverPort can be re-attached.
-    for (const rec of store.listAll()) {
-      if (rec.provider !== "opencode" || rec.mode !== "interactive") continue;
-      if (TERMINAL_STATES.has(rec.state)) continue;
-      if (!rec.serverPort) continue;
-      opencodeBridge.start({ taskId: rec.id, port: rec.serverPort });
-    }
-
-    // B1: start the single cmux native-events subscription (additive; the scrape
-    // fallback is unaffected). Opt out via defaults.cmuxEventsBridge:false. The
-    // REAL (non-injected) bridge is skipped under vitest so daemon tests never
-    // spawn a real `cmux events` child; an injected fake always starts so the
-    // wiring stays testable.
-    const enableCmuxEvents = loadConfig().defaults.cmuxEventsBridge !== false;
-    const cmuxEventsSafe = !!opts.cmuxEventsBridge || !process.env.VITEST;
-    if (enableCmuxEvents && cmuxEventsSafe) {
-      try { cmuxEventsBridge.start(); } catch (e) { log(`cmux events bridge start failed: ${(e as Error).message}`); }
-    }
-
-    // #348: when daemon-direct is opt-in ON, ensure the cmux socket auto-config
-    // (comment-preserving write + non-cmux probe) on every boot. Idempotent, and
-    // it recovers the "cmux not running at first write" edge case (§3.4 / §4.4):
-    // the next boot re-probes once cmux is (re)launched. Gated on the flag so it's
-    // a no-op under the relay default; skipped under vitest unless injected so
-    // daemon tests never touch the real cmux.json or spawn the orphan probe.
-    const autoConfigSafe = !!opts.runCmuxAutoConfig || !process.env.VITEST;
-    if (daemonDirectCmux && autoConfigSafe) {
-      try {
-        const r = await (opts.runCmuxAutoConfig ?? ensureCmuxAutoConfig)();
-        if (r.configChanged) log(`cmux autoconfig: wrote automation socket mode to ${r.configPath}`);
-        if (r.needsRestart && r.promptedThisRun) {
-          log("cmux autoconfig: socket still rejects the daemon — restart cmux to enable daemon-direct delivery");
-        }
-      } catch (e) {
-        log(`cmux autoconfig failed: ${(e as Error).message}`);
-      }
-    }
-  })();
-
-  const server = createServer(ctx, {
-    buildHealth,
-    gatherSnapshotInputs,
-    cancelPromotionsFor,
-    broadcast,
-  });
-  log(`started pid=${process.pid} sock=${sockPath} stateRoot=${stateRoot}`);
-
-  // #332: daemon-direct delivery loop — see daemon/delivery.ts.
-  let deliveryTick: (() => Promise<void>) | undefined = initialDeliveryTick;
-  let probeTick: (() => Promise<void>) | undefined;
-
-  if (daemonDirectCmux && daemonCmux) {
-    // #332: daemon-direct blocked-crew detection (probe-tick guard is inside
-    // createProbes.buildInteractiveProbe so re-entrancy is handled there).
-    probeTick = probes.buildInteractiveProbe({ cmux: daemonCmux });
-  }
-
-  // #332: production delivery interval (1s poll). Gated on sweepMs so tests
-  // with sweepMs:0 avoid a real timer. The interval is always fire-and-forget so
-  // a slow tick never stacks.
-  let deliveryTimer: NodeJS.Timeout | undefined;
-  if (daemonDirectCmux && daemonCmux && opts.sweepMs && opts.sweepMs > 0) {
-    deliveryTimer = setInterval(() => {
-      void deliveryTick!().catch((e: unknown) => log(`delivery tick error: ${(e as Error).message}`));
-    }, 1000);
-    deliveryTimer.unref?.();
-  }
-
-  // #332: blocked-crew probe interval (10s). Same gate as delivery interval.
-  let probeTimer: NodeJS.Timeout | undefined;
-  if (daemonDirectCmux && daemonCmux && opts.sweepMs && opts.sweepMs > 0) {
-    probeTimer = setInterval(() => {
-      void probeTick!().catch((e: unknown) => log(`probe tick error: ${(e as Error).message}`));
-    }, 10_000);
-    probeTimer.unref?.();
-  }
-
-  let timer: NodeJS.Timeout | undefined;
-  if (opts.sweepMs && opts.sweepMs > 0) {
-    // sweep() is async (#139: it probes cmux surface liveness). Guard against an
-    // overlapping run if a probe is slow — skip this tick rather than stacking
-    // sweeps. Errors are swallowed so a flaky probe never crashes the daemon.
-    let sweeping = false;
-    timer = setInterval(() => {
-      if (sweeping) return;
-      sweeping = true;
-      ctx.lastSweepAt.value = Date.now(); // Tier 0 observability: time of the most recent sweep
-      void d.sweep()
-        .catch((e: unknown) => log(`sweep failed: ${(e as Error).message}`))
-        .finally(() => { sweeping = false; });
-    }, opts.sweepMs);
-    timer.unref?.();
-  }
-
-  const rotationInterval = opts.rotationIntervalMs ?? 60_000;
-  const mboxCfg = {
-    maxBytes: opts.mailboxConfig?.maxBytes ?? 5 * 1024 * 1024,
-    maxAgeMs: opts.mailboxConfig?.maxAgeMs ?? 7 * 24 * 60 * 60 * 1000,
-    keepCount: opts.mailboxConfig?.keepCount ?? 3,
-  };
-  let rotationTimer: NodeJS.Timeout | undefined;
-  if (rotationInterval > 0) {
-    const inboxPath = join(stateRoot, "inbox");
-    rotationTimer = setInterval(async () => {
-      try {
-        let entries: string[];
-        try { entries = await readdir(inboxPath); }
-        catch { return; }
-        const projects = new Set(
-          entries
-            .filter((e) => e.endsWith(".log"))
-            .map((e) => e.slice(0, -".log".length)),
-        );
-        for (const project of projects) {
-          await rotateIfNeeded({ stateRoot, project, ...mboxCfg });
-        }
-      } catch (e) {
-        log(`rotation timer error: ${(e as Error).message}`);
-      }
-    }, rotationInterval);
-    rotationTimer.unref?.();
-  }
-
-  return {
-    stop(): Promise<void> {
-      if (deliveryTimer) clearInterval(deliveryTimer);
-      if (probeTimer) clearInterval(probeTimer);
-      if (timer) clearInterval(timer);
-      if (rotationTimer) clearInterval(rotationTimer);
-      try { cmuxEventsBridge.stop(); } catch { /* best-effort */ }
-      for (const kill of activeHeadlessKills) kill();
-      return new Promise<void>((resolve) => server.close(() => { log("stopped"); resolve(); }));
-    },
-    tickDelivery: deliveryTick,
-    tickProbe: probeTick,
-  };
+  return startDaemon(ctx, { ...opts, launchHeadless, healRelay: opts.healRelay ?? createRelayHealer(log) }, PKG_VERSION);
 }
 
 // Executed by launchd (ProgramArguments → this file's compiled .js).

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -1,12 +1,12 @@
 // src/control/cockpitd.ts
-import { homedir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { spawn as realSpawn } from "node:child_process";
-import { writeFileSync, mkdirSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
-import { createStore } from "./store.js";
 import { createDaemon } from "./daemon.js";
+import { buildContext } from "./daemon/context.js";
+export type { CockpitdOpts } from "./daemon/context.js";
+export { defaultIsPidAlive } from "./daemon/context.js";
 import { startServer, encodeFrame, type AttachFrame, type AttachInbound } from "./protocol.js";
 import { runHeadless } from "./headless-launcher.js";
 import { CodexInteractiveDriver, shouldReattachCodex } from "./codex/driver.js";
@@ -29,7 +29,6 @@ import type { PaneRef } from "../runtimes/types.js";
 import { DaemonCmux } from "./cmux/daemon-cmux.js";
 import { ensureCmuxAutoConfig, type AutoConfigResult } from "@cockpit/shared";
 import { createCmuxDriver } from "../runtimes/index.js";
-import type { AgentDriver, OpencodeBridge, CmuxEventsBridge, DaemonSurfaceDriver } from "./interfaces.js";
 import { distBuiltAt, gatherLogStats, gatherStoreStats, gatherResults } from "./daemon/snapshot-gather.js";
 
 // This module's own compiled file — its mtime is used in readPkgVersion() only.
@@ -45,71 +44,6 @@ const PKG_VERSION = readPkgVersion();
 const SNAPSHOT_LOG_WINDOW_MS = 60 * 60 * 1000; // count daemon-log errors in the last hour
 const CURSOR_SUBSCRIBER = "captain"; // the relay drains the mailbox as "captain" (#207)
 
-export interface CockpitdOpts {
-  stateRoot?: string;
-  sockPath?: string;
-  sweepMs?: number; // 0 disables the interval (tests)
-  isPidAlive?: (pid: number) => boolean; // injectable for the headless reconcile path (tests)
-  // injectable for the #139 interactive surface-liveness reaper (tests); defaults
-  // to the real cmux probe. Returns "alive" | "gone" | "unknown".
-  isSurfaceAlive?: (rec: TaskRecord) => Promise<"alive" | "gone" | "unknown">;
-  spawn?: typeof realSpawn;
-  /**
-   * Push-notification hook (#109). Defaults to appending a structured event
-   * to the mailbox file at <stateRoot>/inbox/<project>.log; an injector
-   * process inside the captain workspace tails the file and delivers entries
-   * to the captain pane. Tests inject a fake to assert call shape.
-   */
-  notify?: (args: {
-    project: string;
-    message: string;
-    record: TaskRecord;
-    event: ControlEvent;
-  }) => Promise<void> | void;
-  /** Background rotation timer interval (ms). 0 disables. Default 60_000. */
-  rotationIntervalMs?: number;
-  /** Mailbox rotation thresholds (size/age/retention). */
-  mailboxConfig?: {
-    maxBytes?: number;
-    maxAgeMs?: number;
-    keepCount?: number;
-  };
-  /** Inject a fake driver for tests. Defaults to a real CodexInteractiveDriver. */
-  codexDriver?: AgentDriver;
-  /** #207 best-effort relay healer. Defaults to a real cmux spawnInjector
-   *  re-spawn (mostly inert under launchd). Tests inject a fake/spy. */
-  healRelay?: (project: string) => Promise<void> | void;
-  /** Inject a fake headless launcher for tests to avoid real process spawns. */
-  launchHeadless?: (rec: TaskRecord) => Promise<void>;
-  /** Override which projects appear in the Tier 2 per-project snapshot. Defaults
-   *  to Object.keys(loadConfig().projects). Tests inject this to avoid real config. */
-  registeredProjects?: string[];
-  /** Inject a fake opencode SSE bridge for tests. Defaults to a real one. */
-  opencodeBridge?: OpencodeBridge;
-  /** B1: inject a fake cmux events bridge for tests. Defaults to a real one
-   *  (gated on defaults.cmuxEventsBridge). */
-  cmuxEventsBridge?: CmuxEventsBridge;
-  /** #332: inject a fake DaemonCmux for testing daemon-direct delivery. When
-   *  absent and daemonDirectCmux is ON, a real cmux driver is created. */
-  daemonCmux?: DaemonSurfaceDriver | DaemonCmux;
-  /** #332: factory for constructing DaemonCmux in production when daemonCmux
-   *  is not injected. Defaults to () => new DaemonCmux(createCmuxDriver()).
-   *  Tests inject this to avoid real cmux. */
-  makeDaemonCmux?: () => DaemonCmux;
-  /** #332: override for daemonDirectCmux flag (bypasses config file load).
-   *  When true and daemonCmux is provided/injected, runs the daemon-direct
-   *  delivery loop instead of relying on the notify-relay. */
-  daemonDirectCmux?: boolean;
-  /** #332: injected captain-surface mapping (project → PaneRef) for the
-   *  daemon-direct delivery loop. Used as fallback when real discovery (Task 5)
-   *  returns no surface (e.g. cmux not reachable or captain not yet running). */
-  captainSurfaces?: Record<string, PaneRef>;
-  /** #348: override the cmux socket auto-config re-check (write+probe). Tests
-   *  inject a fake; in production it runs only when daemonDirectCmux is ON and
-   *  not under vitest. See cmux-autoconfig.ts. */
-  runCmuxAutoConfig?: () => Promise<AutoConfigResult>;
-}
-
 const CAPTAIN_GONE_STREAK_K = 3;
 export type ListSurfacesFn = (wsId: string) => Promise<PaneRef[]>;
 
@@ -121,54 +55,14 @@ export function discoverCaptainSurface(surfaces: PaneRef[], captainTitle: string
   return surfaces.find((s) => s.title === captainTitle) ?? null;
 }
 
-export function defaultIsPidAlive(pid: number): boolean {
-  try { process.kill(pid, 0); return true; }
-  catch (e: any) { return e?.code === "EPERM"; } // EPERM = alive but not ours; ESRCH = dead
-}
-
 export function startCockpitd(opts: CockpitdOpts = {}) {
-  const stateRoot = opts.stateRoot ?? join(homedir(), ".config", "cockpit", "state");
-  const sockPath = opts.sockPath ?? join(homedir(), ".config", "cockpit", "cockpit.sock");
-  const store = createStore(stateRoot);
-  // #44 dashboard: process start-time (for uptime + build-freshness) and the
-  // timestamp of the most recent sweep (Tier 0 "sweep last Ns ago").
-  const bootedAt = Date.now();
-  let lastSweepAt: number | null = null;
-  // #225: hard crew task-timeout ceiling, read once at boot. Falls back to the
-  // daemon's DEFAULT_TASK_TIMEOUT_MS (8h) when unset in config.
-  const taskTimeoutMs = loadConfig().defaults.taskTimeoutMs;
-  const isPidAlive = opts.isPidAlive ?? defaultIsPidAlive;
-  const spawn = opts.spawn ?? realSpawn;
-  const resultsDir = join(stateRoot, "_results");
-  mkdirSync(resultsDir, { recursive: true });
-  const writeResult = (id: string, payload: string) => {
-    const p = join(resultsDir, `${id}.txt`);
-    writeFileSync(p, payload);
-    return p;
-  };
-  // Minimal lifecycle logging (red-team #2: the log was a timestampless wall
-  // of crash stacks with no "started" marker).
-  const log = (m: string) => process.stderr.write(`[cockpitd] ${new Date().toISOString()} ${m}\n`);
-
-  // ── Attach fan-out (spec §4.5/§4.6) ──────────────────────────────────────
-  // Per-task set of live attach connections. Populated in onAttach, cleaned up
-  // in onAttachClose. Not exposed outside this closure.
-  const attachConns = new Map<string, Set<Socket>>();
-
-  // #239 Phase B: relay-as-cmux-proxy for crew-surface liveness.
-  // The relay (running inside the captain's cmux tree) polls relay-proxy-poll
-  // each tick, executes each probe in-lineage, and posts results via relay-proxy-result.
-  // The daemon never calls cmux directly; it only reads this result cache.
-  type ProbeRequest = { taskId: string; name: string };
-  const pendingProbes = new Map<string, ProbeRequest[]>(); // per-project queue
-  const probeResults = new Map<string, "alive" | "gone" | "unknown">(); // per-taskId cache
-  // taskIds handed to the relay (poll sent) but not yet answered (result received).
-  // Prevents the sweep from re-enqueuing a probe that's already in-flight, which
-  // would cause the second relay-proxy-poll to return non-empty despite the queue
-  // being cleared on the first poll.
-  const inFlightProbes = new Set<string>();
-  const inFlightHeadlessIds = new Set<string>(); // #259: tasks being launched (no pid yet)
-  const activeHeadlessKills = new Set<() => void>();
+  const ctx = buildContext(opts);
+  const {
+    stateRoot, sockPath, store, log, isPidAlive, spawn, resultsDir, writeResult,
+    taskTimeoutMs, attachConns, pendingProbes, probeResults, inFlightProbes,
+    inFlightHeadlessIds, activeHeadlessKills, captainMissingStreak, stoppedProjects,
+  } = ctx;
+  const bootedAt = ctx.bootedAt;
 
   // Replaces createSurfaceLivenessProbe(): enqueues a probe for the relay to
   // execute, then returns the most-recent cached result ("unknown" when nothing
@@ -513,7 +407,7 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       processStartedAt: bootedAt,
       version: PKG_VERSION,
       distBuiltAt: distBuiltAt(),
-      lastSweepAt,
+      lastSweepAt: ctx.lastSweepAt.value,
       sweepCadenceMs: opts.sweepMs ?? 30_000,
       log: gatherLogStats(logPath, now, SNAPSHOT_LOG_WINDOW_MS),
       health: buildHealth(),
@@ -700,8 +594,6 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   // entrypoint below adds one).
   let deliveryTick: (() => Promise<void>) | undefined;
   let probeTick: (() => Promise<void>) | undefined;
-  const captainMissingStreak = new Map<string, number>();
-  const stoppedProjects = new Set<string>();
 
   if (daemonDirectCmux && daemonCmux) {
     const cmux = daemonCmux;
@@ -882,7 +774,7 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
     timer = setInterval(() => {
       if (sweeping) return;
       sweeping = true;
-      lastSweepAt = Date.now(); // Tier 0 observability: time of the most recent sweep
+      ctx.lastSweepAt.value = Date.now(); // Tier 0 observability: time of the most recent sweep
       void d.sweep()
         .catch((e: unknown) => log(`sweep failed: ${(e as Error).message}`))
         .finally(() => { sweeping = false; });

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -32,6 +32,7 @@ import type { PaneRef } from "../runtimes/types.js";
 import { DaemonCmux } from "./cmux/daemon-cmux.js";
 import { ensureCmuxAutoConfig, type AutoConfigResult } from "@cockpit/shared";
 import { createCmuxDriver } from "../runtimes/index.js";
+import type { AgentDriver, OpencodeBridge, CmuxEventsBridge, DaemonSurfaceDriver } from "./interfaces.js";
 
 // This module's own compiled file — its mtime is the dist build-time used for
 // the Tier 0 build-freshness check (process start vs build time). package.json
@@ -77,15 +78,7 @@ export interface CockpitdOpts {
     keepCount?: number;
   };
   /** Inject a fake driver for tests. Defaults to a real CodexInteractiveDriver. */
-  codexDriver?: import("./codex/driver.js").CodexInteractiveDriver | {
-    dispatch: (rec: any) => Promise<void>;
-    reattach: (rec: any) => Promise<void>;
-    say: (taskId: string, text: string) => Promise<void>;
-    steer: (taskId: string, text: string) => Promise<void>;
-    interrupt: (taskId: string) => Promise<void>;
-    answer: (taskId: string, payload: unknown) => Promise<void>;
-    close: (taskId: string) => Promise<void>;
-  };
+  codexDriver?: AgentDriver;
   /** #207 best-effort relay healer. Defaults to a real cmux spawnInjector
    *  re-spawn (mostly inert under launchd). Tests inject a fake/spy. */
   healRelay?: (project: string) => Promise<void> | void;
@@ -95,18 +88,13 @@ export interface CockpitdOpts {
    *  to Object.keys(loadConfig().projects). Tests inject this to avoid real config. */
   registeredProjects?: string[];
   /** Inject a fake opencode SSE bridge for tests. Defaults to a real one. */
-  opencodeBridge?: {
-    start: (o: { taskId: string; port: number }) => void;
-    stop: (taskId: string) => void;
-    /** CP3: POST the captain's approve/deny decision to the crew's server. */
-    answer: (taskId: string, decision: "approve" | "deny") => Promise<boolean>;
-  };
+  opencodeBridge?: OpencodeBridge;
   /** B1: inject a fake cmux events bridge for tests. Defaults to a real one
    *  (gated on defaults.cmuxEventsBridge). */
-  cmuxEventsBridge?: { start: () => void; stop: () => void };
+  cmuxEventsBridge?: CmuxEventsBridge;
   /** #332: inject a fake DaemonCmux for testing daemon-direct delivery. When
    *  absent and daemonDirectCmux is ON, a real cmux driver is created. */
-  daemonCmux?: DaemonCmux;
+  daemonCmux?: DaemonSurfaceDriver | DaemonCmux;
   /** #332: factory for constructing DaemonCmux in production when daemonCmux
    *  is not injected. Defaults to () => new DaemonCmux(createCmuxDriver()).
    *  Tests inject this to avoid real cmux. */

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -5,6 +5,7 @@ import { readFileSync } from "node:fs";
 import { createDaemon } from "./daemon.js";
 import { buildContext } from "./daemon/context.js";
 import { createAttach } from "./daemon/attach.js";
+import { createProbes, buildSurfaceProbe } from "./daemon/probes.js";
 export type { CockpitdOpts } from "./daemon/context.js";
 export { defaultIsPidAlive } from "./daemon/context.js";
 import { startServer, encodeFrame, type AttachFrame, type AttachInbound } from "./protocol.js";
@@ -14,8 +15,7 @@ import { OpencodeSseBridge } from "./opencode/sse-bridge.js";
 import { CmuxEventsBridge } from "./cmux/events-bridge.js";
 import { appendToMailbox, rotateIfNeeded, mailboxStats, readCursor, writeCursor, readFromCursor } from "./mailbox.js";
 import { createRelayHealer } from "./relay-healer.js";
-import { createDirectSurfaceLivenessProbe, createDirectCrewPaneReader } from "./crew-pane-reader.js";
-import { createInteractiveProbe, STALE_THRESHOLD_MS } from "../commands/notify-relay.js";
+import { STALE_THRESHOLD_MS } from "../commands/notify-relay.js";
 import { CaptainDelivery } from "./delivery/captain-delivery.js";
 import { projectHealth, type ComponentHealth } from "./liveness.js";
 import { assembleDaemonSnapshot, type DaemonSnapshotInputs } from "./snapshot.js";
@@ -63,21 +63,7 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   } = ctx;
   const bootedAt = ctx.bootedAt;
 
-  // Replaces createSurfaceLivenessProbe(): enqueues a probe for the relay to
-  // execute, then returns the most-recent cached result ("unknown" when nothing
-  // has been received yet — "unknown" never reaps, so the first tick is safe).
-  const proxiedSurfaceAlive = async (rec: TaskRecord): Promise<"alive" | "gone" | "unknown"> => {
-    if (rec.mode !== "interactive" || !rec.name) return "unknown";
-    // If the relay already has this probe, don't enqueue again until it answers.
-    if (inFlightProbes.has(rec.id)) return probeResults.get(rec.id) ?? "unknown";
-    const list = pendingProbes.get(rec.project) ?? [];
-    // Dedup: only enqueue once per taskId until the relay drains the queue.
-    if (!list.some((p) => p.taskId === rec.id)) {
-      list.push({ taskId: rec.id, name: rec.name });
-      pendingProbes.set(rec.project, list);
-    }
-    return probeResults.get(rec.id) ?? "unknown";
-  };
+  const probes = createProbes(ctx);
 
   const { broadcast, schedulePromotion, cancelPromotionsFor } = createAttach(ctx);
   ctx.broadcast = broadcast;
@@ -206,18 +192,7 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
   const daemonCmux = opts.daemonCmux
     ?? (daemonDirectCmux ? (opts.makeDaemonCmux ?? (() => new DaemonCmux(createCmuxDriver())))() : undefined);
 
-  // #332: daemon-direct mode replaces the proxy-based surface liveness probe
-  // with a direct cmux probe (DaemonCmux.listSurfaces + surfaceVerdict).
-  const surfaceProbe = opts.isSurfaceAlive
-    ?? (daemonDirectCmux && daemonCmux
-      ? createDirectSurfaceLivenessProbe(
-          daemonCmux,
-          (project) => {
-            const cfg = loadConfig();
-            return cfg.projects?.[project]?.captainName ?? `${project}-captain`;
-          },
-        )
-      : proxiedSurfaceAlive);
+  const surfaceProbe = buildSurfaceProbe(ctx, probes, daemonDirectCmux, daemonCmux);
 
   const d = createDaemon({
     store, now: () => Date.now(), isPidAlive, notify, taskTimeoutMs,
@@ -286,6 +261,8 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       } catch (e) { log(`gate-resolve answer failed: ${(e as Error).message}`); }
     },
   });
+
+  ctx.d = d; // late-bind so daemon/* closures that reference ctx.d resolve correctly
 
   // #77 service-health surface. Assembles per-component liveness for the health
   // socket verb: relay map from the daemon, captain liveness from relay heartbeat
@@ -659,41 +636,9 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       }
     };
 
-    // #332: daemon-direct blocked-crew detection. Reuses createInteractiveProbe
-    // (from notify-relay.ts) with a direct cmux pane reader injected as the
-    // readPaneTail dep. Matches the relay's PROBE_INTERVAL_MS (10s).
-    const directPaneReader = createDirectCrewPaneReader(cmux, (project) => {
-      const cfg2 = loadConfig();
-      return cfg2.projects?.[project]?.captainName ?? `${project}-captain`;
-    });
-
-    const interactiveProbe = createInteractiveProbe({
-      project: "_all_",
-      listTasks: async () => store.listAll(),
-      readPaneTail: directPaneReader,
-      sendEvent: async (event) => {
-        const rec = store.listAll().find((r) => r.id === event.id);
-        if (rec) {
-          await d.handle({ kind: "event", project: rec.project, event });
-        }
-      },
-      now: () => Date.now(),
-      log,
-    });
-    // #332 storm BUG (re-entrancy): the probe reads crew panes via slow cmux
-    // subprocess calls and can exceed its 10s interval. Give it its own
-    // independent guard (separate from `delivering`) so an overlapping probe
-    // fire is skipped rather than stacking back-to-back cmux reads.
-    let probing = false;
-    probeTick = async () => {
-      if (probing) return;
-      probing = true;
-      try {
-        await interactiveProbe.tick();
-      } finally {
-        probing = false;
-      }
-    };
+    // #332: daemon-direct blocked-crew detection (probe-tick guard is inside
+    // createProbes.buildInteractiveProbe so re-entrancy is handled there).
+    probeTick = probes.buildInteractiveProbe({ cmux });
   }
 
   // #332: production delivery interval (1s poll). Gated on sweepMs so tests

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -7,9 +7,11 @@ import { buildContext } from "./daemon/context.js";
 import { createAttach } from "./daemon/attach.js";
 import { createProbes, buildSurfaceProbe } from "./daemon/probes.js";
 import { createDelivery } from "./daemon/delivery.js";
+import { createGateResolver } from "./daemon/gates.js";
+import { createServer } from "./daemon/server.js";
 export type { CockpitdOpts } from "./daemon/context.js";
 export { defaultIsPidAlive } from "./daemon/context.js";
-import { startServer, encodeFrame, type AttachFrame, type AttachInbound } from "./protocol.js";
+import type { AttachFrame } from "./protocol.js";
 import { runHeadless } from "./headless-launcher.js";
 import { CodexInteractiveDriver, shouldReattachCodex } from "./codex/driver.js";
 import { OpencodeSseBridge } from "./opencode/sse-bridge.js";
@@ -18,7 +20,7 @@ import { rotateIfNeeded, mailboxStats, readCursor } from "./mailbox.js";
 import { createRelayHealer } from "./relay-healer.js";
 import { STALE_THRESHOLD_MS } from "../commands/notify-relay.js";
 import { projectHealth, type ComponentHealth } from "./liveness.js";
-import { assembleDaemonSnapshot, type DaemonSnapshotInputs } from "./snapshot.js";
+import type { DaemonSnapshotInputs } from "./snapshot.js";
 import { loadConfig } from "@cockpit/shared";
 import { readdir } from "node:fs/promises";
 import type { TaskRecord, ControlEvent } from "@cockpit/shared";
@@ -151,6 +153,12 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
       log,
     });
 
+  // Set late-bound driver fields so daemon/* modules (gates.ts, server.ts) can
+  // reference them lazily via ctx at call time.
+  ctx.codexDriver = codexDriver;
+  ctx.opencodeBridge = opencodeBridge;
+  ctx.cmuxEventsBridge = cmuxEventsBridge;
+
   const ingest = (project: string) => (e: import("@cockpit/shared").ControlEvent) =>
     void d.handle({ kind: "event", project, event: e });
 
@@ -222,22 +230,7 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
         `interactive mode is not yet implemented for provider '${rec.provider}'; only 'codex', 'claude', and 'opencode' are supported`,
       );
     },
-    resolveInteractiveGate: async (taskId, payload) => {
-      // Route the captain's decision to the owning provider's driver. Opencode
-      // crews resolve via the SSE bridge (POST to the crew's server); codex via
-      // its app-server respondToServerRequest. Provider comes from the record.
-      const rec = store.listAll().find((r) => r.id === taskId);
-      try {
-        if (rec?.provider === "opencode") {
-          // Only an explicit "approve" approves; any other reply (incl. an
-          // ambiguous one) denies — never auto-approve a permission gate.
-          const decision = (payload as { decision?: string })?.decision === "approve" ? "approve" : "deny";
-          await opencodeBridge.answer(taskId, decision);
-        } else {
-          await codexDriver.answer(taskId, payload);
-        }
-      } catch (e) { log(`gate-resolve answer failed: ${(e as Error).message}`); }
-    },
+    resolveInteractiveGate: createGateResolver(ctx),
   });
 
   ctx.d = d; // late-bind so daemon/* closures that reference ctx.d resolve correctly
@@ -396,100 +389,11 @@ export function startCockpitd(opts: CockpitdOpts = {}) {
     }
   })();
 
-  const server = startServer(sockPath, {
-    handler: async (msg: any) => {
-      if (msg.kind === "seed") { store.put(msg.record as TaskRecord); return { ok: true }; }
-      // Crew-close teardown for codex: the cmux pane only hosts the `crew attach`
-      // renderer — the thread lives on the shared app-server, so closing the pane
-      // doesn't reap it. `cockpit crew close` calls this to archive the thread and
-      // its per-thread MCP servers (else they leak ~53MB/crew). Fires for terminal
-      // and non-terminal crews alike.
-      if (msg.kind === "codex-close") {
-        await codexDriver.close(msg.taskId).catch((e: unknown) => log(`codex close err: ${e}`));
-        return { ok: true };
-      }
-      // #207 relay registration: the notify-relay announces itself on boot and
-      // heartbeats every ~10s so the daemon can health-check it on the sweep.
-      if (msg.kind === "relay-register") {
-        d.registerRelay({ project: msg.project, pid: msg.pid, startedAt: msg.startedAt ?? Date.now() });
-        return { ok: true };
-      }
-      if (msg.kind === "relay-heartbeat") {
-        d.relayHeartbeat({ project: msg.project, pid: msg.pid });
-        return { ok: true };
-      }
-      // #239 Phase B: relay proxy — crew-surface liveness probes.
-      // The relay polls for pending probes, executes them in-lineage (cmux-accessible),
-      // and posts results back. Handled inline like relay-register/heartbeat so they
-      // never reach d.handle()'s unknown-kind guard.
-      if (msg.kind === "relay-proxy-poll") {
-        const project = msg.project as string;
-        const probes = pendingProbes.get(project) ?? [];
-        pendingProbes.set(project, []); // clear after handing off to the relay
-        for (const p of probes) inFlightProbes.add(p.taskId); // mark in-flight
-        return probes;
-      }
-      if (msg.kind === "relay-proxy-result") {
-        const results = msg.results as Array<{ taskId: string; liveness: "alive" | "gone" | "unknown" }>;
-        for (const r of results) {
-          probeResults.set(r.taskId, r.liveness);
-          inFlightProbes.delete(r.taskId); // result received — no longer in-flight
-        }
-        return { ok: true };
-      }
-      // #77 service-health surface: per-component liveness for the queried
-      // project (or all). Captain liveness derived from relay heartbeat (#239).
-      if (msg.kind === "health") {
-        return buildHealth(msg.project as string | undefined);
-      }
-      // #44 dashboard: read-only full system snapshot (Tier 0/1/2). Additive —
-      // the `health` verb above is untouched. Pure assembly; all I/O is gathered
-      // here and fed in. Never mutates state.
-      if (msg.kind === "snapshot") {
-        const now = Date.now();
-        return assembleDaemonSnapshot(await gatherSnapshotInputs(now), now);
-      }
-      // #239 Phase B: on any event that terminates a task, evict its entries from
-      // inFlightProbes and probeResults so the Sets never leak. Tasks reaped by
-      // sweep/reconcile (not via the socket) are naturally safe — proxiedSurfaceAlive
-      // is only called for reapable (non-terminal) states.
-      if (msg.kind === "event") {
-        const rec = await d.handle(msg) as TaskRecord;
-        if (TERMINAL_STATES.has(rec.state)) {
-          inFlightProbes.delete(rec.id);
-          probeResults.delete(rec.id);
-        }
-        return rec;
-      }
-      return d.handle(msg);
-    },
-    onAttach: (conn, frame) => {
-      let set = attachConns.get(frame.taskId);
-      if (!set) { set = new Set(); attachConns.set(frame.taskId, set); }
-      set.add(conn);
-      // A client arriving within the 5s window defuses any pending gate timer.
-      cancelPromotionsFor(frame.taskId);
-      // Immediately ack the attach so the client knows it's live.
-      try { conn.write(encodeFrame({ type: "reattached", taskId: frame.taskId })); } catch { /* ignore */ }
-    },
-    onAttachInbound: (_conn, frame) => {
-      // A second 'attach' on an already-claimed conn is ignored by protocol.ts,
-      // so every frame here is a genuine inbound op.
-      const f = frame as AttachInbound;
-      if (f.op === "say")
-        void codexDriver.say(f.taskId, f.text).catch((e: unknown) => log(`say err: ${e}`));
-      else if (f.op === "steer")
-        void codexDriver.steer(f.taskId, f.text).catch((e: unknown) => log(`steer err: ${e}`));
-      else if (f.op === "interrupt")
-        void codexDriver.interrupt(f.taskId).catch((e: unknown) => log(`interrupt err: ${e}`));
-      else if (f.op === "answer")
-        void codexDriver.answer(f.taskId, f.payload).catch((e: unknown) => log(`answer err: ${e}`));
-    },
-    onAttachClose: (conn) => {
-      // Remove the conn from every task's set (the conn only exists in one set,
-      // but a linear scan over a small map is fine).
-      for (const set of attachConns.values()) set.delete(conn);
-    },
+  const server = createServer(ctx, {
+    buildHealth,
+    gatherSnapshotInputs,
+    cancelPromotionsFor,
+    broadcast,
   });
   log(`started pid=${process.pid} sock=${sockPath} stateRoot=${stateRoot}`);
 

--- a/src/control/daemon/README.md
+++ b/src/control/daemon/README.md
@@ -1,0 +1,44 @@
+# src/control/daemon/
+
+Driver-agnostic daemon core. Contains all logic that does not depend on
+concrete agent drivers (CodexInteractiveDriver, DaemonCmux, headless-launcher,
+etc.). Those live in the host (`cockpitd.ts`).
+
+## Owns
+
+| File | Responsibility |
+|------|----------------|
+| `start.ts` | `startDaemon(ctx, opts, pkgVersion)` — wires all factories, runs boot recovery, starts timers, returns `DaemonHandle` |
+| `context.ts` | `DaemonContext` shared state bag + `buildContext(opts)` + `CockpitdOpts` type |
+| `attach.ts` | `createAttach(ctx)` — broadcast fan-out + gate-promotion timers |
+| `probes.ts` | `createProbes(ctx)` — relay-proxy and daemon-direct surface-liveness probes |
+| `delivery.ts` | `createDelivery(ctx, ...)` — mailbox append + daemon-direct captain delivery loop (#332) |
+| `gates.ts` | `createGateResolver(ctx)` — routes captain approve/deny to the owning driver |
+| `server.ts` | `createServer(ctx, handlers)` — IPC socket server + message router |
+| `snapshot-gather.ts` | Pure I/O helpers for the dashboard snapshot (log stats, store stats, results) |
+
+## Public Interface
+
+```typescript
+import { startDaemon } from "./daemon/start.js";
+// ctx must have: attach handlers, codexDriver, opencodeBridge,
+// cmuxEventsBridge, daemonCmux, daemonDirectCmux already set.
+const handle = startDaemon(ctx, opts, pkgVersion);
+```
+
+## Depends On
+
+- `../daemon.ts` (`createDaemon`) — state machine
+- `../protocol.ts` — IPC framing
+- `../mailbox.ts` — mailbox I/O
+- `../liveness.ts` — health assembly
+- `../snapshot.ts` — dashboard snapshot assembly
+- `../relay-healer.ts` — relay health
+- `@cockpit/shared` — types, config, constants
+
+## Doesn't Belong Here
+
+Concrete driver classes (`CodexInteractiveDriver`, `OpencodeSseBridge`,
+`CmuxEventsBridge`, `DaemonCmux`), `headless-launcher`, and `runtimes/index`
+all live in the host (`cockpitd.ts`). Importing them here would break the
+driver-agnostic boundary verified by the Task-9 grep gate.

--- a/src/control/daemon/attach.ts
+++ b/src/control/daemon/attach.ts
@@ -1,0 +1,76 @@
+// src/control/daemon/attach.ts
+// Attach fan-out and gate-promotion logic (spec §4.5/§4.6/§4.9).
+import { randomUUID } from "node:crypto";
+import { encodeFrame } from "../protocol.js";
+import { makeGate } from "../codex/gate.js";
+import type { AttachFrame } from "../protocol.js";
+import type { Gate } from "@cockpit/shared";
+import type { DaemonContext } from "./context.js";
+
+export interface AttachHandlers {
+  broadcast: (taskId: string, f: AttachFrame) => void;
+  schedulePromotion: (taskId: string, requestId: number, kind: "input" | "approval", question: string) => void;
+  cancelPromotionsFor: (taskId: string) => void;
+}
+
+/** Build the attach fan-out and gate-promotion machinery. Call once in start.ts
+ *  immediately after buildContext; assign the returned handlers onto ctx so the
+ *  driver emit callbacks can reference them via the context object. */
+export function createAttach(ctx: DaemonContext): AttachHandlers {
+  const { attachConns, store, log } = ctx;
+
+  function broadcast(taskId: string, f: AttachFrame): void {
+    const conns = attachConns.get(taskId);
+    if (!conns) return;
+    const wire = encodeFrame(f);
+    for (const conn of conns) {
+      try { conn.write(wire); } catch { /* client gone; onAttachClose will clean up */ }
+    }
+  }
+
+  // ── Gate promotion (spec §4.9) ─────────────────────────────────────────────
+  // When a server-request event fires and no client is attached, start a 5s
+  // timer. If still unattached at fire time, promote to a Gate in the store
+  // and broadcast gate-promoted so any later-attaching client can offer takeover.
+  const pendingGateTimers = new Map<string, { taskId: string; timer: NodeJS.Timeout }>();
+
+  function schedulePromotion(
+    taskId: string,
+    requestId: number,
+    kind: "input" | "approval",
+    question: string,
+  ): void {
+    // If a client is already attached for this task, no promotion needed.
+    const conns = attachConns.get(taskId);
+    if (conns && conns.size > 0) return;
+    const key = `${taskId}#${requestId}`;
+    // Clear any prior timer for the same (taskId, requestId).
+    const prior = pendingGateTimers.get(key);
+    if (prior) clearTimeout(prior.timer);
+    const timer = setTimeout(() => {
+      pendingGateTimers.delete(key);
+      // Re-check at fire time — a client may have attached in the 5s window.
+      if (attachConns.get(taskId)?.size) return;
+      const rec = store.listAll().find((r) => r.id === taskId);
+      if (!rec) return;
+      const gate: Gate = makeGate({ taskId, kind, question, now: Date.now(), mkId: () => randomUUID() });
+      const gates = [...(rec.gates ?? []), gate];
+      store.put({ ...rec, gates });
+      broadcast(taskId, { type: "gate-promoted", taskId, gateId: gate.gateId });
+      log(`gate promoted gateId=${gate.gateId} taskId=${taskId} kind=${kind}`);
+    }, 5_000);
+    timer.unref?.();
+    pendingGateTimers.set(key, { taskId, timer });
+  }
+
+  function cancelPromotionsFor(taskId: string): void {
+    for (const [key, slot] of pendingGateTimers.entries()) {
+      if (slot.taskId === taskId) {
+        clearTimeout(slot.timer);
+        pendingGateTimers.delete(key);
+      }
+    }
+  }
+
+  return { broadcast, schedulePromotion, cancelPromotionsFor };
+}

--- a/src/control/daemon/context.ts
+++ b/src/control/daemon/context.ts
@@ -1,0 +1,194 @@
+// src/control/daemon/context.ts
+// CockpitdOpts, defaultIsPidAlive, DaemonContext, and buildContext.
+// Kept here (not in cockpitd.ts) so daemon/* modules can import this file
+// without creating a circular dependency on the host entrypoint.
+// cockpitd.ts re-exports CockpitdOpts and defaultIsPidAlive for backward compat.
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { spawn as realSpawn } from "node:child_process";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { createStore } from "../store.js";
+import { createDaemon } from "../daemon.js";
+import { loadConfig } from "@cockpit/shared";
+import type { TaskRecord, ControlEvent, Gate, AutoConfigResult } from "@cockpit/shared";
+import type { Socket } from "node:net";
+import type { PaneRef } from "../../runtimes/types.js";
+import type { AgentDriver, OpencodeBridge, CmuxEventsBridge, DaemonSurfaceDriver } from "../interfaces.js";
+import type { AttachFrame } from "../protocol.js";
+
+// ── Public injectable options (equivalent of old cockpitd.ts CockpitdOpts) ───
+
+export interface CockpitdOpts {
+  stateRoot?: string;
+  sockPath?: string;
+  sweepMs?: number; // 0 disables the interval (tests)
+  isPidAlive?: (pid: number) => boolean;
+  isSurfaceAlive?: (rec: TaskRecord) => Promise<"alive" | "gone" | "unknown">;
+  spawn?: typeof realSpawn;
+  /**
+   * Push-notification hook (#109). Defaults to appending a structured event
+   * to the mailbox file at <stateRoot>/inbox/<project>.log; an injector
+   * process inside the captain workspace tails the file and delivers entries
+   * to the captain pane. Tests inject a fake to assert call shape.
+   */
+  notify?: (args: {
+    project: string;
+    message: string;
+    record: TaskRecord;
+    event: ControlEvent;
+  }) => Promise<void> | void;
+  /** Background rotation timer interval (ms). 0 disables. Default 60_000. */
+  rotationIntervalMs?: number;
+  /** Mailbox rotation thresholds (size/age/retention). */
+  mailboxConfig?: {
+    maxBytes?: number;
+    maxAgeMs?: number;
+    keepCount?: number;
+  };
+  /** Inject a fake driver for tests. Defaults to a real CodexInteractiveDriver. */
+  codexDriver?: AgentDriver;
+  /** #207 best-effort relay healer. */
+  healRelay?: (project: string) => Promise<void> | void;
+  /** Inject a fake headless launcher for tests to avoid real process spawns. */
+  launchHeadless?: (rec: TaskRecord) => Promise<void>;
+  /** Override which projects appear in the Tier 2 per-project snapshot. */
+  registeredProjects?: string[];
+  /** Inject a fake opencode SSE bridge for tests. */
+  opencodeBridge?: OpencodeBridge;
+  /** B1: inject a fake cmux events bridge for tests. */
+  cmuxEventsBridge?: CmuxEventsBridge;
+  /** #332: inject a fake surface driver for testing daemon-direct delivery. */
+  daemonCmux?: DaemonSurfaceDriver;
+  /** #332: factory for constructing the surface driver in production. */
+  makeDaemonCmux?: () => DaemonSurfaceDriver;
+  /** #332: override for daemonDirectCmux flag (bypasses config file load). */
+  daemonDirectCmux?: boolean;
+  /** #332: injected captain-surface mapping (project → PaneRef) for tests. */
+  captainSurfaces?: Record<string, PaneRef>;
+  /** #348: override the cmux socket auto-config re-check. */
+  runCmuxAutoConfig?: () => Promise<AutoConfigResult>;
+}
+
+export function defaultIsPidAlive(pid: number): boolean {
+  try { process.kill(pid, 0); return true; }
+  catch (e: any) { return e?.code === "EPERM"; } // EPERM = alive but not ours; ESRCH = dead
+}
+
+// ── Shared state bag ──────────────────────────────────────────────────────────
+
+/** Relay-proxy probe request queued for the relay to execute (#239 Phase B). */
+export type ProbeRequest = { taskId: string; name: string };
+
+/** All shared mutable state for the running daemon. Most fields are set in
+ *  buildContext; late-bound fields (d, notify, broadcast, etc.) are assigned
+ *  by start.ts after building the daemon and factories, before any event fires. */
+export interface DaemonContext {
+  opts: CockpitdOpts;
+  stateRoot: string;
+  sockPath: string;
+  store: ReturnType<typeof createStore>;
+  bootedAt: number;
+  /** Mutable box so sweep timer can update lastSweepAt without a closure rebind. */
+  lastSweepAt: { value: number | null };
+  taskTimeoutMs: number | undefined;
+  isPidAlive: (pid: number) => boolean;
+  spawn: typeof realSpawn;
+  resultsDir: string;
+  writeResult: (id: string, payload: string) => string;
+  log: (m: string) => void;
+  /** Per-task live attach connections (spec §4.5/§4.6). */
+  attachConns: Map<string, Set<Socket>>;
+  /** Per-project relay-proxy probe queue (#239 Phase B). */
+  pendingProbes: Map<string, ProbeRequest[]>;
+  /** Per-taskId liveness result cache. */
+  probeResults: Map<string, "alive" | "gone" | "unknown">;
+  /** taskIds handed to relay but not yet answered. */
+  inFlightProbes: Set<string>;
+  /** Tasks being launched headlessly with no pid yet (#259). */
+  inFlightHeadlessIds: Set<string>;
+  /** Cancel handles for in-flight headless runs. */
+  activeHeadlessKills: Set<() => void>;
+  /** #332 delivery streak counter per project for captain-absent reaping. */
+  captainMissingStreak: Map<string, number>;
+  /** #332 projects whose captain surface is confirmed gone. */
+  stoppedProjects: Set<string>;
+
+  // ── Late-bound: assigned by start.ts before any timer/server fires ──────────
+
+  /** Resolved daemon instance. */
+  d: ReturnType<typeof createDaemon>;
+  /** Resolved notify function. */
+  notify: (args: { project: string; message: string; record: TaskRecord; event: ControlEvent }) => Promise<void> | void;
+  /** Daemon-direct flag (#332). */
+  daemonDirectCmux: boolean;
+  /** Resolved surface driver (undefined when relay mode). */
+  daemonCmux: DaemonSurfaceDriver | undefined;
+  /** Resolved agent driver. */
+  codexDriver: AgentDriver;
+  /** Resolved opencode SSE bridge. */
+  opencodeBridge: OpencodeBridge;
+  /** Resolved cmux events bridge. */
+  cmuxEventsBridge: CmuxEventsBridge;
+  /** Fan-out to attach clients (set by createAttach). */
+  broadcast: (taskId: string, f: AttachFrame) => void;
+  /** Schedule gate promotion (set by createAttach). */
+  schedulePromotion: (taskId: string, requestId: number, kind: "input" | "approval", question: string) => void;
+  /** Cancel gate timers for a task (set by createAttach). */
+  cancelPromotionsFor: (taskId: string) => void;
+}
+
+/** Initialize the pure-state fields of DaemonContext from opts.
+ *  Late-bound fields are zero-initialized and MUST be set by start.ts
+ *  (or cockpitd.ts for drivers) before any event, timer, or socket fires. */
+export function buildContext(opts: CockpitdOpts): DaemonContext {
+  const stateRoot = opts.stateRoot ?? join(homedir(), ".config", "cockpit", "state");
+  const sockPath = opts.sockPath ?? join(homedir(), ".config", "cockpit", "cockpit.sock");
+  const store = createStore(stateRoot);
+  const bootedAt = Date.now();
+  const taskTimeoutMs = loadConfig().defaults.taskTimeoutMs;
+  const isPidAlive = opts.isPidAlive ?? defaultIsPidAlive;
+  const spawn = opts.spawn ?? realSpawn;
+  const resultsDir = join(stateRoot, "_results");
+  mkdirSync(resultsDir, { recursive: true });
+  const writeResult = (id: string, payload: string) => {
+    const p = join(resultsDir, `${id}.txt`);
+    writeFileSync(p, payload);
+    return p;
+  };
+  const log = (m: string) =>
+    process.stderr.write(`[cockpitd] ${new Date().toISOString()} ${m}\n`);
+
+  return {
+    opts,
+    stateRoot,
+    sockPath,
+    store,
+    bootedAt,
+    lastSweepAt: { value: null },
+    taskTimeoutMs,
+    isPidAlive,
+    spawn,
+    resultsDir,
+    writeResult,
+    log,
+    attachConns: new Map(),
+    pendingProbes: new Map(),
+    probeResults: new Map(),
+    inFlightProbes: new Set(),
+    inFlightHeadlessIds: new Set(),
+    activeHeadlessKills: new Set(),
+    captainMissingStreak: new Map(),
+    stoppedProjects: new Set(),
+    // Late-bound — start.ts fills these before first use:
+    d: null as unknown as ReturnType<typeof createDaemon>,
+    notify: null as unknown as DaemonContext["notify"],
+    daemonDirectCmux: false,
+    daemonCmux: undefined,
+    codexDriver: null as unknown as AgentDriver,
+    opencodeBridge: null as unknown as OpencodeBridge,
+    cmuxEventsBridge: null as unknown as CmuxEventsBridge,
+    broadcast: () => {},
+    schedulePromotion: () => {},
+    cancelPromotionsFor: () => {},
+  };
+}

--- a/src/control/daemon/delivery.ts
+++ b/src/control/daemon/delivery.ts
@@ -1,0 +1,159 @@
+// src/control/daemon/delivery.ts
+// Mailbox notification + daemon-direct captain delivery loop (#332).
+import { appendToMailbox, readCursor, writeCursor, readFromCursor } from "../mailbox.js";
+import { CaptainDelivery } from "../delivery/captain-delivery.js";
+import { discoverCaptainSurface } from "../cockpitd.js";
+import { loadConfig } from "@cockpit/shared";
+import { STALE_THRESHOLD_MS } from "../../commands/notify-relay.js";
+import type { TaskRecord, ControlEvent } from "@cockpit/shared";
+import type { PaneRef } from "../../runtimes/types.js";
+import type { DaemonSurfaceDriver } from "../interfaces.js";
+import type { DaemonContext } from "./context.js";
+
+const CURSOR_SUBSCRIBER = "captain";
+const CAPTAIN_GONE_STREAK_K = 3;
+
+export interface DeliveryResult {
+  defaultNotify: (args: { project: string; message: string; record: TaskRecord; event: ControlEvent }) => Promise<void>;
+  /** Guarded delivery tick — undefined when daemon-direct mode is OFF. */
+  deliveryTick: (() => Promise<void>) | undefined;
+}
+
+export function createDelivery(
+  ctx: DaemonContext,
+  daemonCmux: DaemonSurfaceDriver | undefined,
+  daemonDirectCmux: boolean,
+): DeliveryResult {
+  const { stateRoot, store, log, captainMissingStreak, stoppedProjects, opts } = ctx;
+
+  // ── Default push-notification wiring (mailbox-injector spec) ─────────────
+  const defaultNotify = async (args: {
+    project: string;
+    message: string;
+    record: TaskRecord;
+    event: ControlEvent;
+  }): Promise<void> => {
+    try {
+      await appendToMailbox({
+        stateRoot,
+        project: args.project,
+        taskRecord: args.record,
+        event: args.event,
+        // Persist the daemon-rendered message (#214/#210): the relay delivers it
+        // verbatim instead of re-deriving from the raw event (which drifted).
+        message: args.message,
+      });
+    } catch (e) {
+      log(`mailbox append failed project=${args.project}: ${(e as Error).message}`);
+    }
+  };
+
+  // ── Daemon-direct delivery loop (#332) ───────────────────────────────────
+  if (!daemonDirectCmux || !daemonCmux) {
+    return { defaultNotify, deliveryTick: undefined };
+  }
+
+  const cmux = daemonCmux;
+  const cfg = loadConfig();
+  const deliveries = new Map<string, CaptainDelivery>();
+  // #332 storm BUG 3: captured once at delivery-loop setup. Entries older than
+  // sessionStartMs - STALE_THRESHOLD_MS are silently acked (cursor advanced)
+  // without delivery, mirroring the relay's drain(). This stops a fresh/empty
+  // cursor from re-delivering the entire historical backlog.
+  const sessionStartMs = Date.now();
+
+  // #332 storm BUG (re-entrancy): each tick does multiple slow cmux subprocess
+  // calls and can exceed the 1s interval. Mirror the relay's drain() guard.
+  let delivering = false;
+
+  const deliveryCore = async () => {
+    const injectedSurfaces = opts.captainSurfaces ?? {};
+    const allProjects = [...new Set([
+      ...Object.keys(cfg.projects ?? {}),
+      ...Object.keys(injectedSurfaces),
+      ...store.listAll().map((t) => t.project),
+    ])];
+
+    for (const project of allProjects) {
+      const projCfg = cfg.projects?.[project];
+      const captainTitle = projCfg?.captainName ?? `${project}-captain`;
+
+      // Try real discovery from cmux.
+      const wsId = cmux.findWorkspaceId ? await cmux.findWorkspaceId(captainTitle) : null;
+      let surface: PaneRef | null = null;
+      let surfacesLength = 0;
+
+      if (wsId) {
+        const surfaces = await cmux.listSurfaces(wsId);
+        surfacesLength = surfaces.length;
+        surface = discoverCaptainSurface(surfaces, captainTitle);
+      }
+
+      // Fall back to injected surface (tests / config-less projects).
+      if (!surface) surface = injectedSurfaces[project] ?? null;
+
+      if (surface) {
+        // Captain found — if previously reaped, un-reap and reset streak.
+        if (stoppedProjects.has(project)) {
+          stoppedProjects.delete(project);
+          captainMissingStreak.set(project, 0);
+        }
+        captainMissingStreak.set(project, 0);
+      } else {
+        // Streak tracking: surfaces.length > 0 means cmux is reachable but the
+        // captain's pane is provably absent. surfaces.length === 0 means cmux
+        // was unreachable (fail-soft → []), treat as "unknown" — never increment.
+        if (surfacesLength > 0) {
+          const streak = (captainMissingStreak.get(project) ?? 0) + 1;
+          captainMissingStreak.set(project, streak);
+          if (streak >= CAPTAIN_GONE_STREAK_K) {
+            if (!stoppedProjects.has(project)) {
+              stoppedProjects.add(project);
+              log(`captain ${captainTitle}: surface gone for ${CAPTAIN_GONE_STREAK_K} sweeps — stopping delivery`);
+            }
+          }
+        }
+        continue;
+      }
+
+      const cursor = await readCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER });
+      const lastAcked = cursor?.lastAckedSeq ?? 0;
+      let d = deliveries.get(project);
+      if (!d) {
+        d = new CaptainDelivery({
+          maxDefers: cfg.relay?.maxDeferDeliveries ?? 300,
+          stableProbePolls: cfg.relay?.stableProbePolls ?? 3,
+        });
+        deliveries.set(project, d);
+      }
+      for await (const entry of readFromCursor({ stateRoot, project, fromSeq: lastAcked + 1 })) {
+        // #332 storm BUG 3: silently ack entries that pre-date this daemon
+        // session by more than STALE_THRESHOLD_MS.
+        if (new Date(entry.ts).getTime() < sessionStartMs - STALE_THRESHOLD_MS) {
+          await writeCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER, lastAckedSeq: entry.seq });
+          continue;
+        }
+        const result = await d.deliver(entry, (text, sendOpts) =>
+          cmux.send(surface!, text, sendOpts),
+        );
+        if ("delivered" in result) {
+          await writeCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER, lastAckedSeq: entry.seq });
+        } else {
+          break;
+        }
+      }
+    }
+  };
+
+  const deliveryTick = async () => {
+    if (delivering) return;
+    delivering = true;
+    try {
+      await deliveryCore();
+    } finally {
+      delivering = false;
+    }
+  };
+
+  return { defaultNotify, deliveryTick };
+}

--- a/src/control/daemon/gates.ts
+++ b/src/control/daemon/gates.ts
@@ -1,0 +1,21 @@
+// src/control/daemon/gates.ts
+// resolveInteractiveGate: route the captain's approve/deny to the owning driver.
+// Reads ctx.codexDriver and ctx.opencodeBridge lazily (set by cockpitd.ts before
+// any gate message can arrive on the socket).
+import type { DaemonContext } from "./context.js";
+
+export function createGateResolver(ctx: DaemonContext) {
+  return async (taskId: string, payload: unknown): Promise<void> => {
+    const rec = ctx.store.listAll().find((r) => r.id === taskId);
+    try {
+      if (rec?.provider === "opencode") {
+        // Only an explicit "approve" approves; any other reply denies —
+        // never auto-approve a permission gate.
+        const decision = (payload as { decision?: string })?.decision === "approve" ? "approve" : "deny";
+        await ctx.opencodeBridge.answer(taskId, decision);
+      } else {
+        await ctx.codexDriver.answer(taskId, payload);
+      }
+    } catch (e) { ctx.log(`gate-resolve answer failed: ${(e as Error).message}`); }
+  };
+}

--- a/src/control/daemon/probes.ts
+++ b/src/control/daemon/probes.ts
@@ -1,0 +1,101 @@
+// src/control/daemon/probes.ts
+// Surface-liveness probe logic for the daemon-direct delivery path.
+// Two probes:
+//   proxiedSurfaceAlive — relay-proxy path (#239 Phase B)
+//   buildInteractiveProbe — daemon-direct blocked-crew detection (#332)
+import { createInteractiveProbe } from "../../commands/notify-relay.js";
+import { createDirectCrewPaneReader, createDirectSurfaceLivenessProbe } from "../crew-pane-reader.js";
+import { loadConfig } from "@cockpit/shared";
+import type { TaskRecord } from "@cockpit/shared";
+import type { DaemonSurfaceDriver } from "../interfaces.js";
+import type { DaemonContext } from "./context.js";
+
+export interface ProbeHandlers {
+  /** Relay-proxy probe path: enqueue + cache liveness for interactive tasks. */
+  proxiedSurfaceAlive: (rec: TaskRecord) => Promise<"alive" | "gone" | "unknown">;
+  /** Build the probe-tick function for the daemon-direct delivery loop.
+   *  Call once after the surface driver is resolved; returns a guarded tick. */
+  buildInteractiveProbe: (deps: { cmux: DaemonSurfaceDriver }) => () => Promise<void>;
+  /** Direct-cmux surface liveness probe (replaces proxiedSurfaceAlive in daemon-direct mode). */
+  directSurfaceProbe: (rec: TaskRecord) => Promise<"alive" | "gone" | "unknown">;
+}
+
+/** Resolve the captain pane name for a project from the config. */
+function captainNameForProject(project: string): string {
+  const cfg = loadConfig();
+  return cfg.projects?.[project]?.captainName ?? `${project}-captain`;
+}
+
+export function createProbes(ctx: DaemonContext): ProbeHandlers {
+  const { pendingProbes, probeResults, inFlightProbes, store, log } = ctx;
+
+  // ── Relay-proxy surface-liveness probe (#239 Phase B) ────────────────────
+  // The relay (running inside the captain's cmux tree) polls relay-proxy-poll
+  // each tick, executes each probe in-lineage, and posts results back.
+  const proxiedSurfaceAlive = async (rec: TaskRecord): Promise<"alive" | "gone" | "unknown"> => {
+    if (rec.mode !== "interactive" || !rec.name) return "unknown";
+    // Don't re-enqueue a probe that's already in-flight with the relay.
+    if (inFlightProbes.has(rec.id)) return probeResults.get(rec.id) ?? "unknown";
+    const list = pendingProbes.get(rec.project) ?? [];
+    // Dedup: only enqueue once per taskId until the relay drains the queue.
+    if (!list.some((p) => p.taskId === rec.id)) {
+      list.push({ taskId: rec.id, name: rec.name });
+      pendingProbes.set(rec.project, list);
+    }
+    return probeResults.get(rec.id) ?? "unknown";
+  };
+
+  // ── Daemon-direct: direct cmux surface probe (replaces proxied in #332 mode) ─
+  const directSurfaceProbe = (rec: TaskRecord): Promise<"alive" | "gone" | "unknown"> => {
+    // Will be filled with a real implementation when buildInteractiveProbe is
+    // called with the resolved cmux. Until then, fall back to proxied path.
+    return proxiedSurfaceAlive(rec);
+  };
+
+  // ── Daemon-direct: blocked-crew detection (#332) ──────────────────────────
+  // Reuses createInteractiveProbe (from notify-relay.ts) with a direct cmux
+  // pane reader injected as the readPaneTail dep. The returned tick function
+  // must be called from within the delivery loop's interval.
+  function buildInteractiveProbe(deps: { cmux: DaemonSurfaceDriver }): () => Promise<void> {
+    const directPaneReader = createDirectCrewPaneReader(deps.cmux, captainNameForProject);
+    const probe = createInteractiveProbe({
+      project: "_all_",
+      listTasks: async () => store.listAll(),
+      readPaneTail: directPaneReader,
+      sendEvent: async (event) => {
+        const rec = store.listAll().find((r) => r.id === event.id);
+        if (rec) {
+          // ctx.d is late-bound — populated by start.ts before any tick fires.
+          await ctx.d.handle({ kind: "event", project: rec.project, event });
+        }
+      },
+      now: () => Date.now(),
+      log,
+    });
+    // Guard against overlapping ticks (cmux reads can be slow).
+    let probing = false;
+    return async () => {
+      if (probing) return;
+      probing = true;
+      try { await probe.tick(); }
+      finally { probing = false; }
+    };
+  }
+
+  return { proxiedSurfaceAlive, buildInteractiveProbe, directSurfaceProbe };
+}
+
+/** Build the surface-liveness probe used by createDaemon — selects direct or
+ *  proxied path based on the daemon-direct flag. Pure: no side effects. */
+export function buildSurfaceProbe(
+  ctx: DaemonContext,
+  probes: ProbeHandlers,
+  daemonDirectCmux: boolean,
+  daemonCmux: DaemonSurfaceDriver | undefined,
+): (rec: TaskRecord) => Promise<"alive" | "gone" | "unknown"> {
+  if (ctx.opts.isSurfaceAlive) return ctx.opts.isSurfaceAlive;
+  if (daemonDirectCmux && daemonCmux) {
+    return createDirectSurfaceLivenessProbe(daemonCmux, captainNameForProject);
+  }
+  return probes.proxiedSurfaceAlive;
+}

--- a/src/control/daemon/server.ts
+++ b/src/control/daemon/server.ts
@@ -1,0 +1,117 @@
+// src/control/daemon/server.ts
+// IPC socket server: message router + attach fan-in.
+// All state lives on DaemonContext; callbacks that can't yet be on ctx are
+// passed via ServerHandlers (built once in cockpitd.ts/start.ts).
+import { startServer, encodeFrame } from "../protocol.js";
+import { TERMINAL_STATES } from "@cockpit/shared";
+import type { AttachFrame, AttachInbound } from "../protocol.js";
+import type { ComponentHealth } from "../liveness.js";
+import type { DaemonSnapshotInputs } from "../snapshot.js";
+import type { DaemonContext } from "./context.js";
+
+export interface ServerHandlers {
+  /** Build per-component health list (optionally filtered to one project). */
+  buildHealth: (project?: string) => ComponentHealth[];
+  /** Gather full snapshot inputs (all I/O). */
+  gatherSnapshotInputs: (now: number) => Promise<DaemonSnapshotInputs>;
+  /** Cancel pending gate-promotion timers when a client attaches. */
+  cancelPromotionsFor: (taskId: string) => void;
+  /** Fan-out an AttachFrame to all clients watching a task. */
+  broadcast: (taskId: string, f: AttachFrame) => void;
+}
+
+export function createServer(
+  ctx: DaemonContext,
+  handlers: ServerHandlers,
+) {
+  const { store, log, pendingProbes, inFlightProbes, probeResults, attachConns } = ctx;
+  const { buildHealth, gatherSnapshotInputs, cancelPromotionsFor, broadcast } = handlers;
+
+  return startServer(ctx.sockPath, {
+    handler: async (msg: any) => {
+      if (msg.kind === "seed") { store.put(msg.record); return { ok: true }; }
+      // Crew-close teardown for codex: the cmux pane only hosts the `crew attach`
+      // renderer — the thread lives on the shared app-server, so closing the pane
+      // doesn't reap it. `cockpit crew close` calls this to archive the thread and
+      // its per-thread MCP servers (else they leak ~53MB/crew). Fires for terminal
+      // and non-terminal crews alike.
+      if (msg.kind === "codex-close") {
+        await ctx.codexDriver.close(msg.taskId).catch((e: unknown) => log(`codex close err: ${e}`));
+        return { ok: true };
+      }
+      // #207 relay registration: the notify-relay announces itself on boot and
+      // heartbeats every ~10s so the daemon can health-check it on the sweep.
+      if (msg.kind === "relay-register") {
+        ctx.d.registerRelay({ project: msg.project, pid: msg.pid, startedAt: msg.startedAt ?? Date.now() });
+        return { ok: true };
+      }
+      if (msg.kind === "relay-heartbeat") {
+        ctx.d.relayHeartbeat({ project: msg.project, pid: msg.pid });
+        return { ok: true };
+      }
+      // #239 Phase B: relay proxy — crew-surface liveness probes.
+      // The relay polls for pending probes, executes them in-lineage (cmux-accessible),
+      // and posts results back. Handled inline so they never reach d.handle()'s
+      // unknown-kind guard.
+      if (msg.kind === "relay-proxy-poll") {
+        const project = msg.project as string;
+        const probes = pendingProbes.get(project) ?? [];
+        pendingProbes.set(project, []); // clear after handing off to the relay
+        for (const p of probes) inFlightProbes.add(p.taskId); // mark in-flight
+        return probes;
+      }
+      if (msg.kind === "relay-proxy-result") {
+        const results = msg.results as Array<{ taskId: string; liveness: "alive" | "gone" | "unknown" }>;
+        for (const r of results) {
+          probeResults.set(r.taskId, r.liveness);
+          inFlightProbes.delete(r.taskId); // result received — no longer in-flight
+        }
+        return { ok: true };
+      }
+      // #77 service-health surface: per-component liveness for the queried project (or all).
+      if (msg.kind === "health") {
+        return buildHealth(msg.project as string | undefined);
+      }
+      // #44 dashboard: read-only full system snapshot (Tier 0/1/2).
+      if (msg.kind === "snapshot") {
+        const now = Date.now();
+        const { assembleDaemonSnapshot } = await import("../snapshot.js");
+        return assembleDaemonSnapshot(await gatherSnapshotInputs(now), now);
+      }
+      // #239 Phase B: on any event that terminates a task, evict its entries from
+      // inFlightProbes and probeResults so the Sets never leak.
+      if (msg.kind === "event") {
+        const rec = await ctx.d.handle(msg);
+        if (TERMINAL_STATES.has((rec as any).state)) {
+          inFlightProbes.delete((rec as any).id);
+          probeResults.delete((rec as any).id);
+        }
+        return rec;
+      }
+      return ctx.d.handle(msg);
+    },
+    onAttach: (conn, frame) => {
+      let set = attachConns.get(frame.taskId);
+      if (!set) { set = new Set(); attachConns.set(frame.taskId, set); }
+      set.add(conn);
+      // A client arriving within the 5s window defuses any pending gate timer.
+      cancelPromotionsFor(frame.taskId);
+      // Immediately ack the attach so the client knows it's live.
+      try { conn.write(encodeFrame({ type: "reattached", taskId: frame.taskId })); } catch { /* ignore */ }
+    },
+    onAttachInbound: (_conn, frame) => {
+      const f = frame as AttachInbound;
+      if (f.op === "say")
+        void ctx.codexDriver.say(f.taskId, f.text).catch((e: unknown) => log(`say err: ${e}`));
+      else if (f.op === "steer")
+        void ctx.codexDriver.steer(f.taskId, f.text).catch((e: unknown) => log(`steer err: ${e}`));
+      else if (f.op === "interrupt")
+        void ctx.codexDriver.interrupt(f.taskId).catch((e: unknown) => log(`interrupt err: ${e}`));
+      else if (f.op === "answer")
+        void ctx.codexDriver.answer(f.taskId, f.payload).catch((e: unknown) => log(`answer err: ${e}`));
+    },
+    onAttachClose: (conn) => {
+      for (const set of attachConns.values()) set.delete(conn);
+    },
+  });
+}

--- a/src/control/daemon/snapshot-gather.ts
+++ b/src/control/daemon/snapshot-gather.ts
@@ -1,0 +1,87 @@
+// src/control/daemon/snapshot-gather.ts
+// Snapshot I/O edge: pure helpers that gather raw inputs for the snapshot verb.
+// Each tolerates missing files and never throws.
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import {
+  statSync, openSync, readSync, closeSync, readdirSync, readFileSync,
+} from "node:fs";
+import type { DaemonSnapshotInputs, ResultArtifacts } from "../snapshot.js";
+import type { TaskRecord } from "@cockpit/shared";
+
+// The compiled snapshot-gather.js shares the dist/ build time with cockpitd.js
+// (tsup compiles all entries in the same pass), so its mtime == dist build-time.
+const SELF_PATH = fileURLToPath(import.meta.url);
+
+/** mtime (epoch ms) of the running daemon's compiled code, for build-freshness. */
+export function distBuiltAt(): number {
+  try { return statSync(SELF_PATH).mtimeMs; } catch { return 0; }
+}
+
+/** Daemon-log error count (last window) + total size. Reads only the tail so a
+ *  large log never makes the snapshot tick expensive. */
+export function gatherLogStats(path: string, now: number, windowMs: number): DaemonSnapshotInputs["log"] {
+  let sizeBytes = 0;
+  try { sizeBytes = statSync(path).size; }
+  catch { return { errorCount: 0, sizeBytes: 0, windowMs }; }
+  if (sizeBytes === 0) return { errorCount: 0, sizeBytes, windowMs };
+  const CAP = 256 * 1024;
+  const start = Math.max(0, sizeBytes - CAP);
+  const len = sizeBytes - start;
+  let text = "";
+  try {
+    const fd = openSync(path, "r");
+    try {
+      const buf = Buffer.alloc(len);
+      readSync(fd, buf, 0, len, start);
+      text = buf.toString("utf-8");
+    } finally { closeSync(fd); }
+  } catch { return { errorCount: 0, sizeBytes, windowMs }; }
+  const cutoff = now - windowMs;
+  let errorCount = 0;
+  for (const line of text.split("\n")) {
+    if (!/error|failed/i.test(line)) continue;
+    // Lines carry an ISO timestamp ("[cockpitd] 2026-... msg"); skip ones older
+    // than the window. Lines without a parseable timestamp are counted (conservative).
+    const m = line.match(/\d{4}-\d{2}-\d{2}T[\d:.]+Z/);
+    if (m) { const ts = Date.parse(m[0]); if (!Number.isNaN(ts) && ts < cutoff) continue; }
+    errorCount++;
+  }
+  return { errorCount, sizeBytes, windowMs };
+}
+
+/** Per-project store state counts + corrupt/quarantined file count. */
+export function gatherStoreStats(
+  store: { list: (p: string) => TaskRecord[] },
+  stateRoot: string,
+  project: string,
+): { byState: Record<string, number>; corruptCount: number } {
+  const byState: Record<string, number> = {};
+  for (const r of store.list(project)) byState[r.state] = (byState[r.state] ?? 0) + 1;
+  let corruptCount = 0;
+  const dir = join(stateRoot, project);
+  try {
+    for (const n of readdirSync(dir)) {
+      if (n.includes(".corrupt.")) { corruptCount++; continue; }
+      if (!n.endsWith(".json")) continue;
+      try { JSON.parse(readFileSync(join(dir, n), "utf-8")); }
+      catch { corruptCount++; }
+    }
+  } catch { /* no project dir yet */ }
+  return { byState, corruptCount };
+}
+
+/** Global _results/ artifact count + total bytes (unbounded-growth watch). */
+export function gatherResults(resultsDir: string): ResultArtifacts {
+  let fileCount = 0;
+  let totalBytes = 0;
+  try {
+    for (const n of readdirSync(resultsDir)) {
+      try {
+        const s = statSync(join(resultsDir, n));
+        if (s.isFile()) { fileCount++; totalBytes += s.size; }
+      } catch { /* vanished mid-scan */ }
+    }
+  } catch { /* no results dir */ }
+  return { fileCount, totalBytes };
+}

--- a/src/control/daemon/start.ts
+++ b/src/control/daemon/start.ts
@@ -147,7 +147,7 @@ export function startDaemon(ctx: DaemonContext, opts: CockpitdOpts, pkgVersion: 
     for (const rec of store.listAll()) {
       if (rec.provider !== "codex" || rec.mode !== "interactive") continue;
       if (TERMINAL_STATES.has(rec.state)) continue;
-      // Mirrors shouldReattachCodex from codex/driver (inlined to avoid importing that module).
+      // Inline of shouldReattachCodex (concrete driver module stays in host).
       const lastAttempt = rec.attempts?.at(-1);
       const last = lastAttempt?.lastHeartbeatAt ?? rec.lastHeartbeat ?? 0;
       if (bootNow - last > REATTACH_STALE_MS) continue;

--- a/src/control/daemon/start.ts
+++ b/src/control/daemon/start.ts
@@ -1,0 +1,270 @@
+// src/control/daemon/start.ts
+// Core daemon assembly: wires all daemon/* factories, runs boot recovery,
+// starts timers, and returns the DaemonHandle.
+// Concrete driver construction (CodexInteractiveDriver, DaemonCmux, etc.)
+// lives in the host (cockpitd.ts) — this file stays free of those imports.
+import { join, dirname } from "node:path";
+import { readdir } from "node:fs/promises";
+import { createDaemon } from "../daemon.js";
+import { createProbes, buildSurfaceProbe } from "./probes.js";
+import { createDelivery } from "./delivery.js";
+import { createGateResolver } from "./gates.js";
+import { createServer } from "./server.js";
+import { rotateIfNeeded, mailboxStats, readCursor } from "../mailbox.js";
+import { createRelayHealer } from "../relay-healer.js";
+import { projectHealth, type ComponentHealth } from "../liveness.js";
+import type { DaemonSnapshotInputs } from "../snapshot.js";
+import { loadConfig, TERMINAL_STATES, ensureCmuxAutoConfig } from "@cockpit/shared";
+import { distBuiltAt, gatherLogStats, gatherStoreStats, gatherResults } from "./snapshot-gather.js";
+import type { CockpitdOpts, DaemonContext } from "./context.js";
+
+const CURSOR_SUBSCRIBER = "captain";
+const SNAPSHOT_LOG_WINDOW_MS = 60 * 60 * 1000;
+
+export interface DaemonHandle {
+  stop(): Promise<void>;
+  tickDelivery: (() => Promise<void>) | undefined;
+  tickProbe: (() => Promise<void>) | undefined;
+}
+
+/** Wire all daemon/* factories, run boot recovery, start timers.
+ *  ctx must already have: attach handlers, codexDriver, opencodeBridge,
+ *  cmuxEventsBridge, daemonCmux, daemonDirectCmux set on it by the host. */
+export function startDaemon(ctx: DaemonContext, opts: CockpitdOpts, pkgVersion: string): DaemonHandle {
+  const {
+    stateRoot, store, log, isPidAlive, resultsDir,
+    taskTimeoutMs, inFlightHeadlessIds, activeHeadlessKills,
+    broadcast, cancelPromotionsFor,
+  } = ctx;
+  const { daemonDirectCmux, daemonCmux } = ctx;
+
+  const probes = createProbes(ctx);
+  const { defaultNotify, deliveryTick: initialDeliveryTick } = createDelivery(ctx, daemonCmux, daemonDirectCmux);
+  const notify = opts.notify ?? defaultNotify;
+  const surfaceProbe = buildSurfaceProbe(ctx, probes, daemonDirectCmux, daemonCmux);
+
+  const ingest = (project: string) => (e: import("@cockpit/shared").ControlEvent) =>
+    void ctx.d.handle({ kind: "event", project, event: e });
+
+  const d = createDaemon({
+    store, now: () => Date.now(), isPidAlive, notify, taskTimeoutMs,
+    isSurfaceAlive: surfaceProbe,
+    healRelay: opts.healRelay ?? createRelayHealer(log),
+    launchHeadless: opts.launchHeadless!,
+    isHeadlessInFlight: (id) => inFlightHeadlessIds.has(id),
+    launchInteractive: async (rec) => {
+      if (rec.provider === "codex") {
+        await ctx.codexDriver.dispatch(rec as any);
+        return;
+      }
+      if (rec.provider === "claude") {
+        ingest(rec.project)({ type: "task.started", id: rec.id });
+        return;
+      }
+      if (rec.provider === "opencode") {
+        ingest(rec.project)({ type: "task.started", id: rec.id });
+        if (rec.serverPort) ctx.opencodeBridge.start({ taskId: rec.id, port: rec.serverPort });
+        return;
+      }
+      throw new Error(
+        `interactive mode is not yet implemented for provider '${rec.provider}'; only 'codex', 'claude', and 'opencode' are supported`,
+      );
+    },
+    resolveInteractiveGate: createGateResolver(ctx),
+  });
+
+  ctx.d = d;
+
+  // ── Health + snapshot ─────────────────────────────────────────────────────
+
+  function buildHealth(only?: string): ComponentHealth[] {
+    const config = loadConfig();
+    const relays = d.getRelayHealth();
+    const now = Date.now();
+    const known = new Set<string>([
+      ...Object.keys(config.projects),
+      ...relays.map((r) => r.project),
+      ...store.listAll().map((t) => t.project),
+    ]);
+    const names = only ? [only] : [...known];
+    const out: ComponentHealth[] = [];
+    for (const project of names) {
+      const proj = config.projects[project];
+      const captainName = proj?.captainName ?? `${project}-captain`;
+      out.push(
+        ...projectHealth({
+          project, now, captainName,
+          relay: relays.find((r) => r.project === project) ?? null,
+          commandPresent: null,
+          crews: store.list(project),
+        }),
+      );
+    }
+    return out;
+  }
+
+  async function gatherSnapshotInputs(now: number): Promise<DaemonSnapshotInputs> {
+    const logPath = join(dirname(stateRoot), "cockpitd.log");
+    const tier2Projects = opts.registeredProjects ?? Object.keys(loadConfig().projects);
+    const projects = await Promise.all(
+      tier2Projects.map(async (project) => {
+        const cursor = await readCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER });
+        const storeStats = gatherStoreStats(store, stateRoot, project);
+        return {
+          project,
+          mailbox: await mailboxStats(stateRoot, project),
+          lastAckedSeq: cursor?.lastAckedSeq ?? 0,
+          storeByState: storeStats.byState,
+          corruptCount: storeStats.corruptCount,
+        };
+      }),
+    );
+    return {
+      pid: process.pid,
+      processStartedAt: ctx.bootedAt,
+      version: pkgVersion,
+      distBuiltAt: distBuiltAt(),
+      lastSweepAt: ctx.lastSweepAt.value,
+      sweepCadenceMs: opts.sweepMs ?? 30_000,
+      log: gatherLogStats(logPath, now, SNAPSHOT_LOG_WINDOW_MS),
+      health: buildHealth(),
+      projects,
+      results: gatherResults(resultsDir),
+    };
+  }
+
+  // ── Boot recovery ─────────────────────────────────────────────────────────
+
+  void (async () => {
+    try { await d.reconcile(); }
+    catch (e) { log(`reconcile on boot failed: ${(e as Error).message}`); }
+
+    // Restart-reattach: reattach live codex crews. Guard against the storm
+    // (each reattach re-spawns per-thread MCP servers). Skip terminal and stale tasks.
+    // Inline predicate avoids importing from the concrete codex driver module.
+    const bootNow = Date.now();
+    const REATTACH_STALE_MS = 10 * 60_000;
+    for (const rec of store.listAll()) {
+      if (rec.provider !== "codex" || rec.mode !== "interactive") continue;
+      if (TERMINAL_STATES.has(rec.state)) continue;
+      // Mirrors shouldReattachCodex from codex/driver (inlined to avoid importing that module).
+      const lastAttempt = rec.attempts?.at(-1);
+      const last = lastAttempt?.lastHeartbeatAt ?? rec.lastHeartbeat ?? 0;
+      if (bootNow - last > REATTACH_STALE_MS) continue;
+      if (!lastAttempt?.resumeRef) continue;
+      ctx.codexDriver.reattach(rec).catch((e: unknown) => {
+        log(`reattach failed for ${rec.id}: ${(e as Error).message}`);
+      });
+    }
+
+    // Re-subscribe opencode SSE bridge after a daemon bounce.
+    for (const rec of store.listAll()) {
+      if (rec.provider !== "opencode" || rec.mode !== "interactive") continue;
+      if (TERMINAL_STATES.has(rec.state)) continue;
+      if (!rec.serverPort) continue;
+      ctx.opencodeBridge.start({ taskId: rec.id, port: rec.serverPort });
+    }
+
+    // B1: start cmux native-events bridge. Skipped under vitest unless injected.
+    const enableCmuxEvents = loadConfig().defaults.cmuxEventsBridge !== false;
+    const cmuxEventsSafe = !!opts.cmuxEventsBridge || !process.env.VITEST;
+    if (enableCmuxEvents && cmuxEventsSafe) {
+      try { ctx.cmuxEventsBridge.start(); }
+      catch (e) { log(`cmux events bridge start failed: ${(e as Error).message}`); }
+    }
+
+    // #348: cmux socket auto-config on boot when daemon-direct is ON.
+    const autoConfigSafe = !!opts.runCmuxAutoConfig || !process.env.VITEST;
+    if (daemonDirectCmux && autoConfigSafe) {
+      try {
+        const r = await (opts.runCmuxAutoConfig ?? ensureCmuxAutoConfig)();
+        if (r.configChanged) log(`cmux autoconfig: wrote automation socket mode to ${r.configPath}`);
+        if (r.needsRestart && r.promptedThisRun) {
+          log("cmux autoconfig: socket still rejects the daemon — restart cmux to enable daemon-direct delivery");
+        }
+      } catch (e) {
+        log(`cmux autoconfig failed: ${(e as Error).message}`);
+      }
+    }
+  })();
+
+  // ── Server + timers ───────────────────────────────────────────────────────
+
+  const server = createServer(ctx, { buildHealth, gatherSnapshotInputs, cancelPromotionsFor, broadcast });
+  log(`started pid=${process.pid} sock=${ctx.sockPath} stateRoot=${stateRoot}`);
+
+  let deliveryTick: (() => Promise<void>) | undefined = initialDeliveryTick;
+  let probeTick: (() => Promise<void>) | undefined;
+
+  if (daemonDirectCmux && daemonCmux) {
+    probeTick = probes.buildInteractiveProbe({ cmux: daemonCmux });
+  }
+
+  let deliveryTimer: NodeJS.Timeout | undefined;
+  if (daemonDirectCmux && daemonCmux && opts.sweepMs && opts.sweepMs > 0) {
+    deliveryTimer = setInterval(() => {
+      void deliveryTick!().catch((e: unknown) => log(`delivery tick error: ${(e as Error).message}`));
+    }, 1000);
+    deliveryTimer.unref?.();
+  }
+
+  let probeTimer: NodeJS.Timeout | undefined;
+  if (daemonDirectCmux && daemonCmux && opts.sweepMs && opts.sweepMs > 0) {
+    probeTimer = setInterval(() => {
+      void probeTick!().catch((e: unknown) => log(`probe tick error: ${(e as Error).message}`));
+    }, 10_000);
+    probeTimer.unref?.();
+  }
+
+  let timer: NodeJS.Timeout | undefined;
+  if (opts.sweepMs && opts.sweepMs > 0) {
+    let sweeping = false;
+    timer = setInterval(() => {
+      if (sweeping) return;
+      sweeping = true;
+      ctx.lastSweepAt.value = Date.now();
+      void d.sweep()
+        .catch((e: unknown) => log(`sweep failed: ${(e as Error).message}`))
+        .finally(() => { sweeping = false; });
+    }, opts.sweepMs);
+    timer.unref?.();
+  }
+
+  const rotationInterval = opts.rotationIntervalMs ?? 60_000;
+  const mboxCfg = {
+    maxBytes: opts.mailboxConfig?.maxBytes ?? 5 * 1024 * 1024,
+    maxAgeMs: opts.mailboxConfig?.maxAgeMs ?? 7 * 24 * 60 * 60 * 1000,
+    keepCount: opts.mailboxConfig?.keepCount ?? 3,
+  };
+  let rotationTimer: NodeJS.Timeout | undefined;
+  if (rotationInterval > 0) {
+    const inboxPath = join(stateRoot, "inbox");
+    rotationTimer = setInterval(async () => {
+      try {
+        let entries: string[];
+        try { entries = await readdir(inboxPath); } catch { return; }
+        const projects = new Set(
+          entries.filter((e) => e.endsWith(".log")).map((e) => e.slice(0, -".log".length)),
+        );
+        for (const project of projects) await rotateIfNeeded({ stateRoot, project, ...mboxCfg });
+      } catch (e) {
+        log(`rotation timer error: ${(e as Error).message}`);
+      }
+    }, rotationInterval);
+    rotationTimer.unref?.();
+  }
+
+  return {
+    stop(): Promise<void> {
+      if (deliveryTimer) clearInterval(deliveryTimer);
+      if (probeTimer) clearInterval(probeTimer);
+      if (timer) clearInterval(timer);
+      if (rotationTimer) clearInterval(rotationTimer);
+      try { ctx.cmuxEventsBridge.stop(); } catch { /* best-effort */ }
+      for (const kill of ctx.activeHeadlessKills) kill();
+      return new Promise<void>((resolve) => server.close(() => { log("stopped"); resolve(); }));
+    },
+    tickDelivery: deliveryTick,
+    tickProbe: probeTick,
+  };
+}

--- a/src/control/interfaces.ts
+++ b/src/control/interfaces.ts
@@ -1,0 +1,37 @@
+// src/control/interfaces.ts
+// Driver-seam interfaces: the contracts that cockpitd's driver-agnostic core depends on.
+// Concrete implementations (CodexInteractiveDriver, OpencodeSseBridge, CmuxEventsBridge,
+// DaemonCmux) live in the root package host and implement these structurally.
+import type { PaneRef } from "../runtimes/types.js";
+
+/** Interactive agent runtime driver (codex/claude/opencode thread ops). */
+export interface AgentDriver {
+  dispatch: (rec: any) => Promise<void>;
+  reattach: (rec: any) => Promise<void>;
+  say: (taskId: string, text: string) => Promise<void>;
+  steer: (taskId: string, text: string) => Promise<void>;
+  interrupt: (taskId: string) => Promise<void>;
+  answer: (taskId: string, payload: unknown) => Promise<void>;
+  close: (taskId: string) => Promise<void>;
+}
+
+/** Opencode SSE bridge seam (start/stop per-crew subscription + approve/deny). */
+export interface OpencodeBridge {
+  start: (o: { taskId: string; port: number }) => void;
+  stop: (taskId: string) => void;
+  /** CP3: POST the captain's approve/deny decision to the crew's server. */
+  answer: (taskId: string, decision: "approve" | "deny") => Promise<boolean>;
+}
+
+/** cmux native-events subscription seam (single global start/stop). */
+export interface CmuxEventsBridge {
+  start: () => void;
+  stop: () => void;
+}
+
+/** DaemonCmux surface subset used by the daemon-direct delivery loop (#332). */
+export interface DaemonSurfaceDriver {
+  findWorkspaceId?: (name: string) => Promise<string | null>;
+  listSurfaces: (wsId: string) => Promise<PaneRef[]>;
+  send: (surface: PaneRef, text: string, opts?: { probe?: boolean }) => Promise<void>;
+}


### PR DESCRIPTION
Part of the monorepo reorg ([spec](docs/superpowers/specs/2026-06-17-monorepo-reorg-step4-extract-core-design.md)), rollout step 4a.

## What changed

- Carved the driver-agnostic core out of `cockpitd.ts` (1032 LOC) into `src/control/daemon/`:
  - `context.ts` — `DaemonContext` shared state bag + `CockpitdOpts` + `buildContext`
  - `attach.ts` — broadcast fan-out + gate-promotion timers (`createAttach`)
  - `probes.ts` — relay-proxy + daemon-direct surface-liveness probes (`createProbes`, `buildSurfaceProbe`)
  - `delivery.ts` — mailbox append + daemon-direct captain delivery loop (`createDelivery`)
  - `gates.ts` — approve/deny routing to owning driver (`createGateResolver`)
  - `server.ts` — IPC socket server + full message router (`createServer`)
  - `snapshot-gather.ts` — pure I/O helpers for dashboard snapshot
  - `start.ts` — `startDaemon(ctx, opts, pkgVersion)`: wires all factories, boot recovery, timers, `DaemonHandle`
  - `interfaces.ts` — driver-seam interfaces (`AgentDriver`, `OpencodeBridge`, `CmuxEventsBridge`, `DaemonSurfaceDriver`)
  - `README.md` — module boundary docs

- `cockpitd.ts` becomes the **thin host** (139 LOC): constructs `CodexInteractiveDriver`, `OpencodeSseBridge`, `CmuxEventsBridge`, `DaemonCmux`, `launchHeadless`, then calls `startDaemon`. Entrypoint filename unchanged → `dist/cockpitd.js`, launchd plist, tsup entry untouched.

## What didn't change

- No package move (that is step 4b). Everything stays in `src/`.
- No behavior changes — behavior-preserving refactor only.
- Existing `startCockpitd(opts)` export preserved for test compatibility.

## Verified

- `pnpm i --frozen-lockfile && pnpm run build && pnpm test` — build green, 3 pre-existing relay-proxy flakes only
- `node dist/cockpitd.js` boots + logs `started pid=...`
- `node dist/index.js --help` works
- Task-9 grep gate passes: `git grep -nE "codex/driver|opencode/sse-bridge|cmux/events-bridge|cmux/daemon-cmux|runtimes/index|headless-launcher" -- src/control/daemon` → no output