### PR TITLE
Telegram v0.10 stability: auto-launch + general command channel + user-id allowlist (#403/#402/#321)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-06-23
+
+The Telegram stability slice — closes two usability gaps so the integration is solid enough to release, both gated behind a fail-closed user-id allowlist + an opt-in master switch. Default behavior is unchanged on upgrade (`remoteControl` defaults to `false`).
+
+### Added
+
+- **Project-topic auto-launch ([#403](https://github.com/tu11aa/squadrant/issues/403)).** When a project-topic message arrives and no captain is alive, the daemon boots one (async `execFile`, bounded warmup poll, per-project debounce) then delivers the message — instead of silently queuing. Acts only with remote control enabled.
+- **General command channel ([#402](https://github.com/tu11aa/squadrant/issues/402)).** Slash commands in the supergroup's General topic run a curated registry of squadrant operations from the phone: `/help`, `/status`, `/projects`, `/crews`, `/launch`, `/effort`, `/config get|set`, `/spawn`. Each maps to a validated CLI argv run via async `execFile` (no shell passthrough); unknown/freeform input gets a `/help` hint.
+- **User-id allowlist + `remoteControl` opt-in ([#321](https://github.com/tu11aa/squadrant/issues/321)).** `TelegramConfig` gains `users?: number[]` and `remoteControl?: boolean`. Control surfaces act **only** when `remoteControl === true` **and** `message.from.id ∈ users[]` — fail-closed; chat membership alone is never enough.
+- **`squadrant config get` / `config set`** — read/write a config value by dotted key. `config set` over Telegram is restricted to a default-deny writable-key allowlist (currently `defaults.effort`); secrets can never be written remotely.
+- **`telegram setup` enhancement** — the wizard now captures your Telegram user-id and offers to enable remote control, writing `users` + `remoteControl` idempotently.
+
+### Security
+
+- `/config set` over Telegram rejects `telegram.botToken`, `telegram.users`, `telegram.chats`, and `telegram.supergroupId` (default-deny allowlist). Inbound handlers never let an error escape the poll loop, preserving at-least-once offset semantics.
+
 ## [0.9.2] - 2026-06-22
 
 A patch release adding the agent self-reporting feedback loop and fixing a stale version in the feedback command.

--- a/README.md
+++ b/README.md
@@ -179,22 +179,34 @@ Pass `--direction right|left|up|down` to use a split pane instead of a tab. Stat
 Drive squadrant from your phone ([#65](https://github.com/tu11aa/squadrant/issues/65)). When a `telegram` block is present in config, a daemon-internal bridge:
 
 - **Outbound** — pushes each project's crew lifecycle events (CREW DONE / BLOCKED / IDLE) and other captain notifications to that project's Telegram forum topic. Best-effort: a Telegram failure never delays or breaks delivery to the captain pane.
-- **Inbound (captain-only)** — a message you send in a project's topic is delivered into that project's **captain pane** as a labeled `📩 [from Telegram]` message; the captain decides what to do with it.
+- **Inbound (project topic)** — a message you send in a project's topic is delivered into that project's **captain pane** as a labeled `📩 [from Telegram]` message; the captain decides what to do with it. With remote control enabled (see below), if no captain is alive the daemon **auto-launches** one, then delivers ([#403](https://github.com/tu11aa/squadrant/issues/403)).
+- **General command channel** — slash commands in the supergroup's **General topic** run a curated set of squadrant operations from your phone ([#402](https://github.com/tu11aa/squadrant/issues/402)). Available: `/help`, `/status`, `/projects`, `/crews <project>`, `/launch <project>`, `/effort [max|balance|low]`, `/config get <key>`, `/config set <key> <value>`, `/spawn <project> <task…>`. Each maps to a validated CLI argv run via async `execFile` — never a shell passthrough. Unknown commands and freeform text get a `/help` hint.
 
 Absent the config block, the bridge is never constructed — zero behavior change. No runtime SDK is added (plain `fetch`; `@grammyjs/types` is a dev-only type dependency).
 
 **Setup (recommended):**
 1. Create a bot with [@BotFather](https://t.me/BotFather) and copy its token.
-2. Run `squadrant telegram setup` — it prompts for the bot token (input hidden), validates it via the Bot API, and auto-detects your supergroup id.
+2. Run `squadrant telegram setup` — it prompts for the bot token (input hidden), validates it via the Bot API, auto-detects your supergroup id, captures your Telegram user-id, and offers to enable remote control.
 3. Bind a project to a topic: `squadrant telegram link <project>` (creates the forum topic and records the binding).
 4. Check wiring with `squadrant telegram status`.
 
 **Setup (manual):**
 Put the token + ids in config (or export `TELEGRAM_BOT_TOKEN`) — see the `telegram` block under [Config](#config). Then run `squadrant telegram link <project>`.
 
-> **⚠️ Security gap (v1):** anyone who can post in the linked supergroup can steer the captain — **chat membership implies captain control**. Inbound is only filtered by a `chat_id` allowlist; a per-user-id allowlist that closes this is deferred to [#321](https://github.com/tu11aa/squadrant/issues/321). Inbound text is always treated as data (a captain message), never executed as a shell command.
+#### Security model (#321) — fail-closed remote control
 
-> **Interim note (link ↔ daemon 409):** the Telegram Bot API allows only one `getUpdates` consumer at a time. If a future link flow needs `getUpdates` and the daemon's inbound poll is running, you may hit a 409 conflict — run `squadrant telegram link` with the daemon stopped (#321 MAJOR-4). v1's `link` uses only `createForumTopic`, so this does not apply today, but keep it in mind for hardening.
+The control surfaces (auto-launch + General command channel) are **off by default** and gated by two independent checks. A control action runs **only when both** hold:
+
+1. `remoteControl: true` — an explicit opt-in master switch (default `false`).
+2. `message.from.id ∈ users[]` — the sender's Telegram **user-id** is on the allowlist. An empty/absent `users` list ⇒ control is disabled (fail-closed). Chat membership alone is **never** enough for control.
+
+When remote control is off (the default after upgrade), behavior is **exactly v1**: project-topic messages queue to the captain pane (no auto-launch), and General-topic slash commands are rejected with `⛔ not authorized`. Inbound text is always treated as data; only the curated registry maps to actions, and `/config set` is restricted to a default-deny writable-key allowlist (currently just `defaults.effort`) — **secrets (`botToken`, `users`, `chats`, `supergroupId`) can never be written over Telegram.**
+
+#### Remote wake (#403) — operator-side
+
+Auto-launch boots a captain when the **daemon is already running**. Waking a *sleeping Mac* from your phone (Wake-on-LAN / a relay that nudges the machine) is operator-side infrastructure, out of scope for this repo — see [#403](https://github.com/tu11aa/squadrant/issues/403) for the end-to-end flow.
+
+> **Interim note (link ↔ daemon 409):** the Telegram Bot API allows only one `getUpdates` consumer at a time. The `setup` wizard polls `getUpdates` to detect your group/user-id, so run it with the daemon stopped. `link` uses only `createForumTopic`, so it's unaffected.
 
 ### Projection (Cross-Agent Config Sync)
 
@@ -239,6 +251,8 @@ The user-level projection now also inlines `templates/captain.generic.md` and `t
     "botToken": "123456:ABC...",
     "supergroupId": -1001234567890,
     "chats": [-1001234567890],
+    "users": [987654321],
+    "remoteControl": true,
     "pollMs": 1000
   },
   "projects": {
@@ -270,7 +284,7 @@ The user-level projection now also inlines `templates/captain.generic.md` and `t
 }
 ```
 
-The `telegram` block is **optional** — omit it and the Telegram bridge is never constructed. `botToken` may be left out of the file and supplied via the `TELEGRAM_BOT_TOKEN` env var instead. `chats` is the inbound `chat_id` allowlist; `pollMs` (default `1000`) is the inbound long-poll cadence. See [Telegram (Two-Way, opt-in)](#telegram-two-way-opt-in).
+The `telegram` block is **optional** — omit it and the Telegram bridge is never constructed. `botToken` may be left out of the file and supplied via the `TELEGRAM_BOT_TOKEN` env var instead. `chats` is the inbound `chat_id` allowlist; `users` is the per-user-id allowlist for **control** actions and `remoteControl` (default `false`) is the master opt-in for auto-launch + the General command channel — both must be set for any remote control to act (fail-closed, [#321](https://github.com/tu11aa/squadrant/issues/321)). `pollMs` (default `1000`) is the inbound long-poll cadence. See [Telegram (Two-Way, opt-in)](#telegram-two-way-opt-in).
 
 ## Supported Agents
 

--- a/packages/cli/src/commands/__tests__/config.test.ts
+++ b/packages/cli/src/commands/__tests__/config.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { runConfigCheck } from "../config.js";
+import { runConfigCheck, runConfigGet, runConfigSet } from "../config.js";
 import { getDefaultConfig } from "@squadrant/shared";
 
 const __thisDir = dirname(fileURLToPath(import.meta.url));
@@ -59,6 +59,34 @@ describe("runConfigCheck", () => {
     const onDisk = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
     expect(onDisk._squadrantVersion).toBe("0.5.3");
     expect(onDisk.defaults.roles.crew.model).toBe("sonnet");
+  });
+});
+
+describe("runConfigGet / runConfigSet (dotted path)", () => {
+  it("reads a nested value by dotted key", () => {
+    writeUser((c) => { c.defaults.effort = "low"; });
+    expect(runConfigGet("defaults.effort", cfgPath)).toBe("low");
+  });
+
+  it("throws on an unknown key", () => {
+    writeUser(() => {});
+    expect(() => runConfigGet("defaults.nope.deep", cfgPath)).toThrow();
+  });
+
+  it("sets a nested string value and persists it", () => {
+    writeUser(() => {});
+    runConfigSet("defaults.effort", "max", cfgPath);
+    const onDisk = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
+    expect(onDisk.defaults.effort).toBe("max");
+  });
+
+  it("parses JSON-looking values (numbers/bools) but keeps bare strings", () => {
+    writeUser(() => {});
+    runConfigSet("defaults.maxCrew", "9", cfgPath);
+    runConfigSet("defaults.effort", "balance", cfgPath);
+    const onDisk = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
+    expect(onDisk.defaults.maxCrew).toBe(9);
+    expect(onDisk.defaults.effort).toBe("balance");
   });
 });
 

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import chalk from "chalk";
-import { DEFAULT_CONFIG_PATH, getDefaultConfig, type SquadrantConfig } from "@squadrant/shared";
+import { DEFAULT_CONFIG_PATH, getDefaultConfig, loadConfig, saveConfig, type SquadrantConfig } from "@squadrant/shared";
 import { detectDrift, applySafeFixes, type DriftItem } from "@squadrant/shared";
 import { withStamp } from "@squadrant/shared";
 
@@ -48,6 +48,41 @@ export function runConfigCheck(opts: ConfigCheckOptions): ConfigCheckResult {
   }
 
   return { items, applied, remaining, stamped };
+}
+
+/** Read a value at a dotted path (e.g. "defaults.effort"). Throws if the path
+ *  does not resolve. Returns the raw value (stringified by the caller for display). */
+export function runConfigGet(key: string, configPath = DEFAULT_CONFIG_PATH): unknown {
+  const config = loadConfig(configPath);
+  const parts = key.split(".");
+  let node: unknown = config;
+  for (const p of parts) {
+    if (node === null || typeof node !== "object" || !(p in (node as Record<string, unknown>))) {
+      throw new Error(`config key not found: ${key}`);
+    }
+    node = (node as Record<string, unknown>)[p];
+  }
+  return node;
+}
+
+/** Write a value at a dotted path, creating intermediate objects as needed.
+ *  The value is JSON-parsed when it parses (numbers/bools/arrays); otherwise the
+ *  raw string is kept (so `low` stays "low", not a parse error). Persists to disk.
+ *  NOTE: this is a generic local CLI surface; the Telegram channel restricts which
+ *  keys may be set via WRITABLE_CONFIG_KEYS, so secrets can't be written remotely. */
+export function runConfigSet(key: string, value: string, configPath = DEFAULT_CONFIG_PATH): void {
+  let parsed: unknown;
+  try { parsed = JSON.parse(value); } catch { parsed = value; }
+  const config = loadConfig(configPath) as unknown as Record<string, unknown>;
+  const parts = key.split(".");
+  let node = config;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const p = parts[i];
+    if (node[p] === null || typeof node[p] !== "object") node[p] = {};
+    node = node[p] as Record<string, unknown>;
+  }
+  node[parts[parts.length - 1]] = parsed;
+  saveConfig(config as unknown as SquadrantConfig, configPath);
 }
 
 const SEV_COLOR: Record<string, (s: string) => string> = {
@@ -107,6 +142,35 @@ configCommand
       console.log(chalk.yellow(`\n${judgment.length} item(s) need review \u2014 run the config-doctor skill, or \`squadrant config check --accept\` to keep your values.`));
     } else if (res.stamped) {
       console.log(chalk.green("\n\u2714 Config reconciled and stamped."));
+    }
+  });
+
+configCommand
+  .command("get")
+  .description("Read a config value by dotted key (e.g. defaults.effort)")
+  .argument("<key>", "dotted config key")
+  .action((key: string) => {
+    try {
+      const value = runConfigGet(key);
+      console.log(typeof value === "string" ? value : JSON.stringify(value));
+    } catch (e) {
+      console.error(chalk.red((e as Error).message));
+      process.exit(1);
+    }
+  });
+
+configCommand
+  .command("set")
+  .description("Write a config value by dotted key (e.g. defaults.effort low)")
+  .argument("<key>", "dotted config key")
+  .argument("<value>", "value (JSON-parsed when possible, else a bare string)")
+  .action((key: string, value: string) => {
+    try {
+      runConfigSet(key, value);
+      console.log(chalk.green(`✔ set ${key} = ${value}`));
+    } catch (e) {
+      console.error(chalk.red((e as Error).message));
+      process.exit(1);
     }
   });
 

--- a/packages/cli/src/commands/telegram.ts
+++ b/packages/cli/src/commands/telegram.ts
@@ -4,7 +4,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { loadConfig, DEFAULT_CONFIG_PATH } from "@squadrant/shared";
 import type { SquadrantConfig, TelegramConfig } from "@squadrant/shared";
-import { createTelegramClient, loadState, setTopic, topicKey, topicName, detectGroupId, writeTelegramConfig, maskToken } from "@squadrant/core";
+import { createTelegramClient, loadState, setTopic, topicKey, topicName, detectGroupAndUser, writeTelegramConfig, maskToken } from "@squadrant/core";
 import type { TelegramClient } from "@squadrant/core";
 
 /** Daemon state root (mirrors buildContext): ~/.config/squadrant/state. */
@@ -101,6 +101,20 @@ export async function questionMasked(): Promise<string> {
   });
 }
 
+// Visible yes/no prompt (default No). Used for opt-ins where masking is wrong.
+// Pauses stdin afterward so the process can exit cleanly (prior wizard-hang fix).
+async function questionYesNo(prompt: string): Promise<boolean> {
+  const { createInterface } = await import("node:readline");
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise<boolean>((resolve) => {
+    rl.question(prompt, (ans) => {
+      rl.close();
+      process.stdin.pause();
+      resolve(/^y(es)?$/i.test(ans.trim()));
+    });
+  });
+}
+
 export const telegramCommand = new Command("telegram")
   .description("Two-way Telegram integration: push crew events to a topic and reply into the captain pane");
 
@@ -182,8 +196,9 @@ telegramCommand
     console.log("Add the bot to your forum supergroup, then send any message in it.");
     console.log(chalk.dim("Waiting for a message (up to 60s)…"));
     let supergroupId: number;
+    let userId: number | undefined;
     try {
-      supergroupId = await detectGroupId(client, { timeoutMs: 60_000 });
+      ({ supergroupId, userId } = await detectGroupAndUser(client, { timeoutMs: 60_000 }));
     } catch {
       console.error(chalk.red("Timed out — no supergroup message received within 60s."));
       console.error(chalk.yellow("Check: bot is an admin in the group · privacy mode is OFF · Topics enabled"));
@@ -192,10 +207,32 @@ telegramCommand
     console.log(chalk.green(`Found group: ${supergroupId}`));
     console.log();
 
-    // Step 3/3 — Save
-    console.log(chalk.bold("Step 3/3 — Save"));
-    writeTelegramConfig(DEFAULT_CONFIG_PATH, { token, supergroupId });
+    // Step 3/3 — Remote control (opt-in, #321) + Save
+    console.log(chalk.bold("Step 3/3 — Remote control + Save"));
+    console.log(chalk.dim("Remote control enables auto-launching captains and the General command channel"));
+    console.log(chalk.dim("from your phone — gated to your Telegram user-id only (fail-closed)."));
+    let users: number[] | undefined;
+    let remoteControl: boolean | undefined;
+    if (userId === undefined) {
+      console.log(chalk.yellow("Could not read your user-id from that message — skipping remote control."));
+      console.log(chalk.yellow("Re-run setup once it's available, or edit telegram.users in config manually."));
+    } else {
+      const enable = await questionYesNo(
+        `Enable remote control for your user-id ${userId}? [y/N] `,
+      );
+      if (enable) {
+        users = [userId];
+        remoteControl = true;
+      }
+    }
+
+    writeTelegramConfig(DEFAULT_CONFIG_PATH, { token, supergroupId, users, remoteControl });
     console.log(chalk.green(`Wrote telegram config — token: ${maskToken(token)}  group: ${supergroupId}`));
+    if (remoteControl) {
+      console.log(chalk.green(`Remote control: ON (allowlisted user-id ${users?.[0]})`));
+    } else {
+      console.log(chalk.dim("Remote control: off (default). Re-run setup to enable later."));
+    }
     console.log();
     console.log(`Next: ${chalk.cyan("squadrant telegram link <project>")}`);
   });

--- a/packages/cli/src/control/__tests__/telegram-control.test.ts
+++ b/packages/cli/src/control/__tests__/telegram-control.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { capOutput } from "../telegram-control.js";
+
+describe("capOutput", () => {
+  it("returns trimmed stdout when present", () => {
+    expect(capOutput("  hello\n", "")).toBe("hello");
+  });
+
+  it("appends a stderr tail when stderr is non-empty", () => {
+    const out = capOutput("ok", "a warning");
+    expect(out).toContain("ok");
+    expect(out).toContain("a warning");
+  });
+
+  it("falls back to a placeholder when both streams are empty", () => {
+    expect(capOutput("", "")).toBe("(no output)");
+  });
+
+  it("caps overly long output and marks truncation", () => {
+    const long = "x".repeat(5000);
+    const out = capOutput(long, "", 3500);
+    expect(out.length).toBeLessThanOrEqual(3500 + 20);
+    expect(out).toContain("truncated");
+  });
+});

--- a/packages/cli/src/control/squadrantd.ts
+++ b/packages/cli/src/control/squadrantd.ts
@@ -9,9 +9,10 @@ import { buildContext } from "@squadrant/core";
 import { createAttach } from "@squadrant/core";
 import { startDaemon } from "@squadrant/core";
 import { isDaemonSocketLive } from "@squadrant/core";
-import { appendCaptainMessage, createTelegramClient, createTelegramBridge } from "@squadrant/core";
+import { appendCaptainMessage, createTelegramClient, createTelegramBridge, createEnsureCaptainAlive } from "@squadrant/core";
 import type { TelegramBridge } from "@squadrant/core";
 import type { TelegramConfig } from "@squadrant/shared";
+import { createRunCommand, createIsCaptainAlive, createLaunch } from "./telegram-control.js";
 export type { SquadrantdOpts } from "@squadrant/core";
 export { defaultIsPidAlive } from "@squadrant/core";
 export { discoverCaptainSurface } from "@squadrant/core";
@@ -23,6 +24,11 @@ import { loadConfig, TERMINAL_STATES } from "@squadrant/shared";
 import { createCmuxDriver } from "@squadrant/workspaces";
 
 const SELF_PATH = fileURLToPath(import.meta.url);
+// Bundled CLI bin sits next to this daemon entry (dist/index.js · dist/squadrantd.js).
+// Dist-relative + invariant to source moves (see learning #363). Run via
+// `process.execPath <CLI_BIN> ...argv` so we don't depend on PATH (launchd's is minimal).
+const CLI_BIN = join(dirname(SELF_PATH), "index.js");
+const DAEMON_SOCK = join(homedir(), ".config", "squadrant", "squadrant.sock");
 function readPkgVersion(): string {
   try {
     const pkgPath = join(dirname(SELF_PATH), "..", "package.json");
@@ -46,7 +52,19 @@ function buildTelegramBridge(
     return undefined;
   }
   const client = createTelegramClient({ token });
-  return createTelegramBridge({ cfg, stateRoot, client, appendCaptainMessage, log });
+  // Control surfaces (#402/#403). These act only when remoteControl is on AND the
+  // sender is allowlisted (gated inside the bridge); passing them is always safe.
+  const ensureCaptainAlive = createEnsureCaptainAlive({
+    isAlive: createIsCaptainAlive(DAEMON_SOCK),
+    launch: createLaunch(CLI_BIN),
+  });
+  const runCommand = createRunCommand(CLI_BIN);
+  const sendReply = (threadId: number | undefined, text: string) =>
+    client.sendMessage(cfg.supergroupId, threadId, text);
+  return createTelegramBridge({
+    cfg, stateRoot, client, appendCaptainMessage, log,
+    ensureCaptainAlive, runCommand, sendReply,
+  });
 }
 
 export function startSquadrantd(opts: import("@squadrant/core").SquadrantdOpts = {}) {

--- a/packages/cli/src/control/telegram-control.ts
+++ b/packages/cli/src/control/telegram-control.ts
@@ -1,0 +1,69 @@
+// Daemon-side capabilities for the Telegram control surfaces (#402/#403). The
+// CLI layer owns process spawning + socket access; the core bridge only sees the
+// injected closures. EVERYTHING that shells out uses async execFile (promisified)
+// with an argv array — never *Sync on the daemon poll path (event-loop
+// starvation, learning #2) and never a shell string (argv already validated by
+// parseCommand).
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { sendRequest } from "@squadrant/core";
+
+const pExecFile = promisify(execFile);
+
+// Telegram message hard limit is 4096 chars; cap below it with headroom for the
+// truncation marker + any reply framing.
+const MAX_OUTPUT = 3500;
+
+/** Combine a command's stdout/stderr into one capped, human-readable reply. */
+export function capOutput(stdout: string, stderr: string, max = MAX_OUTPUT): string {
+  const out = stdout.trim();
+  const err = stderr.trim();
+  let combined = out;
+  if (err) combined = combined ? `${combined}\n[stderr] ${err}` : `[stderr] ${err}`;
+  if (!combined) combined = "(no output)";
+  if (combined.length > max) combined = combined.slice(0, max) + "\n…[truncated]";
+  return combined;
+}
+
+const COMMAND_TIMEOUT_MS = 60_000;
+
+/** Run a curated squadrant CLI argv via async execFile, returning capped output.
+ *  argv is the validated vector from parseCommand — passed as an array (no shell). */
+export function createRunCommand(cliBin: string): (argv: string[]) => Promise<string> {
+  return async (argv: string[]) => {
+    try {
+      const { stdout, stderr } = await pExecFile(
+        process.execPath,
+        [cliBin, ...argv],
+        { timeout: COMMAND_TIMEOUT_MS, maxBuffer: 4 * 1024 * 1024 },
+      );
+      return capOutput(stdout ?? "", stderr ?? "");
+    } catch (e) {
+      // execFile rejects on non-zero exit / timeout; surface its captured output.
+      const err = e as { stdout?: string; stderr?: string; message?: string };
+      return capOutput(err.stdout ?? "", err.stderr ?? err.message ?? "command failed");
+    }
+  };
+}
+
+/** Liveness probe via the daemon health endpoint (mirrors group.ts isCaptainAlive). */
+export function createIsCaptainAlive(sock: string): (project: string) => Promise<boolean> {
+  return async (project: string) => {
+    try {
+      const health = (await sendRequest(sock, { kind: "health", project }, 5000)) as Array<{
+        kind: string; project: string; state: string;
+      }>;
+      const captain = health?.find((h) => h.kind === "captain" && h.project === project);
+      return captain != null && captain.state !== "gone" && captain.state !== "unknown";
+    } catch {
+      return false;
+    }
+  };
+}
+
+/** Boot a captain via async execFile (NEVER execSync on the daemon hot path). */
+export function createLaunch(cliBin: string): (project: string) => Promise<void> {
+  return async (project: string) => {
+    await pExecFile(process.execPath, [cliBin, "launch", project], { timeout: 30_000 });
+  };
+}

--- a/packages/core/src/telegram/__tests__/setup.test.ts
+++ b/packages/core/src/telegram/__tests__/setup.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { TelegramClient } from "../client.js";
-import { detectGroupId, writeTelegramConfig } from "../setup.js";
+import { detectGroupId, detectGroupAndUser, writeTelegramConfig } from "../setup.js";
 
 let tmpdir: string;
 beforeEach(() => { tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "sq-tg-setup-")); });
@@ -61,7 +61,48 @@ describe("detectGroupId", () => {
   });
 });
 
+describe("detectGroupAndUser", () => {
+  it("returns the supergroup id and the sender's user id from one message", async () => {
+    const client = {
+      getUpdates: async () => [
+        { update_id: 1, message: { chat: { id: -100500, type: "supergroup", title: "G" }, from: { id: 777 }, message_id: 10, date: 0 } },
+      ],
+      sendMessage: async () => {},
+      createForumTopic: async () => 0,
+      getMe: async () => ({ id: 0, username: "" }),
+    } as unknown as TelegramClient;
+
+    const r = await detectGroupAndUser(client, { timeoutMs: 5000, sleep: async () => {} });
+
+    expect(r).toEqual({ supergroupId: -100500, userId: 777 });
+  });
+});
+
 describe("writeTelegramConfig", () => {
+  it("writes users + remoteControl when provided", () => {
+    const configPath = path.join(tmpdir, "config.json");
+    writeTelegramConfig(configPath, { token: "T", supergroupId: -100, users: [777], remoteControl: true });
+    const raw = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    expect(raw.telegram).toEqual({ botToken: "T", supergroupId: -100, chats: [-100], users: [777], remoteControl: true });
+  });
+
+  it("preserves existing users/remoteControl when re-run without them", () => {
+    const configPath = path.join(tmpdir, "config.json");
+    fs.writeFileSync(configPath, JSON.stringify({
+      commandName: "cmd", hubVault: "/tmp/hub", projects: {},
+      defaults: { maxCrew: 5, worktreeDir: ".wt", teammateMode: "in-process", permissions: { command: "auto", captain: "auto", crew: "auto" } },
+      metrics: { enabled: true, path: "/tmp/metrics" },
+      telegram: { botToken: "OLD", supergroupId: -1, chats: [-1], users: [5], remoteControl: true },
+    }));
+
+    writeTelegramConfig(configPath, { token: "NEW", supergroupId: -100 });
+
+    const raw = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    expect(raw.telegram.botToken).toBe("NEW");
+    expect(raw.telegram.users).toEqual([5]);
+    expect(raw.telegram.remoteControl).toBe(true);
+  });
+
   it("creates a fresh config when the file does not exist", () => {
     const configPath = path.join(tmpdir, "nonexistent.json");
 

--- a/packages/core/src/telegram/auth.test.ts
+++ b/packages/core/src/telegram/auth.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { isAuthorized, isControlEnabled } from "./auth.js";
+import type { TelegramConfig } from "@squadrant/shared";
+
+const base: TelegramConfig = { supergroupId: -100, chats: [-100] };
+
+describe("telegram auth", () => {
+  it("control disabled when remoteControl is unset/false", () => {
+    expect(isControlEnabled(base)).toBe(false);
+    expect(isControlEnabled({ ...base, remoteControl: false })).toBe(false);
+    expect(isControlEnabled({ ...base, remoteControl: true })).toBe(true);
+  });
+  it("fails closed when users[] is empty or undefined", () => {
+    expect(isAuthorized(42, base)).toBe(false);
+    expect(isAuthorized(42, { ...base, users: [] })).toBe(false);
+  });
+  it("authorizes only allowlisted user ids", () => {
+    const cfg = { ...base, users: [42] };
+    expect(isAuthorized(42, cfg)).toBe(true);
+    expect(isAuthorized(99, cfg)).toBe(false);
+    expect(isAuthorized(undefined, cfg)).toBe(false);
+  });
+});

--- a/packages/core/src/telegram/auth.ts
+++ b/packages/core/src/telegram/auth.ts
@@ -1,0 +1,13 @@
+// Pure auth predicates for the Telegram CONTROL surfaces (auto-launch, general
+// commands). No I/O. Fail-closed: control requires both the master switch and a
+// user-id match — chat membership alone is never enough for control.
+import type { TelegramConfig } from "@squadrant/shared";
+
+export function isControlEnabled(cfg: TelegramConfig): boolean {
+  return cfg.remoteControl === true;
+}
+
+export function isAuthorized(fromId: number | undefined, cfg: TelegramConfig): boolean {
+  if (fromId === undefined) return false;
+  return Array.isArray(cfg.users) && cfg.users.includes(fromId);
+}

--- a/packages/core/src/telegram/bridge.test.ts
+++ b/packages/core/src/telegram/bridge.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createTelegramBridge, type TelegramBridgeOptions } from "./bridge.js";
+import { setTopic } from "./state.js";
+import type { TelegramConfig } from "@squadrant/shared";
+import type { Update } from "@grammyjs/types";
+
+// Drive the real poll loop with one batch of updates, resolving once the batch is
+// fully drained (the loop asks for a 2nd batch). Returns the bridge so the caller
+// can stop it. The 2nd getUpdates hangs so the loop parks instead of busy-looping.
+function drive(opts: Omit<TelegramBridgeOptions, "client">, updates: Array<Partial<Update>>) {
+  let served = false;
+  let resolveDrained!: () => void;
+  const drained = new Promise<void>((r) => { resolveDrained = r; });
+  const client = {
+    getUpdates: vi.fn(async () => {
+      if (!served) { served = true; return updates as Update[]; }
+      resolveDrained();
+      return new Promise<Update[]>(() => {}); // park
+    }),
+    sendMessage: vi.fn(async () => {}),
+    createForumTopic: vi.fn(async () => 999),
+    getMe: vi.fn(async () => ({ id: 1, username: "bot" })),
+  };
+  const bridge = createTelegramBridge({ ...opts, client });
+  bridge.start();
+  return { bridge, client, drained };
+}
+
+const CHAT = -100;
+const ALLOWED_USER = 42;
+const baseCfg: TelegramConfig = { supergroupId: CHAT, chats: [CHAT], pollMs: 5 };
+
+function generalMsg(text: string, fromId = ALLOWED_USER): Partial<Update> {
+  return { update_id: 1, message: { chat: { id: CHAT }, text, from: { id: fromId } } as any };
+}
+function topicMsg(text: string, threadId: number, fromId = ALLOWED_USER): Partial<Update> {
+  return { update_id: 1, message: { chat: { id: CHAT }, message_thread_id: threadId, text, from: { id: fromId } } as any };
+}
+
+let stateRoot: string;
+beforeEach(() => { stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), "tg-bridge-")); });
+afterEach(() => { fs.rmSync(stateRoot, { recursive: true, force: true }); });
+
+function deps(over: Partial<TelegramBridgeOptions> = {}) {
+  return {
+    stateRoot,
+    appendCaptainMessage: vi.fn(async () => {}),
+    log: vi.fn(),
+    ensureCaptainAlive: vi.fn(async () => "alive" as const),
+    runCommand: vi.fn(async () => "output"),
+    sendReply: vi.fn(async () => {}),
+    ...over,
+  };
+}
+
+describe("handleUpdate routing", () => {
+  it("replies with a hint to freeform text in the General topic", async () => {
+    const d = deps();
+    const { bridge, drained } = drive({ cfg: baseCfg, ...d }, [generalMsg("hello there")]);
+    await drained;
+    expect(d.sendReply).toHaveBeenCalledWith(undefined, expect.stringContaining("/help"));
+    expect(d.runCommand).not.toHaveBeenCalled();
+    expect(d.appendCaptainMessage).not.toHaveBeenCalled();
+    bridge.stop();
+  });
+
+  it("rejects a General command when remoteControl is off", async () => {
+    const d = deps();
+    const { bridge, drained } = drive({ cfg: baseCfg, ...d }, [generalMsg("/status")]);
+    await drained;
+    expect(d.sendReply).toHaveBeenCalledWith(undefined, expect.stringContaining("not authorized"));
+    expect(d.runCommand).not.toHaveBeenCalled();
+    bridge.stop();
+  });
+
+  it("runs a General command when control is on and sender is authorized", async () => {
+    const cfg = { ...baseCfg, remoteControl: true, users: [ALLOWED_USER] };
+    const d = deps();
+    const { bridge, drained } = drive({ cfg, ...d }, [generalMsg("/status")]);
+    await drained;
+    expect(d.runCommand).toHaveBeenCalledWith(["status"]);
+    expect(d.sendReply).toHaveBeenCalledWith(undefined, "output");
+    bridge.stop();
+  });
+
+  it("rejects a General command from a non-allowlisted user even when control is on", async () => {
+    const cfg = { ...baseCfg, remoteControl: true, users: [ALLOWED_USER] };
+    const d = deps();
+    const { bridge, drained } = drive({ cfg, ...d }, [generalMsg("/status", 9999)]);
+    await drained;
+    expect(d.runCommand).not.toHaveBeenCalled();
+    expect(d.sendReply).toHaveBeenCalledWith(undefined, expect.stringContaining("not authorized"));
+    bridge.stop();
+  });
+
+  it("auto-launches then delivers in a project topic when control is on + authorized", async () => {
+    setTopic(stateRoot, "brove", 7);
+    const cfg = { ...baseCfg, remoteControl: true, users: [ALLOWED_USER] };
+    const d = deps({ ensureCaptainAlive: vi.fn(async () => "launched" as const) });
+    const { bridge, drained } = drive({ cfg, ...d }, [topicMsg("ship it", 7)]);
+    await drained;
+    expect(d.ensureCaptainAlive).toHaveBeenCalledWith("brove");
+    expect(d.appendCaptainMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ project: "brove", source: "telegram" }),
+    );
+    bridge.stop();
+  });
+
+  it("delivers without auto-launch in a project topic when control is off (v1 parity)", async () => {
+    setTopic(stateRoot, "brove", 7);
+    const d = deps();
+    const { bridge, drained } = drive({ cfg: baseCfg, ...d }, [topicMsg("ship it", 7)]);
+    await drained;
+    expect(d.ensureCaptainAlive).not.toHaveBeenCalled();
+    expect(d.appendCaptainMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ project: "brove", source: "telegram" }),
+    );
+    bridge.stop();
+  });
+
+  it("warns into the topic when warmup times out but still queues the message", async () => {
+    setTopic(stateRoot, "brove", 7);
+    const cfg = { ...baseCfg, remoteControl: true, users: [ALLOWED_USER] };
+    const d = deps({ ensureCaptainAlive: vi.fn(async () => "timeout" as const) });
+    const { bridge, drained } = drive({ cfg, ...d }, [topicMsg("ship it", 7)]);
+    await drained;
+    expect(d.sendReply).toHaveBeenCalledWith(7, expect.stringContaining("warm up"));
+    expect(d.appendCaptainMessage).toHaveBeenCalled();
+    bridge.stop();
+  });
+
+  it("drops messages from non-allowlisted chats", async () => {
+    const d = deps();
+    const msg = { update_id: 1, message: { chat: { id: -999 }, text: "/status", from: { id: ALLOWED_USER } } as any };
+    const { bridge, drained } = drive({ cfg: baseCfg, ...d }, [msg]);
+    await drained;
+    expect(d.sendReply).not.toHaveBeenCalled();
+    expect(d.runCommand).not.toHaveBeenCalled();
+    expect(d.appendCaptainMessage).not.toHaveBeenCalled();
+    bridge.stop();
+  });
+});

