### PR TITLE
Fix #363 (config ENOENT), #2 (crew tasks timeout / event-loop starvation), #3 (codex app-server teardown)

### DIFF
--- a/packages/agents/src/codex/driver.ts
+++ b/packages/agents/src/codex/driver.ts
@@ -170,6 +170,11 @@ export class CodexInteractiveDriver {
     }
   }
 
+  /** Kill the long-lived app-server child process on daemon shutdown. */
+  stop(): void {
+    this.client?.kill();
+  }
+
   async answer(taskId: string, payload: unknown): Promise<void> {
     const c = this.client!;
     const rec = this.serverRequestByTask.get(taskId);

--- a/packages/core/src/daemon/start.ts
+++ b/packages/core/src/daemon/start.ts
@@ -260,6 +260,7 @@ export function startDaemon(ctx: DaemonContext, opts: CockpitdOpts, pkgVersion: 
       if (timer) clearInterval(timer);
       if (rotationTimer) clearInterval(rotationTimer);
       try { ctx.cmuxEventsBridge.stop(); } catch { /* best-effort */ }
+      try { ctx.codexDriver.stop?.(); } catch { /* best-effort */ }
       for (const kill of ctx.activeHeadlessKills) kill();
       return new Promise<void>((resolve) => server.close(() => { log("stopped"); resolve(); }));
     },

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -13,6 +13,8 @@ export interface AgentDriver {
   interrupt: (taskId: string) => Promise<void>;
   answer: (taskId: string, payload: unknown) => Promise<void>;
   close: (taskId: string) => Promise<void>;
+  /** Tear down any long-lived child process (e.g. codex app-server) on daemon stop. */
+  stop?: () => void;
 }
 
 /** Opencode SSE bridge seam (start/stop per-crew subscription + approve/deny). */

--- a/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
+++ b/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
@@ -5,13 +5,22 @@ import { createCmuxDriver, sanitizeForCmuxSend, parseDraftFromScreen, classifySt
 
 const execFileMock = vi.hoisted(() => vi.fn());
 vi.mock("node:child_process", () => ({
-  execFileSync: execFileMock,
+  // Bridge: execFileMock is kept synchronous so assertions on mock.calls stay
+  // unchanged; this wrapper adapts it to the callback-based execFile signature.
+  execFile: (bin: string, args: string[], opts: unknown, cb: (err: Error | null, stdout: string) => void) => {
+    try {
+      const result = execFileMock(bin, args, opts);
+      cb(null, result ?? "");
+    } catch (err) {
+      cb(err as Error, "");
+    }
+  },
 }));
 
-// cmux() now invokes execFileSync(CMUX_BIN, argv[], opts) with no shell, so the
-// command + its arguments arrive as an argv array (calls[i][1]). These helpers
-// surface the argv for assertions; the binary path itself (calls[i][0]) is
-// irrelevant to behavior.
+// cmux() now invokes execFile(CMUX_BIN, argv[], opts, callback) with no shell,
+// so the command + its arguments arrive as an argv array (calls[i][1]). These
+// helpers surface the argv for assertions; the binary path itself (calls[i][0])
+// is irrelevant to behavior.
 const argvOf = (call: unknown[]): string[] => call[1] as string[];
 const cmdOf = (call: unknown[]): string => (call[1] as string[]).join(" ");
 

--- a/packages/workspaces/src/runtimes/cmux.ts
+++ b/packages/workspaces/src/runtimes/cmux.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import type { RuntimeDriver, RuntimeProbeResult, RuntimeSpawnOptions, WorkspaceRef, PaneRef, RuntimePaneOptions } from "./types.js";
 import { resolveCmuxBin } from "@cockpit/shared";
 import { checkToolCompat } from "@cockpit/shared";
@@ -23,23 +23,28 @@ export { DeferDelivery };
 // Invoke cmux with an argv array and NO shell. Every element (especially crew
 // prompt text passed through send/send-to-surface) reaches cmux as a single
 // literal argument — backticks, $(), quotes are never parsed. See #118.
-function cmux(args: string[]): string {
-  try {
-    // CMUX_QUIET=1 silences cmux 0.64's one-time deprecation hints (e.g. the
-    // "list-workspaces is now an alias for cmux workspace list" notice). Those
-    // notices print to the command's stdout and would otherwise pollute the
-    // output we parse. Inherit the rest of the environment unchanged.
-    return execFileSync(resolveCmuxBin(), args, {
-      encoding: "utf-8",
-      timeout: CMUX_TIMEOUT,
-      env: { ...process.env, CMUX_QUIET: "1" },
-    }).trim();
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ETIMEDOUT") {
-      throw new CmuxTimeoutError(args.join(" "));
-    }
-    throw err;
-  }
+// Async to avoid blocking the Node.js event loop during daemon timer ticks.
+function cmux(args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      resolveCmuxBin(),
+      args,
+      // CMUX_QUIET=1 silences cmux 0.64's one-time deprecation hints (e.g. the
+      // "list-workspaces is now an alias for cmux workspace list" notice). Those
+      // notices print to the command's stdout and would otherwise pollute the
+      // output we parse. Inherit the rest of the environment unchanged.
+      { encoding: "utf-8", timeout: CMUX_TIMEOUT, env: { ...process.env, CMUX_QUIET: "1" } },
+      (err, stdout) => {
+        if (err) {
+          reject((err as NodeJS.ErrnoException).code === "ETIMEDOUT"
+            ? new CmuxTimeoutError(args.join(" "))
+            : err);
+          return;
+        }
+        resolve((stdout as string).trim());
+      },
+    );
+  });
 }
 
 // Shape of `cmux workspace list --json` (cmux 0.64.16). Only the fields we
