### PR TITLE
fix(rebrand): sweep + self-heal stale 'cockpit' refs in per-project Claude settings

### DIFF
--- a/packages/cli/src/lib/__tests__/per-crew-settings.test.ts
+++ b/packages/cli/src/lib/__tests__/per-crew-settings.test.ts
@@ -6,6 +6,7 @@ import {
   writePerCrewSettings,
   writePerCrewSettingsLocal,
   writePerCrewOpencodeConfig,
+  healStaleCockpitRefs,
   CREW_PERMISSION_ALLOWLIST,
   mergeCrewPermissions,
 } from "../per-crew-settings.js";
@@ -132,6 +133,61 @@ describe("writePerCrewSettingsLocal — permission allowlist", () => {
     const counts = new Map<string, number>();
     for (const e of json.permissions.allow) counts.set(e, (counts.get(e) ?? 0) + 1);
     for (const [, n] of counts) expect(n).toBe(1);
+  });
+});
+
+describe("healStaleCockpitRefs — self-heal pre-rebrand tokens", () => {
+  it("rewrites the hook command, config path, and hub vault tokens", () => {
+    const raw = [
+      "cockpit crew _hook Stop",
+      "~/.config/cockpit/scripts/write-status.sh",
+      "//Users/me/cockpit-hub/spokes/x/**",
+    ].join("\n");
+    expect(healStaleCockpitRefs(raw)).toBe(
+      [
+        "squadrant crew _hook Stop",
+        "~/.config/squadrant/scripts/write-status.sh",
+        "//Users/me/squadrant-hub/spokes/x/**",
+      ].join("\n"),
+    );
+  });
+
+  it("is idempotent — a second pass changes nothing", () => {
+    const once = healStaleCockpitRefs("cockpit crew _hook Stop");
+    expect(healStaleCockpitRefs(once)).toBe(once);
+  });
+
+  it("leaves unrelated text (e.g. Bash(cockpit:*)) untouched", () => {
+    const raw = 'Bash(cockpit:*)';
+    expect(healStaleCockpitRefs(raw)).toBe(raw);
+  });
+});
+
+describe("writePerCrewSettingsLocal — self-heals stale cockpit hooks in existing file", () => {
+  let tmp: string;
+  const settingsPath = () => path.join(tmp, ".claude", "settings.local.json");
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "squadrant-heal-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("rewrites pre-rebrand 'cockpit crew _hook' commands left in the file", () => {
+    fs.mkdirSync(path.join(tmp, ".claude"), { recursive: true });
+    fs.writeFileSync(
+      settingsPath(),
+      JSON.stringify({
+        hooks: { Stop: [{ hooks: [{ type: "command", command: "cockpit crew _hook Stop" }] }] },
+        permissions: { allow: ["Bash(~/.config/cockpit/scripts/write-status.sh:*)"] },
+      }, null, 2),
+    );
+    writePerCrewSettingsLocal({ projectCwd: tmp });
+    const raw = fs.readFileSync(settingsPath(), "utf-8");
+    expect(raw).not.toContain("cockpit crew _hook");
+    expect(raw).not.toContain(".config/cockpit");
+    expect(raw).toContain("squadrant crew _hook");
   });
 });
 

