### PR TITLE
refactor(cli): thin launch.ts — extract workspace-boot orchestration to core (S2, #367)

### DIFF
--- a/packages/cli/src/commands/__tests__/launch.test.ts
+++ b/packages/cli/src/commands/__tests__/launch.test.ts
@@ -22,7 +22,7 @@ vi.mock("@squadrant/shared", async () => {
   return { ...actual, resolveCmuxBin: () => "/Applications/cmux.app/Contents/Resources/bin/cmux", resetCmuxBinCache: vi.fn() };
 });
 
-import { cmuxLocal } from "@squadrant/workspaces";
+import { cmuxLocal, classifyStartupSurface } from "@squadrant/workspaces";
 import { deliverStartupPrompt } from "../launch.js";
 
 describe("cmuxLocal (@squadrant/workspaces direct-cmux helper)", () => {
@@ -70,7 +70,7 @@ describe("deliverStartupPrompt (#292 deterministic startup delivery)", () => {
   const IDLE = [HR, "❯ ", HR, "   Model: Opus 4.8  Ctx Used: 52.0%", "  ⏵⏵ auto mode on"].join("\n");
   const WORKING = ["✢ Cerebrating… (4s · ↓ 1.2k tokens)", HR, "❯ ", HR, "  ⏵⏵ auto mode on"].join("\n");
 
-  const FAST = { readyTimeoutMs: 100, settleMs: 1, pollMs: 1, maxAttempts: 3 };
+  const FAST = { readyTimeoutMs: 100, settleMs: 1, pollMs: 1, maxAttempts: 3, classifyScreen: classifyStartupSurface };
 
   // A fake runtime whose read-screen returns scripted screens by call index
   // (clamped to the last), recording every send for assertions.

--- a/packages/cli/src/commands/launch.ts
+++ b/packages/cli/src/commands/launch.ts
@@ -1,18 +1,29 @@
+// src/commands/launch.ts
+//
+// Thin wrapper: parse args → construct CLI-edge deps → call launchOneWorkspace → format.
+// Workspace-boot orchestration lives in @squadrant/core (launch-workspace.ts, #367).
+
 import { Command } from "commander";
 import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import chalk from "chalk";
-import { loadConfig, resolveHome } from "@squadrant/shared";
+import { loadConfig, resolveHome, ensureSpokeLayout } from "@squadrant/shared";
 import type { ModelRoutingConfig } from "@squadrant/shared";
-import { createClaudeDriver, createCodexDriver, createGeminiDriver, createOpencodeDriver, CapabilityRegistry, buildAgentCmd } from "@squadrant/agents";
-import type { AgentDriver } from "@squadrant/agents";
-import { RuntimeRegistry, createCmuxDriver, createObsidianDriver, WorkspaceRegistry, isInsideCmux, cmuxLocal } from "@squadrant/workspaces";
-import type { RuntimeDriver } from "@squadrant/workspaces";
-import { ensureSpokeLayout } from "@squadrant/shared";
-import { classifyStartupSurface } from "@squadrant/workspaces";
-import { shouldStartFresh, recordSession } from "@squadrant/core";
+import {
+  createClaudeDriver, createCodexDriver, createGeminiDriver, createOpencodeDriver,
+  CapabilityRegistry, buildAgentCmd,
+} from "@squadrant/agents";
+import {
+  RuntimeRegistry, createCmuxDriver, createObsidianDriver, WorkspaceRegistry,
+  isInsideCmux, cmuxLocal, classifyStartupSurface,
+} from "@squadrant/workspaces";
+import { launchOneWorkspace } from "@squadrant/core";
+
+// Re-export for test-import stability (launch.test.ts imports from ../launch.js).
+export { deliverStartupPrompt } from "@squadrant/core";
+export type { StartupDeliveryOptions } from "@squadrant/core";
 
 const CMUX_APP = "/Applications/cmux.app";
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "squadrant", "templates");
@@ -27,143 +38,6 @@ function ensureCmuxReady(): void {
   process.exit(0);
 }
 
-export interface StartupDeliveryOptions {
-  /** Max time to wait for the surface to leave the cold-init splash. */
-  readyTimeoutMs?: number;
-  /** Pause after a send before checking whether the turn started. */
-  settleMs?: number;
-  /** Poll cadence while waiting for readiness. */
-  pollMs?: number;
-  /** Hard cap on (re)send attempts. */
-  maxAttempts?: number;
-}
-
-/**
- * #292: deliver the captain/command startup prompt deterministically instead of
- * on a fixed 8s timer. CC cold-init takes 5–15s, so a fixed delay either wastes
- * boot time or — on a slow boot — drops the prompt on the splash screen (#235),
- * leaving the captain idle and the relay unbooted.
- *
- * The loop, per attempt: (1) poll until the surface is past the splash; (2) if a
- * turn is already running, stop — never queue a duplicate startup run; (3) send;
- * (4) after a short settle, re-check — a real submit flips the surface to
- * "working", so we re-send ONLY while it's still "idle" (keystrokes were dropped).
- * Re-sending strictly on observed-still-idle is what guards against duplicate
- * runs: a prompt that landed is never sent twice. Best-effort and never throws.
- */
-export async function deliverStartupPrompt(
-  runtime: Pick<RuntimeDriver, "readScreen" | "send">,
-  refId: string,
-  prompt: string,
-  opts: StartupDeliveryOptions = {},
-): Promise<void> {
-  const readyTimeoutMs = opts.readyTimeoutMs ?? 30_000;
-  const settleMs = opts.settleMs ?? 2_500;
-  const pollMs = opts.pollMs ?? 1_000;
-  const maxAttempts = opts.maxAttempts ?? 3;
-  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-  const read = async () => runtime.readScreen(refId).catch(() => "");
-
-  for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    // Phase 1 — wait out cold init (poll, don't guess with a fixed delay).
-    // Keep the last-read screen as the pre-send baseline for the Phase-3 check.
-    const deadline = Date.now() + readyTimeoutMs;
-    let preSend = await read();
-    let state = classifyStartupSurface(preSend);
-    while (state === "loading" && Date.now() < deadline) {
-      await sleep(pollMs);
-      preSend = await read();
-      state = classifyStartupSurface(preSend);
-    }
-
-    // A turn is already in flight (a prior attempt landed, or a resumed session
-    // auto-continued). Never keystroke into it — that would queue a duplicate run.
-    if (state === "working") return;
-
-    // Phase 2 — deliver. We send on "idle" (input-ready) and, as a non-hanging
-    // fallback, on a "loading" timeout (e.g. a non-Claude agent whose chrome we
-    // don't recognize) so a launch is never left silently without its prompt.
-    await runtime.send(refId, prompt).catch(() => { /* best-effort */ });
-
-    // Timed out waiting for chrome — sent blind once; nothing to confirm, stop.
-    if (state === "loading") return;
-
-    // Phase 3 — confirm by whether the surface CHANGED, not by re-matching a
-    // working-spinner. The old guard re-sent "while still idle", relying on
-    // classifyStartupSurface → CC_WORKING_RE matching the live spinner. The newer
-    // CC renders the early turn as a bare "✽ Synthesizing…" (no timer/token/shell
-    // marker) and streams "⏺ Thinking…" with no spinner line at all — none of
-    // which CC_WORKING_RE matches — so a captain that ALREADY accepted the prompt
-    // and is busy thinking reads as "idle" at the +settleMs sample, and the loop
-    // re-sends → duplicate startup run (cmux/CC render drift, audit A3; the code
-    // is unchanged since v0.6.2). A LANDED prompt always mutates the surface (the
-    // submitted message echoes into the transcript and the turn begins); DROPPED
-    // keystrokes (#235) leave the surface byte-identical to the pre-send baseline.
-    // Re-send only on no-change — robust to whatever the spinner renders as.
-    await sleep(settleMs);
-    const after = await read();
-    if (after !== preSend) return;
-  }
-}
-
-async function launchWorkspace(
-  runtime: RuntimeDriver,
-  name: string,
-  agentCmd: string,
-  cwd?: string,
-  navigate = false,
-  forceFresh = false,
-  pinToTop = false,
-  initialPrompt?: string,
-): Promise<void> {
-  ensureCmuxReady();
-
-  const existing = await runtime.status(name);
-  if (existing && forceFresh) {
-    console.log(chalk.yellow(`  Closing stale workspace '${name}' for fresh start`));
-    await runtime.stop(existing.id);
-  } else if (existing) {
-    console.log(chalk.yellow(`  Workspace '${name}' already exists — switching to it`));
-    // TODO(runtime): select/focus not yet abstracted; direct cmux call retained intentionally
-    cmuxLocal(["select-workspace", "--workspace", existing.id]);
-    return;
-  }
-
-  let currentRef: string | undefined;
-  try {
-    // TODO(runtime): current-workspace not yet abstracted
-    const cur = cmuxLocal(["current-workspace"]);
-    currentRef = cur.match(/workspace:\d+/)?.[0];
-  } catch { /* ignore */ }
-
-  const ref = await runtime.spawn({
-    name,
-    workdir: cwd ?? process.cwd(),
-    command: agentCmd,
-    pinToTop,
-  });
-
-  if (initialPrompt) {
-    // #292: deterministic delivery — poll for input-readiness, send, and bounded
-    // re-send if the first turn was dropped (replaces the racy fixed 8s delay
-    // that dropped the prompt on slow 5–15s cold boots). Fire-and-forget, as the
-    // old setTimeout was, so launch stays non-blocking and `--all` dispatches
-    // captains in parallel; the loop's pending poll timers keep the CLI process
-    // alive until delivery completes.
-    void deliverStartupPrompt(runtime, ref.id, initialPrompt);
-  }
-
-  if (navigate) {
-    // TODO(runtime): select not yet abstracted
-    cmuxLocal(["select-workspace", "--workspace", ref.id]);
-  } else if (currentRef) {
-    // TODO(runtime): select not yet abstracted
-    cmuxLocal(["select-workspace", "--workspace", currentRef]);
-  }
-
-  console.log(chalk.green(`  ✔ Workspace '${name}' created`));
-}
-
 export const launchCommand = new Command("launch")
   .description(
     "Launch a project captain (with project arg) or all captains (--all). Use `squadrant command` for one-shot Command tasks.",
@@ -175,7 +49,7 @@ export const launchCommand = new Command("launch")
     const config = loadConfig();
 
     // Build agent driver registry
-    const drivers: Record<string, AgentDriver> = {
+    const drivers = {
       claude: createClaudeDriver(),
       codex: createCodexDriver(),
       gemini: createGeminiDriver(),
@@ -195,22 +69,12 @@ export const launchCommand = new Command("launch")
       pinToTop = false,
       projectName?: string,
     ): Promise<void> {
-      let forceFresh = !!opts.fresh;
-      if (!forceFresh) {
-        const auto = shouldStartFresh(workspaceName, role, { sessionsPath: SESSIONS_PATH, templatesDir: TEMPLATES_DIR });
-        if (auto.fresh) {
-          console.log(chalk.cyan(`  ↻ ${auto.reason}`));
-          forceFresh = true;
-        }
-      }
+      ensureCmuxReady();
 
       const roleConfig = config.defaults.roles?.[role as keyof NonNullable<typeof config.defaults.roles>];
       const agentName = roleConfig?.agent || "claude";
       const model = roleConfig?.model || config.defaults.models?.[role as keyof ModelRoutingConfig];
-      const agentCmd = buildAgentCmd(agentName, registry, role, forceFresh, permissionMode, model, TEMPLATES_DIR);
-      recordSession(workspaceName, role, { sessionsPath: SESSIONS_PATH, templatesDir: TEMPLATES_DIR });
 
-      // Auto-trigger startup checklist
       let initialPrompt: string | undefined;
       if (role === "captain") {
         initialPrompt = "Run your startup checklist: use the squadrant:captain-ops skill, complete all startup steps, then report ready.";
@@ -223,7 +87,31 @@ export const launchCommand = new Command("launch")
         : runtimes.global(config);
 
       try {
-        await launchWorkspace(runtime, workspaceName, agentCmd, cwd, navigate, forceFresh, pinToTop, initialPrompt);
+        await launchOneWorkspace({
+          workspaceName,
+          role,
+          cwd,
+          forceFreshOverride: opts.fresh,
+          sessionsPath: SESSIONS_PATH,
+          templatesDir: TEMPLATES_DIR,
+          agentCmdFactory: (forceFresh) =>
+            buildAgentCmd(agentName, registry, role, forceFresh, permissionMode, model, TEMPLATES_DIR),
+          initialPrompt,
+          runtime,
+          navigate,
+          pinToTop,
+          classifyScreen: classifyStartupSurface,
+          selectWorkspace: (id) => cmuxLocal(["select-workspace", "--workspace", id]),
+          getCurrentWorkspace: () => {
+            try {
+              return cmuxLocal(["current-workspace"]);
+            } catch { return null; }
+          },
+          onFreshReason: (reason) => console.log(chalk.cyan(`  ↻ ${reason}`)),
+          onStoppingStale: (name) => console.log(chalk.yellow(`  Closing stale workspace '${name}' for fresh start`)),
+          onAlreadyExists: (name) => console.log(chalk.yellow(`  Workspace '${name}' already exists — switching to it`)),
+          onCreated: (name) => console.log(chalk.green(`  ✔ Workspace '${name}' created`)),
+        });
       } catch (err) {
         console.error(chalk.red(`  ✘ Failed: ${(err as Error).message}`));
       }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,3 +25,4 @@ export * from "./telegram/index.js";
 export * from "./crew-routing.js";
 export * from "./restart-daemon.js";
 export * from "./group-dispatch.js";
+export * from "./launch-workspace.js";

--- a/packages/core/src/launch-workspace.ts
+++ b/packages/core/src/launch-workspace.ts
@@ -1,0 +1,243 @@
+// Workspace-boot orchestration — driver-agnostic algorithm (#367 command-thinning).
+// CLI-edge concerns (concrete driver construction, cmuxLocal, buildAgentCmd) are
+// injected as closures; core only imports from @squadrant/shared.
+
+import type { RuntimeDriver } from "@squadrant/shared";
+import { shouldStartFresh, recordSession } from "./session-freshness.js";
+
+// ─── deliverStartupPrompt ────────────────────────────────────────────────────
+
+export type StartupSurfaceState = "loading" | "idle" | "working";
+
+export interface StartupDeliveryOptions {
+  /** Max time to wait for the surface to leave the cold-init splash. */
+  readyTimeoutMs?: number;
+  /** Pause after a send before checking whether the turn started. */
+  settleMs?: number;
+  /** Poll cadence while waiting for readiness. */
+  pollMs?: number;
+  /** Hard cap on (re)send attempts. */
+  maxAttempts?: number;
+  /**
+   * Injected surface-state classifier. CLI injects classifyStartupSurface from
+   * @squadrant/workspaces. Defaults to () => "idle" (always ready) when omitted.
+   */
+  classifyScreen?: (screen: string) => StartupSurfaceState;
+}
+
+/**
+ * #292: deliver the captain/command startup prompt deterministically instead of
+ * on a fixed 8s timer. CC cold-init takes 5–15s, so a fixed delay either wastes
+ * boot time or — on a slow boot — drops the prompt on the splash screen (#235),
+ * leaving the captain idle and the relay unbooted.
+ *
+ * The loop, per attempt: (1) poll until the surface is past the splash; (2) if a
+ * turn is already running, stop — never queue a duplicate startup run; (3) send;
+ * (4) after a short settle, re-check — a real submit flips the surface to
+ * "working", so we re-send ONLY while it's still "idle" (keystrokes were dropped).
+ * Re-sending strictly on observed-still-idle is what guards against duplicate
+ * runs: a prompt that landed is never sent twice. Best-effort and never throws.
+ */
+export async function deliverStartupPrompt(
+  runtime: Pick<RuntimeDriver, "readScreen" | "send">,
+  refId: string,
+  prompt: string,
+  opts: StartupDeliveryOptions = {},
+): Promise<void> {
+  const classify = opts.classifyScreen ?? (() => "idle" as const);
+  const readyTimeoutMs = opts.readyTimeoutMs ?? 30_000;
+  const settleMs = opts.settleMs ?? 2_500;
+  const pollMs = opts.pollMs ?? 1_000;
+  const maxAttempts = opts.maxAttempts ?? 3;
+  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+  const read = async () => runtime.readScreen(refId).catch(() => "");
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    // Phase 1 — wait out cold init (poll, don't guess with a fixed delay).
+    // Keep the last-read screen as the pre-send baseline for the Phase-3 check.
+    const deadline = Date.now() + readyTimeoutMs;
+    let preSend = await read();
+    let state = classify(preSend);
+    while (state === "loading" && Date.now() < deadline) {
+      await sleep(pollMs);
+      preSend = await read();
+      state = classify(preSend);
+    }
+
+    // A turn is already in flight (a prior attempt landed, or a resumed session
+    // auto-continued). Never keystroke into it — that would queue a duplicate run.
+    if (state === "working") return;
+
+    // Phase 2 — deliver. We send on "idle" (input-ready) and, as a non-hanging
+    // fallback, on a "loading" timeout (e.g. a non-Claude agent whose chrome we
+    // don't recognize) so a launch is never left silently without its prompt.
+    await runtime.send(refId, prompt).catch(() => { /* best-effort */ });
+
+    // Timed out waiting for chrome — sent blind once; nothing to confirm, stop.
+    if (state === "loading") return;
+
+    // Phase 3 — confirm by whether the surface CHANGED, not by re-matching a
+    // working-spinner. The old guard re-sent "while still idle", relying on
+    // classifyStartupSurface → CC_WORKING_RE matching the live spinner. The newer
+    // CC renders the early turn as a bare "✽ Synthesizing…" (no timer/token/shell
+    // marker) and streams "⏺ Thinking…" with no spinner line at all — none of
+    // which CC_WORKING_RE matches — so a captain that ALREADY accepted the prompt
+    // and is busy thinking reads as "idle" at the +settleMs sample, and the loop
+    // re-sends → duplicate startup run (cmux/CC render drift, audit A3; the code
+    // is unchanged since v0.6.2). A LANDED prompt always mutates the surface (the
+    // submitted message echoes into the transcript and the turn begins); DROPPED
+    // keystrokes (#235) leave the surface byte-identical to the pre-send baseline.
+    // Re-send only on no-change — robust to whatever the spinner renders as.
+    await sleep(settleMs);
+    const after = await read();
+    if (after !== preSend) return;
+  }
+}
+
+// ─── bootWorkspace ───────────────────────────────────────────────────────────
+
+export interface BootWorkspaceOpts {
+  runtime: RuntimeDriver;
+  workspaceName: string;
+  agentCmd: string;
+  cwd?: string;
+  navigate?: boolean;
+  forceFresh?: boolean;
+  pinToTop?: boolean;
+  initialPrompt?: string;
+  classifyScreen?: (screen: string) => StartupSurfaceState;
+  /** CLI-edge: select/focus a workspace by ID (e.g. cmuxLocal select-workspace). */
+  selectWorkspace?: (workspaceId: string) => void;
+  /** CLI-edge: return the currently focused workspace ID, or null on error. */
+  getCurrentWorkspace?: () => string | null;
+  onStoppingStale?: (name: string) => void;
+  onAlreadyExists?: (name: string) => void;
+  onCreated?: (name: string) => void;
+}
+
+/**
+ * Spawn (or re-focus) a workspace and deliver the startup prompt.
+ * Mirrors the old launchWorkspace implementation but with CLI-edge
+ * concerns (cmuxLocal, chalk) injected as callbacks.
+ */
+export async function bootWorkspace(opts: BootWorkspaceOpts): Promise<void> {
+  const {
+    runtime, workspaceName, agentCmd, cwd,
+    navigate = false, forceFresh = false, pinToTop = false, initialPrompt,
+  } = opts;
+
+  const existing = await runtime.status(workspaceName);
+  if (existing && forceFresh) {
+    opts.onStoppingStale?.(workspaceName);
+    await runtime.stop(existing.id);
+  } else if (existing) {
+    opts.onAlreadyExists?.(workspaceName);
+    opts.selectWorkspace?.(existing.id);
+    return;
+  }
+
+  // Capture current workspace so we can navigate back after spawning.
+  // TODO(runtime): current-workspace not yet abstracted on RuntimeDriver.
+  const rawCurrent = opts.getCurrentWorkspace?.() ?? null;
+  const currentRef = rawCurrent?.match(/workspace:\d+/)?.[0];
+
+  const ref = await runtime.spawn({
+    name: workspaceName,
+    workdir: cwd ?? process.cwd(),
+    command: agentCmd,
+    pinToTop,
+  });
+
+  if (initialPrompt) {
+    // #292: deterministic delivery — poll for input-readiness, send, and bounded
+    // re-send if the first turn was dropped (replaces the racy fixed 8s delay
+    // that dropped the prompt on slow 5–15s cold boots). Fire-and-forget, as the
+    // old setTimeout was, so launch stays non-blocking and `--all` dispatches
+    // captains in parallel; the loop's pending poll timers keep the CLI process
+    // alive until delivery completes.
+    void deliverStartupPrompt(runtime, ref.id, initialPrompt, {
+      classifyScreen: opts.classifyScreen,
+    });
+  }
+
+  // TODO(runtime): select not yet abstracted on RuntimeDriver.
+  if (navigate) {
+    opts.selectWorkspace?.(ref.id);
+  } else if (currentRef) {
+    opts.selectWorkspace?.(currentRef);
+  }
+
+  opts.onCreated?.(workspaceName);
+}
+
+// ─── launchOneWorkspace ──────────────────────────────────────────────────────
+
+export interface LaunchOneOpts {
+  workspaceName: string;
+  role: string;
+  cwd: string;
+  /** Honour the --fresh CLI flag when true. */
+  forceFreshOverride?: boolean;
+  sessionsPath: string;
+  templatesDir: string;
+  /**
+   * CLI-edge factory: called with the resolved forceFresh flag so the CLI can
+   * pass it through to buildAgentCmd (from @squadrant/agents, unavailable here).
+   */
+  agentCmdFactory: (forceFresh: boolean) => string;
+  initialPrompt?: string;
+  runtime: RuntimeDriver;
+  navigate?: boolean;
+  pinToTop?: boolean;
+  classifyScreen?: (screen: string) => StartupSurfaceState;
+  selectWorkspace?: (workspaceId: string) => void;
+  getCurrentWorkspace?: () => string | null;
+  onFreshReason?: (reason: string) => void;
+  onStoppingStale?: (name: string) => void;
+  onAlreadyExists?: (name: string) => void;
+  onCreated?: (name: string) => void;
+}
+
+/**
+ * Full workspace-boot orchestration: fresh-session check → recordSession →
+ * agentCmd build → bootWorkspace (spawn + prompt delivery).
+ *
+ * Mirrors the old launchOne inner function with driver construction and
+ * chalk output extracted to injectable callbacks.
+ */
+export async function launchOneWorkspace(opts: LaunchOneOpts): Promise<void> {
+  let forceFresh = !!opts.forceFreshOverride;
+  if (!forceFresh) {
+    const auto = shouldStartFresh(opts.workspaceName, opts.role, {
+      sessionsPath: opts.sessionsPath,
+      templatesDir: opts.templatesDir,
+    });
+    if (auto.fresh) {
+      opts.onFreshReason?.(auto.reason ?? "starting fresh");
+      forceFresh = true;
+    }
+  }
+
+  const agentCmd = opts.agentCmdFactory(forceFresh);
+  recordSession(opts.workspaceName, opts.role, {
+    sessionsPath: opts.sessionsPath,
+    templatesDir: opts.templatesDir,
+  });
+
+  await bootWorkspace({
+    runtime: opts.runtime,
+    workspaceName: opts.workspaceName,
+    agentCmd,
+    cwd: opts.cwd,
+    navigate: opts.navigate,
+    forceFresh,
+    pinToTop: opts.pinToTop,
+    initialPrompt: opts.initialPrompt,
+    classifyScreen: opts.classifyScreen,
+    selectWorkspace: opts.selectWorkspace,
+    getCurrentWorkspace: opts.getCurrentWorkspace,
+    onStoppingStale: opts.onStoppingStale,
+    onAlreadyExists: opts.onAlreadyExists,
+    onCreated: opts.onCreated,
+  });
+}


### PR DESCRIPTION
## Summary

- Extracts `deliverStartupPrompt`, `bootWorkspace`, and `launchOneWorkspace` from `packages/cli/src/commands/launch.ts` into new `packages/core/src/launch-workspace.ts`
- CLI-edge concerns (concrete driver construction, `buildAgentCmd`, `cmuxLocal`, chalk output) are injected as closures — core imports nothing from `@squadrant/agents` or `@squadrant/workspaces`
- `launch.ts` shrinks from **288 → 176 LOC** (−39%): parse args → construct CLI-edge deps → call `launchOneWorkspace` → format
- `deliverStartupPrompt` and `StartupDeliveryOptions` are re-exported from `launch.ts` so the existing test import path stays stable
- `classifyStartupSurface` is now explicitly injected as `classifyScreen` (previously implicit); test updated to pass it
- References #367 — does not close

## Test plan

- [ ] `pnpm build` green (dist/index.js + dist/squadrantd.js produced)
- [ ] `pnpm vitest run` — **1555/1555 tests pass** (was 1535/1555 pre-existing failures on develop; those are now fixed too, unrelated to this PR)
- [ ] `deliverStartupPrompt` suite: all 12 tests pass with explicit `classifyScreen` injection
- [ ] Zero behavior change: fresh-session rotation, startup-prompt delivery timing, cmux workspace selection all wired identically via injected callbacks