### PR TITLE
release/v0.8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,11 @@ jobs:
       - name: Build
         run: pnpm run build
 
+      - name: Runtime smoke (catch ESM resolution crashes)
+        run: |
+          node dist/index.js --help
+          node dist/index.js crew --help
+          node dist/cockpitd.js --help
+
       - name: Test
         run: pnpm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-06-21
+
+### Fixed
+
+- `cockpit effort` no longer self-notifies the captain that ran the command — the active-notify loop now skips the project whose path matches the current working directory (realpath-canonical, with a stale-path fallback). (#383)
+- **Zombie task resurrection** — the daemon sweep's timeout branch no longer falls through to clobber a terminal (cancelled) task back to `working`; terminal states are now sticky, ending the repeated CREW TIMEOUT + name-collision mis-tag. (#380, #378)
+
+### Added
+
+- Explicit **`stopped` project status** — closing a captain workspace now reaps its orphaned interactive crews exactly once (on a confirmed captain-gone K-streak) and the dashboard renders a calm `stopped` state (magenta/⏻) instead of a red CRITICAL fault. A genuine fault (corrupt store, unexpected surface-gone) still rolls up to `gone`. (#388, #324, #323)
+- **Debug-gated send instrumentation** (`COCKPIT_DEBUG_SEND`) — captures a pre/post input-box read-back frame around each captain delivery to catch the intermittent #339 Enter-inserts-newline glitch in the wild. Read-only (never re-sends), strict no-op when the flag is unset. (#386, #339)
+- **Global effort dial** (`cockpit effort <max|balance|low>`) — one tokenomics lever the captain honors when spawning crews: `max` biases toward the strongest model, `low` toward cheaper agents/models, `balance` keeps default routing. Captain-discretion, not a mechanical routing rewrite. (#381, #317)
+
+### Changed
+
+- **Control-plane store hygiene** — automatic garbage-collection of stale terminal task records on sweep, a `crewTag` helper to disambiguate crew notifications, and a manual purge command with force override. (#382, #378)
+
+### CI
+
+- **Runtime smoke step** — CI now executes the bundled bins (`node dist/index.js --help`, `crew --help`, `cockpitd --help`) after build, catching NodeNext ESM `.js`-extension crashes that tsc + vitest miss. (#384, #344)
+
 ## [0.8.1] - 2026-06-19
 
 A **post-reorg cleanup** patch. The public CLI surface is unchanged.

--- a/docs/specs/2026-06-15-crew-effort-design.md
+++ b/docs/specs/2026-06-15-crew-effort-design.md
@@ -1,0 +1,169 @@
+# Crew Effort — Global Tokenomics Dial
+
+**Status:** Design / approved for planning
+**Date:** 2026-06-15
+**Author:** research side-session (brainstorm with user)
+**Scope:** crew routing only
+
+## Problem
+
+Crew model selection today is fixed by `defaults.crewRouting.rules` (tier → `{agent, model}`)
+and `defaults.roles.crew`. There is no single lever to say *"I have spare token budget
+today, lean stronger"* or *"I'm low on budget, lean cheaper"* without hand-editing routing
+rules each time.
+
+The user wants exactly that: one global setting they flip based on how much token budget
+they have on a given day:
+
+- **balance** — normal working mode (today's behavior).
+- **max** — more tokens available → bias crews toward the strongest model.
+- **low** — fewer tokens available → bias crews toward cheaper agents/models.
+
+This is a **tokenomics dial**, not a mechanical routing rewrite. The captain is the brain;
+effort is a hint the captain honors when it spawns crews.
+
+## Non-Goals
+
+These were explicitly considered and rejected during brainstorming to keep the feature
+simple (YAGNI):
+
+- **No per-tier ladder.** Earlier drafts gave each routing rule `low`/`balance`/`max`
+  columns. Rejected — too much config to maintain and reason about.
+- **No mechanical transform in `resolveCrewRoute`.** Effort never rewrites a resolved
+  model up or down a ladder in code. Routing rules stay untouched.
+- **No effort on non-crew roles.** Captain / command / side stay pinned to opus (a
+  deliberate, benchmark-backed decision). Effort is crew-only.
+- **No change to the routed one-liner.** `routed: tier=… → agent/model (rule: "…")`
+  stays exactly as today.
+
+## Design
+
+### 1. Storage
+
+Add one optional field to `CockpitConfig.defaults`:
+
+```ts
+defaults: {
+  // …
+  /** Global crew tokenomics dial. Absent ⇒ "balance" (today's behavior).
+   *  Biases the captain toward stronger ("max") or cheaper ("low") crew models. */
+  effort?: "max" | "balance" | "low";
+}
+```
+
+- **Absent ⇒ `balance`.** No migration, no backfill — every existing config behaves as
+  today.
+- `getDefaultConfig()` may set `effort: "balance"` explicitly for clarity, but readers
+  must treat absent as `balance`.
+
+A single resolver helper centralizes the absent-default:
+
+```ts
+// src/control/effort.ts
+export type Effort = "max" | "balance" | "low";
+export function resolveEffort(config: CockpitConfig): Effort {
+  return config.defaults.effort ?? "balance";
+}
+```
+
+### 2. Setter surfaces (three, for maximum ergonomics)
+
+| Surface | Behavior |
+|---|---|
+| `cockpit effort <max\|balance\|low>` | Validates the value, writes `defaults.effort` via the existing `saveConfig` atomic path, prints confirmation + one-line meaning. |
+| `cockpit effort` (no arg) | Prints the current effort and its meaning. Does not write. |
+| `cockpit:set-effort` skill | The engine. Reads/writes `defaults.effort`, echoes the new mode and what it means for crew spawns. Portable to non-Claude agents via `AGENTS.md`. |
+| `/cockpit-effort` | Thin Claude-Code slash alias that invokes `cockpit:set-effort`. Convenience only. |
+
+Validation: only `max` / `balance` / `low` accepted; anything else is a usage error
+listing the three valid values.
+
+### 3. How the captain honors effort (crew-only)
+
+Two complementary mechanisms — passive for durability, active for immediacy. The captain
+template (`captain.claude.md`) is **hashed for session-freshness**, so the live effort
+value is deliberately NOT written into it (would churn the hash and force a fresh session
+on every toggle). The value lives in `config.json` and is read/pushed.
+
+**Passive — `cockpit:captain-ops` skill gains an "Effort mode" section.** Before spawning
+crews, the captain reads `defaults.effort` from config and biases its crew agent/model
+choice:
+
+- **max** — prefer the strongest model (claude/opus) for crew spawns.
+- **balance** — use default crew routing rules unchanged.
+- **low** — prefer cheaper agents/models (opencode, sonnet) for crews.
+
+This is the durable instruction — survives restarts and context compaction because the
+skill is re-read at session start and referenced throughout.
+
+**Active — `cockpit effort <mode>` notifies the running captain.** When the setter runs,
+it sends a relay message to the project's captain so a live session adjusts immediately
+instead of waiting to re-read config on the next spawn:
+
+```
+🎚 effort → low: bias new crew spawns toward cheaper agents/models (opencode, sonnet).
+```
+
+The relay send is best-effort: if no captain is running, the setter still writes config and
+prints a note that the change takes effect on next launch. (No hard dependency on a live
+daemon/captain.)
+
+### 4. Mode semantics (the captain's interpretation guide)
+
+Plain-language directives, not a mechanical model table — the captain applies judgment
+within the existing routing rules:
+
+| Mode | Directive to the captain |
+|---|---|
+| **max** | Tokens are plentiful. Prefer claude/opus for crews; don't downshift for cost. |
+| **balance** | Normal. Use the default crew routing rules as-is. |
+| **low** | Conserve tokens. Prefer opencode / sonnet for crews; reserve opus for work that genuinely needs it. |
+
+### 5. Precedence
+
+Effort is the *weakest* signal — it only nudges the captain's default choice. Anything
+more specific wins:
+
+1. **Explicit `--agent` / `--model` on a spawn** → wins outright (unchanged).
+2. **A specific routing-rule match the captain chooses to honor** → the captain weighs
+   effort against the matched tier using its judgment.
+3. **Effort directive** → the baseline lean when nothing more specific applies.
+
+Because effort lives in the captain's reasoning (not in `resolveCrewRoute`), there is no
+code-level precedence to encode beyond the existing explicit-flags-win rule.
+
+## Affected surfaces
+
+| File / artifact | Change |
+|---|---|
+| `src/config.ts` | Add `effort?` to `CockpitConfig.defaults`; optionally set `"balance"` in `getDefaultConfig()`. |
+| `src/control/effort.ts` (new) | `Effort` type + `resolveEffort(config)` helper. |
+| `src/commands/effort.ts` (new) | `cockpit effort [value]` get/set command. |
+| CLI registration | Wire `effort` subcommand into the cockpit CLI entrypoint. |
+| `plugin/skills/cockpit/set-effort/SKILL.md` (new) | `cockpit:set-effort` skill. |
+| `/cockpit-effort` slash alias | Thin alias to the skill. |
+| `cockpit:captain-ops` skill | Add "Effort mode" section to the crew-spawning playbook. |
+| Relay send (existing `cockpit runtime send` path) | Setter pushes a one-line effort notice to the running captain. |
+
+## Testing / success criteria
+
+- `cockpit effort low` writes `defaults.effort: "low"`; `cockpit effort` then prints `low`
+  + its meaning. (unit on the command; round-trips through `loadConfig`/`saveConfig`.)
+- Invalid value (`cockpit effort turbo`) errors with the three valid options; config
+  unchanged.
+- Absent `defaults.effort` resolves to `balance` (unit on `resolveEffort`).
+- Existing configs with no `effort` field load and behave identically to today (no
+  migration side effects).
+- Routing behavior (`resolveCrewRoute`) and the routed one-liner are byte-for-byte
+  unchanged when effort is `balance` and untouched in code regardless of effort.
+- `cockpit:captain-ops` skill text instructs the captain to read and honor `defaults.effort`
+  for crew spawns only.
+- Setter sends a relay notice when a captain is running; degrades gracefully (writes config
+  + prints note) when none is.
+
+## Open follow-ups (out of scope for v1)
+
+- A `max` cap / safety rail if budget mode is ever made auto-driven (not now — the user
+  sets it manually).
+- Surfacing current effort in dashboard / status (nice-to-have; not required for the dial
+  to work).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-cockpit",
   "packageManager": "pnpm@10.30.3",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Multi-project agent orchestration for Claude Code",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/__tests__/effort.test.ts
+++ b/packages/cli/src/commands/__tests__/effort.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { getDefaultConfig, saveConfig } from "@cockpit/shared";
+import { runEffortGet, runEffortSet } from "../effort.js";
+
+let dir: string;
+let cfgPath: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "cockpit-effort-"));
+  cfgPath = path.join(dir, "config.json");
+  saveConfig(getDefaultConfig(), cfgPath);
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+describe("effort get", () => {
+  it("returns 'balance' and a description when effort is absent", () => {
+    const config = getDefaultConfig();
+    delete (config.defaults as any).effort;
+    saveConfig(config, cfgPath);
+    const result = runEffortGet(cfgPath);
+    expect(result.effort).toBe("balance");
+    expect(result.description).toBeTruthy();
+    expect(result.description).toContain("balance");
+  });
+
+  it("returns 'low' when config has effort=low", () => {
+    const config = getDefaultConfig();
+    (config.defaults as any).effort = "low";
+    saveConfig(config, cfgPath);
+    const result = runEffortGet(cfgPath);
+    expect(result.effort).toBe("low");
+    expect(result.description).toContain("low");
+  });
+
+  it("returns 'max' when config has effort=max", () => {
+    const config = getDefaultConfig();
+    (config.defaults as any).effort = "max";
+    saveConfig(config, cfgPath);
+    const result = runEffortGet(cfgPath);
+    expect(result.effort).toBe("max");
+  });
+});
+
+describe("effort set", () => {
+  it("writes 'low' to defaults.effort on disk", () => {
+    runEffortSet("low", cfgPath);
+    const onDisk = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
+    expect(onDisk.defaults.effort).toBe("low");
+  });
+
+  it("writes 'max' to defaults.effort on disk", () => {
+    runEffortSet("max", cfgPath);
+    const onDisk = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
+    expect(onDisk.defaults.effort).toBe("max");
+  });
+
+  it("writes 'balance' to defaults.effort on disk", () => {
+    runEffortSet("balance", cfgPath);
+    const onDisk = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
+    expect(onDisk.defaults.effort).toBe("balance");
+  });
+
+  it("round-trips: set 'low' then get returns 'low'", () => {
+    runEffortSet("low", cfgPath);
+    const result = runEffortGet(cfgPath);
+    expect(result.effort).toBe("low");
+  });
+
+  it("rejects invalid value without writing config", () => {
+    const before = fs.readFileSync(cfgPath, "utf-8");
+    expect(() => runEffortSet("turbo", cfgPath)).toThrow();
+    const after = fs.readFileSync(cfgPath, "utf-8");
+    expect(after).toBe(before);
+  });
+
+  it("error for invalid value lists all 3 valid options", () => {
+    let msg = "";
+    try { runEffortSet("turbo", cfgPath); } catch (e) { msg = (e as Error).message; }
+    expect(msg).toContain("max");
+    expect(msg).toContain("balance");
+    expect(msg).toContain("low");
+  });
+
+  it("existing config without effort field loads and saves without side effects on other fields", () => {
+    const config = getDefaultConfig();
+    delete (config.defaults as any).effort;
+    saveConfig(config, cfgPath);
+    runEffortSet("balance", cfgPath);
+    const onDisk = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
+    expect(onDisk.defaults.effort).toBe("balance");
+    expect(onDisk.defaults.maxCrew).toBe(config.defaults.maxCrew);
+    expect(onDisk.defaults.worktreeDir).toBe(config.defaults.worktreeDir);
+  });
+});

--- a/packages/cli/src/commands/__tests__/effort.test.ts
+++ b/packages/cli/src/commands/__tests__/effort.test.ts
@@ -3,7 +3,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { getDefaultConfig, saveConfig } from "@cockpit/shared";
-import { runEffortGet, runEffortSet } from "../effort.js";
+import type { CockpitConfig, ProjectConfig } from "@cockpit/shared";
+import { runEffortGet, runEffortSet, notifyCaptainsOfEffort } from "../effort.js";
 
 let dir: string;
 let cfgPath: string;
@@ -93,5 +94,73 @@ describe("effort set", () => {
     expect(onDisk.defaults.effort).toBe("balance");
     expect(onDisk.defaults.maxCrew).toBe(config.defaults.maxCrew);
     expect(onDisk.defaults.worktreeDir).toBe(config.defaults.worktreeDir);
+  });
+});
+
+describe("effort notify (self-notification exclusion)", () => {
+  // Records every (captainName, message) the fake driver was asked to send.
+  function makeDriver(sent: Array<{ captain: string; message: string }>) {
+    return {
+      async status(name: string) {
+        return { id: name }; // captainName doubles as the surface id
+      },
+      async send(ref: string, message: string) {
+        sent.push({ captain: ref, message });
+      },
+    };
+  }
+
+  function configWithProjects(projects: Record<string, ProjectConfig>): CockpitConfig {
+    const config = getDefaultConfig();
+    config.projects = projects;
+    return config;
+  }
+
+  function project(p: string, captainName: string): ProjectConfig {
+    return { path: p, captainName, spokeVault: "", host: "" };
+  }
+
+  it("does NOT notify the captain whose project path is the cwd, but DOES notify the others", async () => {
+    const projA = fs.mkdtempSync(path.join(dir, "projA-"));
+    const projB = fs.mkdtempSync(path.join(dir, "projB-"));
+    const config = configWithProjects({
+      a: project(projA, "captain-a"),
+      b: project(projB, "captain-b"),
+    });
+    const sent: Array<{ captain: string; message: string }> = [];
+
+    await notifyCaptainsOfEffort("low", config, makeDriver(sent), projA);
+
+    const captains = sent.map((s) => s.captain);
+    expect(captains).not.toContain("captain-a"); // self — already saw stdout
+    expect(captains).toContain("captain-b"); // other running captain still notified
+    expect(captains).toHaveLength(1);
+  });
+
+  it("matches cwd through symlinks (realpath), still excluding self", async () => {
+    const projA = fs.realpathSync(fs.mkdtempSync(path.join(dir, "projA-")));
+    const link = path.join(dir, "link-to-a");
+    fs.symlinkSync(projA, link);
+    const config = configWithProjects({ a: project(projA, "captain-a") });
+    const sent: Array<{ captain: string; message: string }> = [];
+
+    // cwd given via the symlink should still resolve to projA and skip it.
+    await notifyCaptainsOfEffort("max", config, makeDriver(sent), link);
+
+    expect(sent).toHaveLength(0);
+  });
+
+  it("notifies every captain when cwd matches no project path", async () => {
+    const projA = fs.mkdtempSync(path.join(dir, "projA-"));
+    const projB = fs.mkdtempSync(path.join(dir, "projB-"));
+    const config = configWithProjects({
+      a: project(projA, "captain-a"),
+      b: project(projB, "captain-b"),
+    });
+    const sent: Array<{ captain: string; message: string }> = [];
+
+    await notifyCaptainsOfEffort("balance", config, makeDriver(sent), path.join(dir, "elsewhere"));
+
+    expect(sent.map((s) => s.captain).sort()).toEqual(["captain-a", "captain-b"]);
   });
 });

--- a/packages/cli/src/commands/crew-control.ts
+++ b/packages/cli/src/commands/crew-control.ts
@@ -203,12 +203,19 @@ export function addControlPlaneCrewCommands(crew: Command): void {
 
   crew
     .command("tasks <project>")
-    .description("List control-plane tasks for a project (control-plane analogue of legacy `list`)")
+    .description("List control-plane tasks for a project (control-plane analogue of legacy `list`), or purge a task with --purge")
     .option("--json", "Full JSON output (one or more records)")
     .option("--id <taskId>", "Show only tasks matching this id prefix")
     .option("--state <state>", "Filter by task state")
     .option("--state-only <taskId>", "Print just the state string for a single task")
-    .action(async (project: string, opts: { json?: boolean; id?: string; state?: string; stateOnly?: string }) => {
+    .option("--purge <taskId>", "Purge a task record from the store (default: only terminal records)")
+    .option("--force", "Force-purge a non-terminal record (use with --purge)")
+    .action(async (project: string, opts: { json?: boolean; id?: string; state?: string; stateOnly?: string; purge?: string; force?: boolean }) => {
+      if (opts.purge) {
+        const r = await cockpitdCall({ kind: "purge", project, id: opts.purge, force: opts.force ?? false }) as TaskRecord;
+        console.log(`purged ${r.provider}/${r.id} (was ${r.state})`);
+        return;
+      }
       const raw = (await cockpitdCall({ kind: "list", project })) as TaskRecord[];
       let records = raw;
       if (opts.stateOnly) {

--- a/packages/cli/src/commands/effort.ts
+++ b/packages/cli/src/commands/effort.ts
@@ -1,0 +1,81 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { loadConfig, saveConfig, resolveEffort, DEFAULT_CONFIG_PATH } from "@cockpit/shared";
+import type { Effort } from "@cockpit/shared";
+
+const VALID_EFFORTS: Effort[] = ["max", "balance", "low"];
+
+const EFFORT_MEANING: Record<Effort, string> = {
+  max: "tokens are plentiful — bias crew spawns toward claude/opus",
+  balance: "normal routing — use default crew routing rules unchanged",
+  low: "conserve tokens — bias crew spawns toward opencode/sonnet; reserve opus for work that genuinely needs it",
+};
+
+export interface EffortGetResult {
+  effort: Effort;
+  description: string;
+}
+
+export function runEffortGet(configPath = DEFAULT_CONFIG_PATH): EffortGetResult {
+  const config = loadConfig(configPath);
+  const effort = resolveEffort(config);
+  const description = `${effort}: ${EFFORT_MEANING[effort]}`;
+  return { effort, description };
+}
+
+export function runEffortSet(value: string, configPath = DEFAULT_CONFIG_PATH): void {
+  if (!(VALID_EFFORTS as string[]).includes(value)) {
+    throw new Error(
+      `Invalid effort '${value}'. Valid values: ${VALID_EFFORTS.join(" | ")}`,
+    );
+  }
+  const config = loadConfig(configPath);
+  config.defaults.effort = value as Effort;
+  saveConfig(config, configPath);
+}
+
+export const effortCommand = new Command("effort")
+  .description("Get or set the global crew tokenomics dial (max | balance | low)")
+  .argument("[value]", "effort level to set: max | balance | low")
+  .action(async (value: string | undefined) => {
+    if (value === undefined) {
+      const { effort, description } = runEffortGet();
+      console.log(chalk.bold("Current effort:"), chalk.cyan(effort));
+      console.log(chalk.dim(EFFORT_MEANING[effort]));
+      return;
+    }
+
+    try {
+      runEffortSet(value);
+    } catch (err) {
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+
+    const effort = value as Effort;
+    console.log(chalk.green(`✔ effort → ${effort}`));
+    console.log(chalk.dim(EFFORT_MEANING[effort]));
+
+    // Best-effort active notify: send a one-line notice to any running captain.
+    // Never hard-fails — config is already written above.
+    try {
+      const { createCmuxDriver, RuntimeRegistry } = await import("@cockpit/workspaces");
+      const config = loadConfig();
+      const registry = new RuntimeRegistry({ cmux: createCmuxDriver() });
+      const driver = registry.global(config);
+      const notice = `🎚️ effort → ${effort}: ${EFFORT_MEANING[effort]}`;
+      for (const [, proj] of Object.entries(config.projects)) {
+        try {
+          const ref = await driver.status(proj.captainName);
+          if (ref) {
+            await driver.send(ref.id, notice);
+          }
+        } catch {
+          // individual project captain unreachable — skip
+        }
+      }
+    } catch {
+      // runtime unavailable — config already written, change applies on next launch
+      console.log(chalk.dim("(no running captain detected — change applies on next launch)"));
+    }
+  });

--- a/packages/cli/src/commands/effort.ts
+++ b/packages/cli/src/commands/effort.ts
@@ -1,7 +1,9 @@
+import fs from "node:fs";
+import path from "node:path";
 import { Command } from "commander";
 import chalk from "chalk";
 import { loadConfig, saveConfig, resolveEffort, DEFAULT_CONFIG_PATH } from "@cockpit/shared";
-import type { Effort } from "@cockpit/shared";
+import type { CockpitConfig, Effort } from "@cockpit/shared";
 
 const VALID_EFFORTS: Effort[] = ["max", "balance", "low"];
 
@@ -34,6 +36,50 @@ export function runEffortSet(value: string, configPath = DEFAULT_CONFIG_PATH): v
   saveConfig(config, configPath);
 }
 
+/** Minimal slice of RuntimeDriver used to notify a captain. */
+interface EffortNotifyDriver {
+  status(nameOrId: string): Promise<{ id: string } | null>;
+  send(ref: string, message: string): Promise<void>;
+}
+
+/** Resolve a path through symlinks; fall back to a plain resolve if it
+ *  doesn't exist on disk (e.g. a stale/unmounted project entry). */
+function canonical(p: string): string {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return path.resolve(p);
+  }
+}
+
+/**
+ * Send the effort-change notice to every running captain EXCEPT the one in the
+ * current working directory. The captain that ran `cockpit effort` already saw
+ * the stdout '✔ effort → ...' confirmation, so injecting the notice into its own
+ * pane is a duplicate self-notification. Other running captains still get it.
+ */
+export async function notifyCaptainsOfEffort(
+  effort: Effort,
+  config: CockpitConfig,
+  driver: EffortNotifyDriver,
+  cwd: string = process.cwd(),
+): Promise<void> {
+  const here = canonical(cwd);
+  const notice = `🎚️ effort → ${effort}: ${EFFORT_MEANING[effort]}`;
+  for (const [, proj] of Object.entries(config.projects)) {
+    // Skip the captain running in this same directory — it already saw stdout.
+    if (canonical(proj.path) === here) continue;
+    try {
+      const ref = await driver.status(proj.captainName);
+      if (ref) {
+        await driver.send(ref.id, notice);
+      }
+    } catch {
+      // individual project captain unreachable — skip
+    }
+  }
+}
+
 export const effortCommand = new Command("effort")
   .description("Get or set the global crew tokenomics dial (max | balance | low)")
   .argument("[value]", "effort level to set: max | balance | low")
@@ -63,17 +109,7 @@ export const effortCommand = new Command("effort")
       const config = loadConfig();
       const registry = new RuntimeRegistry({ cmux: createCmuxDriver() });
       const driver = registry.global(config);
-      const notice = `🎚️ effort → ${effort}: ${EFFORT_MEANING[effort]}`;
-      for (const [, proj] of Object.entries(config.projects)) {
-        try {
-          const ref = await driver.status(proj.captainName);
-          if (ref) {
-            await driver.send(ref.id, notice);
-          }
-        } catch {
-          // individual project captain unreachable — skip
-        }
-      }
+      await notifyCaptainsOfEffort(effort, config, driver);
     } catch {
       // runtime unavailable — config already written, change applies on next launch
       console.log(chalk.dim("(no running captain detected — change applies on next launch)"));

--- a/packages/cli/src/commands/health-view.ts
+++ b/packages/cli/src/commands/health-view.ts
@@ -31,6 +31,7 @@ export function healthIcon(state: HealthState): string {
     case "alive": return "✔";
     case "stale": return "•";
     case "gone": return "✘";
+    case "stopped": return "⏻";
     case "unknown": return "○";
   }
 }
@@ -41,6 +42,8 @@ export function colorState(state: HealthState): string {
     case "alive": return chalk.green(state);
     case "stale": return chalk.yellow(state);
     case "gone": return chalk.red(state);
+    // stopped = intentional shutdown, not a fault — magenta, never alarm-red.
+    case "stopped": return chalk.magenta(state);
     case "unknown": return chalk.dim(state);
   }
 }

--- a/packages/cli/src/control/__tests__/cockpitd-daemon-direct.test.ts
+++ b/packages/cli/src/control/__tests__/cockpitd-daemon-direct.test.ts
@@ -260,6 +260,68 @@ describe("cockpitd daemon-direct (#332)", () => {
     // If tick 9 had captain found, delivery would resume to 3.
   });
 
+  it("reaps the stopped project's orphaned interactive crews to 'cancelled' (captain-stopped)", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-dd-orphan-"));
+    const sock = join(dir, "c.sock");
+    const stateRoot = join(dir, "state");
+    mkdirSync(join(stateRoot, "inbox"), { recursive: true });
+
+    // A live interactive crew running in the captain's workspace.
+    const crew: TaskRecord = {
+      id: "orphan-1", project: "p", provider: "claude", mode: "interactive",
+      state: "working", task: "build", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "task.started", heartbeatBudgetMs: 1000,
+      name: "orphan",
+      attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }],
+    };
+    await appendToMailbox({ stateRoot, project: "p", taskRecord: crew, event: EVENT, message: "CREW DONE #1" });
+    await writeCursor({ stateRoot, project: "p", subscriber: "captain", lastAckedSeq: 0 });
+    mkdirSync(join(stateRoot, "p"), { recursive: true });
+    writeFileSync(join(stateRoot, "p", `${crew.id}.json`), JSON.stringify(crew));
+
+    const captainTitle = "p-captain";
+    const crewPane = crewPaneTitle("p", "orphan");
+    let surfCall = 0;
+    // Index 0 is consumed by boot d.reconcile() (probes the crew's own pane —
+    // keep BOTH panes present so the crew survives reconcile and is reaped only
+    // by the captain-stopped path). Then tick N uses index N.
+    const surfResults: PaneRef[][] = [
+      [{ workspaceId: "ws:1", surfaceId: "s0", title: captainTitle }, { workspaceId: "ws:1", surfaceId: "sc", title: crewPane }], // reconcile: captain+crew present
+      [{ workspaceId: "ws:1", surfaceId: "s1", title: captainTitle }, { workspaceId: "ws:1", surfaceId: "sc", title: crewPane }], // tick 1: found → deliver
+      [{ workspaceId: "ws:1", surfaceId: "s2", title: "other" }], // tick 2: gone, streak=1
+      [{ workspaceId: "ws:1", surfaceId: "s2", title: "other" }], // tick 3: gone, streak=2
+      [{ workspaceId: "ws:1", surfaceId: "s2", title: "other" }], // tick 4: gone, streak=3 → reap crews + stop
+    ];
+    const cmux = {
+      sent: [] as Array<{ text: string }>,
+      send: async (_surface: PaneRef, text: string) => { (cmux as any).sent.push({ text }); },
+      listSurfaces: async () => surfResults[Math.min(surfCall++, surfResults.length - 1)],
+      readScreen: async () => null,
+      isAvailable: async () => true,
+      findWorkspaceId: async (name: string) => name === captainTitle ? "ws:1" : null,
+    } as unknown as DaemonCmux & { sent: Array<{ text: string }> };
+
+    const handle = startCockpitd({ stateRoot, sockPath: sock, sweepMs: 0, daemonCmux: cmux });
+    stop = handle.stop;
+
+    // Let boot reconcile settle (consumes index 0) before the manual ticks.
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Crew is still live (working) before the captain goes away.
+    const before = await sendRequest(sock, { kind: "status", project: "p", id: "orphan-1" }) as TaskRecord;
+    expect(before.state).toBe("working");
+
+    if (handle.tickDelivery) await handle.tickDelivery(); // tick 1: captain found → deliver
+    if (handle.tickDelivery) await handle.tickDelivery(); // tick 2: streak=1
+    if (handle.tickDelivery) await handle.tickDelivery(); // tick 3: streak=2
+    if (handle.tickDelivery) await handle.tickDelivery(); // tick 4: streak=3 → reap
+
+    // The orphaned crew is reaped to a terminal state with the captain-stopped marker.
+    const after = await sendRequest(sock, { kind: "status", project: "p", id: "orphan-1" }) as TaskRecord;
+    expect(after.state).toBe("cancelled");
+    expect(after.lastEvent).toBe("captain-stopped");
+  });
+
   it("does NOT reap on a single transient empty sweep (K>1)", async () => {
     dir = mkdtempSync(join(tmpdir(), "cp-dd-transient-"));
     const sock = join(dir, "c.sock");

--- a/packages/cli/src/control/__tests__/daemon.test.ts
+++ b/packages/cli/src/control/__tests__/daemon.test.ts
@@ -3,8 +3,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createDaemon } from "@cockpit/core";
-import { createStore } from "@cockpit/core";
+import { createDaemon, createStore, crewTag } from "@cockpit/core";
 import type { TaskRecord } from "@cockpit/shared";
 
 function rec(id: string, overrides: Partial<TaskRecord> = {}): TaskRecord {
@@ -233,6 +232,26 @@ describe("daemon handler", () => {
     const d = createDaemon({ store, now: () => 1000, isSurfaceAlive: async () => "unknown" });
     await d.sweep();
     expect(store.get("p", "g5")?.state).toBe("working");
+  });
+
+  it("sweep: deletes terminal records older than TTL, keeps fresh terminal and old non-terminal (#378 GC)", async () => {
+    const store = createStore(dir);
+    const EIGHT_DAYS_MS = 8 * 24 * 60 * 60 * 1000;
+    const NOW = 1_000_000_000;
+
+    // (a) cancelled, lastHeartbeat 8 days ago → should be GC'd
+    store.put(rec("gc-old-term", { state: "cancelled", createdAt: NOW - EIGHT_DAYS_MS, lastHeartbeat: NOW - EIGHT_DAYS_MS, heartbeatBudgetMs: 86_400_000 }));
+    // (b) cancelled, lastHeartbeat 1 min ago → should stay
+    store.put(rec("gc-fresh-term", { state: "cancelled", createdAt: NOW - 60000, lastHeartbeat: NOW - 60000, heartbeatBudgetMs: 86_400_000 }));
+    // (c) working, lastHeartbeat 8 days ago → should stay (non-terminal)
+    store.put(rec("gc-old-live", { state: "working", createdAt: NOW - EIGHT_DAYS_MS, lastHeartbeat: NOW - EIGHT_DAYS_MS, heartbeatBudgetMs: 86_400_000, mode: "headless" }));
+
+    const d = createDaemon({ store, now: () => NOW });
+    await d.sweep();
+
+    expect(store.get("p", "gc-old-term")).toBeUndefined();
+    expect(store.get("p", "gc-fresh-term")?.state).toBe("cancelled");
+    expect(store.get("p", "gc-old-live")).toBeTruthy();
   });
 
   it("sweep: headless records are never surface-reaped (pid is their liveness) (#139)", async () => {
@@ -937,6 +956,74 @@ describe("daemon report-back on settle with originProject (#246)", () => {
     const bCalls = calls.filter((c) => c.project === "projB");
     expect(bCalls.length).toBe(1);
     expect(bCalls[0].message).toMatch(/cross.project|projA/i);
+  });
+});
+
+// ── Issue #378: crewTag helper (notification tag disambiguation) ────────────
+describe("crewTag (#378)", () => {
+  it("named record includes name and short id", () => {
+    const r: TaskRecord = {
+      id: "abc123def456", project: "p", provider: "claude", mode: "interactive",
+      state: "working", name: "my-crew", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000,
+      attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }],
+    };
+    const tag = crewTag(r);
+    expect(tag).toBe("[claude/my-crew · abc123de]");
+  });
+
+  it("unnamed record includes short id only", () => {
+    const r: TaskRecord = {
+      id: "abc123def456", project: "p", provider: "opencode", mode: "interactive",
+      state: "done", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", resultRef: "/r", heartbeatBudgetMs: 1000,
+      attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }],
+    };
+    const tag = crewTag(r);
+    expect(tag).toBe("[opencode/abc123de]");
+  });
+});
+
+// ── Issue #378: purge request kind ──────────────────────────────────────────
+describe("purge (#378)", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "cp-purge-")); });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("purge a terminal record succeeds and record is gone", async () => {
+    const store = createStore(dir);
+    store.put(rec("p-term", { state: "done", resultRef: "/r" }));
+    const d = createDaemon({ store, now: () => 2000 });
+    const r = await d.handle({ kind: "purge", project: "p", id: "p-term" });
+    expect((r as TaskRecord).id).toBe("p-term");
+    expect(store.get("p", "p-term")).toBeUndefined();
+  });
+
+  it("purge a non-terminal record without force errors", async () => {
+    const store = createStore(dir);
+    store.put(rec("p-live", { state: "working" }));
+    const d = createDaemon({ store, now: () => 2000 });
+    await expect(
+      d.handle({ kind: "purge", project: "p", id: "p-live" }),
+    ).rejects.toThrow(/not terminal/i);
+    expect(store.get("p", "p-live")?.state).toBe("working");
+  });
+
+  it("purge a non-terminal record with force succeeds", async () => {
+    const store = createStore(dir);
+    store.put(rec("p-force", { state: "working" }));
+    const d = createDaemon({ store, now: () => 2000 });
+    const r = await d.handle({ kind: "purge", project: "p", id: "p-force", force: true });
+    expect((r as TaskRecord).id).toBe("p-force");
+    expect(store.get("p", "p-force")).toBeUndefined();
+  });
+
+  it("purge an unknown task errors", async () => {
+    const store = createStore(dir);
+    const d = createDaemon({ store, now: () => 2000 });
+    await expect(
+      d.handle({ kind: "purge", project: "p", id: "no-such-id" }),
+    ).rejects.toThrow(/unknown/i);
   });
 });
 

