### PR TITLE
feat(daemon): auto-restart on daemon-cached config writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Daemon auto-restarts when you change daemon-cached config.** `squadrant telegram setup`, `squadrant config set <telegram.*|defaults.taskTimeoutMs|defaults.cmuxEventsBridge|projects.*>`, and project registration now restart the daemon so the change takes effect immediately (was: silently stale until a manual `squadrant heal daemon`). Use `--no-restart` to opt out. Interactive crews + tasks + Telegram state recover automatically via the disk store + boot reconcile.
 - **Telegram `/command` menu registration.** `squadrant telegram setup` now registers the bot's command menu automatically, and `squadrant telegram register-commands` (re)registers it on demand — so `/status`, `/notify`, `/mute`, etc. appear in Telegram's `/` autocomplete. Setup also reuses an existing bot token on re-run (use `--reset-token` to rotate it), reports existing project topics so you can see what's already linked, and never recreates topics that already exist in state.
 - **`squadrant:telegram` skill** documenting setup, remote control, command registration, and notification tuning.
 - **Telegram mute confirmations.** Turning a project quieter via `squadrant telegram notify <p> off|cap off|crew <lower>` now posts a one-time confirmation into that project's topic (bypassing the mute), so you can tell on Telegram that it went silent rather than guessing.
@@ -15,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Telegram notification tiers (per-project).** Outbound lifecycle pushes are filtered by a per-project **crew tier** — `none` ⊂ `done_only` (`task.done`/`task.failed`) ⊂ `alert_only` (+ blocked/approval/input/timeout, the default) ⊂ `all`. New CLI `squadrant telegram notify <project> crew <tier>` / `cap <on|off>` and Telegram `/notify crew <tier>` / `/notify cap <on|off>` (fail-closed behind remote control) write the per-project config file. The live `active` mute axis (`/mute` / `/unmute` / `notify <project> on|off`) is unchanged and stays in `telegram-state.json`; the live value overrides the config-default `active`.
 - **Distinct Telegram formatting** for `task.failed` (CREW FAILED + error), `task.approval.requested` (APPROVAL NEEDED + question), `task.input.requested` (INPUT NEEDED + question), and `task.timeout` (CREW TIMEOUT) — previously these fell to the generic line.
 - **`cap` gate on `squadrant telegram send`** — with a project's resolved `cap=off`, explicit captain messages are suppressed (not sent), independent of idle-mute.