--- a/packages/core/src/telegram/bridge.ts
+++ b/packages/core/src/telegram/bridge.ts
@@ -3,6 +3,9 @@
 // crash-contained: no send/poll error may escape into the daemon.
 import type { ControlEvent, TelegramConfig } from "@squadrant/shared";
 import type { TelegramClient } from "./client.js";
+import { isAuthorized, isControlEnabled } from "./auth.js";
+import { parseCommand } from "./commands.js";
+import type { EnsureResult } from "./ensure-captain.js";
 import { formatInbound, formatLifecycle, topicName } from "./format.js";
 import { findProjectByThread, loadState, saveState, setTopic, topicKey } from "./state.js";
 
@@ -19,6 +22,14 @@ export interface TelegramBridgeOptions {
   client: TelegramClient;
   appendCaptainMessage: (a: { stateRoot: string; project: string; text: string; source: "telegram" }) => Promise<void>;
   log: (msg: string) => void;
+  // ── Control surfaces (#402/#403/#321) — all optional. When undefined the bridge
+  // keeps exact v1 behavior (queue-only project topics, General topic dropped).
+  /** Boot-if-down before delivering to a project topic. Injected by the daemon host. */
+  ensureCaptainAlive?: (project: string) => Promise<EnsureResult>;
+  /** Execute a curated squadrant CLI argv and return capped output. */
+  runCommand?: (argv: string[]) => Promise<string>;
+  /** Post a reply to the General topic (threadId undefined) or a project topic. */
+  sendReply?: (threadId: number | undefined, text: string) => Promise<void>;
 }
 
 // Bot API long-poll window. The loop also sleeps cfg.pollMs between iterations so