--- a/packages/cli/src/lib/per-crew-settings.ts
+++ b/packages/cli/src/lib/per-crew-settings.ts
@@ -105,6 +105,26 @@ export const CREW_PERMISSION_ALLOWLIST: readonly string[] = [
 ];
 
 /**
+ * Pure: rewrite the three pre-rebrand `cockpit` tokens left in a Claude Code
+ * settings file by the claude-cockpit era. The hook command especially fails
+ * with "cockpit: command not found" on every captain/crew turn-end. Token-
+ * scoped (NOT a blanket cockpit→squadrant) so unrelated patterns like
+ * `Bash(cockpit:*)` are left untouched. Idempotent — a second pass is a no-op.
+ *
+ * This is the runtime self-heal counterpart to the one-time migration sweep
+ * (scripts/migrate-to-squadrant.sh step 4.6): `writePerCrewSettingsLocal`
+ * applies it to a project's settings.local.json on every crew spawn, so a
+ * project that drifted (or was never swept) repairs itself the next time a
+ * crew launches in it.
+ */
+export function healStaleCockpitRefs(raw: string): string {
+  return raw
+    .replaceAll("cockpit crew _hook", "squadrant crew _hook")
+    .replaceAll(".config/cockpit", ".config/squadrant")
+    .replaceAll("cockpit-hub", "squadrant-hub");
+}
+
+/**
  * Pure: merge the crew permission allowlist into a settings object's
  * `permissions.allow`, de-duplicating and preserving any existing entries and
  * sibling permission keys (deny/ask). Never mutates the input.
@@ -157,7 +177,10 @@ export function writePerCrewSettingsLocal(o: {
   const file = join(dir, "settings.local.json");
   let existing: Record<string, unknown> = {};
   try {
-    const raw = readFileSync(file, "utf-8");
+    // Self-heal pre-rebrand `cockpit` tokens (e.g. a stale `cockpit crew _hook`
+    // that would otherwise survive the merge and keep firing "command not
+    // found") before parsing the user's existing settings.
+    const raw = healStaleCockpitRefs(readFileSync(file, "utf-8"));
     existing = JSON.parse(raw);
   } catch {
     // File doesn't exist or isn't valid JSON — start fresh

--- a/scripts/migrate-to-squadrant.sh
+++ b/scripts/migrate-to-squadrant.sh
@@ -223,30 +223,56 @@ else
   note "no $CLAUDE_PROJECTS dir — skipping session/memory preservation"
 fi
 
-step "4.6 Rewrite stale 'cockpit crew _hook' commands in Claude Code settings files"
-# The hook-generation source already emits `squadrant crew _hook`, but settings
-# files written on disk BEFORE the rebrand still invoke the removed `cockpit`
-# binary, so every Stop/PostToolUse hook in the captain (and any pre-rebrand crew)
-# fails with "cockpit: command not found". Rewrite the command token in place.
-# Scoped to the leading "cockpit crew _hook" so permission patterns like
+step "4.6 Rewrite stale 'cockpit' tokens in Claude Code settings files (this repo, global ~/.claude, AND every registered project)"
+# Settings files written on disk BEFORE the rebrand still invoke the removed
+# `cockpit` binary — every Stop/PostToolUse hook fails "cockpit: command not
+# found" — and reference old ~/.config/cockpit script paths and the cockpit-hub
+# vault in permission allowlists. Rewrite three exact tokens in place:
+#   cockpit crew _hook -> squadrant crew _hook   (the failing hook command)
+#   .config/cockpit    -> .config/squadrant      (write-status/read-handoff paths)
+#   cockpit-hub        -> squadrant-hub          (spoke-vault Read allowlist)
+# Token-scoped (NOT a blanket cockpit->squadrant) so unrelated patterns like
 # Bash(cockpit:*) are left untouched. Idempotent (a second run matches nothing).
-HOOK_SETTINGS=(
-  "$NEW_REPO/.claude/settings.json"
-  "$NEW_REPO/.claude/settings.local.json"
-  "$HOME/.claude/settings.json"
-  "$HOME/.claude/settings.local.json"
-)
-hooks_fixed=0
-for sf in "${HOOK_SETTINGS[@]}"; do
-  [ -f "$sf" ] || continue
-  if grep -q 'cockpit crew _hook' "$sf" 2>/dev/null; then
-    run "sed -i '' 's/cockpit crew _hook/squadrant crew _hook/g' '$sf'"
-    hooks_fixed=$((hooks_fixed + 1))
-  else
-    note "ok (no stale hook): $sf"
-  fi
-done
-note "$([ "$DRY_RUN" -eq 1 ] && echo 'would rewrite' || echo 'rewrote') hook command in $hooks_fixed settings file(s)"
+# Earlier versions swept only this repo + global ~/.claude and ORPHANED every
+# registered project, so the per-project files are read from config.json here.
+CFG_FOR_HOOKS="$NEW_CONFIG/config.json"; [ -f "$CFG_FOR_HOOKS" ] || CFG_FOR_HOOKS="$OLD_CONFIG/config.json"
+DRY_RUN="$DRY_RUN" NEW_REPO="$NEW_REPO" HOME_DIR="$HOME" CFG="$CFG_FOR_HOOKS" python3 - <<'PY'
+import json, os
+dry = os.environ["DRY_RUN"] == "1"
+repo, home, cfg = os.environ["NEW_REPO"], os.environ["HOME_DIR"], os.environ["CFG"]
+SUBS = [("cockpit crew _hook", "squadrant crew _hook"),
+        (".config/cockpit", ".config/squadrant"),
+        ("cockpit-hub", "squadrant-hub")]
+files = [f"{repo}/.claude/settings.json", f"{repo}/.claude/settings.local.json",
+         f"{home}/.claude/settings.json", f"{home}/.claude/settings.local.json"]
+if os.path.isfile(cfg):
+    try:
+        for p in json.load(open(cfg)).get("projects", {}).values():
+            path = p.get("path") if isinstance(p, dict) else None
+            if path:
+                files.append(os.path.join(path, ".claude", "settings.json"))
+                files.append(os.path.join(path, ".claude", "settings.local.json"))
+    except (ValueError, OSError) as e:
+        print(f"  · could not read registered projects from {cfg}: {e}")
+fixed = 0
+for f in files:
+    if not os.path.isfile(f):
+        continue
+    text = open(f, encoding="utf-8").read()
+    if "cockpit" not in text:
+        continue
+    new = text
+    for a, b in SUBS:
+        new = new.replace(a, b)
+    if new == text:
+        continue
+    print(f"  $ {'would rewrite' if dry else 'rewrite'} {f}")
+    if not dry:
+        json.loads(new)  # guard: only write back valid JSON
+        open(f, "w", encoding="utf-8").write(new)
+    fixed += 1
+print(f"  · {'would rewrite' if dry else 'rewrote'} cockpit tokens in {fixed} settings file(s)")
+PY
 
 step "5. Remove old launchd plist (the rebuilt daemon installs com.squadrant.daemon.plist on first run)"
 [ -f "$OLD_PLIST" ] && run "rm -f '$OLD_PLIST'" || note "old plist absent"


### PR DESCRIPTION
## Problem

Post-rebrand fallout: 11 of 19 registered projects have `.claude/settings.local.json` files written during the **claude-cockpit** era that still invoke the removed `cockpit` binary. Every captain turn-end fires `/bin/sh: cockpit: command not found`.

The hook **generator** is already correct (`per-crew-settings.ts` emits `squadrant crew _hook`) — these are **orphaned on-disk files** the rebrand migration never swept. `migrate-to-squadrant.sh` step 4.6 only rewrote this repo + global `~/.claude`, never iterating registered projects.

## Fix (Parts B + C — the live sweep, Part A, was applied out-of-band)

**Part B — harden `migrate-to-squadrant.sh` step 4.6.** Now reads `config.json` and rewrites three exact tokens across **every** `projects[].path` settings file, not just the 4 hardcoded ones:
- `cockpit crew _hook` → `squadrant crew _hook` (the failing hook)
- `.config/cockpit` → `.config/squadrant` (write-status/read-handoff script paths)
- `cockpit-hub` → `squadrant-hub` (spoke-vault Read allowlist)

Token-scoped (not a blanket `cockpit`→`squadrant`, so `Bash(cockpit:*)` is untouched), idempotent, `--dry-run` aware, and JSON-guarded before write.

**Part C — runtime self-heal (`healStaleCockpitRefs`).** `writePerCrewSettingsLocal` now rewrites those same three tokens on the existing `settings.local.json` before merging, so a project that drifted or was never swept **repairs itself the next time a crew launches in it**. Without this, `mergeClaudeHooks` preserved the stale `cockpit crew _hook` already on disk.

## Out of scope (surfaced, not changed)
Global `~/.claude/settings*.json` still has stale cockpit refs, but they are **permission-allowlist entries only (no `cockpit crew _hook`)** — they do not cause the turn-end error. They also include `me/claude-cockpit` paths outside the 3-token set; a deliberate global cleanup is separate. The hardened step 4.6 covers their 3-token subset on any future migration run.

## Verification
- `per-crew-settings.test.ts`: 30 pass (+4 new — token rewrite, idempotency, scope, write self-heal)
- `crew.test.ts` + `side.test.ts` (exercise `writePerCrewSettingsLocal`): 71 pass
- `tsc -b` clean (exit 0)
- `bash -n migrate-to-squadrant.sh` valid; step 4.6 logic validated against live config

## Impact analysis
`gitnexus_impact(writePerCrewSettingsLocal, upstream)` → **LOW**, 0 affected symbols/processes. Change is internal (clean `existing` text before parse); function signature, return value, and hook-merge contract unchanged.