### PR TITLE
chore(cmux): debug-gated send instrumentation for #339

### DIFF
--- a/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
+++ b/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { createCmuxDriver, sanitizeForCmuxSend, parseDraftFromScreen, classifyStartupSurface, DeferDelivery } from "../cmux.js";
+import { createCmuxDriver, sanitizeForCmuxSend, parseDraftFromScreen, classifyStartupSurface, classifySendOutcome, DeferDelivery } from "../cmux.js";
 
 const execFileMock = vi.hoisted(() => vi.fn());
 vi.mock("node:child_process", () => ({
@@ -760,6 +760,110 @@ describe("sendToSurface draft-preservation", () => {
     const cmds = execFileMock.mock.calls.map(cmdOf);
     // Must not have sent anything — deferred
     expect(cmds.filter((c) => c.startsWith("send ") && !c.startsWith("send-key"))).toHaveLength(0);
+  });
+});
+
+// #339: debug-gated send instrumentation. The DONE→captain submit is a text
+// burst then a SEPARATE send-key Enter; intermittently the Enter mis-lands as a
+// newline, stranding the payload in the input box. COCKPIT_DEBUG_SEND turns on a
+// pre-send + post-send read-back that logs one real frame so the fault can be
+// caught in the wild. It must be a strict no-op (no extra reads, no log) when off
+// and must NEVER re-send (no double-submit).
+describe("sendToSurface #339 send instrumentation (COCKPIT_DEBUG_SEND)", () => {
+  const driver = createCmuxDriver();
+  let stderrWrites: string[];
+  let restoreStderr: () => void;
+
+  beforeEach(() => {
+    execFileMock.mockReset();
+    stderrWrites = [];
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+      stderrWrites.push(String(chunk));
+      return true;
+    });
+    restoreStderr = () => spy.mockRestore();
+    delete process.env.COCKPIT_DEBUG_SEND;
+  });
+
+  afterEach(() => {
+    restoreStderr();
+    delete process.env.COCKPIT_DEBUG_SEND;
+  });
+
+  it("is silent and adds no extra read-screen when the flag is unset", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return makeTestScreen("❯ ▌");
+      return "";
+    });
+    await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done");
+    // No send-debug line emitted
+    expect(stderrWrites.some((w) => w.includes("send-debug"))).toBe(false);
+    // Exactly the gate's single read-screen — no pre/post read-back added
+    const reads = execFileMock.mock.calls.map(argvOf).filter((a) => a.includes("read-screen"));
+    expect(reads).toHaveLength(1);
+  });
+
+  it("logs a 'submitted' frame and never re-sends when the box is empty after Enter", async () => {
+    process.env.COCKPIT_DEBUG_SEND = "1";
+    // Box empty before AND after — a clean submit.
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return makeTestScreen("❯ ▌");
+      return "";
+    });
+    await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done");
+
+    // The instrumentation added a pre-send and a post-send read-back (3 reads total).
+    const reads = execFileMock.mock.calls.map(argvOf).filter((a) => a.includes("read-screen"));
+    expect(reads).toHaveLength(3);
+
+    // Exactly ONE payload send + ONE Enter — the read-back never re-submits.
+    const calls = execFileMock.mock.calls.map(argvOf);
+    expect(calls.filter((a) => a[0] === "send" && a.includes("crew done"))).toHaveLength(1);
+    expect(calls.filter((a) => a.includes("send-key") && a.includes("Enter"))).toHaveLength(1);
+
+    const debugLine = stderrWrites.find((w) => w.includes("send-debug"));
+    expect(debugLine).toBeDefined();
+    const frame = JSON.parse(debugLine!.replace(/^\[cockpit\] send-debug /, "").trim());
+    expect(frame.surface).toBe("surface:8");
+    expect(frame.payload).toBe("crew done");
+    expect(frame.verdict).toBe("submitted");
+  });
+
+  it("logs a 'stuck' frame when the input box still holds the payload after Enter", async () => {
+    process.env.COCKPIT_DEBUG_SEND = "1";
+    // Empty at the gate read (so we deliver), then the payload is stranded in the
+    // box on the post-send read-back — the #339 fault signature.
+    let reads = 0;
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) {
+        reads++;
+        // gate (1) + pre-send (2) see an empty box; post-send (3) shows it stuck.
+        return reads >= 3 ? makeTestScreen("❯ crew done") : makeTestScreen("❯ ▌");
+      }
+      return "";
+    });
+    await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done");
+
+    const debugLine = stderrWrites.find((w) => w.includes("send-debug"));
+    expect(debugLine).toBeDefined();
+    const frame = JSON.parse(debugLine!.replace(/^\[cockpit\] send-debug /, "").trim());
+    expect(frame.verdict).toBe("stuck");
+    expect(frame.postBox).toContain("crew done");
+  });
+});
+
+describe("classifySendOutcome (#339 verdict)", () => {
+  it("returns 'submitted' for an empty post-send box", () => {
+    expect(classifySendOutcome("crew done", "")).toBe("submitted");
+  });
+  it("returns 'stuck' when the box still holds the payload", () => {
+    expect(classifySendOutcome("crew done", "crew done")).toBe("stuck");
+  });
+  it("returns 'box-gone' when the box is not visible (null)", () => {
+    expect(classifySendOutcome("crew done", null)).toBe("box-gone");
+  });
+  it("returns 'unknown' for unrelated box content", () => {
+    expect(classifySendOutcome("crew done", "a fresh draft")).toBe("unknown");
   });
 });
 

