### PR TITLE
ci: runtime smoke step to catch ESM .js extension crashes (#344)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,11 @@ jobs:
       - name: Build
         run: pnpm run build
 
+      - name: Runtime smoke (catch ESM resolution crashes)
+        run: |
+          node dist/index.js --help
+          node dist/index.js crew --help
+          node dist/cockpitd.js --help
+
       - name: Test
         run: pnpm test


### PR DESCRIPTION
## Summary

- Adds a **Runtime smoke** CI step between Build and Test in `.github/workflows/ci.yml`
- Executes `node dist/index.js --help`, `node dist/index.js crew --help`, and `node dist/cockpitd.js --help` against the freshly built `dist/` output
- NodeNext requires `.js` extensions on all relative imports; a missing extension compiles cleanly but crashes the Node runtime — this gap let two broken builds reach `develop` silently before (#342→#343)

## Safety

`cockpitd.js --help` is explicitly short-circuited in the entry point (added for #360 layer 1, line 130-133 of `packages/cli/src/control/cockpitd.ts`) — it prints a one-liner and exits 0 **without binding the daemon socket**, so CI is safe.

## Local smoke output (verified on clean build)

```
$ node dist/index.js --help
Usage: cockpit [options] [command]
Multi-project agent orchestration for Claude Code
...
EXIT: 0

$ node dist/index.js crew --help
Usage: cockpit crew [options] [command]
...
EXIT: 0

$ node dist/cockpitd.js --help
cockpitd: launchd-managed daemon entry (no CLI args). Use `cockpit` for commands.
EXIT: 0
```

## Change scope

Surgical — only `.github/workflows/ci.yml`, 6 lines added.

Closes #344