### PR TITLE
Release v0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2] - 2026-06-24
+
+### Changed
+- Bumped the cmux compatibility manifest last-verified version to `0.64.17`. The `0.64.16`→`0.64.17` release is iOS features + macOS-app-internal Swift/SPM refactors + CI; it changes none of the cmux CLI subcommands or socket contract squadrant depends on, so `doctor` no longer warns when running against `0.64.17`.
+
 ## [0.11.1] - 2026-06-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "squadrant",
   "packageManager": "pnpm@10.30.3",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Multi-project orchestration for your coding agents (Claude, Codex, opencode, Gemini)",
   "type": "module",
   "bin": {

--- a/packages/shared/src/lib/__tests__/tool-compat.test.ts
+++ b/packages/shared/src/lib/__tests__/tool-compat.test.ts
@@ -3,19 +3,19 @@ import { checkToolCompat } from "../tool-compat.js";
 
 describe("checkToolCompat", () => {
   it("returns null when version is within range", () => {
-    expect(checkToolCompat("cmux", "cmux 0.64.8", { min: "0.64.0", lastVerified: "0.64.16" })).toBeNull();
+    expect(checkToolCompat("cmux", "cmux 0.64.8", { min: "0.64.0", lastVerified: "0.64.17" })).toBeNull();
   });
 
   it("returns null when version equals min exactly", () => {
-    expect(checkToolCompat("cmux", "cmux 0.64.0", { min: "0.64.0", lastVerified: "0.64.16" })).toBeNull();
+    expect(checkToolCompat("cmux", "cmux 0.64.0", { min: "0.64.0", lastVerified: "0.64.17" })).toBeNull();
   });
 
   it("returns null when version equals lastVerified exactly", () => {
-    expect(checkToolCompat("cmux", "cmux 0.64.16", { min: "0.64.0", lastVerified: "0.64.16" })).toBeNull();
+    expect(checkToolCompat("cmux", "cmux 0.64.17", { min: "0.64.0", lastVerified: "0.64.17" })).toBeNull();
   });
 
   it("warns when version is below min", () => {
-    const warn = checkToolCompat("cmux", "cmux 0.63.5", { min: "0.64.0", lastVerified: "0.64.16" });
+    const warn = checkToolCompat("cmux", "cmux 0.63.5", { min: "0.64.0", lastVerified: "0.64.17" });
     expect(warn).not.toBeNull();
     expect(warn).toMatch(/< min/);
     expect(warn).toMatch(/0\.64\.0/);
@@ -28,16 +28,16 @@ describe("checkToolCompat", () => {
   });
 
   it("warns when installed version exceeds lastVerified (drift signal)", () => {
-    const warn = checkToolCompat("cmux", "cmux 0.65.0", { min: "0.64.0", lastVerified: "0.64.16" });
+    const warn = checkToolCompat("cmux", "cmux 0.65.0", { min: "0.64.0", lastVerified: "0.64.17" });
     expect(warn).not.toBeNull();
     expect(warn).toMatch(/last-verified/);
-    expect(warn).toMatch(/0\.64\.16/);
+    expect(warn).toMatch(/0\.64\.17/);
     expect(warn).toMatch(/compat audit/i);
   });
 
   it("warn message includes tool name and installed version when above lastVerified", () => {
-    const warn = checkToolCompat("cmux", "cmux 0.65.0", { min: "0.64.0", lastVerified: "0.64.16" });
-    expect(warn).toMatch(/cmux 0\.65\.0 > last-verified 0\.64\.16/);
+    const warn = checkToolCompat("cmux", "cmux 0.65.0", { min: "0.64.0", lastVerified: "0.64.17" });
+    expect(warn).toMatch(/cmux 0\.65\.0 > last-verified 0\.64\.17/);
   });
 
   it("returns null when no lastVerified and version is above min", () => {
@@ -84,7 +84,7 @@ describe("checkToolCompat", () => {
 
   // Manifest shape: all six tools should produce a null when version is in-range
   it("manifest tool entries for cmux/claude/node each have a min and are checkable", () => {
-    expect(checkToolCompat("cmux",  "cmux 0.64.16", { min: "0.64.0",  lastVerified: "0.64.16" })).toBeNull();
+    expect(checkToolCompat("cmux",  "cmux 0.64.17", { min: "0.64.0",  lastVerified: "0.64.17" })).toBeNull();
     expect(checkToolCompat("claude","claude 2.1.32", { min: "2.1.32" })).toBeNull();
     expect(checkToolCompat("node",  "22.0.0",        { min: "18.0.0", lastVerified: "24.6.0" })).toBeNull();
   });

--- a/packages/shared/src/lib/compat-manifest.ts
+++ b/packages/shared/src/lib/compat-manifest.ts
@@ -2,7 +2,7 @@ export type ToolEntry = { min?: string; lastVerified?: string };
 
 export const compatManifest = {
   tools: {
-    cmux:     { min: "0.64.0",  lastVerified: "0.64.16" } satisfies ToolEntry,
+    cmux:     { min: "0.64.0",  lastVerified: "0.64.17" } satisfies ToolEntry,
     claude:   { min: "2.1.32" }                           satisfies ToolEntry,
     node:     { min: "18.0.0",  lastVerified: "24.6.0"  } satisfies ToolEntry,
     // presence-checked; no floor enforced yet


### PR DESCRIPTION
## Release v0.11.2 — cmux compat 0.64.17

Surgical compat-manifest bump. No behavior change to squadrant itself.

### Changed
- Bumped the cmux compatibility manifest `lastVerified` from `0.64.16` to `0.64.17` in `packages/shared/src/lib/compat-manifest.ts`. `min` stays `0.64.0`.
- The `0.64.16`→`0.64.17` cmux release is iOS features + macOS-app-internal Swift/SPM refactors + CI. It changes **none** of the cmux CLI subcommands or socket contract squadrant depends on (verified: zero CLI-related TS/JS changes; ~300 files changed, concentrated in iOS/Swift packages). So `doctor` no longer warns when running against `0.64.17`.

### Tests
- Updated `tool-compat.test.ts` fixtures/assertions that hardcoded `lastVerified: '0.64.16'` to `0.64.17` (the `min: '0.64.16'` patch-level fixture left untouched). All 17 tests green.

### Version
- Root `package.json`: `0.11.1` → `0.11.2`. `packages/*` stay `0.0.0`.

Do not merge yet — flagged for review.