### PR TITLE
feat(crew): global effort dial (max|balance|low) (#317)

### DIFF
--- a/docs/specs/2026-06-15-crew-effort-design.md
+++ b/docs/specs/2026-06-15-crew-effort-design.md
@@ -1,0 +1,169 @@
+# Crew Effort — Global Tokenomics Dial
+
+**Status:** Design / approved for planning
+**Date:** 2026-06-15
+**Author:** research side-session (brainstorm with user)
+**Scope:** crew routing only
+
+## Problem
+
+Crew model selection today is fixed by `defaults.crewRouting.rules` (tier → `{agent, model}`)
+and `defaults.roles.crew`. There is no single lever to say *"I have spare token budget
+today, lean stronger"* or *"I'm low on budget, lean cheaper"* without hand-editing routing
+rules each time.
+
+The user wants exactly that: one global setting they flip based on how much token budget
+they have on a given day:
+
+- **balance** — normal working mode (today's behavior).
+- **max** — more tokens available → bias crews toward the strongest model.
+- **low** — fewer tokens available → bias crews toward cheaper agents/models.
+
+This is a **tokenomics dial**, not a mechanical routing rewrite. The captain is the brain;
+effort is a hint the captain honors when it spawns crews.
+
+## Non-Goals
+
+These were explicitly considered and rejected during brainstorming to keep the feature
+simple (YAGNI):
+
+- **No per-tier ladder.** Earlier drafts gave each routing rule `low`/`balance`/`max`
+  columns. Rejected — too much config to maintain and reason about.
+- **No mechanical transform in `resolveCrewRoute`.** Effort never rewrites a resolved
+  model up or down a ladder in code. Routing rules stay untouched.
+- **No effort on non-crew roles.** Captain / command / side stay pinned to opus (a
+  deliberate, benchmark-backed decision). Effort is crew-only.
+- **No change to the routed one-liner.** `routed: tier=… → agent/model (rule: "…")`
+  stays exactly as today.
+
+## Design
+
+### 1. Storage
+
+Add one optional field to `CockpitConfig.defaults`:
+
+```ts
+defaults: {
+  // …
+  /** Global crew tokenomics dial. Absent ⇒ "balance" (today's behavior).
+   *  Biases the captain toward stronger ("max") or cheaper ("low") crew models. */
+  effort?: "max" | "balance" | "low";
+}
+```
+
+- **Absent ⇒ `balance`.** No migration, no backfill — every existing config behaves as
+  today.
+- `getDefaultConfig()` may set `effort: "balance"` explicitly for clarity, but readers
+  must treat absent as `balance`.
+
+A single resolver helper centralizes the absent-default:
+
+```ts
+// src/control/effort.ts
+export type Effort = "max" | "balance" | "low";
+export function resolveEffort(config: CockpitConfig): Effort {
+  return config.defaults.effort ?? "balance";
+}
+```
+
+### 2. Setter surfaces (three, for maximum ergonomics)
+
+| Surface | Behavior |
+|---|---|
+| `cockpit effort <max\|balance\|low>` | Validates the value, writes `defaults.effort` via the existing `saveConfig` atomic path, prints confirmation + one-line meaning. |
+| `cockpit effort` (no arg) | Prints the current effort and its meaning. Does not write. |
+| `cockpit:set-effort` skill | The engine. Reads/writes `defaults.effort`, echoes the new mode and what it means for crew spawns. Portable to non-Claude agents via `AGENTS.md`. |
+| `/cockpit-effort` | Thin Claude-Code slash alias that invokes `cockpit:set-effort`. Convenience only. |
+
+Validation: only `max` / `balance` / `low` accepted; anything else is a usage error
+listing the three valid values.
+
+### 3. How the captain honors effort (crew-only)
+
+Two complementary mechanisms — passive for durability, active for immediacy. The captain
+template (`captain.claude.md`) is **hashed for session-freshness**, so the live effort
+value is deliberately NOT written into it (would churn the hash and force a fresh session
+on every toggle). The value lives in `config.json` and is read/pushed.
+
+**Passive — `cockpit:captain-ops` skill gains an "Effort mode" section.** Before spawning
+crews, the captain reads `defaults.effort` from config and biases its crew agent/model
+choice:
+
+- **max** — prefer the strongest model (claude/opus) for crew spawns.
+- **balance** — use default crew routing rules unchanged.
+- **low** — prefer cheaper agents/models (opencode, sonnet) for crews.
+
+This is the durable instruction — survives restarts and context compaction because the
+skill is re-read at session start and referenced throughout.
+
+**Active — `cockpit effort <mode>` notifies the running captain.** When the setter runs,
+it sends a relay message to the project's captain so a live session adjusts immediately
+instead of waiting to re-read config on the next spawn:
+
+```
+🎚 effort → low: bias new crew spawns toward cheaper agents/models (opencode, sonnet).
+```
+
+The relay send is best-effort: if no captain is running, the setter still writes config and
+prints a note that the change takes effect on next launch. (No hard dependency on a live
+daemon/captain.)
+
+### 4. Mode semantics (the captain's interpretation guide)
+
+Plain-language directives, not a mechanical model table — the captain applies judgment
+within the existing routing rules:
+
+| Mode | Directive to the captain |
+|---|---|
+| **max** | Tokens are plentiful. Prefer claude/opus for crews; don't downshift for cost. |
+| **balance** | Normal. Use the default crew routing rules as-is. |
+| **low** | Conserve tokens. Prefer opencode / sonnet for crews; reserve opus for work that genuinely needs it. |
+
+### 5. Precedence
+
+Effort is the *weakest* signal — it only nudges the captain's default choice. Anything
+more specific wins:
+
+1. **Explicit `--agent` / `--model` on a spawn** → wins outright (unchanged).
+2. **A specific routing-rule match the captain chooses to honor** → the captain weighs
+   effort against the matched tier using its judgment.
+3. **Effort directive** → the baseline lean when nothing more specific applies.
+
+Because effort lives in the captain's reasoning (not in `resolveCrewRoute`), there is no
+code-level precedence to encode beyond the existing explicit-flags-win rule.
+
+## Affected surfaces
+
+| File / artifact | Change |
+|---|---|
+| `src/config.ts` | Add `effort?` to `CockpitConfig.defaults`; optionally set `"balance"` in `getDefaultConfig()`. |
+| `src/control/effort.ts` (new) | `Effort` type + `resolveEffort(config)` helper. |
+| `src/commands/effort.ts` (new) | `cockpit effort [value]` get/set command. |
+| CLI registration | Wire `effort` subcommand into the cockpit CLI entrypoint. |
+| `plugin/skills/cockpit/set-effort/SKILL.md` (new) | `cockpit:set-effort` skill. |
+| `/cockpit-effort` slash alias | Thin alias to the skill. |
+| `cockpit:captain-ops` skill | Add "Effort mode" section to the crew-spawning playbook. |
+| Relay send (existing `cockpit runtime send` path) | Setter pushes a one-line effort notice to the running captain. |
+
+## Testing / success criteria
+
+- `cockpit effort low` writes `defaults.effort: "low"`; `cockpit effort` then prints `low`
+  + its meaning. (unit on the command; round-trips through `loadConfig`/`saveConfig`.)
+- Invalid value (`cockpit effort turbo`) errors with the three valid options; config
+  unchanged.
+- Absent `defaults.effort` resolves to `balance` (unit on `resolveEffort`).
+- Existing configs with no `effort` field load and behave identically to today (no
+  migration side effects).
+- Routing behavior (`resolveCrewRoute`) and the routed one-liner are byte-for-byte
+  unchanged when effort is `balance` and untouched in code regardless of effort.
+- `cockpit:captain-ops` skill text instructs the captain to read and honor `defaults.effort`
+  for crew spawns only.
+- Setter sends a relay notice when a captain is running; degrades gracefully (writes config
+  + prints note) when none is.
+
+## Open follow-ups (out of scope for v1)
+
+- A `max` cap / safety rail if budget mode is ever made auto-driven (not now — the user
+  sets it manually).
+- Surfacing current effort in dashboard / status (nice-to-have; not required for the dial
+  to work).

--- a/packages/cli/src/commands/__tests__/effort.test.ts
+++ b/packages/cli/src/commands/__tests__/effort.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { getDefaultConfig, saveConfig } from "@cockpit/shared";
+import { runEffortGet, runEffortSet } from "../effort.js";
+
+let dir: string;
+let cfgPath: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "cockpit-effort-"));
+  cfgPath = path.join(dir, "config.json");
+  saveConfig(getDefaultConfig(), cfgPath);
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+describe("effort get", () => {
+  it("returns 'balance' and a description when effort is absent", () => {
+    const config = getDefaultConfig();
+    delete (config.defaults as any).effort;
+    saveConfig(config, cfgPath);
+    const result = runEffortGet(cfgPath);
+    expect(result.effort).toBe("balance");
+    expect(result.description).toBeTruthy();
+    expect(result.description).toContain("balance");
+  });
+
+  it("returns 'low' when config has effort=low", () => {
+    const config = getDefaultConfig();
+    (config.defaults as any).effort = "low";
+    saveConfig(config, cfgPath);
+    const result = runEffortGet(cfgPath);
+    expect(result.effort).toBe("low");
+    expect(result.description).toContain("low");
+  });
+
+  it("returns 'max' when config has effort=max", () => {
+    const config = getDefaultConfig();
+    (config.defaults as any).effort = "max";
+    saveConfig(config, cfgPath);
+    const result = runEffortGet(cfgPath);
+    expect(result.effort).toBe("max");
+  });
+});
+
+describe("effort set", () => {
+  it("writes 'low' to defaults.effort on disk", () => {
+    runEffortSet("low", cfgPath);
+    const onDisk = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
+    expect(onDisk.defaults.effort).toBe("low");
+  });
+
+  it("writes 'max' to defaults.effort on disk", () => {
+    runEffortSet("max", cfgPath);
+    const onDisk = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
+    expect(onDisk.defaults.effort).toBe("max");
+  });
+
+  it("writes 'balance' to defaults.effort on disk", () => {
+    runEffortSet("balance", cfgPath);
+    const onDisk = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
+    expect(onDisk.defaults.effort).toBe("balance");
+  });
+
+  it("round-trips: set 'low' then get returns 'low'", () => {
+    runEffortSet("low", cfgPath);
+    const result = runEffortGet(cfgPath);
+    expect(result.effort).toBe("low");
+  });
+
+  it("rejects invalid value without writing config", () => {
+    const before = fs.readFileSync(cfgPath, "utf-8");
+    expect(() => runEffortSet("turbo", cfgPath)).toThrow();
+    const after = fs.readFileSync(cfgPath, "utf-8");
+    expect(after).toBe(before);
+  });
+
+  it("error for invalid value lists all 3 valid options", () => {
+    let msg = "";
+    try { runEffortSet("turbo", cfgPath); } catch (e) { msg = (e as Error).message; }
+    expect(msg).toContain("max");
+    expect(msg).toContain("balance");
+    expect(msg).toContain("low");
+  });
+
+  it("existing config without effort field loads and saves without side effects on other fields", () => {
+    const config = getDefaultConfig();
+    delete (config.defaults as any).effort;
+    saveConfig(config, cfgPath);
+    runEffortSet("balance", cfgPath);
+    const onDisk = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
+    expect(onDisk.defaults.effort).toBe("balance");
+    expect(onDisk.defaults.maxCrew).toBe(config.defaults.maxCrew);
+    expect(onDisk.defaults.worktreeDir).toBe(config.defaults.worktreeDir);
+  });
+});

