### PR TITLE
feat(onboarding-ux): doctor hints + guided 5-step init

### DIFF
--- a/packages/cli/src/commands/__tests__/doctor.test.ts
+++ b/packages/cli/src/commands/__tests__/doctor.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { check } from "../doctor.js";
+
+describe("doctor check() hint rendering", () => {
+  let output: string[];
+
+  beforeEach(() => {
+    output = [];
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      output.push(args.map(String).join(" "));
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("prints only the PASS line when pass=true (no hint)", () => {
+    const result = check("Claude Code installed", true);
+    expect(result).toBe(true);
+    expect(output).toHaveLength(1);
+    expect(output[0]).toMatch(/PASS/);
+    expect(output[0]).toMatch(/Claude Code installed/);
+  });
+
+  it("prints only the FAIL line when pass=false and no hint", () => {
+    const result = check("Node.js >= 18", false);
+    expect(result).toBe(false);
+    expect(output).toHaveLength(1);
+    expect(output[0]).toMatch(/FAIL/);
+  });
+
+  it("prints FAIL line + hint line when pass=false with hint", () => {
+    const result = check("Squadrant config exists", false, "Run: squadrant init");
+    expect(result).toBe(false);
+    expect(output).toHaveLength(2);
+    expect(output[0]).toMatch(/FAIL/);
+    expect(output[0]).toMatch(/Squadrant config exists/);
+    expect(output[1]).toMatch(/squadrant init/);
+  });
+
+  it("does NOT print hint when pass=true even if hint is provided", () => {
+    check("Agent Teams enabled (CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1)", true,
+      "Run: squadrant init  (enables automatically)");
+    expect(output).toHaveLength(1);
+    expect(output[0]).not.toMatch(/squadrant init/);
+  });
+
+  it("hint line contains the → indicator", () => {
+    check("Plugin: superpowers", false, "In Claude Code, run: /plugin marketplace add superpowers");
+    expect(output[1]).toMatch(/→/);
+    expect(output[1]).toMatch(/\/plugin marketplace add superpowers/);
+  });
+
+  it("hint line contains the → indicator for claude-mem", () => {
+    check("Plugin: claude-mem", false, "In Claude Code, run: /plugin marketplace add thedotmack/claude-mem");
+    expect(output[1]).toMatch(/thedotmack\/claude-mem/);
+  });
+
+  it("hint line contains the → indicator for context7", () => {
+    check("Plugin: context7", false, "In Claude Code, run: /plugin marketplace add context7");
+    expect(output[1]).toMatch(/context7/);
+  });
+
+  it("workspace hint points to squadrant init", () => {
+    check("Workspace 'obsidian' — hub reachable", false, "Run: squadrant init  to scaffold the hub vault");
+    expect(output[1]).toMatch(/squadrant init/);
+  });
+});

--- a/packages/cli/src/commands/__tests__/init.test.ts
+++ b/packages/cli/src/commands/__tests__/init.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const saveConfigMock = vi.hoisted(() => vi.fn());
+const getDefaultConfigMock = vi.hoisted(() => vi.fn(() => ({ hubVault: "", projects: {} })));
+const loadConfigMock = vi.hoisted(() => vi.fn(() => ({ projects: {} })));
+const ensureRuntimeSyncedMock = vi.hoisted(() => vi.fn());
+const readUserLevelSourceMock = vi.hoisted(() => vi.fn(async () => ({ instructions: "", skills: [] })));
+
+const emitMock = vi.hoisted(() => vi.fn(async (_src: unknown, dest: { path: string }) => ({
+  written: true,
+  path: dest.path,
+  bytesWritten: 42,
+})));
+
+vi.mock("@squadrant/shared", async () => {
+  const actual = await vi.importActual<typeof import("@squadrant/shared")>("@squadrant/shared");
+  return {
+    ...actual,
+    saveConfig: saveConfigMock,
+    getDefaultConfig: getDefaultConfigMock,
+    loadConfig: loadConfigMock,
+    ensureRuntimeSynced: ensureRuntimeSyncedMock,
+    readUserLevelSource: readUserLevelSourceMock,
+    DEFAULT_CONFIG_PATH: "/tmp/squadrant-test/config.json",
+    resolveHome: (p: string) => p.replace("~", os.homedir()),
+  };
+});
+
+vi.mock("@squadrant/workspaces", () => ({
+  createObsidianDriver: vi.fn(() => ({ root: "/tmp" })),
+  WorkspaceRegistry: class {
+    get(_name: string) { return {}; }
+  },
+}));
+
+vi.mock("@squadrant/agents", () => ({
+  ProjectionRegistry: class {
+    list() { return ["codex", "gemini", "opencode"]; }
+    get(name: string) {
+      return {
+        name,
+        destinations: (_scope: string) => [{ path: `/tmp/proj-${name}.md`, shared: true, format: "markdown" }],
+        emit: emitMock,
+      };
+    }
+  },
+  createCursorEmitter: vi.fn(),
+  createCodexEmitter: vi.fn(),
+  createGeminiEmitter: vi.fn(),
+  createOpencodeEmitter: vi.fn(),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+let output: string[];
+let originalStdin: PropertyDescriptor | undefined;
+
+function captureOutput() {
+  output = [];
+  vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    output.push(args.map(String).join(" "));
+  });
+}
+
+async function runInit(opts: { hub?: string; isTTY?: boolean } = {}) {
+  const { initCommand } = await import("../init.js");
+  // Override isTTY on process.stdin for this call
+  Object.defineProperty(process.stdin, "isTTY", {
+    value: opts.isTTY ?? false,
+    configurable: true,
+    writable: true,
+  });
+  await initCommand.parseAsync(["node", "squadrant", ...(opts.hub ? ["--hub", opts.hub] : [])]);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("init — non-TTY path", () => {
+  beforeEach(() => {
+    captureOutput();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("prints checklist and returns without blocking when stdin is not a TTY", async () => {
+    await runInit({ isTTY: false });
+
+    const text = output.join("\n");
+    expect(text).toContain("1/5");
+    expect(text).toContain("2/5");
+    expect(text).toContain("3/5");
+    expect(text).toContain("4/5");
+    expect(text).toContain("5/5");
+    expect(text).toContain("squadrant init");
+    expect(text).toContain("/plugin marketplace add superpowers");
+    expect(text).toContain("squadrant projects add");
+    expect(text).toContain("squadrant telegram setup");
+    expect(text).toContain("squadrant launch");
+  });
+
+  it("does NOT call saveConfig in non-TTY mode (no side effects)", async () => {
+    await runInit({ isTTY: false });
+    expect(saveConfigMock).not.toHaveBeenCalled();
+    expect(ensureRuntimeSyncedMock).not.toHaveBeenCalled();
+  });
+
+  it("does not hang when stdin is /dev/null equivalent (isTTY=false)", async () => {
+    // This verifies TTY-safety: the command should complete without awaiting any prompt.
+    const settled = await Promise.race([
+      runInit({ isTTY: false }).then(() => "done"),
+      new Promise<string>((resolve) => setTimeout(() => resolve("timeout"), 2000)),
+    ]);
+    expect(settled).toBe("done");
+  });
+});
+
+describe("init — re-run-safe (TTY mode)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "squadrant-init-test-"));
+    captureOutput();
+    vi.clearAllMocks();
+
+    // Mock readline so promptLine() doesn't block
+    vi.mock("node:readline", () => ({
+      default: {
+        createInterface: () => ({
+          question: (_q: string, cb: (a: string) => void) => cb(""),
+          close: vi.fn(),
+        }),
+      },
+    }));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("skips config creation when config already exists", async () => {
+    vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+      if (String(p) === "/tmp/squadrant-test/config.json") return true;
+      return false;
+    });
+    vi.spyOn(fs, "readFileSync").mockImplementation((p) => {
+      if (String(p) === "/tmp/squadrant-test/config.json") {
+        return JSON.stringify({ workspace: "obsidian", projects: {} });
+      }
+      return "{}";
+    });
+    vi.spyOn(fs, "mkdirSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "writeFileSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "copyFileSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "readdirSync").mockImplementation(() => []);
+
+    await runInit({ isTTY: true, hub: tmpDir });
+
+    const text = output.join("\n");
+    expect(text).toContain("Config already exists");
+    expect(saveConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("creates config when it does not exist", async () => {
+    vi.spyOn(fs, "existsSync").mockImplementation(() => false);
+    vi.spyOn(fs, "mkdirSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "writeFileSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "readFileSync").mockImplementation(() => "{}");
+    vi.spyOn(fs, "copyFileSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "readdirSync").mockImplementation(() => []);
+
+    await runInit({ isTTY: true, hub: tmpDir });
+
+    expect(saveConfigMock).toHaveBeenCalledOnce();
+  });
+
+  it("skips hub scaffold when vault dir already exists", async () => {
+    const hubPath = tmpDir;
+    // Hub exists but config does not
+    vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+      return String(p) === hubPath;
+    });
+    vi.spyOn(fs, "mkdirSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "writeFileSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "readFileSync").mockImplementation(() => "{}");
+    vi.spyOn(fs, "copyFileSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "readdirSync").mockImplementation(() => []);
+
+    await runInit({ isTTY: true, hub: hubPath });
+
+    const text = output.join("\n");
+    expect(text).toContain("Hub vault already exists");
+  });
+
+  it("emits projections for non-Claude agents in step 2/5", async () => {
+    vi.spyOn(fs, "existsSync").mockImplementation(() => false);
+    vi.spyOn(fs, "mkdirSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "writeFileSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "readFileSync").mockImplementation(() => "{}");
+    vi.spyOn(fs, "copyFileSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "readdirSync").mockImplementation(() => []);
+
+    await runInit({ isTTY: true, hub: tmpDir });
+
+    // emitMock should have been called for codex, gemini, opencode
+    expect(emitMock).toHaveBeenCalledTimes(3);
+    const text = output.join("\n");
+    expect(text).toMatch(/codex.*proj-codex|proj-codex.*codex/i);
+  });
+
+  it("skips agent-teams write when already enabled", async () => {
+    vi.spyOn(fs, "existsSync").mockImplementation(() => false);
+    vi.spyOn(fs, "mkdirSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "writeFileSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "copyFileSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "readdirSync").mockImplementation(() => []);
+    vi.spyOn(fs, "readFileSync").mockImplementation((p) => {
+      if (String(p).endsWith("settings.json")) {
+        return JSON.stringify({ env: { CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: "1" } });
+      }
+      return "{}";
+    });
+    // Make settingsPath.existsSync return true
+    vi.spyOn(fs, "existsSync").mockImplementation((p) => String(p).endsWith("settings.json"));
+
+    await runInit({ isTTY: true, hub: tmpDir });
+
+    const text = output.join("\n");
+    expect(text).toContain("Agent Teams already enabled");
+    // writeFileSync should not have been called for settings.json
+    const settingsCalls = (fs.writeFileSync as ReturnType<typeof vi.fn>).mock?.calls ?? [];
+    const wrote = settingsCalls.some(([p]: [string]) => String(p).endsWith("settings.json"));
+    expect(wrote).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/__tests__/init.test.ts
+++ b/packages/cli/src/commands/__tests__/init.test.ts
@@ -239,7 +239,7 @@ describe("init — re-run-safe (TTY mode)", () => {
     expect(text).toContain("Agent Teams already enabled");
     // writeFileSync should not have been called for settings.json
     const settingsCalls = (fs.writeFileSync as ReturnType<typeof vi.fn>).mock?.calls ?? [];
-    const wrote = settingsCalls.some(([p]: [string]) => String(p).endsWith("settings.json"));
+    const wrote = settingsCalls.some((args: unknown[]) => String(args[0]).endsWith("settings.json"));
     expect(wrote).toBe(false);
   });
 });

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -84,9 +84,13 @@ function tryGetVersion(cmd: string): string {
   }
 }
 
-function check(label: string, pass: boolean): boolean {
+/** Exported for unit testing. */
+export function check(label: string, pass: boolean, hint?: string): boolean {
   const icon = pass ? chalk.green("✔ PASS") : chalk.red("✘ FAIL");
   console.log(`  ${icon}  ${label}`);
+  if (!pass && hint) {
+    console.log(`         ${chalk.cyan("→")} ${chalk.dim(hint)}`);
+  }
   return pass;
 }
 
@@ -97,21 +101,29 @@ export const doctorCommand = new Command("doctor")
 
     const results: boolean[] = [];
 
-    results.push(check("Claude Code installed", commandExists("claude")));
-    results.push(check(`Claude Code version >= ${compatManifest.tools.claude.min}`, claudeVersionOk()));
-    results.push(check("Obsidian installed", commandExists("obsidian") || fs.existsSync("/Applications/Obsidian.app")));
-    results.push(check("Node.js >= 18", nodeVersionOk()));
+    results.push(check("Claude Code installed", commandExists("claude"),
+      "Install from: https://claude.ai/code"));
+    results.push(check(`Claude Code version >= ${compatManifest.tools.claude.min}`, claudeVersionOk(),
+      `Update Claude Code to >= ${compatManifest.tools.claude.min}`));
+    results.push(check("Obsidian installed", commandExists("obsidian") || fs.existsSync("/Applications/Obsidian.app"),
+      "Install from: https://obsidian.md"));
+    results.push(check("Node.js >= 18", nodeVersionOk(),
+      "Install from: https://nodejs.org"));
     results.push(
       check(
         "Agent Teams enabled (CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1)",
         settingsHaveAgentTeams(),
+        "Run: squadrant init  (enables automatically), or add to shell profile: export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1",
       ),
     );
-    results.push(check("Plugin: superpowers", pluginInstalled("superpowers@claude-plugins-official")));
+    results.push(check("Plugin: superpowers", pluginInstalled("superpowers@claude-plugins-official"),
+      "In Claude Code, run: /plugin marketplace add superpowers"));
     results.push(
-      check("Plugin: claude-mem", pluginInstalled("claude-mem@thedotmack")),
+      check("Plugin: claude-mem", pluginInstalled("claude-mem@thedotmack"),
+        "In Claude Code, run: /plugin marketplace add thedotmack/claude-mem"),
     );
-    results.push(check("Plugin: context7", pluginInstalled("context7@claude-plugins-official")));
+    results.push(check("Plugin: context7", pluginInstalled("context7@claude-plugins-official"),
+      "In Claude Code, run: /plugin marketplace add context7"));
 
     const config = loadConfig();
 
@@ -124,6 +136,9 @@ export const doctorCommand = new Command("doctor")
     results.push(check(
       `Runtime '${globalRuntimeName}' installed`,
       !!globalProbe?.installed,
+      globalRuntimeName === "cmux"
+        ? "Install: npm install -g cmux  or download from https://cmux.dev"
+        : undefined,
     ));
 
     // Any project-level override must also be installed
@@ -146,6 +161,7 @@ export const doctorCommand = new Command("doctor")
     results.push(check(
       `Workspace '${config.workspace ?? "obsidian"}' — hub reachable`,
       hubProbe.installed && hubProbe.rootExists,
+      "Run: squadrant init  to scaffold the hub vault",
     ));
 
     for (const [name] of Object.entries(config.projects)) {
@@ -203,6 +219,7 @@ export const doctorCommand = new Command("doctor")
           process.env.SQUADRANT_CONFIG ||
             `${process.env.HOME}/.config/squadrant/config.json`,
         ),
+        "Run: squadrant init",
       ),
     );
 

--- a/packages/cli/src/commands/health-view.ts
+++ b/packages/cli/src/commands/health-view.ts
@@ -61,7 +61,8 @@ export function healthRow(c: ComponentHealth, now: number): string {
 export function printServiceHealth(rows: ComponentHealth[] | null, now: number = Date.now()): void {
   console.log(chalk.bold("\nService Health\n"));
   if (rows == null) {
-    console.log(`  ${chalk.red("✘")} daemon unreachable — squadrant liveness is unknown (start the daemon)`);
+    console.log(`  ${chalk.red("✘")} daemon unreachable — squadrant liveness is unknown`);
+    console.log(`         ${chalk.cyan("→")} ${chalk.dim("Run: squadrant heal daemon")}`);
     return;
   }
   if (rows.length === 0) {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import readline from "node:readline";
 import { execSync } from "node:child_process";
 import chalk from "chalk";
 import {
@@ -9,9 +10,18 @@ import {
   saveConfig,
   DEFAULT_CONFIG_PATH,
   resolveHome,
+  readUserLevelSource,
+  loadConfig,
 } from "@squadrant/shared";
 import { createObsidianDriver, WorkspaceRegistry } from "@squadrant/workspaces";
 import { ensureRuntimeSynced } from "@squadrant/shared";
+import {
+  createCursorEmitter,
+  createCodexEmitter,
+  createGeminiEmitter,
+  createOpencodeEmitter,
+  ProjectionRegistry,
+} from "@squadrant/agents";
 
 function findPackageRoot(): string {
   let dir = path.dirname(new URL(import.meta.url).pathname);
@@ -35,69 +45,101 @@ function copyDirRecursive(src: string, dest: string): void {
   }
 }
 
+function stepHeader(n: number, total: number, label: string): void {
+  console.log(chalk.bold(`\n  ${n}/${total}  ${label}`));
+}
+
+function promptLine(question: string): Promise<string> {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
 export const initCommand = new Command("init")
-  .description("First-time setup: scaffold hub vault, scripts, and config")
+  .description("Guided first-time setup: hub vault, agents, plugins, projects (re-run-safe)")
   .option("--hub <path>", "Hub vault path", "~/squadrant-hub")
-  .action((opts: { hub: string }) => {
+  .action(async (opts: { hub: string }) => {
     const hubPath = resolveHome(opts.hub);
     const pkgRoot = findPackageRoot();
     const configDir = path.join(os.homedir(), ".config", "squadrant");
+    const isTTY = process.stdin.isTTY === true;
 
     console.log(chalk.bold("\nSquadrant Init\n"));
 
-    // Verify the default workspace provider is registered (squadrant ships obsidian;
-    // if user already has a config pointing to an unknown provider, bail early)
-    const registry = new WorkspaceRegistry({ obsidian: createObsidianDriver });
+    // Non-TTY: print step checklist + next-commands and exit without blocking
+    if (!isTTY) {
+      console.log("  Run these steps to get started:\n");
+      console.log(chalk.bold("  1/5  Hub vault"));
+      console.log(chalk.cyan(`       squadrant init --hub ${opts.hub}`));
+      console.log(chalk.bold("\n  2/5  Agent + projection setup"));
+      console.log("       (handled automatically by: " + chalk.cyan("squadrant init") + ")");
+      console.log(chalk.bold("\n  3/5  Plugins — open Claude Code and run:"));
+      console.log(chalk.cyan("       /plugin marketplace add superpowers"));
+      console.log(chalk.cyan("       /plugin marketplace add thedotmack/claude-mem"));
+      console.log(chalk.cyan("       /plugin marketplace add context7"));
+      console.log(chalk.bold("\n  4/5  Register first project"));
+      console.log(chalk.cyan("       squadrant projects add <name> <path>"));
+      console.log(chalk.bold("\n  5/5  Telegram (optional)"));
+      console.log(chalk.cyan("       squadrant telegram setup"));
+      console.log(chalk.bold("\n  Then:"));
+      console.log(chalk.cyan("       squadrant launch <projectname>\n"));
+      return;
+    }
+
+    // Verify the default workspace provider is registered
+    const wsRegistry = new WorkspaceRegistry({ obsidian: createObsidianDriver });
     try {
       if (fs.existsSync(DEFAULT_CONFIG_PATH)) {
         const existing = JSON.parse(fs.readFileSync(DEFAULT_CONFIG_PATH, "utf-8"));
-        const wsName = existing.workspace ?? "obsidian";
-        registry.get(wsName);
+        wsRegistry.get(existing.workspace ?? "obsidian");
       }
     } catch (err) {
       console.log(chalk.red(`  ✘ ${(err as Error).message}`));
       return;
     }
 
-    // 1. Create config
+    // ── 1/5  Hub vault ──────────────────────────────────────────────────────
+    stepHeader(1, 5, "Hub vault");
+
     if (fs.existsSync(DEFAULT_CONFIG_PATH)) {
-      console.log(chalk.yellow("  ⚠ Config already exists, skipping creation"));
+      console.log(chalk.yellow("    ⚠ Config already exists, skipping creation"));
     } else {
       const config = getDefaultConfig();
       config.hubVault = hubPath;
       saveConfig(config);
-      console.log(chalk.green(`  ✔ Config created at ${DEFAULT_CONFIG_PATH}`));
+      console.log(chalk.green(`    ✔ Config created at ${DEFAULT_CONFIG_PATH}`));
     }
 
-    // 2. Scaffold hub vault from template
     const hubTemplate = path.join(pkgRoot, "obsidian", "hub");
     if (fs.existsSync(hubPath)) {
-      console.log(chalk.yellow(`  ⚠ Hub vault already exists at ${hubPath}, skipping`));
+      console.log(chalk.yellow(`    ⚠ Hub vault already exists at ${hubPath}`));
     } else if (fs.existsSync(hubTemplate)) {
       copyDirRecursive(hubTemplate, hubPath);
-      console.log(chalk.green(`  ✔ Hub vault scaffolded at ${hubPath}`));
+      console.log(chalk.green(`    ✔ Hub vault scaffolded at ${hubPath}`));
     } else {
       fs.mkdirSync(hubPath, { recursive: true });
-      console.log(chalk.yellow(`  ⚠ Hub template not found; created empty dir at ${hubPath}`));
+      console.log(chalk.yellow(`    ⚠ Hub template not found; created empty directory at ${hubPath}`));
     }
 
-    // 2b. Always refresh dashboard.md and ensure projects/ exists (idempotent — see #44)
+    // Refresh dashboard.md and ensure projects/ dir exist (idempotent — #44)
     const hubDashboardSrc = path.join(pkgRoot, "obsidian", "hub", "dashboard.md");
     const hubDashboardDest = path.join(hubPath, "dashboard.md");
     if (fs.existsSync(hubDashboardSrc)) {
       fs.copyFileSync(hubDashboardSrc, hubDashboardDest);
-      console.log(chalk.green(`  ✔ Dashboard page refreshed at ${hubDashboardDest}`));
+      console.log(chalk.green(`    ✔ Dashboard refreshed`));
     }
-    const projectsDir = path.join(hubPath, "projects");
-    fs.mkdirSync(projectsDir, { recursive: true });
+    fs.mkdirSync(path.join(hubPath, "projects"), { recursive: true });
 
-    // 3. Sync source-managed runtime dirs (plugin, scripts, templates) via
-    // the same self-heal path the CLI runs on every invocation: copy +
-    // prune + chmod, so a re-init never leaves stale files behind.
     ensureRuntimeSynced({ sourceRoot: pkgRoot, runtimeRoot: configDir });
-    console.log(chalk.green(`  ✔ Runtime assets synced to ${configDir}`));
+    console.log(chalk.green(`    ✔ Runtime assets synced to ${configDir}`));
 
-    // 6. Enable Agent Teams in settings.json if not set
+    // ── 2/5  Agent + projection setup ───────────────────────────────────────
+    stepHeader(2, 5, "Agent + projection setup");
+
     const settingsPath = path.join(os.homedir(), ".claude", "settings.json");
     try {
       let settings: Record<string, unknown> = {};
@@ -109,30 +151,77 @@ export const initCommand = new Command("init")
         settings.env = { ...env, CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: "1" };
         fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
         fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n");
-        console.log(chalk.green("  ✔ Agent Teams enabled in ~/.claude/settings.json"));
+        console.log(chalk.green("    ✔ Agent Teams enabled in ~/.claude/settings.json"));
       } else {
-        console.log(chalk.green("  ✔ Agent Teams already enabled"));
+        console.log(chalk.green("    ✔ Agent Teams already enabled"));
       }
     } catch {
-      console.log(chalk.yellow("  ⚠ Could not update ~/.claude/settings.json"));
+      console.log(chalk.yellow("    ⚠ Could not update ~/.claude/settings.json"));
+      console.log(chalk.dim("      Add manually to shell profile: export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1"));
     }
 
-    // 5. Print manual steps
-    console.log(chalk.bold("\nManual steps required:\n"));
-    console.log("  1. Install plugins in Claude Code:");
-    console.log(chalk.cyan("       /plugin marketplace add thedotmack/claude-mem"));
-    console.log(chalk.cyan("       /plugin install claude-mem"));
-    console.log("       Install context7 and superpowers from /plugin marketplace");
-    console.log("");
-    console.log("  2. Install cmux if not already installed:");
-    console.log(chalk.cyan("       npm install -g cmux"));
-    console.log("");
-    console.log("  3. Open Obsidian and add the hub vault:");
-    console.log(chalk.cyan(`       ${hubPath}`));
-    console.log("");
-    console.log("  4. Run " + chalk.cyan("squadrant doctor") + " to verify setup\n");
-
-    if (!fs.existsSync("/Applications/cmux.app")) {
-      console.log(chalk.yellow("  ⚠ cmux not found — download from https://cmux.dev\n"));
+    // Emit projection files so non-Claude agents (codex, gemini, opencode, cursor)
+    // each get their AGENTS.md / GEMINI.md with up-to-date instructions.
+    try {
+      const projRegistry = new ProjectionRegistry({
+        cursor: createCursorEmitter,
+        codex: createCodexEmitter,
+        gemini: createGeminiEmitter,
+        opencode: createOpencodeEmitter,
+      });
+      const workspace = createObsidianDriver({ root: process.cwd() });
+      const source = await readUserLevelSource(workspace, { pkgRoot });
+      for (const name of projRegistry.list()) {
+        const emitter = projRegistry.get(name);
+        for (const dest of emitter.destinations("user")) {
+          const result = await emitter.emit(source, dest);
+          if (result.written) {
+            console.log(chalk.green(`    ✔ ${name} → ${dest.path}`));
+          } else {
+            console.log(chalk.dim(`    - ${name} → ${dest.path} (unchanged)`));
+          }
+        }
+      }
+    } catch (err) {
+      console.log(chalk.yellow(`    ⚠ Projection emit skipped: ${(err as Error).message}`));
     }
+
+    // ── 3/5  Plugins ────────────────────────────────────────────────────────
+    stepHeader(3, 5, "Plugins");
+    console.log("    Install these plugins inside Claude Code:\n");
+    console.log(chalk.cyan("      /plugin marketplace add superpowers"));
+    console.log(chalk.cyan("      /plugin marketplace add thedotmack/claude-mem"));
+    console.log(chalk.cyan("      /plugin marketplace add context7\n"));
+    console.log(chalk.dim("    Squadrant never auto-installs plugins — open Claude Code and run the commands above."));
+
+    // ── 4/5  Register first project ─────────────────────────────────────────
+    stepHeader(4, 5, "Register first project");
+
+    const projectPath = await promptLine(
+      chalk.cyan("    Absolute path to your first project (Enter to skip): "),
+    );
+    if (projectPath) {
+      const projectName = path.basename(projectPath);
+      console.log(chalk.bold(`\n    Run this to register it:`));
+      console.log(chalk.cyan(`      squadrant projects add ${projectName} ${projectPath}\n`));
+    } else {
+      console.log(chalk.dim("    Skipped. Register later with:"));
+      console.log(chalk.cyan("      squadrant projects add <name> <path>"));
+    }
+
+    // ── 5/5  Telegram ───────────────────────────────────────────────────────
+    stepHeader(5, 5, "Telegram (optional)");
+    console.log("    Get notified on your phone when crews complete tasks:");
+    console.log(chalk.cyan("      squadrant telegram setup\n"));
+
+    // ── Final summary ────────────────────────────────────────────────────────
+    let launchTarget = "<projectname>";
+    try {
+      const cfg = loadConfig();
+      const first = Object.keys(cfg.projects)[0];
+      if (first) launchTarget = first;
+    } catch { /* config may not exist if init just created it */ }
+
+    console.log(chalk.bold.green("\n  ✔ You are ready!\n"));
+    console.log(`     Run: ${chalk.cyan(`squadrant launch ${launchTarget}`)}\n`);
   });

--- a/packages/shared/src/lib/__tests__/tool-compat.test.ts
+++ b/packages/shared/src/lib/__tests__/tool-compat.test.ts
@@ -79,7 +79,7 @@ describe("checkToolCompat", () => {
   });
 
   it("returns null when only lastVerified is set and version matches it exactly", () => {
-    expect(checkToolCompat("opencode", "1.17.4", { lastVerified: "1.17.4" })).toBeNull();
+    expect(checkToolCompat("opencode", "1.17.9", { lastVerified: "1.17.9" })).toBeNull();
   });
 
   // Manifest shape: all six tools should produce a null when version is in-range

--- a/packages/shared/src/lib/compat-manifest.ts
+++ b/packages/shared/src/lib/compat-manifest.ts
@@ -8,6 +8,6 @@ export const compatManifest = {
     // presence-checked; no floor enforced yet
     codex:    { lastVerified: "0.139.0" }                 satisfies ToolEntry,
     gemini:   { lastVerified: "0.38.2"  }                 satisfies ToolEntry,
-    opencode: { lastVerified: "1.17.4"  }                 satisfies ToolEntry,
+    opencode: { lastVerified: "1.17.9"  }                 satisfies ToolEntry,
   },
 } as const;


### PR DESCRIPTION
## Summary

Three cohesive parts shipped on this branch:

**Part 0 — compat manifest freshness**
- Bumps `opencode` `lastVerified` from `1.17.4` → `1.17.9` (lifecycle-verified this session)
- Updates the corresponding test fixture in `tool-compat.test.ts`

**Part 1 — Doctor remediation hints**
- `check()` now accepts an optional `hint` string; when a check FAILs the hint is printed indented below with a `→` indicator
- Hints mapped to every actionable check: config exists, agent-teams, plugins (superpowers/claude-mem/context7), runtime, workspace hub
- `printServiceHealth` gains a `→ Run: squadrant heal daemon` hint when the daemon is unreachable
- 8 new unit tests in `doctor.test.ts` covering pass/fail/hint rendering paths

**Part 2 — Guided 5-step init (re-run-safe, TTY-safe)**
- `squadrant init` now walks a numbered 5-step flow:
  - `1/5` Hub vault (existing --hub scaffold, idempotent)
  - `2/5` Agent Teams enable + projection emit for codex/gemini/opencode/cursor (non-Claude agents get their `AGENTS.md`/`GEMINI.md`)
  - `3/5` Plugin install guidance only (never auto-installs)
  - `4/5` Register first project: prompts for path or prints the exact `squadrant projects add` command
  - `5/5` Telegram setup pointer
  - Final: `✔ You are ready! → squadrant launch <project>`
- **Re-run-safe**: each step checks current state and skips if already done
- **TTY-safe**: `init </dev/null` prints the full step checklist + commands and exits 0 without blocking on any prompt
- 8 new tests in `init.test.ts` covering non-TTY (3) and re-run-safe idempotency (5)

## Test plan

- [ ] `npx vitest run packages/cli/src/commands/__tests__/doctor.test.ts` — 8 tests green
- [ ] `npx vitest run packages/cli/src/commands/__tests__/init.test.ts` — 8 tests green
- [ ] `npx vitest run packages/shared/src/lib/__tests__/tool-compat.test.ts` — opencode 1.17.9 fixture passes
- [ ] `pnpm build` — clean exit 0
- [ ] `squadrant doctor` on a fresh env shows `→` hints under each FAIL line
- [ ] `squadrant init </dev/null` prints checklist and exits immediately (no hang)
- [ ] `squadrant init` (TTY) walks all 5 steps, skips already-done steps on re-run