### PR TITLE
fix(cli): honor COCKPIT_DAEMON_SKIP to skip ensureDaemon (CI launchctl ENOENT on Linux)

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -77,7 +77,11 @@ if (process.argv[2] !== "config") {
 // best-effort, never throws; the CLI fails loud later if the socket is unreachable.
 // ensureDaemon resolves its own entrypoint (see launchd.daemonEntryPath) — no
 // path is passed here so no call site can get it wrong.
-ensureDaemon();
+// COCKPIT_DAEMON_SKIP short-circuits this for read-only / CI invocations that must
+// not attempt to boot the daemon (e.g. config-check tests on Linux without launchctl).
+if (!process.env.COCKPIT_DAEMON_SKIP) {
+  ensureDaemon();
+}
 
 const program = new Command();
 


### PR DESCRIPTION
## Summary

- `packages/cli/src/index.ts` called `ensureDaemon()` unconditionally on every CLI startup
- On Linux CI `launchctl` doesn't exist → `spawnSync launchctl ENOENT` leaks into test output
- `config.test.ts` (`#363`) sets `COCKPIT_DAEMON_SKIP=1` expecting the daemon skip — but nothing read that env var
- On macOS the test passed by luck (launchctl exists); on Linux it tripped `not.toMatch(/ENOENT/)` on the wrong ENOENT

## Fix

Guard the `ensureDaemon()` call in `packages/cli/src/index.ts` (one line):

```ts
if (!process.env.COCKPIT_DAEMON_SKIP) {
  ensureDaemon();
}
```

No test changes. No other files touched.

## Verification

- `pnpm build` ✅
- `COCKPIT_DAEMON_SKIP=1 node dist/index.js config check` from `/tmp` → prints config, zero launchctl/daemon spawn ✅
- `node dist/index.js --help` → works normally ✅
- `npx vitest run` → 1298 tests, 3 fails (all baseline #353 relay-proxy) ✅ — config `#363` test now passes

## Test plan

- [ ] CI on Linux should now pass the config check test without launchctl ENOENT
- [ ] macOS behaviour unchanged (normal invocations still boot the daemon)