### PR TITLE
feat: agent self-reporting of squadrant defects (#398)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,31 @@ Every coding task in this repo follows [`plugin/skills/karpathy-principles/SKILL
 2. **Simplicity first** — no speculative abstractions, no impossible-case error handling
 3. **Surgical changes** — every changed line traces to the request; no drive-by refactors
 4. **Goal-driven execution** — define verifiable success criteria before implementing
+
+## Reporting squadrant bugs
+
+**Captain** (interactive — can search, decide, and file): If you or a crew hit an error or behavior that looks like a defect in *squadrant itself* — a `squadrant`/`squadrantd` command throwing a stack trace through `dist/`/`packages/`, a daemon/socket crash (`ECONNREFUSED`/`EADDRINUSE`), an `ENOENT` or wrong path in a path squadrant computed, a state-machine invariant throw, or a lifecycle signal that should have fired and didn't — and it is **not** one of the noise cases below, then search `tu11aa/squadrant`:
+
+```
+gh issue search --repo tu11aa/squadrant --state all "<short signature>"
+```
+
+- **Already fixed** in a release newer than the running version? → tell the user to update (`npm i -g squadrant@latest`); don't file.
+- **Open duplicate?** → don't file; optionally mention "+1, already tracked as #NNN."
+- **New?** → offer the user a one-line **y/n** to file (semi-auto — prompt, don't nag). On yes, file with title `[agent-report] <signature>`, label `bug`, and a body containing what happened, best-effort repro, environment (squadrant version + agent + version + OS + node), and a **redacted** error excerpt (banner + top few stack frames only — strip tokens like `ANTHROPIC_API_KEY`/`gh[pousr]_…`/Telegram `\d+:…`, and rewrite `/Users/<name>/…` → `~`).
+- If the fix looks small, offer to draft a **PR** instead of / in addition to the issue (see `CONTRIBUTING.md`).
+
+**Never file** (noise — the failures you hit most are not squadrant defects):
+- transient model-infra: `API Error: 529`, `Overloaded`, `429`, `retrying 7/10`, `retries exhausted`
+- network: DNS/timeout/TLS to the model API
+- user/config error: bad project name, a token the user must set, not-a-git-repo
+- expected failure: a red TDD test, a lint/type error in the crew's *target* repo
+- known flakiness: the relay-proxy tests (baseline = 3 fails)
+
+When any signal is ambiguous, **don't file** — silence beats spam. Cap: at most one new issue per session by judgment; recurring known bugs get a mention, not a re-file.
+
+**Crew** (headless — can't prompt the user, so it routes up): If a task failed because of a defect in *squadrant itself* (not infra/config/an expected failure), say so in your `signal blocked`/`done` message so the captain can check the repo and file it. **Don't file from the crew.**
+
 # Memory Context
 
 # [Squadrant] recent context, 2026-06-01 10:23pm GMT+7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing to Squadrant
+
+Thanks for helping improve Squadrant. This guide captures the conventions already
+true in the repo — follow them and your change will land cleanly.
+
+## Setup
+
+Squadrant uses **pnpm** (pinned to `pnpm@10.30.3` via `packageManager`):
+
+```bash
+pnpm install      # install workspace deps
+pnpm build        # tsc -b across the six packages, then tsup bundles dist/
+pnpm test         # vitest (run mode)
+pnpm lint         # tsc --noEmit
+```
+
+`pnpm build` must run before `pnpm test` on a fresh checkout — the tests resolve
+the internal packages (`@squadrant/*`) from their build outputs.
+
+## Branching (GitFlow)
+
+- Branch off **`develop`**.
+- Open your PR back into **`develop`**.
+- **`main` is release-only** — never PR a feature straight to `main`.
+
+## Run tests + lint locally before opening a PR
+
+**There is no PR-time CI.** Tests only run on push to `main`, so broken tests have
+reached `develop` silently before. Run `pnpm test` and `pnpm lint` on a clean
+checkout and confirm both are green before you open a PR.
+
+## The ESM / NodeNext `.js`-extension gotcha
+
+This is a NodeNext ESM project: **relative imports must include the `.js`
+extension** (`import { x } from "./foo.js"`), even though the source is `.ts`.
+`tsc` and `vitest` will happily pass with a missing extension, but the bundled
+runtime crashes. The real gate is:
+
+```bash
+node dist/index.js --help
+```
+
+If that works after a build, your imports are correct.
+
+## Coding discipline — Karpathy principles
+
+Every change follows [`plugin/skills/karpathy-principles/SKILL.md`](plugin/skills/karpathy-principles/SKILL.md):
+
+1. **Think before coding** — surface assumptions and tradeoffs; ask if ambiguous.
+2. **Simplicity first** — no speculative abstractions, no impossible-case error handling.
+3. **Surgical changes** — every changed line traces to the request; no drive-by refactors.
+4. **Goal-driven execution** — define verifiable success criteria before implementing.
+
+## Monorepo shape
+
+Six packages in a one-way DAG — put each change in the right package:
+
+```
+shared ◄ core ◄ {agents, workspaces, web} ◄ cli
+```
+
+| Package | Owns |
+|---|---|
+| `@squadrant/shared` | Config schema, types, constants — leaf, zero internal deps |
+| `@squadrant/core` | Daemon, state-machine, protocol, `AgentDriver` interface |
+| `@squadrant/agents` | AI driver seam: claude / codex / opencode / gemini |
+| `@squadrant/workspaces` | Runtime (cmux), workspace (obsidian), notifier drivers |
+| `@squadrant/web` | Observability dashboard (bundled HTML/JS) |
+| `@squadrant/cli` | Commands, bin entry, daemon host — root package |
+
+## Platform
+
+Squadrant is **macOS-only** for now. Guard platform-specific tests accordingly
+(`it.skipIf(process.platform !== "darwin")`).
+
+## Agent-filed issues
+
+Issues opened by an agent are titled **`[agent-report] <signature>`** (see the
+"Reporting squadrant bugs" block in `AGENTS.md`). If you're picking one up, this
+guide is the path that closes the loop: **bug found → issue → fix → PR**.

--- a/packages/cli/src/commands/__tests__/feedback.test.ts
+++ b/packages/cli/src/commands/__tests__/feedback.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { buildIssueUrl } from "../feedback.js";
+
+describe("buildIssueUrl", () => {
+  it("embeds the supplied squadrant version, not a hardcoded one", () => {
+    const url = buildIssueUrl({}, "0.9.1");
+    const body = decodeURIComponent(new URL(url).searchParams.get("body") ?? "");
+    expect(body).toContain("squadrant: 0.9.1");
+    expect(body).not.toContain("0.1.0");
+  });
+
+  it("reflects whatever version it is given", () => {
+    const body = decodeURIComponent(
+      new URL(buildIssueUrl({}, "1.2.3")).searchParams.get("body") ?? "",
+    );
+    expect(body).toContain("squadrant: 1.2.3");
+  });
+});

--- a/packages/cli/src/commands/feedback.ts
+++ b/packages/cli/src/commands/feedback.ts
@@ -2,11 +2,24 @@ import { Command } from "commander";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { execSync } from "node:child_process";
 import chalk from "chalk";
-import { loadConfig } from "@squadrant/shared";
+import { loadConfig, readStamp } from "@squadrant/shared";
 
 const REPO_URL = "https://github.com/tu11aa/squadrant";
+
+// Real running version. Path math is dist-relative and invariant to source
+// moves: the bundle lives at dist/index.js, so "../package.json" is the root
+// package.json (mirrors readPkgVersion in config.ts and index.ts).
+function readPkgVersion(): string {
+  try {
+    const pkgPath = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "package.json");
+    return (JSON.parse(fs.readFileSync(pkgPath, "utf-8")).version as string) ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}
 
 interface Metrics {
   projects?: number;
@@ -24,10 +37,9 @@ function readMetrics(metricsPath: string): Metrics {
   }
 }
 
-function buildIssueUrl(metrics: Metrics): string {
+export function buildIssueUrl(metrics: Metrics, squadrantVersion: string): string {
   const nodeVersion = process.versions.node;
   const platform = process.platform;
-  const squadrantVersion = "0.1.0";
 
   const body = [
     "## Feedback / Bug Report",
@@ -67,7 +79,8 @@ export const feedbackCommand = new Command("feedback")
     const metricsPath = config.metrics?.path || path.join(os.homedir(), ".config", "squadrant", "metrics.json");
     const metrics = readMetrics(metricsPath);
 
-    const issueUrl = buildIssueUrl(metrics);
+    const version = readStamp(config) ?? readPkgVersion();
+    const issueUrl = buildIssueUrl(metrics, version);
 
     console.log(chalk.bold("\nOpening feedback issue in browser...\n"));
     console.log(chalk.dim(`  URL: ${issueUrl.substring(0, 80)}...\n`));

--- a/packages/core/src/__tests__/crew-protocol.test.ts
+++ b/packages/core/src/__tests__/crew-protocol.test.ts
@@ -85,8 +85,15 @@ describe("buildCompletionProtocol (#278)", () => {
       "COMPLETION PROTOCOL (required): When this task is fully complete, your FINAL action MUST be to run exactly:\n" +
       "  squadrant crew signal done --task-id TASK-ID --project PROJECT --message \"<one-line summary>\"\n" +
       "Run it as a discrete final step AFTER you report your results. If you are blocked or need a decision, instead run:\n" +
-      "  squadrant crew signal blocked --task-id TASK-ID --project PROJECT --question \"<your question>\""
+      "  squadrant crew signal blocked --task-id TASK-ID --project PROJECT --question \"<your question>\"\n" +
+      "If this task failed because of a defect in squadrant itself (not an API/infra blip, a config/user error, or an expected failure), say so in your signal done/blocked message so the captain can check tu11aa/squadrant and file it. Don't file issues from the crew."
     );
+  });
+
+  it("includes the crew route-up line for squadrant defects", () => {
+    const result = buildCompletionProtocol("task-abc123", "my-project");
+    expect(result).toContain("a defect in squadrant itself");
+    expect(result).toContain("Don't file issues from the crew");
   });
 });
 

--- a/packages/core/src/crew-protocol.ts
+++ b/packages/core/src/crew-protocol.ts
@@ -46,6 +46,7 @@ export function buildCompletionProtocol(taskId: string, project: string): string
     `  squadrant crew signal done --task-id ${taskId} --project ${project} --message "<one-line summary>"`,
     "Run it as a discrete final step AFTER you report your results. If you are blocked or need a decision, instead run:",
     `  squadrant crew signal blocked --task-id ${taskId} --project ${project} --question "<your question>"`,
+    "If this task failed because of a defect in squadrant itself (not an API/infra blip, a config/user error, or an expected failure), say so in your signal done/blocked message so the captain can check tu11aa/squadrant and file it. Don't file issues from the crew.",
   ].join("\n");
 }
 


### PR DESCRIPTION
Implements the self-reporting-squadrant-defects feature (#398).

Per the spec [`docs/superpowers/specs/2026-06-22-self-report-squadrant-defects-design.md`](docs/superpowers/specs/2026-06-22-self-report-squadrant-defects-design.md), this is deliberately a **prompt-line feature, not a subsystem** — no new CLI command, classifier module, or redaction library. Agents already have `gh` + judgment.

## Changes

1. **`AGENTS.md` — "Reporting squadrant bugs" block** (new section, multi-agent: claude/codex/opencode read it). Captain check→update-or-file loop (search `tu11aa/squadrant`; nudge to update if fixed in a newer release; else offer semi-auto y/n to file a redacted issue; offer a small fix PR). The critical **noise rubric** explicitly excludes transient API/infra blips (`529`, `Overloaded`, `retrying N/M`, `429`, retries exhausted), network errors, config/user errors, expected test failures, and the known relay-proxy flakiness. Plus the **crew route-up line**.

2. **Crew completion-protocol suffix** (`packages/core/src/crew-protocol.ts`) — one route-up line: a crew that failed due to a squadrant defect (not infra/config/expected) says so in its `signal blocked`/`done` message so the captain can check the repo. Crews never file directly. The load-bearing snapshot test (#278 guard) was updated in lockstep.

3. **New root `CONTRIBUTING.md`** — sourced from real repo conventions: `pnpm install` (`pnpm@10.30.3`), build/test/lint, GitFlow (branch off `develop`, PR to `develop`, `main` release-only), **no PR-time CI → run tests+lint locally**, the ESM `.js`-extension gotcha (`node dist/index.js --help` is the real gate), karpathy principles, the six-package DAG, macOS-only. Closes the bug→issue→fix→PR loop for `[agent-report]` issues.

4. **`feedback.ts` version fix** — it hardcoded `const squadrantVersion = "0.1.0"`. Now `buildIssueUrl(metrics, version)` takes the version as a parameter, and the command resolves the real version from the config `_squadrantVersion` stamp, falling back to `package.json` (dist-relative path math, mirrors `config.ts`/`index.ts`). TDD: new `feedback.test.ts`.

## Gates

- `pnpm build` — clean
- `pnpm test` — **1300 passed / 115 files** (baseline 1297/114; +3 new tests, all green)
- `node dist/index.js --help` — exit 0
- `pnpm lint` — pre-existing failures only (`node_modules/**` + `tsup.config.ts`, identical on pristine `baf510f`); **no new type errors** from this PR

Spec: `docs/superpowers/specs/2026-06-22-self-report-squadrant-defects-design.md`

Closes #398

> Note: README untouched to avoid conflicts with in-flight Telegram PR #397; the AGENTS.md edit is a distinct new section.
