### PR TITLE
feat(#354): semantic heartbeat — alive-thinking vs hung-tool vs turn-end

### DIFF
--- a/packages/cli/src/control/__tests__/cockpitd-push.test.ts
+++ b/packages/cli/src/control/__tests__/cockpitd-push.test.ts
@@ -99,29 +99,31 @@ describe("cockpitd push notifications (#109)", () => {
     expect(n.calls[0]?.message).toMatch(/no heartbeat/i);
   });
 
-  it("INTERACTIVE idle (from sweep) triggers exactly one CREW IDLE notify", async () => {
+  it("INTERACTIVE quiet (from sweep) triggers exactly one CREW QUIET notify, stays working (#354)", async () => {
     const store = createStore(dir);
-    // rec() defaults to mode: "interactive"
+    // rec() defaults to mode: "interactive"; no pendingTool → alive-thinking path.
     store.put(rec("task-idle-1", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250 }));
     const n = fakeNotify();
     const d = createDaemon({ store, now: () => 5000, notify: n.notify });
     await d.sweep();
-    expect(store.get("p", "task-idle-1")?.state).toBe("awaiting-input");
+    // Stays working — a quiet thinking turn is NOT awaiting-input (that lie is gone).
+    expect(store.get("p", "task-idle-1")?.state).toBe("working");
     expect(n.calls).toHaveLength(1);
-    expect(n.calls[0]?.message).toMatch(/^CREW IDLE \[claude\/task-idl/);
-    expect(n.calls[0]?.message).not.toMatch(/stall/i); // reads as idle, not failure
-    expect(n.calls[0]?.message).toMatch(/awaiting your input/i);
+    expect(n.calls[0]?.message).toMatch(/^CREW QUIET \[claude\/task-idl/);
+    expect(n.calls[0]?.message).not.toMatch(/stall/i);              // not a failure
+    expect(n.calls[0]?.message).not.toMatch(/awaiting your input/i); // not idle/turn-end
+    expect(n.calls[0]?.message).toMatch(/deep thinking/i);
   });
 
-  it("awaiting-input sits idle across repeated sweeps → no notification storm", async () => {
+  it("CREW QUIET fires once per quiet episode across repeated sweeps → no storm (#354)", async () => {
     const store = createStore(dir);
     store.put(rec("task-idle-2", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250 }));
     const n = fakeNotify();
     const d = createDaemon({ store, now: () => 5000, notify: n.notify });
-    await d.sweep(); // working → awaiting-input, one push
-    await d.sweep(); // awaiting-input is not 'working' → no re-stall, no re-notify
+    await d.sweep(); // quiet → one CREW QUIET
+    await d.sweep(); // same liveness episode → debounced, no re-notify
     await d.sweep();
-    expect(store.get("p", "task-idle-2")?.state).toBe("awaiting-input");
+    expect(store.get("p", "task-idle-2")?.state).toBe("working");
     expect(n.calls).toHaveLength(1);
   });
 

--- a/packages/cli/src/control/__tests__/daemon.test.ts
+++ b/packages/cli/src/control/__tests__/daemon.test.ts
@@ -116,12 +116,51 @@ describe("daemon handler", () => {
     expect(store.get("p", "s1")?.state).toBe("stalled");
   });
 
-  it("sweep: marks an over-budget working INTERACTIVE task awaiting-input (not stalled)", async () => {
+  // #354: a quiet INTERACTIVE crew with no tool in flight is alive-thinking, NOT
+  // awaiting-input — the watchdog no longer flips it. It stays `working` and the
+  // sweep emits a distinct, non-alarming CREW QUIET notify (once per episode).
+  it("sweep: over-budget INTERACTIVE task with no tool in flight stays working + CREW QUIET (#354)", async () => {
     const store = createStore(dir);
-    store.put(rec("s1i", { mode: "interactive", state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 100 }));
-    const d = createDaemon({ store, now: () => 1000 });
+    const calls: any[] = [];
+    store.put(rec("s1i", { mode: "interactive", state: "working", lastHeartbeat: 0,
+      heartbeatBudgetMs: 100, attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 0 }] }));
+    const d = createDaemon({ store, now: () => 1000, notify: async (a) => { calls.push(a); } });
     await d.sweep();
-    expect(store.get("p", "s1i")?.state).toBe("awaiting-input");
+    expect(store.get("p", "s1i")?.state).toBe("working");
+    expect(calls.length).toBe(1);
+    expect(calls[0].message).toMatch(/CREW QUIET/);
+    expect(calls[0].event.type).toBe("task.quiet");
+  });
+
+  // #354: an interactive crew with a tool in flight (PreToolUse, no PostToolUse)
+  // past the tool-stall budget IS a hung tool call → stalled, with a tool-named,
+  // recoverable CREW STALLED warn.
+  it("sweep: INTERACTIVE crew with a hung tool past tool-stall budget → stalled + CREW STALLED(tool) (#354)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    store.put(rec("s1t", { mode: "interactive", state: "working", lastHeartbeat: 0,
+      heartbeatBudgetMs: 100, pendingTool: { name: "Bash", since: 0 },
+      attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 0 }] }));
+    // now far beyond the 10-min default tool-stall budget
+    const d = createDaemon({ store, now: () => 11 * 60_000, notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    expect(store.get("p", "s1t")?.state).toBe("stalled");
+    expect(calls.length).toBe(1);
+    expect(calls[0].message).toMatch(/CREW STALLED.*Bash.*possibly hung/);
+  });
+
+  // #354: a long-but-live tool (within the tool-stall budget) does NOT trip —
+  // the false-stalled guard for legit multi-minute test suites / builds.
+  it("sweep: INTERACTIVE crew with a tool in flight WITHIN tool-stall budget → no stall, no QUIET (#354)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    store.put(rec("s1l", { mode: "interactive", state: "working", lastHeartbeat: 0,
+      heartbeatBudgetMs: 100, pendingTool: { name: "Bash", since: 0 },
+      attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 0 }] }));
+    const d = createDaemon({ store, now: () => 5 * 60_000, notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    expect(store.get("p", "s1l")?.state).toBe("working");
+    expect(calls.length).toBe(0);
   });
 
   it("sweep: recovers a stalled task that has a fresh heartbeat", async () => {
@@ -175,22 +214,25 @@ describe("daemon handler", () => {
   });
 
   // The critical non-regression: a LEGITIMATELY-IDLE live crew (surface alive)
-  // that is over its heartbeat budget must still become awaiting-input (CREW
-  // IDLE), NEVER reaped. This preserves the #131/#133 24h-budget false-stall fix.
-  it("sweep: interactive over-budget record with a LIVE surface → awaiting-input, not reaped (#139)", async () => {
+  // that is over its heartbeat budget must NEVER be reaped. Post-#354 a quiet
+  // thinking crew stays `working` (CREW QUIET, not awaiting-input); the point of
+  // this test — alive/unknown surfaces are not false-reaped — still holds.
+  it("sweep: interactive over-budget record with a LIVE surface → stays working, not reaped (#139/#354)", async () => {
     const store = createStore(dir);
-    store.put(rec("g4", { mode: "interactive", state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 100 }));
+    store.put(rec("g4", { mode: "interactive", state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 100,
+      attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 0 }] }));
     const d = createDaemon({ store, now: () => 1000, isSurfaceAlive: async () => "alive" });
     await d.sweep();
-    expect(store.get("p", "g4")?.state).toBe("awaiting-input");
+    expect(store.get("p", "g4")?.state).toBe("working");
   });
 
-  it("sweep: interactive over-budget record with UNKNOWN surface → awaiting-input, never false-reaped (#139)", async () => {
+  it("sweep: interactive over-budget record with UNKNOWN surface → stays working, never false-reaped (#139/#354)", async () => {
     const store = createStore(dir);
-    store.put(rec("g5", { mode: "interactive", state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 100 }));
+    store.put(rec("g5", { mode: "interactive", state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 100,
+      attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 0 }] }));
     const d = createDaemon({ store, now: () => 1000, isSurfaceAlive: async () => "unknown" });
     await d.sweep();
-    expect(store.get("p", "g5")?.state).toBe("awaiting-input");
+    expect(store.get("p", "g5")?.state).toBe("working");
   });
 
   it("sweep: headless records are never surface-reaped (pid is their liveness) (#139)", async () => {

--- a/packages/cli/src/control/__tests__/state-machine.test.ts
+++ b/packages/cli/src/control/__tests__/state-machine.test.ts
@@ -173,6 +173,58 @@ describe("state-machine reduce", () => {
     expect(postToolUse.lastEvent).toBe("task.progress");
   });
 
+  // ── #354: pendingTool lifecycle (hung-tool vs thinking discriminator) ────────
+  it("task.progress PreToolUse opens a pendingTool window with the tool name", () => {
+    const next = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Bash" }, 7000);
+    expect(next.pendingTool).toEqual({ name: "Bash", since: 7000 });
+  });
+
+  it("task.progress PreToolUse with no tool name falls back to a generic label", () => {
+    const next = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse" }, 7000);
+    expect(next.pendingTool).toEqual({ name: "tool", since: 7000 });
+  });
+
+  it("task.progress PostToolUse closes the pendingTool window", () => {
+    const open = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Bash" }, 7000);
+    const closed = reduce(open, { type: "task.progress", id: "t1", note: "posttooluse" }, 8000);
+    expect(closed.pendingTool).toBeUndefined();
+  });
+
+  it("task.progress UserPromptSubmit (new turn) closes the pendingTool window", () => {
+    const open = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Bash" }, 7000);
+    const closed = reduce(open, { type: "task.progress", id: "t1", note: "agent.hook.UserPromptSubmit" }, 8000);
+    expect(closed.pendingTool).toBeUndefined();
+  });
+
+  it("a non-bounding liveness note (notification) leaves pendingTool untouched", () => {
+    const open = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Bash" }, 7000);
+    const still = reduce(open, { type: "task.progress", id: "t1", note: "notification" }, 8000);
+    expect(still.pendingTool).toEqual({ name: "Bash", since: 7000 });
+  });
+
+  it("turn boundaries clear pendingTool (turn.completed / task.started)", () => {
+    const open = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Bash" }, 7000);
+    const ended = reduce(open, { type: "task.turn.completed", id: "t1", turnId: "x" }, 8000);
+    expect(ended.pendingTool).toBeUndefined();
+    const started = reduce(reduce(open, { type: "task.blocked", id: "t1", reason: "r", question: "q?" }, 8000),
+      { type: "task.started", id: "t1" }, 9000);
+    expect(started.pendingTool).toBeUndefined();
+  });
+
+  it("stalled + task.progress (matching PostToolUse) recovers to working AND clears pendingTool (#354 auto-clear)", () => {
+    const stalledHung = rec({ state: "stalled", pendingTool: { name: "Bash", since: 1000 } });
+    const recovered = reduce(stalledHung, { type: "task.progress", id: "t1", note: "posttooluse" }, 9000);
+    expect(recovered.state).toBe("working");
+    expect(recovered.pendingTool).toBeUndefined();
+    expect(recovered.lastHeartbeat).toBe(9000);
+  });
+
+  it("task.quiet is a no-op (notify-only; crew stays in its current state)", () => {
+    const working = rec({ state: "working" });
+    const next = reduce(working, { type: "task.quiet", id: "t1", quietMs: 400000 }, 9000);
+    expect(next).toBe(working); // same reference — pure no-op
+  });
+
   it("awaiting-input + task.done still transitions to done (terminal not blocked)", () => {
     const next = reduce(rec({ state: "awaiting-input" }), { type: "task.done", id: "t1", resultRef: "/r" }, 10000);
     expect(next.state).toBe("done");

--- a/packages/cli/src/control/__tests__/watchdog.test.ts
+++ b/packages/cli/src/control/__tests__/watchdog.test.ts
@@ -21,15 +21,26 @@ describe("evaluateStall", () => {
     expect(out?.lastEvent).toBe("watchdog.stall");
   });
 
-  it("working INTERACTIVE past budget → awaiting-input, not stalled", () => {
-    // An idle interactive crew has simply ended a turn and is awaiting the
-    // captain's next message — that is NOT a stall. Surface it as the
-    // answerable 'awaiting-input' state so the captain gets an accurate,
-    // non-alarming nudge instead of a misleading CREW STALLED.
-    const out = evaluateStall(rec({ mode: "interactive" }), 6001);
-    expect(out?.state).toBe("awaiting-input");
-    expect(out?.state).not.toBe("stalled");
-    expect(out?.lastEvent).toBe("watchdog.idle");
+  it("working INTERACTIVE past budget with NO tool in flight → null (alive-thinking, #354)", () => {
+    // A quiet interactive crew with no tool in flight is deep-thinking, not
+    // stalled and NOT awaiting-input (the turn never ended). evaluateStall stays
+    // out of it; the daemon sweep surfaces CREW QUIET instead. This replaces the
+    // old wall-clock → 'awaiting-input' flip that produced the false CREW IDLE.
+    expect(evaluateStall(rec({ mode: "interactive" }), 6001)).toBeNull();
+  });
+
+  it("working INTERACTIVE with a hung tool past tool-stall budget → stalled (#354)", () => {
+    // A PreToolUse with no matching PostToolUse, outstanding past the tool-stall
+    // budget, is a hung tool call — recoverable CREW STALLED, named by tool.
+    const out = evaluateStall(rec({ mode: "interactive", pendingTool: { name: "Bash", since: 0 } }), 11 * 60_000);
+    expect(out?.state).toBe("stalled");
+    expect(out?.lastEvent).toBe("watchdog.tool-stall");
+  });
+
+  it("working INTERACTIVE with a tool in flight WITHIN tool-stall budget → null (legit long tool, #354)", () => {
+    // A 5-min test suite / build is a long unpaired PreToolUse but must NOT trip.
+    const out = evaluateStall(rec({ mode: "interactive", pendingTool: { name: "Bash", since: 0 } }), 5 * 60_000);
+    expect(out).toBeNull();
   });
 
   it("working within budget → no change (null)", () => {
@@ -60,12 +71,13 @@ describe("recoverStall", () => {
   });
 });
 
-describe("idle interactive-codex = warn-don't-autofail (spec §4.8, #90 slice)", () => {
-  // #90's intent ("warn-don't-autofail") was that an idle interactive-codex
-  // task must remain answerable, never auto-failed. We now express that as
-  // 'awaiting-input' rather than 'stalled': both are non-terminal & answerable,
-  // but 'awaiting-input' reads to the captain as normal idle (turn ended)
-  // instead of a failure, and resumes to 'working' on the next liveness/turn.
+describe("idle interactive = warn-don't-autofail (spec §4.8, #90 slice; #354 degradation)", () => {
+  // #90's intent ("warn-don't-autofail") was that an idle interactive task must
+  // remain answerable, never auto-failed. Post-#354 a quiet interactive crew
+  // with no tool in flight stays `working` (CREW QUIET) — strictly more
+  // answerable than the old 'awaiting-input' flip, and certainly never failed.
+  // codex/opencode have no PreToolUse feed, so they never set pendingTool and so
+  // always take this Tier-A (QUIET-only) path — the clean degradation.
   function rec(overrides: Partial<TaskRecord> = {}): TaskRecord {
     return {
       id: "t1", project: "p", provider: "codex", mode: "interactive",
@@ -76,20 +88,14 @@ describe("idle interactive-codex = warn-don't-autofail (spec §4.8, #90 slice)",
     };
   }
 
-  it("an idle interactive-codex task is non-terminal & answerable (awaiting-input, never failed)", () => {
-    const idle = evaluateStall(rec(), 100_000);
-    expect(idle).not.toBeNull();
-    expect(idle!.state).toBe("awaiting-input");
-    expect(idle!.state).not.toBe("failed");
-    expect(idle!.state).not.toBe("done");
+  it("a quiet interactive task (no tool in flight) is never stalled/failed by the watchdog (#354)", () => {
+    const out = evaluateStall(rec(), 100_000);
+    expect(out).toBeNull(); // stays working — the sweep emits CREW QUIET, not a state change
   });
 
-  it("an idle interactive-codex task resumes to working on the next turn (task.started/PostToolUse)", () => {
-    // awaiting-input → working is the reducer's job (task.started / task.progress);
-    // the watchdog itself never re-stalls an awaiting-input task.
-    const idle = evaluateStall(rec(), 100_000)!;
-    expect(evaluateStall(idle, 200_000)).toBeNull(); // no re-stall while idle
-    expect(recoverStall(idle, 101_000)).toBeNull();  // recoverStall only acts on 'stalled'
+  it("the watchdog never re-stalls and recoverStall ignores a working task", () => {
+    expect(evaluateStall(rec(), 200_000)).toBeNull();
+    expect(recoverStall(rec(), 101_000)).toBeNull(); // recoverStall only acts on 'stalled'
   });
 });
 

--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -112,8 +112,17 @@ function formatMessage(rec: TaskRecord, event?: ControlEvent): string | null {
       return `CREW BLOCKED ${tag}: ${(rec.question ?? "(no question)").trim()}`;
     case "failed":
       return `CREW FAILED ${tag}: ${(rec.error ?? "(no error)").trim()}`;
-    case "stalled":
+    case "stalled": {
+      // #354: a hung interactive tool call reads differently from a headless
+      // heartbeat stall — name the tool and how long it has been outstanding,
+      // and frame it as "possibly hung" (recoverable, auto-clears on the tool's
+      // PostToolUse), NOT a death notice.
+      if (event?.type === "task.stalled" && event.tool) {
+        const mins = event.elapsedMs != null ? Math.max(1, Math.round(event.elapsedMs / 60000)) : null;
+        return `CREW STALLED ${tag}: still running ${event.tool}${mins != null ? ` ~${mins}min` : ""} — possibly hung (no result yet).`;
+      }
       return `CREW STALLED ${tag}: no heartbeat in ${rec.heartbeatBudgetMs}ms`;
+    }
     case "awaiting-input":
       return `CREW IDLE ${tag}: turn ended / awaiting your input — review and reply or close.`;
     default:
@@ -207,7 +216,7 @@ const KNOWN_EVENT_TYPES: ReadonlySet<string> = new Set([
   "task.session", "task.turn.started", "task.turn.completed",
   "task.delta", "task.input.requested", "task.approval.requested",
   "task.reattached", "task.reopened",
-  "task.stalled", "task.idle", "task.timeout", "task.reconcile-failed",
+  "task.stalled", "task.idle", "task.quiet", "task.timeout", "task.reconcile-failed",
   "task.cancelled", "task.session.ended",
 ]);
 
@@ -218,6 +227,10 @@ export function createDaemon(deps: DaemonDeps) {
   // active back-and-forth. Bounded by the live task set; never read after a
   // task terminates (terminal states don't transition to awaiting-input).
   const lastCaptainTurnAt = new Map<string, number>();
+  // #354: per-task debounce for CREW QUIET. Keyed to the liveness timestamp of
+  // the quiet episode so exactly one QUIET fires per episode; when the crew shows
+  // activity again, liveness advances and a later quiet episode re-notifies.
+  const quietNotifiedAt = new Map<string, number>();
   return {
     async handle(req: Req): Promise<TaskRecord | TaskRecord[]> {
       switch (req.kind) {
@@ -373,19 +386,48 @@ export function createDaemon(deps: DaemonDeps) {
             continue;
           }
         }
+        // #354: evaluateStall now only stalls a HEADLESS heartbeat timeout or a
+        // hung INTERACTIVE tool call (PreToolUse with no PostToolUse past the
+        // tool-stall budget). A quiet interactive thinking turn no longer stalls
+        // here — it is surfaced as CREW QUIET below, keeping the crew `working`.
         const idle = evaluateStall(r, t);
         if (idle) {
           store.put(idle);
-          // Interactive idle → awaiting-input (task.idle); headless → stalled
-          // (task.stalled). The synth event only carries the notify payload;
-          // the reducer treats both as no-ops (state already updated above).
-          const synthEvent: ControlEvent =
-            idle.state === "awaiting-input"
-              ? { type: "task.idle", id: r.id, heartbeatBudgetMs: r.heartbeatBudgetMs }
-              : { type: "task.stalled", id: r.id, heartbeatBudgetMs: r.heartbeatBudgetMs };
+          // The synth event only carries the notify payload; the reducer treats
+          // it as a no-op (state already updated above). A hung-tool stall carries
+          // the tool name + elapsed so the notifier renders the accurate message.
+          const synthEvent: ControlEvent = idle.pendingTool
+            ? { type: "task.stalled", id: r.id, heartbeatBudgetMs: r.heartbeatBudgetMs, tool: idle.pendingTool.name, elapsedMs: t - idle.pendingTool.since }
+            : { type: "task.stalled", id: r.id, heartbeatBudgetMs: r.heartbeatBudgetMs };
           firePush(deps, r.project, r.state, idle, synthEvent, lastCaptainTurnAt.get(r.id));
           continue;
         }
+        // #354 CREW QUIET: a `working` interactive crew quiet past its heartbeat
+        // budget with NO tool in flight is alive but deep-thinking (no hook fires
+        // during pure model thinking). Surface a distinct, non-alarming nudge —
+        // NOT 'awaiting-input' (the turn never ended; real CREW IDLE comes only
+        // from the Stop hook). State stays `working`; notify once per episode.
+        if (r.mode === "interactive" && r.state === "working" && !r.pendingTool) {
+          const liveness = r.attempts.at(-1)?.lastHeartbeatAt ?? r.lastHeartbeat;
+          const quiet = t - liveness;
+          if (quiet > r.heartbeatBudgetMs) {
+            if (deps.notify && quietNotifiedAt.get(r.id) !== liveness) {
+              quietNotifiedAt.set(r.id, liveness);
+              const tag = `[${r.provider}/${r.name != null ? r.name : shortId(r.id)}]`;
+              const mins = Math.max(1, Math.round(quiet / 60000));
+              const message = `CREW QUIET ${tag}: working ~${mins}min with no tool activity — likely deep thinking (no reply expected yet).`;
+              const synthEvent: ControlEvent = { type: "task.quiet", id: r.id, quietMs: quiet };
+              try {
+                const p = deps.notify({ project: r.project, message, record: r, event: synthEvent });
+                if (p && typeof (p as Promise<void>).catch === "function") (p as Promise<void>).catch(() => {});
+              } catch { /* swallowed — a flaky notifier must never trip the sweep */ }
+            }
+            continue;
+          }
+        }
+        // Activity resumed (or never went quiet) → drop any QUIET debounce marker
+        // so the next genuine quiet episode notifies again, and avoid map growth.
+        if (quietNotifiedAt.has(r.id)) quietNotifiedAt.delete(r.id);
         const recovered = recoverStall(r, t);
         // recoverStall does NOT check heartbeat freshness — guard per its contract
         if (recovered && t - r.lastHeartbeat <= r.heartbeatBudgetMs) store.put(recovered);

--- a/packages/core/src/state-machine.ts
+++ b/packages/core/src/state-machine.ts
@@ -19,6 +19,25 @@ function stampAttempt(
 }
 
 /**
+ * #354: compute the next pendingTool marker for a task.progress liveness signal.
+ * A PreToolUse (carried from the cmux events-bridge, with the tool name) opens a
+ * tool-in-flight window; a PostToolUse or a new UserPromptSubmit closes it. Other
+ * liveness notes (subagentstop / notification) leave the marker untouched — they
+ * do not bound a tool call. The note strings match the two feeds: the events-bridge
+ * emits the raw cmux hook name ("agent.hook.PreToolUse"); the claude hook bridge
+ * emits the lower-cased event ("posttooluse").
+ */
+function nextPendingTool(
+  current: TaskRecord["pendingTool"],
+  ev: Extract<ControlEvent, { type: "task.progress" }>,
+  now: number,
+): TaskRecord["pendingTool"] {
+  if (ev.note === "agent.hook.PreToolUse") return { name: ev.tool ?? "tool", since: now };
+  if (ev.note === "posttooluse" || ev.note === "agent.hook.UserPromptSubmit") return undefined;
+  return current;
+}
+
+/**
  * Pure transition. `now` is injected (epoch ms) so callers control time.
  * Returns a new record; never mutates the input.
  */
@@ -43,17 +62,24 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
         pid: ev.pid ?? rec.pid,
         sessionId: ev.sessionId ?? rec.sessionId,
         question: undefined, // resuming after a blocked→reply clears the question
+        pendingTool: undefined, // #354: a new turn closes any prior tool window
       };
-    case "task.progress":
+    case "task.progress": {
       // task.progress is a real-activity signal (stdout chunk for headless,
-      // PostToolUse/SubagentStop hook for interactive). Stamp the attempt so
-      // lastHeartbeatAt stays current and the watchdog stall-check (#89) can
-      // key off it without false-stalling long-running headless tasks.
+      // PreToolUse/PostToolUse/SubagentStop hook for interactive). Stamp the
+      // attempt so lastHeartbeatAt stays current and the watchdog stall-check
+      // (#89) can key off it without false-stalling long-running headless tasks.
+      // #354: also track the in-flight tool (PreToolUse opens, PostToolUse closes)
+      // so a hung tool call is distinguishable from a quiet thinking turn.
       // From blocked: liveness only — do not auto-unblock (explicit reply required).
-      // From awaiting-input: resume to working (PostToolUse on the next turn).
-      if (rec.state === "blocked") return { ...rec, lastHeartbeat: now, lastEvent: ev.type };
-      if (rec.state === "awaiting-input") return { ...stampAttempt(base, {}, now), state: "working" };
-      return stampAttempt(base, {}, now);
+      // From awaiting-input OR stalled: resume to working — the next real activity
+      // (e.g. the matching PostToolUse) auto-clears a hung-tool warn instantly.
+      const pendingTool = nextPendingTool(rec.pendingTool, ev, now);
+      if (rec.state === "blocked") return { ...rec, lastHeartbeat: now, lastEvent: ev.type, pendingTool };
+      const b = { ...base, pendingTool };
+      if (rec.state === "awaiting-input" || rec.state === "stalled") return { ...stampAttempt(b, {}, now), state: "working" };
+      return stampAttempt(b, {}, now);
+    }
     case "heartbeat":
       // Raw liveness ping — intentionally does NOT stamp the attempt so a late
       // heartbeat from a dead dispatch cannot mask stalls on the new one (#89).
@@ -70,7 +96,7 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
       // no-op so the FIRST (explicit) question wins and no duplicate CREW
       // BLOCKED fires. Terminal states are already absorbed above.
       if (rec.state === "blocked") return { ...rec, lastHeartbeat: now, lastEvent: ev.type };
-      return { ...base, state: "blocked", question: ev.question };
+      return { ...base, state: "blocked", question: ev.question, pendingTool: undefined };
     case "task.done":
       return { ...base, state: "done", resultRef: ev.resultRef, parseWarning: ev.parseWarning };
     case "task.failed":
@@ -85,7 +111,7 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
     case "task.session":
       return stampAttempt(base, { resumeRef: ev.resumeRef }, now);
     case "task.turn.started":
-      return { ...stampAttempt(base, {}, now), state: "working" };
+      return { ...stampAttempt(base, {}, now), state: "working", pendingTool: undefined };
     case "task.turn.completed":
       // Anti-#2576 invariant: TurnCompleted is liveness, NEVER completion. Spec §4.8.
       // A turn ending while blocked must NOT unblock — only the captain's answer
@@ -93,20 +119,22 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
       // opencode SSE bridge emits task.turn.completed right after an explicit
       // `signal blocked`, and that trailing turn-end must not drop the question.
       if (rec.state === "blocked") return { ...rec, lastHeartbeat: now, lastEvent: ev.type };
-      return { ...stampAttempt(base, {}, now), state: "awaiting-input" };
+      return { ...stampAttempt(base, {}, now), state: "awaiting-input", pendingTool: undefined };
     case "task.delta":
       return stampAttempt(base, {}, now);  // heartbeat-only
     case "task.input.requested":
     case "task.approval.requested":
-      return { ...stampAttempt(base, {}, now), state: "blocked", question: ev.question };
+      return { ...stampAttempt(base, {}, now), state: "blocked", question: ev.question, pendingTool: undefined };
     case "task.reattached":
       return stampAttempt(base, {}, now);
     case "task.stalled":
     case "task.idle":
+    case "task.quiet":
     case "task.timeout":
     case "task.reconcile-failed":
       // Synthetic notify-only events; the daemon has already updated state
-      // directly via the watchdog/reconcile paths. Reducer is a no-op.
+      // directly via the watchdog/reconcile paths (task.quiet carries no state
+      // change at all — the crew stays `working`). Reducer is a no-op.
       return rec;
     default:
       // #87: unknown/future event type from the wire — safe no-op.

--- a/packages/core/src/watchdog.ts
+++ b/packages/core/src/watchdog.ts
@@ -2,29 +2,53 @@
 import type { TaskRecord } from "@cockpit/shared";
 
 /**
- * Pure. Returns an idle-transitioned record if a `working` task has exceeded
- * its heartbeat budget at time `now` (epoch ms), else null. No I/O, no clock.
- *
- * Mode decides what "idle" means:
- *  - interactive → 'awaiting-input'. An idle interactive crew has merely ended
- *    a turn and is awaiting the captain's next message — answerable, NOT a
- *    failure. This reframes the old interactive-codex 'stalled' surfacing
- *    (#90 "warn-don't-autofail", spec §4.8) into an explicitly answerable
- *    state that reads as normal idle and resumes to 'working' on next liveness.
- *  - headless → 'stalled'. A batch child that stops heartbeating is genuinely
- *    stuck; there is no captain turn to await, so surface it as a stall.
- *
- * Neither state is terminal; this function never produces `failed` directly.
+ * #354: how long an interactive tool call may be in flight before it is treated
+ * as hung. Deliberately generous (much larger than the 5-min heartbeat budget)
+ * so a legitimately long tool — a multi-minute test suite, a big build, a slow
+ * git/network op — does NOT trip it: those are real, recoverable work, and the
+ * matching PostToolUse auto-clears the warn the instant it returns. Only a tool
+ * that produces no result for this long is suspicious enough to surface as
+ * "possibly hung". Default 10 min; tune via evaluateStall's `toolStallMs`.
  */
-export function evaluateStall(rec: TaskRecord, now: number): TaskRecord | null {
+export const TOOL_STALL_BUDGET_MS = 10 * 60 * 1000;
+
+/**
+ * Pure. Returns a stalled-transitioned record if a `working` task is genuinely
+ * stuck at time `now` (epoch ms), else null. No I/O, no clock. #354 splits the
+ * old single wall-clock timeout by what we can actually prove:
+ *
+ *  - headless → 'stalled' once quiet past the heartbeat budget. A batch child
+ *    that stops emitting stdout is stuck; there is no captain turn to await.
+ *  - interactive WITH a tool in flight (pendingTool) → 'stalled' once that tool
+ *    has been outstanding past `toolStallMs`. A PreToolUse with no matching
+ *    PostToolUse is a hung tool call (we know which tool). Recoverable: the next
+ *    PostToolUse recovers it to `working` (state-machine / recoverStall).
+ *  - interactive with NO tool in flight → null. A quiet thinking turn is alive,
+ *    not stalled and NOT awaiting-input (the turn never ended — real CREW IDLE
+ *    comes only from the Stop hook). The daemon sweep surfaces this as a
+ *    distinct, non-alarming CREW QUIET notify instead (#354), keeping the crew
+ *    `working`. This replaces the old wall-clock → 'awaiting-input' flip, which
+ *    mislabeled deep-thinking crews as "awaiting your input".
+ *
+ * This function never produces `failed` or `awaiting-input` directly.
+ */
+export function evaluateStall(
+  rec: TaskRecord,
+  now: number,
+  toolStallMs: number = TOOL_STALL_BUDGET_MS,
+): TaskRecord | null {
   if (rec.state !== "working") return null;
-  // Key off the latest attempt's lastHeartbeatAt so a stale event from a dead
-  // prior attempt cannot refresh the liveness clock of the new dispatch (#89).
+  if (rec.mode === "interactive") {
+    // Only a hung tool call is a stall for an interactive crew; a quiet thinking
+    // turn (no pendingTool) is alive and handled by the sweep's CREW QUIET path.
+    if (!rec.pendingTool) return null;
+    if (now - rec.pendingTool.since <= toolStallMs) return null;
+    return { ...rec, state: "stalled", lastEvent: "watchdog.tool-stall" };
+  }
+  // headless: key off the latest attempt's lastHeartbeatAt so a stale event from
+  // a dead prior attempt cannot refresh the liveness clock of the new dispatch (#89).
   const liveness = rec.attempts.at(-1)?.lastHeartbeatAt ?? rec.lastHeartbeat;
   if (now - liveness <= rec.heartbeatBudgetMs) return null;
-  if (rec.mode === "interactive") {
-    return { ...rec, state: "awaiting-input", lastEvent: "watchdog.idle" };
-  }
   return { ...rec, state: "stalled", lastEvent: "watchdog.stall" };
 }
 
@@ -38,5 +62,7 @@ export function evaluateStall(rec: TaskRecord, now: number): TaskRecord | null {
  */
 export function recoverStall(rec: TaskRecord, now: number): TaskRecord | null {
   if (rec.state !== "stalled") return null;
-  return { ...rec, state: "working", lastHeartbeat: now, lastEvent: "watchdog.recover" };
+  // #354: clear any hung-tool marker on recovery so a recovered crew never
+  // carries a stale pendingTool into its next quiet window.
+  return { ...rec, state: "working", lastHeartbeat: now, lastEvent: "watchdog.recover", pendingTool: undefined };
 }

--- a/packages/shared/src/types/control.ts
+++ b/packages/shared/src/types/control.ts
@@ -77,11 +77,19 @@ export interface TaskRecord {
    *  name when this task was dispatched by a sibling captain. When the task
    *  settles, the daemon fans the outcome back to originProject's mailbox. */
   originProject?: string;
+  /** #354: the tool call currently in flight, if any. Set when a PreToolUse
+   *  liveness signal arrives (cmux events-bridge carries the tool name); cleared
+   *  the moment its PostToolUse / next turn boundary arrives. A `working` crew
+   *  whose pendingTool has been outstanding past TOOL_STALL_BUDGET_MS is treated
+   *  as hung-on-a-tool (CREW STALLED warn) — distinct from a quiet thinking turn
+   *  (no pendingTool → CREW QUIET). Auto-clears: the next PostToolUse recovers
+   *  the record to `working` (state-machine + recoverStall). */
+  pendingTool?: { name: string; since: number };
 }
 
 export type ControlEvent =
   | { type: "task.started"; id: string; pid?: number; sessionId?: string }
-  | { type: "task.progress"; id: string; note?: string }
+  | { type: "task.progress"; id: string; note?: string; tool?: string }
   | { type: "heartbeat"; id: string }
   | { type: "task.blocked"; id: string; reason: string; question: string }
   | { type: "task.done"; id: string; resultRef: string; message?: string; parseWarning?: boolean }
@@ -100,11 +108,21 @@ export type ControlEvent =
   // Synthetic events: emitted by the daemon (watchdog / reconcile) purely as
   // notify payloads. They are never sent over the wire and the reducer treats
   // them as no-ops; the watchdog has already updated state directly.
-  | { type: "task.stalled"; id: string; heartbeatBudgetMs: number }
+  // #354: `tool`/`elapsedMs` are set when the stall is a hung interactive tool
+  // call (PreToolUse with no matching PostToolUse past TOOL_STALL_BUDGET_MS),
+  // letting the notifier render "still running {tool} ~{N}min" instead of the
+  // generic headless "no heartbeat" message.
+  | { type: "task.stalled"; id: string; heartbeatBudgetMs: number; tool?: string; elapsedMs?: number }
   // task.idle is the interactive analogue of task.stalled: the watchdog has
   // already moved an idle interactive task to 'awaiting-input', and this carries
   // the accurate (non-alarming) notify payload to the captain.
   | { type: "task.idle"; id: string; heartbeatBudgetMs: number }
+  // #354: a `working` interactive crew that has been quiet past its heartbeat
+  // budget with NO tool in flight — alive but deep-thinking (no hook fires
+  // during pure model thinking). Notify-only (reducer no-op): the crew stays
+  // `working`, NOT awaiting-input. Real CREW IDLE still comes only from the Stop
+  // hook (a genuine turn-end). `quietMs` = how long it has been silent.
+  | { type: "task.quiet"; id: string; quietMs: number }
   // #225: emitted by the sweep when a task's wall-clock age exceeds the ceiling.
   // Notify-only (detect-first, #77); reducer is a no-op.
   | { type: "task.timeout"; id: string; taskTimeoutMs: number }

--- a/packages/workspaces/src/cmux/__tests__/events-bridge.test.ts
+++ b/packages/workspaces/src/cmux/__tests__/events-bridge.test.ts
@@ -202,6 +202,26 @@ describe("CmuxEventsBridge working hooks → task.progress", () => {
     bridge.stop();
   });
 
+  it("#354: carries the tool name from a PreToolUse frame onto task.progress", async () => {
+    const events: ControlEvent[] = [];
+    const frame = JSON.stringify({
+      type: "event", category: "agent", name: "agent.hook.PreToolUse", seq: 3, source: "claude",
+      payload: { _source: "claude", session_id: "claude-abc", cwd: "/wt/crew-a", phase: "completed", tool_name: "Bash" },
+    }) + "\n";
+    const bridge = new CmuxEventsBridge({
+      emit: (e) => events.push(e),
+      resolve: () => ({ id: "task-a" }),
+      cursorFile: "/tmp/seq",
+      spawnImpl: (() => fakeChild([ack, frame])) as never,
+      stopAfterFirstRun: true,
+    });
+    bridge.start();
+    await flush();
+    await flush();
+    expect(events).toEqual([{ type: "task.progress", id: "task-a", note: "agent.hook.PreToolUse", tool: "Bash" }]);
+    bridge.stop();
+  });
+
   it("maps agent.hook.UserPromptSubmit → task.progress", async () => {
     const events: ControlEvent[] = [];
     const bridge = new CmuxEventsBridge({
@@ -274,17 +294,19 @@ describe("working-hook run-state suppresses false-stall (#292)", () => {
     };
   }
 
-  it("without a working hook, a quiet crew past budget false-idles", () => {
+  it("a quiet crew past budget with no tool in flight is NOT stalled by the watchdog (#354)", () => {
     const now = 100_000; // 100s since the last heartbeat at t=0, budget 60s
-    const idle = evaluateStall(workingCrew(0), now);
-    expect(idle?.state).toBe("awaiting-input");
+    // Post-#354 the watchdog never flips a quiet interactive crew to awaiting-input;
+    // a deep-thinking turn stays working (the sweep surfaces CREW QUIET instead).
+    expect(evaluateStall(workingCrew(0), now)).toBeNull();
   });
 
-  it("a PreToolUse-derived task.progress refreshes liveness so the crew does NOT idle", () => {
+  it("a PreToolUse-derived task.progress opens a tool window that does NOT immediately stall (#292/#354)", () => {
     const now = 100_000;
     // The bridge's working-hook event lands as task.progress just before the sweep.
-    const progressed = reduce(workingCrew(0), { type: "task.progress", id: "task-a", note: "agent.hook.PreToolUse" }, now);
-    // evaluateStall now keys off the refreshed lastHeartbeatAt → no false idle.
+    const progressed = reduce(workingCrew(0), { type: "task.progress", id: "task-a", note: "agent.hook.PreToolUse", tool: "Bash" }, now);
+    // The tool window just opened (since=now) → well within the tool-stall budget.
+    expect(progressed.pendingTool).toEqual({ name: "Bash", since: now });
     expect(evaluateStall(progressed, now)).toBeNull();
     expect(progressed.state).toBe("working");
   });

--- a/packages/workspaces/src/cmux/events-bridge.ts
+++ b/packages/workspaces/src/cmux/events-bridge.ts
@@ -192,7 +192,7 @@ export class CmuxEventsBridge {
           category?: string;
           name?: string;
           source?: string;
-          payload?: { _source?: string; session_id?: string; cwd?: string; phase?: string };
+          payload?: { _source?: string; session_id?: string; cwd?: string; phase?: string; tool_name?: string };
         }
       | undefined;
     try {
@@ -231,6 +231,9 @@ export class CmuxEventsBridge {
     // that is mid long tool-call but screen-quiet is NOT false-stalled (#292),
     // and a crew the scrape path wrongly idled resumes to 'working'. ADDITIVE:
     // the reducer absorbs this idempotently, and a blocked crew stays blocked.
-    this.deps.emit({ type: "task.progress", id: rec.id, note: f.name });
+    // #354: carry the tool name on PreToolUse so the reducer can open a
+    // tool-in-flight window (pendingTool) — the discriminator the watchdog uses
+    // to tell a hung tool call apart from a quiet thinking turn.
+    this.deps.emit({ type: "task.progress", id: rec.id, note: f.name, tool: p.tool_name });
   }
 }


### PR DESCRIPTION
## What & why

`#354` — the watchdog's single wall-clock timeout flipped **any** quiet `working`
interactive crew to `awaiting-input` → a **false, ambiguous `CREW IDLE`** that
read as "awaiting your input" even while the model was deep in a long thinking
turn. It could not tell *alive-thinking* from *genuinely hung*.

**Research finding (Stage 1):** the `cmux events` stream carries **no** token/cost/
usage deltas — only relayed Claude Code hook frames — and the pane cost/context
freeze mid-turn, so liveness can't be read from a wall clock or a status line.
The one event-only discriminator: a **`PreToolUse`** (cmux events-bridge, with the
tool name) with **no matching `PostToolUse`** (cockpit's own claude hook) past a
generous budget = a **hung tool call**; a stale heartbeat with **no tool in flight**
= a **thinking turn**.

## Design (Tier B, approved)

Three accurate, distinct signals replace the one overloaded pulse:

| Signal | When | State |
|---|---|---|
| **CREW IDLE** | real turn-end (`Stop` hook only) | `awaiting-input` |
| **CREW QUIET** | quiet past heartbeat budget, **no** tool in flight (deep thinking) | stays `working` |
| **CREW STALLED** | tool in flight past `TOOL_STALL_BUDGET_MS` (hung tool) | `stalled` (recoverable) |

- `TaskRecord.pendingTool` tracks the in-flight tool. Reducer opens it on
  `PreToolUse`, closes it on `PostToolUse`/`UserPromptSubmit`/any turn boundary.
- **False-stalled guard:** `TOOL_STALL_BUDGET_MS = 10min` (documented headroom) so
  a legit long test suite / build / git op does **not** trip. The hung-tool warn
  is a recoverable *"still running {tool} ~{N}min — possibly hung"*, **not** a
  death notice, and **auto-clears** the instant the matching `PostToolUse` arrives
  (reducer recovers `stalled → working`; `recoverStall` also clears `pendingTool`).
- **CREW QUIET** keeps the crew `working`, debounced once per quiet episode.
- **Degrades to Tier A** for opencode/codex: no `PreToolUse` feed → no `pendingTool`
  → never hung-tool-stalled. opencode's 24h budget + SSE turn-end path untouched.

## Tests

Build clean; **full suite green (1218)**; CLI boots. New coverage:
- `watchdog`: thinking → null, hung-tool past budget → stalled, long-tool within budget → null.
- `state-machine`: `pendingTool` open/close lifecycle, turn-boundary clears, `stalled`+`PostToolUse` instant auto-clear, `task.quiet` no-op.
- `daemon` sweep: CREW QUIET (stays working) / hung-tool CREW STALLED(tool) / within-budget no-trip.
- `cockpitd-push`: CREW QUIET fires once per episode (no storm).
- `events-bridge`: tool name carried on `PreToolUse` → `task.progress`.

## Crew-lifecycle checklist (reported)

The repo checklist is a **live, spawn-based** harness and predates the #373 relay
deletion. This change touches the daemon notification path it validates:

- **CP4 (idle)** — the checkpoint this PR changes. Old behavior: daemon flipped to
  `awaiting-input` on wall-clock and the captain got **no** ping (GAP #210). New:
  a deep-thinking crew **stays `working`** and the captain gets a distinct, honest
  **CREW QUIET**; a real turn-end still yields `awaiting-input` via the `Stop` hook;
  a hung tool yields **CREW STALLED(tool)**.
- **CP1/2/3/5/6** — unchanged (no edits to spawn/block/permission/done/reopen paths).

The deterministic daemon path (`createDaemon` + `sweep` + reducer) these checkpoints
exercise at runtime is covered by the green unit/integration suite above. A live
interactive spawn-run against the **rebuilt** daemon should be done by the captain
(crew worktrees shouldn't spawn nested crews against the shared live daemon).

Closes #354.
