### PR TITLE
Release v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-06-24
+
+### Added
+- **Channel commands now run in any Telegram project topic ([#419](https://github.com/tu11aa/squadrant/pull/419)).** Slash commands like `/status`, `/crews`, and `/notify` previously only worked in the supergroup's General command channel; they now run from any project topic too, via a shared `runChannelCommand` helper that the General channel and project-topic handlers both delegate to.
+
 ## [0.11.0] - 2026-06-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "squadrant",
   "packageManager": "pnpm@10.30.3",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Multi-project orchestration for your coding agents (Claude, Codex, opencode, Gemini)",
   "type": "module",
   "bin": {

--- a/packages/core/src/telegram/bridge.test.ts
+++ b/packages/core/src/telegram/bridge.test.ts
@@ -202,3 +202,39 @@ describe("/notify in a project topic", () => {
     bridge.stop();
   });
 });
+
+describe("channel commands in a project topic (#cmds-anytopic)", () => {
+  const ctrlCfg = { ...baseCfg, remoteControl: true, users: [ALLOWED_USER] };
+
+  it("/status runs and replies into the same topic, never appended", async () => {
+    setTopic(stateRoot, "brove", 7);
+    const d = deps();
+    const { bridge, drained } = drive({ cfg: ctrlCfg, ...d }, [topicMsg("/status", 7)]);
+    await drained;
+    expect(d.runCommand).toHaveBeenCalledWith(["status"]);
+    expect(d.sendReply).toHaveBeenCalledWith(7, "output");
+    expect(d.appendCaptainMessage).not.toHaveBeenCalled();
+    bridge.stop();
+  });
+
+  it("/effort (no arg) replies the effort panel into the topic, never appended", async () => {
+    setTopic(stateRoot, "brove", 7);
+    const d = deps();
+    const { bridge, drained } = drive({ cfg: ctrlCfg, ...d }, [topicMsg("/effort", 7)]);
+    await drained;
+    expect(d.sendReply).toHaveBeenCalledWith(7, "Effort mode:", expect.objectContaining({ inline_keyboard: expect.anything() }));
+    expect(d.appendCaptainMessage).not.toHaveBeenCalled();
+    bridge.stop();
+  });
+
+  it("a recognized channel command from an unauthorized sender is rejected, never appended", async () => {
+    setTopic(stateRoot, "brove", 7);
+    const d = deps();
+    const { bridge, drained } = drive({ cfg: baseCfg, ...d }, [topicMsg("/status", 7)]);
+    await drained;
+    expect(d.runCommand).not.toHaveBeenCalled();
+    expect(d.sendReply).toHaveBeenCalledWith(7, expect.stringContaining("not authorized"));
+    expect(d.appendCaptainMessage).not.toHaveBeenCalled();
+    bridge.stop();
+  });
+});

--- a/packages/core/src/telegram/bridge.ts
+++ b/packages/core/src/telegram/bridge.ts
@@ -56,6 +56,11 @@ const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
 const CREW_TIERS = ["all", "alert_only", "done_only", "none"];
 
+// Channel commands that may run in ANY topic (#cmds-anytopic). mute/unmute/notify
+// are intentionally absent: in a project topic they carry topic-scoped semantics
+// (handled before delegating). Matched against the slash-stripped first token.
+const RECOGNIZED_CHANNEL_COMMANDS = new Set(["status", "projects", "crews", "launch", "effort", "spawn"]);
+
 /** Parse a `/notify crew <tier>` or `/notify cap <on|off>` preference command.
  *  Returns null for anything else (ordinary message or malformed). */
 export function parseNotifyPref(text: string): { dimension: "crew" | "cap"; value: string } | null {
@@ -252,54 +257,60 @@ export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridg
     await reply(threadId, "Pick a project to spawn a crew on:", spawnPicker(projects));
   }
 
-  // General topic (no thread id): curated command channel (#402). Fail-closed —
-  // a slash command runs ONLY when remoteControl is on AND the sender is
-  // allowlisted. Freeform text gets a /help hint (never silently dropped).
-  // Command/reply failures are caught here so they can't escape the poll loop.
-  async function handleGeneral(text: string, fromId: number | undefined): Promise<void> {
-    if (!text.startsWith("/")) {
-      await reply(undefined, "Send /help for commands.");
-      return;
-    }
+  // Curated command channel (#402), shared by the General topic (threadId
+  // undefined) and project topics (#cmds-anytopic). Fail-closed — a command runs
+  // ONLY when remoteControl is on AND the sender is allowlisted. Tap-first: a
+  // parameterized command with NO argument replies a button panel instead of a
+  // usage error; typed forms (with an arg) fall through to run. Replies land in
+  // the given thread; failures are caught here so they can't escape the poll loop.
+  async function runChannelCommand(text: string, fromId: number | undefined, threadId: number | undefined): Promise<void> {
     if (!isControlEnabled(cfg) || !isAuthorized(fromId, cfg)) {
-      await reply(undefined, "⛔ not authorized");
+      await reply(threadId, "⛔ not authorized");
       return;
     }
-    // Tap-first: a parameterized command with NO argument replies a button panel
-    // instead of a usage error. Typed forms (with an arg) fall through to run.
     const tokens = text.trim().slice(1).split(/\s+/).filter((t) => t.length > 0);
     const name = stripBotMention(tokens[0] ?? "").toLowerCase();
     const noArg = tokens.length === 1;
     if (noArg && name === "effort") {
-      await reply(undefined, "Effort mode:", effortPanel(currentEffort()));
+      await reply(threadId, "Effort mode:", effortPanel(currentEffort()));
       return;
     }
     if (noArg && name === "spawn") {
-      await replySpawnPicker(undefined);
+      await replySpawnPicker(threadId);
       return;
     }
     const PICKERS: Record<string, PickAction> = { crews: "cr", launch: "lc", mute: "mu", unmute: "um" };
     if (noArg && name in PICKERS) {
       const projects = projectNames();
       if (projects.length === 0) {
-        await reply(undefined, "no projects registered");
+        await reply(threadId, "no projects registered");
         return;
       }
-      await reply(undefined, `Pick a project:`, projectPicker(PICKERS[name], projects));
+      await reply(threadId, `Pick a project:`, projectPicker(PICKERS[name], projects));
       return;
     }
     const parsed = parseCommand(text);
     if (parsed.kind !== "ok") {
-      await reply(undefined, parsed.message);
+      await reply(threadId, parsed.message);
       return;
     }
     try {
       const out = runCommand ? await runCommand(parsed.argv) : "(command runner unavailable)";
-      await reply(undefined, out);
+      await reply(threadId, out);
     } catch (e) {
-      await reply(undefined, `⚠️ command failed: ${(e as Error).message}`);
+      await reply(threadId, `⚠️ command failed: ${(e as Error).message}`);
       log(`telegram command failed argv=${JSON.stringify(parsed.argv)}: ${(e as Error).message}`);
     }
+  }
+
+  // General topic (no thread id): freeform text gets a /help hint (never silently
+  // dropped); slash commands run through the shared channel-command dispatcher.
+  async function handleGeneral(text: string, fromId: number | undefined): Promise<void> {
+    if (!text.startsWith("/")) {
+      await reply(undefined, "Send /help for commands.");
+      return;
+    }
+    await runChannelCommand(text, fromId, undefined);
   }
 
   // Project topic: the v1 captain.message flow + Gap-1 auto-launch (#403). When

--- a/packages/core/src/telegram/bridge.ts
+++ b/packages/core/src/telegram/bridge.ts
@@ -378,6 +378,15 @@ export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridg
       return;
     }
 
+    // Recognized channel commands run in this topic too (#cmds-anytopic), with the
+    // reply landing here instead of falling through to a captain message. mute/
+    // unmute/notify are handled above (topic-scoped) and excluded from the set.
+    const firstTok = stripBotMention(text.trim().split(/\s+/)[0] ?? "").toLowerCase();
+    if (firstTok.startsWith("/") && RECOGNIZED_CHANNEL_COMMANDS.has(firstTok.slice(1))) {
+      await runChannelCommand(text, fromId, threadId);
+      return;
+    }
+
     setNotify(stateRoot, resolved.project, true); // engagement → auto-unmute (sticky)
     if (ensureCaptainAlive && isControlEnabled(cfg) && isAuthorized(fromId, cfg)) {
       try {


### PR DESCRIPTION
## Release v0.11.1

A small, surgical patch release. Bumps the root package version `0.11.0 → 0.11.1` and adds the CHANGELOG entry. Merging to `main` triggers `release.yml` (tag + npm publish + GitHub release).

### Added
- **Channel commands now run in any Telegram project topic ([#419](https://github.com/tu11aa/squadrant/pull/419)).** Slash commands like `/status`, `/crews`, and `/notify` previously only worked in the supergroup's General command channel; they now run from any project topic too, via a shared `runChannelCommand` helper that the General channel and project-topic handlers both delegate to.

### Release mechanics
- Root `package.json`: `0.11.0 → 0.11.1` (workspace `packages/*` stay `0.0.0`, unchanged).
- `CHANGELOG.md`: new `## [0.11.1] - 2026-06-24` section under `[Unreleased]`, Keep-a-Changelog format.

Off `develop` @ `c3d5398`. Single content change (#419) already merged to develop.