### PR TITLE
feat(daemon): control-plane store hygiene (#378 follow-up)

### DIFF
--- a/packages/cli/src/commands/crew-control.ts
+++ b/packages/cli/src/commands/crew-control.ts
@@ -203,12 +203,19 @@ export function addControlPlaneCrewCommands(crew: Command): void {
 
   crew
     .command("tasks <project>")
-    .description("List control-plane tasks for a project (control-plane analogue of legacy `list`)")
+    .description("List control-plane tasks for a project (control-plane analogue of legacy `list`), or purge a task with --purge")
     .option("--json", "Full JSON output (one or more records)")
     .option("--id <taskId>", "Show only tasks matching this id prefix")
     .option("--state <state>", "Filter by task state")
     .option("--state-only <taskId>", "Print just the state string for a single task")
-    .action(async (project: string, opts: { json?: boolean; id?: string; state?: string; stateOnly?: string }) => {
+    .option("--purge <taskId>", "Purge a task record from the store (default: only terminal records)")
+    .option("--force", "Force-purge a non-terminal record (use with --purge)")
+    .action(async (project: string, opts: { json?: boolean; id?: string; state?: string; stateOnly?: string; purge?: string; force?: boolean }) => {
+      if (opts.purge) {
+        const r = await cockpitdCall({ kind: "purge", project, id: opts.purge, force: opts.force ?? false }) as TaskRecord;
+        console.log(`purged ${r.provider}/${r.id} (was ${r.state})`);
+        return;
+      }
       const raw = (await cockpitdCall({ kind: "list", project })) as TaskRecord[];
       let records = raw;
       if (opts.stateOnly) {

--- a/packages/cli/src/control/__tests__/daemon.test.ts
+++ b/packages/cli/src/control/__tests__/daemon.test.ts
@@ -3,8 +3,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createDaemon } from "@cockpit/core";
-import { createStore } from "@cockpit/core";
+import { createDaemon, createStore, crewTag } from "@cockpit/core";
 import type { TaskRecord } from "@cockpit/shared";
 
 function rec(id: string, overrides: Partial<TaskRecord> = {}): TaskRecord {
@@ -233,6 +232,26 @@ describe("daemon handler", () => {
     const d = createDaemon({ store, now: () => 1000, isSurfaceAlive: async () => "unknown" });
     await d.sweep();
     expect(store.get("p", "g5")?.state).toBe("working");
+  });
+
+  it("sweep: deletes terminal records older than TTL, keeps fresh terminal and old non-terminal (#378 GC)", async () => {
+    const store = createStore(dir);
+    const EIGHT_DAYS_MS = 8 * 24 * 60 * 60 * 1000;
+    const NOW = 1_000_000_000;
+
+    // (a) cancelled, lastHeartbeat 8 days ago → should be GC'd
+    store.put(rec("gc-old-term", { state: "cancelled", createdAt: NOW - EIGHT_DAYS_MS, lastHeartbeat: NOW - EIGHT_DAYS_MS, heartbeatBudgetMs: 86_400_000 }));
+    // (b) cancelled, lastHeartbeat 1 min ago → should stay
+    store.put(rec("gc-fresh-term", { state: "cancelled", createdAt: NOW - 60000, lastHeartbeat: NOW - 60000, heartbeatBudgetMs: 86_400_000 }));
+    // (c) working, lastHeartbeat 8 days ago → should stay (non-terminal)
+    store.put(rec("gc-old-live", { state: "working", createdAt: NOW - EIGHT_DAYS_MS, lastHeartbeat: NOW - EIGHT_DAYS_MS, heartbeatBudgetMs: 86_400_000, mode: "headless" }));
+
+    const d = createDaemon({ store, now: () => NOW });
+    await d.sweep();
+
+    expect(store.get("p", "gc-old-term")).toBeUndefined();
+    expect(store.get("p", "gc-fresh-term")?.state).toBe("cancelled");
+    expect(store.get("p", "gc-old-live")).toBeTruthy();
   });
 
   it("sweep: headless records are never surface-reaped (pid is their liveness) (#139)", async () => {
@@ -937,6 +956,74 @@ describe("daemon report-back on settle with originProject (#246)", () => {
     const bCalls = calls.filter((c) => c.project === "projB");
     expect(bCalls.length).toBe(1);
     expect(bCalls[0].message).toMatch(/cross.project|projA/i);
+  });
+});
+
+// ── Issue #378: crewTag helper (notification tag disambiguation) ────────────
+describe("crewTag (#378)", () => {
+  it("named record includes name and short id", () => {
+    const r: TaskRecord = {
+      id: "abc123def456", project: "p", provider: "claude", mode: "interactive",
+      state: "working", name: "my-crew", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000,
+      attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }],
+    };
+    const tag = crewTag(r);
+    expect(tag).toBe("[claude/my-crew · abc123de]");
+  });
+
+  it("unnamed record includes short id only", () => {
+    const r: TaskRecord = {
+      id: "abc123def456", project: "p", provider: "opencode", mode: "interactive",
+      state: "done", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", resultRef: "/r", heartbeatBudgetMs: 1000,
+      attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }],
+    };
+    const tag = crewTag(r);
+    expect(tag).toBe("[opencode/abc123de]");
+  });
+});
+
+// ── Issue #378: purge request kind ──────────────────────────────────────────
+describe("purge (#378)", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "cp-purge-")); });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("purge a terminal record succeeds and record is gone", async () => {
+    const store = createStore(dir);
+    store.put(rec("p-term", { state: "done", resultRef: "/r" }));
+    const d = createDaemon({ store, now: () => 2000 });
+    const r = await d.handle({ kind: "purge", project: "p", id: "p-term" });
+    expect((r as TaskRecord).id).toBe("p-term");
+    expect(store.get("p", "p-term")).toBeUndefined();
+  });
+
+  it("purge a non-terminal record without force errors", async () => {
+    const store = createStore(dir);
+    store.put(rec("p-live", { state: "working" }));
+    const d = createDaemon({ store, now: () => 2000 });
+    await expect(
+      d.handle({ kind: "purge", project: "p", id: "p-live" }),
+    ).rejects.toThrow(/not terminal/i);
+    expect(store.get("p", "p-live")?.state).toBe("working");
+  });
+
+  it("purge a non-terminal record with force succeeds", async () => {
+    const store = createStore(dir);
+    store.put(rec("p-force", { state: "working" }));
+    const d = createDaemon({ store, now: () => 2000 });
+    const r = await d.handle({ kind: "purge", project: "p", id: "p-force", force: true });
+    expect((r as TaskRecord).id).toBe("p-force");
+    expect(store.get("p", "p-force")).toBeUndefined();
+  });
+
+  it("purge an unknown task errors", async () => {
+    const store = createStore(dir);
+    const d = createDaemon({ store, now: () => 2000 });
+    await expect(
+      d.handle({ kind: "purge", project: "p", id: "no-such-id" }),
+    ).rejects.toThrow(/unknown/i);
   });
 });
 

