### PR TITLE
fix(telegram): strip @botname suffix from menu-tapped commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Telegram commands tapped from the `/` menu in groups now work correctly.** Telegram appends `@<botname>` to menu-tapped commands (e.g. `/status@squadrant_bot`). The three command parsers (`parseCommand`, `parseNotifyPref`, `notifyToggle`) now strip this suffix from the first token before matching, so menu-tapped commands are recognized identically to manually typed bare commands.
+
 ### Added
 - **`squadrant telegram setup` is now re-run-safe.** Re-running setup with an existing supergroup configured skips `getUpdates` entirely — avoids the 60 s timeout caused by the daemon's poll consuming the single-consumer long-poll channel. New `--redetect` flag forces fresh group detection; new `--user-id <id>` flag lets you enable remote control on a re-run without touching `getUpdates`. Allowlist precedence: `--user-id` > detected userId (first-run only) > existing `cfg.users` (preserved).
 - **Daemon auto-restarts when you change daemon-cached config.** `squadrant telegram setup`, `squadrant config set <telegram.*|defaults.taskTimeoutMs|defaults.cmuxEventsBridge|projects.*>`, and project registration now restart the daemon so the change takes effect immediately (was: silently stale until a manual `squadrant heal daemon`). Use `--no-restart` to opt out. Interactive crews + tasks + Telegram state recover automatically via the disk store + boot reconcile.

