### PR TITLE
docs: refresh all docs for 0.8.2 (drop relay, add effort/lifecycle, fix install)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,19 @@ Captain → cockpit crew spawn …    → Crew (new tab in the captain workspace
 
 ## Install
 
+The packages are private (not yet on npm), so install from source and link the bin:
+
 ```bash
-npm install -g claude-cockpit
+git clone https://github.com/tu11aa/claude-cockpit.git
+cd claude-cockpit
+pnpm install
+pnpm build                       # produces dist/index.js (the cockpit bin)
+npm link                         # symlinks the global `cockpit` to dist/index.js
 cockpit init
 cockpit doctor
 ```
+
+> npm publishing is pending a package-name decision (the bare name `claude-cockpit` is taken on npm).
 
 ## Prerequisites
 
@@ -88,6 +96,12 @@ See `obsidian/plugins.md` for Dataview, Templater setup.
 | `cockpit crew close <project> <name>` | Shutdown a crew session (closes its tab) |
 | `cockpit crew list <project>` | List live crews for a project |
 | `cockpit shutdown [project]` | Graceful shutdown |
+| `cockpit effort [max\|balance\|low]` | Get or set the global crew tokenomics dial (no arg prints current) |
+| `cockpit retro` | Generate a retro (weekly/sprint summary) from daily logs and git (zero tokens) |
+| `cockpit config check` | Detect config drift vs the current default schema |
+| `cockpit heal [--dry-run\|daemon]` | Targeted, idempotent remediation for cockpit components (daemon, health) |
+| `cockpit group dispatch …` | Cross-project intra-group operations (dispatch a task to a sibling project) |
+| `cockpit cmux …` | cmux integration helpers |
 | `cockpit feedback` | Open opt-in feedback issue |
 
 ## Monorepo structure
@@ -143,6 +157,16 @@ User-facing notifications run behind a pluggable **notifier driver** (currently 
 Crew is the captain's equivalent of an Agent Team subagent — but runtime-agnostic. The captain spawns a crew via `cockpit crew spawn <project> "<task>" [--name <n>]`, which opens a new tab in the captain's cmux workspace, boots an interactive Claude session (no `-p`), and sends the task as the first turn. The crew works on it and **stays idle** waiting for follow-ups. The captain drives the session with `cockpit crew send/read/close/list`, addressing each crew by its tab title (`🔧 <project>:<name>`).
 
 Pass `--direction right|left|up|down` to use a split pane instead of a tab. State lives in the surface buffer + git; tabs die with the captain workspace on `cockpit shutdown`. Non-Claude agents (codex/gemini) currently still launch in print-mode; full interactive support is a follow-up. See [`docs/specs/archive/2026-05-05-cockpit-thin-redirect-design.md`](docs/specs/archive/2026-05-05-cockpit-thin-redirect-design.md).
+
+### Effort Dial (Tokenomics)
+
+`cockpit effort max|balance|low` is a single global dial that biases how aggressively crews consume tokens — a captain-discretion signal, not mechanical routing. `max` favors quality/tokens, `low` biases toward economy (e.g. preferring opencode for cheap work); `balance` sits between. Run `cockpit effort` with no argument to print the current setting. The value lives in config and is honored by captains via the captain-ops playbook ([#317](https://github.com/tu11aa/claude-cockpit/issues/317) / [#381](https://github.com/tu11aa/claude-cockpit/pull/381)).
+
+### Crew Lifecycle & Delivery
+
+- **Daemon-direct delivery** — crew turns and handoffs are delivered straight to the cmux surface by the daemon. The old `notify-relay` supervisor was deleted; there is no relay process to keep alive ([#332](https://github.com/tu11aa/claude-cockpit/issues/332)).
+- **Semantic heartbeat** — crews emit a lifecycle signal the captain reads as **CREW IDLE / QUIET / STALLED**, distinguishing "waiting for you" from "wedged" without scraping the pane ([#354](https://github.com/tu11aa/claude-cockpit/issues/354)).
+- **`stopped` project status + orphan reap** — when a captain goes away, the daemon reaps its orphaned crews and marks the project `stopped` (intentional shutdown) rather than leaving stale tabs or faulting ([#324](https://github.com/tu11aa/claude-cockpit/issues/324) / [#323](https://github.com/tu11aa/claude-cockpit/issues/323) / [#388](https://github.com/tu11aa/claude-cockpit/pull/388)).
 
 ### Projection (Cross-Agent Config Sync)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,6 +12,17 @@ Cockpit v0.1.x is a working multi-project agent orchestration system with:
 - Self-enhancement via learnings system
 - CLI: init, launch, status, doctor, projects, shutdown, feedback
 
+## ✅ Shipped
+
+Landed since the entries below were written (as of v0.8.2):
+
+- **Global effort dial** — `cockpit effort max|balance|low` tokenomics dial (#317 / #381).
+- **Monorepo reorg** — six internal packages (`shared`/`core`/`agents`/`workspaces`/`web`/`cli`) in a one-way DAG, single bundled bin.
+- **Daemon-direct delivery** — crew/handoff delivery moved onto the daemon→cmux path; `notify-relay` deleted (#332).
+- **Semantic crew heartbeat** — CREW IDLE / QUIET / STALLED lifecycle signal (#354).
+- **`stopped` project status + orphan-crew reap** — daemon reaps orphaned crews and marks intentional shutdown as `stopped` (#324 / #323 / #388).
+- **Control-plane store hygiene** — task-store GC / purge to keep the daemon store bounded.
+
 ## Roadmap
 
 ### P0 — Critical (Next 2 weeks) — ✅ ALL DONE

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ Current references that stay accurate as the project evolves.
 | [architecture.vi.html](architecture.vi.html) | Vietnamese companion to architecture.html | Active (refreshed 2026-06-18) |
 | [diagrams/2026-06-18-cockpit-monorepo-architecture.html](diagrams/2026-06-18-cockpit-monorepo-architecture.html) | **Current** — 6-package monorepo architecture diagram (EN) | Active |
 | [diagrams/2026-06-18-cockpit-monorepo-architecture.vi.html](diagrams/2026-06-18-cockpit-monorepo-architecture.vi.html) | Vietnamese companion to current architecture diagram | Active |
-| [testing/crew-lifecycle-checklist.md](testing/crew-lifecycle-checklist.md) | Regression checklist — crew/daemon/relay/template changes | Active (living) |
+| [testing/crew-lifecycle-checklist.md](testing/crew-lifecycle-checklist.md) | Regression checklist — crew/daemon/delivery/template changes | Active (living) |
 
 ---
 

--- a/docs/diagrams/2026-06-18-cockpit-monorepo-architecture.html
+++ b/docs/diagrams/2026-06-18-cockpit-monorepo-architecture.html
@@ -290,7 +290,7 @@
         <thead><tr><th>Package</th><th>Contents</th><th>Depends on</th><th>Notes</th></tr></thead>
         <tbody>
           <tr><td><code style="color:var(--shared)">@cockpit/shared</code></td><td>Config schema, TypeScript types, leaf constants</td><td>—</td><td>Zero internal deps. Imported by everything.</td></tr>
-          <tr><td><code style="color:var(--core)">@cockpit/core</code></td><td>Daemon logic, protocol, state-machine, task/crew bus, <code>AgentDriver</code> interface, relay, dashboard state</td><td>shared</td><td>No concrete drivers — pure interfaces + orchestration.</td></tr>
+          <tr><td><code style="color:var(--core)">@cockpit/core</code></td><td>Daemon logic, protocol, state-machine, task/crew bus, <code>AgentDriver</code> interface, dashboard state</td><td>shared</td><td>No concrete drivers — pure interfaces + orchestration.</td></tr>
           <tr><td><code style="color:var(--agents)">@cockpit/agents</code></td><td>AI driver seam: <code>claude.ts</code>, <code>codex.ts</code>, <code>opencode.ts</code>, <code>gemini.ts</code> + registry</td><td>core, shared</td><td>Implements <code>AgentDriver</code>. Swap here to add a new AI agent.</td></tr>
           <tr><td><code style="color:var(--workspaces)">@cockpit/workspaces</code></td><td>Runtime (cmux), workspace (obsidian), notifier (cmux) drivers + registries</td><td>core, shared</td><td>Implements surface/workspace/notifier seams. Add tmux, Slack, etc. here.</td></tr>
           <tr><td><code style="color:var(--web)">@cockpit/web</code></td><td>Observability dashboard — bundled HTML/JS served by CLI</td><td>core, shared</td><td>Read-only UI; no agent-facing code. Bundled inline by CLI's tsup build.</td></tr>

--- a/docs/diagrams/2026-06-18-cockpit-monorepo-architecture.vi.html
+++ b/docs/diagrams/2026-06-18-cockpit-monorepo-architecture.vi.html
@@ -290,7 +290,7 @@
         <thead><tr><th>Package</th><th>Contents</th><th>Depends on</th><th>Notes</th></tr></thead>
         <tbody>
           <tr><td><code style="color:var(--shared)">@cockpit/shared</code></td><td>Config schema, TypeScript types, leaf constants</td><td>—</td><td>Zero internal deps. Imported by everything.</td></tr>
-          <tr><td><code style="color:var(--core)">@cockpit/core</code></td><td>Daemon logic, protocol, state-machine, task/crew bus, <code>AgentDriver</code> interface, relay, dashboard state</td><td>shared</td><td>No concrete drivers — pure interfaces + orchestration.</td></tr>
+          <tr><td><code style="color:var(--core)">@cockpit/core</code></td><td>Daemon logic, protocol, state-machine, task/crew bus, <code>AgentDriver</code> interface, dashboard state</td><td>shared</td><td>No concrete drivers — pure interfaces + orchestration.</td></tr>
           <tr><td><code style="color:var(--agents)">@cockpit/agents</code></td><td>AI driver seam: <code>claude.ts</code>, <code>codex.ts</code>, <code>opencode.ts</code>, <code>gemini.ts</code> + registry</td><td>core, shared</td><td>Implements <code>AgentDriver</code>. Swap here to add a new AI agent.</td></tr>
           <tr><td><code style="color:var(--workspaces)">@cockpit/workspaces</code></td><td>Runtime (cmux), workspace (obsidian), notifier (cmux) drivers + registries</td><td>core, shared</td><td>Implements surface/workspace/notifier seams. Add tmux, Slack, etc. here.</td></tr>
           <tr><td><code style="color:var(--web)">@cockpit/web</code></td><td>Observability dashboard — bundled HTML/JS served by CLI</td><td>core, shared</td><td>Read-only UI; no agent-facing code. Bundled inline by CLI's tsup build.</td></tr>

--- a/docs/plans/2026-06-15-telegram-integration.md
+++ b/docs/plans/2026-06-15-telegram-integration.md
@@ -1,5 +1,7 @@
 # Telegram Integration Implementation Plan
 
+> **POST-#332 NOTE:** This plan assumes the `notify-relay` transport, which was **deleted in #332**. Inbound/outbound messages now ride **daemon-direct cmux delivery**. Rebase the transport assumptions below onto daemon-direct before resuming implementation.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Drive cockpit from Telegram — push curated crew lifecycle events to per-session Telegram forum topics, and route replies back to the captain.

--- a/docs/reports/2026-06-03-captain-crew-architecture.html
+++ b/docs/reports/2026-06-03-captain-crew-architecture.html
@@ -103,6 +103,10 @@
   <a href="#appendix">8 · Event reference</a>
 </nav>
 <main>
+<div style="background:#3d1d1d;border:1px solid var(--crit);border-radius:8px;padding:16px 20px;margin-bottom:24px;color:var(--fg);">
+  <strong style="color:var(--crit);">⚠ SUPERSEDED (post-#332).</strong>
+  This report documents <code class="inline">notify-relay</code> as a live component. The relay was <strong>deleted in <a href="https://github.com/tu11aa/claude-cockpit/issues/332">#332</a></strong>; crew delivery is now <strong>daemon-direct cmux</strong> (the daemon writes to the surface directly, no relay supervisor). Treat all relay references below as historical.
+</div>
 <header class="hero">
   <h1>Captain ↔ Crew Lifecycle Architecture</h1>
   <div class="sub">A code-grounded analysis of how a cockpit <strong>captain</strong> dispatches work to and receives signals from <strong>claude</strong>, <strong>codex</strong>, and <strong>opencode</strong> crews — on the current <code class="inline">develop</code> branch.</div>

--- a/docs/specs/2026-04-24-multi-agent-direction.md
+++ b/docs/specs/2026-04-24-multi-agent-direction.md
@@ -6,7 +6,7 @@
 
 ## Decision
 
-Cockpit is a **multi-agent orchestration layer**, not a Claude Code accessory. It should support Claude Code, Codex, Cursor, Gemini CLI, Aider, and future coding agents equally. Features that only work for Claude Code are a migration target, not a permanent state.
+Cockpit is a **multi-agent orchestration layer**, not a Claude Code accessory. It should support Claude Code, Codex, Cursor, Gemini CLI, and future coding agents equally. Features that only work for Claude Code are a migration target, not a permanent state.
 
 ## Why now
 
@@ -21,13 +21,13 @@ The abstraction proved out. The missing layer is **agent-side**: templates, skil
 
 ## What "supports all" means concretely
 
-| Layer | Claude Code | Codex | Cursor | Gemini CLI | Aider |
-|---|---|---|---|---|---|
-| Runtime | ✅ cmux | ✅ (runtime driver) | ✅ (runtime driver) | ✅ (runtime driver) | ✅ (runtime driver) |
-| Instructions | `CLAUDE.md` | `AGENTS.md` | `.cursor/rules/*.mdc` | `GEMINI.md` | `CONVENTIONS.md` |
-| Skills | `SKILL.md` via Skill tool | via AGENTS.md include | via rule include | via GEMINI.md include | via CONVENTIONS include |
-| MCP config | `~/.claude/settings.json` | `~/.codex/config.toml` | `~/.cursor/mcp.json` | varies | varies |
-| Memory | claude-mem (MCP) | claude-mem (MCP, if MCP supported) | claude-mem (MCP) | claude-mem (MCP) | — |
+| Layer | Claude Code | Codex | Cursor | Gemini CLI |
+|---|---|---|---|---|
+| Runtime | ✅ cmux | ✅ (runtime driver) | ✅ (runtime driver) | ✅ (runtime driver) |
+| Instructions | `CLAUDE.md` | `AGENTS.md` | `.cursor/rules/*.mdc` | `GEMINI.md` |
+| Skills | `SKILL.md` via Skill tool | via AGENTS.md include | via rule include | via GEMINI.md include |
+| MCP config | `~/.claude/settings.json` | `~/.codex/config.toml` | `~/.cursor/mcp.json` | varies |
+| Memory | claude-mem (MCP) | claude-mem (MCP, if MCP supported) | claude-mem (MCP) | claude-mem (MCP) |
 
 ## Pain points when using non-Claude agents today
 

--- a/docs/specs/2026-06-15-telegram-integration-design.md
+++ b/docs/specs/2026-06-15-telegram-integration-design.md
@@ -1,5 +1,7 @@
 # Telegram Integration — Design Spec
 
+> **POST-#332 NOTE:** This spec assumes the `notify-relay` transport, which was **deleted in #332**. Inbound/outbound messages now ride **daemon-direct cmux delivery**. Rebase the transport assumptions below onto daemon-direct before resuming implementation.
+
 **Issue:** #65 — Telegram integration for remote cockpit control
 **Date:** 2026-06-15
 **Status:** Approved design → ready for implementation plan

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -5,9 +5,9 @@
 ## Owns
 
 - `src/index.ts` — bin entry (compiled by tsup to `dist/index.js`)
-- `src/commands/` — 29 CLI commands (captain, crew, config, launch, relay, etc.)
+- `src/commands/` — 22 top-level CLI commands (crew, config, launch, effort, etc.)
 - `src/control/cockpitd.ts` — daemon-host entry (compiled by tsup to `dist/cockpitd.js`)
-- `src/control/{crew-routing,relay-supervisor,relay-supervisor-loop,relay-log-broadcaster}.ts` — cli-side control plane
+- `src/control/crew-routing.ts` — cli-side control plane
 - `src/lib/per-crew-settings.ts` — per-crew settings helper
 
 ## Depends on

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -7,7 +7,7 @@
 - `daemon/` modules: start, context, server, attach, delivery, probes, gates, snapshot-gather
 - `delivery/` — CaptainDelivery
 - Driver-seam interfaces (AgentDriver, OpencodeBridge, CmuxEventsBridge, DaemonSurfaceDriver)
-- Pure helpers: gate, DeferDelivery, interactive-probe, launchd, relay-healer, crew-pane-reader
+- Pure helpers: gate, DeferDelivery, interactive-probe, launchd, crew-pane-reader
 
 **Public interface:** Everything exported from `packages/core/src/index.ts`.
 

--- a/packages/core/src/daemon/README.md
+++ b/packages/core/src/daemon/README.md
@@ -11,7 +11,7 @@ etc.). Those live in the host (`cockpitd.ts`).
 | `start.ts` | `startDaemon(ctx, opts, pkgVersion)` — wires all factories, runs boot recovery, starts timers, returns `DaemonHandle` |
 | `context.ts` | `DaemonContext` shared state bag + `buildContext(opts)` + `CockpitdOpts` type |
 | `attach.ts` | `createAttach(ctx)` — broadcast fan-out + gate-promotion timers |
-| `probes.ts` | `createProbes(ctx)` — relay-proxy and daemon-direct surface-liveness probes |
+| `probes.ts` | `createProbes(ctx)` — daemon-direct surface-liveness probes |
 | `delivery.ts` | `createDelivery(ctx, ...)` — mailbox append + daemon-direct captain delivery loop (#332) |
 | `gates.ts` | `createGateResolver(ctx)` — routes captain approve/deny to the owning driver |
 | `server.ts` | `createServer(ctx, handlers)` — IPC socket server + message router |
@@ -33,7 +33,6 @@ const handle = startDaemon(ctx, opts, pkgVersion);
 - `../mailbox.ts` — mailbox I/O
 - `../liveness.ts` — health assembly
 - `../snapshot.ts` — dashboard snapshot assembly
-- `../relay-healer.ts` — relay health
 - `@cockpit/shared` — types, config, constants
 
 ## Doesn't Belong Here

--- a/plugin/skills/side-session/SKILL.md
+++ b/plugin/skills/side-session/SKILL.md
@@ -63,7 +63,7 @@ If the topic already contains all of this, it confirms and proceeds. Otherwise i
 3. On yes:
    - Writes durable record: {spokeVault}/side-handoffs/<topic>.md
    - Sends: cockpit runtime send <project> "🗒 Side handoff [<role>] — <topic> ..."
-4. Primary captain receives handoff via relay.
+4. Primary captain receives handoff delivered daemon-direct via cmux (#332).
 5. Captain does NOT auto-spawn a crew — waits for user's go.
 ```
 
@@ -104,7 +104,7 @@ cockpit side send <project> side-1 "<follow-up>"
 cockpit side close <project> side-1
 ```
 
-When the session completes, its handoff will arrive via relay with the `🗒 Side handoff` prefix.
+When the session completes, its handoff is delivered daemon-direct via cmux (#332) with the `🗒 Side handoff` prefix.
 
 ## Key invariants
 


### PR DESCRIPTION
Documentation sweep for the 0.8.2 release. Surgical, audit-driven edits only — no CHANGELOG history touched. **Ground truth:** notify-relay was deleted (#332, daemon-direct cmux delivery); reactor/aider drivers removed.

## Changes by group

**A — README.md (highest impact)**
- Install block now reflects the *real* path: clone → `pnpm install` → `pnpm build` → `npm link` (the bare `npm install -g claude-cockpit` over-promised; packages are private). Added note that npm publishing awaits a package-name decision.
- Commands table: added `effort`, `retro`, `config`, `heal`, `group`, `cmux` (standup was already present).
- New **Effort Dial** subsection (`cockpit effort max|balance|low`, #317/#381).
- New **Crew Lifecycle & Delivery** subsection: daemon-direct delivery (#332), semantic heartbeat CREW IDLE/QUIET/STALLED (#354), `stopped` status + orphan reap (#324/#323/#388).

**B — Architecture diagrams** (EN + VI): dropped `relay` from the `@cockpit/core` Owns cell.

**C — reports/2026-06-03-captain-crew-architecture.html**: prepended a SUPERSEDED (post-#332) banner; body left intact (dated report).

**D — Package READMEs**: `cli/README.md` command count 29 → 22 and dropped `relay`/`relay-supervisor`/`-loop`/`-log-broadcaster`; `core/README.md` dropped `relay-healer`; `core/src/daemon/README.md` fixed the probes line and dropped the `relay-healer.ts` row.

**E — side-session SKILL.md**: handoff now described as daemon-direct via cmux (#332).

**F — quick fixes**: `docs/README.md` (delivery wording); `ROADMAP.md` new `## ✅ Shipped` section; `multi-agent-direction.md` dropped Aider from the support matrix.

**G — Telegram docs**: prepended POST-#332 transport-rebase notes to the design spec and implementation plan (banner only — do not purge).

## Verification
- `pnpm build` clean (tsc -b + tsup) — confirms no source references to deleted relay code.
- No new broken relative markdown links (only external GitHub URLs added).
- 13 files changed; no lockfile/build artifacts staged.