### PR TITLE
fix(telegram): usage hint for incomplete /notify in project topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **An incomplete `/notify` in a Telegram project topic now replies with a usage hint instead of being sent to the captain.** A bare `/notify` (or `/notify@<botname>`, or a dimension with no value like `/notify cap`) previously fell through and was appended as a captain message. It is now recognized as a `/notify` attempt: fail-closed behind remote control, then either applied (when complete) or answered with `usage: /notify crew <all|alert_only|done_only|none> | cap <on|off>`. Ordinary messages and `/mute`/`/unmute` are unchanged.
 - **Telegram commands tapped from the `/` menu in groups now work correctly.** Telegram appends `@<botname>` to menu-tapped commands (e.g. `/status@squadrant_bot`). The three command parsers (`parseCommand`, `parseNotifyPref`, `notifyToggle`) now strip this suffix from the first token before matching, so menu-tapped commands are recognized identically to manually typed bare commands.
 
 ### Added

--- a/packages/core/src/telegram/bridge.test.ts
+++ b/packages/core/src/telegram/bridge.test.ts
@@ -144,3 +144,58 @@ describe("handleUpdate routing", () => {
     bridge.stop();
   });
 });
+
+describe("/notify in a project topic", () => {
+  const ctrlCfg = { ...baseCfg, remoteControl: true, users: [ALLOWED_USER] };
+
+  it("bare /notify (authorized) replies with usage and never appends a captain message", async () => {
+    setTopic(stateRoot, "brove", 7);
+    const d = deps();
+    const { bridge, drained } = drive({ cfg: ctrlCfg, ...d }, [topicMsg("/notify", 7)]);
+    await drained;
+    expect(d.sendReply).toHaveBeenCalledWith(7, expect.stringContaining("usage: /notify"));
+    expect(d.appendCaptainMessage).not.toHaveBeenCalled();
+    bridge.stop();
+  });
+
+  it("bare /notify@botname (authorized) replies with usage (proves @botname strip)", async () => {
+    setTopic(stateRoot, "brove", 7);
+    const d = deps();
+    const { bridge, drained } = drive({ cfg: ctrlCfg, ...d }, [topicMsg("/notify@squadrant_bot", 7)]);
+    await drained;
+    expect(d.sendReply).toHaveBeenCalledWith(7, expect.stringContaining("usage: /notify"));
+    expect(d.appendCaptainMessage).not.toHaveBeenCalled();
+    bridge.stop();
+  });
+
+  it("bare /notify (unauthorized) replies not authorized and never appends", async () => {
+    setTopic(stateRoot, "brove", 7);
+    const d = deps();
+    const { bridge, drained } = drive({ cfg: baseCfg, ...d }, [topicMsg("/notify", 7)]);
+    await drained;
+    expect(d.sendReply).toHaveBeenCalledWith(7, expect.stringContaining("not authorized"));
+    expect(d.appendCaptainMessage).not.toHaveBeenCalled();
+    bridge.stop();
+  });
+
+  it("/notify cap on (authorized) applies the preference and never appends", async () => {
+    setTopic(stateRoot, "brove", 7);
+    const d = deps();
+    const { bridge, drained } = drive({ cfg: ctrlCfg, ...d }, [topicMsg("/notify cap on", 7)]);
+    await drained;
+    expect(d.sendReply).toHaveBeenCalledWith(7, expect.stringContaining("cap = on"));
+    expect(d.appendCaptainMessage).not.toHaveBeenCalled();
+    bridge.stop();
+  });
+
+  it("a normal message is still appended as a captain message", async () => {
+    setTopic(stateRoot, "brove", 7);
+    const d = deps();
+    const { bridge, drained } = drive({ cfg: ctrlCfg, ...d }, [topicMsg("ship it", 7)]);
+    await drained;
+    expect(d.appendCaptainMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ project: "brove", source: "telegram" }),
+    );
+    bridge.stop();
+  });
+});

--- a/packages/core/src/telegram/bridge.ts
+++ b/packages/core/src/telegram/bridge.ts
@@ -151,14 +151,22 @@ export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridg
       return;
     }
 
-    const pref = parseNotifyPref(text);
-    if (pref !== null) {
-      // Deliberate preference change — fail-closed, writes the per-project config
-      // file (not live state), never appended as a captain message.
+    // Any /notify attempt (including an incomplete one like a bare `/notify`) is
+    // handled here and NEVER appended as a captain message. The first token is
+    // matched after stripping a `@botname` suffix Telegram adds in groups.
+    if (stripBotMention(text.trim().split(/\s+/)[0] ?? "").toLowerCase() === "/notify") {
+      // Fail-closed: only an allowlisted sender under remoteControl may proceed.
       if (!isControlEnabled(cfg) || !isAuthorized(fromId, cfg)) {
         await reply(threadId, "⛔ not authorized");
         return;
       }
+      const pref = parseNotifyPref(text);
+      if (pref === null) {
+        // Incomplete (bare `/notify`, or a dimension with no value) → usage hint.
+        await reply(threadId, "usage: /notify crew <all|alert_only|done_only|none> | cap <on|off>");
+        return;
+      }
+      // Deliberate preference change — writes the per-project config file (not live state).
       if (pref.dimension === "crew") {
         if (!CREW_TIERS.includes(pref.value)) {
           await reply(threadId, "crew must be all|alert_only|done_only|none");


### PR DESCRIPTION
## What

In a Telegram **project topic**, a bare/incomplete `/notify` (e.g. `/notify`, `/notify@squadrant_bot`, or a dimension with no value like `/notify cap`) fell through `handleProjectTopic` and was appended as a **captain message** instead of replying with usage.

## Fix

`handleProjectTopic` now matches **any** `/notify` attempt on the `@botname`-stripped first token and handles it in place, never appending it as a captain message:

1. **Fail-closed** — `!isControlEnabled || !isAuthorized` → `⛔ not authorized`, return.
2. **Complete** (`parseNotifyPref` returns a pref) → apply via the existing per-project override write + `✅ <dim> = <value>` reply.
3. **Incomplete** (`parseNotifyPref` returns null) → reply `usage: /notify crew <all|alert_only|done_only|none> | cap <on|off>`, return.

Ordinary messages (still auto-unmute + append) and `/mute`/`/unmute` are unchanged. Reuses existing `stripBotMention` + `parseNotifyPref` + `isControlEnabled`/`isAuthorized`.

## Tests (TDD)

Extended `bridge.test.ts` with a `/notify in a project topic` suite:
- bare `/notify` (authorized) → usage reply + **no** `appendCaptainMessage`
- bare `/notify@squadrant_bot` (authorized) → usage reply (proves `@botname` strip) + no append
- bare `/notify` (unauthorized) → `not authorized` + no append
- `/notify cap on` (authorized) → applies + no append (unchanged behavior)
- normal message → still appended

Build gate (`node dist/index.js --help`) passes. Full suite: 1498/1499 pass — the one failure (`pushLifecycle notify gate > delivers when the project is ACTIVE`) is a **pre-existing timing flake** confirmed failing on the base commit `725df38` without this change.

CHANGELOG updated.