### PR TITLE
feat(config): per-project layered config + Telegram notification tiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Per-project layered config.** A new override layer at `~/.config/squadrant/projects/<name>.json` resolves as built-in → global `config.json` → per-project, merged per key (`resolveNotify` / `loadProjectOverride` / `saveProjectOverride` in `@squadrant/shared`). Fully additive: an absent project file behaves exactly as the global defaults — no migration. The resolver is generic; Telegram notification is its first tenant (per-project `effort`/`models` keys are reserved, not yet wired).
+- **Telegram notification tiers (per-project).** Outbound lifecycle pushes are filtered by a per-project **crew tier** — `none` ⊂ `done_only` (`task.done`/`task.failed`) ⊂ `alert_only` (+ blocked/approval/input/timeout, the default) ⊂ `all`. New CLI `squadrant telegram notify <project> crew <tier>` / `cap <on|off>` and Telegram `/notify crew <tier>` / `/notify cap <on|off>` (fail-closed behind remote control) write the per-project config file. The live `active` mute axis (`/mute` / `/unmute` / `notify <project> on|off`) is unchanged and stays in `telegram-state.json`; the live value overrides the config-default `active`.
+- **Distinct Telegram formatting** for `task.failed` (CREW FAILED + error), `task.approval.requested` (APPROVAL NEEDED + question), `task.input.requested` (INPUT NEEDED + question), and `task.timeout` (CREW TIMEOUT) — previously these fell to the generic line.
+- **`cap` gate on `squadrant telegram send`** — with a project's resolved `cap=off`, explicit captain messages are suppressed (not sent), independent of idle-mute.
+
 ### Changed
 - **Telegram notifications are now per-project and muted by default.** Lifecycle events (crew done/blocked/idle) are delivered to a project's topic only after you engage that project — by sending any message into its topic, by `/unmute` (Telegram, requires remoteControl), or by `squadrant telegram notify <project> on`. This changes prior behavior where every project pushed all lifecycle events. Mute again with `/mute <project>` or `squadrant telegram notify <project> off`. Command replies and the General command channel are unaffected.
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Pass `--direction right|left|up|down` to use a split pane instead of a tab. Stat
 
 Drive squadrant from your phone ([#65](https://github.com/tu11aa/squadrant/issues/65)). When a `telegram` block is present in config, a daemon-internal bridge:
 
-- **Outbound** — pushes each project's crew lifecycle events (CREW DONE / BLOCKED / IDLE) and other captain notifications to that project's Telegram forum topic. Best-effort: a Telegram failure never delays or breaks delivery to the captain pane.
+- **Outbound** — pushes each project's crew lifecycle events (CREW DONE / FAILED / BLOCKED / APPROVAL / INPUT / TIMEOUT / IDLE) and other captain notifications to that project's Telegram forum topic, filtered by a per-project **crew tier** (see [Notification tuning](#notification-tuning-per-project) below). Best-effort: a Telegram failure never delays or breaks delivery to the captain pane.
 - **Inbound (project topic)** — a message you send in a project's topic is delivered into that project's **captain pane** as a labeled `📩 [from Telegram]` message; the captain decides what to do with it. With remote control enabled (see below), if no captain is alive the daemon **auto-launches** one, then delivers ([#403](https://github.com/tu11aa/squadrant/issues/403)).
 - **General command channel** — slash commands in the supergroup's **General topic** run a curated set of squadrant operations from your phone ([#402](https://github.com/tu11aa/squadrant/issues/402)). Available: `/help`, `/status`, `/projects`, `/crews <project>`, `/launch <project>`, `/effort [max|balance|low]`, `/config get <key>`, `/config set <key> <value>`, `/spawn <project> <task…>`. Each maps to a validated CLI argv run via async `execFile` — never a shell passthrough. Unknown commands and freeform text get a `/help` hint.
 
@@ -201,6 +201,26 @@ The control surfaces (auto-launch + General command channel) are **off by defaul
 2. `message.from.id ∈ users[]` — the sender's Telegram **user-id** is on the allowlist. An empty/absent `users` list ⇒ control is disabled (fail-closed). Chat membership alone is **never** enough for control.
 
 When remote control is off (the default after upgrade), behavior is **exactly v1**: project-topic messages queue to the captain pane (no auto-launch), and General-topic slash commands are rejected with `⛔ not authorized`. Inbound text is always treated as data; only the curated registry maps to actions, and `/config set` is restricted to a default-deny writable-key allowlist (currently just `defaults.effort`) — **secrets (`botToken`, `users`, `chats`, `supergroupId`) can never be written over Telegram.**
+
+#### Notification tuning (per-project)
+
+Notifications resolve through a **layered config**: built-in defaults → global `config.json` (`telegram.notify`) → per-project `~/.config/squadrant/projects/<name>.json`, merged per key (overriding one key never resets its siblings). Two axes are independent:
+
+- **Live mute (`active`)** — system-tracked *session* state in `telegram-state.json`. Flipped by engagement (any message into a topic auto-unmutes), `/mute` / `/unmute` (Telegram), or `squadrant telegram notify <project> on|off`. The live value wins over the config default when present.
+- **Deliberate preferences (`crew`, `cap`)** — persistent settings in the per-project config file. Written by `squadrant telegram notify <project> crew <tier>` / `cap <on|off>` (CLI) or `/notify crew <tier>` / `/notify cap <on|off>` (Telegram, fail-closed behind remote control).
+
+**Crew tiers** (cumulative) select which lifecycle events reach a topic when active:
+
+| Tier | Events delivered |
+|---|---|
+| `none` | nothing |
+| `done_only` | `task.done`, `task.failed` |
+| `alert_only` *(default)* | `done_only` + `task.blocked`, `task.approval.requested`, `task.input.requested`, `task.timeout` |
+| `all` | every lifecycle event (incl. progress/heartbeat noise) |
+
+**`cap`** (default `on`) gates explicit captain pushes via `squadrant telegram send` — set `cap off` for a project to stop the captain DM-ing you there (independent of idle-mute; an explicit push is not dropped just because the topic is idle-muted).
+
+Config (deliberate prefs) and state (live toggles) are kept separate by design: `/unmute` flips your session, it does **not** rewrite your config file. An absent `projects/<name>.json` behaves exactly as the global defaults — the layer is fully additive, no migration. See `docs/superpowers/specs/2026-06-23-per-project-layered-config-design.md`.
 
 #### Remote wake (#403) — operator-side
 

--- a/packages/cli/src/commands/__tests__/telegram.notify.test.ts
+++ b/packages/cli/src/commands/__tests__/telegram.notify.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import fs from "node:fs"; import os from "node:os"; import path from "node:path";
+import { loadProjectOverride } from "@squadrant/shared";
+import { runTelegramNotifyPref } from "../telegram.js";
+
+let root: string;
+beforeEach(() => { root = fs.mkdtempSync(path.join(os.tmpdir(), "sq-tn-")); });
+
+describe("runTelegramNotifyPref", () => {
+  it("writes crew tier to the override file", () => {
+    expect(runTelegramNotifyPref({ project: "p", dimension: "crew", value: "all", root })).toEqual({ ok: true });
+    expect(loadProjectOverride("p", root)).toEqual({ telegram: { notify: { crew: "all" } } });
+  });
+  it("rejects a bad crew tier", () => {
+    expect(runTelegramNotifyPref({ project: "p", dimension: "crew", value: "loud", root }).ok).toBe(false);
+  });
+  it("writes cap on/off as boolean", () => {
+    runTelegramNotifyPref({ project: "p", dimension: "cap", value: "off", root });
+    expect(loadProjectOverride("p", root)).toEqual({ telegram: { notify: { cap: false } } });
+  });
+});

--- a/packages/cli/src/commands/__tests__/telegram.send.test.ts
+++ b/packages/cli/src/commands/__tests__/telegram.send.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import fs from "node:fs"; import os from "node:os"; import path from "node:path";
+import { saveProjectOverride } from "@squadrant/shared";
+import { capAllowed } from "../telegram.js";
+
+let root: string;
+beforeEach(() => { root = fs.mkdtempSync(path.join(os.tmpdir(), "sq-ts-")); });
+
+describe("capAllowed", () => {
+  it("defaults to true (built-in cap=true)", () => {
+    expect(capAllowed("p", undefined, root)).toBe(true);
+  });
+  it("project cap=false suppresses captain sends", () => {
+    saveProjectOverride("p", { telegram: { notify: { cap: false } } }, root);
+    expect(capAllowed("p", undefined, root)).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/telegram.ts
+++ b/packages/cli/src/commands/telegram.ts
@@ -2,7 +2,7 @@ import { join, dirname } from "node:path";
 import { emitKeypressEvents } from "node:readline";
 import { Command } from "commander";
 import chalk from "chalk";
-import { loadConfig, DEFAULT_CONFIG_PATH } from "@squadrant/shared";
+import { loadConfig, DEFAULT_CONFIG_PATH, saveProjectOverride } from "@squadrant/shared";
 import type { SquadrantConfig, TelegramConfig } from "@squadrant/shared";
 import { createTelegramClient, loadState, setTopic, topicKey, topicName, detectGroupAndUser, writeTelegramConfig, maskToken, isNotifyActive, setNotify } from "@squadrant/core";
 import type { TelegramClient } from "@squadrant/core";
@@ -52,6 +52,23 @@ export async function runTelegramSend(opts: {
 /** Set a project's notification flag in telegram-state.json. */
 export function runTelegramNotifySet(opts: { project: string; active: boolean; stateRoot: string }): void {
   setNotify(opts.stateRoot, opts.project, opts.active);
+}
+
+/** Write a deliberate per-project notification preference (crew tier / cap) to
+ *  projects/<name>.json. Distinct from live on|off state (telegram-state.json). */
+export function runTelegramNotifyPref(
+  args: { project: string; dimension: "crew" | "cap"; value: string; root?: string },
+): { ok: true } | { ok: false; message: string } {
+  const { project, dimension, value, root } = args;
+  if (dimension === "crew") {
+    if (!["all", "alert_only", "done_only", "none"].includes(value))
+      return { ok: false, message: "crew must be all|alert_only|done_only|none" };
+    saveProjectOverride(project, { telegram: { notify: { crew: value as any } } }, root);
+    return { ok: true };
+  }
+  if (value !== "on" && value !== "off") return { ok: false, message: "cap must be on|off" };
+  saveProjectOverride(project, { telegram: { notify: { cap: value === "on" } } }, root);
+  return { ok: true };
 }
 
 /** List every known project (union of linked topics and notify keys) with its state. */
@@ -257,10 +274,11 @@ telegramCommand
 telegramCommand
   .command("notify")
   .argument("[project]", "project to toggle")
-  .argument("[state]", "on | off")
+  .argument("[state]", "on | off | crew | cap")
+  .argument("[value]", "tier for crew (all|alert_only|done_only|none) or on|off for cap")
   .option("--status", "list notification state for all projects")
-  .description("Per-project lifecycle notifications: on|off, or --status to list")
-  .action((project: string | undefined, state: string | undefined, opts: { status?: boolean }) => {
+  .description("Live on|off (state), or crew <tier> / cap <on|off> preference (per-project config)")
+  .action((project: string | undefined, state: string | undefined, value: string | undefined, opts: { status?: boolean }) => {
     const stateRoot = defaultStateRoot();
     if (opts.status || !project) {
       const rows = runTelegramNotifyStatus({ stateRoot });
@@ -273,8 +291,23 @@ telegramCommand
       }
       return;
     }
+    // Deliberate preference (per-project config file): crew tier / cap.
+    if (state === "crew" || state === "cap") {
+      if (value === undefined) {
+        console.error(chalk.red(`usage: squadrant telegram notify <project> ${state} <value>`));
+        process.exit(1);
+      }
+      const res = runTelegramNotifyPref({ project, dimension: state, value });
+      if (!res.ok) {
+        console.error(chalk.red(res.message));
+        process.exit(1);
+      }
+      console.log(chalk.green(`${project} ${state} = ${value}`));
+      return;
+    }
+    // Live session toggle (telegram-state.json), unchanged.
     if (state !== "on" && state !== "off") {
-      console.error(chalk.red("usage: squadrant telegram notify <project> <on|off>"));
+      console.error(chalk.red("usage: squadrant telegram notify <project> <on|off|crew <tier>|cap <on|off>>"));
       process.exit(1);
     }
     runTelegramNotifySet({ project, active: state === "on", stateRoot });

--- a/packages/cli/src/commands/telegram.ts
+++ b/packages/cli/src/commands/telegram.ts
@@ -2,7 +2,7 @@ import { join, dirname } from "node:path";
 import { emitKeypressEvents } from "node:readline";
 import { Command } from "commander";
 import chalk from "chalk";
-import { loadConfig, DEFAULT_CONFIG_PATH, saveProjectOverride } from "@squadrant/shared";
+import { loadConfig, DEFAULT_CONFIG_PATH, saveProjectOverride, resolveNotify, loadProjectOverride } from "@squadrant/shared";
 import type { SquadrantConfig, TelegramConfig } from "@squadrant/shared";
 import { createTelegramClient, loadState, setTopic, topicKey, topicName, detectGroupAndUser, writeTelegramConfig, maskToken, isNotifyActive, setNotify } from "@squadrant/core";
 import type { TelegramClient } from "@squadrant/core";
@@ -69,6 +69,14 @@ export function runTelegramNotifyPref(
   if (value !== "on" && value !== "off") return { ok: false, message: "cap must be on|off" };
   saveProjectOverride(project, { telegram: { notify: { cap: value === "on" } } }, root);
   return { ok: true };
+}
+
+/** Resolved `cap` for a project — whether explicit captain messages may be sent.
+ *  `cap=false` is the deliberate "don't let the captain DM me" switch; live
+ *  idle-mute (active) is intentionally NOT consulted here (an explicit push
+ *  shouldn't be dropped just because the topic is idle-muted). */
+export function capAllowed(project: string, globalNotify: TelegramConfig["notify"], root?: string): boolean {
+  return resolveNotify(globalNotify, loadProjectOverride(project, root)).cap;
 }
 
 /** List every known project (union of linked topics and notify keys) with its state. */
@@ -329,6 +337,11 @@ telegramCommand
     if (!token) {
       console.error(chalk.red("no botToken in config and TELEGRAM_BOT_TOKEN is unset"));
       process.exit(1);
+    }
+
+    if (!capAllowed(project, cfg.notify)) {
+      console.log(chalk.dim(`${project}: captain messages muted (cap=off) — not sent`));
+      return;
     }
 
     let message: string;

--- a/packages/cli/src/control/squadrantd.ts
+++ b/packages/cli/src/control/squadrantd.ts
@@ -62,7 +62,7 @@ function buildTelegramBridge(
   const sendReply = (threadId: number | undefined, text: string) =>
     client.sendMessage(cfg.supergroupId, threadId, text);
   return createTelegramBridge({
-    cfg, stateRoot, client, appendCaptainMessage, log,
+    cfg, stateRoot, configRoot: dirname(stateRoot), client, appendCaptainMessage, log,
     ensureCaptainAlive, runCommand, sendReply,
   });
 }

--- a/packages/core/src/telegram/__tests__/bridge.notify.test.ts
+++ b/packages/core/src/telegram/__tests__/bridge.notify.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createTelegramBridge } from "../bridge.js";
+import { saveProjectOverride } from "@squadrant/shared";
+import { setNotify } from "../state.js";
+
+function harness(root: string, globalNotify?: any) {
+  const sent: string[] = [];
+  const client = {
+    getUpdates: vi.fn(async () => []),
+    sendMessage: vi.fn(async (_c: number, _t: number | undefined, text: string) => { sent.push(text); }),
+    createForumTopic: vi.fn(async () => 111),
+    getMe: vi.fn(async () => ({ id: 1, username: "bot" })),
+  };
+  const bridge = createTelegramBridge({
+    cfg: { supergroupId: -100, chats: [], notify: globalNotify } as any,
+    stateRoot: root, configRoot: root, client: client as any,
+    appendCaptainMessage: vi.fn(), log: vi.fn(),
+  });
+  return { bridge, sent, client };
+}
+
+let root: string;
+beforeEach(() => { root = fs.mkdtempSync(path.join(os.tmpdir(), "sq-br-")); });
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe("deliverOutbound notify resolution", () => {
+  it("drops everything when muted (default, absent state)", async () => {
+    const { bridge, sent } = harness(root);
+    bridge.pushLifecycle("p", { type: "task.done", id: "t1", resultRef: "r" } as any);
+    await flush();
+    expect(sent).toEqual([]);
+  });
+
+  it("alert_only sends outcomes + alerts but drops progress noise when active", async () => {
+    // alert_only is cumulative (⊇ done_only), so task.done IS included; the tier
+    // filter only drops the non-alert noise (e.g. task.progress). See tiers.ts.
+    setNotify(root, "p", true); // live unmute
+    const { bridge, sent } = harness(root); // global default crew=alert_only
+    bridge.pushLifecycle("p", { type: "task.progress", id: "t1", note: "n" } as any);
+    bridge.pushLifecycle("p", { type: "task.blocked", id: "t2", reason: "x", question: "q" } as any);
+    bridge.pushLifecycle("p", { type: "task.done", id: "t3", resultRef: "r" } as any);
+    await flush();
+    expect(sent.some((t) => t.includes("task.progress"))).toBe(false);
+    expect(sent.some((t) => t.includes("BLOCKED"))).toBe(true);
+    expect(sent.some((t) => t.includes("CREW DONE"))).toBe(true);
+  });
+
+  it("project crew=all sends progress when active", async () => {
+    setNotify(root, "p", true);
+    saveProjectOverride("p", { telegram: { notify: { crew: "all" } } }, root);
+    const { bridge, sent } = harness(root);
+    bridge.pushLifecycle("p", { type: "task.progress", id: "t1", note: "n" } as any);
+    await flush();
+    expect(sent.length).toBe(1);
+  });
+
+  it("config-default active=true sends with absent live state", async () => {
+    saveProjectOverride("p", { telegram: { notify: { active: true } } }, root);
+    const { bridge, sent } = harness(root);
+    bridge.pushLifecycle("p", { type: "task.done", id: "t1", resultRef: "r" } as any);
+    // crew default alert_only includes task.done
+    await flush();
+    expect(sent.length).toBe(1);
+  });
+});

--- a/packages/core/src/telegram/__tests__/bridge.notifycmd.test.ts
+++ b/packages/core/src/telegram/__tests__/bridge.notifycmd.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { parseNotifyPref } from "../bridge.js";
+
+describe("parseNotifyPref", () => {
+  it("parses /notify crew all", () => {
+    expect(parseNotifyPref("/notify crew all")).toEqual({ dimension: "crew", value: "all" });
+  });
+  it("parses /notify cap off", () => {
+    expect(parseNotifyPref("/notify cap off")).toEqual({ dimension: "cap", value: "off" });
+  });
+  it("returns null for ordinary text", () => {
+    expect(parseNotifyPref("please ship it")).toBeNull();
+  });
+  it("returns null for /notify with no dimension", () => {
+    expect(parseNotifyPref("/notify")).toBeNull();
+  });
+});

--- a/packages/core/src/telegram/__tests__/format.test.ts
+++ b/packages/core/src/telegram/__tests__/format.test.ts
@@ -30,8 +30,30 @@ describe("formatLifecycle", () => {
   });
 
   it("falls back to a generic line for other event types (never throws)", () => {
-    const ev: ControlEvent = { type: "task.failed", id: "xyz000", error: "boom" };
-    expect(formatLifecycle("squadrant", ev)).toBe("ℹ️ [squadrant] task.failed · xyz000");
+    const ev: ControlEvent = { type: "task.progress", id: "xyz000", note: "still going" };
+    expect(formatLifecycle("squadrant", ev)).toBe("ℹ️ [squadrant] task.progress · xyz000");
+  });
+});
+
+describe("formatLifecycle new cases", () => {
+  it("failed shows the error", () => {
+    const s = formatLifecycle("p", { type: "task.failed", id: "t1", error: "boom" } as any);
+    expect(s).toContain("CREW FAILED");
+    expect(s).toContain("boom");
+  });
+  it("approval shows the question", () => {
+    const s = formatLifecycle("p", { type: "task.approval.requested", id: "t1", requestId: 1, question: "run rm?", kind: "shell" } as any);
+    expect(s).toContain("APPROVAL");
+    expect(s).toContain("run rm?");
+  });
+  it("input shows the question", () => {
+    const s = formatLifecycle("p", { type: "task.input.requested", id: "t1", requestId: 1, question: "which env?" } as any);
+    expect(s).toContain("INPUT");
+    expect(s).toContain("which env?");
+  });
+  it("timeout shows a timeout line", () => {
+    const s = formatLifecycle("p", { type: "task.timeout", id: "t1", taskTimeoutMs: 1000 } as any);
+    expect(s).toContain("CREW TIMEOUT");
   });
 });
 

--- a/packages/core/src/telegram/__tests__/tiers.test.ts
+++ b/packages/core/src/telegram/__tests__/tiers.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { tierIncludes } from "../tiers.js";
+
+describe("tierIncludes", () => {
+  it("none lets nothing through", () => {
+    expect(tierIncludes("none", "task.done")).toBe(false);
+    expect(tierIncludes("none", "task.blocked")).toBe(false);
+  });
+  it("done_only = terminal outcomes only", () => {
+    expect(tierIncludes("done_only", "task.done")).toBe(true);
+    expect(tierIncludes("done_only", "task.failed")).toBe(true);
+    expect(tierIncludes("done_only", "task.blocked")).toBe(false);
+    expect(tierIncludes("done_only", "task.progress")).toBe(false);
+  });
+  it("alert_only adds the needs-you events, still drops noise", () => {
+    expect(tierIncludes("alert_only", "task.blocked")).toBe(true);
+    expect(tierIncludes("alert_only", "task.approval.requested")).toBe(true);
+    expect(tierIncludes("alert_only", "task.input.requested")).toBe(true);
+    expect(tierIncludes("alert_only", "task.timeout")).toBe(true);
+    expect(tierIncludes("alert_only", "task.done")).toBe(true);
+    expect(tierIncludes("alert_only", "task.progress")).toBe(false);
+    expect(tierIncludes("alert_only", "task.idle")).toBe(false);
+  });
+  it("all lets everything through", () => {
+    expect(tierIncludes("all", "task.progress")).toBe(true);
+    expect(tierIncludes("all", "heartbeat")).toBe(true);
+  });
+});

--- a/packages/core/src/telegram/bridge.ts
+++ b/packages/core/src/telegram/bridge.ts
@@ -4,7 +4,7 @@
 import os from "node:os";
 import path from "node:path";
 import type { ControlEvent, TelegramConfig } from "@squadrant/shared";
-import { resolveNotify, loadProjectOverride } from "@squadrant/shared";
+import { resolveNotify, loadProjectOverride, saveProjectOverride } from "@squadrant/shared";
 import type { TelegramClient } from "./client.js";
 import { isAuthorized, isControlEnabled } from "./auth.js";
 import { parseCommand } from "./commands.js";
@@ -43,6 +43,18 @@ export interface TelegramBridgeOptions {
 const LONG_POLL_SEC = 50;
 
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+const CREW_TIERS = ["all", "alert_only", "done_only", "none"];
+
+/** Parse a `/notify crew <tier>` or `/notify cap <on|off>` preference command.
+ *  Returns null for anything else (ordinary message or malformed). */
+export function parseNotifyPref(text: string): { dimension: "crew" | "cap"; value: string } | null {
+  const parts = text.trim().split(/\s+/);
+  if (parts[0]?.toLowerCase() !== "/notify") return null;
+  const dimension = parts[1]?.toLowerCase();
+  if ((dimension === "crew" || dimension === "cap") && parts[2]) return { dimension, value: parts[2].toLowerCase() };
+  return null;
+}
 
 export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridge {
   const { cfg, stateRoot, client, appendCaptainMessage, log, ensureCaptainAlive, runCommand, sendReply } = opts;
@@ -136,6 +148,31 @@ export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridg
       }
       setNotify(stateRoot, resolved.project, toggle);
       await reply(threadId, toggle ? `🔔 ${resolved.project} notifications ON` : `🔕 ${resolved.project} notifications OFF`);
+      return;
+    }
+
+    const pref = parseNotifyPref(text);
+    if (pref !== null) {
+      // Deliberate preference change — fail-closed, writes the per-project config
+      // file (not live state), never appended as a captain message.
+      if (!isControlEnabled(cfg) || !isAuthorized(fromId, cfg)) {
+        await reply(threadId, "⛔ not authorized");
+        return;
+      }
+      if (pref.dimension === "crew") {
+        if (!CREW_TIERS.includes(pref.value)) {
+          await reply(threadId, "crew must be all|alert_only|done_only|none");
+          return;
+        }
+        saveProjectOverride(resolved.project, { telegram: { notify: { crew: pref.value as never } } }, configRoot);
+      } else {
+        if (pref.value !== "on" && pref.value !== "off") {
+          await reply(threadId, "cap must be on|off");
+          return;
+        }
+        saveProjectOverride(resolved.project, { telegram: { notify: { cap: pref.value === "on" } } }, configRoot);
+      }
+      await reply(threadId, `✅ ${pref.dimension} = ${pref.value}`);
       return;
     }
 

--- a/packages/core/src/telegram/bridge.ts
+++ b/packages/core/src/telegram/bridge.ts
@@ -1,13 +1,17 @@
 // Daemon-internal Telegram subsystem (modeled on CmuxEventsBridge). Owns one
 // outbound hook (pushLifecycle) and one inbound getUpdates long-poll. Opt-in and
 // crash-contained: no send/poll error may escape into the daemon.
+import os from "node:os";
+import path from "node:path";
 import type { ControlEvent, TelegramConfig } from "@squadrant/shared";
+import { resolveNotify, loadProjectOverride } from "@squadrant/shared";
 import type { TelegramClient } from "./client.js";
 import { isAuthorized, isControlEnabled } from "./auth.js";
 import { parseCommand } from "./commands.js";
 import type { EnsureResult } from "./ensure-captain.js";
 import { formatInbound, formatLifecycle, topicName } from "./format.js";
-import { findProjectByThread, isNotifyActive, loadState, saveState, setNotify, setTopic, topicKey } from "./state.js";
+import { findProjectByThread, loadState, saveState, setNotify, setTopic, topicKey } from "./state.js";
+import { tierIncludes } from "./tiers.js";
 
 export interface TelegramBridge {
   start(): void;
@@ -19,6 +23,8 @@ export interface TelegramBridge {
 export interface TelegramBridgeOptions {
   cfg: TelegramConfig;
   stateRoot: string;
+  /** Root for per-project override files. Defaults to ~/.config/squadrant. */
+  configRoot?: string;
   client: TelegramClient;
   appendCaptainMessage: (a: { stateRoot: string; project: string; text: string; source: "telegram" }) => Promise<void>;
   log: (msg: string) => void;
@@ -40,6 +46,7 @@ const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
 export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridge {
   const { cfg, stateRoot, client, appendCaptainMessage, log, ensureCaptainAlive, runCommand, sendReply } = opts;
+  const configRoot = opts.configRoot ?? path.join(os.homedir(), ".config", "squadrant");
   const pollMs = cfg.pollMs ?? 1000;
   let running = false;
 
@@ -49,9 +56,14 @@ export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridg
     saveState(stateRoot, s);
   }
 
-  // Outbound: resolve (or lazily create) the project's topic, then send.
+  // Outbound: resolve active (live state wins over config default) + crew-tier
+  // filter, then resolve (or lazily create) the project's topic and send.
   async function deliverOutbound(project: string, ev: ControlEvent): Promise<void> {
-    if (!isNotifyActive(stateRoot, project)) return; // muted (default) → no topic create, no send
+    const resolved = resolveNotify(cfg.notify, loadProjectOverride(project, configRoot));
+    const live = loadState(stateRoot).notify[project]; // boolean | undefined
+    const active = live ?? resolved.active;
+    if (!active) return;                                // muted → no topic create, no send
+    if (!tierIncludes(resolved.crew, ev.type)) return; // tier filter
     let threadId = loadState(stateRoot).topics[topicKey(project)];
     if (threadId === undefined) {
       threadId = await client.createForumTopic(cfg.supergroupId, topicName(project));

--- a/packages/core/src/telegram/format.ts
+++ b/packages/core/src/telegram/format.ts
@@ -15,6 +15,14 @@ export function formatLifecycle(project: string, ev: ControlEvent): string {
       return `🚧 [${project}] CREW BLOCKED · ${ev.id}\n${ev.question}`;
     case "task.idle":
       return `💤 [${project}] CREW IDLE · ${ev.id}`;
+    case "task.failed":
+      return `❌ [${project}] CREW FAILED · ${ev.id}\n${ev.error}`;
+    case "task.approval.requested":
+      return `🔐 [${project}] APPROVAL NEEDED · ${ev.id}\n${ev.question}`;
+    case "task.input.requested":
+      return `❓ [${project}] INPUT NEEDED · ${ev.id}\n${ev.question}`;
+    case "task.timeout":
+      return `⏱️ [${project}] CREW TIMEOUT · ${ev.id}`;
     default:
       return `ℹ️ [${project}] ${ev.type} · ${ev.id}`;
   }

--- a/packages/core/src/telegram/tiers.ts
+++ b/packages/core/src/telegram/tiers.ts
@@ -1,0 +1,21 @@
+// Crew notification tier → event-type membership. Tiers are cumulative:
+// done_only ⊂ alert_only ⊂ all. See the layered-notification design.
+import type { CrewTier } from "@squadrant/shared";
+
+const DONE_ONLY = new Set(["task.done", "task.failed"]);
+const ALERTS = new Set([
+  ...DONE_ONLY,
+  "task.blocked",
+  "task.approval.requested",
+  "task.input.requested",
+  "task.timeout",
+]);
+
+export function tierIncludes(tier: CrewTier, eventType: string): boolean {
+  switch (tier) {
+    case "none": return false;
+    case "done_only": return DONE_ONLY.has(eventType);
+    case "alert_only": return ALERTS.has(eventType);
+    case "all": return true;
+  }
+}

--- a/packages/shared/src/__tests__/project-config.test.ts
+++ b/packages/shared/src/__tests__/project-config.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { loadProjectOverride, saveProjectOverride, projectConfigPath } from "../project-config.js";
+import { loadProjectOverride, saveProjectOverride, projectConfigPath, resolveNotify, DEFAULT_NOTIFY } from "../project-config.js";
 
 let root: string;
 beforeEach(() => {
@@ -24,5 +24,21 @@ describe("project override file", () => {
     saveProjectOverride("squadrant", { telegram: { notify: { cap: false } } }, root);
     saveProjectOverride("squadrant", { telegram: { notify: { crew: "none" } } }, root);
     expect(loadProjectOverride("squadrant", root)).toEqual({ telegram: { notify: { cap: false, crew: "none" } } });
+  });
+});
+
+describe("resolveNotify", () => {
+  it("returns built-in defaults with no global and no override", () => {
+    expect(resolveNotify(undefined, {})).toEqual({ active: false, cap: true, crew: "alert_only" });
+    expect(DEFAULT_NOTIFY).toEqual({ active: false, cap: true, crew: "alert_only" });
+  });
+
+  it("global overrides built-in", () => {
+    expect(resolveNotify({ crew: "done_only" }, {})).toEqual({ active: false, cap: true, crew: "done_only" });
+  });
+
+  it("project overrides global per-key, keeping siblings", () => {
+    const r = resolveNotify({ cap: false, crew: "done_only" }, { telegram: { notify: { crew: "all" } } });
+    expect(r).toEqual({ active: false, cap: false, crew: "all" });
   });
 });

--- a/packages/shared/src/__tests__/project-config.test.ts
+++ b/packages/shared/src/__tests__/project-config.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { loadProjectOverride, saveProjectOverride, projectConfigPath } from "../project-config.js";
+
+let root: string;
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "sq-pc-"));
+});
+
+describe("project override file", () => {
+  it("returns {} when the file is absent", () => {
+    expect(loadProjectOverride("squadrant", root)).toEqual({});
+  });
+
+  it("round-trips a saved override", () => {
+    saveProjectOverride("squadrant", { telegram: { notify: { crew: "all" } } }, root);
+    expect(loadProjectOverride("squadrant", root)).toEqual({ telegram: { notify: { crew: "all" } } });
+    expect(projectConfigPath("squadrant", root)).toBe(path.join(root, "projects", "squadrant.json"));
+  });
+
+  it("deep-merges on save, preserving sibling keys", () => {
+    saveProjectOverride("squadrant", { telegram: { notify: { cap: false } } }, root);
+    saveProjectOverride("squadrant", { telegram: { notify: { crew: "none" } } }, root);
+    expect(loadProjectOverride("squadrant", root)).toEqual({ telegram: { notify: { cap: false, crew: "none" } } });
+  });
+});

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -46,6 +46,8 @@ export interface TelegramConfig {
   users?: number[];        // user-id allowlist for CONTROL actions (#321); empty ⇒ control disabled
   remoteControl?: boolean; // opt-in master switch for auto-launch + general commands (default false)
   pollMs?: number;         // getUpdates long-poll cadence (default 1000)
+  /** Global notification defaults (per-project override lives in projects/<name>.json). */
+  notify?: { active?: boolean; cap?: boolean; crew?: "all" | "alert_only" | "done_only" | "none" };
 }
 
 export interface ModelRoutingConfig {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 // @squadrant/shared — pure types + leaf utilities + config.
 export * from "./config.js";
+export * from "./project-config.js";
 export * from "./effort.js";
 export * from "./types/runtime.js";
 export * from "./types/control.js";

--- a/packages/shared/src/project-config.ts
+++ b/packages/shared/src/project-config.ts
@@ -54,3 +54,16 @@ export function saveProjectOverride(name: string, patch: ProjectOverrideConfig, 
   fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.writeFileSync(file, JSON.stringify(merged, null, 2) + "\n");
 }
+
+export const DEFAULT_NOTIFY: NotifyConfig = { active: false, cap: true, crew: "alert_only" };
+
+/** Built-in → global → project, per-key. Does NOT apply live state (bridge's job). */
+export function resolveNotify(
+  globalNotify: Partial<NotifyConfig> | undefined,
+  override: ProjectOverrideConfig,
+): NotifyConfig {
+  let n: NotifyConfig = { ...DEFAULT_NOTIFY };
+  if (globalNotify) n = deepMerge(n, globalNotify);
+  if (override.telegram?.notify) n = deepMerge(n, override.telegram.notify);
+  return n;
+}

--- a/packages/shared/src/project-config.ts
+++ b/packages/shared/src/project-config.ts
@@ -1,0 +1,56 @@
+// Per-project layered config override file. Pure, file-backed, no daemon
+// knowledge. Resolved as built-in → global config.json → projects/<name>.json.
+// See docs/superpowers/specs/2026-06-23-per-project-layered-config-design.md.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ModelRoutingConfig } from "./config.js";
+
+export type CrewTier = "all" | "alert_only" | "done_only" | "none";
+
+export interface NotifyConfig {
+  active: boolean;
+  cap: boolean;
+  crew: CrewTier;
+}
+
+/** Per-project override layer. Every key optional; mirrors the global settings. */
+export interface ProjectOverrideConfig {
+  telegram?: { notify?: Partial<NotifyConfig> };
+  // Reserved future tenants (resolver is already generic; consumers not yet wired):
+  effort?: "max" | "balance" | "low";
+  models?: Partial<ModelRoutingConfig>;
+}
+
+function defaultRoot(): string {
+  return path.join(os.homedir(), ".config", "squadrant");
+}
+
+export function projectConfigPath(name: string, root = defaultRoot()): string {
+  return path.join(root, "projects", `${name}.json`);
+}
+
+export function loadProjectOverride(name: string, root = defaultRoot()): ProjectOverrideConfig {
+  try {
+    return JSON.parse(fs.readFileSync(projectConfigPath(name, root), "utf-8")) as ProjectOverrideConfig;
+  } catch {
+    return {};
+  }
+}
+
+/** Deep-merge a generic plain-object tree. Arrays/primitives in `patch` replace. */
+export function deepMerge<T>(base: T, patch: unknown): T {
+  if (patch === null || typeof patch !== "object" || Array.isArray(patch)) return (patch as T) ?? base;
+  const out: Record<string, unknown> = { ...(base as Record<string, unknown>) };
+  for (const [k, v] of Object.entries(patch as Record<string, unknown>)) {
+    out[k] = deepMerge(out[k], v);
+  }
+  return out as T;
+}
+
+export function saveProjectOverride(name: string, patch: ProjectOverrideConfig, root = defaultRoot()): void {
+  const merged = deepMerge(loadProjectOverride(name, root), patch);
+  const file = projectConfigPath(name, root);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(merged, null, 2) + "\n");
+}


### PR DESCRIPTION
## Per-project layered config + Telegram notification tiers

Adds a generic per-project config-override layer in `@squadrant/shared`, resolved as **built-in → global `config.json` → `projects/<name>.json`** (per-key deep merge), and makes Telegram notifications its first tenant. Builds on the merged #406 gate (`79aca2d`) — `TelegramState.notify` remains the live `active` axis and `deliverOutbound`'s mute early-return is preserved.

Implements the 8-task TDD plan in `docs/superpowers/plans/2026-06-23-per-project-layered-config.md`. Confirmed decisions baked in: cap/crew cross-layer resolution = **(A) project-overrides-global**; `done_only = {task.done, task.failed}`.

### Storage decision (as required by the plan)

The plan is authoritative and unambiguous, and I followed it:

- **Deliberate preferences** (`cap`, `crew` tier) → per-project **config** file `~/.config/squadrant/projects/<name>.json`. Written by `squadrant telegram notify <project> crew|cap …` (CLI) and `/notify crew|cap …` (Telegram, fail-closed).
- **Live, system-tracked toggle** (`active`) → **state** file `telegram-state.json` (unchanged from #406). Written by engagement auto-unmute, `/mute`, `/unmute`, `notify <project> on|off`.

This resolves the spec inconsistency flagged in the brief (the telegram spec sketched `notifyCrew` in state): crew tier is a deliberate pref, so it lives in the config layer per the mechanism spec and the plan. `resolveNotify` takes the live `active` if present, else the config default; `cap`/`crew` always resolve at the config layer.

### Plan inconsistency found & resolved

Task 3's `tierIncludes` (explicitly unit-tested) defines tiers as **cumulative** — `alert_only ⊇ done_only`, so `alert_only` includes `task.done`. Task 4's draft test asserted `alert_only` *drops* `task.done` while sending `task.blocked`, which is impossible under that locked model (both events live only in `alert_only`/`all`). I treated Task 3's `tierIncludes` as authoritative (it matches the design's cumulative tier model) and corrected that single Task 4 test case to assert the real, meaningful behavior: `alert_only` sends outcomes + alerts but drops `task.progress` noise. No production code intent changed.

### What landed (one commit per task)

1. `project-config.ts` — override file load/save + `deepMerge`.
2. Global `telegram.notify` schema + `resolveNotify` (built-in→global→project).
3. `tiers.ts` — `tierIncludes(tier, eventType)`.
4. `deliverOutbound` — resolve `active` (live state wins over config default) + crew-tier filter; `configRoot` threaded from `squadrantd.ts` (`dirname(stateRoot)`).
5. Distinct Telegram formatting for `failed`/`approval`/`input`/`timeout`.
6. CLI `telegram notify <project> crew <tier>|cap <on|off>` → per-project override.
7. `/notify crew|cap` Telegram command → per-project override (fail-closed behind remoteControl + allowlist).
8. `cap` gate on `squadrant telegram send`.

Plus README "Notification tuning (per-project)" section + CHANGELOG Unreleased entries.

### Additive / zero-migration

Absent `projects/<name>.json` behaves exactly as today; old `config.json` (no `telegram.notify`) and `telegram-state.json` load unchanged. Proven by tests (built-in-default fallbacks, absent-file → `{}`, config-default-active vs live-state, muted-by-default).

### Tests

- New: `project-config.test.ts` (6), `tiers.test.ts` (4), `bridge.notify.test.ts` (4), `bridge.notifycmd.test.ts` (4), `telegram.notify.test.ts` (3), `telegram.send.test.ts` (2); extended `format.test.ts` (+4).
- Full suite green: **1440 passed (135 files)**, run once at the end.
- `node dist/index.js --help` + `telegram notify/send --help` gates pass after each build (NodeNext ESM `.js` imports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
