### PR TITLE
fix(cli): skip self-notification in `cockpit effort`

### DIFF
--- a/packages/cli/src/commands/__tests__/effort.test.ts
+++ b/packages/cli/src/commands/__tests__/effort.test.ts
@@ -3,7 +3,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { getDefaultConfig, saveConfig } from "@cockpit/shared";
-import { runEffortGet, runEffortSet } from "../effort.js";
+import type { CockpitConfig, ProjectConfig } from "@cockpit/shared";
+import { runEffortGet, runEffortSet, notifyCaptainsOfEffort } from "../effort.js";
 
 let dir: string;
 let cfgPath: string;
@@ -93,5 +94,73 @@ describe("effort set", () => {
     expect(onDisk.defaults.effort).toBe("balance");
     expect(onDisk.defaults.maxCrew).toBe(config.defaults.maxCrew);
     expect(onDisk.defaults.worktreeDir).toBe(config.defaults.worktreeDir);
+  });
+});
+
+describe("effort notify (self-notification exclusion)", () => {
+  // Records every (captainName, message) the fake driver was asked to send.
+  function makeDriver(sent: Array<{ captain: string; message: string }>) {
+    return {
+      async status(name: string) {
+        return { id: name }; // captainName doubles as the surface id
+      },
+      async send(ref: string, message: string) {
+        sent.push({ captain: ref, message });
+      },
+    };
+  }
+
+  function configWithProjects(projects: Record<string, ProjectConfig>): CockpitConfig {
+    const config = getDefaultConfig();
+    config.projects = projects;
+    return config;
+  }
+
+  function project(p: string, captainName: string): ProjectConfig {
+    return { path: p, captainName, spokeVault: "", host: "" };
+  }
+
+  it("does NOT notify the captain whose project path is the cwd, but DOES notify the others", async () => {
+    const projA = fs.mkdtempSync(path.join(dir, "projA-"));
+    const projB = fs.mkdtempSync(path.join(dir, "projB-"));
+    const config = configWithProjects({
+      a: project(projA, "captain-a"),
+      b: project(projB, "captain-b"),
+    });
+    const sent: Array<{ captain: string; message: string }> = [];
+
+    await notifyCaptainsOfEffort("low", config, makeDriver(sent), projA);
+
+    const captains = sent.map((s) => s.captain);
+    expect(captains).not.toContain("captain-a"); // self — already saw stdout
+    expect(captains).toContain("captain-b"); // other running captain still notified
+    expect(captains).toHaveLength(1);
+  });
+
+  it("matches cwd through symlinks (realpath), still excluding self", async () => {
+    const projA = fs.realpathSync(fs.mkdtempSync(path.join(dir, "projA-")));
+    const link = path.join(dir, "link-to-a");
+    fs.symlinkSync(projA, link);
+    const config = configWithProjects({ a: project(projA, "captain-a") });
+    const sent: Array<{ captain: string; message: string }> = [];
+
+    // cwd given via the symlink should still resolve to projA and skip it.
+    await notifyCaptainsOfEffort("max", config, makeDriver(sent), link);
+
+    expect(sent).toHaveLength(0);
+  });
+
+  it("notifies every captain when cwd matches no project path", async () => {
+    const projA = fs.mkdtempSync(path.join(dir, "projA-"));
+    const projB = fs.mkdtempSync(path.join(dir, "projB-"));
+    const config = configWithProjects({
+      a: project(projA, "captain-a"),
+      b: project(projB, "captain-b"),
+    });
+    const sent: Array<{ captain: string; message: string }> = [];
+
+    await notifyCaptainsOfEffort("balance", config, makeDriver(sent), path.join(dir, "elsewhere"));
+
+    expect(sent.map((s) => s.captain).sort()).toEqual(["captain-a", "captain-b"]);
   });
 });

--- a/packages/cli/src/commands/effort.ts
+++ b/packages/cli/src/commands/effort.ts
@@ -1,7 +1,9 @@
+import fs from "node:fs";
+import path from "node:path";
 import { Command } from "commander";
 import chalk from "chalk";
 import { loadConfig, saveConfig, resolveEffort, DEFAULT_CONFIG_PATH } from "@cockpit/shared";
