### PR TITLE
feat(telegram): per-project notification gate — muted by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Telegram notifications are now per-project and muted by default.** Lifecycle events (crew done/blocked/idle) are delivered to a project's topic only after you engage that project — by sending any message into its topic, by `/unmute` (Telegram, requires remoteControl), or by `squadrant telegram notify <project> on`. This changes prior behavior where every project pushed all lifecycle events. Mute again with `/mute <project>` or `squadrant telegram notify <project> off`. Command replies and the General command channel are unaffected.
+
 ## [0.10.0] - 2026-06-23
 
 The Telegram stability slice — closes two usability gaps so the integration is solid enough to release, both gated behind a fail-closed user-id allowlist + an opt-in master switch. Default behavior is unchanged on upgrade (`remoteControl` defaults to `false`).

--- a/docs/superpowers/plans/2026-06-23-telegram-notification-gate.md
+++ b/docs/superpowers/plans/2026-06-23-telegram-notification-gate.md
@@ -1,0 +1,558 @@
+# Telegram Per-Project Notification Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Gate outbound Telegram lifecycle notifications per-project — muted by default, auto-unmuted when the user messages into a project topic, with manual `/mute`/`/unmute` (Telegram) and `squadrant telegram notify` (CLI) toggles.
+
+**Architecture:** Add a per-project `notify` flag to the existing `telegram-state.json`. A synchronous early-return gate in `deliverOutbound` drops lifecycle events for muted projects (no network call). Inbound messages into a project topic flip the project active (auto-unmute). Manual toggles route through the existing fail-closed command surfaces — General-topic `/mute <project>` reuses the curated CLI argv channel; in-topic `/mute` is handled directly in the bridge.
+
+**Tech Stack:** TypeScript (NodeNext ESM — relative imports MUST end in `.js`), vitest, commander.
+
+## Global Constraints
+
+- **ESM `.js` extensions:** every relative import in `.ts` source MUST end in `.js` (NodeNext). Missing it compiles but crashes at runtime.
+- **Default muted:** a project absent from `state.notify` (or `false`) is MUTED. No config schema change, no migration, no backfill.
+- **Fail-closed Telegram toggles:** `/mute` and `/unmute` run ONLY when `isControlEnabled(cfg) && isAuthorized(fromId, cfg)`. Auto-unmute-on-message is independent of `remoteControl` (gated only by the existing `cfg.chats` coarse filter).
+- **Gate scope:** only auto-pushed lifecycle events (`pushLifecycle`/`deliverOutbound`) are gated. Command replies and the General command channel are never gated.
+- **Single-file test runs:** `npx vitest run <path>` (the bare `vitest` script is watch mode). Do not run the full suite repeatedly.
+- **Exports:** `packages/core/src/telegram/index.ts` does `export * from "./state.js"`, re-exported by `packages/core/src/index.ts`. New `state.ts` exports are automatically available as `@squadrant/core` imports.
+
+---
+
+### Task 1: `notify` state field + helpers
+
+**Files:**
+- Modify: `packages/core/src/telegram/state.ts`
+- Test: `packages/core/src/telegram/__tests__/state.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `interface TelegramState { offset: number; topics: Record<string, number>; notify: Record<string, boolean> }`
+  - `isNotifyActive(stateRoot: string, project: string): boolean` — `true` iff `state.notify[project] === true`
+  - `setNotify(stateRoot: string, project: string, active: boolean): void` — read-modify-write, mirrors `setTopic`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/core/src/telegram/__tests__/state.test.ts` (reuse the file's existing tmp-dir helper; if none, create a tmp dir per test with `fs.mkdtempSync(path.join(os.tmpdir(), "tg-state-"))`):
+
+```ts
+import { isNotifyActive, setNotify } from "../state.js";
+
+describe("notify state", () => {
+  it("defaults to muted (absent key → false)", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tg-state-"));
+    expect(isNotifyActive(dir, "squadrant")).toBe(false);
+  });
+
+  it("loadState defaults notify to {} when file lacks it", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tg-state-"));
+    fs.writeFileSync(path.join(dir, "telegram-state.json"), JSON.stringify({ offset: 3, topics: {} }));
+    expect(loadState(dir).notify).toEqual({});
+  });
+
+  it("setNotify round-trips through save/load", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tg-state-"));
+    setNotify(dir, "squadrant", true);
+    expect(isNotifyActive(dir, "squadrant")).toBe(true);
+    setNotify(dir, "squadrant", false);
+    expect(isNotifyActive(dir, "squadrant")).toBe(false);
+  });
+
+  it("setNotify preserves offset and topics", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tg-state-"));
+    setTopic(dir, "squadrant", 7);
+    setNotify(dir, "squadrant", true);
+    const s = loadState(dir);
+    expect(s.topics).toEqual({ "squadrant::project": 7 });
+    expect(s.notify).toEqual({ squadrant: true });
+  });
+});
+```
+
+Ensure `fs`, `path`, `os`, `loadState`, `setTopic` are imported at the top of the test file (add any missing).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run packages/core/src/telegram/__tests__/state.test.ts`
+Expected: FAIL — `isNotifyActive`/`setNotify` not exported.
+
+- [ ] **Step 3: Implement in `state.ts`**
+
+Add `notify` to the interface:
+
+```ts
+export interface TelegramState {
+  offset: number;
+  /** key = `${project}::${scope}` (see topicKey); value = message_thread_id. */
+  topics: Record<string, number>;
+  /** key = project; value = true when active. Absent/false = MUTED (default). */
+  notify: Record<string, boolean>;
+}
+```
+
+In `loadState`, default the field:
+
+```ts
+return {
+  offset: typeof data.offset === "number" ? data.offset : 0,
+  topics: data.topics ?? {},
+  notify: data.notify ?? {},
+};
+```
+
+Add helpers (after `setTopic`):
+
+```ts
+export function isNotifyActive(stateRoot: string, project: string): boolean {
+  return loadState(stateRoot).notify[project] === true;
+}
+
+export function setNotify(stateRoot: string, project: string, active: boolean): void {
+  const s = loadState(stateRoot);
+  s.notify[project] = active;
+  saveState(stateRoot, s);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run packages/core/src/telegram/__tests__/state.test.ts`
+Expected: PASS (all notify tests + pre-existing state tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/telegram/state.ts packages/core/src/telegram/__tests__/state.test.ts
+git commit -m "feat(telegram): per-project notify flag in telegram-state"
+```
+
+---
+
+### Task 2: CLI `telegram notify` subcommand
+
+**Files:**
+- Modify: `packages/cli/src/commands/telegram.ts`
+- Test: `packages/cli/src/commands/__tests__/telegram.test.ts`
+
+**Interfaces:**
+- Consumes: `isNotifyActive`, `setNotify`, `loadState` from `@squadrant/core`
+- Produces:
+  - `runTelegramNotifySet(opts: { project: string; active: boolean; stateRoot: string }): void`
+  - `runTelegramNotifyStatus(opts: { stateRoot: string }): Array<{ project: string; active: boolean }>`
+  - CLI: `squadrant telegram notify <project> <on|off>` and `squadrant telegram notify --status` (also: no args → status)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/cli/src/commands/__tests__/telegram.test.ts` (match its existing import style and tmp-dir helper):
+
+```ts
+import { runTelegramNotifySet, runTelegramNotifyStatus } from "../telegram.js";
+import { isNotifyActive, setTopic } from "@squadrant/core";
+
+describe("telegram notify CLI", () => {
+  it("runTelegramNotifySet writes the flag", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tg-cli-"));
+    runTelegramNotifySet({ project: "squadrant", active: true, stateRoot: dir });
+    expect(isNotifyActive(dir, "squadrant")).toBe(true);
+    runTelegramNotifySet({ project: "squadrant", active: false, stateRoot: dir });
+    expect(isNotifyActive(dir, "squadrant")).toBe(false);
+  });
+
+  it("runTelegramNotifyStatus lists known projects (from topics ∪ notify)", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tg-cli-"));
+    setTopic(dir, "alpha", 1);          // linked but never toggled → muted
+    runTelegramNotifySet({ project: "beta", active: true, stateRoot: dir });
+    const rows = runTelegramNotifyStatus({ stateRoot: dir }).sort((a, b) => a.project.localeCompare(b.project));
+    expect(rows).toEqual([
+      { project: "alpha", active: false },
+      { project: "beta", active: true },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run packages/cli/src/commands/__tests__/telegram.test.ts`
+Expected: FAIL — `runTelegramNotifySet`/`runTelegramNotifyStatus` not exported.
+
+- [ ] **Step 3: Implement the helpers + subcommand**
+
+In `packages/cli/src/commands/telegram.ts`, extend the existing `@squadrant/core` import to include `isNotifyActive, setNotify` (it already imports `loadState, setTopic, topicKey`).
+
+Add the helper functions (near `runTelegramStatus`):
+
+```ts
+/** Set a project's notification flag in telegram-state.json. */
+export function runTelegramNotifySet(opts: { project: string; active: boolean; stateRoot: string }): void {
+  setNotify(opts.stateRoot, opts.project, opts.active);
+}
+
+/** List every known project (union of linked topics and notify keys) with its state. */
+export function runTelegramNotifyStatus(opts: { stateRoot: string }): Array<{ project: string; active: boolean }> {
+  const s = loadState(opts.stateRoot);
+  const projects = new Set<string>();
+  for (const key of Object.keys(s.topics)) {
+    const sep = key.indexOf("::");
+    projects.add(sep === -1 ? key : key.slice(0, sep));
+  }
+  for (const p of Object.keys(s.notify)) projects.add(p);
+  return [...projects].map((project) => ({ project, active: s.notify[project] === true }));
+}
+```
+
+Register the subcommand (after the `link` command block):
+
+```ts
+telegramCommand
+  .command("notify")
+  .argument("[project]", "project to toggle")
+  .argument("[state]", "on | off")
+  .option("--status", "list notification state for all projects")
+  .description("Per-project lifecycle notifications: on|off, or --status to list")
+  .action((project: string | undefined, state: string | undefined, opts: { status?: boolean }) => {
+    const stateRoot = defaultStateRoot();
+    if (opts.status || !project) {
+      const rows = runTelegramNotifyStatus({ stateRoot });
+      if (rows.length === 0) {
+        console.log("no projects linked");
+        return;
+      }
+      for (const r of rows) {
+        console.log(`  ${r.project}: ${r.active ? chalk.green("on") : chalk.dim("off (muted)")}`);
+      }
+      return;
+    }
+    if (state !== "on" && state !== "off") {
+      console.error(chalk.red("usage: squadrant telegram notify <project> <on|off>"));
+      process.exit(1);
+    }
+    runTelegramNotifySet({ project, active: state === "on", stateRoot });
+    console.log(chalk.green(`${project} notifications ${state === "on" ? "ON" : "OFF"}`));
+  });
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run packages/cli/src/commands/__tests__/telegram.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Verify the CLI wiring compiles & runs**
+
+Run: `pnpm build && node dist/index.js telegram notify --help`
+Expected: help text for the `notify` subcommand prints (no crash — guards the ESM `.js` extension rule).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cli/src/commands/telegram.ts packages/cli/src/commands/__tests__/telegram.test.ts
+git commit -m "feat(telegram): squadrant telegram notify <project> on|off + --status"
+```
+
+---
+
+### Task 3: Outbound gate in `deliverOutbound`
+
+**Files:**
+- Modify: `packages/core/src/telegram/bridge.ts`
+- Test: `packages/core/src/telegram/__tests__/bridge.test.ts`
+
+**Interfaces:**
+- Consumes: `isNotifyActive` from `./state.js`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `packages/core/src/telegram/__tests__/bridge.test.ts`, follow the file's existing harness (a fake `TelegramClient` recording calls + a tmp `stateRoot`). Add:
+
+```ts
+it("pushLifecycle drops the event when the project is MUTED (no client calls)", async () => {
+  // bridge built with the file's existing makeBridge/fakeClient helper
+  bridge.pushLifecycle("squadrant", { kind: "task.idle", /* …minimal ControlEvent… */ } as any);
+  await flush(); // the file's existing microtask flush for fire-and-forget
+  expect(fakeClient.createForumTopic).not.toHaveBeenCalled();
+  expect(fakeClient.sendMessage).not.toHaveBeenCalled();
+});
+
+it("pushLifecycle delivers when the project is ACTIVE", async () => {
+  setNotify(stateRoot, "squadrant", true);
+  fakeClient.createForumTopic.mockResolvedValue(7);
+  bridge.pushLifecycle("squadrant", { kind: "task.idle" } as any);
+  await flush();
+  expect(fakeClient.sendMessage).toHaveBeenCalledTimes(1);
+});
+```
+
+Import `setNotify` from `../state.js` in the test. Reuse the existing `ControlEvent` shape already used elsewhere in this test file (copy a valid event literal rather than inventing fields).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run packages/core/src/telegram/__tests__/bridge.test.ts`
+Expected: FAIL — muted project still calls `sendMessage` (gate not present).
+
+- [ ] **Step 3: Implement the gate**
+
+In `bridge.ts`, add `isNotifyActive` to the `./state.js` import. Gate at the top of `deliverOutbound`:
+
+```ts
+async function deliverOutbound(project: string, ev: ControlEvent): Promise<void> {
+  if (!isNotifyActive(stateRoot, project)) return; // muted (default) → no topic create, no send
+  let threadId = loadState(stateRoot).topics[topicKey(project)];
+  // …unchanged…
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run packages/core/src/telegram/__tests__/bridge.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/telegram/bridge.ts packages/core/src/telegram/__tests__/bridge.test.ts
+git commit -m "feat(telegram): gate outbound lifecycle on per-project notify flag"
+```
+
+---
+
+### Task 4: Auto-unmute + in-topic `/mute`·`/unmute` routing
+
+**Files:**
+- Modify: `packages/core/src/telegram/bridge.ts`
+- Test: `packages/core/src/telegram/__tests__/bridge.test.ts`
+
+**Interfaces:**
+- Consumes: `setNotify` from `./state.js`; `isControlEnabled`, `isAuthorized` from `./auth.js` (already imported)
+
+**Behavior of `handleProjectTopic(text, threadId, fromId)`:**
+1. Resolve project via `findProjectByThread`; return if none.
+2. If the trimmed text's first token is `/mute` or `/unmute` (case-insensitive): this is a toggle, not a message.
+   - If `isControlEnabled(cfg) && isAuthorized(fromId, cfg)`: `setNotify(project, /unmute→true | /mute→false)`, then `reply(threadId, "🔔 <project> notifications ON" | "🔕 <project> notifications OFF")`.
+   - Else: `reply(threadId, "⛔ not authorized")`.
+   - **Return without appending** a captain.message and without auto-unmuting.
+3. Otherwise (a normal message): `setNotify(project, true)` (auto-unmute), then the existing `ensureCaptainAlive` (gated) + `appendCaptainMessage` flow — unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `bridge.test.ts` (reuse the existing inbound-update harness — the helper that feeds a fake `getUpdates` result through the poll loop, or calls the exported handler if the file exposes one):
+
+```ts
+it("auto-unmutes a project when a normal message lands in its topic", async () => {
+  setTopic(stateRoot, "squadrant", 7);
+  await deliverInbound({ message: { chat: { id: CHAT_ID }, message_thread_id: 7, text: "hello", from: { id: USER_ID } } });
+  expect(isNotifyActive(stateRoot, "squadrant")).toBe(true);
+  expect(appendCaptainMessage).toHaveBeenCalledTimes(1);
+});
+
+it("auto-unmute works even when remoteControl is OFF", async () => {
+  // cfg.remoteControl = false in this bridge instance
+  setTopic(stateRoot, "squadrant", 7);
+  await deliverInbound({ message: { chat: { id: CHAT_ID }, message_thread_id: 7, text: "hi", from: { id: USER_ID } } });
+  expect(isNotifyActive(stateRoot, "squadrant")).toBe(true);
+});
+
+it("/unmute in a project topic toggles ON and does NOT append a captain message (authorized)", async () => {
+  // cfg.remoteControl = true, cfg.users = [USER_ID]
+  setTopic(stateRoot, "squadrant", 7);
+  setNotify(stateRoot, "squadrant", false);
+  await deliverInbound({ message: { chat: { id: CHAT_ID }, message_thread_id: 7, text: "/unmute", from: { id: USER_ID } } });
+  expect(isNotifyActive(stateRoot, "squadrant")).toBe(true);
+  expect(appendCaptainMessage).not.toHaveBeenCalled();
+  expect(sendReply).toHaveBeenCalled();
+});
+
+it("/mute in a project topic is rejected (and not appended) when remoteControl is OFF", async () => {
+  // cfg.remoteControl = false
+  setTopic(stateRoot, "squadrant", 7);
+  setNotify(stateRoot, "squadrant", true);
+  await deliverInbound({ message: { chat: { id: CHAT_ID }, message_thread_id: 7, text: "/mute", from: { id: USER_ID } } });
+  expect(isNotifyActive(stateRoot, "squadrant")).toBe(true); // unchanged — toggle refused
+  expect(appendCaptainMessage).not.toHaveBeenCalled();
+  expect(sendReply).toHaveBeenCalledWith(7, expect.stringContaining("not authorized"));
+});
+```
+
+Use the test file's actual harness names — `deliverInbound`/`CHAT_ID`/`USER_ID`/`sendReply`/`appendCaptainMessage` here are placeholders for whatever the file already defines. If the file exercises inbound only through `getUpdates`, drive these through that same path.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run packages/core/src/telegram/__tests__/bridge.test.ts`
+Expected: FAIL — no auto-unmute, `/mute` text appended as a captain message.
+
+- [ ] **Step 3: Implement**
+
+Add `setNotify` to the `./state.js` import in `bridge.ts`. Add a small helper above `handleProjectTopic`:
+
+```ts
+// Recognize the two in-topic notification toggles. Returns the desired active
+// state, or null if the text is an ordinary message.
+function notifyToggle(text: string): boolean | null {
+  const first = text.trim().split(/\s+/)[0]?.toLowerCase();
+  if (first === "/unmute") return true;
+  if (first === "/mute") return false;
+  return null;
+}
+```
+
+Rewrite `handleProjectTopic`:
+
+```ts
+async function handleProjectTopic(text: string, threadId: number, fromId: number | undefined): Promise<void> {
+  const resolved = findProjectByThread(stateRoot, threadId);
+  if (!resolved) return; // no project bound to this topic
+
+  const toggle = notifyToggle(text);
+  if (toggle !== null) {
+    // Explicit toggle command — fail-closed, never appended as a captain message.
+    if (!isControlEnabled(cfg) || !isAuthorized(fromId, cfg)) {
+      await reply(threadId, "⛔ not authorized");
+      return;
+    }
+    setNotify(stateRoot, resolved.project, toggle);
+    await reply(threadId, toggle ? `🔔 ${resolved.project} notifications ON` : `🔕 ${resolved.project} notifications OFF`);
+    return;
+  }
+
+  setNotify(stateRoot, resolved.project, true); // engagement → auto-unmute (sticky)
+  if (ensureCaptainAlive && isControlEnabled(cfg) && isAuthorized(fromId, cfg)) {
+    try {
+      const r = await ensureCaptainAlive(resolved.project);
+      if (r === "timeout") await reply(threadId, "⚠️ captain didn't warm up; message queued.");
+    } catch (e) {
+      log(`telegram auto-launch failed project=${resolved.project}: ${(e as Error).message}`);
+    }
+  }
+  await appendCaptainMessage({ stateRoot, project: resolved.project, text: formatInbound(text), source: "telegram" });
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run packages/core/src/telegram/__tests__/bridge.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/telegram/bridge.ts packages/core/src/telegram/__tests__/bridge.test.ts
+git commit -m "feat(telegram): auto-unmute on inbound + in-topic /mute /unmute toggle"
+```
+
+---
+
+### Task 5: General-topic `/mute <project>` · `/unmute <project>` in the command registry
+
+**Files:**
+- Modify: `packages/core/src/telegram/commands.ts`
+- Test: `packages/core/src/telegram/commands.test.ts`
+
+**Interfaces:**
+- Produces: registry entries `mute` → argv `["telegram","notify",<project>,"off"]`, `unmute` → argv `["telegram","notify",<project>,"on"]` (require a `<project>` arg; the General topic has no thread to infer from).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/core/src/telegram/commands.test.ts` (match its existing `parseCommand` test style):
+
+```ts
+it("/unmute <project> → telegram notify <project> on", () => {
+  expect(parseCommand("/unmute squadrant")).toEqual({ kind: "ok", name: "unmute", argv: ["telegram", "notify", "squadrant", "on"] });
+});
+
+it("/mute <project> → telegram notify <project> off", () => {
+  expect(parseCommand("/mute squadrant")).toEqual({ kind: "ok", name: "mute", argv: ["telegram", "notify", "squadrant", "off"] });
+});
+
+it("/mute with no project → usage", () => {
+  expect(parseCommand("/mute")).toEqual({ kind: "usage", name: "mute", message: "usage: /mute <project>" });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run packages/core/src/telegram/commands.test.ts`
+Expected: FAIL — `/mute`/`/unmute` return `unknown`.
+
+- [ ] **Step 3: Implement the registry entries**
+
+In `commands.ts`, add to `REGISTRY` (alongside the other entries):
+
+```ts
+mute: {
+  usage: "/mute <project>",
+  build: (a) => (a[0] ? ok("mute", ["telegram", "notify", a[0], "off"]) : usage("mute", "usage: /mute <project>")),
+},
+unmute: {
+  usage: "/unmute <project>",
+  build: (a) => (a[0] ? ok("unmute", ["telegram", "notify", a[0], "on"]) : usage("unmute", "usage: /unmute <project>")),
+},
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run packages/core/src/telegram/commands.test.ts`
+Expected: PASS. `/help` now lists `/mute <project>` and `/unmute <project>` automatically (helpText derives from REGISTRY).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/telegram/commands.ts packages/core/src/telegram/commands.test.ts
+git commit -m "feat(telegram): /mute /unmute <project> in General command registry"
+```
+
+---
+
+### Task 6: Full build, suite, CHANGELOG, docs
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Verify: whole repo build + test
+
+- [ ] **Step 1: Clean build**
+
+Run: `pnpm build`
+Expected: build succeeds; `dist/index.js` + `dist/squadrantd.js` emitted.
+
+- [ ] **Step 2: Smoke-test the CLI surface**
+
+Run: `node dist/index.js telegram notify --status`
+Expected: prints linked-project notify states (or "no projects linked") — no crash.
+
+- [ ] **Step 3: Full test suite once**
+
+Run: `npx vitest run`
+Expected: PASS (no regressions; new tests included). Run ONCE — do not loop the suite.
+
+- [ ] **Step 4: CHANGELOG entry (behavior change)**
+
+Add under the next unreleased heading in `CHANGELOG.md`:
+
+```markdown
+### Changed
+- **Telegram notifications are now per-project and muted by default.** Lifecycle events (crew done/blocked/idle) are delivered to a project's topic only after you engage that project — by sending any message into its topic, by `/unmute` (Telegram, requires remoteControl), or by `squadrant telegram notify <project> on`. This changes prior behavior where every project pushed all lifecycle events. Mute again with `/mute <project>` or `squadrant telegram notify <project> off`. Command replies and the General command channel are unaffected.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(telegram): changelog for per-project notification gate"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- State / `notify` field + helpers → Task 1 ✓
+- Outbound gate (muted = no send) → Task 3 ✓
+- Auto-unmute on inbound (remoteControl-independent) → Task 4 ✓
+- Sticky lifetime (no timers) → inherent (on-disk flag, no expiry) ✓
+- Telegram in-topic `/mute`·`/unmute` (fail-closed) → Task 4 ✓
+- Telegram General `/mute <project>`·`/unmute <project>` → Task 5 ✓
+- CLI `notify <project> on|off` + `--status` → Task 2 ✓
+- Backward-compat CHANGELOG note → Task 6 ✓
+- Replies/General channel never gated → preserved (gate only in `deliverOutbound`) ✓
+
+**Type consistency:** `isNotifyActive`/`setNotify`/`notify` field used identically across Tasks 1–4; registry argv `["telegram","notify",<project>,"on|off"]` (Task 5) matches the CLI subcommand signature `<project> <on|off>` (Task 2). ✓
+
+**Placeholder scan:** test-harness identifiers in Tasks 3–4 (`deliverInbound`, `flush`, `CHAT_ID`, `USER_ID`, `fakeClient`, `appendCaptainMessage`, `sendReply`) are explicitly flagged as placeholders to map onto the existing `bridge.test.ts` harness — not invented production symbols. All production code is shown in full.

--- a/docs/superpowers/specs/2026-06-23-telegram-notification-gate-design.md
+++ b/docs/superpowers/specs/2026-06-23-telegram-notification-gate-design.md
@@ -1,0 +1,179 @@
+# Telegram Per-Project Notification Gate — Design
+
+**Date:** 2026-06-23
+**Status:** Approved (design); pending spec review → implementation plan
+**Scope:** `@squadrant/core` telegram subsystem + `@squadrant/cli` telegram command
+**Relates to:** v0.10.0 Telegram stability (#321/#402/#403), composes with side-1 research on TG message buildup
+
+## Problem
+
+The daemon pushes every crew lifecycle event (done / blocked / idle) to that project's
+Telegram topic via `pushLifecycle` → `deliverOutbound` (`packages/core/src/telegram/bridge.ts`).
+This is **unconditional**: as soon as a project has activity, its topic fills with
+notifications whether or not the user is paying attention to that project right now.
+
+The user wants notifications to flow **only when they are engaged** with a project —
+i.e. notifications are OFF by default and turn ON when the user either (a) sends a
+message into that project's Telegram topic, or (b) flips them on explicitly.
+
+## Goals
+
+- Per-project mute gate in front of the **outbound lifecycle** path only.
+- Default **muted** — fresh / never-toggled projects send nothing.
+- **Auto-unmute** a project when the user messages into its topic.
+- **Sticky** lifetime — once active, stays active until explicitly muted.
+- Manual toggle from **both** Telegram (`/mute`, `/unmute`) and the **CLI**.
+
+## Non-Goals (YAGNI)
+
+- No global master switch (per-project only — confirmed with user).
+- No timers / quiet-window auto-re-mute (sticky only).
+- No `TelegramConfig` schema change / config migration.
+- No change to command-reply delivery — replies to user commands always go through;
+  only auto-pushed **lifecycle** events are gated.
+- Cleanup of **existing** topic clutter (delete/coalesce/digest) is out of scope here —
+  tracked separately by the side-1 research thread. The two features compose: this gate
+  stops *new* clutter; that research handles *existing* clutter.
+
+## Design
+
+### 1. State
+
+Per-project notification flag persisted in the existing `telegram-state.json`
+(alongside `offset` + `topics`):
+
+```jsonc
+{
+  "offset": 12345,
+  "topics": { "squadrant::project": 7 },
+  "notify": { "squadrant": true }   // present & true = ACTIVE; absent or false = MUTED
+}
+```
+
+- **Absent key = muted** (the default). No backfill, no migration.
+- `TelegramState` interface gains `notify: Record<string, boolean>`; `loadState`
+  defaults it to `{}`; `saveState` persists it.
+- New helpers in `state.ts`:
+  - `isNotifyActive(stateRoot, project): boolean` — `state.notify[project] === true`.
+  - `setNotify(stateRoot, project, active: boolean): void` — read-modify-write
+    (mirrors `setTopic`).
+
+### 2. The gate (outbound)
+
+In `bridge.ts`, gate **before** any network call inside the outbound path:
+
+```ts
+function deliverOutbound(project, ev) {
+  if (!isNotifyActive(stateRoot, project)) return;  // muted → drop, no topic creation
+  // …existing lazy-topic-create + sendMessage…
+}
+```
+
+Placing the check first means a muted project triggers **no** `createForumTopic`
+and **no** `sendMessage` — nothing reaches the phone. `pushLifecycle` stays
+fire-and-forget; the gate is a synchronous early-return.
+
+### 3. Auto-unmute (inbound)
+
+In `handleProjectTopic` (`bridge.ts`), when an inbound message lands in a project
+topic, mark that project active **before** appending the captain message:
+
+```ts
+async function handleProjectTopic(text, threadId, fromId) {
+  const resolved = findProjectByThread(stateRoot, threadId);
+  if (!resolved) return;
+  setNotify(stateRoot, resolved.project, true);   // ← engagement = unmute (sticky)
+  // …existing ensureCaptainAlive (gated) + appendCaptainMessage…
+}
+```
+
+- **Independent of `remoteControl`.** Auto-unmute fires for any inbound that passes
+  the coarse chat allowlist (`cfg.chats.includes(chat.id)`), the same filter v1 already
+  applies before appending a captain message. Rationale: receiving the user's message
+  *is* the engagement signal; gating it behind `remoteControl` would leave the user
+  messaging into a silent topic. This guarantees the user is never stuck muted — a
+  message always reopens the channel.
+
+### 4. Manual toggle — two surfaces
+
+**Telegram** (`commands.ts` registry + `bridge.ts` routing):
+- `/unmute` / `/mute` **inside a project topic** (message has a `message_thread_id`):
+  resolve the project via `findProjectByThread`, toggle it.
+- `/mute <project>` / `/unmute <project>` **from the General topic** (no thread id):
+  explicit project argument.
+- **Fail-closed** (confirmed with user): these are explicit commands and follow the
+  existing command rule — they run only when `isControlEnabled(cfg)` **and**
+  `isAuthorized(fromId, cfg)`. When unauthorized: `⛔ not authorized` (same as other
+  commands). The user is still never stuck, because auto-unmute-on-message (§3) works
+  without `remoteControl`.
+- On success, reply with confirmation, e.g. `🔔 squadrant notifications ON` /
+  `🔕 squadrant notifications OFF`.
+
+> Routing note: `/mute` and `/unmute` are the first commands that are also valid
+> **inside a project topic** (today the project topic only does captain.message +
+> auto-launch). `handleProjectTopic` must recognize these two commands and route them
+> to the toggle instead of appending them as a captain message. All other `/`-text in a
+> project topic keeps current behavior (appended as captain.message). Keep this
+> allowlist explicit and minimal.
+
+**CLI** (`packages/cli/src/commands/telegram.ts`):
+- `squadrant telegram notify <project> on|off` — set the flag (writes `telegram-state.json`
+  under the resolved `stateRoot`).
+- `squadrant telegram notify --status` (or `squadrant telegram notify` with no args) —
+  list each known project's state (active / muted), derived from `state.notify` plus
+  known topics.
+- Works regardless of `remoteControl` — local operator escape hatch.
+
+### 5. Sticky lifetime
+
+No timers. Active persists until `/mute` or `notify off`. A daemon restart preserves
+state (it's on disk in `telegram-state.json`).
+
+## Behavior matrix
+
+| remoteControl | User messages in topic | Telegram `/unmute` | CLI `notify on` |
+|---|---|---|---|
+| OFF (default) | ✅ unmutes (sticky) | ⛔ unauthorized | ✅ works |
+| ON + allowlisted | ✅ unmutes | ✅ works | ✅ works |
+
+Lifecycle delivery after gating:
+
+| Project state | `pushLifecycle` result |
+|---|---|
+| muted (default / `/mute` / `notify off`) | dropped — no topic create, no send |
+| active (messaged-in / `/unmute` / `notify on`) | delivered as today |
+
+## Backward-compatibility note
+
+This **changes v0.10 behavior**: previously every project sent all lifecycle events;
+now a project is silent until engaged. This is the explicitly requested behavior
+(muted-by-default). Documented in CHANGELOG as a behavior change, not a silent one.
+Command replies and the General command channel are unaffected.
+
+## Components touched
+
+| File | Change |
+|---|---|
+| `packages/core/src/telegram/state.ts` | `notify` field + `isNotifyActive` / `setNotify` |
+| `packages/core/src/telegram/bridge.ts` | gate in `deliverOutbound`; auto-unmute + `/mute`/`/unmute` routing in `handleProjectTopic`; General-topic toggle in `handleGeneral` |
+| `packages/core/src/telegram/commands.ts` | parse `/mute` / `/unmute` (optional `<project>` arg) |
+| `packages/cli/src/commands/telegram.ts` | `notify <project> on|off` + `notify --status` subcommand |
+| tests | state defaults/round-trip; gate drops when muted; auto-unmute on inbound; fail-closed toggle; CLI subcommand |
+
+## Testing strategy
+
+- **state**: `notify` defaults to `{}`; `isNotifyActive` false when absent; `setNotify`
+  round-trips through save/load.
+- **gate**: muted project → `deliverOutbound` makes zero client calls; active project →
+  sends as before.
+- **auto-unmute**: inbound to a project topic flips `notify[project]` true and still
+  appends the captain message; works with `remoteControl` OFF.
+- **toggle (Telegram)**: `/unmute` in-topic and `/mute <project>` from General flip
+  state when authorized; rejected `⛔ not authorized` when control off / not allowlisted;
+  a `/mute` in a project topic is NOT appended as a captain message.
+- **toggle (CLI)**: `notify on|off` writes state; `--status` lists states.
+
+## Open questions
+
+None remaining — all design decisions confirmed with the user
+(per-project · muted-by-default · sticky · both surfaces · fail-closed Telegram toggle).

--- a/packages/cli/src/commands/__tests__/telegram.test.ts
+++ b/packages/cli/src/commands/__tests__/telegram.test.ts
@@ -23,9 +23,9 @@ function fakeClient(onCreate?: () => void) {
 }
 
 describe("telegramCommand registration", () => {
-  it("exposes the link, send, setup, and status subcommands", () => {
+  it("exposes the link, notify, send, setup, and status subcommands", () => {
     const names = telegramCommand.commands.map((c) => c.name()).sort();
-    expect(names).toEqual(["link", "send", "setup", "status"]);
+    expect(names).toEqual(["link", "notify", "send", "setup", "status"]);
   });
 });
 
@@ -96,6 +96,30 @@ describe("runTelegramSend", () => {
     const client = fakeClient();
     await expect(runTelegramSend({ project: "nope", message: "hi", cfg, client, stateRoot: root }))
       .rejects.toThrow('project "nope" is not linked — run: squadrant telegram link nope');
+  });
+});
+
+import { runTelegramNotifySet, runTelegramNotifyStatus } from "../telegram.js";
+import { isNotifyActive, setTopic as setTopicDirect } from "@squadrant/core";
+
+describe("telegram notify CLI", () => {
+  it("runTelegramNotifySet writes the flag", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tg-cli-"));
+    runTelegramNotifySet({ project: "squadrant", active: true, stateRoot: dir });
+    expect(isNotifyActive(dir, "squadrant")).toBe(true);
+    runTelegramNotifySet({ project: "squadrant", active: false, stateRoot: dir });
+    expect(isNotifyActive(dir, "squadrant")).toBe(false);
+  });
+
+  it("runTelegramNotifyStatus lists known projects (from topics ∪ notify)", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tg-cli-"));
+    setTopicDirect(dir, "alpha", 1);
+    runTelegramNotifySet({ project: "beta", active: true, stateRoot: dir });
+    const rows = runTelegramNotifyStatus({ stateRoot: dir }).sort((a, b) => a.project.localeCompare(b.project));
+    expect(rows).toEqual([
+      { project: "alpha", active: false },
+      { project: "beta", active: true },
+    ]);
   });
 });
 

--- a/packages/cli/src/commands/telegram.ts
+++ b/packages/cli/src/commands/telegram.ts
@@ -4,7 +4,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { loadConfig, DEFAULT_CONFIG_PATH } from "@squadrant/shared";
 import type { SquadrantConfig, TelegramConfig } from "@squadrant/shared";
-import { createTelegramClient, loadState, setTopic, topicKey, topicName, detectGroupAndUser, writeTelegramConfig, maskToken } from "@squadrant/core";
+import { createTelegramClient, loadState, setTopic, topicKey, topicName, detectGroupAndUser, writeTelegramConfig, maskToken, isNotifyActive, setNotify } from "@squadrant/core";
 import type { TelegramClient } from "@squadrant/core";
 
 /** Daemon state root (mirrors buildContext): ~/.config/squadrant/state. */
@@ -47,6 +47,23 @@ export async function runTelegramSend(opts: {
   }
   await opts.client.sendMessage(opts.cfg.supergroupId, topicId, opts.message);
   return { chatId: opts.cfg.supergroupId, topicId };
+}
+
+/** Set a project's notification flag in telegram-state.json. */
+export function runTelegramNotifySet(opts: { project: string; active: boolean; stateRoot: string }): void {
+  setNotify(opts.stateRoot, opts.project, opts.active);
+}
+
+/** List every known project (union of linked topics and notify keys) with its state. */
+export function runTelegramNotifyStatus(opts: { stateRoot: string }): Array<{ project: string; active: boolean }> {
+  const s = loadState(opts.stateRoot);
+  const projects = new Set<string>();
+  for (const key of Object.keys(s.topics)) {
+    const sep = key.indexOf("::");
+    projects.add(sep === -1 ? key : key.slice(0, sep));
+  }
+  for (const p of Object.keys(s.notify)) projects.add(p);
+  return [...projects].map((project) => ({ project, active: s.notify[project] === true }));
 }
 
 /** Bind a project to a forum topic, creating it on first link. Idempotent. */
@@ -235,6 +252,33 @@ telegramCommand
     }
     console.log();
     console.log(`Next: ${chalk.cyan("squadrant telegram link <project>")}`);
+  });
+
+telegramCommand
+  .command("notify")
+  .argument("[project]", "project to toggle")
+  .argument("[state]", "on | off")
+  .option("--status", "list notification state for all projects")
+  .description("Per-project lifecycle notifications: on|off, or --status to list")
+  .action((project: string | undefined, state: string | undefined, opts: { status?: boolean }) => {
+    const stateRoot = defaultStateRoot();
+    if (opts.status || !project) {
+      const rows = runTelegramNotifyStatus({ stateRoot });
+      if (rows.length === 0) {
+        console.log("no projects linked");
+        return;
+      }
+      for (const r of rows) {
+        console.log(`  ${r.project}: ${r.active ? chalk.green("on") : chalk.dim("off (muted)")}`);
+      }
+      return;
+    }
+    if (state !== "on" && state !== "off") {
+      console.error(chalk.red("usage: squadrant telegram notify <project> <on|off>"));
+      process.exit(1);
+    }
+    runTelegramNotifySet({ project, active: state === "on", stateRoot });
+    console.log(chalk.green(`${project} notifications ${state === "on" ? "ON" : "OFF"}`));
   });
 
 telegramCommand

--- a/packages/core/src/telegram/__tests__/bridge.test.ts
+++ b/packages/core/src/telegram/__tests__/bridge.test.ts
@@ -144,6 +144,130 @@ describe("pushLifecycle notify gate", () => {
   });
 });
 
+describe("auto-unmute + in-topic /mute /unmute", () => {
+  const USER_ID = 42;
+  const cfgWithControl: TelegramConfig = {
+    botToken: "T", supergroupId: -100500, chats: [-100111], pollMs: 1,
+    remoteControl: true, users: [USER_ID],
+  } as any; // TelegramConfig already has these fields; `as any` bypasses stale dist types
+
+  it("auto-unmutes a project when a normal message lands in its topic", async () => {
+    const root = freshRoot();
+    setTopic(root, "demo", 100);
+    const appendCalls: unknown[] = [];
+    let n = 0;
+    const client: TelegramClient = {
+      sendMessage: async () => {},
+      createForumTopic: async () => 1,
+      getUpdates: async () => {
+        n++;
+        if (n === 1) return [{ update_id: 10, message: { chat: { id: -100111 }, message_thread_id: 100, text: "hello", from: { id: USER_ID } } } as never];
+        return [];
+      },
+      getMe: async () => ({ id: 0, username: "" }),
+    };
+    const bridge = createTelegramBridge({
+      cfg, stateRoot: root, client,
+      appendCaptainMessage: async (a) => { appendCalls.push(a); },
+      log: () => {},
+    });
+    active = bridge;
+    bridge.start();
+    await waitFor(() => loadState(root).offset === 11);
+    expect(isNotifyActive(root, "demo")).toBe(true);
+    expect(appendCalls).toHaveLength(1);
+  });
+
+  it("auto-unmute works even when remoteControl is OFF", async () => {
+    const root = freshRoot();
+    setTopic(root, "demo", 100);
+    const appendCalls: unknown[] = [];
+    let n = 0;
+    const client: TelegramClient = {
+      sendMessage: async () => {},
+      createForumTopic: async () => 1,
+      getUpdates: async () => {
+        n++;
+        if (n === 1) return [{ update_id: 10, message: { chat: { id: -100111 }, message_thread_id: 100, text: "hi", from: { id: USER_ID } } } as never];
+        return [];
+      },
+      getMe: async () => ({ id: 0, username: "" }),
+    };
+    const bridge = createTelegramBridge({
+      cfg, stateRoot: root, client, // remoteControl=false (default cfg)
+      appendCaptainMessage: async (a) => { appendCalls.push(a); },
+      log: () => {},
+    });
+    active = bridge;
+    bridge.start();
+    await waitFor(() => loadState(root).offset === 11);
+    expect(isNotifyActive(root, "demo")).toBe(true);
+    expect(appendCalls).toHaveLength(1);
+  });
+
+  it("/unmute in topic toggles ON and does NOT append a captain message (authorized)", async () => {
+    const root = freshRoot();
+    setTopic(root, "demo", 100);
+    setNotify(root, "demo", false);
+    const appendCalls: unknown[] = [];
+    const replyCalls: Array<[number | undefined, string]> = [];
+    let n = 0;
+    const client: TelegramClient = {
+      sendMessage: async () => {},
+      createForumTopic: async () => 1,
+      getUpdates: async () => {
+        n++;
+        if (n === 1) return [{ update_id: 10, message: { chat: { id: -100111 }, message_thread_id: 100, text: "/unmute", from: { id: USER_ID } } } as never];
+        return [];
+      },
+      getMe: async () => ({ id: 0, username: "" }),
+    };
+    const bridge = createTelegramBridge({
+      cfg: cfgWithControl, stateRoot: root, client,
+      appendCaptainMessage: async (a) => { appendCalls.push(a); },
+      log: () => {},
+      sendReply: async (threadId, text) => { replyCalls.push([threadId, text]); },
+    });
+    active = bridge;
+    bridge.start();
+    await waitFor(() => loadState(root).offset === 11);
+    expect(isNotifyActive(root, "demo")).toBe(true);
+    expect(appendCalls).toHaveLength(0);
+    expect(replyCalls.some(([, t]) => t.includes("ON"))).toBe(true);
+  });
+
+  it("/mute in topic is rejected when remoteControl is OFF (notify unchanged)", async () => {
+    const root = freshRoot();
+    setTopic(root, "demo", 100);
+    setNotify(root, "demo", true);
+    const appendCalls: unknown[] = [];
+    const replyCalls: Array<[number | undefined, string]> = [];
+    let n = 0;
+    const client: TelegramClient = {
+      sendMessage: async () => {},
+      createForumTopic: async () => 1,
+      getUpdates: async () => {
+        n++;
+        if (n === 1) return [{ update_id: 10, message: { chat: { id: -100111 }, message_thread_id: 100, text: "/mute", from: { id: USER_ID } } } as never];
+        return [];
+      },
+      getMe: async () => ({ id: 0, username: "" }),
+    };
+    const bridge = createTelegramBridge({
+      cfg, stateRoot: root, client, // remoteControl=false
+      appendCaptainMessage: async (a) => { appendCalls.push(a); },
+      log: () => {},
+      sendReply: async (threadId, text) => { replyCalls.push([threadId, text]); },
+    });
+    active = bridge;
+    bridge.start();
+    await waitFor(() => loadState(root).offset === 11);
+    expect(isNotifyActive(root, "demo")).toBe(true); // unchanged
+    expect(appendCalls).toHaveLength(0);
+    expect(replyCalls.some(([, t]) => t.includes("not authorized"))).toBe(true);
+  });
+});
+
 describe("inbound poll", () => {
   it("appends a captain.message for an allowlisted chat on a known thread", async () => {
     const root = freshRoot();

--- a/packages/core/src/telegram/__tests__/bridge.test.ts
+++ b/packages/core/src/telegram/__tests__/bridge.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { TelegramConfig, ControlEvent } from "@squadrant/shared";
 import { createTelegramBridge, type TelegramBridge } from "../bridge.js";
 import type { TelegramClient } from "../client.js";
-import { loadState, setTopic } from "../state.js";
+import { loadState, setTopic, setNotify, isNotifyActive } from "../state.js";
 
 const cfg: TelegramConfig = { botToken: "T", supergroupId: -100500, chats: [-100111], pollMs: 1 };
 
@@ -39,6 +39,7 @@ describe("pushLifecycle (outbound)", () => {
   it("sends the formatted lifecycle text to the project's existing topic", async () => {
     const root = freshRoot();
     setTopic(root, "demo", 55);
+    setNotify(root, "demo", true);
     const sent = deferred();
     const sendCalls: Array<[number, number | undefined, string]> = [];
     const client: TelegramClient = {
@@ -58,6 +59,7 @@ describe("pushLifecycle (outbound)", () => {
 
   it("creates and persists the topic on first use, then sends to it", async () => {
     const root = freshRoot();
+    setNotify(root, "demo", true);
     const sent = deferred();
     const createCalls: Array<[number, string]> = [];
     const sendCalls: Array<[number, number | undefined, string]> = [];
@@ -81,6 +83,7 @@ describe("pushLifecycle (outbound)", () => {
   it("swallows a rejecting sendMessage (crash-contained, logged, never throws)", async () => {
     const root = freshRoot();
     setTopic(root, "demo", 55);
+    setNotify(root, "demo", true);
     const logged = deferred();
     const logs: string[] = [];
     const client: TelegramClient = {
@@ -99,6 +102,45 @@ describe("pushLifecycle (outbound)", () => {
     expect(() => bridge.pushLifecycle("demo", doneEv)).not.toThrow();
     await logged.promise;
     expect(logs.some((m) => m.includes("network down"))).toBe(true);
+  });
+});
+
+describe("pushLifecycle notify gate", () => {
+  it("drops the event when the project is MUTED (no client calls)", async () => {
+    const root = freshRoot();
+    const sendMessage = vi.fn();
+    const createForumTopic = vi.fn();
+    const client: TelegramClient = {
+      getUpdates: async () => [],
+      createForumTopic,
+      sendMessage,
+      getMe: async () => ({ id: 0, username: "" }),
+    };
+    const bridge = createTelegramBridge({ cfg, stateRoot: root, client, appendCaptainMessage: async () => {}, log: () => {} });
+    active = bridge;
+
+    bridge.pushLifecycle("squadrant", doneEv);
+    await new Promise<void>((r) => setTimeout(r, 20));
+
+    expect(createForumTopic).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("delivers when the project is ACTIVE", async () => {
+    const root = freshRoot();
+    setNotify(root, "squadrant", true);
+    const sent = deferred();
+    const client: TelegramClient = {
+      getUpdates: async () => [],
+      createForumTopic: async () => 7,
+      sendMessage: async () => { sent.resolve(); },
+      getMe: async () => ({ id: 0, username: "" }),
+    };
+    const bridge = createTelegramBridge({ cfg, stateRoot: root, client, appendCaptainMessage: async () => {}, log: () => {} });
+    active = bridge;
+
+    bridge.pushLifecycle("squadrant", doneEv);
+    await sent.promise;
   });
 });
 

--- a/packages/core/src/telegram/__tests__/state.test.ts
+++ b/packages/core/src/telegram/__tests__/state.test.ts
@@ -65,7 +65,7 @@ describe("setTopic / findProjectByThread", () => {
   });
 
   it("setTopic preserves the existing offset", () => {
-    saveState(root, { offset: 5, topics: {} });
+    saveState(root, { offset: 5, topics: {}, notify: {} });
     setTopic(root, "squadrant", 100);
     expect(loadState(root).offset).toBe(5);
   });

--- a/packages/core/src/telegram/__tests__/state.test.ts
+++ b/packages/core/src/telegram/__tests__/state.test.ts
@@ -8,6 +8,8 @@ import {
   saveState,
   setTopic,
   findProjectByThread,
+  isNotifyActive,
+  setNotify,
   type TelegramState,
 } from "../state.js";
 
@@ -29,19 +31,19 @@ describe("topicKey", () => {
 });
 
 describe("loadState / saveState", () => {
-  it("returns {offset:0, topics:{}} when the file is missing", () => {
-    expect(loadState(root)).toEqual({ offset: 0, topics: {} });
+  it("returns {offset:0, topics:{}, notify:{}} when the file is missing", () => {
+    expect(loadState(root)).toEqual({ offset: 0, topics: {}, notify: {} });
   });
 
   it("round-trips offset and topics through save → load", () => {
-    const s: TelegramState = { offset: 42, topics: { "squadrant::project": 7 } };
+    const s: TelegramState = { offset: 42, topics: { "squadrant::project": 7 }, notify: {} };
     saveState(root, s);
     expect(loadState(root)).toEqual(s);
   });
 
   it("returns the default state when the file is corrupt", () => {
     fs.writeFileSync(path.join(root, "telegram-state.json"), "{not json");
-    expect(loadState(root)).toEqual({ offset: 0, topics: {} });
+    expect(loadState(root)).toEqual({ offset: 0, topics: {}, notify: {} });
   });
 });
 
@@ -66,5 +68,35 @@ describe("setTopic / findProjectByThread", () => {
     saveState(root, { offset: 5, topics: {} });
     setTopic(root, "squadrant", 100);
     expect(loadState(root).offset).toBe(5);
+  });
+});
+
+describe("notify state", () => {
+  it("defaults to muted (absent key → false)", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tg-state-"));
+    expect(isNotifyActive(dir, "squadrant")).toBe(false);
+  });
+
+  it("loadState defaults notify to {} when file lacks it", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tg-state-"));
+    fs.writeFileSync(path.join(dir, "telegram-state.json"), JSON.stringify({ offset: 3, topics: {} }));
+    expect(loadState(dir).notify).toEqual({});
+  });
+
+  it("setNotify round-trips through save/load", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tg-state-"));
+    setNotify(dir, "squadrant", true);
+    expect(isNotifyActive(dir, "squadrant")).toBe(true);
+    setNotify(dir, "squadrant", false);
+    expect(isNotifyActive(dir, "squadrant")).toBe(false);
+  });
+
+  it("setNotify preserves offset and topics", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tg-state-"));
+    setTopic(dir, "squadrant", 7);
+    setNotify(dir, "squadrant", true);
+    const s = loadState(dir);
+    expect(s.topics).toEqual({ "squadrant::project": 7 });
+    expect(s.notify).toEqual({ squadrant: true });
   });
 });

--- a/packages/core/src/telegram/bridge.ts
+++ b/packages/core/src/telegram/bridge.ts
@@ -97,6 +97,15 @@ export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridg
     }
   }
 
+  // Recognize the two in-topic notification toggles. Returns the desired active
+  // state, or null if the text is an ordinary message.
+  function notifyToggle(text: string): boolean | null {
+    const first = text.trim().split(/\s+/)[0]?.toLowerCase();
+    if (first === "/unmute") return true;
+    if (first === "/mute") return false;
+    return null;
+  }
+
   // Project topic: the v1 captain.message flow + Gap-1 auto-launch (#403). When
   // control is off OR the sender isn't allowlisted, behaves exactly as v1
   // (append only). The append throws on delivery-infra failure so the caller can
@@ -105,6 +114,20 @@ export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridg
   async function handleProjectTopic(text: string, threadId: number, fromId: number | undefined): Promise<void> {
     const resolved = findProjectByThread(stateRoot, threadId);
     if (!resolved) return; // no project bound to this topic
+
+    const toggle = notifyToggle(text);
+    if (toggle !== null) {
+      // Explicit toggle command — fail-closed, never appended as a captain message.
+      if (!isControlEnabled(cfg) || !isAuthorized(fromId, cfg)) {
+        await reply(threadId, "⛔ not authorized");
+        return;
+      }
+      setNotify(stateRoot, resolved.project, toggle);
+      await reply(threadId, toggle ? `🔔 ${resolved.project} notifications ON` : `🔕 ${resolved.project} notifications OFF`);
+      return;
+    }
+
+    setNotify(stateRoot, resolved.project, true); // engagement → auto-unmute (sticky)
     if (ensureCaptainAlive && isControlEnabled(cfg) && isAuthorized(fromId, cfg)) {
       try {
         const r = await ensureCaptainAlive(resolved.project);

--- a/packages/core/src/telegram/bridge.ts
+++ b/packages/core/src/telegram/bridge.ts
@@ -7,7 +7,7 @@ import { isAuthorized, isControlEnabled } from "./auth.js";
 import { parseCommand } from "./commands.js";
 import type { EnsureResult } from "./ensure-captain.js";
 import { formatInbound, formatLifecycle, topicName } from "./format.js";
-import { findProjectByThread, loadState, saveState, setTopic, topicKey } from "./state.js";
+import { findProjectByThread, isNotifyActive, loadState, saveState, setNotify, setTopic, topicKey } from "./state.js";
 
 export interface TelegramBridge {
   start(): void;
@@ -51,6 +51,7 @@ export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridg
 
   // Outbound: resolve (or lazily create) the project's topic, then send.
   async function deliverOutbound(project: string, ev: ControlEvent): Promise<void> {
+    if (!isNotifyActive(stateRoot, project)) return; // muted (default) → no topic create, no send
     let threadId = loadState(stateRoot).topics[topicKey(project)];
     if (threadId === undefined) {
       threadId = await client.createForumTopic(cfg.supergroupId, topicName(project));

--- a/packages/core/src/telegram/commands.test.ts
+++ b/packages/core/src/telegram/commands.test.ts
@@ -78,4 +78,16 @@ describe("parseCommand", () => {
     expect(parseCommand("/spawn").kind).toBe("usage");
     expect(parseCommand("/spawn brove").kind).toBe("usage");
   });
+
+  it("/unmute <project> → telegram notify <project> on", () => {
+    expect(parseCommand("/unmute squadrant")).toEqual({ kind: "ok", name: "unmute", argv: ["telegram", "notify", "squadrant", "on"] });
+  });
+
+  it("/mute <project> → telegram notify <project> off", () => {
+    expect(parseCommand("/mute squadrant")).toEqual({ kind: "ok", name: "mute", argv: ["telegram", "notify", "squadrant", "off"] });
+  });
+
+  it("/mute with no project → usage", () => {
+    expect(parseCommand("/mute")).toEqual({ kind: "usage", name: "mute", message: "usage: /mute <project>" });
+  });
 });

--- a/packages/core/src/telegram/commands.ts
+++ b/packages/core/src/telegram/commands.ts
@@ -86,6 +86,14 @@ const REGISTRY: Record<string, Entry> = {
       return ok("spawn", ["crew", "spawn", project, task]);
     },
   },
+  mute: {
+    usage: "/mute <project>",
+    build: (a) => (a[0] ? ok("mute", ["telegram", "notify", a[0], "off"]) : usage("mute", "usage: /mute <project>")),
+  },
+  unmute: {
+    usage: "/unmute <project>",
+    build: (a) => (a[0] ? ok("unmute", ["telegram", "notify", a[0], "on"]) : usage("unmute", "usage: /unmute <project>")),
+  },
 };
 
 function helpText(): string {

--- a/packages/core/src/telegram/state.ts
+++ b/packages/core/src/telegram/state.ts
@@ -7,6 +7,8 @@ export interface TelegramState {
   offset: number;
   /** key = `${project}::${scope}` (see topicKey); value = message_thread_id. */
   topics: Record<string, number>;
+  /** key = project; value = true when active. Absent/false = MUTED (default). */
+  notify: Record<string, boolean>;
 }
 
 function statePath(stateRoot: string): string {
@@ -26,9 +28,10 @@ export function loadState(stateRoot: string): TelegramState {
     return {
       offset: typeof data.offset === "number" ? data.offset : 0,
       topics: data.topics ?? {},
+      notify: data.notify ?? {},
     };
   } catch {
-    return { offset: 0, topics: {} };
+    return { offset: 0, topics: {}, notify: {} };
   }
 }
 
@@ -45,6 +48,16 @@ export function setTopic(
 ): void {
   const s = loadState(stateRoot);
   s.topics[topicKey(project, scope)] = topicId;
+  saveState(stateRoot, s);
+}
+
+export function isNotifyActive(stateRoot: string, project: string): boolean {
+  return loadState(stateRoot).notify[project] === true;
+}
+
+export function setNotify(stateRoot: string, project: string, active: boolean): void {
+  const s = loadState(stateRoot);
+  s.notify[project] = active;
   saveState(stateRoot, s);
 }
 


### PR DESCRIPTION
## Summary

- **Muted by default**: outbound lifecycle events (crew done/blocked/idle) are dropped for any project not explicitly active — no network calls, no topic creation
- **Auto-unmute on engagement**: any inbound message into a project topic flips that project active (sticky, `remoteControl`-independent)
- **Manual toggles — two surfaces**: in-topic `/mute`·`/unmute` (fail-closed: requires `remoteControl` + allowlist); General-channel `/mute <project>`·`/unmute <project>` via the command registry; `squadrant telegram notify <project> on|off` + `--status` as a local escape hatch
- **State**: `notify` field added to `telegram-state.json`; absent/false = muted; no config schema change, no migration

## Files changed

| File | Change |
|---|---|
| `packages/core/src/telegram/state.ts` | `notify` field + `isNotifyActive`/`setNotify` helpers |
| `packages/core/src/telegram/bridge.ts` | early-return gate in `deliverOutbound`; auto-unmute + `/mute`/`/unmute` routing in `handleProjectTopic` |
| `packages/core/src/telegram/commands.ts` | `/mute <project>` and `/unmute <project>` registry entries |
| `packages/cli/src/commands/telegram.ts` | `notify <project> on|off` + `notify --status` subcommand |
| `CHANGELOG.md` | behavior-change note under `[Unreleased]` |

## Test plan

- [x] `npx vitest run packages/core/src/telegram/__tests__/state.test.ts` — 13 pass (notify defaults, round-trip, preserves offset+topics)
- [x] `npx vitest run packages/cli/src/commands/__tests__/telegram.test.ts` — 11 pass (runTelegramNotifySet/Status helpers + subcommand registration)
- [x] `npx vitest run packages/core/src/telegram/__tests__/bridge.test.ts` — 12 pass (gate drops muted, delivers active, auto-unmute, authorized toggle, unauthorized rejection)
- [x] `npx vitest run packages/core/src/telegram/commands.test.ts` — 17 pass (/mute /unmute parse correctly, no-arg usage)
- [x] `npx vitest run` — **1413/1413 pass**, no regressions
- [x] `node dist/index.js telegram notify --status` — prints live projects in muted state, no crash