--- a/packages/workspaces/src/runtimes/cmux.ts
+++ b/packages/workspaces/src/runtimes/cmux.ts
@@ -271,6 +271,27 @@ export function classifyStartupSurface(screen: string): "loading" | "idle" | "wo
   return "loading";
 }
 
+// #339 instrumentation gate. The DONE→captain submit is a text burst then a
+// SEPARATE send-key Enter (two distinct socket writes); intermittently the Enter
+// lands as a newline instead of a submit, stranding the payload in the input box.
+// Root-causing needs ONE real frame in the wild. Gated behind COCKPIT_DEBUG_SEND
+// so it is a strict no-op — zero extra reads, zero latency — when unset.
+export function sendDebugEnabled(): boolean {
+  return !!process.env.COCKPIT_DEBUG_SEND;
+}
+
+// Classify a post-send input-box read into a submit verdict for #339:
+//   "submitted" — box empty after Enter (the payload left the input box)
+//   "stuck"     — box still holds the payload (Enter inserted a newline, no submit)
+//   "box-gone"  — box not visible post-send (overlay/scroll — inconclusive)
+//   "unknown"   — box has unrelated content (a fresh draft / next turn rendered)
+export function classifySendOutcome(payload: string, postBox: string | null): string {
+  if (postBox === null) return "box-gone";
+  if (postBox === "") return "submitted";
+  if (postBox === payload || postBox.includes(payload)) return "stuck";
+  return "unknown";
+}
+
 export function createCmuxDriver(): RuntimeDriver {
   return {
     name: "cmux",
@@ -462,8 +483,31 @@ export function createCmuxDriver(): RuntimeDriver {
       const ws = surface.workspaceId;
       const sf = surface.surfaceId;
       const deliver = async () => {
-        await cmux(["send", "--workspace", ws, "--surface", sf, sanitizeForCmuxSend(text)]);
+        // #339 debug-gated instrumentation. When OFF this is the exact two-write
+        // submit it always was (no extra reads, no latency). When ON we capture
+        // one real frame: the input box BEFORE the send, the payload, and the box
+        // AFTER the Enter — so a stranded submit can be told apart from a clean one.
+        const dbg = sendDebugEnabled();
+        let preBox: string | null = null;
+        if (dbg) {
+          try {
+            preBox = readInputBoxRaw(await cmux(["read-screen", "--workspace", ws, "--surface", sf]));
+          } catch { /* unreadable — leave preBox null, logged as such */ }
+        }
+        const payload = sanitizeForCmuxSend(text);
+        await cmux(["send", "--workspace", ws, "--surface", sf, payload]);
         await cmux(["send-key", "--workspace", ws, "--surface", sf, "Enter"]);
+        // Post-send read-back is READ-ONLY — never a re-send — so it can NEVER
+        // double-submit (the #339 constraint). It only observes whether the box
+        // still holds the payload (Enter mis-landed) or is empty (submit took).
+        if (dbg) {
+          let postBox: string | null = null;
+          try {
+            postBox = readInputBoxRaw(await cmux(["read-screen", "--workspace", ws, "--surface", sf]));
+          } catch { /* unreadable — leave postBox null, classified box-gone */ }
+          const verdict = classifySendOutcome(payload, postBox);
+          process.stderr.write(`[cockpit] send-debug ${JSON.stringify({ surface: sf, verdict, payload, preBox, postBox })}\n`);
+        }
       };
 
       // #258/#268 Approach B: deliver only when the captain's input is positively


### PR DESCRIPTION
## What

Adds **debug-gated, instrumentation-only** logging around the captain-delivery submit in `packages/workspaces/src/runtimes/cmux.ts` (`sendToSurface` → `deliver()`) to capture one real frame of the intermittent #339 fault (crew DONE → captain Enter sometimes inserts a newline instead of submitting).

## Why

The submit is two distinct socket writes: the text burst (`cmux send`, no trailing CR) then a **separate** `cmux send-key Enter` one `execFile` later. The DONE payload is single-line (sanitize collapses newlines to spaces), so the fault can only be a dropped/mis-landed second write under live socket/timing pressure. We need one captured frame in the wild to root-cause.

## What it logs (per captain delivery, flag ON only)

A single JSON line to stderr (lands in the daemon log):

```
[cockpit] send-debug {"surface":"surface:8","verdict":"submitted","payload":"...","preBox":"...","postBox":"..."}
```

- **surface** — the target surface id
- **preBox** — input-box state read *before* the send
- **payload** — the sanitized text being sent
- **postBox** — read-back of the input box *after* the `send-key Enter`
- **verdict** — `submitted` (box empty → submit took) · `stuck` (box still holds the payload → Enter mis-landed, the #339 signature) · `box-gone` · `unknown`

## Safety / constraints honored

- **Instrumentation only** — delivery behavior is byte-identical when the flag is unset.
- **No double-submit risk** — the post-send read-back is *read-only* (a `read-screen`), never a re-send or retry.
- **Zero-cost when off** — gated on `COCKPIT_DEBUG_SEND`; when unset, `deliver()` does the exact two writes it always did, with no extra reads and no latency (verified by a test asserting only the gate's single `read-screen` occurs).
- Surgical: only `cmux.ts` + a focused test using the existing fake-cmux harness.

## How to enable in a live session

Set the env var on the **daemon** (it's the process that calls `sendToSurface`), then restart it so it picks up the var:

```bash
launchctl setenv COCKPIT_DEBUG_SEND 1
launchctl kickstart -k gui/$(id -u)/com.cockpit.daemon
```

Then tail the daemon log and grep for `send-debug` — each captain DONE delivery emits one frame. A `"verdict":"stuck"` line with `postBox` still holding the payload is the #339 fault captured. To disable: `launchctl unsetenv COCKPIT_DEBUG_SEND` and kickstart again.

## Tests

`packages/workspaces/src/runtimes/__tests__/cmux.test.ts` — new cases: silent + no extra read when flag unset; `submitted` frame logged with single send/Enter (no re-send) when flag set; `stuck` frame when the box still holds the payload; plus unit cases for `classifySendOutcome`. Full file: 105/105 pass. `node dist/index.js --help` verified post-build.

Refs #339