--- a/packages/cli/src/control/__tests__/daemon.test.ts
+++ b/packages/cli/src/control/__tests__/daemon.test.ts
@@ -744,6 +744,49 @@ describe("sweep: task-timeout (#225)", () => {
     await d2.sweep();
     expect(timeoutCalls()).toBe(1);
   });
+
+  // ── #378 regression: zombie resurrection ────────────────────────────────────
+  // A timed-out interactive task with a hung pendingTool would have evaluateStall
+  // operate on the stale `r` (still 'working'), clobbering the just-written
+  // 'cancelled' state back to 'stalled'. This caused infinite CREW TIMEOUT re-fire.
+  it("#378: timeout-cancelled state is NOT clobbered by evaluateStall on the same sweep", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    const TOOL_STALL_BUDGET_MS = 10 * 60 * 1000;
+    // createdAt=0, now=2000, ceiling=1000 → age 2000ms > ceiling (triggers timeout)
+    // pendingTool.since = 2000 - (TOOL_STALL_BUDGET_MS + 1000) → hung > tool-stall budget
+    // → without the fix, evaluateStall would return state='stalled' and clobber 'cancelled'
+    const now = 2000;
+    store.put(rec("t378a", {
+      state: "working", mode: "interactive", createdAt: 0,
+      lastHeartbeat: 1990, heartbeatBudgetMs: 86_400_000,
+      pendingTool: { name: "Bash", since: now - TOOL_STALL_BUDGET_MS - 1000 },
+    }));
+    const d = createDaemon({ store, now: () => now, taskTimeoutMs: 1_000, notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    // Terminal state must survive — evaluateStall must not clobber it
+    const r = store.get("p", "t378a");
+    expect(r?.state).toBe("cancelled");
+    expect(r?.lastEvent).toBe("sweep.task-timeout");
+  });
+
+  it("#378: second sweep on a timeout-cancelled task fires CREW TIMEOUT exactly once total", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    const TOOL_STALL_BUDGET_MS = 10 * 60 * 1000;
+    const now = 2000;
+    store.put(rec("t378b", {
+      state: "working", mode: "interactive", createdAt: 0,
+      lastHeartbeat: 1990, heartbeatBudgetMs: 86_400_000,
+      pendingTool: { name: "Bash", since: now - TOOL_STALL_BUDGET_MS - 1000 },
+    }));
+    const d = createDaemon({ store, now: () => now, taskTimeoutMs: 1_000, notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    await d.sweep(); // second sweep — must see cancelled, skip entirely
+    const timeoutCalls = calls.filter((c) => c.message.includes("CREW TIMEOUT")).length;
+    expect(timeoutCalls).toBe(1);
+    expect(store.get("p", "t378b")?.state).toBe("cancelled");
+  });
 });
 
 // ── Issue #87: socket-boundary schema validation ──────────────────────────────

