### PR TITLE
docs: fix stale cockpit diagram link in AGENTS.md (#423 follow-up)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ Six packages in a one-way DAG: `shared ◄ core ◄ {agents, workspaces, web} �
 | `@squadrant/web` | Observability dashboard (bundled HTML/JS) |
 | `@squadrant/cli` | Commands, bin entry, daemon host — root package |
 
-Build outputs: `dist/index.js` (CLI bin) · `dist/squadrantd.js` (daemon). See [architecture diagram](docs/diagrams/2026-06-18-cockpit-monorepo-architecture.html).
+Build outputs: `dist/index.js` (CLI bin) · `dist/squadrantd.js` (daemon). See [architecture diagram](docs/diagrams/2026-06-18-squadrant-monorepo-architecture.html).
 
 ## Telegram (opt-in, #65)
 


### PR DESCRIPTION
AGENTS.md referenced `docs/diagrams/2026-06-18-cockpit-monorepo-architecture.html` which was renamed to `-squadrant-monorepo-architecture.html` in the #423 rebranding sweep. AGENTS.md was missed.

Changes:
- Line 70: `cockpit-monorepo-architecture.html` → `squadrant-monorepo-architecture.html`

Verified: `grep -n cockpit AGENTS.md` returns zero hits.