--- a/packages/cli/src/commands/effort.ts
+++ b/packages/cli/src/commands/effort.ts
@@ -1,0 +1,81 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { loadConfig, saveConfig, resolveEffort, DEFAULT_CONFIG_PATH } from "@cockpit/shared";
+import type { Effort } from "@cockpit/shared";
+
+const VALID_EFFORTS: Effort[] = ["max", "balance", "low"];
+
+const EFFORT_MEANING: Record<Effort, string> = {
+  max: "tokens are plentiful — bias crew spawns toward claude/opus",
+  balance: "normal routing — use default crew routing rules unchanged",
+  low: "conserve tokens — bias crew spawns toward opencode/sonnet; reserve opus for work that genuinely needs it",
+};
+
+export interface EffortGetResult {
+  effort: Effort;
+  description: string;
+}
+
+export function runEffortGet(configPath = DEFAULT_CONFIG_PATH): EffortGetResult {
+  const config = loadConfig(configPath);
+  const effort = resolveEffort(config);
+  const description = `${effort}: ${EFFORT_MEANING[effort]}`;
+  return { effort, description };
+}
+
+export function runEffortSet(value: string, configPath = DEFAULT_CONFIG_PATH): void {
+  if (!(VALID_EFFORTS as string[]).includes(value)) {
+    throw new Error(
+      `Invalid effort '${value}'. Valid values: ${VALID_EFFORTS.join(" | ")}`,
+    );
+  }
+  const config = loadConfig(configPath);
+  config.defaults.effort = value as Effort;
+  saveConfig(config, configPath);
+}
+
+export const effortCommand = new Command("effort")
+  .description("Get or set the global crew tokenomics dial (max | balance | low)")
+  .argument("[value]", "effort level to set: max | balance | low")
+  .action(async (value: string | undefined) => {
+    if (value === undefined) {
+      const { effort, description } = runEffortGet();
+      console.log(chalk.bold("Current effort:"), chalk.cyan(effort));
+      console.log(chalk.dim(EFFORT_MEANING[effort]));
+      return;
+    }
+
+    try {
+      runEffortSet(value);
+    } catch (err) {
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+
+    const effort = value as Effort;
+    console.log(chalk.green(`✔ effort → ${effort}`));
+    console.log(chalk.dim(EFFORT_MEANING[effort]));
+
+    // Best-effort active notify: send a one-line notice to any running captain.
+    // Never hard-fails — config is already written above.
+    try {
+      const { createCmuxDriver, RuntimeRegistry } = await import("@cockpit/workspaces");
+      const config = loadConfig();
+      const registry = new RuntimeRegistry({ cmux: createCmuxDriver() });
+      const driver = registry.global(config);
+      const notice = `🎚️ effort → ${effort}: ${EFFORT_MEANING[effort]}`;
+      for (const [, proj] of Object.entries(config.projects)) {
+        try {
+          const ref = await driver.status(proj.captainName);
+          if (ref) {
+            await driver.send(ref.id, notice);
+          }
+        } catch {
+          // individual project captain unreachable — skip
+        }
+      }
+    } catch {
+      // runtime unavailable — config already written, change applies on next launch
+      console.log(chalk.dim("(no running captain detected — change applies on next launch)"));
+    }
+  });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,6 +30,7 @@ import { configCommand } from "./commands/config.js";
 import { healCommand } from "./commands/heal.js";
 import { groupCommand } from "./commands/group.js";
 import { cmuxCommand } from "./commands/cmux.js";
+import { effortCommand } from "./commands/effort.js";
 import { detectDrift } from "@cockpit/shared";
 import { needsCheck, withStamp } from "@cockpit/shared";
 import { getDefaultConfig } from "@cockpit/shared";
@@ -114,6 +115,7 @@ program.addCommand(configCommand);
 program.addCommand(healCommand);
 program.addCommand(groupCommand);
 program.addCommand(cmuxCommand);
+program.addCommand(effortCommand);
 
 program.parseAsync().catch((e) => {
   process.stderr.write(`error: ${e instanceof Error ? e.message : String(e)}\n`);

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -103,6 +103,9 @@ export interface CockpitConfig {
      * See docs/research/2026-06-16-cmux-events-stream.md (C2 finding).
      */
     cmuxAgentHibernation?: boolean;
+    /** #317 global crew tokenomics dial. Absent ⇒ "balance" (today's behavior).
+     *  Biases the captain toward stronger ("max") or cheaper ("low") crew models. */
+    effort?: "max" | "balance" | "low";
   };
   metrics: {
     enabled: boolean;

--- a/packages/shared/src/effort.ts
+++ b/packages/shared/src/effort.ts
@@ -1,0 +1,7 @@
+import type { CockpitConfig } from "./config.js";
+
+export type Effort = "max" | "balance" | "low";
+
+export function resolveEffort(config: CockpitConfig): Effort {
+  return config.defaults.effort ?? "balance";
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 // @cockpit/shared — pure types + leaf utilities + config.
 export * from "./config.js";
+export * from "./effort.js";
 export * from "./types/runtime.js";
 export * from "./types/control.js";
 export * from "./types/projection.js";

--- a/packages/shared/src/lib/__tests__/effort.test.ts
+++ b/packages/shared/src/lib/__tests__/effort.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { resolveEffort, getDefaultConfig } from "@cockpit/shared";
+
+describe("resolveEffort", () => {
+  it("returns 'balance' when effort is absent", () => {
+    const config = getDefaultConfig();
+    delete (config.defaults as any).effort;
+    expect(resolveEffort(config)).toBe("balance");
+  });
+
+  it("returns 'max' when explicitly set to max", () => {
+    const config = getDefaultConfig();
+    (config.defaults as any).effort = "max";
+    expect(resolveEffort(config)).toBe("max");
+  });
+
+  it("returns 'balance' when explicitly set to balance", () => {
+    const config = getDefaultConfig();
+    (config.defaults as any).effort = "balance";
+    expect(resolveEffort(config)).toBe("balance");
+  });
+
+  it("returns 'low' when explicitly set to low", () => {
+    const config = getDefaultConfig();
+    (config.defaults as any).effort = "low";
+    expect(resolveEffort(config)).toBe("low");
+  });
+});

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -165,6 +165,22 @@ cockpit crew spawn brove "fix typo" --model opus           # forces opus despite
 
 To add, edit, or remove routing rules: use the `cockpit:add-pick-crew-rule` skill.
 
+### Effort mode
+
+Before spawning a crew, read `defaults.effort` from `~/.config/cockpit/config.json` (run `cockpit effort` to check). Apply the following bias to your crew agent/model choice:
+
+| Mode | Directive |
+|------|-----------|
+| **max** | Tokens are plentiful. Prefer claude/opus for crew spawns; don't downshift for cost. |
+| **balance** | Normal. Use default crew routing rules unchanged. (Absent field = balance.) |
+| **low** | Conserve tokens. Prefer opencode/sonnet for crews; reserve opus for work that genuinely needs it. |
+
+**Effort is crew-only.** Captain, command, and side roles are unaffected — keep them at their configured model regardless of effort.
+
+**Effort is the weakest signal.** An explicit `--agent` / `--model` on a spawn always wins. Effort only nudges your default choice when nothing more specific applies.
+
+To change the effort dial: `cockpit effort <max|balance|low>` or use the `cockpit:set-effort` skill.
+
 ### Rules
 
 - **Reuse with `send` before spawning a new one.** Same task track, same crew. New track = new crew.

--- a/plugin/skills/cockpit-effort/SKILL.md
+++ b/plugin/skills/cockpit-effort/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: cockpit-effort
+description: Shortcut for cockpit:set-effort — get or set the global crew tokenomics dial (max | balance | low). Use when the user types /cockpit-effort or asks about the effort setting.
+---
+
+# cockpit-effort — shortcut for cockpit:set-effort
+
+Shorthand alias. **Invoke the `set-effort` skill** (via the Skill tool) and follow it exactly. All logic lives there — this file intentionally holds none, so the two never drift.

--- a/plugin/skills/set-effort/SKILL.md
+++ b/plugin/skills/set-effort/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: set-effort
+description: Read or set the global crew tokenomics dial (max | balance | low). Use when the user wants to change how aggressively crews consume tokens, or to check the current setting.
+---
+
+# cockpit:set-effort — Global Crew Effort Dial
+
+The effort dial is a one-field toggle in `~/.config/cockpit/config.json` that biases the captain's crew spawning decisions. It does **not** rewrite routing rules — it is a hint the captain honors when choosing agent/model for new crews.
+
+## Modes
+
+| Mode | Meaning |
+|------|---------|
+| **max** | Tokens are plentiful. Prefer claude/opus for crew spawns; don't downshift for cost. |
+| **balance** | Normal. Use default crew routing rules unchanged. (Default when field is absent.) |
+| **low** | Conserve tokens. Prefer opencode/sonnet for crews; reserve opus for work that genuinely needs it. |
+
+## Get current effort
+
+```bash
+cockpit effort
+```
+
+Prints the current mode and its one-line meaning. Does not write anything.
+
+## Set effort
+
+```bash
+cockpit effort max
+cockpit effort balance
+cockpit effort low
+```
+
+- Validates the value (errors with the 3 valid options if invalid).
+- Writes `defaults.effort` via the existing `saveConfig` atomic path.
+- Prints a confirmation line.
+- Best-effort: sends a one-line notice to any running captain workspace so a live session adjusts immediately. If no captain is running, the change applies on next launch.
+
+## Manual edit (fallback)
+
+If the CLI is unavailable, edit `~/.config/cockpit/config.json` directly:
+
+```json
+{
+  "defaults": {
+    "effort": "low"
+  }
+}
+```
+
+Valid values: `"max"` | `"balance"` | `"low"`. Absent field is equivalent to `"balance"`.
+
+## Scope
+
+Effort is **crew-only**. It does not affect captain, command, or side roles — those stay pinned to their configured model regardless of effort.
+
+## Precedence
+
+Effort is the weakest signal. Explicit `--agent` / `--model` flags on `cockpit crew spawn` always win. Effort only biases the captain's default choice when nothing more specific applies.


### PR DESCRIPTION
## Summary

- **3 setter surfaces**: `cockpit effort <max|balance|low>` (CLI get/set), `cockpit:set-effort` skill, `/cockpit-effort` thin slash alias
- **Captain-ops honoring**: added "Effort mode" section to `plugin/skills/captain-ops/SKILL.md` — captain reads `defaults.effort` before spawning crews and biases agent/model choice accordingly (max→opus, balance→default routing, low→opencode/sonnet)
- **Relay→runtime-send adaptation**: spec's "relay send" is replaced with daemon-direct `driver.send()` via `@cockpit/workspaces` RuntimeRegistry — best-effort, catches all errors, never hard-fails; prints note when no captain is running
- **Storage**: optional `effort?` field in `CockpitConfig.defaults`; absent ⇒ `"balance"` via `resolveEffort()` in `@cockpit/shared` — no migration, existing configs unchanged
- **Spec doc**: `docs/specs/2026-06-15-crew-effort-design.md` checked onto branch (closes the docs/crew-effort-spec branch)

## Test plan

- [x] `resolveEffort`: absent → `"balance"`; explicit `max`/`balance`/`low` pass through (4 unit tests, `@cockpit/shared`)
- [x] `cockpit effort` (no arg) prints current effort + meaning; does not write config
- [x] `cockpit effort low` writes `defaults.effort = "low"` via `saveConfig`; round-trip confirmed
- [x] `cockpit effort turbo` throws, lists 3 valid options, config unchanged
- [x] Existing config without `effort` field loads + saves without side effects on other fields
- [x] `node dist/index.js effort` → `Current effort: balance` (runtime NodeNext gate)
- [x] `node dist/index.js effort low` → `✔ effort → low` (runtime gate)
- [x] `node dist/index.js effort turbo` → error + exit 1 (runtime gate)
- [x] Full CI: `pnpm run build && pnpm test` → 114 test files, 1275 tests, all pass

Closes #317