### PR TITLE
fix(daemon): terminal-stickiness in sweep — stop zombie task resurrection (#378)

### DIFF
--- a/packages/cli/src/control/__tests__/daemon.test.ts
+++ b/packages/cli/src/control/__tests__/daemon.test.ts
@@ -744,6 +744,49 @@ describe("sweep: task-timeout (#225)", () => {
     await d2.sweep();
     expect(timeoutCalls()).toBe(1);
   });
+
+  // ── #378 regression: zombie resurrection ────────────────────────────────────
+  // A timed-out interactive task with a hung pendingTool would have evaluateStall
+  // operate on the stale `r` (still 'working'), clobbering the just-written
+  // 'cancelled' state back to 'stalled'. This caused infinite CREW TIMEOUT re-fire.
+  it("#378: timeout-cancelled state is NOT clobbered by evaluateStall on the same sweep", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    const TOOL_STALL_BUDGET_MS = 10 * 60 * 1000;
+    // createdAt=0, now=2000, ceiling=1000 → age 2000ms > ceiling (triggers timeout)
+    // pendingTool.since = 2000 - (TOOL_STALL_BUDGET_MS + 1000) → hung > tool-stall budget
+    // → without the fix, evaluateStall would return state='stalled' and clobber 'cancelled'
+    const now = 2000;
+    store.put(rec("t378a", {
+      state: "working", mode: "interactive", createdAt: 0,
+      lastHeartbeat: 1990, heartbeatBudgetMs: 86_400_000,
+      pendingTool: { name: "Bash", since: now - TOOL_STALL_BUDGET_MS - 1000 },
+    }));
+    const d = createDaemon({ store, now: () => now, taskTimeoutMs: 1_000, notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    // Terminal state must survive — evaluateStall must not clobber it
+    const r = store.get("p", "t378a");
+    expect(r?.state).toBe("cancelled");
+    expect(r?.lastEvent).toBe("sweep.task-timeout");
+  });
+
+  it("#378: second sweep on a timeout-cancelled task fires CREW TIMEOUT exactly once total", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    const TOOL_STALL_BUDGET_MS = 10 * 60 * 1000;
+    const now = 2000;
+    store.put(rec("t378b", {
+      state: "working", mode: "interactive", createdAt: 0,
+      lastHeartbeat: 1990, heartbeatBudgetMs: 86_400_000,
+      pendingTool: { name: "Bash", since: now - TOOL_STALL_BUDGET_MS - 1000 },
+    }));
+    const d = createDaemon({ store, now: () => now, taskTimeoutMs: 1_000, notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    await d.sweep(); // second sweep — must see cancelled, skip entirely
+    const timeoutCalls = calls.filter((c) => c.message.includes("CREW TIMEOUT")).length;
+    expect(timeoutCalls).toBe(1);
+    expect(store.get("p", "t378b")?.state).toBe("cancelled");
+  });
 });
 
 // ── Issue #87: socket-boundary schema validation ──────────────────────────────

--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -369,6 +369,7 @@ export function createDaemon(deps: DaemonDeps) {
                 // swallowed — a flaky notifier must never trip the sweep
               }
             }
+            continue; // #378: skip remaining sweep body — stale `r` must not clobber just-written terminal state
           }
         }
         // #139 backstop: reap interactive records whose backing surface is


### PR DESCRIPTION
## Root cause

In `packages/core/src/daemon.ts`, `sweep()`: the wall-clock TIMEOUT branch terminalized via `store.put({...r, state:'cancelled', lastEvent:'sweep.task-timeout'})` but did **not** `continue` to the next record. It fell through to:

- the surface-gone reap,
- `evaluateStall(r, t)` → `store.put(idle)`,
- the CREW QUIET path,
- `recoverStall(r, t)` → `store.put(recovered)`.

All of these operated on the **stale local `r`** (still non-terminal, e.g. `working` with a hung `pendingTool`). So `evaluateStall` returned `{...r, state:'stalled'}` and `store.put` **clobbered** the just-written `cancelled` back to non-terminal. The next sweep saw a non-terminal task → re-fired CREW TIMEOUT indefinitely.

## Fix

One `continue` after the `store.put` in the timeout branch — once a task is terminalized, skip the remaining sweep body for that record so the stale `r` cannot overwrite the terminal state.

## Test evidence

```
pnpm run build && pnpm test

Test Files  112 passed (112)
    Tests  1259 passed (1259)
```

Closes #378