### PR TITLE
feat(telegram): run channel commands in any topic (#cmds-anytopic)

### DIFF
--- a/packages/core/src/telegram/bridge.test.ts
+++ b/packages/core/src/telegram/bridge.test.ts
@@ -202,3 +202,39 @@ describe("/notify in a project topic", () => {
     bridge.stop();
   });
 });
+
+describe("channel commands in a project topic (#cmds-anytopic)", () => {
+  const ctrlCfg = { ...baseCfg, remoteControl: true, users: [ALLOWED_USER] };
+
+  it("/status runs and replies into the same topic, never appended", async () => {
+    setTopic(stateRoot, "brove", 7);
+    const d = deps();
+    const { bridge, drained } = drive({ cfg: ctrlCfg, ...d }, [topicMsg("/status", 7)]);
+    await drained;
+    expect(d.runCommand).toHaveBeenCalledWith(["status"]);
+    expect(d.sendReply).toHaveBeenCalledWith(7, "output");
+    expect(d.appendCaptainMessage).not.toHaveBeenCalled();
+    bridge.stop();
+  });
+
+  it("/effort (no arg) replies the effort panel into the topic, never appended", async () => {
+    setTopic(stateRoot, "brove", 7);
+    const d = deps();
+    const { bridge, drained } = drive({ cfg: ctrlCfg, ...d }, [topicMsg("/effort", 7)]);
+    await drained;
+    expect(d.sendReply).toHaveBeenCalledWith(7, "Effort mode:", expect.objectContaining({ inline_keyboard: expect.anything() }));
+    expect(d.appendCaptainMessage).not.toHaveBeenCalled();
+    bridge.stop();
+  });
+
+  it("a recognized channel command from an unauthorized sender is rejected, never appended", async () => {
+    setTopic(stateRoot, "brove", 7);
+    const d = deps();
+    const { bridge, drained } = drive({ cfg: baseCfg, ...d }, [topicMsg("/status", 7)]);
+    await drained;
+    expect(d.runCommand).not.toHaveBeenCalled();
+    expect(d.sendReply).toHaveBeenCalledWith(7, expect.stringContaining("not authorized"));
+    expect(d.appendCaptainMessage).not.toHaveBeenCalled();
+    bridge.stop();
+  });
+});

--- a/packages/core/src/telegram/bridge.ts
+++ b/packages/core/src/telegram/bridge.ts
@@ -56,6 +56,11 @@ const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
 const CREW_TIERS = ["all", "alert_only", "done_only", "none"];
 
+// Channel commands that may run in ANY topic (#cmds-anytopic). mute/unmute/notify
+// are intentionally absent: in a project topic they carry topic-scoped semantics
+// (handled before delegating). Matched against the slash-stripped first token.
+const RECOGNIZED_CHANNEL_COMMANDS = new Set(["status", "projects", "crews", "launch", "effort", "spawn"]);
+
 /** Parse a `/notify crew <tier>` or `/notify cap <on|off>` preference command.
  *  Returns null for anything else (ordinary message or malformed). */
 export function parseNotifyPref(text: string): { dimension: "crew" | "cap"; value: string } | null {
@@ -252,54 +257,60 @@ export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridg
     await reply(threadId, "Pick a project to spawn a crew on:", spawnPicker(projects));
   }
 