-import type { Effort } from "@cockpit/shared";
+import type { CockpitConfig, Effort } from "@cockpit/shared";
 
 const VALID_EFFORTS: Effort[] = ["max", "balance", "low"];
 
@@ -34,6 +36,50 @@ export function runEffortSet(value: string, configPath = DEFAULT_CONFIG_PATH): v
   saveConfig(config, configPath);
 }
 
+/** Minimal slice of RuntimeDriver used to notify a captain. */
+interface EffortNotifyDriver {
+  status(nameOrId: string): Promise<{ id: string } | null>;
+  send(ref: string, message: string): Promise<void>;
+}
+
+/** Resolve a path through symlinks; fall back to a plain resolve if it
+ *  doesn't exist on disk (e.g. a stale/unmounted project entry). */
+function canonical(p: string): string {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return path.resolve(p);
+  }
+}
+
+/**
+ * Send the effort-change notice to every running captain EXCEPT the one in the
+ * current working directory. The captain that ran `cockpit effort` already saw
+ * the stdout '✔ effort → ...' confirmation, so injecting the notice into its own
+ * pane is a duplicate self-notification. Other running captains still get it.
+ */
+export async function notifyCaptainsOfEffort(
+  effort: Effort,
+  config: CockpitConfig,
+  driver: EffortNotifyDriver,
+  cwd: string = process.cwd(),
+): Promise<void> {
+  const here = canonical(cwd);
+  const notice = `🎚️ effort → ${effort}: ${EFFORT_MEANING[effort]}`;
+  for (const [, proj] of Object.entries(config.projects)) {
+    // Skip the captain running in this same directory — it already saw stdout.
+    if (canonical(proj.path) === here) continue;
+    try {
+      const ref = await driver.status(proj.captainName);
+      if (ref) {
+        await driver.send(ref.id, notice);
+      }
+    } catch {
+      // individual project captain unreachable — skip
+    }
+  }
+}
+
 export const effortCommand = new Command("effort")
   .description("Get or set the global crew tokenomics dial (max | balance | low)")
   .argument("[value]", "effort level to set: max | balance | low")
@@ -63,17 +109,7 @@ export const effortCommand = new Command("effort")
       const config = loadConfig();
       const registry = new RuntimeRegistry({ cmux: createCmuxDriver() });
       const driver = registry.global(config);
-      const notice = `🎚️ effort → ${effort}: ${EFFORT_MEANING[effort]}`;
-      for (const [, proj] of Object.entries(config.projects)) {
-        try {
-          const ref = await driver.status(proj.captainName);
-          if (ref) {
-            await driver.send(ref.id, notice);
-          }
-        } catch {
-          // individual project captain unreachable — skip
-        }
-      }
+      await notifyCaptainsOfEffort(effort, config, driver);
     } catch {
       // runtime unavailable — config already written, change applies on next launch
       console.log(chalk.dim("(no running captain detected — change applies on next launch)"));


### PR DESCRIPTION
## Problem

`cockpit effort <mode>`'s active-notify loop (packages/cli/src/commands/effort.ts) iterated over **all** projects and sent the `🎚️ effort → ...` notice to each project's captain via `driver.send()` — **including the captain that ran the command from its own pane**. That captain already sees the stdout `✔ effort → ...` confirmation, so the injected keystroke is a duplicate self-notification (the Claude harness surfaces the injected message twice).

## Fix

Extract the notify loop into a testable, exported function:

```ts
notifyCaptainsOfEffort(effort, config, driver, cwd = process.cwd())
```

It skips the project whose `path` resolves (via `fs.realpathSync`, falling back to `path.resolve` for stale entries) to `cwd`. Every **other** running captain still receives the notice.

The `effortCommand` action now just builds the driver and delegates to this function — same best-effort, never-hard-fails behavior.

## Tests (3 new, 13 total pass)

- captain in `cwd=projectA` is **not** notified; `projectB` **is** (and only B)
- cwd given via a symlink to projectA still resolves and excludes self
- when cwd matches no project path, **all** captains are notified

## Verification

- `npx vitest run packages/cli/src/commands/__tests__/effort.test.ts` → 13 passed
- `npx tsc -b packages/cli` → clean (exit 0)
- gitnexus impact (upstream, `effortCommand`): **LOW** — no upstream consumers beyond command registration

Surgical: only `effort.ts` + its test changed. Follows karpathy-principles.