### PR TITLE
feat(daemon): reap orphaned crews + 'stopped' project status (#324, #323)

### DIFF
--- a/packages/cli/src/commands/health-view.ts
+++ b/packages/cli/src/commands/health-view.ts
@@ -31,6 +31,7 @@ export function healthIcon(state: HealthState): string {
     case "alive": return "✔";
     case "stale": return "•";
     case "gone": return "✘";
+    case "stopped": return "⏻";
     case "unknown": return "○";
   }
 }
@@ -41,6 +42,8 @@ export function colorState(state: HealthState): string {
     case "alive": return chalk.green(state);
     case "stale": return chalk.yellow(state);
     case "gone": return chalk.red(state);
+    // stopped = intentional shutdown, not a fault — magenta, never alarm-red.
+    case "stopped": return chalk.magenta(state);
     case "unknown": return chalk.dim(state);
   }
 }

--- a/packages/cli/src/control/__tests__/cockpitd-daemon-direct.test.ts
+++ b/packages/cli/src/control/__tests__/cockpitd-daemon-direct.test.ts
@@ -260,6 +260,68 @@ describe("cockpitd daemon-direct (#332)", () => {
     // If tick 9 had captain found, delivery would resume to 3.
   });
 
+  it("reaps the stopped project's orphaned interactive crews to 'cancelled' (captain-stopped)", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-dd-orphan-"));
+    const sock = join(dir, "c.sock");
+    const stateRoot = join(dir, "state");
+    mkdirSync(join(stateRoot, "inbox"), { recursive: true });
+
+    // A live interactive crew running in the captain's workspace.
+    const crew: TaskRecord = {
+      id: "orphan-1", project: "p", provider: "claude", mode: "interactive",
+      state: "working", task: "build", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "task.started", heartbeatBudgetMs: 1000,
+      name: "orphan",
+      attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }],
+    };
+    await appendToMailbox({ stateRoot, project: "p", taskRecord: crew, event: EVENT, message: "CREW DONE #1" });
+    await writeCursor({ stateRoot, project: "p", subscriber: "captain", lastAckedSeq: 0 });
+    mkdirSync(join(stateRoot, "p"), { recursive: true });
+    writeFileSync(join(stateRoot, "p", `${crew.id}.json`), JSON.stringify(crew));
+
+    const captainTitle = "p-captain";
+    const crewPane = crewPaneTitle("p", "orphan");
+    let surfCall = 0;
+    // Index 0 is consumed by boot d.reconcile() (probes the crew's own pane —
+    // keep BOTH panes present so the crew survives reconcile and is reaped only
+    // by the captain-stopped path). Then tick N uses index N.
+    const surfResults: PaneRef[][] = [
+      [{ workspaceId: "ws:1", surfaceId: "s0", title: captainTitle }, { workspaceId: "ws:1", surfaceId: "sc", title: crewPane }], // reconcile: captain+crew present
+      [{ workspaceId: "ws:1", surfaceId: "s1", title: captainTitle }, { workspaceId: "ws:1", surfaceId: "sc", title: crewPane }], // tick 1: found → deliver
+      [{ workspaceId: "ws:1", surfaceId: "s2", title: "other" }], // tick 2: gone, streak=1
+      [{ workspaceId: "ws:1", surfaceId: "s2", title: "other" }], // tick 3: gone, streak=2
+      [{ workspaceId: "ws:1", surfaceId: "s2", title: "other" }], // tick 4: gone, streak=3 → reap crews + stop
+    ];
+    const cmux = {
+      sent: [] as Array<{ text: string }>,
+      send: async (_surface: PaneRef, text: string) => { (cmux as any).sent.push({ text }); },
+      listSurfaces: async () => surfResults[Math.min(surfCall++, surfResults.length - 1)],
+      readScreen: async () => null,
+      isAvailable: async () => true,
+      findWorkspaceId: async (name: string) => name === captainTitle ? "ws:1" : null,
+    } as unknown as DaemonCmux & { sent: Array<{ text: string }> };
+
+    const handle = startCockpitd({ stateRoot, sockPath: sock, sweepMs: 0, daemonCmux: cmux });
+    stop = handle.stop;
+
+    // Let boot reconcile settle (consumes index 0) before the manual ticks.
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Crew is still live (working) before the captain goes away.
+    const before = await sendRequest(sock, { kind: "status", project: "p", id: "orphan-1" }) as TaskRecord;
+    expect(before.state).toBe("working");
+
+    if (handle.tickDelivery) await handle.tickDelivery(); // tick 1: captain found → deliver
+    if (handle.tickDelivery) await handle.tickDelivery(); // tick 2: streak=1
+    if (handle.tickDelivery) await handle.tickDelivery(); // tick 3: streak=2
+    if (handle.tickDelivery) await handle.tickDelivery(); // tick 4: streak=3 → reap
+
+    // The orphaned crew is reaped to a terminal state with the captain-stopped marker.
+    const after = await sendRequest(sock, { kind: "status", project: "p", id: "orphan-1" }) as TaskRecord;
+    expect(after.state).toBe("cancelled");
+    expect(after.lastEvent).toBe("captain-stopped");
+  });
+
   it("does NOT reap on a single transient empty sweep (K>1)", async () => {
     dir = mkdtempSync(join(tmpdir(), "cp-dd-transient-"));
     const sock = join(dir, "c.sock");

--- a/packages/cli/src/control/__tests__/liveness.test.ts
+++ b/packages/cli/src/control/__tests__/liveness.test.ts
@@ -43,9 +43,12 @@ describe("projectHealth (pure projection)", () => {
     expect(find(cs, "captain")!.state).toBe("alive");
   });
 
-  it("captainStopped=true → captain gone", () => {
+  it("captainStopped=true → captain stopped (intentional close, distinct from fault)", () => {
     const cs = projectHealth({ ...base, now: 1_000, captainStopped: true });
-    expect(find(cs, "captain")!.state).toBe("gone");
+    const captain = find(cs, "captain")!;
+    expect(captain.state).toBe("stopped");
+    // A stopped captain carries a calm, explanatory detail — not an alarm.
+    expect(captain.detail).toMatch(/closed/i);
   });
 
   it("captainStopped=null → captain unknown (no signal yet)", () => {

--- a/packages/core/src/daemon/delivery.ts
+++ b/packages/core/src/daemon/delivery.ts
@@ -2,10 +2,11 @@
 // Mailbox notification + daemon-direct captain delivery loop (#332).
 import { appendToMailbox, readCursor, writeCursor, readFromCursor } from "../mailbox.js";
 import { CaptainDelivery } from "../delivery/captain-delivery.js";
-import { loadConfig } from "@cockpit/shared";
+import { loadConfig, TERMINAL_STATES } from "@cockpit/shared";
 import { STALE_THRESHOLD_MS } from "./interactive-probe.js";
 import type { TaskRecord, ControlEvent } from "@cockpit/shared";
 import type { PaneRef } from "@cockpit/shared";
+import type { Store } from "../store.js";
 import type { DaemonSurfaceDriver } from "../interfaces.js";
 import type { DaemonContext } from "./context.js";
 
@@ -15,6 +16,27 @@ const CAPTAIN_GONE_STREAK_K = 3;
 /** Pure: find the captain surface by title in a surface list (#332). */
 export function discoverCaptainSurface(surfaces: PaneRef[], captainTitle: string): PaneRef | null {
   return surfaces.find((s) => s.title === captainTitle) ?? null;
+}
+
+/**
+ * Reap a stopped project's orphaned crews (#324). When the user closes the
+ * captain workspace, its crew panes die with it — every non-terminal
+ * interactive crew is orphaned. Terminalize them to 'cancelled' with a distinct
+ * `captain-stopped` marker (traceable; not a fault). Silent: no push fires (the
+ * captain that would receive it is gone). Returns the count reaped.
+ *
+ * Headless crews are excluded — they run as detached processes, not panes in the
+ * captain's workspace, and are reconciled by their own pid liveness instead.
+ */
+export function reapOrphanedCrews(store: Pick<Store, "list" | "put">, project: string): number {
+  let reaped = 0;
+  for (const r of store.list(project)) {
+    if (TERMINAL_STATES.has(r.state)) continue;
+    if (r.mode !== "interactive") continue;
+    store.put({ ...r, state: "cancelled", lastEvent: "captain-stopped" });
+    reaped++;
+  }
+  return reaped;
 }
 
 export interface DeliveryResult {
@@ -112,7 +134,8 @@ export function createDelivery(
           if (streak >= CAPTAIN_GONE_STREAK_K) {
             if (!stoppedProjects.has(project)) {
               stoppedProjects.add(project);
-              log(`captain ${captainTitle}: surface gone for ${CAPTAIN_GONE_STREAK_K} sweeps — stopping delivery`);
+              const reaped = reapOrphanedCrews(store, project);
+              log(`captain ${captainTitle}: surface gone for ${CAPTAIN_GONE_STREAK_K} sweeps — stopping delivery${reaped > 0 ? `, reaped ${reaped} orphaned crew(s)` : ""}`);
             }
           }
         }

--- a/packages/core/src/liveness.ts
+++ b/packages/core/src/liveness.ts
@@ -9,11 +9,14 @@ import type { TaskState, Mode } from "@cockpit/shared";
 
 export type ComponentKind = "captain" | "crew" | "command";
 
-// alive  = seen within the stale window (healthy)
-// stale  = quiet past stale but not yet gone (degrading)
-// gone   = dark past the gone window (treat as down)
+// alive   = seen within the stale window (healthy)
+// stale   = quiet past stale but not yet gone (degrading)
+// gone    = dark past the gone window (treat as down — a FAULT)
+// stopped = intentionally offline (user closed the captain workspace) — NOT a
+//           fault. Distinct from `gone` so the surface never red-alarms an
+//           expected shutdown (#324/#323).
 // unknown = no signal / not applicable (never alarms)
-export type HealthState = "alive" | "stale" | "gone" | "unknown";
+export type HealthState = "alive" | "stale" | "gone" | "stopped" | "unknown";
 
 export interface ComponentHealth {
   kind: ComponentKind;
@@ -72,7 +75,9 @@ export interface CrewLiveness {
  *
  * Captain liveness (#332): driven by the daemon-direct delivery loop.
  *   captainStopped === false  → captain surface was found on last delivery tick → ALIVE
- *   captainStopped === true   → surface gone for 3+ consecutive ticks → GONE
+ *   captainStopped === true   → surface gone for 3+ consecutive ticks → STOPPED
+ *                               (intentional close — its crews are reaped and
+ *                               delivery is paused; NOT a fault — #324/#323)
  *   captainStopped === null   → not yet checked / cmux unreachable → UNKNOWN
  */
 export function projectHealth(input: {
@@ -90,7 +95,7 @@ export function projectHealth(input: {
 
   // ── captain ────────────────────────────────────────────────────────────
   const captainState: HealthState =
-    captainStopped === true ? "gone" :
+    captainStopped === true ? "stopped" :
     captainStopped === false ? "alive" :
     "unknown";
   out.push({
@@ -99,7 +104,7 @@ export function projectHealth(input: {
     ref: captainName,
     state: captainState,
     lastSeenMs: null,
-    detail: captainState === "gone" ? "captain surface gone — delivery stopped" : undefined,
+    detail: captainState === "stopped" ? "captain workspace closed — crews reaped; delivery paused" : undefined,
   });
 
   // ── command (on-demand; only surfaced when applicable) ───────────────────

--- a/packages/web/src/__tests__/web-render.test.ts
+++ b/packages/web/src/__tests__/web-render.test.ts
@@ -224,6 +224,52 @@ describe("severity rollup + remediation", () => {
   });
 });
 
+describe("stopped distinguished from fault (#324/#323)", () => {
+  const stoppedCaptain: DaemonSnapshot["tier1"] = [
+    { kind: "captain", project: "pact", ref: "pact-captain", state: "stopped", lastSeenMs: null },
+  ];
+
+  it("a stopped captain rolls its project card up to 'stopped', not 'gone'", () => {
+    const out = renderContent(full(daemon({}, stoppedCaptain)));
+    expect(out).toMatch(/data-rollup="stopped"/);
+    expect(out).not.toMatch(/data-rollup="gone"/);
+  });
+
+  it("a stopped captain does NOT trip the master CRITICAL alarm", () => {
+    // A genuinely-gone captain trips CRITICAL; a stopped (intentionally closed)
+    // one must not — it is an expected, calm state, not a fault.
+    const out = renderContent(full(daemon({}, stoppedCaptain)));
+    expect(out).not.toContain('class="annunciator a-crit');
+    expect(out).not.toContain("CRITICAL");
+    expect(out).toContain("stopped");
+  });
+
+  it("a stopped project's unread mail is not counted as a stale caution", () => {
+    const d = daemon({}, stoppedCaptain);
+    d.tier2.projects = [{
+      project: "pact",
+      mailbox: { maxSeq: 10, sizeBytes: 100, oldestEntryAgeMs: 60_000, rotationCount: 0 },
+      delivery: { maxSeq: 10, lastAckedSeq: 2, behind: 8 },
+      store: { byState: { cancelled: 2 }, corruptCount: 0 },
+    }];
+    const out = renderContent(full(d));
+    // The card stays 'stopped' — delivery lag behind a closed captain is expected.
+    expect(out).toMatch(/data-rollup="stopped"/);
+  });
+
+  it("a real fault (corrupt store) still rolls up to 'gone' even when captain is stopped", () => {
+    const d = daemon({}, stoppedCaptain);
+    d.tier2.projects = [{
+      project: "pact",
+      mailbox: { maxSeq: 10, sizeBytes: 100, oldestEntryAgeMs: 60_000, rotationCount: 0 },
+      delivery: { maxSeq: 10, lastAckedSeq: 10, behind: 0 },
+      store: { byState: {}, corruptCount: 1 },
+    }];
+    const out = renderContent(full(d));
+    expect(out).toMatch(/data-rollup="gone"/);
+  });
+});
+
 describe("delivery lag bar", () => {
   it("renders an SVG-free delivery bar with acked + behind segments", () => {
     const d = daemon();

--- a/packages/web/src/web-render.ts
+++ b/packages/web/src/web-render.ts
@@ -20,11 +20,13 @@ import type { ExternalProbes, Probe, ProbeState } from "./probes.js";
 
 type AnyState = HealthState | ProbeState;
 
-const ICON: Record<AnyState, string> = { alive: "✔", stale: "•", gone: "✘", unknown: "○" };
-// Rollup ordering: gone is worst, unknown never out-ranks a real degradation.
-const SEV: Record<AnyState, number> = { alive: 0, unknown: 1, stale: 2, gone: 3 };
+const ICON: Record<AnyState, string> = { alive: "✔", stale: "•", gone: "✘", stopped: "⏻", unknown: "○" };
+// Rollup ordering: gone (fault) is worst. `stopped` is an intentional shutdown —
+// it out-ranks a stale caution (it is the headline state of an offline project)
+// but never a genuine fault. unknown never out-ranks a real degradation.
+const SEV: Record<AnyState, number> = { alive: 0, unknown: 1, stale: 2, stopped: 3, gone: 4 };
 // Cockpit annunciator vernacular for each state.
-const STATE_WORD: Record<AnyState, string> = { alive: "nominal", stale: "caution", gone: "fault", unknown: "unknown" };
+const STATE_WORD: Record<AnyState, string> = { alive: "nominal", stale: "caution", gone: "fault", stopped: "stopped", unknown: "unknown" };
 
 function esc(s: string): string {
   return s
@@ -61,10 +63,10 @@ function worst(states: AnyState[]): AnyState {
 }
 
 // ── Health tallies ────────────────────────────────────────────────────────────
-interface Tally { alive: number; stale: number; gone: number; unknown: number; total: number }
+interface Tally { alive: number; stale: number; gone: number; stopped: number; unknown: number; total: number }
 
 function tally(states: AnyState[]): Tally {
-  const t: Tally = { alive: 0, stale: 0, gone: 0, unknown: 0, total: states.length };
+  const t: Tally = { alive: 0, stale: 0, gone: 0, stopped: 0, unknown: 0, total: states.length };
   for (const s of states) t[s]++;
   return t;
 }
@@ -104,7 +106,7 @@ function probeCell(label: string, p: Probe): string {
 }
 
 // ── Donut gauge (inline SVG) ────────────────────────────────────────────────────
-const DONUT_ORDER: AnyState[] = ["alive", "stale", "gone", "unknown"];
+const DONUT_ORDER: AnyState[] = ["alive", "stale", "stopped", "gone", "unknown"];
 
 /** The signature element: a four-segment health ring. Segment arc lengths are
  *  proportional to the tally; everything is plain SVG math so it is deterministic
@@ -209,6 +211,7 @@ function sectionHead(title: string, sub: string): string {
 function tierCard(name: string, t: Tally, desc: string): string {
   const w = t.total ? worst(([] as AnyState[]).concat(
     ...Array.from({ length: t.gone }, () => "gone" as AnyState),
+    ...Array.from({ length: t.stopped }, () => "stopped" as AnyState),
     ...Array.from({ length: t.stale }, () => "stale" as AnyState),
     ...Array.from({ length: t.unknown }, () => "unknown" as AnyState),
     ...Array.from({ length: t.alive }, () => "alive" as AnyState),
@@ -221,6 +224,7 @@ function tierCard(name: string, t: Tally, desc: string): string {
     `<span class="tc s-alive">${t.alive}<i>ok</i></span>`,
     `<span class="tc s-stale">${t.stale}<i>caution</i></span>`,
     `<span class="tc s-gone">${t.gone}<i>fault</i></span>`,
+    ...(t.stopped > 0 ? [`<span class="tc s-stopped">${t.stopped}<i>stopped</i></span>`] : []),
     `<span class="tc s-unknown">${t.unknown}<i>unknown</i></span>`,
     `</div></div>`,
   ].join("");
@@ -246,6 +250,7 @@ function renderOverview(snap: FullSnapshot, col: Collected): string {
     legendRow("alive", col.overall.alive),
     legendRow("stale", col.overall.stale),
     legendRow("gone", col.overall.gone),
+    ...(col.overall.stopped > 0 ? [legendRow("stopped", col.overall.stopped)] : []),
     legendRow("unknown", col.overall.unknown),
     `</div>`,
     `</div>`,
@@ -313,9 +318,14 @@ function renderProjects(snap: FullSnapshot, now: number): string {
   for (const project of projects) {
     const comps = d.tier1.filter((c) => c.project === project);
     const dp = d.tier2.projects.find((p) => p.project === project);
+    // A stopped captain means the project is intentionally offline — its unread
+    // mail is expected backlog, not a live caution, so the delivery lag does not
+    // contribute a `stale` to the rollup (#324/#323). A genuine fault (corrupt
+    // store) still bubbles `gone` and out-ranks the stopped headline.
+    const captainStopped = comps.some((c) => c.kind === "captain" && c.state === "stopped");
     const rollupStates: AnyState[] = [
       ...comps.map((c) => c.state),
-      dp && dp.delivery.behind > 0 ? "stale" : "alive",
+      !captainStopped && dp && dp.delivery.behind > 0 ? "stale" : "alive",
       dp && dp.store.corruptCount > 0 ? "gone" : "alive",
     ];
     const rollup = worst(rollupStates);
@@ -459,7 +469,7 @@ function metricsBlob(col: Collected, linkLost: boolean): string {
     errors: linkLost ? 0 : col.errors,
     behind: linkLost ? 0 : col.behind,
     crewAgeMs: linkLost ? 0 : col.crewAgeMs,
-    alive: col.overall.alive, stale: col.overall.stale, gone: col.overall.gone, unknown: col.overall.unknown,
+    alive: col.overall.alive, stale: col.overall.stale, gone: col.overall.gone, stopped: col.overall.stopped, unknown: col.overall.unknown,
   };
   // Escape `</` defensively so the JSON can never close the <script> early.
   const json = JSON.stringify(m).replace(/</g, "\\u003c");
@@ -481,7 +491,8 @@ export function renderContent(snap: FullSnapshot): string {
   ];
 
   // Master annunciator (status summary) — glanceable on every tab.
-  const sumLine = `${col.overall.alive} nominal · ${col.overall.stale} caution · ${col.overall.gone} fault · ${col.overall.unknown} unknown`;
+  const stoppedPart = col.overall.stopped > 0 ? ` · ${col.overall.stopped} stopped` : "";
+  const sumLine = `${col.overall.alive} nominal · ${col.overall.stale} caution · ${col.overall.gone} fault${stoppedPart} · ${col.overall.unknown} unknown`;
   out.push(
     `<section class="annunciator a-${mc}" role="status" aria-label="Status summary">`,
     `<div class="ann-main"><span class="ann-eyebrow">Status summary</span><span class="ann-word">${esc(word)}</span></div>`,
@@ -518,7 +529,7 @@ const STYLE = `
 :root{
   --bg:#f6f7f9;--panel:#ffffff;--panel-2:#eef1f6;--bezel:#e3e7ef;--track:#e9ecf2;
   --ink:#1b2333;--ink-dim:#5b6678;--hud:#0b6fc2;--hud-deep:#0b6fc2;
-  --ok:#157f3c;--warn:#b45309;--crit:#c01f2e;--unk:#5f6b7d;
+  --ok:#157f3c;--warn:#b45309;--crit:#c01f2e;--unk:#5f6b7d;--stopped:#7c5cbf;
   --shadow:0 1px 2px rgba(16,24,40,.05),0 4px 14px rgba(16,24,40,.06);
 }
 *{box-sizing:border-box}
@@ -591,7 +602,7 @@ body{margin:0;min-height:100vh;background:radial-gradient(1200px 760px at 50% -2
 .donut{width:172px;height:172px;animation:rise .55s ease}
 .donut-track{stroke:var(--track)}
 .seg{transition:stroke-dasharray .5s ease}
-.seg.s-alive{stroke:var(--ok)}.seg.s-stale{stroke:var(--warn)}.seg.s-gone{stroke:var(--crit)}.seg.s-unknown{stroke:var(--unk)}
+.seg.s-alive{stroke:var(--ok)}.seg.s-stale{stroke:var(--warn)}.seg.s-gone{stroke:var(--crit)}.seg.s-stopped{stroke:var(--stopped)}.seg.s-unknown{stroke:var(--unk)}
 .a-ok .seg.s-alive{filter:drop-shadow(0 0 4px var(--ok))}
 .gauge-core{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;gap:1px}
 .gauge-n{font-size:38px;font-weight:800;font-family:system-ui,sans-serif;line-height:1}
@@ -603,7 +614,7 @@ body{margin:0;min-height:100vh;background:radial-gradient(1200px 760px at 50% -2
 .leg-n{font-size:20px;font-weight:700;font-family:system-ui,sans-serif;min-width:1.4em;text-align:right}
 .leg-l{color:var(--ink-dim);text-transform:uppercase;letter-spacing:.1em;font-size:10px;font-family:system-ui,sans-serif}
 .leg.s-alive .pdot{background:var(--ok)}.leg.s-stale .pdot{background:var(--warn)}
-.leg.s-gone .pdot{background:var(--crit)}.leg.s-unknown .pdot{background:var(--unk)}
+.leg.s-gone .pdot{background:var(--crit)}.leg.s-stopped .pdot{background:var(--stopped)}.leg.s-unknown .pdot{background:var(--unk)}
 
 /* Tier + trend cards */
 .tier-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px;margin-bottom:16px}
@@ -614,7 +625,7 @@ body{margin:0;min-height:100vh;background:radial-gradient(1200px 760px at 50% -2
 .tier-counts{display:flex;gap:14px}
 .tc{display:flex;flex-direction:column;font-size:21px;font-weight:700;font-family:system-ui,sans-serif;line-height:1.1}
 .tc i{font-size:9px;font-weight:600;font-style:normal;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-dim)}
-.tc.s-alive{color:var(--ok)}.tc.s-stale{color:var(--warn)}.tc.s-gone{color:var(--crit)}.tc.s-unknown{color:var(--unk)}
+.tc.s-alive{color:var(--ok)}.tc.s-stale{color:var(--warn)}.tc.s-gone{color:var(--crit)}.tc.s-stopped{color:var(--stopped)}.tc.s-unknown{color:var(--unk)}
 
 .trend-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:12px;margin-bottom:16px}
 .trend{border:1px solid var(--bezel);border-radius:12px;background:var(--panel);padding:13px 15px;box-shadow:var(--shadow)}
@@ -631,6 +642,7 @@ body{margin:0;min-height:100vh;background:radial-gradient(1200px 760px at 50% -2
 .card{border:1px solid var(--bezel);border-radius:12px;background:var(--panel);box-shadow:var(--shadow);padding:14px 16px;margin-bottom:14px;border-left:3px solid var(--bezel)}
 .card[data-rollup="gone"]{border-left-color:var(--crit)}
 .card[data-rollup="stale"]{border-left-color:var(--warn)}
+.card[data-rollup="stopped"]{border-left-color:var(--stopped)}
 .card[data-rollup="alive"]{border-left-color:var(--ok)}
 .card[data-rollup="unknown"]{border-left-color:var(--unk)}
 .card-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:12px}
@@ -651,6 +663,7 @@ body{margin:0;min-height:100vh;background:radial-gradient(1200px 760px at 50% -2
 .pill.s-alive{color:var(--ok)}.pill.s-alive .pdot{background:var(--ok);box-shadow:0 0 6px var(--ok)}
 .pill.s-stale{color:var(--warn)}.pill.s-stale .pdot{background:var(--warn);box-shadow:0 0 6px var(--warn)}
 .pill.s-gone{color:var(--crit)}.pill.s-gone .pdot{background:var(--crit);box-shadow:0 0 6px var(--crit)}
+.pill.s-stopped{color:var(--stopped)}.pill.s-stopped .pdot{background:var(--stopped);box-shadow:0 0 6px var(--stopped)}
 .pill.s-unknown{color:var(--unk)}.pill.s-unknown .pdot{background:var(--unk)}
 .cell-detail{color:var(--ink-dim)}
 


### PR DESCRIPTION
## What

Closes #324 and #323 as one coherent change. When the user closes a captain workspace, the existing captain-gone detection (K=3 absent delivery sweeps → `stoppedProjects`) now does three new things instead of *only* pausing delivery:

### 1. Reap orphaned crews (#324)
On the stopped transition, `reapOrphanedCrews()` terminalizes the project's non-terminal **interactive** crews to `cancelled` with a distinct `captain-stopped` `lastEvent`. Their cmux panes died with the closed workspace, so they're genuinely orphaned. The reap is **silent** (no push — the captain that would read it is gone). Headless crews are excluded (they're detached processes, reconciled by pid liveness).

### 2. Explicit `stopped` project status (#323)
New `stopped` `HealthState`. `projectHealth` maps `captainStopped === true` → `stopped` (intentional close) instead of the fault-colored `gone`.

### 3. Dashboard distinguishes stopped from fault
`web-render`:
- Renders `stopped` with its own calm violet visual + ⏻ glyph (pill, donut segment, legend, tier count, card rollup).
- Ranks `stopped` below a genuine fault (`gone`) in the severity rollup — a real fault (corrupt store / gone crew) **still rolls up red** even when the captain is stopped.
- Suppresses the expected delivery-lag `stale` caution for a stopped project (its unread mail is expected backlog, not a live problem).
- **Never trips the master CRITICAL alarm** for a stopped project.

CLI `health-view` (doctor / status) gains the matching `stopped` icon + magenta color.

## Why

Previously a user-closed captain rendered identically to a crash — red `gone`/CRITICAL — and its crews lingered as live records. This makes intentional shutdown a first-class, calm state and cleans up after it.

## Tests
- `cockpitd-daemon-direct.test.ts`: new test extends the reap harness to assert orphaned crew records become `cancelled` with `lastEvent === "captain-stopped"` (and stay live until the captain-stop fires).
- `liveness.test.ts`: `captainStopped=true → captain stopped` with explanatory detail.
- `web-render.test.ts`: stopped→`data-rollup="stopped"` (not gone); no master CRITICAL; lag-stale suppressed; real fault still rolls up `gone`.

## Verification
- `pnpm build` (tsc -b + tsup) — clean.
- Full suite: **1290 passed / 0 failed** (114 files).
- Runtime smoke: `node dist/index.js --help` → exit 0.