@@ -109,7 +114,7 @@ export function sanitizeForCmuxSend(text: string): string {
  * Handles both `>` (synthetic/test) and `❯` (U+276F, the real Claude Code
  * prompt character) as the input caret. The real prompt is followed by a
  * non-breaking space (U+00A0); JS `\s` covers it, so `\s+` matches either.
- * Also handles box-drawing `│ ❯ text │` variants.
+ * Also handles box-drawing `│ ❯ text │` variants.
  *
  * Three-state return (#268):
  *   "draft text" — input box found with content  → caller must DEFER
@@ -255,7 +260,7 @@ export function createCmuxDriver(): RuntimeDriver {
 
     async probe(): Promise<RuntimeProbeResult> {
       try {
-        const version = cmux(["--version"]);
+        const version = await cmux(["--version"]);
         const warn = checkToolCompat("cmux", version, compatManifest.tools.cmux);
         if (warn) process.stderr.write(`[cockpit] ${warn}\n`);
         return { installed: true, version };
@@ -268,7 +273,7 @@ export function createCmuxDriver(): RuntimeDriver {
       try {
         // --json: structured output (B2); --id-format refs: ids as
         // workspace:N refs, not numeric (from #325). Both are required.
-        return parseList(cmux(["workspace", "list", "--json", "--id-format", "refs"]));
+        return parseList(await cmux(["workspace", "list", "--json", "--id-format", "refs"]));
       } catch {
         return [];
       }
@@ -283,29 +288,29 @@ export function createCmuxDriver(): RuntimeDriver {
     async spawn(opts: RuntimeSpawnOptions): Promise<WorkspaceRef> {
       const newWorkspaceArgs = ["workspace", "create", "--command", opts.command];
       if (opts.workdir) newWorkspaceArgs.push("--cwd", opts.workdir);
-      const output = cmux(newWorkspaceArgs);
+      const output = await cmux(newWorkspaceArgs);
       const id = output.match(/workspace:\d+/)?.[0] || output.split(/\s+/).pop() || "";
       if (!id) {
         throw new Error(`cmux spawn did not return a workspace id: ${output}`);
       }
-      cmux(["workspace", "rename", id, "--title", opts.name]);
+      await cmux(["workspace", "rename", id, "--title", opts.name]);
       // Rename the initial tab to the workspace name so send() can route to it
       let initialSurface: string | undefined;
       try {
-        const tree = cmux(["tree", "--workspace", id, "--id-format", "refs"]);
+        const tree = await cmux(["tree", "--workspace", id, "--id-format", "refs"]);
         const m = tree.match(/surface\s+(surface:\d+)\s+\[\w+\]\s+"([^"]*)"/);
         if (m) {
           initialSurface = m[1];
-          cmux(["rename-tab", "--workspace", id, "--surface", m[1], opts.name]);
+          await cmux(["rename-tab", "--workspace", id, "--surface", m[1], opts.name]);
         }
       } catch { /* rename is best-effort */ }
       if (opts.pinToTop) {
         try {
-          cmux(["workspace-action", "--workspace", id, "--action", "pin"]);
-        } catch { /* pin is best-effort */ }
+          await cmux(["workspace-action", "--workspace", id, "--action", "pin"]);
+        } catch { /* workspace may not be pinned — proceed to close regardless */ }
         if (initialSurface) {
           try {
-            cmux(["tab-action", "--workspace", id, "--surface", initialSurface, "--action", "pin"]);
+            await cmux(["tab-action", "--workspace", id, "--surface", initialSurface, "--action", "pin"]);
           } catch { /* tab pin is best-effort */ }
         }
       }
@@ -323,23 +328,23 @@ export function createCmuxDriver(): RuntimeDriver {
           const surfaces = await this.listSurfaces(ws.id);
           const target = surfaces.find((s) => s.title === ws.name);
           if (target) {
-            cmux(["send", "--workspace", ws.id, "--surface", target.surfaceId, sanitizeForCmuxSend(message)]);
-            cmux(["send-key", "--workspace", ws.id, "--surface", target.surfaceId, "Enter"]);
+            await cmux(["send", "--workspace", ws.id, "--surface", target.surfaceId, sanitizeForCmuxSend(message)]);
+            await cmux(["send-key", "--workspace", ws.id, "--surface", target.surfaceId, "Enter"]);
             return;
           }
         } catch { /* fall through to default */ }
       }
-      cmux(["send", "--workspace", ref, sanitizeForCmuxSend(message)]);
-      cmux(["send-key", "--workspace", ref, "Enter"]);
+      await cmux(["send", "--workspace", ref, sanitizeForCmuxSend(message)]);
+      await cmux(["send-key", "--workspace", ref, "Enter"]);
     },
 
     async sendKey(ref: string, key: string): Promise<void> {
-      cmux(["send-key", "--workspace", ref, key]);
+      await cmux(["send-key", "--workspace", ref, key]);
     },
 
     async readScreen(ref: string): Promise<string> {
       try {
-        return cmux(["read-screen", "--workspace", ref]);
+        return await cmux(["read-screen", "--workspace", ref]);
       } catch {
         return "";
       }
@@ -349,10 +354,10 @@ export function createCmuxDriver(): RuntimeDriver {
       // cmux 0.64.16 refuses to close a pinned workspace. Unpin first so that
       // cockpit launch --fresh works even when the captain workspace is pinned.
       try {
-        cmux(["workspace-action", "--workspace", ref, "--action", "unpin"]);
+        await cmux(["workspace-action", "--workspace", ref, "--action", "unpin"]);
       } catch { /* workspace may not be pinned — proceed to close regardless */ }
       try {
-        cmux(["workspace", "close", ref]);
+        await cmux(["workspace", "close", ref]);
       } catch { /* may already be closed */ }
     },
 
@@ -367,7 +372,7 @@ export function createCmuxDriver(): RuntimeDriver {
       const cmd = opts.direction === "tab"
         ? ["new-surface", "--type", "terminal", "--workspace", opts.workspaceId, "--focus", "false"]
         : ["new-pane", "--type", "terminal", "--direction", opts.direction, "--workspace", opts.workspaceId, "--focus", "false"];
-      const output = cmux(cmd);
+      const output = await cmux(cmd);
       const surfaceId = output.match(/surface:\d+/)?.[0];
       if (!surfaceId) {
         const verb = opts.direction === "tab" ? "new-surface" : "new-pane";
@@ -375,7 +380,7 @@ export function createCmuxDriver(): RuntimeDriver {
       }
       if (opts.title) {
         try {
-          cmux(["rename-tab", "--workspace", opts.workspaceId, "--surface", surfaceId, "--title", opts.title]);
+          await cmux(["rename-tab", "--workspace", opts.workspaceId, "--surface", surfaceId, "--title", opts.title]);
         } catch { /* rename is best-effort */ }
       }
       return { workspaceId: opts.workspaceId, surfaceId };
@@ -383,18 +388,18 @@ export function createCmuxDriver(): RuntimeDriver {
 
     async closePane(pane: PaneRef): Promise<void> {
       try {
-        cmux(["close-surface", "--workspace", pane.workspaceId, "--surface", pane.surfaceId]);
+        await cmux(["close-surface", "--workspace", pane.workspaceId, "--surface", pane.surfaceId]);
       } catch { /* may already be closed */ }
     },
 
     async sendToPane(pane: PaneRef, message: string): Promise<void> {
-      cmux(["send", "--workspace", pane.workspaceId, "--surface", pane.surfaceId, sanitizeForCmuxSend(message)]);
-      cmux(["send-key", "--workspace", pane.workspaceId, "--surface", pane.surfaceId, "Enter"]);
+      await cmux(["send", "--workspace", pane.workspaceId, "--surface", pane.surfaceId, sanitizeForCmuxSend(message)]);
+      await cmux(["send-key", "--workspace", pane.workspaceId, "--surface", pane.surfaceId, "Enter"]);
     },
 
     async readPaneScreen(pane: PaneRef): Promise<string> {
       try {
-        return cmux(["read-screen", "--workspace", pane.workspaceId, "--surface", pane.surfaceId]);
+        return await cmux(["read-screen", "--workspace", pane.workspaceId, "--surface", pane.surfaceId]);
       } catch {
         return "";
       }
@@ -421,34 +426,34 @@ export function createCmuxDriver(): RuntimeDriver {
       // debug tab focused for ergonomics.
       const wsId = opts.captainWorkspace.id;
       const focus = opts.placement === "visible" ? "true" : "false";
-      const output = cmux(["new-surface", "--type", "terminal", "--workspace", wsId, "--focus", focus]);
+      const output = await cmux(["new-surface", "--type", "terminal", "--workspace", wsId, "--focus", focus]);
       const surfaceId = output.match(/surface:\d+/)?.[0];
       if (!surfaceId) {
         throw new Error(`cmux spawnInjector did not return a surface id: ${output}`);
       }
       if (opts.title) {
         try {
-          cmux(["rename-tab", "--workspace", wsId, "--surface", surfaceId, "--title", opts.title]);
+          await cmux(["rename-tab", "--workspace", wsId, "--surface", surfaceId, "--title", opts.title]);
         } catch { /* rename is best-effort */ }
       }
-      cmux(["send", "--workspace", wsId, "--surface", surfaceId, opts.command]);
-      cmux(["send-key", "--workspace", wsId, "--surface", surfaceId, "Enter"]);
+      await cmux(["send", "--workspace", wsId, "--surface", surfaceId, opts.command]);
+      await cmux(["send-key", "--workspace", wsId, "--surface", surfaceId, "Enter"]);
       return { workspaceId: wsId, surfaceId, title: opts.title };
     },
 
     async sendToSurface(surface: PaneRef, text: string, opts?: { probe?: boolean }): Promise<void> {
       const ws = surface.workspaceId;
       const sf = surface.surfaceId;
-      const deliver = () => {
-        cmux(["send", "--workspace", ws, "--surface", sf, sanitizeForCmuxSend(text)]);
-        cmux(["send-key", "--workspace", ws, "--surface", sf, "Enter"]);
+      const deliver = async () => {
+        await cmux(["send", "--workspace", ws, "--surface", sf, sanitizeForCmuxSend(text)]);
+        await cmux(["send-key", "--workspace", ws, "--surface", sf, "Enter"]);
       };
 
       // #258/#268 Approach B: deliver only when the captain's input is positively
       // confirmed empty. null = box not visible (overlay/menu/scroll) → always defer.
       let screen = "";
       try {
-        screen = cmux(["read-screen", "--workspace", ws, "--surface", sf]);
+        screen = await cmux(["read-screen", "--workspace", ws, "--surface", sf]);
       } catch { /* screen unreadable — parseDraftFromScreen("") → null → defer below */ }
       const draft = parseDraftFromScreen(screen);
 
@@ -456,7 +461,7 @@ export function createCmuxDriver(): RuntimeDriver {
       if (draft === null) throw new DeferDelivery(null);
 
       // Empty input — nothing to protect, deliver directly.
-      if (draft === "") { deliver(); return; }
+      if (draft === "") { await deliver(); return; }
 
       // A draft is present. On the hot path (no probe) we NEVER keystroke — we
       // defer and carry the content so the relay can track stability (#302).
@@ -469,10 +474,10 @@ export function createCmuxDriver(): RuntimeDriver {
       // stays invariant or dismisses to empty. So we PROTECT only on that exact
       // signature, and we NEVER re-paste screen-read content.
       const before = readInputBoxRaw(screen);
-      cmux(["send-key", "--workspace", ws, "--surface", sf, "backspace"]);
+      await cmux(["send-key", "--workspace", ws, "--surface", sf, "backspace"]);
       let afterScreen = "";
       try {
-        afterScreen = cmux(["read-screen", "--workspace", ws, "--surface", sf]);
+        afterScreen = await cmux(["read-screen", "--workspace", ws, "--surface", sf]);
       } catch { /* unreadable after probe — treat as no real draft, fall through to deliver */ }
       const after = readInputBoxRaw(afterScreen);
 
@@ -480,12 +485,12 @@ export function createCmuxDriver(): RuntimeDriver {
         // Confirmed REAL draft. Restore the single char our probe removed (NOT a
         // full re-paste — at most one known char), then defer. Never clobber, and
         // a ghost can never reach this branch, so it can never be materialized.
-        cmux(["send", "--workspace", ws, "--surface", sf, before.slice(-1)]);
+        await cmux(["send", "--workspace", ws, "--surface", sf, before.slice(-1)]);
         throw new DeferDelivery(draft);
       }
 
       // No real draft (ghost dismissed/invariant, or buffer now empty) → deliver.
-      deliver();
+      await deliver();
     },
 
     async listSurfaces(workspaceId: string): Promise<PaneRef[]> {
@@ -493,7 +498,7 @@ export function createCmuxDriver(): RuntimeDriver {
       try {
         // --json: structured output (B2); --id-format refs: surface ids as
         // surface:N refs, not numeric (from #325). Both are required.
-        output = cmux(["tree", "--workspace", workspaceId, "--json", "--id-format", "refs"]);
+        output = await cmux(["tree", "--workspace", workspaceId, "--json", "--id-format", "refs"]);
       } catch {
         return [];
       }

--- a/src/commands/__tests__/config.test.ts
+++ b/src/commands/__tests__/config.test.ts
@@ -1,9 +1,16 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import { spawnSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 import { runConfigCheck } from "../config.js";
 import { getDefaultConfig } from "@cockpit/shared";
+
+const __thisDir = dirname(fileURLToPath(import.meta.url));
+// Built CLI lives at <repo>/dist/index.js — three levels up from src/commands/__tests__/
+const DIST_CLI = join(__thisDir, "..", "..", "..", "dist", "index.js");
 
 let dir: string;
 let cfgPath: string;
@@ -52,5 +59,22 @@ describe("runConfigCheck", () => {
     const onDisk = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
     expect(onDisk._cockpitVersion).toBe("0.5.3");
     expect(onDisk.defaults.roles.crew.model).toBe("sonnet");
+  });
+});
+
+// #363: readPkgVersion() used "../../package.json" relative to import.meta.url
+// which overshoots to the parent of the repo root when bundled in dist/index.js.
+// Fixed to "../package.json" (one level up from dist/, landing on repo root).
+// This test runs the built CLI from /tmp to confirm no ENOENT (#363 regression).
+describe("readPkgVersion (bundled path, #363)", () => {
+  it.skipIf(!fs.existsSync(DIST_CLI))("config check does not ENOENT when invoked from outside the repo", () => {
+    const result = spawnSync("node", [DIST_CLI, "config", "check"], {
+      cwd: os.tmpdir(),
+      encoding: "utf-8",
+      timeout: 15_000,
+      env: { ...process.env, COCKPIT_DAEMON_SKIP: "1" },
+    });
+    expect(result.stderr ?? "").not.toMatch(/ENOENT/);
+    expect(result.error).toBeUndefined();
   });
 });

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,5 +1,7 @@
 import { Command } from "commander";
 import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 import chalk from "chalk";
 import { DEFAULT_CONFIG_PATH, getDefaultConfig, type CockpitConfig } from "@cockpit/shared";
 import { detectDrift, applySafeFixes, type DriftItem } from "@cockpit/shared";
@@ -109,6 +111,6 @@ configCommand
   });
 
 function readPkgVersion(): string {
-  const url = new URL("../../package.json", import.meta.url);
-  return JSON.parse(fs.readFileSync(url, "utf-8")).version as string;
+  const pkgPath = join(dirname(fileURLToPath(import.meta.url)), "..", "package.json");
+  return JSON.parse(fs.readFileSync(pkgPath, "utf-8")).version as string;
 }

--- a/src/control/__tests__/cockpitd-list.test.ts
+++ b/src/control/__tests__/cockpitd-list.test.ts
@@ -1,0 +1,84 @@
+// src/control/__tests__/cockpitd-list.test.ts
+// Integration test for kind:"list" round-trip (Bug #2 regression guard).
+// The "crew tasks" command was timing out because no existing test covered
+// the list path — this ensures the round-trip stays working.
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startCockpitd } from "../cockpitd.js";
+import { sendRequest } from "@cockpit/core";
+
+describe("kind:list round-trip (#2 crew tasks)", () => {
+  let stop: (() => Promise<void>) | undefined;
+  let dir: string;
+
+  afterEach(async () => {
+    if (stop) await stop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns [] for an empty project (no ENOENT, no timeout)", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-list-"));
+    const sock = join(dir, "c.sock");
+    const handle = startCockpitd({ stateRoot: join(dir, "state"), sockPath: sock, sweepMs: 0, rotationIntervalMs: 0 });
+    stop = handle.stop;
+
+    const result = await sendRequest(sock, { kind: "list", project: "myproject" });
+    expect(Array.isArray(result)).toBe(true);
+    expect((result as unknown[]).length).toBe(0);
+  });
+
+  it("returns seeded tasks for a project", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-list-"));
+    const sock = join(dir, "c.sock");
+    const handle = startCockpitd({ stateRoot: join(dir, "state"), sockPath: sock, sweepMs: 0, rotationIntervalMs: 0 });
+    stop = handle.stop;
+
+    const record = {
+      id: "task-abc", project: "myproject", provider: "claude" as const, mode: "interactive" as const,
+      state: "submitted" as const, task: "do something", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 300_000,
+      attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }],
+    };
+    await sendRequest(sock, { kind: "seed", record });
+
+    const result = await sendRequest(sock, { kind: "list", project: "myproject" });
+    expect(Array.isArray(result)).toBe(true);
+    const tasks = result as Array<{ id: string; state: string }>;
+    expect(tasks.length).toBe(1);
+    expect(tasks[0].id).toBe("task-abc");
+    expect(tasks[0].state).toBe("submitted");
+  });
+
+  it("does not include tasks from other projects", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-list-"));
+    const sock = join(dir, "c.sock");
+    const handle = startCockpitd({ stateRoot: join(dir, "state"), sockPath: sock, sweepMs: 0, rotationIntervalMs: 0 });
+    stop = handle.stop;
+
+    await sendRequest(sock, {
+      kind: "seed",
+      record: {
+        id: "task-p1", project: "proj1", provider: "claude" as const, mode: "interactive" as const,
+        state: "submitted" as const, task: "t", createdAt: 1, lastHeartbeat: 1,
+        lastEvent: "", heartbeatBudgetMs: 300_000,
+        attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }],
+      },
+    });
+    await sendRequest(sock, {
+      kind: "seed",
+      record: {
+        id: "task-p2", project: "proj2", provider: "claude" as const, mode: "interactive" as const,
+        state: "submitted" as const, task: "t", createdAt: 1, lastHeartbeat: 1,
+        lastEvent: "", heartbeatBudgetMs: 300_000,
+        attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }],
+      },
+    });
+
+    const result = await sendRequest(sock, { kind: "list", project: "proj1" });
+    const tasks = result as Array<{ id: string }>;
+    expect(tasks.length).toBe(1);
+    expect(tasks[0].id).toBe("task-p1");
+  });
+});

