### PR TITLE
feat(telegram): typing indicator on inbound captain message (#430)

### DIFF
--- a/packages/cli/src/commands/__tests__/telegram.test.ts
+++ b/packages/cli/src/commands/__tests__/telegram.test.ts
@@ -22,6 +22,7 @@ function fakeClient(onCreate?: () => void) {
     setMyCommands: async () => {},
     answerCallbackQuery: async () => {},
     editMessageReplyMarkup: async () => {},
+    sendChatAction: async () => {},
   };
 }
 
@@ -222,6 +223,7 @@ describe("runNotifyConfirmation", () => {
       setMyCommands: async () => {},
       answerCallbackQuery: async () => {},
       editMessageReplyMarkup: async () => {},
+      sendChatAction: async () => {},
     };
   }
   const tgCfg = { supergroupId: 5, chats: [1] } as any;

--- a/packages/core/src/telegram/__tests__/bridge.callback.test.ts
+++ b/packages/core/src/telegram/__tests__/bridge.callback.test.ts
@@ -159,6 +159,7 @@ function makeInbound(message: unknown): InboundHarness {
     sendMessage,
     answerCallbackQuery: async () => {},
     editMessageReplyMarkup: async () => {},
+    sendChatAction: async () => {},
     createForumTopic: async () => 1,
     getMe: async () => ({ id: 0, username: "" }),
     setMyCommands: async () => {},

--- a/packages/core/src/telegram/__tests__/bridge.test.ts
+++ b/packages/core/src/telegram/__tests__/bridge.test.ts
@@ -50,6 +50,7 @@ describe("pushLifecycle (outbound)", () => {
       setMyCommands: async () => {},
       answerCallbackQuery: async () => {},
       editMessageReplyMarkup: async () => {},
+      sendChatAction: async () => {},
     };
     const bridge = createTelegramBridge({ cfg, stateRoot: root, client, appendCaptainMessage: async () => {}, log: () => {} });
     active = bridge;
@@ -74,6 +75,7 @@ describe("pushLifecycle (outbound)", () => {
       setMyCommands: async () => {},
       answerCallbackQuery: async () => {},
       editMessageReplyMarkup: async () => {},
+      sendChatAction: async () => {},
     };
     const bridge = createTelegramBridge({ cfg, stateRoot: root, client, appendCaptainMessage: async () => {}, log: () => {} });
     active = bridge;
@@ -100,6 +102,7 @@ describe("pushLifecycle (outbound)", () => {
       setMyCommands: async () => {},
       answerCallbackQuery: async () => {},
       editMessageReplyMarkup: async () => {},
+      sendChatAction: async () => {},
     };
     const bridge = createTelegramBridge({
       cfg, stateRoot: root, client,
@@ -127,6 +130,7 @@ describe("pushLifecycle notify gate", () => {
       setMyCommands: async () => {},
       answerCallbackQuery: async () => {},
       editMessageReplyMarkup: async () => {},
+      sendChatAction: async () => {},
     };
     const bridge = createTelegramBridge({ cfg, stateRoot: root, client, appendCaptainMessage: async () => {}, log: () => {} });
     active = bridge;
@@ -150,6 +154,7 @@ describe("pushLifecycle notify gate", () => {
       setMyCommands: async () => {},
       answerCallbackQuery: async () => {},
       editMessageReplyMarkup: async () => {},
+      sendChatAction: async () => {},
     };
     // Isolate from the real ~/.config/squadrant override (else a live crew="none"
     // tier filters out task.done and this never sends). The temp root has no
@@ -186,6 +191,7 @@ describe("auto-unmute + in-topic /mute /unmute", () => {
       setMyCommands: async () => {},
       answerCallbackQuery: async () => {},
       editMessageReplyMarkup: async () => {},
+      sendChatAction: async () => {},
     };
     const bridge = createTelegramBridge({
       cfg, stateRoot: root, client,
@@ -216,6 +222,7 @@ describe("auto-unmute + in-topic /mute /unmute", () => {
       setMyCommands: async () => {},
       answerCallbackQuery: async () => {},
       editMessageReplyMarkup: async () => {},
+      sendChatAction: async () => {},
     };
     const bridge = createTelegramBridge({
       cfg, stateRoot: root, client, // remoteControl=false (default cfg)
@@ -248,6 +255,7 @@ describe("auto-unmute + in-topic /mute /unmute", () => {
       setMyCommands: async () => {},
       answerCallbackQuery: async () => {},
       editMessageReplyMarkup: async () => {},
+      sendChatAction: async () => {},
     };
     const bridge = createTelegramBridge({
       cfg: cfgWithControl, stateRoot: root, client,
@@ -282,6 +290,7 @@ describe("auto-unmute + in-topic /mute /unmute", () => {
       setMyCommands: async () => {},
       answerCallbackQuery: async () => {},
       editMessageReplyMarkup: async () => {},
+      sendChatAction: async () => {},
     };
     const bridge = createTelegramBridge({
       cfg, stateRoot: root, client, // remoteControl=false
@@ -317,6 +326,7 @@ describe("inbound poll", () => {
       setMyCommands: async () => {},
       answerCallbackQuery: async () => {},
       editMessageReplyMarkup: async () => {},
+      sendChatAction: async () => {},
     };
     const bridge = createTelegramBridge({
       cfg, stateRoot: root, client,
@@ -349,6 +359,7 @@ describe("inbound poll", () => {
       setMyCommands: async () => {},
       answerCallbackQuery: async () => {},
       editMessageReplyMarkup: async () => {},
+      sendChatAction: async () => {},
     };
     const bridge = createTelegramBridge({
       cfg, stateRoot: root, client,
@@ -381,6 +392,7 @@ describe("inbound poll", () => {
       setMyCommands: async () => {},
       answerCallbackQuery: async () => {},
       editMessageReplyMarkup: async () => {},
+      sendChatAction: async () => {},
     };
     const bridge = createTelegramBridge({
       cfg, stateRoot: root, client,
@@ -413,6 +425,7 @@ describe("lastUserId passive capture", () => {
       setMyCommands: async () => {},
       answerCallbackQuery: async () => {},
       editMessageReplyMarkup: async () => {},
+      sendChatAction: async () => {},
     };
     const bridge = createTelegramBridge({ cfg, stateRoot: root, client, appendCaptainMessage: async () => {}, log: () => {} });
     active = bridge;
@@ -436,6 +449,7 @@ describe("lastUserId passive capture", () => {
       setMyCommands: async () => {},
       answerCallbackQuery: async () => {},
       editMessageReplyMarkup: async () => {},
+      sendChatAction: async () => {},
     };
     const bridge = createTelegramBridge({ cfg, stateRoot: root, client, appendCaptainMessage: async () => {}, log: () => {} });
     active = bridge;

--- a/packages/core/src/telegram/__tests__/client.test.ts
+++ b/packages/core/src/telegram/__tests__/client.test.ts
@@ -144,6 +144,27 @@ describe("createTelegramClient.createForumTopic", () => {
   });
 });
 
+describe("createTelegramClient.sendChatAction", () => {
+  it("POSTs chat_id, message_thread_id, and action when a thread is given", async () => {
+    const { fn, calls } = fakeFetch({ ok: true, result: true });
+    const client = createTelegramClient({ token: "TKN", fetch: fn });
+
+    await client.sendChatAction(-100, 7, "typing");
+
+    expect(calls[0].url).toBe("https://api.telegram.org/botTKN/sendChatAction");
+    expect(bodyOf(calls[0])).toEqual({ chat_id: -100, message_thread_id: 7, action: "typing" });
+  });
+
+  it("omits message_thread_id when no thread is given", async () => {
+    const { fn, calls } = fakeFetch({ ok: true, result: true });
+    const client = createTelegramClient({ token: "TKN", fetch: fn });
+
+    await client.sendChatAction(-100, undefined, "typing");
+
+    expect(bodyOf(calls[0])).toEqual({ chat_id: -100, action: "typing" });
+  });
+});
+
 describe("createTelegramClient.setMyCommands", () => {
   it("POSTs commands array under the setMyCommands method and resolves", async () => {
     const { fn, calls } = fakeFetch({ ok: true, result: true });

--- a/packages/core/src/telegram/bridge.test.ts
+++ b/packages/core/src/telegram/bridge.test.ts
@@ -26,6 +26,7 @@ function drive(opts: Omit<TelegramBridgeOptions, "client">, updates: Array<Parti
     setMyCommands: vi.fn(async () => {}),
     answerCallbackQuery: vi.fn(async () => {}),
     editMessageReplyMarkup: vi.fn(async () => {}),
+    sendChatAction: vi.fn(async () => {}),
   };
   const bridge = createTelegramBridge({ ...opts, client });
   bridge.start();
@@ -234,6 +235,40 @@ describe("channel commands in a project topic (#cmds-anytopic)", () => {
     await drained;
     expect(d.runCommand).not.toHaveBeenCalled();
     expect(d.sendReply).toHaveBeenCalledWith(7, expect.stringContaining("not authorized"));
+    expect(d.appendCaptainMessage).not.toHaveBeenCalled();
+    bridge.stop();
+  });
+});
+
+describe("typing indicator", () => {
+  it("fires sendChatAction('typing') for an inbound captain message", async () => {
+    setTopic(stateRoot, "brove", 7);
+    const d = deps();
+    const { bridge, client, drained } = drive({ cfg: baseCfg, ...d }, [topicMsg("ship it", 7)]);
+    await drained;
+    expect(client.sendChatAction).toHaveBeenCalledWith(CHAT, 7, "typing");
+    expect(d.appendCaptainMessage).toHaveBeenCalled();
+    bridge.stop();
+  });
+
+  it("does NOT fire sendChatAction for a /notify command in a project topic", async () => {
+    setTopic(stateRoot, "brove", 7);
+    const ctrlCfg = { ...baseCfg, remoteControl: true, users: [ALLOWED_USER] };
+    const d = deps();
+    const { bridge, client, drained } = drive({ cfg: ctrlCfg, ...d }, [topicMsg("/notify", 7)]);
+    await drained;
+    expect(client.sendChatAction).not.toHaveBeenCalled();
+    expect(d.appendCaptainMessage).not.toHaveBeenCalled();
+    bridge.stop();
+  });
+
+  it("does NOT fire sendChatAction for a /status channel command in a project topic", async () => {
+    setTopic(stateRoot, "brove", 7);
+    const ctrlCfg = { ...baseCfg, remoteControl: true, users: [ALLOWED_USER] };
+    const d = deps();
+    const { bridge, client, drained } = drive({ cfg: ctrlCfg, ...d }, [topicMsg("/status", 7)]);
+    await drained;
+    expect(client.sendChatAction).not.toHaveBeenCalled();
     expect(d.appendCaptainMessage).not.toHaveBeenCalled();
     bridge.stop();
   });

--- a/packages/core/src/telegram/bridge.ts
+++ b/packages/core/src/telegram/bridge.ts
@@ -387,6 +387,9 @@ export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridg
       return;
     }
 
+    void client.sendChatAction(cfg.supergroupId, threadId, "typing").catch((e) => {
+      log(`telegram sendChatAction failed: ${(e as Error).message}`);
+    });
     setNotify(stateRoot, resolved.project, true); // engagement → auto-unmute (sticky)
     if (ensureCaptainAlive && isControlEnabled(cfg) && isAuthorized(fromId, cfg)) {
       try {

--- a/packages/core/src/telegram/client.ts
+++ b/packages/core/src/telegram/client.ts
@@ -16,6 +16,8 @@ export interface TelegramClient {
   getMe(): Promise<{ id: number; username: string }>;
   /** Register the bot's command menu with Telegram. */
   setMyCommands(commands: Array<{ command: string; description: string }>): Promise<void>;
+  /** Send a chat action (e.g. "typing") to show activity to the user. */
+  sendChatAction(chatId: number, threadId: number | undefined, action: string): Promise<void>;
 }
 
 interface TgResponse<T> {
@@ -72,6 +74,11 @@ export function createTelegramClient(opts: { token: string; fetch?: typeof fetch
     },
     async setMyCommands(commands) {
       await call<boolean>("setMyCommands", { commands });
+    },
+    async sendChatAction(chatId, threadId, action) {
+      const body: Record<string, unknown> = { chat_id: chatId, action };
+      if (threadId !== undefined) body.message_thread_id = threadId;
+      await call<unknown>("sendChatAction", body);
     },
   };
 }


### PR DESCRIPTION
## Summary

- Adds `sendChatAction` method to the `TelegramClient` interface and `createTelegramClient` implementation (mirrors `sendMessage` body-building, includes `message_thread_id` for topic threads)
- Fires `sendChatAction("typing")` fire-and-forget in `handleProjectTopic` at the captain-message path (after all command checks), giving instant visual feedback in Telegram while the captain processes the request
- Only fires on the inbound captain-message path — command messages (`/notify`, `/mute`, `/unmute`, channel commands, callback queries) are explicitly excluded

## Test plan

- [x] New `describe("typing indicator")` block in `bridge.test.ts`: asserts `sendChatAction("typing")` is called for an inbound captain message, and NOT called for `/notify` or `/status` commands
- [x] New `describe("createTelegramClient.sendChatAction")` block in `client.test.ts`: verifies correct POST body with and without `message_thread_id`
- [x] All 191 existing + new tests pass (`vitest run`)
- [x] Full build green: `pnpm build` (tsc typecheck + tsup bundle)

Closes #430