-  // General topic (no thread id): curated command channel (#402). Fail-closed —
-  // a slash command runs ONLY when remoteControl is on AND the sender is
-  // allowlisted. Freeform text gets a /help hint (never silently dropped).
-  // Command/reply failures are caught here so they can't escape the poll loop.
-  async function handleGeneral(text: string, fromId: number | undefined): Promise<void> {
-    if (!text.startsWith("/")) {
-      await reply(undefined, "Send /help for commands.");
-      return;
-    }
+  // Curated command channel (#402), shared by the General topic (threadId
+  // undefined) and project topics (#cmds-anytopic). Fail-closed — a command runs
+  // ONLY when remoteControl is on AND the sender is allowlisted. Tap-first: a
+  // parameterized command with NO argument replies a button panel instead of a
+  // usage error; typed forms (with an arg) fall through to run. Replies land in
+  // the given thread; failures are caught here so they can't escape the poll loop.
+  async function runChannelCommand(text: string, fromId: number | undefined, threadId: number | undefined): Promise<void> {
     if (!isControlEnabled(cfg) || !isAuthorized(fromId, cfg)) {
-      await reply(undefined, "⛔ not authorized");
+      await reply(threadId, "⛔ not authorized");
       return;
     }
-    // Tap-first: a parameterized command with NO argument replies a button panel
-    // instead of a usage error. Typed forms (with an arg) fall through to run.
     const tokens = text.trim().slice(1).split(/\s+/).filter((t) => t.length > 0);
     const name = stripBotMention(tokens[0] ?? "").toLowerCase();
     const noArg = tokens.length === 1;
     if (noArg && name === "effort") {
-      await reply(undefined, "Effort mode:", effortPanel(currentEffort()));
+      await reply(threadId, "Effort mode:", effortPanel(currentEffort()));
       return;
     }
     if (noArg && name === "spawn") {
-      await replySpawnPicker(undefined);
+      await replySpawnPicker(threadId);
       return;
     }
     const PICKERS: Record<string, PickAction> = { crews: "cr", launch: "lc", mute: "mu", unmute: "um" };
     if (noArg && name in PICKERS) {
       const projects = projectNames();
       if (projects.length === 0) {
-        await reply(undefined, "no projects registered");
+        await reply(threadId, "no projects registered");
         return;
       }
-      await reply(undefined, `Pick a project:`, projectPicker(PICKERS[name], projects));
+      await reply(threadId, `Pick a project:`, projectPicker(PICKERS[name], projects));
       return;
     }
     const parsed = parseCommand(text);
     if (parsed.kind !== "ok") {
-      await reply(undefined, parsed.message);
+      await reply(threadId, parsed.message);
       return;
     }
     try {
       const out = runCommand ? await runCommand(parsed.argv) : "(command runner unavailable)";
-      await reply(undefined, out);
+      await reply(threadId, out);
     } catch (e) {
-      await reply(undefined, `⚠️ command failed: ${(e as Error).message}`);
+      await reply(threadId, `⚠️ command failed: ${(e as Error).message}`);
       log(`telegram command failed argv=${JSON.stringify(parsed.argv)}: ${(e as Error).message}`);
     }
+  }
+
+  // General topic (no thread id): freeform text gets a /help hint (never silently
+  // dropped); slash commands run through the shared channel-command dispatcher.
+  async function handleGeneral(text: string, fromId: number | undefined): Promise<void> {
+    if (!text.startsWith("/")) {
+      await reply(undefined, "Send /help for commands.");
+      return;
+    }
+    await runChannelCommand(text, fromId, undefined);
   }
 
   // Project topic: the v1 captain.message flow + Gap-1 auto-launch (#403). When

--- a/packages/core/src/telegram/bridge.ts
+++ b/packages/core/src/telegram/bridge.ts
@@ -378,6 +378,15 @@ export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridg
       return;
     }
 
+    // Recognized channel commands run in this topic too (#cmds-anytopic), with the
+    // reply landing here instead of falling through to a captain message. mute/
+    // unmute/notify are handled above (topic-scoped) and excluded from the set.
+    const firstTok = stripBotMention(text.trim().split(/\s+/)[0] ?? "").toLowerCase();
+    if (firstTok.startsWith("/") && RECOGNIZED_CHANNEL_COMMANDS.has(firstTok.slice(1))) {
+      await runChannelCommand(text, fromId, threadId);
+      return;
+    }
+
     setNotify(stateRoot, resolved.project, true); // engagement → auto-unmute (sticky)
     if (ensureCaptainAlive && isControlEnabled(cfg) && isAuthorized(fromId, cfg)) {
       try {


### PR DESCRIPTION
## Problem

General-channel Telegram commands (`/status`, `/projects`, `/crews`, `/launch`, `/effort`, `/spawn`) only ran in the **General** topic. In a **project** topic they fell through and were appended as a captain message — so tapping `/status` in the squadrant topic silently vanished.

## Fix

`packages/core/src/telegram/bridge.ts`:

1. **Extract** the command-channel dispatch (fail-closed gate → tap-first panels → `parseCommand` → `runCommand`) out of `handleGeneral` into a shared `runChannelCommand(text, fromId, threadId)` that replies into the **given** thread (works for General `threadId=undefined` and a project topic's threadId). True shared helper — no copy-paste.
2. `handleGeneral` keeps its non-slash `/help` hint, then delegates to `runChannelCommand(text, fromId, undefined)`.
3. `handleProjectTopic`: **after** the existing topic-scoped `/notify`, `/mute`, `/unmute` handling, if the slash-stripped first token is a recognized channel command (`status|projects|crews|launch|effort|spawn` — **not** mute/unmute/notify), delegate to `runChannelCommand(text, fromId, thisThreadId)` and return (never appended). Otherwise unchanged (auto-unmute + `captain.message`).

So `/status`, `/effort` (panel), `/crews`/`/launch`/`/projects`, typed `/spawn`, and the guided bare `/spawn` picker now all work **inside a project topic**, replying into that topic. Plain chat and unrecognized `/text` still go to the captain. `/notify`/`/mute`/`/unmute` keep their project-topic semantics. Fail-closed gating (remoteControl + authorized) preserved in **both** topics.

## Tests

Added to `bridge.test.ts`:
- `/status` in a project topic runs + replies to that topic + **not** appended
- `/effort` (no arg) in a project topic replies the effort panel into the topic + not appended
- a recognized channel command from an unauthorized sender is rejected (not authorized) + not appended

Unchanged-behavior tests still green: plain message still appended, bare `/notify` still uses the notify panel, General topic behavior intact.

- Single-file: `npx vitest run packages/core/src/telegram/bridge.test.ts` → **16/16**
- Full suite → **1530/1530**
- Gate: `node dist/index.js --help` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)