--- a/packages/core/src/telegram/__tests__/bridge.notifycmd.test.ts
+++ b/packages/core/src/telegram/__tests__/bridge.notifycmd.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseNotifyPref } from "../bridge.js";
+import { parseNotifyPref, notifyToggle } from "../bridge.js";
 
 describe("parseNotifyPref", () => {
   it("parses /notify crew all", () => {
@@ -23,4 +23,14 @@ describe("parseNotifyPref", () => {
   it("strips @botname from /notify@squadrant_bot crew all", () => {
     expect(parseNotifyPref("/notify@squadrant_bot crew all")).toEqual({ dimension: "crew", value: "all" });
   });
+});
+
+describe("notifyToggle", () => {
+  it("/unmute returns true", () => { expect(notifyToggle("/unmute")).toBe(true); });
+  it("/mute returns false", () => { expect(notifyToggle("/mute")).toBe(false); });
+  it("ordinary text returns null", () => { expect(notifyToggle("hello")).toBeNull(); });
+
+  // @botname suffix — tapped from / menu in groups
+  it("/unmute@squadrant_bot returns true", () => { expect(notifyToggle("/unmute@squadrant_bot")).toBe(true); });
+  it("/mute@squadrant_bot returns false", () => { expect(notifyToggle("/mute@squadrant_bot")).toBe(false); });
 });

--- a/packages/core/src/telegram/__tests__/bridge.notifycmd.test.ts
+++ b/packages/core/src/telegram/__tests__/bridge.notifycmd.test.ts
@@ -14,4 +14,13 @@ describe("parseNotifyPref", () => {
   it("returns null for /notify with no dimension", () => {
     expect(parseNotifyPref("/notify")).toBeNull();
   });
+
+  // @botname suffix — Telegram appends this when tapped from / menu in groups
+  it("strips @botname from /notify@squadrant_bot cap on", () => {
+    expect(parseNotifyPref("/notify@squadrant_bot cap on")).toEqual({ dimension: "cap", value: "on" });
+  });
+
+  it("strips @botname from /notify@squadrant_bot crew all", () => {
+    expect(parseNotifyPref("/notify@squadrant_bot crew all")).toEqual({ dimension: "crew", value: "all" });
+  });
 });

--- a/packages/core/src/telegram/bridge.ts
+++ b/packages/core/src/telegram/bridge.ts
@@ -7,7 +7,7 @@ import type { ControlEvent, TelegramConfig } from "@squadrant/shared";
 import { resolveNotify, loadProjectOverride, saveProjectOverride } from "@squadrant/shared";
 import type { TelegramClient } from "./client.js";
 import { isAuthorized, isControlEnabled } from "./auth.js";
-import { parseCommand } from "./commands.js";
+import { parseCommand, stripBotMention } from "./commands.js";
 import type { EnsureResult } from "./ensure-captain.js";
 import { formatInbound, formatLifecycle, topicName } from "./format.js";
 import { findProjectByThread, loadState, saveState, setNotify, setTopic, topicKey } from "./state.js";
@@ -50,7 +50,7 @@ const CREW_TIERS = ["all", "alert_only", "done_only", "none"];
  *  Returns null for anything else (ordinary message or malformed). */
 export function parseNotifyPref(text: string): { dimension: "crew" | "cap"; value: string } | null {
   const parts = text.trim().split(/\s+/);
-  if (parts[0]?.toLowerCase() !== "/notify") return null;
+  if (stripBotMention(parts[0] ?? "").toLowerCase() !== "/notify") return null;
   const dimension = parts[1]?.toLowerCase();
   if ((dimension === "crew" || dimension === "cap") && parts[2]) return { dimension, value: parts[2].toLowerCase() };
   return null;

--- a/packages/core/src/telegram/bridge.ts
+++ b/packages/core/src/telegram/bridge.ts
@@ -56,6 +56,15 @@ export function parseNotifyPref(text: string): { dimension: "crew" | "cap"; valu
   return null;
 }
 
+/** Recognize the two in-topic notification toggles. Returns the desired active
+ *  state, or null if the text is an ordinary message. */
+export function notifyToggle(text: string): boolean | null {
+  const first = stripBotMention(text.trim().split(/\s+/)[0] ?? "").toLowerCase();
+  if (first === "/unmute") return true;
+  if (first === "/mute") return false;
+  return null;
+}
+
 export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridge {
   const { cfg, stateRoot, client, appendCaptainMessage, log, ensureCaptainAlive, runCommand, sendReply } = opts;
   const configRoot = opts.configRoot ?? path.join(os.homedir(), ".config", "squadrant");
@@ -119,15 +128,6 @@ export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridg
       await reply(undefined, `⚠️ command failed: ${(e as Error).message}`);
       log(`telegram command failed argv=${JSON.stringify(parsed.argv)}: ${(e as Error).message}`);
     }
-  }
-
-  // Recognize the two in-topic notification toggles. Returns the desired active
-  // state, or null if the text is an ordinary message.
-  function notifyToggle(text: string): boolean | null {
-    const first = text.trim().split(/\s+/)[0]?.toLowerCase();
-    if (first === "/unmute") return true;
-    if (first === "/mute") return false;
-    return null;
   }
 
   // Project topic: the v1 captain.message flow + Gap-1 auto-launch (#403). When

--- a/packages/core/src/telegram/commands.test.ts
+++ b/packages/core/src/telegram/commands.test.ts
@@ -90,4 +90,25 @@ describe("parseCommand", () => {
   it("/mute with no project → usage", () => {
     expect(parseCommand("/mute")).toEqual({ kind: "usage", name: "mute", message: "usage: /mute <project>" });
   });
+
+  // @botname suffix — Telegram appends this when a command is tapped from the / menu in groups
+  it("strips @botname suffix from /status@squadrant_bot", () => {
+    expect(parseCommand("/status@squadrant_bot")).toEqual({ kind: "ok", name: "status", argv: ["status"] });
+  });
+
+  it("strips @botname suffix from /mute@squadrant_bot squadrant", () => {
+    expect(parseCommand("/mute@squadrant_bot squadrant")).toEqual({
+      kind: "ok", name: "mute", argv: ["telegram", "notify", "squadrant", "off"],
+    });
+  });
+
+  it("strips @botname suffix from /unmute@squadrant_bot squadrant", () => {
+    expect(parseCommand("/unmute@squadrant_bot squadrant")).toEqual({
+      kind: "ok", name: "unmute", argv: ["telegram", "notify", "squadrant", "on"],
+    });
+  });
+
+  it("bare command (no @botname) still works identically", () => {
+    expect(parseCommand("/status")).toEqual({ kind: "ok", name: "status", argv: ["status"] });
+  });
 });

--- a/packages/core/src/telegram/commands.ts
+++ b/packages/core/src/telegram/commands.ts
@@ -101,6 +101,11 @@ function helpText(): string {
   return ["Available commands:", ...lines, "  /help"].join("\n");
 }
 
+/** Strip the `@botname` suffix Telegram appends to menu-tapped commands in groups. */
+export function stripBotMention(token: string): string {
+  return token.split("@")[0];
+}
+
 /** Parse a raw Telegram message into a curated command. Non-slash text and
  *  unregistered commands return `unknown`. */
 export function parseCommand(text: string): ParsedCommand {
@@ -109,7 +114,7 @@ export function parseCommand(text: string): ParsedCommand {
     return { kind: "unknown", message: "unknown command — send /help" };
   }
   const tokens = trimmed.slice(1).split(/\s+/).filter((t) => t.length > 0);
-  const name = (tokens[0] ?? "").toLowerCase();
+  const name = stripBotMention(tokens[0] ?? "").toLowerCase();
   const args = tokens.slice(1);
 
   if (name === "help") {


### PR DESCRIPTION
## Summary

Telegram appends `@<botname>` to commands tapped from the `/` menu in groups (e.g. `/status@squadrant_bot`). All three command parsers were matching the bare form only, so every menu-tapped command fell through unrecognised.

- Add `stripBotMention(token)` pure helper in `commands.ts` (exported)
- Apply to `parseCommand` first token — `/status@squadrant_bot` → `status`
- Apply to `parseNotifyPref` first token — `/notify@squadrant_bot cap on` → recognised
- Extract `notifyToggle` as a module-level export (was closure-private) and apply the helper — `/mute@squadrant_bot` / `/unmute@squadrant_bot` now work
- Unit tests for all three parsers with the `@botname` form; bare-command regression tests confirm no behaviour change

## Test plan

- [ ] `npx vitest run packages/core/src/telegram/commands.test.ts` — 21 pass (3 new)
- [ ] `npx vitest run packages/core/src/telegram/__tests__/bridge.notifycmd.test.ts` — 11 pass (5 new)
- [ ] `node dist/index.js --help` — CLI boots
- [ ] Tap `/status` from the bot's command menu in a Telegram group — receives a valid reply (was: "unknown command")