@@ -28,7 +39,7 @@ const LONG_POLL_SEC = 50;
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
 export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridge {
-  const { cfg, stateRoot, client, appendCaptainMessage, log } = opts;
+  const { cfg, stateRoot, client, appendCaptainMessage, log, ensureCaptainAlive, runCommand, sendReply } = opts;
   const pollMs = cfg.pollMs ?? 1000;
   let running = false;
 
@@ -48,16 +59,73 @@ export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridg
     await client.sendMessage(cfg.supergroupId, threadId, formatLifecycle(project, ev));
   }
 
-  // Inbound: one update → at most one captain.message. Returns nothing; throws only
-  // on an append (delivery-infra) failure so the caller can decline to advance the
-  // offset (at-least-once). Allowlist/resolution misses are silent drops.
-  async function handleUpdate(u: { message?: { chat: { id: number }; message_thread_id?: number; text?: string } }): Promise<void> {
-    const m = u.message;
-    if (!m || m.text === undefined || m.message_thread_id === undefined) return;
-    if (!cfg.chats.includes(m.chat.id)) return; // not an allowlisted chat
-    const resolved = findProjectByThread(stateRoot, m.message_thread_id);
+  // Reply best-effort: a send failure must never escape into the poll loop.
+  async function reply(threadId: number | undefined, text: string): Promise<void> {
+    if (!sendReply) return;
+    try {
+      await sendReply(threadId, text);
+    } catch (e) {
+      log(`telegram reply failed: ${(e as Error).message}`);
+    }
+  }
+
+  // General topic (no thread id): curated command channel (#402). Fail-closed —
+  // a slash command runs ONLY when remoteControl is on AND the sender is
+  // allowlisted. Freeform text gets a /help hint (never silently dropped).
+  // Command/reply failures are caught here so they can't escape the poll loop.
+  async function handleGeneral(text: string, fromId: number | undefined): Promise<void> {
+    if (!text.startsWith("/")) {
+      await reply(undefined, "Send /help for commands.");
+      return;
+    }
+    if (!isControlEnabled(cfg) || !isAuthorized(fromId, cfg)) {
+      await reply(undefined, "⛔ not authorized");
+      return;
+    }
+    const parsed = parseCommand(text);
+    if (parsed.kind !== "ok") {
+      await reply(undefined, parsed.message);
+      return;
+    }
+    try {
+      const out = runCommand ? await runCommand(parsed.argv) : "(command runner unavailable)";
+      await reply(undefined, out);
+    } catch (e) {
+      await reply(undefined, `⚠️ command failed: ${(e as Error).message}`);
+      log(`telegram command failed argv=${JSON.stringify(parsed.argv)}: ${(e as Error).message}`);
+    }
+  }
+
+  // Project topic: the v1 captain.message flow + Gap-1 auto-launch (#403). When
+  // control is off OR the sender isn't allowlisted, behaves exactly as v1
+  // (append only). The append throws on delivery-infra failure so the caller can
+  // decline to advance the offset (at-least-once); auto-launch failures are
+  // contained and never block the append.
+  async function handleProjectTopic(text: string, threadId: number, fromId: number | undefined): Promise<void> {
+    const resolved = findProjectByThread(stateRoot, threadId);
     if (!resolved) return; // no project bound to this topic
-    await appendCaptainMessage({ stateRoot, project: resolved.project, text: formatInbound(m.text), source: "telegram" });
+    if (ensureCaptainAlive && isControlEnabled(cfg) && isAuthorized(fromId, cfg)) {
+      try {
+        const r = await ensureCaptainAlive(resolved.project);
+        if (r === "timeout") await reply(threadId, "⚠️ captain didn't warm up; message queued.");
+      } catch (e) {
+        log(`telegram auto-launch failed project=${resolved.project}: ${(e as Error).message}`);
+      }
+    }
+    await appendCaptainMessage({ stateRoot, project: resolved.project, text: formatInbound(text), source: "telegram" });
+  }
+
+  // Inbound: classify by thread id. General topic → command channel; project
+  // topic → captain.message (+ auto-launch). Throws only on append failure.
+  async function handleUpdate(u: { message?: { chat: { id: number }; message_thread_id?: number; text?: string; from?: { id: number } } }): Promise<void> {
+    const m = u.message;
+    if (!m || m.text === undefined) return;
+    if (!cfg.chats.includes(m.chat.id)) return; // not an allowlisted chat (coarse filter)
+    if (m.message_thread_id === undefined) {
+      await handleGeneral(m.text, m.from?.id);
+      return;
+    }
+    await handleProjectTopic(m.text, m.message_thread_id, m.from?.id);
   }
 
   async function pollLoop(): Promise<void> {

--- a/packages/core/src/telegram/commands.test.ts
+++ b/packages/core/src/telegram/commands.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { parseCommand, WRITABLE_CONFIG_KEYS } from "./commands.js";
+
+describe("parseCommand", () => {
+  it("maps /status to argv", () => {
+    expect(parseCommand("/status")).toEqual({ kind: "ok", name: "status", argv: ["status"] });
+  });
+
+  it("maps /projects to the real CLI subcommand", () => {
+    expect(parseCommand("/projects")).toEqual({ kind: "ok", name: "projects", argv: ["projects", "list"] });
+  });
+
+  it("requires a project for /crews and builds crew list argv", () => {
+    expect(parseCommand("/crews").kind).toBe("usage");
+    expect(parseCommand("/crews brove")).toEqual({ kind: "ok", name: "crews", argv: ["crew", "list", "brove"] });
+  });
+
+  it("requires a project for /launch", () => {
+    expect(parseCommand("/launch").kind).toBe("usage");
+    expect(parseCommand("/launch brove")).toEqual({ kind: "ok", name: "launch", argv: ["launch", "brove"] });
+  });
+
+  it("reads and sets the effort dial", () => {
+    expect(parseCommand("/effort")).toEqual({ kind: "ok", name: "effort", argv: ["effort"] });
+    expect(parseCommand("/effort low")).toEqual({ kind: "ok", name: "effort", argv: ["effort", "low"] });
+    expect(parseCommand("/effort bogus").kind).toBe("usage");
+  });
+
+  it("requires a key for /config get", () => {
+    expect(parseCommand("/config get").kind).toBe("usage");
+    expect(parseCommand("/config get defaults.effort")).toEqual({
+      kind: "ok",
+      name: "config",
+      argv: ["config", "get", "defaults.effort"],
+    });
+  });
+
+  it("denies /config set on a protected key", () => {
+    expect(parseCommand("/config set telegram.botToken X").kind).toBe("denied");
+    expect(parseCommand("/config set telegram.users [1] ").kind).toBe("denied");
+    expect(parseCommand("/config set telegram.chats [1]").kind).toBe("denied");
+    expect(parseCommand("/config set telegram.supergroupId -100").kind).toBe("denied");
+  });
+
+  it("allows /config set only on writable keys", () => {
+    expect(WRITABLE_CONFIG_KEYS).toContain("defaults.effort");
+    const p = parseCommand("/config set defaults.effort low");
+    expect(p).toEqual({ kind: "ok", name: "config", argv: ["config", "set", "defaults.effort", "low"] });
+  });
+
+  it("requires key and value for /config set", () => {
+    expect(parseCommand("/config set defaults.effort").kind).toBe("usage");
+  });
+
+  it("rejects unknown commands", () => {
+    expect(parseCommand("/frobnicate").kind).toBe("unknown");
+  });
+
+  it("rejects non-slash text as unknown", () => {
+    expect(parseCommand("hello there").kind).toBe("unknown");
+  });
+
+  it("returns a usage listing for /help", () => {
+    const p = parseCommand("/help");
+    expect(p.kind).toBe("usage");
+    if (p.kind === "usage") {
+      expect(p.message).toContain("/status");
+      expect(p.message).toContain("/spawn");
+    }
+  });
+
+  it("captures the rest of the line as the spawn task", () => {
+    const p = parseCommand("/spawn brove fix the header bug");
+    expect(p).toMatchObject({ kind: "ok", name: "spawn", argv: ["crew", "spawn", "brove", "fix the header bug"] });
+  });
+
+  it("requires a project and task for /spawn", () => {
+    expect(parseCommand("/spawn").kind).toBe("usage");
+    expect(parseCommand("/spawn brove").kind).toBe("usage");
+  });
+});

--- a/packages/core/src/telegram/commands.ts
+++ b/packages/core/src/telegram/commands.ts
@@ -1,0 +1,115 @@
+// Curated registry for the Telegram GENERAL command channel (#402). Pure logic:
+// parses "/cmd args" into a squadrant CLI argv vector — never a shell string. No
+// I/O, no execution (Task 5 wires argv → async execFile). Default-deny on
+// /config set: only WRITABLE_CONFIG_KEYS may be written over Telegram, so secrets
+// (botToken/users/chats/supergroupId) can never be set from the phone.
+//
+// argv tokens are verified against the real CLI (packages/cli/src/commands/):
+//   status → `status`, projects → `projects list`, crews → `crew list <p>`,
+//   launch → `launch <p>`, effort → `effort [mode]`, config → `config get|set`,
+//   spawn → `crew spawn <p> <task>`.
+
+export type ParsedCommand =
+  | { kind: "ok"; name: string; argv: string[] }     // argv to pass to the squadrant CLI
+  | { kind: "usage"; name: string; message: string } // known command, bad args
+  | { kind: "unknown"; message: string }             // not in registry / not a slash command
+  | { kind: "denied"; message: string };             // e.g. /config set on a protected key
+
+/** Default-deny allowlist of config keys writable over Telegram (#321). Starts
+ *  intentionally tiny; extend deliberately. Secrets are NEVER added here. */
+export const WRITABLE_CONFIG_KEYS: readonly string[] = ["defaults.effort"];
+
+const EFFORT_MODES = new Set(["max", "balance", "low"]);
+
+interface Entry {
+  /** Build the argv (or a usage/denied result) from the post-name token list. */
+  build(args: string[]): ParsedCommand;
+  usage: string;
+}
+
+function ok(name: string, argv: string[]): ParsedCommand {
+  return { kind: "ok", name, argv };
+}
+function usage(name: string, message: string): ParsedCommand {
+  return { kind: "usage", name, message };
+}
+
+const REGISTRY: Record<string, Entry> = {
+  status: { usage: "/status", build: () => ok("status", ["status"]) },
+  projects: { usage: "/projects", build: () => ok("projects", ["projects", "list"]) },
+  crews: {
+    usage: "/crews <project>",
+    build: (a) => (a[0] ? ok("crews", ["crew", "list", a[0]]) : usage("crews", "usage: /crews <project>")),
+  },
+  launch: {
+    usage: "/launch <project>",
+    build: (a) => (a[0] ? ok("launch", ["launch", a[0]]) : usage("launch", "usage: /launch <project>")),
+  },
+  effort: {
+    usage: "/effort [max|balance|low]",
+    build: (a) => {
+      if (a.length === 0) return ok("effort", ["effort"]);
+      if (!EFFORT_MODES.has(a[0])) return usage("effort", "usage: /effort [max|balance|low]");
+      return ok("effort", ["effort", a[0]]);
+    },
+  },
+  config: {
+    usage: "/config get <key> | /config set <key> <value>",
+    build: (a) => {
+      const sub = a[0];
+      if (sub === "get") {
+        const key = a[1];
+        if (!key) return usage("config", "usage: /config get <key>");
+        return ok("config", ["config", "get", key]);
+      }
+      if (sub === "set") {
+        const key = a[1];
+        const value = a.slice(2).join(" ");
+        if (!key || value === "") return usage("config", "usage: /config set <key> <value>");
+        if (!WRITABLE_CONFIG_KEYS.includes(key)) {
+          return {
+            kind: "denied",
+            message: `⛔ '${key}' is not writable over Telegram. Allowed: ${WRITABLE_CONFIG_KEYS.join(", ")}`,
+          };
+        }
+        return ok("config", ["config", "set", key, value]);
+      }
+      return usage("config", "usage: /config get <key> | /config set <key> <value>");
+    },
+  },
+  spawn: {
+    usage: "/spawn <project> <task...>",
+    build: (a) => {
+      const project = a[0];
+      const task = a.slice(1).join(" ");
+      if (!project || task === "") return usage("spawn", "usage: /spawn <project> <task...>");
+      return ok("spawn", ["crew", "spawn", project, task]);
+    },
+  },
+};
+
+function helpText(): string {
+  const lines = Object.values(REGISTRY).map((e) => `  ${e.usage}`);
+  return ["Available commands:", ...lines, "  /help"].join("\n");
+}
+
+/** Parse a raw Telegram message into a curated command. Non-slash text and
+ *  unregistered commands return `unknown`. */
+export function parseCommand(text: string): ParsedCommand {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("/")) {
+    return { kind: "unknown", message: "unknown command — send /help" };
+  }
+  const tokens = trimmed.slice(1).split(/\s+/).filter((t) => t.length > 0);
+  const name = (tokens[0] ?? "").toLowerCase();
+  const args = tokens.slice(1);
+
+  if (name === "help") {
+    return { kind: "usage", name: "help", message: helpText() };
+  }
+  const entry = REGISTRY[name];
+  if (!entry) {
+    return { kind: "unknown", message: `unknown command '/${name}' — send /help` };
+  }
+  return entry.build(args);
+}

--- a/packages/core/src/telegram/ensure-captain.test.ts
+++ b/packages/core/src/telegram/ensure-captain.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+import { createEnsureCaptainAlive } from "./ensure-captain.js";
+
+const fastSleep = () => Promise.resolve();
+
+describe("ensureCaptainAlive", () => {
+  it("returns alive immediately when captain is up", async () => {
+    const launch = vi.fn();
+    const ensure = createEnsureCaptainAlive({ isAlive: async () => true, launch, sleep: fastSleep });
+    expect(await ensure("p")).toBe("alive");
+    expect(launch).not.toHaveBeenCalled();
+  });
+
+  it("launches and returns launched when warmup succeeds", async () => {
+    let alive = false;
+    const launch = vi.fn(async () => { alive = true; });
+    const ensure = createEnsureCaptainAlive({ isAlive: async () => alive, launch, sleep: fastSleep });
+    expect(await ensure("p")).toBe("launched");
+    expect(launch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns timeout when warmup never completes", async () => {
+    let t = 0;
+    const ensure = createEnsureCaptainAlive({
+      isAlive: async () => false, launch: async () => {}, sleep: fastSleep,
+      warmupTimeoutMs: 50, pollMs: 10, now: () => (t += 20),
+    });
+    expect(await ensure("p")).toBe("timeout");
+  });
+
+  it("debounces concurrent calls into a single launch", async () => {
+    // launch flips `alive` synchronously: relying on setTimeout under a microtask-
+    // only `fastSleep` would starve the timer (the poll loop never yields to the
+    // macrotask queue). The debounce guard is set synchronously, so both calls
+    // share one launch regardless.
+    let alive = false;
+    const launch = vi.fn(async () => { alive = true; });
+    const ensure = createEnsureCaptainAlive({ isAlive: async () => alive, launch, sleep: fastSleep });
+    const [a, b] = await Promise.all([ensure("p"), ensure("p")]);
+    expect(launch).toHaveBeenCalledTimes(1);
+    expect([a, b].every((r) => r === "launched" || r === "alive")).toBe(true);
+  });
+});

--- a/packages/core/src/telegram/ensure-captain.ts
+++ b/packages/core/src/telegram/ensure-captain.ts
@@ -1,0 +1,56 @@
+// Boot-if-down capability for Telegram auto-launch (#403). Mirrors the
+// `group dispatch` warmup pattern (liveness probe → spawn `squadrant launch` →
+// bounded warmup poll) but as an injectable factory: deps are stubbed in tests
+// and wired from the daemon host (Task 5). The bridge stays decoupled from
+// captain lifecycle — it only sees the returned `ensure(project)` closure.
+//
+// Debounce: concurrent calls for the same project share ONE launch + poll loop
+// via an in-flight promise map, so a burst of inbound messages can't spawn N
+// captains. The map entry clears on resolution (alive | launched | timeout).
+
+export type EnsureResult = "alive" | "launched" | "timeout";
+
+export interface EnsureCaptainDeps {
+  isAlive: (project: string) => Promise<boolean>; // liveness probe
+  launch: (project: string) => Promise<void>;     // spawn `squadrant launch <project>`
+  warmupTimeoutMs?: number;                        // default 120_000
+  pollMs?: number;                                 // default 1_000
+  sleep?: (ms: number) => Promise<void>;           // injectable for tests
+  now?: () => number;                              // injectable for tests
+}
+
+const DEFAULT_WARMUP_TIMEOUT_MS = 120_000;
+const DEFAULT_POLL_MS = 1_000;
+const defaultSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+export function createEnsureCaptainAlive(
+  deps: EnsureCaptainDeps,
+): (project: string) => Promise<EnsureResult> {
+  const warmupTimeoutMs = deps.warmupTimeoutMs ?? DEFAULT_WARMUP_TIMEOUT_MS;
+  const pollMs = deps.pollMs ?? DEFAULT_POLL_MS;
+  const sleep = deps.sleep ?? defaultSleep;
+  const now = deps.now ?? (() => Date.now());
+
+  const inFlight = new Map<string, Promise<EnsureResult>>();
+
+  async function run(project: string): Promise<EnsureResult> {
+    if (await deps.isAlive(project)) return "alive";
+    await deps.launch(project);
+    const deadline = now() + warmupTimeoutMs;
+    while (now() < deadline) {
+      if (await deps.isAlive(project)) return "launched";
+      await sleep(pollMs);
+    }
+    return "timeout";
+  }
+
+  return function ensure(project: string): Promise<EnsureResult> {
+    // The guard is read+set synchronously (no await before set) so concurrent
+    // callers for the same project provably share a single launch.
+    const existing = inFlight.get(project);
+    if (existing) return existing;
+    const p = run(project).finally(() => inFlight.delete(project));
+    inFlight.set(project, p);
+    return p;
+  };
+}

--- a/packages/core/src/telegram/index.ts
+++ b/packages/core/src/telegram/index.ts
@@ -1,4 +1,5 @@
 // @squadrant/core Telegram subsystem barrel.
+export * from "./auth.js";
 export * from "./format.js";
 export * from "./state.js";
 export * from "./client.js";

--- a/packages/core/src/telegram/index.ts
+++ b/packages/core/src/telegram/index.ts
@@ -1,6 +1,7 @@
 // @squadrant/core Telegram subsystem barrel.
 export * from "./auth.js";
 export * from "./commands.js";
+export * from "./ensure-captain.js";
 export * from "./format.js";
 export * from "./state.js";
 export * from "./client.js";

--- a/packages/core/src/telegram/index.ts
+++ b/packages/core/src/telegram/index.ts
@@ -1,5 +1,6 @@
 // @squadrant/core Telegram subsystem barrel.
 export * from "./auth.js";
+export * from "./commands.js";
 export * from "./format.js";
 export * from "./state.js";
 export * from "./client.js";

--- a/packages/core/src/telegram/setup.ts
+++ b/packages/core/src/telegram/setup.ts
@@ -5,13 +5,14 @@ import fs from "node:fs";
 import type { TelegramClient } from "./client.js";
 
 /**
- * Poll getUpdates until a supergroup message arrives.
+ * Poll getUpdates until a supergroup message arrives, returning both the chat id
+ * and the sender's user id (the latter seeds the control allowlist, #321).
  * Injects `sleep` for testability; never used with real delays in tests.
  */
-export async function detectGroupId(
+export async function detectGroupAndUser(
   client: TelegramClient,
   opts: { timeoutMs?: number; sleep?: (ms: number) => Promise<void> } = {},
-): Promise<number> {
+): Promise<{ supergroupId: number; userId: number | undefined }> {
   const timeoutMs = opts.timeoutMs ?? 60_000;
   const sleep = opts.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
   const deadline = Date.now() + timeoutMs;
@@ -22,7 +23,7 @@ export async function detectGroupId(
     for (const u of updates) {
       if (u.update_id >= offset) offset = u.update_id + 1;
       if (u.message?.chat?.type === "supergroup") {
-        return u.message.chat.id;
+        return { supergroupId: u.message.chat.id, userId: u.message.from?.id };
       }
     }
     await sleep(2000);
@@ -31,13 +32,21 @@ export async function detectGroupId(
   throw new Error("Timed out waiting for the bot to receive a message in a supergroup");
 }
 
+/** Convenience wrapper that returns only the supergroup id. */
+export async function detectGroupId(
+  client: TelegramClient,
+  opts: { timeoutMs?: number; sleep?: (ms: number) => Promise<void> } = {},
+): Promise<number> {
+  return (await detectGroupAndUser(client, opts)).supergroupId;
+}
+
 /**
  * Write or update the telegram block in a squadrant config file.
  * Preserves all existing keys; creates the file with defaults if absent.
  */
 export function writeTelegramConfig(
   configPath: string,
-  opts: { token: string; supergroupId: number },
+  opts: { token: string; supergroupId: number; users?: number[]; remoteControl?: boolean },
 ): void {
   let config: Record<string, unknown>;
   let raw: string | null = null;
@@ -60,11 +69,20 @@ export function writeTelegramConfig(
     config = {};
   }
 
-  config.telegram = {
+  // Idempotent: re-running setup updates the token/group but preserves existing
+  // control fields (users/remoteControl) unless this run supplies new ones.
+  const prev = (config.telegram && typeof config.telegram === "object")
+    ? (config.telegram as Record<string, unknown>) : {};
+  const next: Record<string, unknown> = {
     botToken: opts.token,
     supergroupId: opts.supergroupId,
     chats: [opts.supergroupId],
   };
+  const users = opts.users ?? prev.users;
+  const remoteControl = opts.remoteControl ?? prev.remoteControl;
+  if (users !== undefined) next.users = users;
+  if (remoteControl !== undefined) next.remoteControl = remoteControl;
+  config.telegram = next;
 
   fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
 }

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -40,10 +40,12 @@ export interface CrewRoutingConfig {
 }
 
 export interface TelegramConfig {
-  botToken?: string;    // falls back to env TELEGRAM_BOT_TOKEN at read time
-  supergroupId: number; // forum supergroup hosting per-project topics
-  chats: number[];      // chat_id allowlist (inbound honored only from these)
-  pollMs?: number;      // getUpdates long-poll cadence (default 1000)
+  botToken?: string;       // falls back to env TELEGRAM_BOT_TOKEN at read time
+  supergroupId: number;    // forum supergroup hosting per-project topics
+  chats: number[];         // chat_id allowlist (inbound honored only from these)
+  users?: number[];        // user-id allowlist for CONTROL actions (#321); empty ⇒ control disabled
+  remoteControl?: boolean; // opt-in master switch for auto-launch + general commands (default false)
+  pollMs?: number;         // getUpdates long-poll cadence (default 1000)
 }
 
 export interface ModelRoutingConfig {


### PR DESCRIPTION
## Telegram v0.10 stability slice

Closes the squadrant-side of **#403**, the general-command facet of **#402**, and the user-id allowlist of **#321**. Builds on the v1 two-way integration (#397). Target release: **v0.10.0** (first npm release to include Telegram).

Makes the Telegram integration stable enough to release by closing two usability gaps — both gated behind a **fail-closed user-id allowlist + an opt-in `remoteControl` master switch**. `remoteControl` defaults to `false`, so **zero behavior change on upgrade**; existing v1 flows are unchanged when off.

### What changed (per the implementation plan, task-by-task with TDD)

1. **Config + auth (#321)** — `TelegramConfig` gains `users?: number[]` + `remoteControl?: boolean`. New `auth.ts` pure predicates: `isControlEnabled` / `isAuthorized`. Fail-closed — control acts only when `remoteControl === true` **and** `from.id ∈ users[]`; chat membership alone is never enough.
2. **Command registry (#402)** — `commands.ts` parses `/cmd args` into a validated CLI **argv vector** (never a shell string). `/config set` is restricted to a default-deny `WRITABLE_CONFIG_KEYS` allowlist (currently just `defaults.effort`), so secrets can't be written over Telegram.
3. **`ensureCaptainAlive` (#403)** — injectable boot-if-down: liveness probe → `squadrant launch` → bounded warmup poll, with a per-project debounce so a burst can't spawn N captains.
4. **Bridge routing (#402/#403)** — `handleUpdate` classifies by `message_thread_id`: General topic → curated command channel; project topic → captain.message + auto-launch. Auth-gated; no inbound handler error escapes the poll loop (at-least-once offset preserved).
5. **Daemon host wiring** — constructs `ensureCaptainAlive` / `runCommand` / `sendReply` and passes them in. **All shell-outs use async `execFile`** (no `*Sync` on the daemon poll path — event-loop starvation). Adds `config get` / `config set` CLI subcommands as the backend for `/config`.
6. **`telegram setup` wizard** — captures the operator's user-id and offers to enable `remoteControl`, writing `users` + `remoteControl` idempotently.
7. **Docs + changelog** — README Telegram section (command list + fail-closed security model + remote-wake note), CHANGELOG v0.10.0.

### Scope decisions (flagged, not guessed)
- **Added `config get`/`config set` CLI subcommands** — they didn't exist (config only had `check`), and the curated `/config` command needs a real backend. The Telegram write path stays hard-gated to `WRITABLE_CONFIG_KEYS`.
- **Deferred `/register`** from the v1 command set — no repo-clone `register` CLI command exists (`projects add` takes a local path), and the plan flagged its semantics as unresolved. Dropping it is fail-safe (less surface); easy follow-up.

### Constraints honored
- NodeNext ESM (`.js` on every relative import); `node dist/index.js --help` + `node dist/squadrantd.js --help` both exit 0 (print one-liner, don't boot).
- `remoteControl` default `false` ⇒ v1 parity verified by test.
- `/config set` rejects `telegram.botToken` / `users` / `chats` / `supergroupId`.

### Testing
- **Full suite: 1398/1398 passing** (129 files) — baseline 1358 + 40 new tests. One-shot `vitest run`.
- TDD throughout (RED→GREEN per task); fresh `pnpm install` + `pnpm build` clean.

> **Note:** GitNexus index is stale for the post-#397 telegram subsystem, so `gitnexus_impact`/`detect_changes` couldn't resolve the new symbols. Blast radius verified manually instead: all edits are additive optional config fields or private single-caller functions — risk LOW. A `npx gitnexus analyze` would refresh the index.