--- a/packages/cli/src/control/__tests__/liveness.test.ts
+++ b/packages/cli/src/control/__tests__/liveness.test.ts
@@ -43,9 +43,12 @@ describe("projectHealth (pure projection)", () => {
     expect(find(cs, "captain")!.state).toBe("alive");
   });
 
-  it("captainStopped=true → captain gone", () => {
+  it("captainStopped=true → captain stopped (intentional close, distinct from fault)", () => {
     const cs = projectHealth({ ...base, now: 1_000, captainStopped: true });
-    expect(find(cs, "captain")!.state).toBe("gone");
+    const captain = find(cs, "captain")!;
+    expect(captain.state).toBe("stopped");
+    // A stopped captain carries a calm, explanatory detail — not an alarm.
+    expect(captain.detail).toMatch(/closed/i);
   });
 
   it("captainStopped=null → captain unknown (no signal yet)", () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,6 +30,7 @@ import { configCommand } from "./commands/config.js";
 import { healCommand } from "./commands/heal.js";
 import { groupCommand } from "./commands/group.js";
 import { cmuxCommand } from "./commands/cmux.js";
+import { effortCommand } from "./commands/effort.js";
 import { detectDrift } from "@cockpit/shared";
 import { needsCheck, withStamp } from "@cockpit/shared";
 import { getDefaultConfig } from "@cockpit/shared";
@@ -114,6 +115,7 @@ program.addCommand(configCommand);
 program.addCommand(healCommand);
 program.addCommand(groupCommand);
 program.addCommand(cmuxCommand);
+program.addCommand(effortCommand);
 
 program.parseAsync().catch((e) => {
   process.stderr.write(`error: ${e instanceof Error ? e.message : String(e)}\n`);

--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -69,6 +69,10 @@ export interface DaemonDeps {
 // catch it. This ceiling does. Configurable via DaemonDeps.taskTimeoutMs.
 export const DEFAULT_TASK_TIMEOUT_MS = 8 * 60 * 60 * 1000;
 
+// #378: GC TTL for terminal records (done/failed/cancelled). Records older
+// than this are pruned from the store during sweep().
+export const TERMINAL_RECORD_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
 // 'awaiting-input' is an attention state: entering it (idle watchdog OR a
 // Stop-hook turn boundary) fires exactly one accurate CREW IDLE push. The
 // firePush prev===next guard keeps it from re-firing while the task sits idle.
@@ -93,8 +97,21 @@ function shortId(id: string): string {
   return id.slice(0, 8);
 }
 
+/**
+ * Build a disambiguated notification tag for a task record. Always appends
+ * the short id so reused crew names are distinguishable across distinct ids.
+ * Named: [provider/name · shortId]  Unnamed: [provider/shortId]
+ */
+export function crewTag(r: TaskRecord): string {
+  const suffix = shortId(r.id);
+  if (r.name != null) {
+    return `[${r.provider}/${r.name} · ${suffix}]`;
+  }
+  return `[${r.provider}/${suffix}]`;
+}
+
 function formatMessage(rec: TaskRecord, event?: ControlEvent): string | null {
-  const tag = `[${rec.provider}/${rec.name != null ? rec.name : shortId(rec.id)}]`;
+  const tag = crewTag(rec);
   switch (rec.state) {
     case "done": {
       // Prefer the crew's own done message (`signal done --message`), carried on
@@ -205,7 +222,8 @@ type Req =
   | { kind: "status"; project: string; id: string }
   | { kind: "list"; project: string }
   | { kind: "reply"; project: string; id: string; message: string }
-  | { kind: "gate-resolve"; project: string; gateId: string; resolvedBy: string; payload: unknown };
+  | { kind: "gate-resolve"; project: string; gateId: string; resolvedBy: string; payload: unknown }
+  | { kind: "purge"; project: string; id: string; force?: boolean };
 
 // #87: exhaustive set of known ControlEvent types for socket-boundary validation.
 // Any event.type arriving from the wire that is not in this set is rejected with
@@ -337,6 +355,15 @@ export function createDaemon(deps: DaemonDeps) {
           if (deps.resolveInteractiveGate) await deps.resolveInteractiveGate(owning.id, req.payload);
           return { ...owning, gates: updatedGates };
         }
+        case "purge": {
+          const r = store.get(req.project, req.id);
+          if (!r) throw new Error(`unknown task ${req.id}`);
+          if (!TERMINAL_STATES.has(r.state) && !req.force) {
+            throw new Error(`task ${req.id} is not terminal (state=${r.state}); use --force to purge anyway`);
+          }
+          store.delete(req.project, req.id);
+          return r;
+        }
         default: { const _exhaustive: never = req; throw new Error(`unhandled request kind`); }
       }
     },
@@ -344,6 +371,11 @@ export function createDaemon(deps: DaemonDeps) {
       const t = now();
       const surfaceAlive = deps.isSurfaceAlive ?? (async () => "unknown" as const);
       for (const r of store.listAll()) {
+        // #378: GC terminal records whose last heartbeat is older than the TTL.
+        if (TERMINAL_STATES.has(r.state) && t - r.lastHeartbeat > TERMINAL_RECORD_TTL_MS) {
+          store.delete(r.project, r.id);
+          continue;
+        }
         // #225 root-fix: terminate non-terminal tasks that exceeded the wall-clock
         // ceiling. Terminalization is the persistent dedup — a daemon restart sees
         // the cancelled record and the TERMINAL_STATES gate above blocks re-fire.
@@ -352,7 +384,7 @@ export function createDaemon(deps: DaemonDeps) {
           const ceiling = deps.taskTimeoutMs ?? DEFAULT_TASK_TIMEOUT_MS;
           if (t - r.createdAt > ceiling) {
             const prevState = r.state; // capture BEFORE terminalization (shown in message)
-            const tag = `[${r.provider}/${r.name != null ? r.name : shortId(r.id)}]`;
+            const tag = crewTag(r);
             const hrs = Math.round(ceiling / 3_600_000);
             const msg = `CREW TIMEOUT ${tag}: wall-clock exceeded ${hrs}h (id: ${r.id}, state: ${prevState})`;
             const synthEvent: ControlEvent = { type: "task.timeout", id: r.id, taskTimeoutMs: ceiling };
@@ -414,7 +446,7 @@ export function createDaemon(deps: DaemonDeps) {
           if (quiet > r.heartbeatBudgetMs) {
             if (deps.notify && quietNotifiedAt.get(r.id) !== liveness) {
               quietNotifiedAt.set(r.id, liveness);
-              const tag = `[${r.provider}/${r.name != null ? r.name : shortId(r.id)}]`;
+              const tag = crewTag(r);
               const mins = Math.max(1, Math.round(quiet / 60000));
               const message = `CREW QUIET ${tag}: working ~${mins}min with no tool activity — likely deep thinking (no reply expected yet).`;
               const synthEvent: ControlEvent = { type: "task.quiet", id: r.id, quietMs: quiet };

--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -369,6 +369,7 @@ export function createDaemon(deps: DaemonDeps) {
                 // swallowed — a flaky notifier must never trip the sweep
               }
             }
+            continue; // #378: skip remaining sweep body — stale `r` must not clobber just-written terminal state
           }
         }
         // #139 backstop: reap interactive records whose backing surface is

--- a/packages/core/src/daemon/delivery.ts
+++ b/packages/core/src/daemon/delivery.ts
@@ -2,10 +2,11 @@
 // Mailbox notification + daemon-direct captain delivery loop (#332).
 import { appendToMailbox, readCursor, writeCursor, readFromCursor } from "../mailbox.js";
 import { CaptainDelivery } from "../delivery/captain-delivery.js";
-import { loadConfig } from "@cockpit/shared";
+import { loadConfig, TERMINAL_STATES } from "@cockpit/shared";
 import { STALE_THRESHOLD_MS } from "./interactive-probe.js";
 import type { TaskRecord, ControlEvent } from "@cockpit/shared";
 import type { PaneRef } from "@cockpit/shared";
+import type { Store } from "../store.js";
 import type { DaemonSurfaceDriver } from "../interfaces.js";
 import type { DaemonContext } from "./context.js";
 
@@ -15,6 +16,27 @@ const CAPTAIN_GONE_STREAK_K = 3;
 /** Pure: find the captain surface by title in a surface list (#332). */
 export function discoverCaptainSurface(surfaces: PaneRef[], captainTitle: string): PaneRef | null {
   return surfaces.find((s) => s.title === captainTitle) ?? null;
+}
+
+/**
+ * Reap a stopped project's orphaned crews (#324). When the user closes the
+ * captain workspace, its crew panes die with it — every non-terminal
+ * interactive crew is orphaned. Terminalize them to 'cancelled' with a distinct
+ * `captain-stopped` marker (traceable; not a fault). Silent: no push fires (the
+ * captain that would receive it is gone). Returns the count reaped.
+ *
+ * Headless crews are excluded — they run as detached processes, not panes in the
+ * captain's workspace, and are reconciled by their own pid liveness instead.
+ */
+export function reapOrphanedCrews(store: Pick<Store, "list" | "put">, project: string): number {
+  let reaped = 0;
+  for (const r of store.list(project)) {
+    if (TERMINAL_STATES.has(r.state)) continue;
+    if (r.mode !== "interactive") continue;
+    store.put({ ...r, state: "cancelled", lastEvent: "captain-stopped" });
+    reaped++;
+  }
+  return reaped;
 }
 
 export interface DeliveryResult {
@@ -112,7 +134,8 @@ export function createDelivery(
           if (streak >= CAPTAIN_GONE_STREAK_K) {
             if (!stoppedProjects.has(project)) {
               stoppedProjects.add(project);
-              log(`captain ${captainTitle}: surface gone for ${CAPTAIN_GONE_STREAK_K} sweeps — stopping delivery`);
+              const reaped = reapOrphanedCrews(store, project);
+              log(`captain ${captainTitle}: surface gone for ${CAPTAIN_GONE_STREAK_K} sweeps — stopping delivery${reaped > 0 ? `, reaped ${reaped} orphaned crew(s)` : ""}`);
             }
           }
         }

--- a/packages/core/src/liveness.ts
+++ b/packages/core/src/liveness.ts
@@ -9,11 +9,14 @@ import type { TaskState, Mode } from "@cockpit/shared";
 
 export type ComponentKind = "captain" | "crew" | "command";
 
-// alive  = seen within the stale window (healthy)
-// stale  = quiet past stale but not yet gone (degrading)
-// gone   = dark past the gone window (treat as down)
+// alive   = seen within the stale window (healthy)
+// stale   = quiet past stale but not yet gone (degrading)
+// gone    = dark past the gone window (treat as down — a FAULT)
+// stopped = intentionally offline (user closed the captain workspace) — NOT a
+//           fault. Distinct from `gone` so the surface never red-alarms an
+//           expected shutdown (#324/#323).
 // unknown = no signal / not applicable (never alarms)
-export type HealthState = "alive" | "stale" | "gone" | "unknown";
+export type HealthState = "alive" | "stale" | "gone" | "stopped" | "unknown";
 
 export interface ComponentHealth {
   kind: ComponentKind;
@@ -72,7 +75,9 @@ export interface CrewLiveness {
  *
  * Captain liveness (#332): driven by the daemon-direct delivery loop.
  *   captainStopped === false  → captain surface was found on last delivery tick → ALIVE
- *   captainStopped === true   → surface gone for 3+ consecutive ticks → GONE
+ *   captainStopped === true   → surface gone for 3+ consecutive ticks → STOPPED
+ *                               (intentional close — its crews are reaped and
+ *                               delivery is paused; NOT a fault — #324/#323)
  *   captainStopped === null   → not yet checked / cmux unreachable → UNKNOWN
  */
 export function projectHealth(input: {
@@ -90,7 +95,7 @@ export function projectHealth(input: {
 
   // ── captain ────────────────────────────────────────────────────────────
   const captainState: HealthState =
-    captainStopped === true ? "gone" :
+    captainStopped === true ? "stopped" :
     captainStopped === false ? "alive" :
     "unknown";
   out.push({
@@ -99,7 +104,7 @@ export function projectHealth(input: {
     ref: captainName,
     state: captainState,
     lastSeenMs: null,
-    detail: captainState === "gone" ? "captain surface gone — delivery stopped" : undefined,
+    detail: captainState === "stopped" ? "captain workspace closed — crews reaped; delivery paused" : undefined,
   });
 
   // ── command (on-demand; only surfaced when applicable) ───────────────────

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1,7 +1,7 @@
 // src/control/store.ts
 import {
   mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync, existsSync,
-  statSync,
+  rmSync, statSync,
 } from "node:fs";
 import { join, resolve, sep } from "node:path";
 import type { TaskRecord } from "@cockpit/shared";
@@ -12,6 +12,7 @@ export interface Store {
   list(project: string): TaskRecord[];
   listAll(): TaskRecord[];
   quarantine(project: string, id: string): void;
+  delete(project: string, id: string): void;
 }
 
 /**
@@ -87,6 +88,10 @@ export function createStore(root: string): Store {
       const f = taskFile(project, id);
       // suffix prevents clobber across process restarts
       if (existsSync(f)) renameSync(f, `${f}.corrupt.${Date.now()}`);
+    },
+    delete(project, id) {
+      const f = taskFile(project, id);
+      if (existsSync(f)) rmSync(f);
     },
   };
 }

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -103,6 +103,9 @@ export interface CockpitConfig {
      * See docs/research/2026-06-16-cmux-events-stream.md (C2 finding).
      */
     cmuxAgentHibernation?: boolean;
+    /** #317 global crew tokenomics dial. Absent ⇒ "balance" (today's behavior).
+     *  Biases the captain toward stronger ("max") or cheaper ("low") crew models. */
+    effort?: "max" | "balance" | "low";
   };
   metrics: {
     enabled: boolean;

--- a/packages/shared/src/effort.ts
+++ b/packages/shared/src/effort.ts
@@ -1,0 +1,7 @@
+import type { CockpitConfig } from "./config.js";
+
+export type Effort = "max" | "balance" | "low";
+
+export function resolveEffort(config: CockpitConfig): Effort {
+  return config.defaults.effort ?? "balance";
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 // @cockpit/shared — pure types + leaf utilities + config.
 export * from "./config.js";
+export * from "./effort.js";
 export * from "./types/runtime.js";
 export * from "./types/control.js";
 export * from "./types/projection.js";

--- a/packages/shared/src/lib/__tests__/effort.test.ts
+++ b/packages/shared/src/lib/__tests__/effort.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { resolveEffort, getDefaultConfig } from "@cockpit/shared";
+
+describe("resolveEffort", () => {
+  it("returns 'balance' when effort is absent", () => {
+    const config = getDefaultConfig();
+    delete (config.defaults as any).effort;
+    expect(resolveEffort(config)).toBe("balance");
+  });
+
+  it("returns 'max' when explicitly set to max", () => {
+    const config = getDefaultConfig();
+    (config.defaults as any).effort = "max";
+    expect(resolveEffort(config)).toBe("max");
+  });
+
+  it("returns 'balance' when explicitly set to balance", () => {
+    const config = getDefaultConfig();
+    (config.defaults as any).effort = "balance";
+    expect(resolveEffort(config)).toBe("balance");
+  });
+
+  it("returns 'low' when explicitly set to low", () => {
+    const config = getDefaultConfig();
+    (config.defaults as any).effort = "low";
+    expect(resolveEffort(config)).toBe("low");
+  });
+});

--- a/packages/web/src/__tests__/web-render.test.ts
+++ b/packages/web/src/__tests__/web-render.test.ts
@@ -224,6 +224,52 @@ describe("severity rollup + remediation", () => {
   });
 });
 
+describe("stopped distinguished from fault (#324/#323)", () => {
+  const stoppedCaptain: DaemonSnapshot["tier1"] = [
+    { kind: "captain", project: "pact", ref: "pact-captain", state: "stopped", lastSeenMs: null },
+  ];
+
+  it("a stopped captain rolls its project card up to 'stopped', not 'gone'", () => {
+    const out = renderContent(full(daemon({}, stoppedCaptain)));
+    expect(out).toMatch(/data-rollup="stopped"/);
+    expect(out).not.toMatch(/data-rollup="gone"/);
+  });
+
+  it("a stopped captain does NOT trip the master CRITICAL alarm", () => {
+    // A genuinely-gone captain trips CRITICAL; a stopped (intentionally closed)
+    // one must not — it is an expected, calm state, not a fault.
+    const out = renderContent(full(daemon({}, stoppedCaptain)));
+    expect(out).not.toContain('class="annunciator a-crit');
+    expect(out).not.toContain("CRITICAL");
+    expect(out).toContain("stopped");
+  });
+
+  it("a stopped project's unread mail is not counted as a stale caution", () => {
+    const d = daemon({}, stoppedCaptain);
+    d.tier2.projects = [{
+      project: "pact",
+      mailbox: { maxSeq: 10, sizeBytes: 100, oldestEntryAgeMs: 60_000, rotationCount: 0 },
+      delivery: { maxSeq: 10, lastAckedSeq: 2, behind: 8 },
+      store: { byState: { cancelled: 2 }, corruptCount: 0 },
+    }];
+    const out = renderContent(full(d));
+    // The card stays 'stopped' — delivery lag behind a closed captain is expected.
+    expect(out).toMatch(/data-rollup="stopped"/);
+  });
+
+  it("a real fault (corrupt store) still rolls up to 'gone' even when captain is stopped", () => {
+    const d = daemon({}, stoppedCaptain);
+    d.tier2.projects = [{
+      project: "pact",
+      mailbox: { maxSeq: 10, sizeBytes: 100, oldestEntryAgeMs: 60_000, rotationCount: 0 },
+      delivery: { maxSeq: 10, lastAckedSeq: 10, behind: 0 },
+      store: { byState: {}, corruptCount: 1 },
+    }];
+    const out = renderContent(full(d));
+    expect(out).toMatch(/data-rollup="gone"/);
+  });
+});
+
 describe("delivery lag bar", () => {
   it("renders an SVG-free delivery bar with acked + behind segments", () => {
     const d = daemon();

--- a/packages/web/src/web-render.ts
+++ b/packages/web/src/web-render.ts
@@ -20,11 +20,13 @@ import type { ExternalProbes, Probe, ProbeState } from "./probes.js";
 
 type AnyState = HealthState | ProbeState;
 
-const ICON: Record<AnyState, string> = { alive: "✔", stale: "•", gone: "✘", unknown: "○" };
-// Rollup ordering: gone is worst, unknown never out-ranks a real degradation.
-const SEV: Record<AnyState, number> = { alive: 0, unknown: 1, stale: 2, gone: 3 };
+const ICON: Record<AnyState, string> = { alive: "✔", stale: "•", gone: "✘", stopped: "⏻", unknown: "○" };
+// Rollup ordering: gone (fault) is worst. `stopped` is an intentional shutdown —
+// it out-ranks a stale caution (it is the headline state of an offline project)
+// but never a genuine fault. unknown never out-ranks a real degradation.
+const SEV: Record<AnyState, number> = { alive: 0, unknown: 1, stale: 2, stopped: 3, gone: 4 };
 // Cockpit annunciator vernacular for each state.
-const STATE_WORD: Record<AnyState, string> = { alive: "nominal", stale: "caution", gone: "fault", unknown: "unknown" };
+const STATE_WORD: Record<AnyState, string> = { alive: "nominal", stale: "caution", gone: "fault", stopped: "stopped", unknown: "unknown" };
 
 function esc(s: string): string {
   return s
@@ -61,10 +63,10 @@ function worst(states: AnyState[]): AnyState {
 }
 
 // ── Health tallies ────────────────────────────────────────────────────────────
-interface Tally { alive: number; stale: number; gone: number; unknown: number; total: number }
+interface Tally { alive: number; stale: number; gone: number; stopped: number; unknown: number; total: number }
 
 function tally(states: AnyState[]): Tally {
-  const t: Tally = { alive: 0, stale: 0, gone: 0, unknown: 0, total: states.length };
+  const t: Tally = { alive: 0, stale: 0, gone: 0, stopped: 0, unknown: 0, total: states.length };
   for (const s of states) t[s]++;
   return t;
 }
@@ -104,7 +106,7 @@ function probeCell(label: string, p: Probe): string {
 }
 
 // ── Donut gauge (inline SVG) ────────────────────────────────────────────────────
-const DONUT_ORDER: AnyState[] = ["alive", "stale", "gone", "unknown"];
+const DONUT_ORDER: AnyState[] = ["alive", "stale", "stopped", "gone", "unknown"];
 
 /** The signature element: a four-segment health ring. Segment arc lengths are
  *  proportional to the tally; everything is plain SVG math so it is deterministic
@@ -209,6 +211,7 @@ function sectionHead(title: string, sub: string): string {
 function tierCard(name: string, t: Tally, desc: string): string {
   const w = t.total ? worst(([] as AnyState[]).concat(
     ...Array.from({ length: t.gone }, () => "gone" as AnyState),
+    ...Array.from({ length: t.stopped }, () => "stopped" as AnyState),
     ...Array.from({ length: t.stale }, () => "stale" as AnyState),
     ...Array.from({ length: t.unknown }, () => "unknown" as AnyState),
     ...Array.from({ length: t.alive }, () => "alive" as AnyState),
@@ -221,6 +224,7 @@ function tierCard(name: string, t: Tally, desc: string): string {
     `<span class="tc s-alive">${t.alive}<i>ok</i></span>`,
     `<span class="tc s-stale">${t.stale}<i>caution</i></span>`,
     `<span class="tc s-gone">${t.gone}<i>fault</i></span>`,
+    ...(t.stopped > 0 ? [`<span class="tc s-stopped">${t.stopped}<i>stopped</i></span>`] : []),
     `<span class="tc s-unknown">${t.unknown}<i>unknown</i></span>`,
     `</div></div>`,
   ].join("");
@@ -246,6 +250,7 @@ function renderOverview(snap: FullSnapshot, col: Collected): string {
     legendRow("alive", col.overall.alive),
     legendRow("stale", col.overall.stale),
     legendRow("gone", col.overall.gone),
+    ...(col.overall.stopped > 0 ? [legendRow("stopped", col.overall.stopped)] : []),
     legendRow("unknown", col.overall.unknown),
     `</div>`,
     `</div>`,
@@ -313,9 +318,14 @@ function renderProjects(snap: FullSnapshot, now: number): string {
   for (const project of projects) {
     const comps = d.tier1.filter((c) => c.project === project);
     const dp = d.tier2.projects.find((p) => p.project === project);
+    // A stopped captain means the project is intentionally offline — its unread
+    // mail is expected backlog, not a live caution, so the delivery lag does not
+    // contribute a `stale` to the rollup (#324/#323). A genuine fault (corrupt
+    // store) still bubbles `gone` and out-ranks the stopped headline.
+    const captainStopped = comps.some((c) => c.kind === "captain" && c.state === "stopped");
     const rollupStates: AnyState[] = [
       ...comps.map((c) => c.state),
-      dp && dp.delivery.behind > 0 ? "stale" : "alive",
+      !captainStopped && dp && dp.delivery.behind > 0 ? "stale" : "alive",
       dp && dp.store.corruptCount > 0 ? "gone" : "alive",
     ];
     const rollup = worst(rollupStates);
@@ -459,7 +469,7 @@ function metricsBlob(col: Collected, linkLost: boolean): string {
     errors: linkLost ? 0 : col.errors,
     behind: linkLost ? 0 : col.behind,
     crewAgeMs: linkLost ? 0 : col.crewAgeMs,
-    alive: col.overall.alive, stale: col.overall.stale, gone: col.overall.gone, unknown: col.overall.unknown,
+    alive: col.overall.alive, stale: col.overall.stale, gone: col.overall.gone, stopped: col.overall.stopped, unknown: col.overall.unknown,
   };
   // Escape `</` defensively so the JSON can never close the <script> early.
   const json = JSON.stringify(m).replace(/</g, "\\u003c");
@@ -481,7 +491,8 @@ export function renderContent(snap: FullSnapshot): string {
   ];
 
   // Master annunciator (status summary) — glanceable on every tab.
-  const sumLine = `${col.overall.alive} nominal · ${col.overall.stale} caution · ${col.overall.gone} fault · ${col.overall.unknown} unknown`;
+  const stoppedPart = col.overall.stopped > 0 ? ` · ${col.overall.stopped} stopped` : "";
+  const sumLine = `${col.overall.alive} nominal · ${col.overall.stale} caution · ${col.overall.gone} fault${stoppedPart} · ${col.overall.unknown} unknown`;
   out.push(
     `<section class="annunciator a-${mc}" role="status" aria-label="Status summary">`,
     `<div class="ann-main"><span class="ann-eyebrow">Status summary</span><span class="ann-word">${esc(word)}</span></div>`,
@@ -518,7 +529,7 @@ const STYLE = `
 :root{
   --bg:#f6f7f9;--panel:#ffffff;--panel-2:#eef1f6;--bezel:#e3e7ef;--track:#e9ecf2;
   --ink:#1b2333;--ink-dim:#5b6678;--hud:#0b6fc2;--hud-deep:#0b6fc2;
-  --ok:#157f3c;--warn:#b45309;--crit:#c01f2e;--unk:#5f6b7d;
+  --ok:#157f3c;--warn:#b45309;--crit:#c01f2e;--unk:#5f6b7d;--stopped:#7c5cbf;
   --shadow:0 1px 2px rgba(16,24,40,.05),0 4px 14px rgba(16,24,40,.06);
 }
 *{box-sizing:border-box}
@@ -591,7 +602,7 @@ body{margin:0;min-height:100vh;background:radial-gradient(1200px 760px at 50% -2
 .donut{width:172px;height:172px;animation:rise .55s ease}
 .donut-track{stroke:var(--track)}
 .seg{transition:stroke-dasharray .5s ease}
-.seg.s-alive{stroke:var(--ok)}.seg.s-stale{stroke:var(--warn)}.seg.s-gone{stroke:var(--crit)}.seg.s-unknown{stroke:var(--unk)}
+.seg.s-alive{stroke:var(--ok)}.seg.s-stale{stroke:var(--warn)}.seg.s-gone{stroke:var(--crit)}.seg.s-stopped{stroke:var(--stopped)}.seg.s-unknown{stroke:var(--unk)}
 .a-ok .seg.s-alive{filter:drop-shadow(0 0 4px var(--ok))}
 .gauge-core{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;gap:1px}
 .gauge-n{font-size:38px;font-weight:800;font-family:system-ui,sans-serif;line-height:1}
@@ -603,7 +614,7 @@ body{margin:0;min-height:100vh;background:radial-gradient(1200px 760px at 50% -2
 .leg-n{font-size:20px;font-weight:700;font-family:system-ui,sans-serif;min-width:1.4em;text-align:right}
 .leg-l{color:var(--ink-dim);text-transform:uppercase;letter-spacing:.1em;font-size:10px;font-family:system-ui,sans-serif}
 .leg.s-alive .pdot{background:var(--ok)}.leg.s-stale .pdot{background:var(--warn)}
-.leg.s-gone .pdot{background:var(--crit)}.leg.s-unknown .pdot{background:var(--unk)}
+.leg.s-gone .pdot{background:var(--crit)}.leg.s-stopped .pdot{background:var(--stopped)}.leg.s-unknown .pdot{background:var(--unk)}
 
 /* Tier + trend cards */
 .tier-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px;margin-bottom:16px}
@@ -614,7 +625,7 @@ body{margin:0;min-height:100vh;background:radial-gradient(1200px 760px at 50% -2
 .tier-counts{display:flex;gap:14px}
 .tc{display:flex;flex-direction:column;font-size:21px;font-weight:700;font-family:system-ui,sans-serif;line-height:1.1}
 .tc i{font-size:9px;font-weight:600;font-style:normal;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-dim)}
-.tc.s-alive{color:var(--ok)}.tc.s-stale{color:var(--warn)}.tc.s-gone{color:var(--crit)}.tc.s-unknown{color:var(--unk)}
+.tc.s-alive{color:var(--ok)}.tc.s-stale{color:var(--warn)}.tc.s-gone{color:var(--crit)}.tc.s-stopped{color:var(--stopped)}.tc.s-unknown{color:var(--unk)}
 
 .trend-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:12px;margin-bottom:16px}
 .trend{border:1px solid var(--bezel);border-radius:12px;background:var(--panel);padding:13px 15px;box-shadow:var(--shadow)}
@@ -631,6 +642,7 @@ body{margin:0;min-height:100vh;background:radial-gradient(1200px 760px at 50% -2
 .card{border:1px solid var(--bezel);border-radius:12px;background:var(--panel);box-shadow:var(--shadow);padding:14px 16px;margin-bottom:14px;border-left:3px solid var(--bezel)}
 .card[data-rollup="gone"]{border-left-color:var(--crit)}
 .card[data-rollup="stale"]{border-left-color:var(--warn)}
+.card[data-rollup="stopped"]{border-left-color:var(--stopped)}
 .card[data-rollup="alive"]{border-left-color:var(--ok)}
 .card[data-rollup="unknown"]{border-left-color:var(--unk)}
 .card-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:12px}
@@ -651,6 +663,7 @@ body{margin:0;min-height:100vh;background:radial-gradient(1200px 760px at 50% -2
 .pill.s-alive{color:var(--ok)}.pill.s-alive .pdot{background:var(--ok);box-shadow:0 0 6px var(--ok)}
 .pill.s-stale{color:var(--warn)}.pill.s-stale .pdot{background:var(--warn);box-shadow:0 0 6px var(--warn)}
 .pill.s-gone{color:var(--crit)}.pill.s-gone .pdot{background:var(--crit);box-shadow:0 0 6px var(--crit)}
+.pill.s-stopped{color:var(--stopped)}.pill.s-stopped .pdot{background:var(--stopped);box-shadow:0 0 6px var(--stopped)}
 .pill.s-unknown{color:var(--unk)}.pill.s-unknown .pdot{background:var(--unk)}
 .cell-detail{color:var(--ink-dim)}
 

--- a/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
+++ b/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { createCmuxDriver, sanitizeForCmuxSend, parseDraftFromScreen, classifyStartupSurface, DeferDelivery } from "../cmux.js";
+import { createCmuxDriver, sanitizeForCmuxSend, parseDraftFromScreen, classifyStartupSurface, classifySendOutcome, DeferDelivery } from "../cmux.js";
 
 const execFileMock = vi.hoisted(() => vi.fn());
 vi.mock("node:child_process", () => ({
@@ -760,6 +760,110 @@ describe("sendToSurface draft-preservation", () => {
     const cmds = execFileMock.mock.calls.map(cmdOf);
     // Must not have sent anything — deferred
     expect(cmds.filter((c) => c.startsWith("send ") && !c.startsWith("send-key"))).toHaveLength(0);
+  });
+});
+
+// #339: debug-gated send instrumentation. The DONE→captain submit is a text
+// burst then a SEPARATE send-key Enter; intermittently the Enter mis-lands as a
+// newline, stranding the payload in the input box. COCKPIT_DEBUG_SEND turns on a
+// pre-send + post-send read-back that logs one real frame so the fault can be
+// caught in the wild. It must be a strict no-op (no extra reads, no log) when off
+// and must NEVER re-send (no double-submit).
+describe("sendToSurface #339 send instrumentation (COCKPIT_DEBUG_SEND)", () => {
+  const driver = createCmuxDriver();
+  let stderrWrites: string[];
+  let restoreStderr: () => void;
+
+  beforeEach(() => {
+    execFileMock.mockReset();
+    stderrWrites = [];
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+      stderrWrites.push(String(chunk));
+      return true;
+    });
+    restoreStderr = () => spy.mockRestore();
+    delete process.env.COCKPIT_DEBUG_SEND;
+  });
+
+  afterEach(() => {
+    restoreStderr();
+    delete process.env.COCKPIT_DEBUG_SEND;
+  });
+
+  it("is silent and adds no extra read-screen when the flag is unset", async () => {
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return makeTestScreen("❯ ▌");
+      return "";
+    });
+    await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done");
+    // No send-debug line emitted
+    expect(stderrWrites.some((w) => w.includes("send-debug"))).toBe(false);
+    // Exactly the gate's single read-screen — no pre/post read-back added
+    const reads = execFileMock.mock.calls.map(argvOf).filter((a) => a.includes("read-screen"));
+    expect(reads).toHaveLength(1);
+  });
+
+  it("logs a 'submitted' frame and never re-sends when the box is empty after Enter", async () => {
+    process.env.COCKPIT_DEBUG_SEND = "1";
+    // Box empty before AND after — a clean submit.
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return makeTestScreen("❯ ▌");
+      return "";
+    });
+    await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done");
+
+    // The instrumentation added a pre-send and a post-send read-back (3 reads total).
+    const reads = execFileMock.mock.calls.map(argvOf).filter((a) => a.includes("read-screen"));
+    expect(reads).toHaveLength(3);
+
+    // Exactly ONE payload send + ONE Enter — the read-back never re-submits.
+    const calls = execFileMock.mock.calls.map(argvOf);
+    expect(calls.filter((a) => a[0] === "send" && a.includes("crew done"))).toHaveLength(1);
+    expect(calls.filter((a) => a.includes("send-key") && a.includes("Enter"))).toHaveLength(1);
+
+    const debugLine = stderrWrites.find((w) => w.includes("send-debug"));
+    expect(debugLine).toBeDefined();
+    const frame = JSON.parse(debugLine!.replace(/^\[cockpit\] send-debug /, "").trim());
+    expect(frame.surface).toBe("surface:8");
+    expect(frame.payload).toBe("crew done");
+    expect(frame.verdict).toBe("submitted");
+  });
+
+  it("logs a 'stuck' frame when the input box still holds the payload after Enter", async () => {
+    process.env.COCKPIT_DEBUG_SEND = "1";
+    // Empty at the gate read (so we deliver), then the payload is stranded in the
+    // box on the post-send read-back — the #339 fault signature.
+    let reads = 0;
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) {
+        reads++;
+        // gate (1) + pre-send (2) see an empty box; post-send (3) shows it stuck.
+        return reads >= 3 ? makeTestScreen("❯ crew done") : makeTestScreen("❯ ▌");
+      }
+      return "";
+    });
+    await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done");
+
+    const debugLine = stderrWrites.find((w) => w.includes("send-debug"));
+    expect(debugLine).toBeDefined();
+    const frame = JSON.parse(debugLine!.replace(/^\[cockpit\] send-debug /, "").trim());
+    expect(frame.verdict).toBe("stuck");
+    expect(frame.postBox).toContain("crew done");
+  });
+});
+
+describe("classifySendOutcome (#339 verdict)", () => {
+  it("returns 'submitted' for an empty post-send box", () => {
+    expect(classifySendOutcome("crew done", "")).toBe("submitted");
+  });
+  it("returns 'stuck' when the box still holds the payload", () => {
+    expect(classifySendOutcome("crew done", "crew done")).toBe("stuck");
+  });
+  it("returns 'box-gone' when the box is not visible (null)", () => {
+    expect(classifySendOutcome("crew done", null)).toBe("box-gone");
+  });
+  it("returns 'unknown' for unrelated box content", () => {
+    expect(classifySendOutcome("crew done", "a fresh draft")).toBe("unknown");
   });
 });
 

--- a/packages/workspaces/src/runtimes/cmux.ts
+++ b/packages/workspaces/src/runtimes/cmux.ts
@@ -271,6 +271,27 @@ export function classifyStartupSurface(screen: string): "loading" | "idle" | "wo
   return "loading";
 }
 
+// #339 instrumentation gate. The DONE→captain submit is a text burst then a
+// SEPARATE send-key Enter (two distinct socket writes); intermittently the Enter
+// lands as a newline instead of a submit, stranding the payload in the input box.
+// Root-causing needs ONE real frame in the wild. Gated behind COCKPIT_DEBUG_SEND
+// so it is a strict no-op — zero extra reads, zero latency — when unset.
+export function sendDebugEnabled(): boolean {
+  return !!process.env.COCKPIT_DEBUG_SEND;
+}
+
+// Classify a post-send input-box read into a submit verdict for #339:
+//   "submitted" — box empty after Enter (the payload left the input box)
+//   "stuck"     — box still holds the payload (Enter inserted a newline, no submit)
+//   "box-gone"  — box not visible post-send (overlay/scroll — inconclusive)
+//   "unknown"   — box has unrelated content (a fresh draft / next turn rendered)
+export function classifySendOutcome(payload: string, postBox: string | null): string {
+  if (postBox === null) return "box-gone";
+  if (postBox === "") return "submitted";
+  if (postBox === payload || postBox.includes(payload)) return "stuck";
+  return "unknown";
+}
+
 export function createCmuxDriver(): RuntimeDriver {
   return {
     name: "cmux",
@@ -462,8 +483,31 @@ export function createCmuxDriver(): RuntimeDriver {
       const ws = surface.workspaceId;
       const sf = surface.surfaceId;
       const deliver = async () => {
-        await cmux(["send", "--workspace", ws, "--surface", sf, sanitizeForCmuxSend(text)]);
+        // #339 debug-gated instrumentation. When OFF this is the exact two-write
+        // submit it always was (no extra reads, no latency). When ON we capture
+        // one real frame: the input box BEFORE the send, the payload, and the box
+        // AFTER the Enter — so a stranded submit can be told apart from a clean one.
+        const dbg = sendDebugEnabled();
+        let preBox: string | null = null;
+        if (dbg) {
+          try {
+            preBox = readInputBoxRaw(await cmux(["read-screen", "--workspace", ws, "--surface", sf]));
+          } catch { /* unreadable — leave preBox null, logged as such */ }
+        }
+        const payload = sanitizeForCmuxSend(text);
+        await cmux(["send", "--workspace", ws, "--surface", sf, payload]);
         await cmux(["send-key", "--workspace", ws, "--surface", sf, "Enter"]);
+        // Post-send read-back is READ-ONLY — never a re-send — so it can NEVER
+        // double-submit (the #339 constraint). It only observes whether the box
+        // still holds the payload (Enter mis-landed) or is empty (submit took).
+        if (dbg) {
+          let postBox: string | null = null;
+          try {
+            postBox = readInputBoxRaw(await cmux(["read-screen", "--workspace", ws, "--surface", sf]));
+          } catch { /* unreadable — leave postBox null, classified box-gone */ }
+          const verdict = classifySendOutcome(payload, postBox);
+          process.stderr.write(`[cockpit] send-debug ${JSON.stringify({ surface: sf, verdict, payload, preBox, postBox })}\n`);
+        }
       };
 
       // #258/#268 Approach B: deliver only when the captain's input is positively

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -165,6 +165,22 @@ cockpit crew spawn brove "fix typo" --model opus           # forces opus despite
 
 To add, edit, or remove routing rules: use the `cockpit:add-pick-crew-rule` skill.
 
+### Effort mode
+
+Before spawning a crew, read `defaults.effort` from `~/.config/cockpit/config.json` (run `cockpit effort` to check). Apply the following bias to your crew agent/model choice:
+
+| Mode | Directive |
+|------|-----------|
+| **max** | Tokens are plentiful. Prefer claude/opus for crew spawns; don't downshift for cost. |
+| **balance** | Normal. Use default crew routing rules unchanged. (Absent field = balance.) |
+| **low** | Conserve tokens. Prefer opencode/sonnet for crews; reserve opus for work that genuinely needs it. |
+
+**Effort is crew-only.** Captain, command, and side roles are unaffected — keep them at their configured model regardless of effort.
+
+**Effort is the weakest signal.** An explicit `--agent` / `--model` on a spawn always wins. Effort only nudges your default choice when nothing more specific applies.
+
+To change the effort dial: `cockpit effort <max|balance|low>` or use the `cockpit:set-effort` skill.
+
 ### Rules
 
 - **Reuse with `send` before spawning a new one.** Same task track, same crew. New track = new crew.

--- a/plugin/skills/cockpit-effort/SKILL.md
+++ b/plugin/skills/cockpit-effort/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: cockpit-effort
+description: Shortcut for cockpit:set-effort — get or set the global crew tokenomics dial (max | balance | low). Use when the user types /cockpit-effort or asks about the effort setting.
+---
+
+# cockpit-effort — shortcut for cockpit:set-effort
+
+Shorthand alias. **Invoke the `set-effort` skill** (via the Skill tool) and follow it exactly. All logic lives there — this file intentionally holds none, so the two never drift.

--- a/plugin/skills/set-effort/SKILL.md
+++ b/plugin/skills/set-effort/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: set-effort
+description: Read or set the global crew tokenomics dial (max | balance | low). Use when the user wants to change how aggressively crews consume tokens, or to check the current setting.
+---
+
+# cockpit:set-effort — Global Crew Effort Dial
+
+The effort dial is a one-field toggle in `~/.config/cockpit/config.json` that biases the captain's crew spawning decisions. It does **not** rewrite routing rules — it is a hint the captain honors when choosing agent/model for new crews.
+
+## Modes
+
+| Mode | Meaning |
+|------|---------|
+| **max** | Tokens are plentiful. Prefer claude/opus for crew spawns; don't downshift for cost. |
+| **balance** | Normal. Use default crew routing rules unchanged. (Default when field is absent.) |
+| **low** | Conserve tokens. Prefer opencode/sonnet for crews; reserve opus for work that genuinely needs it. |
+
+## Get current effort
+
+```bash
+cockpit effort
+```
+
+Prints the current mode and its one-line meaning. Does not write anything.
+
+## Set effort
+
+```bash
+cockpit effort max
+cockpit effort balance
+cockpit effort low
+```
+
+- Validates the value (errors with the 3 valid options if invalid).
+- Writes `defaults.effort` via the existing `saveConfig` atomic path.
+- Prints a confirmation line.
+- Best-effort: sends a one-line notice to any running captain workspace so a live session adjusts immediately. If no captain is running, the change applies on next launch.
+
+## Manual edit (fallback)
+
+If the CLI is unavailable, edit `~/.config/cockpit/config.json` directly:
+
+```json
+{
+  "defaults": {
+    "effort": "low"
+  }
+}
+```
+
+Valid values: `"max"` | `"balance"` | `"low"`. Absent field is equivalent to `"balance"`.
+
+## Scope
+
+Effort is **crew-only**. It does not affect captain, command, or side roles — those stay pinned to their configured model regardless of effort.
+
+## Precedence
+
+Effort is the weakest signal. Explicit `--agent` / `--model` flags on `cockpit crew spawn` always win. Effort only biases the captain's default choice when nothing more specific applies.


### PR DESCRIPTION
Release **v0.8.2** — a focused stability + observability patch off `develop`. Bumps the root version `0.8.1 → 0.8.2` and updates `CHANGELOG.md`. The internal `@cockpit/*` packages stay at `0.0.0` (not independently versioned).

### Fixed
- `cockpit effort` no longer self-notifies the captain that ran the command — the active-notify loop now skips the project whose path matches the current working directory (realpath-canonical, with a stale-path fallback). (#383)

### Added
- Explicit **`stopped` project status** — closing a captain workspace now reaps its orphaned interactive crews exactly once (on a confirmed captain-gone K-streak) and the dashboard renders a calm `stopped` state (magenta/⏻) instead of a red CRITICAL fault. A genuine fault (corrupt store, unexpected surface-gone) still rolls up to `gone`. (#388, #324, #323)
- **Debug-gated send instrumentation** (`COCKPIT_DEBUG_SEND`) — captures a pre/post input-box read-back frame around each captain delivery to catch the intermittent #339 Enter-inserts-newline glitch in the wild. Read-only (never re-sends), strict no-op when the flag is unset. (#386, #339)

### CI
- **Runtime smoke step** — CI now executes the bundled bins (`node dist/index.js --help`, `crew --help`, `cockpitd --help`) after build, catching NodeNext ESM `.js`-extension crashes that tsc + vitest miss. (#384, #344)

---
Docs + version bump only — no source/build changes. CI validates the bundle.