+
+### Known issues
+- A config-write restart can orphan in-flight **headless** crews (interactive crews recover fine) — see [#410](https://github.com/tu11aa/squadrant/issues/410).
 
 ### Changed
 - **Telegram notifications are now per-project and muted by default.** Lifecycle events (crew done/blocked/idle) are delivered to a project's topic only after you engage that project — by sending any message into its topic, by `/unmute` (Telegram, requires remoteControl), or by `squadrant telegram notify <project> on`. This changes prior behavior where every project pushed all lifecycle events. Mute again with `/mute <project>` or `squadrant telegram notify <project> off`. Command replies and the General command channel are unaffected.

--- a/packages/cli/src/commands/__tests__/config.test.ts
+++ b/packages/cli/src/commands/__tests__/config.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs";
 import { spawnSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { runConfigCheck, runConfigGet, runConfigSet } from "../config.js";
+import { runConfigCheck, runConfigGet, runConfigSet, runConfigSetAction } from "../config.js";
 import { getDefaultConfig } from "@squadrant/shared";
 
 const __thisDir = dirname(fileURLToPath(import.meta.url));
@@ -87,6 +87,33 @@ describe("runConfigGet / runConfigSet (dotted path)", () => {
     const onDisk = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
     expect(onDisk.defaults.maxCrew).toBe(9);
     expect(onDisk.defaults.effort).toBe("balance");
+  });
+});
+
+// ── daemon auto-restart on config set ────────────────────────────────────────
+
+describe("runConfigSetAction — daemon restart gating", () => {
+  it("does NOT call restart for a non-daemon-cached key (defaults.effort)", () => {
+    writeUser(() => {});
+    const spy = vi.fn().mockReturnValue("skipped-opt-out");
+    runConfigSetAction({ key: "defaults.effort", value: "low", doRestart: spy, configPath: cfgPath });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("DOES call restart for a daemon-cached key (telegram.notify.crew)", () => {
+    writeUser((c) => { (c as any).telegram = { botToken: "t", supergroupId: -1, notify: { crew: "all" } }; });
+    const spy = vi.fn().mockReturnValue("restarted");
+    runConfigSetAction({ key: "telegram.notify.crew", value: "none", doRestart: spy, configPath: cfgPath });
+    expect(spy).toHaveBeenCalledOnce();
+    expect(spy.mock.calls[0][0]).toMatchObject({ reason: expect.stringContaining("telegram.notify.crew") });
+  });
+
+  it("noRestart suppresses the restart call via noRestart flag passed through", () => {
+    writeUser((c) => { (c as any).telegram = { botToken: "t", supergroupId: -1, notify: { crew: "all" } }; });
+    const spy = vi.fn().mockReturnValue("skipped-opt-out");
+    runConfigSetAction({ key: "telegram.notify.crew", value: "none", noRestart: true, doRestart: spy, configPath: cfgPath });
+    expect(spy).toHaveBeenCalledOnce();
+    expect(spy.mock.calls[0][0]).toMatchObject({ noRestart: true });
   });
 });
 

--- a/packages/cli/src/commands/__tests__/projects.test.ts
+++ b/packages/cli/src/commands/__tests__/projects.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from "vitest";
+import { restartAfterProjectsAdd } from "../projects.js";
+
+describe("restartAfterProjectsAdd — restart gating", () => {
+  it("calls restart helper with reason 'project registration'", () => {
+    const spy = vi.fn().mockReturnValue("restarted");
+    restartAfterProjectsAdd({ doRestart: spy });
+    expect(spy).toHaveBeenCalledOnce();
+    expect(spy.mock.calls[0][0]).toMatchObject({ reason: "project registration" });
+  });
+
+  it("passes noRestart=true through to the helper", () => {
+    const spy = vi.fn().mockReturnValue("skipped-opt-out");
+    restartAfterProjectsAdd({ noRestart: true, doRestart: spy });
+    expect(spy).toHaveBeenCalledOnce();
+    expect(spy.mock.calls[0][0]).toMatchObject({ noRestart: true });
+  });
+});

--- a/packages/cli/src/commands/__tests__/telegram.test.ts
+++ b/packages/cli/src/commands/__tests__/telegram.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { getDefaultConfig, type SquadrantConfig, type TelegramConfig } from "@squadrant/shared";
 import { loadState } from "@squadrant/core";
-import { telegramCommand, runTelegramStatus, runTelegramLink, runTelegramSend, runRegisterCommands, resolveSetupToken, questionMasked } from "../telegram.js";
+import { telegramCommand, runTelegramStatus, runTelegramLink, runTelegramSend, runRegisterCommands, resolveSetupToken, questionMasked, runTelegramPostSetup } from "../telegram.js";
 
 let root: string;
 beforeEach(() => { root = fs.mkdtempSync(path.join(os.tmpdir(), "sq-tg-cmd-")); });
@@ -225,5 +225,16 @@ describe("runNotifyConfirmation", () => {
     setTopicDirect(dir, "squadrant", 9);
     const c: any = { sendMessage: async () => { throw new Error("boom"); } };
     expect(await runNotifyConfirmation({ project: "squadrant", before: { ...ON }, after: { ...ON, cap: false }, cfg: tgCfg, client: c, stateRoot: dir })).toBe(false);
+  });
+});
+
+// ── daemon auto-restart after telegram setup ──────────────────────────────────
+
+describe("runTelegramPostSetup — restart gating", () => {
+  it("calls restart helper with a reason mentioning telegram", () => {
+    const spy = vi.fn().mockReturnValue("restarted");
+    runTelegramPostSetup({ doRestart: spy });
+    expect(spy).toHaveBeenCalledOnce();
+    expect(spy.mock.calls[0][0]).toMatchObject({ reason: expect.stringContaining("telegram") });
   });
 });

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -3,9 +3,10 @@ import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import chalk from "chalk";
-import { DEFAULT_CONFIG_PATH, getDefaultConfig, loadConfig, saveConfig, type SquadrantConfig } from "@squadrant/shared";
+import { DEFAULT_CONFIG_PATH, getDefaultConfig, loadConfig, saveConfig, type SquadrantConfig, isDaemonCachedKey } from "@squadrant/shared";
 import { detectDrift, applySafeFixes, type DriftItem } from "@squadrant/shared";
 import { withStamp } from "@squadrant/shared";