--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -69,6 +69,10 @@ export interface DaemonDeps {
 // catch it. This ceiling does. Configurable via DaemonDeps.taskTimeoutMs.
 export const DEFAULT_TASK_TIMEOUT_MS = 8 * 60 * 60 * 1000;
 
+// #378: GC TTL for terminal records (done/failed/cancelled). Records older
+// than this are pruned from the store during sweep().
+export const TERMINAL_RECORD_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
 // 'awaiting-input' is an attention state: entering it (idle watchdog OR a
 // Stop-hook turn boundary) fires exactly one accurate CREW IDLE push. The
 // firePush prev===next guard keeps it from re-firing while the task sits idle.
@@ -93,8 +97,21 @@ function shortId(id: string): string {
   return id.slice(0, 8);
 }
 
+/**
+ * Build a disambiguated notification tag for a task record. Always appends
+ * the short id so reused crew names are distinguishable across distinct ids.
+ * Named: [provider/name · shortId]  Unnamed: [provider/shortId]
+ */
+export function crewTag(r: TaskRecord): string {
+  const suffix = shortId(r.id);
+  if (r.name != null) {
+    return `[${r.provider}/${r.name} · ${suffix}]`;
+  }
+  return `[${r.provider}/${suffix}]`;
+}
+
 function formatMessage(rec: TaskRecord, event?: ControlEvent): string | null {
-  const tag = `[${rec.provider}/${rec.name != null ? rec.name : shortId(rec.id)}]`;
+  const tag = crewTag(rec);
   switch (rec.state) {
     case "done": {
       // Prefer the crew's own done message (`signal done --message`), carried on
@@ -205,7 +222,8 @@ type Req =
   | { kind: "status"; project: string; id: string }
   | { kind: "list"; project: string }
   | { kind: "reply"; project: string; id: string; message: string }
-  | { kind: "gate-resolve"; project: string; gateId: string; resolvedBy: string; payload: unknown };
+  | { kind: "gate-resolve"; project: string; gateId: string; resolvedBy: string; payload: unknown }
+  | { kind: "purge"; project: string; id: string; force?: boolean };
 
 // #87: exhaustive set of known ControlEvent types for socket-boundary validation.
 // Any event.type arriving from the wire that is not in this set is rejected with
@@ -337,6 +355,15 @@ export function createDaemon(deps: DaemonDeps) {
           if (deps.resolveInteractiveGate) await deps.resolveInteractiveGate(owning.id, req.payload);
           return { ...owning, gates: updatedGates };
         }
+        case "purge": {
+          const r = store.get(req.project, req.id);
+          if (!r) throw new Error(`unknown task ${req.id}`);
+          if (!TERMINAL_STATES.has(r.state) && !req.force) {
+            throw new Error(`task ${req.id} is not terminal (state=${r.state}); use --force to purge anyway`);
+          }
+          store.delete(req.project, req.id);
+          return r;
+        }
         default: { const _exhaustive: never = req; throw new Error(`unhandled request kind`); }
       }
     },
@@ -344,6 +371,11 @@ export function createDaemon(deps: DaemonDeps) {
       const t = now();
       const surfaceAlive = deps.isSurfaceAlive ?? (async () => "unknown" as const);
       for (const r of store.listAll()) {
+        // #378: GC terminal records whose last heartbeat is older than the TTL.
+        if (TERMINAL_STATES.has(r.state) && t - r.lastHeartbeat > TERMINAL_RECORD_TTL_MS) {
+          store.delete(r.project, r.id);
+          continue;
+        }
         // #225 root-fix: terminate non-terminal tasks that exceeded the wall-clock
         // ceiling. Terminalization is the persistent dedup — a daemon restart sees
         // the cancelled record and the TERMINAL_STATES gate above blocks re-fire.
@@ -352,7 +384,7 @@ export function createDaemon(deps: DaemonDeps) {
           const ceiling = deps.taskTimeoutMs ?? DEFAULT_TASK_TIMEOUT_MS;
           if (t - r.createdAt > ceiling) {
             const prevState = r.state; // capture BEFORE terminalization (shown in message)
-            const tag = `[${r.provider}/${r.name != null ? r.name : shortId(r.id)}]`;
+            const tag = crewTag(r);
             const hrs = Math.round(ceiling / 3_600_000);
             const msg = `CREW TIMEOUT ${tag}: wall-clock exceeded ${hrs}h (id: ${r.id}, state: ${prevState})`;
             const synthEvent: ControlEvent = { type: "task.timeout", id: r.id, taskTimeoutMs: ceiling };
@@ -414,7 +446,7 @@ export function createDaemon(deps: DaemonDeps) {
           if (quiet > r.heartbeatBudgetMs) {
             if (deps.notify && quietNotifiedAt.get(r.id) !== liveness) {
               quietNotifiedAt.set(r.id, liveness);
-              const tag = `[${r.provider}/${r.name != null ? r.name : shortId(r.id)}]`;
+              const tag = crewTag(r);
               const mins = Math.max(1, Math.round(quiet / 60000));
               const message = `CREW QUIET ${tag}: working ~${mins}min with no tool activity — likely deep thinking (no reply expected yet).`;
               const synthEvent: ControlEvent = { type: "task.quiet", id: r.id, quietMs: quiet };

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1,7 +1,7 @@
 // src/control/store.ts
 import {
   mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync, existsSync,
-  statSync,
+  rmSync, statSync,
 } from "node:fs";
 import { join, resolve, sep } from "node:path";
 import type { TaskRecord } from "@cockpit/shared";
@@ -12,6 +12,7 @@ export interface Store {
   list(project: string): TaskRecord[];
   listAll(): TaskRecord[];
   quarantine(project: string, id: string): void;
+  delete(project: string, id: string): void;
 }
 
 /**
@@ -87,6 +88,10 @@ export function createStore(root: string): Store {
       const f = taskFile(project, id);
       // suffix prevents clobber across process restarts
       if (existsSync(f)) renameSync(f, `${f}.corrupt.${Date.now()}`);
+    },
+    delete(project, id) {
+      const f = taskFile(project, id);
+      if (existsSync(f)) rmSync(f);
     },
   };
 }


### PR DESCRIPTION
Follow-up to #378.

## Changes

### 1. GC aged terminal records
Terminal records (done/failed/cancelled) accumulate forever. Adds a GC pass in `sweep()` that deletes records whose `lastHeartbeat` is older than `TERMINAL_RECORD_TTL_MS` (7 days). Only removes terminal records — non-terminal records are NEVER pruned regardless of age. Adds `store.delete()` to support this.

### 2. crewTag helper
Notification tags were built inline in 3 places with identical logic. Centralises into `crewTag(r)` which always appends a short-id suffix using middle-dot separator: `[claude/lc-claude · d8e0bc7c]` (named) or `[claude/d8e0bc7c]` (unnamed). All 3 construction sites replaced.

### 3. cockpit crew tasks --purge
Adds `--purge <id>` and `--force` to the `crew tasks` command. Default: only purges terminal records; errors on non-terminal unless `--force` is passed. Daemon gets a new `purge` request kind.

## Verification
- [x] Build: `pnpm run build` (tsc + tsup) — success
- [x] Tests: `pnpm test` — 114 files, 1282 tests, all pass
- [x] CLI: `node dist/index.js crew tasks --help` — purge options present
- [x] TDD: RED→GREEN proof for GC (#378) and purge tests