--- a/src/control/cockpitd.ts
+++ b/src/control/cockpitd.ts
@@ -23,7 +23,7 @@ import { createCmuxDriver, RuntimeRegistry } from "@cockpit/workspaces";
 const SELF_PATH = fileURLToPath(import.meta.url);
 function readPkgVersion(): string {
   try {
-    const pkgPath = join(dirname(SELF_PATH), "..", "..", "package.json");
+    const pkgPath = join(dirname(SELF_PATH), "..", "package.json");
     return (JSON.parse(readFileSync(pkgPath, "utf-8")).version as string) ?? "unknown";
   } catch { return "unknown"; }
 }


### PR DESCRIPTION
Three bugs surfaced during post-reorg verification. All confirmed reproducing on develop; fixed with TDD + systematic-debugging.

## #2 — `cockpit crew tasks` times out (the important one)
**Root cause:** `cmux.ts` used **`execFileSync`**, which **blocks the Node event loop** for ~700ms–2.8s on every daemon delivery/probe tick. On a busy live daemon this starves new socket requests, so `kind:"list"` (used by `crew tasks`) times out — while a fresh/idle daemon answers fine. `crew send`/`close` swallowed the same failure, hiding it; `crew list` reads cmux directly so was unaffected. (Also a likely contributor to the daemon PID churn observed under load.)
**Fix:** convert the `cmux()` helper to **async `execFile`** (Promise-wrapped); add `await` at every call site. All `RuntimeDriver` methods were already `async`, so **no public signature changes / zero caller blast radius**. Delivery ordering (send→Enter, and the #258/#268/#302 draft-protection probe sequence) is preserved — each step awaited sequentially, just non-blocking. New integration test: `cockpitd-list.test.ts`.

## #363 — `cockpit config check` / version read → ENOENT
**Root cause:** `config.ts` `new URL("../../package.json", import.meta.url)` overshot to the repo parent after tsup bundles to `dist/` (1 level). A second instance existed in `cockpitd.ts` (`"..",".."`).
**Fix:** resolve `package.json` one level up from the bundled file (`join(dirname(fileURLToPath(import.meta.url)), "..", "package.json")`) in both spots. Test: `config.test.ts` runs the built CLI from an arbitrary cwd.

## #3 — codex app-server lingers (investigated)
**Verdict:** the app-server is **shared/persistent by design** (survives individual crew close, which only archives the thread). It is **not** a per-close leak — but it *was* leaked on **daemon shutdown**.
**Fix:** add `stop?()` to the `AgentDriver` interface + `CodexInteractiveDriver.stop()` (kills the app-server child), wired into the daemon's stop path. Reaps cleanly on daemon stop without breaking the shared-server design.

## Gates
- `pnpm build` (tsc -b + tsup) green; `node dist/index.js --help` OK; `config check` works from `/tmp`.
- Suite: 1732 passed / 3 failed = the known #353 relay-proxy baseline, nothing new; +7 new passing tests.

Closes #363.