+import { restartDaemonIfRunning, type RestartOutcome } from "../control/restart-daemon.js";
 
 export interface ConfigCheckOptions {
   configPath: string;
@@ -83,6 +84,30 @@ export function runConfigSet(key: string, value: string, configPath = DEFAULT_CO
   }
   node[parts[parts.length - 1]] = parsed;
   saveConfig(config as unknown as SquadrantConfig, configPath);
+}
+
+function printRestartOutcome(outcome: RestartOutcome): void {
+  if (outcome === "skipped-not-running") {
+    console.log(chalk.dim("(daemon not running — change applies on next start)"));
+  } else if (outcome === "skipped-opt-out") {
+    console.log(chalk.dim("(run 'squadrant heal daemon' to apply)"));
+  }
+}
+
+export function runConfigSetAction(opts: {
+  key: string;
+  value: string;
+  noRestart?: boolean;
+  doRestart?: (o: { reason: string; noRestart?: boolean }) => RestartOutcome;
+  configPath?: string;
+}): void {
+  runConfigSet(opts.key, opts.value, opts.configPath);
+  console.log(chalk.green(`✔ set ${opts.key} = ${opts.value}`));
+  if (isDaemonCachedKey(opts.key)) {
+    const doRestart = opts.doRestart ?? restartDaemonIfRunning;
+    const outcome = doRestart({ reason: `config ${opts.key}`, noRestart: opts.noRestart });
+    printRestartOutcome(outcome);
+  }
 }
 
 const SEV_COLOR: Record<string, (s: string) => string> = {
@@ -164,10 +189,10 @@ configCommand
   .description("Write a config value by dotted key (e.g. defaults.effort low)")
   .argument("<key>", "dotted config key")
   .argument("<value>", "value (JSON-parsed when possible, else a bare string)")
-  .action((key: string, value: string) => {
+  .option("--no-restart", "skip daemon restart even if the key is daemon-cached")
+  .action((key: string, value: string, opts: { restart?: boolean }) => {
     try {
-      runConfigSet(key, value);
-      console.log(chalk.green(`✔ set ${key} = ${value}`));
+      runConfigSetAction({ key, value, noRestart: opts.restart === false });
     } catch (e) {
       console.error(chalk.red((e as Error).message));
       process.exit(1);

--- a/packages/cli/src/commands/heal.ts
+++ b/packages/cli/src/commands/heal.ts
@@ -13,8 +13,8 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { queryHealth } from "./health-view.js";
 import { healCmdFor } from "@squadrant/core";
-import { ensureDaemon as _ensureDaemon } from "@squadrant/core";
 import type { ComponentHealth, HealthState } from "@squadrant/core";
+import { restartDaemonIfRunning } from "../control/restart-daemon.js";
 
 // ── pure helpers (fully unit-testable, no I/O) ────────────────────────────────
 
@@ -153,7 +153,7 @@ export const healCommand = new Command("heal")
       .description("Restart squadrantd via the idempotent launchd kickstart path")
       .action(async () => {
         const code = await runHealDaemon({
-          ensureDaemon: _ensureDaemon,
+          ensureDaemon: () => restartDaemonIfRunning({ reason: "heal", isRunning: () => true }),
           stdout: process.stdout,
           stderr: process.stderr,
         });

--- a/packages/cli/src/commands/projects.ts
+++ b/packages/cli/src/commands/projects.ts
@@ -8,6 +8,20 @@ import {
   resolveHome,
   ProjectConfig,
 } from "@squadrant/shared";
+import { restartDaemonIfRunning, type RestartOutcome } from "../control/restart-daemon.js";
+
+export function restartAfterProjectsAdd(opts: {
+  noRestart?: boolean;
+  doRestart?: (o: { reason: string; noRestart?: boolean }) => RestartOutcome;
+}): void {
+  const doRestart = opts.doRestart ?? restartDaemonIfRunning;
+  const outcome = doRestart({ reason: "project registration", noRestart: opts.noRestart });
+  if (outcome === "skipped-not-running") {
+    console.log(chalk.dim("  (daemon not running — change applies on next start)"));
+  } else if (outcome === "skipped-opt-out") {
+    console.log(chalk.dim("  (run 'squadrant heal daemon' to apply)"));
+  }
+}
 
 function findPackageRoot(): string {
   let dir = path.dirname(new URL(import.meta.url).pathname);
@@ -68,7 +82,8 @@ const addCmd = new Command("add")
   .option("--spoke <path>", "Spoke vault path (default: ~/squadrant-hub/spokes/<name>)")
   .option("--group <name>", "Project group name (siblings share context)")
   .option("--group-role <role>", "Role within the group (auto-set to 'primary' if first in group)")
-  .action((name: string, projectPath: string, opts: { captain?: string; spoke?: string; group?: string; groupRole?: string }) => {
+  .option("--no-restart", "skip daemon restart after registration")
+  .action((name: string, projectPath: string, opts: { captain?: string; spoke?: string; group?: string; groupRole?: string; restart?: boolean }) => {
     const config = loadConfig();
 
     if (config.projects[name]) {
@@ -150,6 +165,7 @@ const addCmd = new Command("add")
     config.projects[name] = project;
     saveConfig(config);
     console.log(chalk.green(`\n  ✔ Project '${name}' registered`));
+    restartAfterProjectsAdd({ noRestart: opts.restart === false });
 
     // Scaffold spoke vault from template
     const pkgRoot = findPackageRoot();

--- a/packages/cli/src/commands/telegram.ts
+++ b/packages/cli/src/commands/telegram.ts
@@ -6,6 +6,7 @@ import { loadConfig, DEFAULT_CONFIG_PATH, saveProjectOverride, resolveNotify, lo
 import type { SquadrantConfig, TelegramConfig, NotifyConfig, CrewTier } from "@squadrant/shared";
 import { createTelegramClient, loadState, setTopic, topicKey, topicName, detectGroupAndUser, writeTelegramConfig, maskToken, isNotifyActive, setNotify, BOT_COMMANDS } from "@squadrant/core";
 import type { TelegramClient } from "@squadrant/core";
+import { restartDaemonIfRunning, type RestartOutcome } from "../control/restart-daemon.js";
 
 /** Daemon state root (mirrors buildContext): ~/.config/squadrant/state. */
 function defaultStateRoot(): string {
@@ -199,6 +200,18 @@ export async function runRegisterCommands(opts: { client: TelegramClient }): Pro
   await opts.client.setMyCommands(BOT_COMMANDS);
 }
 
+export function runTelegramPostSetup(opts: {
+  doRestart?: (o: { reason: string }) => RestartOutcome;
+}): void {
+  const doRestart = opts.doRestart ?? restartDaemonIfRunning;
+  const outcome = doRestart({ reason: "telegram config" });
+  if (outcome === "skipped-not-running") {
+    console.log(chalk.dim("(daemon not running — change applies on next start)"));
+  } else if (outcome === "skipped-opt-out") {
+    console.log(chalk.dim("(run 'squadrant heal daemon' to apply)"));
+  }
+}
+
 export const telegramCommand = new Command("telegram")
   .description("Two-way Telegram integration: push crew events to a topic and reply into the captain pane");
 
@@ -368,6 +381,7 @@ telegramCommand
       console.log(chalk.dim("No project topics yet — they're created on first delivery or via: squadrant telegram link <project>"));
     }
 
+    runTelegramPostSetup({});
     console.log();
     console.log(`Next: ${chalk.cyan("squadrant telegram link <project>")}`);
   });

--- a/packages/cli/src/control/__tests__/restart-daemon.test.ts
+++ b/packages/cli/src/control/__tests__/restart-daemon.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { restartDaemonIfRunning } from "../restart-daemon.js";
+
+const base = { reason: "x", env: {} as NodeJS.ProcessEnv };
+
+describe("restartDaemonIfRunning", () => {
+  it("opt-out via noRestart", () => {
+    let ran = false;
+    expect(
+      restartDaemonIfRunning({
+        ...base,
+        noRestart: true,
+        isRunning: () => true,
+        runKickstart: () => { ran = true; },
+      }),
+    ).toBe("skipped-opt-out");
+    expect(ran).toBe(false);
+  });
+
+  it("skips when daemon not running", () => {
+    let ran = false;
+    expect(
+      restartDaemonIfRunning({
+        ...base,
+        isRunning: () => false,
+        runKickstart: () => { ran = true; },
+      }),
+    ).toBe("skipped-not-running");
+    expect(ran).toBe(false);
+  });
+
+  it("restarts when running", () => {
+    let ran = false;
+    expect(
+      restartDaemonIfRunning({
+        ...base,
+        isRunning: () => true,
+        runKickstart: () => { ran = true; },
+      }),
+    ).toBe("restarted");
+    expect(ran).toBe(true);
+  });
+
+  it("never restarts under VITEST env", () => {
+    let ran = false;
+    expect(
+      restartDaemonIfRunning({
+        reason: "x",
+        env: { VITEST: "1" } as NodeJS.ProcessEnv,
+        isRunning: () => true,
+        runKickstart: () => { ran = true; },
+      }),
+    ).toBe("skipped-opt-out");
+    expect(ran).toBe(false);
+  });
+});

--- a/packages/cli/src/control/restart-daemon.ts
+++ b/packages/cli/src/control/restart-daemon.ts
@@ -1,0 +1,46 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { LABEL, kickstartArgv, tryAcquireDaemonLock, releaseDaemonLock } from "@squadrant/core";
+
+export type RestartOutcome = "restarted" | "skipped-not-running" | "skipped-opt-out";
+
+const DEFAULT_SOCK_PATH = join(homedir(), ".config", "squadrant", "squadrant.sock");
+
+function defaultIsRunning(): boolean {
+  return existsSync(DEFAULT_SOCK_PATH);
+}
+
+function defaultRunKickstart(): void {
+  const uid = process.getuid?.() ?? 0;
+  const target = `gui/${uid}/${LABEL}`;
+  if (tryAcquireDaemonLock()) {
+    try {
+      execFileSync("launchctl", kickstartArgv(target, true), { stdio: "ignore" });
+    } finally {
+      releaseDaemonLock();
+    }
+  }
+}
+
+export function restartDaemonIfRunning(opts: {
+  reason: string;
+  noRestart?: boolean;
+  isRunning?: () => boolean;
+  runKickstart?: () => void;
+  env?: NodeJS.ProcessEnv;
+  log?: (m: string) => void;
+}): RestartOutcome {
+  const env = opts.env ?? process.env;
+  if (env["VITEST"] || opts.noRestart) return "skipped-opt-out";
+
+  const isRunning = opts.isRunning ?? defaultIsRunning;
+  if (!isRunning()) return "skipped-not-running";
+
+  const log = opts.log ?? console.log;
+  log(`↻ restarting daemon to apply ${opts.reason}…`);
+  const runKickstart = opts.runKickstart ?? defaultRunKickstart;
+  runKickstart();
+  return "restarted";
+}

--- a/packages/shared/src/__tests__/daemon-keys.test.ts
+++ b/packages/shared/src/__tests__/daemon-keys.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { isDaemonCachedKey } from "../daemon-keys.js";
+
+describe("isDaemonCachedKey", () => {
+  it("flags daemon-cached keys", () => {
+    for (const k of [
+      "telegram.remoteControl",
+      "telegram.notify.crew",
+      "defaults.taskTimeoutMs",
+      "defaults.cmuxEventsBridge",
+      "projects.brove",
+    ]) {
+      expect(isDaemonCachedKey(k), k).toBe(true);
+    }
+  });
+
+  it("ignores fresh-read keys", () => {
+    for (const k of [
+      "defaults.effort",
+      "defaults.crewRouting.rules",
+      "models.crew",
+    ]) {
+      expect(isDaemonCachedKey(k), k).toBe(false);
+    }
+  });
+});

--- a/packages/shared/src/daemon-keys.ts
+++ b/packages/shared/src/daemon-keys.ts
@@ -1,0 +1,10 @@
+const DAEMON_CACHED_PREFIXES = [
+  "telegram.",
+  "defaults.taskTimeoutMs",
+  "defaults.cmuxEventsBridge",
+  "projects.",
+];
+
+export function isDaemonCachedKey(dottedKey: string): boolean {
+  return DAEMON_CACHED_PREFIXES.some((p) => dottedKey === p || dottedKey.startsWith(p));
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -20,3 +20,4 @@ export * from "./lib/tool-compat.js";
 export * from "./lib/canonical-source.js";
 export * from "./lib/daily-logs.js";
 export * from "./lib/vault-layout.js";
+export * from "./daemon-keys.js";


### PR DESCRIPTION
## Summary

- **`isDaemonCachedKey`** pure gate in `@squadrant/shared` — identifies keys the daemon caches at boot (`telegram.*`, `defaults.taskTimeoutMs`, `defaults.cmuxEventsBridge`, `projects.*`)
- **`restartDaemonIfRunning`** shared helper in `packages/cli/src/control/restart-daemon.ts` — injectable (isRunning + runKickstart + env), skips under VITEST, supports `noRestart` opt-out. `squadrant heal daemon` now routes through it.
- **Wired into 3 write paths:** `squadrant telegram setup`, `squadrant config set <daemon-cached-key>` (+ `--no-restart`), `squadrant projects add` (+ `--no-restart`)
- Reuses existing daemon recovery (disk store + boot reconcile + cmux-events cursor) — no new snapshot/persistence

## Known gap
- In-flight **headless** crews may be orphaned by `-k` restart — tracked as [#410](https://github.com/tu11aa/squadrant/issues/410), intentionally not guarded in this slice.

## Test plan
- [ ] `isDaemonCachedKey` unit: 2/2 pass
- [ ] `restartDaemonIfRunning` unit: 4/4 pass (all injected, no real daemon touched)
- [ ] `config set` restart gating: 3 new tests pass
- [ ] `telegram setup` restart: 1 new test passes
- [ ] `projects add` restart: 2 new tests pass
- [ ] `heal daemon` existing tests: still pass (10/10)
- [ ] Full suite: 1467/1468 pass (1 known bridge timeout flake — baseline)
- [ ] `node dist/index.js config set --help` shows `--no-restart`