### PR TITLE
chore(release): 0.9.2 — agent self-reporting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,31 @@ Every coding task in this repo follows [`plugin/skills/karpathy-principles/SKILL
 2. **Simplicity first** — no speculative abstractions, no impossible-case error handling
 3. **Surgical changes** — every changed line traces to the request; no drive-by refactors
 4. **Goal-driven execution** — define verifiable success criteria before implementing
+
+## Reporting squadrant bugs
+
+**Captain** (interactive — can search, decide, and file): If you or a crew hit an error or behavior that looks like a defect in *squadrant itself* — a `squadrant`/`squadrantd` command throwing a stack trace through `dist/`/`packages/`, a daemon/socket crash (`ECONNREFUSED`/`EADDRINUSE`), an `ENOENT` or wrong path in a path squadrant computed, a state-machine invariant throw, or a lifecycle signal that should have fired and didn't — and it is **not** one of the noise cases below, then search `tu11aa/squadrant`:
+
+```
+gh issue search --repo tu11aa/squadrant --state all "<short signature>"
+```
+
+- **Already fixed** in a release newer than the running version? → tell the user to update (`npm i -g squadrant@latest`); don't file.
+- **Open duplicate?** → don't file; optionally mention "+1, already tracked as #NNN."
+- **New?** → offer the user a one-line **y/n** to file (semi-auto — prompt, don't nag). On yes, file with title `[agent-report] <signature>`, label `bug`, and a body containing what happened, best-effort repro, environment (squadrant version + agent + version + OS + node), and a **redacted** error excerpt (banner + top few stack frames only — strip tokens like `ANTHROPIC_API_KEY`/`gh[pousr]_…`/Telegram `\d+:…`, and rewrite `/Users/<name>/…` → `~`).
+- If the fix looks small, offer to draft a **PR** instead of / in addition to the issue (see `CONTRIBUTING.md`).
+
+**Never file** (noise — the failures you hit most are not squadrant defects):
+- transient model-infra: `API Error: 529`, `Overloaded`, `429`, `retrying 7/10`, `retries exhausted`
+- network: DNS/timeout/TLS to the model API
+- user/config error: bad project name, a token the user must set, not-a-git-repo
+- expected failure: a red TDD test, a lint/type error in the crew's *target* repo
+- known flakiness: the relay-proxy tests (baseline = 3 fails)
+
+When any signal is ambiguous, **don't file** — silence beats spam. Cap: at most one new issue per session by judgment; recurring known bugs get a mention, not a re-file.
+
+**Crew** (headless — can't prompt the user, so it routes up): If a task failed because of a defect in *squadrant itself* (not infra/config/an expected failure), say so in your `signal blocked`/`done` message so the captain can check the repo and file it. **Don't file from the crew.**
+
 # Memory Context
 
 # [Squadrant] recent context, 2026-06-01 10:23pm GMT+7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-06-22
+
+A patch release adding the agent self-reporting feedback loop and fixing a stale version in the feedback command.
+
+### Added
+
+- **Agent self-reporting prompt block** — `AGENTS.md` gains a "Reporting squadrant bugs" section that instructs crew agents to route detected squadrant defects up to the captain, who can then file a GitHub issue. Enables a semi-automatic defect feedback loop without requiring CLI tooling.
+- **`CONTRIBUTING.md`** — new root-level contributor guide covering the development setup, the agent self-reporting convention, and how to file issues.
+
+### Fixed
+
+- **`squadrant feedback` now reports the real version.** `packages/cli/src/commands/feedback.ts` was hardcoding `"0.1.0"` as the squadrant version in submitted feedback; it now reads the actual version from the package at runtime.
+
 ## [0.9.1] - 2026-06-22
 
 A patch release fixing four issues that surfaced during the v0.9.0 claude-cockpit → squadrant live cutover.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing to Squadrant
+
+Thanks for helping improve Squadrant. This guide captures the conventions already
+true in the repo — follow them and your change will land cleanly.
+
+## Setup
+
+Squadrant uses **pnpm** (pinned to `pnpm@10.30.3` via `packageManager`):
+
+```bash
+pnpm install      # install workspace deps
+pnpm build        # tsc -b across the six packages, then tsup bundles dist/
+pnpm test         # vitest (run mode)
+pnpm lint         # tsc --noEmit
+```
+
+`pnpm build` must run before `pnpm test` on a fresh checkout — the tests resolve
+the internal packages (`@squadrant/*`) from their build outputs.
+
+## Branching (GitFlow)
+
+- Branch off **`develop`**.
+- Open your PR back into **`develop`**.
+- **`main` is release-only** — never PR a feature straight to `main`.
+
+## Run tests + lint locally before opening a PR
+
+**There is no PR-time CI.** Tests only run on push to `main`, so broken tests have
+reached `develop` silently before. Run `pnpm test` and `pnpm lint` on a clean
+checkout and confirm both are green before you open a PR.
+
+## The ESM / NodeNext `.js`-extension gotcha
+
+This is a NodeNext ESM project: **relative imports must include the `.js`
+extension** (`import { x } from "./foo.js"`), even though the source is `.ts`.
+`tsc` and `vitest` will happily pass with a missing extension, but the bundled
+runtime crashes. The real gate is:
+
+```bash
+node dist/index.js --help
+```
+
+If that works after a build, your imports are correct.
+
+## Coding discipline — Karpathy principles
+
+Every change follows [`plugin/skills/karpathy-principles/SKILL.md`](plugin/skills/karpathy-principles/SKILL.md):
+
+1. **Think before coding** — surface assumptions and tradeoffs; ask if ambiguous.
+2. **Simplicity first** — no speculative abstractions, no impossible-case error handling.
+3. **Surgical changes** — every changed line traces to the request; no drive-by refactors.
+4. **Goal-driven execution** — define verifiable success criteria before implementing.
+
+## Monorepo shape
+
+Six packages in a one-way DAG — put each change in the right package:
+
+```
+shared ◄ core ◄ {agents, workspaces, web} ◄ cli
+```
+
+| Package | Owns |
+|---|---|
+| `@squadrant/shared` | Config schema, types, constants — leaf, zero internal deps |
+| `@squadrant/core` | Daemon, state-machine, protocol, `AgentDriver` interface |
+| `@squadrant/agents` | AI driver seam: claude / codex / opencode / gemini |
+| `@squadrant/workspaces` | Runtime (cmux), workspace (obsidian), notifier drivers |
+| `@squadrant/web` | Observability dashboard (bundled HTML/JS) |
+| `@squadrant/cli` | Commands, bin entry, daemon host — root package |
+
+## Platform
+
+Squadrant is **macOS-only** for now. Guard platform-specific tests accordingly
+(`it.skipIf(process.platform !== "darwin")`).
+
+## Agent-filed issues
+
+Issues opened by an agent are titled **`[agent-report] <signature>`** (see the
+"Reporting squadrant bugs" block in `AGENTS.md`). If you're picking one up, this
+guide is the path that closes the loop: **bug found → issue → fix → PR**.

--- a/docs/plans/2026-06-15-telegram-integration.md
+++ b/docs/plans/2026-06-15-telegram-integration.md
@@ -1,6 +1,8 @@
 # Telegram Integration Implementation Plan
 
-> **POST-#332 NOTE:** This plan assumes the `notify-relay` transport, which was **deleted in #332**. Inbound/outbound messages now ride **daemon-direct cmux delivery**. Rebase the transport assumptions below onto daemon-direct before resuming implementation.
+> **⛔ SUPERSEDED (2026-06-22)** by the v1 design at [`docs/superpowers/specs/2026-06-22-telegram-integration-v1-design.md`](../superpowers/specs/2026-06-22-telegram-integration-v1-design.md) and its forthcoming implementation plan. Kept for history only — do not implement from this.
+>
+> **POST-#332 NOTE (historical):** This plan assumes the `notify-relay` transport, which was **deleted in #332**. Inbound/outbound messages now ride **daemon-direct cmux delivery**.
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 

--- a/docs/specs/2026-06-15-telegram-integration-design.md
+++ b/docs/specs/2026-06-15-telegram-integration-design.md
@@ -1,6 +1,8 @@
 # Telegram Integration — Design Spec
 
-> **POST-#332 NOTE:** This spec assumes the `notify-relay` transport, which was **deleted in #332**. Inbound/outbound messages now ride **daemon-direct cmux delivery**. Rebase the transport assumptions below onto daemon-direct before resuming implementation.
+> **⛔ SUPERSEDED (2026-06-22)** by [`docs/superpowers/specs/2026-06-22-telegram-integration-v1-design.md`](../superpowers/specs/2026-06-22-telegram-integration-v1-design.md). This spec targets the old flat `src/` layout and the `notify-relay` transport (deleted in #332). Kept for history only — do not implement from this. The v1 spec re-homes the design on the monorepo + daemon-direct delivery and scopes inbound to captain-only.
+>
+> **POST-#332 NOTE (historical):** This spec assumes the `notify-relay` transport, which was **deleted in #332**. Inbound/outbound messages now ride **daemon-direct cmux delivery**.
 
 **Issue:** #65 — Telegram integration for remote cockpit control
 **Date:** 2026-06-15

--- a/docs/superpowers/plans/2026-06-22-telegram-integration-v1.md
+++ b/docs/superpowers/plans/2026-06-22-telegram-integration-v1.md
@@ -1,0 +1,204 @@
+# Telegram Integration v1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development for every task — write the failing test first, then the minimal implementation. Steps use checkbox (`- [ ]`) syntax for tracking. This plan fixes the decomposition, file map, interfaces, and test criteria; you write the test + implementation bodies under TDD.
+
+**Goal:** Two-way Telegram for squadrant — push per-project crew lifecycle events to a Telegram topic, and deliver your replies into that project's captain pane.
+
+**Architecture:** A daemon-internal `TelegramBridge` (modeled on `CmuxEventsBridge`) with one outbound hook composed onto `ctx.notify(...)` and one `getUpdates` long-poll. Inbound becomes a new `captain.message` mailbox kind delivered by the existing #332 delivery loop (defer-protected). Opt-in via config; crash-contained.
+
+**Tech Stack:** TypeScript (strict ESM, NodeNext), plain `fetch` for the Bot API (no runtime SDK), `@grammyjs/types` as a **devDependency** for typed payloads, tsup single-binary bundle, vitest.
+
+**Spec:** `docs/superpowers/specs/2026-06-22-telegram-integration-v1-design.md`
+
+## Global Constraints
+
+- **No runtime dependency** for Telegram — plain `fetch` only. `@grammyjs/types` is **devDependencies-only** (types erased at build; zero bundle weight). A runtime dep that doesn't tsup-bundle cleanly is a regression.
+- **Strict ESM / NodeNext** — every relative import ends in `.js`. The real gate is `node dist/index.js --help`, not just `tsc`/vitest.
+- **Opt-in** — absent `config.telegram` ⇒ the bridge is never constructed; zero behavior change. No new always-on work.
+- **Crash-contained** — no Telegram send/poll error may escape into the daemon event loop, mailbox, state machine, or watchdog. Catch-log-continue.
+- **Inbound is data, never a shell command** — it becomes a captain message only.
+- **Brand:** CLI is `squadrant telegram …`; config under `~/.config/squadrant/config.json`.
+- **Package DAG (one-way):** `shared ◄ core ◄ {agents,workspaces,web} ◄ cli`. Config types in `shared`; bridge/client/format/state/mailbox in `core`; command + daemon wiring in `cli`.
+- **Routing key is `(project, scope)`** — v1 emits only `scope:"project"`; never hardcode project-only so per-crew (`scope:"crew:<taskId>"`) is additive later.
+
+---
+
+## File structure
+
+| File | Package | Responsibility |
+|---|---|---|
+| `packages/shared/src/config.ts` (modify) | shared | Add `TelegramConfig` + `telegram?` on `SquadrantConfig` |
+| `packages/core/src/telegram/format.ts` (create) | core | Pure formatters (topic name, lifecycle text, inbound text) |
+| `packages/core/src/telegram/state.ts` (create) | core | Persisted offset + `(project,scope)→topicId` registry |
+| `packages/core/src/telegram/client.ts` (create) | core | Bot API over injectable `fetch` |
+| `packages/core/src/telegram/bridge.ts` (create) | core | The subsystem: start/stop, pushLifecycle, inbound loop |
+| `packages/core/src/telegram/index.ts` (create) | core | Barrel export |
+| `packages/core/src/mailbox.ts` (modify) | core | Add `captain.message` kind + `appendCaptainMessage` |
+| `packages/cli/src/commands/telegram.ts` (create) | cli | `telegram link` / `telegram status` |
+| `packages/cli/src/index.ts` (modify) | cli | Register `telegramCommand` |
+| `packages/cli/src/control/squadrantd.ts` (modify) | cli | Construct bridge when configured; compose onto notify; start/stop |
+| `packages/core/src/daemon/start.ts` (modify) | core | Start/stop hook for the bridge in boot/shutdown |
+| `README.md` / `AGENTS.md` (modify) | — | Setup guide + documented security gap |
+
+**Salvage:** port `client.ts`, `format.ts`, `state.ts` from `origin/crew/telegram` (`src/control/telegram/*`), then rebrand, re-home to `packages/core`, fix ESM `.js` imports, and align to the interfaces below. Do **not** port `subsystem.ts` (built on the deleted relay) — `bridge.ts` is a rewrite.
+
+---
+
+## Wave 1 — Foundations (no daemon wiring; each task independently testable)
+
+### Task 1: TelegramConfig schema (shared)
+
+**Files:** Modify `packages/shared/src/config.ts`; Test `packages/shared/src/__tests__/config.telegram.test.ts`
+
+**Interfaces — Produces:**
+```ts
+export interface TelegramConfig {
+  botToken?: string;        // falls back to env TELEGRAM_BOT_TOKEN at read time
+  supergroupId: number;     // forum supergroup hosting per-project topics
+  chats: number[];          // chat_id allowlist (inbound honored only from these)
+  pollMs?: number;          // getUpdates long-poll cadence (default 1000)
+}
+// on SquadrantConfig:  telegram?: TelegramConfig;
+```
+
+- [ ] **TDD:** Test that a config JSON containing a `telegram` block round-trips through `loadConfig`/type-check with the fields above; and that a config with **no** `telegram` key is still valid (optional). Then add the type. Verify `getDefaultConfig()` is unchanged (no telegram by default).
+- [ ] **Gate:** `pnpm -C packages/shared test` green; `pnpm build` clean.
+- [ ] **Commit:** `feat(telegram): add optional TelegramConfig to shared config schema`
+
+### Task 2: Pure formatters (core)
+
+**Files:** Create `packages/core/src/telegram/format.ts`; Test `packages/core/src/telegram/__tests__/format.test.ts`
+
+**Interfaces — Produces:**
+```ts
+export function topicName(project: string): string;                    // e.g. "squadrant"
+export function formatLifecycle(project: string, ev: ControlEvent): string; // outbound text
+export function formatInbound(text: string): string;                   // captain-pane text for a reply
+```
+
+- [ ] **TDD:** Assert exact output strings for a `task.done`, `task.blocked`, and `task.idle` event, and that `formatInbound` prefixes/labels a reply so the captain can tell it came from Telegram. Pure functions — no I/O, no mocks.
+- [ ] **Gate:** `pnpm -C packages/core test telegram/format` green.
+- [ ] **Commit:** `feat(telegram): pure outbound/inbound formatters`
+
+### Task 3: State (offset + topic registry) (core)
+
+**Files:** Create `packages/core/src/telegram/state.ts`; Test `packages/core/src/telegram/__tests__/state.test.ts`
+
+**Interfaces — Produces:**
+```ts
+export interface TelegramState { offset: number; topics: Record<string, number>; } // key = `${project}::${scope}`
+export function topicKey(project: string, scope?: string): string;   // scope defaults to "project"
+export function loadState(stateRoot: string): TelegramState;
+export function saveState(stateRoot: string, s: TelegramState): void;
+export function setTopic(stateRoot: string, project: string, topicId: number, scope?: string): void;
+export function findProjectByThread(stateRoot: string, threadId: number): { project: string; scope: string } | null;
+```
+
+- [ ] **TDD:** Round-trip `save`→`load`; `setTopic` then `findProjectByThread` returns the right `(project, scope)`; missing file ⇒ `{offset:0, topics:{}}`; default scope is `"project"`. Use a temp `stateRoot`.
+- [ ] **Gate:** `pnpm -C packages/core test telegram/state` green.
+- [ ] **Commit:** `feat(telegram): persistent offset + (project,scope) topic registry`
+
+### Task 4: Bot API client (core) + devDep
+
+**Files:** Create `packages/core/src/telegram/client.ts`; Test `packages/core/src/telegram/__tests__/client.test.ts`; Modify root `package.json` (devDependencies)
+
+**Interfaces — Produces:**
+```ts
+export interface TelegramClient {
+  getUpdates(offset: number, timeoutSec?: number): Promise<Update[]>;          // long-poll
+  sendMessage(chatId: number, threadId: number | undefined, text: string): Promise<void>;
+  createForumTopic(chatId: number, name: string): Promise<number>;             // returns message_thread_id
+}
+export function createTelegramClient(opts: { token: string; fetch?: typeof fetch }): TelegramClient;
+```
+
+- [ ] **Add devDependency** `@grammyjs/types` (types-only) and import `Update`/`Message` from it. Confirm it does **not** appear in the runtime bundle.
+- [ ] **TDD:** Inject a fake `fetch`; assert `getUpdates` calls the right URL with `offset`/`timeout`, `sendMessage` posts `chat_id`+`message_thread_id`+`text`, `createForumTopic` returns the parsed `message_thread_id`. Assert a non-2xx response is surfaced as a rejected promise (so the bridge can catch it).
+- [ ] **Gate:** `pnpm -C packages/core test telegram/client` green; `pnpm build` clean; grep the bundle to confirm no grammy runtime code.
+- [ ] **Commit:** `feat(telegram): fetch-based Bot API client (+@grammyjs/types devDep)`
+
+## Wave 2 — Delivery integration
+
+### Task 5: `captain.message` mailbox kind (core)
+
+**Files:** Modify `packages/core/src/mailbox.ts`; Test `packages/core/src/__tests__/mailbox.captain-message.test.ts`
+
+**Interfaces — Produces:**
+```ts
+// Widen MailboxEntry.kind to include "captain.message" (an external, non-ControlEvent message).
+export function appendCaptainMessage(opts: {
+  stateRoot: string; project: string; text: string; source: "telegram";
+}): Promise<void>;
+```
+
+- [ ] **Consumes:** existing `appendToMailbox`, `readFromCursor`, `MailboxEntry` (mailbox.ts).
+- [ ] **TDD:** `appendCaptainMessage` writes an entry whose `kind==="captain.message"` and `message` is the rendered text, with a monotonic `seq`; `readFromCursor` for the `"captain"` subscriber yields it in order. Confirm the existing delivery loop's `deliverable()` returns the message (non-empty) so it will be delivered to the captain pane.
+- [ ] **Gate:** `pnpm -C packages/core test mailbox` green (existing mailbox tests still pass).
+- [ ] **Commit:** `feat(telegram): captain.message mailbox kind for inbound external messages`
+
+## Wave 3 — The bridge
+
+### Task 6: TelegramBridge (core)
+
+**Files:** Create `packages/core/src/telegram/bridge.ts`, `packages/core/src/telegram/index.ts`; Test `packages/core/src/telegram/__tests__/bridge.test.ts`
+
+**Interfaces — Produces:**
+```ts
+export interface TelegramBridge {
+  start(): void;
+  stop(): void;
+  pushLifecycle(project: string, ev: ControlEvent): void;  // outbound, best-effort, never throws
+}
+export function createTelegramBridge(opts: {
+  cfg: TelegramConfig; stateRoot: string;
+  client: TelegramClient;                                   // injected (real one built by caller)
+  appendCaptainMessage: (a:{stateRoot:string;project:string;text:string;source:"telegram"})=>Promise<void>;
+  log: (msg: string) => void;
+}): TelegramBridge;
+```
+
+- [ ] **Consumes:** Task 2 formatters, Task 3 state, Task 4 client, Task 5 `appendCaptainMessage`.
+- [ ] **TDD — outbound:** `pushLifecycle` calls `client.sendMessage` to the project's topic (creating the topic via `createForumTopic` + `setTopic` on first use); a `sendMessage` that rejects is swallowed (the call resolves, error logged) — **crash-containment** is the key assertion.
+- [ ] **TDD — inbound:** feed fake `getUpdates` returning a message with an allowlisted `chat_id` and a known `message_thread_id` ⇒ `appendCaptainMessage` is called with the resolved project; a **non-allowlisted** `chat_id` ⇒ dropped (no append); offset advances and persists; a throwing `getUpdates` does not escape `start()` (loop catches and continues).
+- [ ] **Gate:** `pnpm -C packages/core test telegram/bridge` green.
+- [ ] **Commit:** `feat(telegram): crash-contained bridge (outbound push + inbound poll)`
+
+## Wave 4 — Wiring + CLI
+
+### Task 7: Daemon wiring (cli + core)
+
+**Files:** Modify `packages/cli/src/control/squadrantd.ts`, `packages/core/src/daemon/start.ts`; Test `packages/core/src/daemon/__tests__/start.telegram.test.ts`
+
+- [ ] **Consumes:** `createTelegramBridge` (Task 6), `createTelegramClient` (Task 4), `loadConfig().telegram`, the existing `notify` composition point and start/stop in `start.ts` (follow `CmuxEventsBridge` wiring exactly).
+- [ ] **TDD:** with `config.telegram` **absent**, no bridge is constructed and `notify` behaves exactly as before (regression guard). With `config.telegram` present, the daemon (a) builds the bridge, (b) composes `pushLifecycle` onto the notify fan-out (a captain notification also pushes to Telegram), (c) calls `bridge.start()` in boot and `bridge.stop()` in shutdown. Use the existing daemon test harness; inject a fake bridge to assert start/stop/compose without real network.
+- [ ] **Gate:** `pnpm -C packages/core test` green; daemon boots in a test.
+- [ ] **Commit:** `feat(telegram): wire bridge into the daemon (opt-in, composed onto notify)`
+
+### Task 8: CLI command (cli)
+
+**Files:** Create `packages/cli/src/commands/telegram.ts`; Modify `packages/cli/src/index.ts`; Test `packages/cli/src/commands/__tests__/telegram.test.ts`
+
+**Interfaces — Produces:** `export const telegramCommand: Command;` (commander) with subcommands `link <project>` and `status`.
+
+- [ ] **TDD:** `status` with no token/config prints `token: unset` / `no projects linked` and exits 0 (no crash). `link <project>` resolves the project, ensures a forum topic exists (via client `createForumTopic` + `setTopic`), and prints the bound topic id; assert via injected client/state. Register `telegramCommand` in `index.ts` and assert `squadrant telegram --help` lists both subcommands.
+- [ ] **Gate:** `node dist/index.js telegram status` runs without crashing; `pnpm -C packages/cli test` green.
+- [ ] **Commit:** `feat(telegram): squadrant telegram link|status command`
+
+## Wave 5 — Docs + final gate
+
+### Task 9: Docs + verification
+
+**Files:** Modify `README.md`, `AGENTS.md`
+
+- [ ] Document setup (create bot, get token, create forum supergroup, `squadrant telegram link <project>`, config block) and **the security gap** (chat membership ⇒ captain control; user-id allowlist deferred to #321). Note `link`↔daemon 409 interim workaround (link with daemon stopped) per #321 MAJOR-4.
+- [ ] **Final gates (run on the authoritative checkout, once):** `pnpm install && pnpm build && pnpm test` (green vs known baseline — note any pre-existing flaky relay-proxy fails); `node dist/index.js --help` (ESM gate); `node dist/index.js telegram status` (no-config no-crash).
+- [ ] **Commit:** `docs(telegram): setup guide + security note for v1`
+
+---
+
+## Self-review (against the spec)
+
+- **Spec coverage:** outbound (Tasks 6–7) · inbound captain-only (Tasks 5–6) · opt-in/crash-contained (Tasks 6–7) · config (Task 1) · client plain-fetch+devDep (Task 4) · topology supergroup/topic-per-project + `(project,scope)` key (Tasks 3,6) · CLI link/status (Task 8) · security allowlist + documented gap (Tasks 6,9) · testing per component (every task) · salvage from #316 (Tasks 2–4 notes). All spec sections map to a task. ✓
+- **Deferred correctly:** per-crew routing, #321 hardening, #309 buttons — not in any task, called out in spec + Task 9 docs. ✓
+- **Type consistency:** `(project,scope)` key (`topicKey`/`findProjectByThread`) consistent across Tasks 3/6; `appendCaptainMessage` signature identical in Tasks 5/6; `TelegramClient` methods identical in Tasks 4/6/8. ✓
+- **No runtime dep:** only `@grammyjs/types` devDep (Task 4) — bundle-checked. ✓

--- a/docs/superpowers/specs/2026-06-22-self-report-squadrant-defects-design.md
+++ b/docs/superpowers/specs/2026-06-22-self-report-squadrant-defects-design.md
@@ -1,0 +1,117 @@
+# Self-Reporting Squadrant Defects — Design
+
+- **Date:** 2026-06-22
+- **Status:** Draft for review (research side-session; spec only, no code, no issue filed)
+- **Originating ask:** Captains and crews hit defects *in squadrant itself* and stay silent. We want a low-noise feedback loop: when an agent hits something that looks like a squadrant bug, it checks the repo, and either tells the user to update (if already fixed) or files a non-duplicate issue — and optionally offers to contribute a fix.
+- **The trigger that prompted this:** a transient `API error, retrying 7/10` (an Anthropic infra blip). That must **never** be filed.
+
+## Approach: a prompt line, not a subsystem
+
+The mechanism is **a few lines injected into the captain and crew prompts**. Agents already have `gh` and their own judgment — that's the entire toolset needed to search issues, check versions, and file. No new CLI command, no local cache, no classifier module, no redaction library. Karpathy: simplest thing that works; no speculative abstraction.
+
+The only thing the line must get right is **signal vs. noise** — without a guard clause it will file the transient-API-error case. That guard is one phrase, not a code path.
+
+### Why this is safe to keep this simple
+
+Squadrant already encodes the noise boundary in code: `packages/agents/src/interactive/pane-classifier.ts` + `packages/core/src/daemon/interactive-probe.ts` detect transient banners (`API Error: 529`, `Overloaded`, `429/5xx … unavailable`, `retries exhausted`) and treat them as **recoverable**, not failures. So the prompt's "not an API/infra blip" clause is aligned with how the daemon already behaves — we're just telling the agent the same line the code already draws.
+
+---
+
+## The prompt line(s)
+
+**Captain** (interactive, human-facing — can search, decide, and file):
+
+> **Reporting squadrant bugs.** If you or a crew hit an error or behavior that looks like a defect in *squadrant itself* — a `squadrant`/`squadrantd` command throwing, a daemon/socket crash, an ENOENT or wrong path in squadrant's own files, a lifecycle signal that should have fired and didn't — and it is **not** a transient API/network blip, a config/user error, or an expected test failure, then search `tu11aa/squadrant` issues. If it's already fixed in a newer release, tell the user to update. Otherwise, if there's no open duplicate, offer to file an issue (include version + agent + OS, redact tokens and home paths). If the fix looks small, offer to draft a PR instead.
+
+**Crew** (headless — can't prompt the user, so it routes up):
+
+> If this task failed because of a defect in *squadrant itself* (not infra/config/an expected failure), say so in your `signal blocked`/`done` message so the captain can check the repo and file it. Don't file from the crew.
+
+That's the whole feature. Everything below is supporting rationale and the noise rubric the captain applies — kept short, and reference-only.
+
+---
+
+## Behavior, step by step (what the captain does)
+
+1. **Notice** an error/weird behavior that points at squadrant's own code/runtime.
+2. **Filter noise** (rubric below). Ambiguous → do nothing. Silence beats spam.
+3. **Search** `gh issue search --repo tu11aa/squadrant --state all "<signature>"`.
+4. **Already fixed?** If a closed issue says it's fixed in a release newer than the running version → *"this is fixed in vX.Y.Z, update with `npm i -g squadrant@latest`."* Don't file.
+5. **Open duplicate?** → don't file; optionally mention "+1, already tracked as #NNN."
+6. **New?** → offer the user a one-line y/n to file (semi-auto; the user prefers prompted-at-key-moments, not nagging). File on yes.
+7. **Small fix?** → offer to draft a PR instead of / in addition to the issue.
+
+The version check in step 4 is the new, genuinely useful twist: a known-and-fixed bug becomes an *update nudge*, not a duplicate issue.
+
+## Noise rubric (the one thing the line must get right)
+
+**File-worthy** — points at squadrant's own code/runtime:
+- a `squadrant`/`squadrantd` command throwing a stack trace through `dist/`/`packages/`
+- daemon crash, socket `ECONNREFUSED`/`EADDRINUSE`, "command not found" after install (the rebrand-hook class)
+- `ENOENT`/wrong path in a path squadrant computed (cf. #363)
+- a state-machine invariant throw; a lifecycle signal that should have fired and didn't (#278/#339 class — captain-observed)
+
+**Never file** — the trigger and its cousins:
+- transient model-infra: `API Error: 529`, `Overloaded`, `429`, `retrying 7/10`, `retries exhausted` *(the originating case)*
+- network: DNS/timeout/TLS to the model API
+- user/config error: bad project name, missing token the user must set, not-a-git-repo
+- expected failure: a red TDD test, a lint/type error in the crew's *target* repo
+- known flakiness: the relay-proxy tests (baseline = 3 fails)
+
+Default when any signal is ambiguous: **don't file.** (Same discipline the pane-classifier already states: "an ambiguous tail returns null.")
+
+## Issue hygiene (captain applies inline, no tooling)
+
+- **Title:** `[agent-report] <short signature>`; label `bug` (+ `filed-by:agent` if that label is added — one-time `gh label create`, optional).
+- **Body:** what happened, best-effort repro, environment (squadrant version from `package.json`, agent + version, OS, node), and a **redacted** error excerpt — banner + top few stack frames only, never file contents; strip tokens (`ANTHROPIC_API_KEY`, `gh[pousr]_…`, Telegram `\d+:…`) and rewrite `/Users/<name>/…` → `~`.
+- **Cap:** at most one new issue per session by judgment; recurring known bugs get a mention, not a re-file.
+
+## Multi-agent portability
+
+The lines go in **AGENTS.md** (read by claude/codex/opencode alike) and the crew **completion-protocol suffix** that's already injected per-agent. No Claude-only surface — it's prompt text + `gh`, both agent-agnostic. Satisfies the multi-agent direction in `CLAUDE.md`/`AGENTS.md`.
+
+---
+
+## CONTRIBUTING.md (part of this feature)
+
+The loop ends in *"offer to draft a PR"* — but there's no `CONTRIBUTING.md` today, and the README has no contribution section. A contributor who (or an agent that) takes up the offer has nothing to point at. So this feature should ship a short `CONTRIBUTING.md` at repo root, and the issue/PR offer links to it.
+
+Keep it minimal and sourced from conventions already true in the repo (don't invent process):
+
+- **Setup:** `pnpm install` (repo pins `pnpm@10.30.3`); `pnpm build`, `pnpm test` (vitest), `pnpm lint` (`tsc --noEmit`).
+- **Branching:** GitFlow — branch off `develop`, PR back into `develop`; `main` is release-only (per `project_gitflow_and_repo_workflow`).
+- **No PR-time CI** — tests only run on push to `main`. **Run `pnpm test` and `pnpm lint` locally on a clean checkout before opening a PR** (the `project_no_pr_ci` lesson — broken tests have reached develop silently).
+- **ESM / NodeNext gotcha:** relative imports need the `.js` extension or the runtime crashes even when tests pass; `node dist/index.js --help` is the real gate (the `project_esm_js_extension_gotcha` lesson).
+- **Coding discipline:** the Karpathy principles (`plugin/skills/karpathy-principles/SKILL.md`) — surgical changes, simplicity first.
+- **Monorepo shape:** six-package one-way DAG `shared ◄ core ◄ {agents, workspaces, web} ◄ cli`; place changes in the right package.
+- **macOS-only** for now (`project_macos_only_for_now`) — guard platform tests accordingly.
+- A line pointing agent-filed issues (`[agent-report]`) at this guide, closing the loop: bug found → issue → fix → PR.
+
+This also benefits human contributors generally, independent of the self-report loop. Optionally add a matching `.github/PULL_REQUEST_TEMPLATE.md` (defer if you want to keep v1 tight).
+
+## Adjacent finding (separate small fix)
+
+`packages/cli/src/commands/feedback.ts` hardcodes `const squadrantVersion = "0.1.0";` — wrong (real version `0.9.1`). Any version string the report includes should come from `package.json` / the `_squadrantVersion` stamp (`packages/shared/src/lib/config-version.ts`), and `feedback.ts` should be fixed too.
+
+## Deferred — only if the prompt-line version proves noisy
+
+If real-world use shows the prompt line is too spammy or too silent, *then* consider escalating to tooling: a `squadrant issue report` helper with a fingerprint-based dedup cache and a mechanical deny-list (reusing the `pane-classifier.ts` regex as a hard safety gate), and/or daemon-side auto-detection in `interactive-probe.ts` (which already classifies panes and excludes transient banners). **Not built in v1** — it's speculative until the simple version is shown to fail. Captured here so the escalation path is known, not so it's built.
+
+---
+
+## Recommendation on a meta dogfood issue
+
+**Recommend filing one** short tracking issue (it dogfoods the very loop it describes). **Leave the filing to the captain/user** — this side-session does not file. Draft:
+
+> **Title:** `[agent-report] Add a self-reporting prompt line so agents flag squadrant defects (check → update-or-file, low-noise)`
+> **Labels:** `enhancement`
+>
+> **Problem.** Captains/crews hit defects in squadrant itself (CLI throw, daemon crash, ENOENT in squadrant paths, a lifecycle signal not firing) and stay silent. Meanwhile the failure they hit *most* is transient model-infra (`API error, retrying 7/10`) which must never be filed.
+>
+> **Proposal (minimal).** A few prompt lines in AGENTS.md + the crew completion-protocol suffix: when an agent hits a likely *squadrant* defect (not an API/infra blip, config/user error, or expected test failure), it searches `tu11aa/squadrant` — if already fixed in a newer release, nudge the user to update; else if no open duplicate, offer to file (redacted, with version/agent/OS); offer a fix PR if small. Crews route the finding up to the captain rather than filing. No new code — agents use `gh` + judgment.
+>
+> **Also add** a root `CONTRIBUTING.md` (setup/branching/test-before-PR/the `.js` + no-PR-CI gotchas) so the "offer a fix PR" path has something to point at.
+>
+> **Spec:** `docs/superpowers/specs/2026-06-22-self-report-squadrant-defects-design.md`.
+> **Adjacent fix:** `feedback.ts` hardcodes version `0.1.0` (should read from package.json).
+> **Escalation path (deferred):** a deduping `squadrant issue report` helper + daemon-side detection, only if the prompt-line version proves noisy.

--- a/docs/superpowers/specs/2026-06-22-telegram-integration-v1-design.md
+++ b/docs/superpowers/specs/2026-06-22-telegram-integration-v1-design.md
@@ -1,0 +1,132 @@
+# Telegram Integration v1 — Design
+
+- **Date:** 2026-06-22
+- **Status:** Approved (brainstorm complete)
+- **Supersedes:** `docs/specs/2026-06-15-telegram-integration-design.md`, `docs/plans/2026-06-15-telegram-integration.md`, PR #316 (`crew/telegram`)
+- **Tracks / defers to:** #321 (hardening fast-follows), #309 (inline approve/deny buttons), per-crew topic routing (new follow-up)
+- **Originating ask:** #65 (CLOSED) — drive squadrant from Telegram: receive push notifications and reply to steer a session from a phone.
+
+## Why this supersedes PR #316
+
+PR #316 was a complete, reviewed implementation, but it was built against an architecture that no longer exists:
+
+1. **Flat `src/` layout.** #316 lives in `src/control/telegram/…`, `src/control/cockpitd.ts`, `src/config.ts`. The repo is now a six-package monorepo (`packages/{shared,core,agents,workspaces,web,cli}`). Every file placement is wrong.
+2. **Mailbox relay deleted (#332).** #316's inbound path routes replies through "the existing mailbox relay" via a `captain.message` kind that `deliverable()` handled in a *separate relay process*. The relay was deleted and replaced by **daemon-direct cmux delivery** (`CaptainDelivery` + the in-daemon delivery loop). The transport at the heart of #316's inbound design is gone.
+3. **Brand.** `cockpit telegram …` → `squadrant telegram …`; config keys rebranded.
+
+The *ideas* in #316 survive (compose outbound onto the notify fan-out; inbound becomes a captain message; forum topics as the routing key; no third-party SDK). The *wiring* is rebuilt on the current architecture. The pure modules (HTTP client, formatters, state) are largely salvageable.
+
+## Goals (v1)
+
+- **Outbound:** crew lifecycle events (done / blocked / idle) and other captain notifications for a project are pushed to that project's Telegram topic.
+- **Inbound (captain-only):** a message you send in a project's topic is delivered to that project's **captain pane** as a captain message. The captain decides what to do with it.
+- **Opt-in & crash-contained:** zero behavior change when `telegram` config is absent; no Telegram failure can throw into the daemon event loop, mailbox, state machine, or watchdog.
+- **Agent-agnostic:** this is captain/crew lifecycle plumbing, independent of which agent (claude/codex/opencode/gemini) a crew runs.
+
+## Non-goals (explicitly deferred)
+
+- **Per-crew topic routing / replying directly to a specific crew task.** v1 routes inbound to the captain only. The design reserves the extension point (see Routing key) so this is additive later.
+- **#321 hardening:** `link` ↔ daemon `getUpdates` 409 race, user-id allowlist, honoring 429 `retry_after`, pruning terminal topics from the registry, at-least-once inbound documentation.
+- **#309:** inline approve/deny keyboards for BLOCKED events (`reply_markup` + `callback_query`). Mine OpenACP (streaming) and CliGate (Approve/Deny inline) as UX references when picked up.
+
+## Architecture
+
+A **daemon-internal subsystem**, `TelegramBridge`, modeled on the existing `CmuxEventsBridge` — started/stopped inside the daemon, **not** a separate relay process. It owns one outbound hook and one inbound long-poll loop.
+
+```
+                         ┌─────────────────── squadrant daemon ───────────────────┐
+crew lifecycle event ───▶│ ctx.notify(...) ──▶ mailbox ──▶ delivery loop ──▶ cmux ─┼─▶ captain pane
+                         │        └────────────▶ TelegramBridge.pushLifecycle() ───┼─▶ Telegram topic (outbound)
+                         │                                                          │
+ Telegram topic msg ─────┼─▶ TelegramBridge.getUpdates loop ─▶ allowlist check ────┤
+   (inbound reply)       │       └─▶ append captain.message mailbox entry ─▶ delivery loop ─▶ cmux ─▶ captain pane
+                         └──────────────────────────────────────────────────────────┘
+```
+
+**Decision (approved): inbound reaches the captain via a new mailbox kind, not a direct surface write.** There is no inbound→captain path today. Two options were considered:
+
+| | Approach | Trade-off |
+|---|---|---|
+| **A (chosen)** | inbound msg → new `captain.message` mailbox entry → existing delivery loop → captain pane | Reuses `CaptainDelivery`: defer-while-the-captain-is-typing (#302), ordered delivery, cursor-ack. Minimal new delivery code. |
+| B | bridge writes directly to the captain cmux surface | Bypasses mailbox; loses defer protection; can clobber the captain's draft. |
+
+Approach A is chosen because the #332 delivery loop already solves ordered, non-clobbering delivery to the captain — the exact problem an inbound message has.
+
+## Components
+
+| Module | Package | Purpose |
+|---|---|---|
+| `telegram/client.ts` | `core` | Bot API over plain `fetch` (no runtime SDK). Methods: `getUpdates`, `sendMessage`, `createForumTopic`. Injectable `fetch` for tests. |
+| `telegram/format.ts` | `core` | Pure formatters: topic name for a project, outbound lifecycle text, inbound→captain message text. No I/O. |
+| `telegram/state.ts` | `core` | Persisted JSON in `stateRoot`: `getUpdates` offset + `{ project → topicId }` registry. |
+| `telegram/bridge.ts` | `core` | The subsystem. `start()/stop()`, `pushLifecycle(project, event)` (outbound), and the `getUpdates` long-poll (inbound). Crash-contained. |
+| `TelegramConfig` | `shared` | Optional `telegram?` field on `SquadrantConfig` (see Config). |
+| `captain.message` mailbox kind | `core` | New `MailboxEntry` kind for inbound external messages; rendered to the captain by the delivery loop. |
+| `telegram` command | `cli` | `squadrant telegram link <project>` (bind a project to a topic) and `squadrant telegram status` (config + bridge liveness). |
+| bridge wiring | `cli` (`squadrantd.ts`) + `core` (`daemon/start.ts`) | Instantiate alongside `CmuxEventsBridge`/`OpencodeSseBridge`; start in boot, stop in shutdown. |
+
+**Dependency note:** runtime stays SDK-free (plain `fetch`). Add **`@grammyjs/types`** as a **devDependency only** — types for `Update`/`Message`/`CallbackQuery`, zero runtime/bundle weight (preserves the tsup single-binary constraint). Research (`side-handoffs/telegram-reuse-vs-build.md`) confirmed no existing project is embeddable as a transport, and full bot frameworks (grammY/telegraf/node-telegram-bot-api) are over-built or EOL for a ~5-endpoint bridge that must share the daemon's own loop.
+
+## Data flow
+
+### Outbound (crew → you)
+1. Daemon fires a captain notification for project X (existing `ctx.notify(...)`).
+2. The bridge's outbound hook *also* calls `client.sendMessage(topicId(X), formatLifecycle(event))`, **best-effort**.
+3. A failed/slow Telegram send is swallowed (logged) and **never blocks or delays** cmux delivery to the captain pane.
+
+### Inbound (you → captain)
+1. Bridge `getUpdates` long-poll receives a message with `(chat_id, message_thread_id)`.
+2. **Allowlist check** on `chat_id` against `config.telegram.chats`; non-allowlisted messages are dropped.
+3. Resolve `message_thread_id → project` via the topic registry.
+4. Append a `captain.message` mailbox entry for that project with the message text.
+5. The existing delivery loop hands it to the project's captain pane, defer-protected.
+6. Inbound text is **data, never a shell command** — it becomes a captain message; the captain interprets it.
+
+## Routing key (extensibility for per-crew, deferred)
+
+The registry maps a **`(project, scope)`** pair to a Telegram topic. v1 only ever uses `scope = "project"`. Adding per-crew topics later means emitting `scope = "crew:<taskId>"` entries and routing those inbound messages to the daemon's `handle({ kind: "reply", project, id, message })` path — additive, no schema change to v1's state file.
+
+## Config
+
+Add an optional field to `SquadrantConfig` (`packages/shared/src/config.ts`):
+
+```jsonc
+"telegram": {
+  "botToken": "…",          // or read from env TELEGRAM_BOT_TOKEN
+  "supergroupId": -1001234,  // the forum supergroup hosting per-project topics
+  "chats": [-1001234],       // chat_id allowlist (inbound honored only from these)
+  "pollMs": 1000             // optional getUpdates long-poll cadence
+}
+```
+
+Absent `telegram` ⇒ the bridge is never constructed; no behavior change. Read in `startSquadrantd` before constructing the bridge.
+
+## Security (v1)
+
+- **`chat_id` allowlist** — only messages from configured chats are honored.
+- **Text is data, not commands** — inbound becomes a captain message; never executed.
+- **Documented gap:** chat membership ⇒ captain control (anyone in the linked supergroup can steer). The user-id allowlist that closes this is deferred to #321 and called out in the setup docs.
+
+## Error handling
+
+- The bridge is **crash-contained**: outbound send and inbound poll are wrapped so a throw/reject cannot escape into the daemon. Failures are logged and the loop continues.
+- **Offset persistence** survives daemon restarts so inbound is at-least-once, not lost (exactly-once is not guaranteed; documented).
+- v1 uses a flat backoff on poll errors; honoring 429 `retry_after` is deferred to #321.
+
+## Testing
+
+- **Unit:** `format` (pure in/out), `state` (offset + registry persistence round-trip), `client` (injected `fetch` asserts URL/method/payload), bridge **crash-containment** (a throwing `sendMessage`/`getUpdates` cannot escape `start()`).
+- **Integration:** inbound message → a `captain.message` mailbox entry appears for the correct project; outbound composes onto `notify` without blocking the captain delivery path.
+- **Gates:** `squadrant telegram status` with no token prints "unset" and does not crash; the ESM gate `node dist/index.js --help` passes; full `pnpm test` green against the known baseline.
+
+## Salvage from PR #316
+
+- **Reusable (port + rebrand):** `client.ts`, `format.ts`, `state.ts` — pure/HTTP, no relay coupling.
+- **Rewrite:** `subsystem.ts` → `bridge.ts` (new daemon-internal lifecycle, Approach A inbound), config wiring (now `packages/shared`), command (now `packages/cli`, rebranded), mailbox change (new `captain.message` kind on the current mailbox, not the deleted relay).
+
+## Rollout
+
+1. Land v1 behind opt-in config (this spec).
+2. Harden via #321.
+3. Add inline approve/deny buttons via #309.
+4. Add per-crew topic routing (new follow-up) using the reserved `(project, scope)` key.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "squadrant",
   "packageManager": "pnpm@10.30.3",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Multi-project orchestration for your coding agents (Claude, Codex, opencode, Gemini)",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/__tests__/feedback.test.ts
+++ b/packages/cli/src/commands/__tests__/feedback.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { buildIssueUrl } from "../feedback.js";
+
+describe("buildIssueUrl", () => {
+  it("embeds the supplied squadrant version, not a hardcoded one", () => {
+    const url = buildIssueUrl({}, "0.9.1");
+    const body = decodeURIComponent(new URL(url).searchParams.get("body") ?? "");
+    expect(body).toContain("squadrant: 0.9.1");
+    expect(body).not.toContain("0.1.0");
+  });
+
+  it("reflects whatever version it is given", () => {
+    const body = decodeURIComponent(
+      new URL(buildIssueUrl({}, "1.2.3")).searchParams.get("body") ?? "",
+    );
+    expect(body).toContain("squadrant: 1.2.3");
+  });
+});

--- a/packages/cli/src/commands/feedback.ts
+++ b/packages/cli/src/commands/feedback.ts
@@ -2,11 +2,24 @@ import { Command } from "commander";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { execSync } from "node:child_process";
 import chalk from "chalk";
-import { loadConfig } from "@squadrant/shared";
+import { loadConfig, readStamp } from "@squadrant/shared";
 
 const REPO_URL = "https://github.com/tu11aa/squadrant";
+
+// Real running version. Path math is dist-relative and invariant to source
+// moves: the bundle lives at dist/index.js, so "../package.json" is the root
+// package.json (mirrors readPkgVersion in config.ts and index.ts).
+function readPkgVersion(): string {
+  try {
+    const pkgPath = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "package.json");
+    return (JSON.parse(fs.readFileSync(pkgPath, "utf-8")).version as string) ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}
 
 interface Metrics {
   projects?: number;
@@ -24,10 +37,9 @@ function readMetrics(metricsPath: string): Metrics {
   }
 }
 
-function buildIssueUrl(metrics: Metrics): string {
+export function buildIssueUrl(metrics: Metrics, squadrantVersion: string): string {
   const nodeVersion = process.versions.node;
   const platform = process.platform;
-  const squadrantVersion = "0.1.0";
 
   const body = [
     "## Feedback / Bug Report",
@@ -67,7 +79,8 @@ export const feedbackCommand = new Command("feedback")
     const metricsPath = config.metrics?.path || path.join(os.homedir(), ".config", "squadrant", "metrics.json");
     const metrics = readMetrics(metricsPath);
 
-    const issueUrl = buildIssueUrl(metrics);
+    const version = readStamp(config) ?? readPkgVersion();
+    const issueUrl = buildIssueUrl(metrics, version);
 
     console.log(chalk.bold("\nOpening feedback issue in browser...\n"));
     console.log(chalk.dim(`  URL: ${issueUrl.substring(0, 80)}...\n`));

--- a/packages/core/src/__tests__/crew-protocol.test.ts
+++ b/packages/core/src/__tests__/crew-protocol.test.ts
@@ -85,8 +85,15 @@ describe("buildCompletionProtocol (#278)", () => {
       "COMPLETION PROTOCOL (required): When this task is fully complete, your FINAL action MUST be to run exactly:\n" +
       "  squadrant crew signal done --task-id TASK-ID --project PROJECT --message \"<one-line summary>\"\n" +
       "Run it as a discrete final step AFTER you report your results. If you are blocked or need a decision, instead run:\n" +
-      "  squadrant crew signal blocked --task-id TASK-ID --project PROJECT --question \"<your question>\""
+      "  squadrant crew signal blocked --task-id TASK-ID --project PROJECT --question \"<your question>\"\n" +
+      "If this task failed because of a defect in squadrant itself (not an API/infra blip, a config/user error, or an expected failure), say so in your signal done/blocked message so the captain can check tu11aa/squadrant and file it. Don't file issues from the crew."
     );
+  });
+
+  it("includes the crew route-up line for squadrant defects", () => {
+    const result = buildCompletionProtocol("task-abc123", "my-project");
+    expect(result).toContain("a defect in squadrant itself");
+    expect(result).toContain("Don't file issues from the crew");
   });
 });
 

--- a/packages/core/src/crew-protocol.ts
+++ b/packages/core/src/crew-protocol.ts
@@ -46,6 +46,7 @@ export function buildCompletionProtocol(taskId: string, project: string): string
     `  squadrant crew signal done --task-id ${taskId} --project ${project} --message "<one-line summary>"`,
     "Run it as a discrete final step AFTER you report your results. If you are blocked or need a decision, instead run:",
     `  squadrant crew signal blocked --task-id ${taskId} --project ${project} --question "<your question>"`,
+    "If this task failed because of a defect in squadrant itself (not an API/infra blip, a config/user error, or an expected failure), say so in your signal done/blocked message so the captain can check tu11aa/squadrant and file it. Don't file issues from the crew.",
   ].join("\n");
 }
 


### PR DESCRIPTION
## Summary

- Bumps version `0.9.1` → `0.9.2` in root `package.json`
- Adds `## [0.9.2]` CHANGELOG entry dated 2026-06-22

## What's in this release (already on develop via PR #399, issue #398)

- **Added:** `AGENTS.md` gains a "Reporting squadrant bugs" prompt block — crew agents route detected squadrant defects up to the captain for GitHub filing (semi-automatic feedback loop).
- **Added:** Root-level `CONTRIBUTING.md` — dev setup, self-reporting convention, issue filing guide.
- **Fixed:** `packages/cli/src/commands/feedback.ts` was hardcoding version `"0.1.0"`; now reads the real package version at runtime.

## Not in this release

- Telegram integration (in progress on separate branch)

## Test plan

- [x] `pnpm install` — clean
- [x] `pnpm build` — ESM build success, output `squadrant@0.9.2`
- [x] `node dist/index.js --version` → `0.9.2`
- [x] `gitnexus detect_changes` — no indexed symbols affected (only package.json + CHANGELOG.md changed)