### PR TITLE
refactor(cli): thin telegram.ts — sort logic to core/telegram, keep stdin at edge (S2, #367)

### DIFF
--- a/packages/cli/src/commands/telegram.ts
+++ b/packages/cli/src/commands/telegram.ts
@@ -2,108 +2,52 @@ import { join, dirname } from "node:path";
 import { emitKeypressEvents } from "node:readline";
 import { Command } from "commander";
 import chalk from "chalk";
-import { loadConfig, DEFAULT_CONFIG_PATH, saveProjectOverride, resolveNotify, loadProjectOverride, isQuieter } from "@squadrant/shared";
-import type { SquadrantConfig, TelegramConfig, NotifyConfig, CrewTier } from "@squadrant/shared";
-import { createTelegramClient, loadState, setTopic, topicKey, topicName, detectGroupAndUser, writeTelegramConfig, maskToken, isNotifyActive, setNotify, BOT_COMMANDS, resolveSetupGroup } from "@squadrant/core";
-import type { TelegramClient } from "@squadrant/core";
-import { restartDaemonIfRunning, type RestartOutcome } from "@squadrant/core";
+import { loadConfig, DEFAULT_CONFIG_PATH, resolveNotify, loadProjectOverride } from "@squadrant/shared";
+import type { NotifyConfig, TelegramConfig, CrewTier } from "@squadrant/shared";
+import {
+  createTelegramClient,
+  loadState,
+  detectGroupAndUser,
+  writeTelegramConfig,
+  maskToken,
+  isNotifyActive,
+  BOT_COMMANDS,
+  resolveSetupGroup,
+  runTelegramStatus,
+  runTelegramNotifySet,
+  runTelegramNotifyPref,
+  runTelegramNotifyStatus,
+  capAllowed,
+  runNotifyConfirmation,
+  runTelegramSend,
+  runTelegramLink,
+  resolveSetupToken,
+  resolveSetupUserId,
+  runRegisterCommands,
+  runTelegramPostSetup,
+} from "@squadrant/core";
+import type { TelegramClient, TelegramStatusResult } from "@squadrant/core";
+
+// Re-export so existing test imports from this module continue to resolve.
+export type { TelegramStatusResult };
+export {
+  runTelegramStatus,
+  runTelegramNotifySet,
+  runTelegramNotifyPref,
+  runTelegramNotifyStatus,
+  capAllowed,
+  runNotifyConfirmation,
+  runTelegramSend,
+  runTelegramLink,
+  resolveSetupToken,
+  resolveSetupUserId,
+  runRegisterCommands,
+  runTelegramPostSetup,
+};
 
 /** Daemon state root (mirrors buildContext): ~/.config/squadrant/state. */
 function defaultStateRoot(): string {
   return join(dirname(DEFAULT_CONFIG_PATH), "state");
-}
-
-export interface TelegramStatusResult {
-  tokenSet: boolean;
-  supergroupId: number | null;
-  links: Array<{ project: string; scope: string; topicId: number }>;
-}
-
-export function runTelegramStatus(opts: {
-  config: SquadrantConfig;
-  stateRoot: string;
-  env?: NodeJS.ProcessEnv;
-}): TelegramStatusResult {
-  const tg = opts.config.telegram;
-  const env = opts.env ?? process.env;
-  const tokenSet = !!(tg?.botToken ?? env.TELEGRAM_BOT_TOKEN);
-  const links = Object.entries(loadState(opts.stateRoot).topics).map(([key, topicId]) => {
-    const sep = key.indexOf("::");
-    return { project: key.slice(0, sep), scope: key.slice(sep + 2), topicId };
-  });
-  return { tokenSet, supergroupId: tg?.supergroupId ?? null, links };
-}
-
-/** Send a message to a project's linked Telegram topic. */
-export async function runTelegramSend(opts: {
-  project: string;
-  message: string;
-  cfg: TelegramConfig;
-  client: TelegramClient;
-  stateRoot: string;
-}): Promise<{ chatId: number; topicId: number }> {
-  const topicId = loadState(opts.stateRoot).topics[topicKey(opts.project)];
-  if (topicId === undefined) {
-    throw new Error(`project "${opts.project}" is not linked — run: squadrant telegram link ${opts.project}`);
-  }
-  await opts.client.sendMessage(opts.cfg.supergroupId, topicId, opts.message);
-  return { chatId: opts.cfg.supergroupId, topicId };
-}
-
-/** Set a project's notification flag in telegram-state.json. */
-export function runTelegramNotifySet(opts: { project: string; active: boolean; stateRoot: string }): void {
-  setNotify(opts.stateRoot, opts.project, opts.active);
-}
-
-/** Write a deliberate per-project notification preference (crew tier / cap) to
- *  projects/<name>.json. Distinct from live on|off state (telegram-state.json). */
-export function runTelegramNotifyPref(
-  args: { project: string; dimension: "crew" | "cap"; value: string; root?: string },
-): { ok: true } | { ok: false; message: string } {
-  const { project, dimension, value, root } = args;
-  if (dimension === "crew") {
-    if (!["all", "alert_only", "done_only", "none"].includes(value))
-      return { ok: false, message: "crew must be all|alert_only|done_only|none" };
-    saveProjectOverride(project, { telegram: { notify: { crew: value as any } } }, root);
-    return { ok: true };
-  }
-  if (value !== "on" && value !== "off") return { ok: false, message: "cap must be on|off" };
-  saveProjectOverride(project, { telegram: { notify: { cap: value === "on" } } }, root);
-  return { ok: true };
-}
-
-/** Resolved `cap` for a project — whether explicit captain messages may be sent.
- *  `cap=false` is the deliberate "don't let the captain DM me" switch; live
- *  idle-mute (active) is intentionally NOT consulted here (an explicit push
- *  shouldn't be dropped just because the topic is idle-muted). */
-export function capAllowed(project: string, globalNotify: TelegramConfig["notify"], root?: string): boolean {
-  return resolveNotify(globalNotify, loadProjectOverride(project, root)).cap;
-}
-
-/** List every known project (union of linked topics and notify keys) with its state. */
-export function runTelegramNotifyStatus(opts: { stateRoot: string }): Array<{ project: string; active: boolean }> {
-  const s = loadState(opts.stateRoot);
-  const projects = new Set<string>();
-  for (const key of Object.keys(s.topics)) {
-    const sep = key.indexOf("::");
-    projects.add(sep === -1 ? key : key.slice(0, sep));
-  }
-  for (const p of Object.keys(s.notify)) projects.add(p);
-  return [...projects].map((project) => ({ project, active: s.notify[project] === true }));
-}
-
-/** Bind a project to a forum topic, creating it on first link. Idempotent. */
-export async function runTelegramLink(opts: {
-  project: string;
-  cfg: TelegramConfig;
-  client: TelegramClient;
-  stateRoot: string;
-}): Promise<{ topicId: number; created: boolean }> {
-  const existing = loadState(opts.stateRoot).topics[topicKey(opts.project)];
-  if (existing !== undefined) return { topicId: existing, created: false };
-  const topicId = await opts.client.createForumTopic(opts.cfg.supergroupId, topicName(opts.project));
-  setTopic(opts.stateRoot, opts.project, topicId);
-  return { topicId, created: true };
 }
 
 // Reads a secret from stdin, printing "*" per character. The caller must print
@@ -156,72 +100,6 @@ async function questionYesNo(prompt: string): Promise<boolean> {
       resolve(/^y(es)?$/i.test(ans.trim()));
     });
   });
-}
-
-function confirmationText(project: string, before: NotifyConfig, after: NotifyConfig, dim: "active" | "cap" | "crew"): string {
-  if (dim === "active") return `🔕 ${project} — all notifications muted here. Unmute: squadrant telegram notify ${project} on`;
-  if (dim === "cap")    return `🔕 ${project} — captain messages muted here. Re-enable: squadrant telegram notify ${project} cap on`;
-  return `🔕 ${project} — crew notifications now '${after.crew}' (was '${before.crew}'). Re-enable: squadrant telegram notify ${project} crew ${before.crew}`;
-}
-
-/** Send a one-time mute confirmation directly to the project topic, bypassing all delivery gates.
- *  Returns true if the message was sent, false if skipped (not quieter / no topic) or failed. */
-export async function runNotifyConfirmation(opts: {
-  project: string;
-  before: NotifyConfig;
-  after: NotifyConfig;
-  cfg: TelegramConfig;
-  client: TelegramClient;
-  stateRoot: string;
-}): Promise<boolean> {
-  const { quieter, dim } = isQuieter(opts.before, opts.after);
-  if (!quieter || dim === null) return false;
-  const topicId = loadState(opts.stateRoot).topics[topicKey(opts.project)];
-  if (topicId === undefined) return false;
-  const text = confirmationText(opts.project, opts.before, opts.after, dim);
-  try {
-    await opts.client.sendMessage(opts.cfg.supergroupId, topicId, text);
-    return true;
-  } catch {
-    console.warn(`[squadrant] mute-confirmation send failed for ${opts.project} — notification preference was still saved`);
-    return false;
-  }
-}
-
-export function resolveSetupToken(
-  existingToken: string | undefined,
-  opts: { resetToken: boolean },
-): "prompt" | "try-reuse" {
-  if (opts.resetToken || !existingToken) return "prompt";
-  return "try-reuse";
-}
-
-/**
- * Precedence: explicit --user-id flag > detected userId (first-run getUpdates) >
- * lastUserId persisted in telegram-state.json by the bridge poll (passive capture).
- */
-export function resolveSetupUserId(
-  flagUserId: number | undefined,
-  detectedUserId: number | undefined,
-  stateRoot: string,
-): number | undefined {
-  return flagUserId ?? detectedUserId ?? loadState(stateRoot).lastUserId;
-}
-
-export async function runRegisterCommands(opts: { client: TelegramClient }): Promise<void> {
-  await opts.client.setMyCommands(BOT_COMMANDS);
-}
-
-export function runTelegramPostSetup(opts: {
-  doRestart?: (o: { reason: string }) => RestartOutcome;
-}): void {
-  const doRestart = opts.doRestart ?? restartDaemonIfRunning;
-  const outcome = doRestart({ reason: "telegram config" });
-  if (outcome === "skipped-not-running") {
-    console.log(chalk.dim("(daemon not running — change applies on next start)"));
-  } else if (outcome === "skipped-opt-out") {
-    console.log(chalk.dim("(run 'squadrant heal daemon' to apply)"));
-  }
 }
 
 export const telegramCommand = new Command("telegram")

--- a/packages/core/src/telegram/index.ts
+++ b/packages/core/src/telegram/index.ts
@@ -9,3 +9,4 @@ export * from "./state.js";
 export * from "./client.js";
 export * from "./bridge.js";
 export * from "./setup.js";
+export * from "./notify.js";

--- a/packages/core/src/telegram/notify.ts
+++ b/packages/core/src/telegram/notify.ts
@@ -1,0 +1,128 @@
+import { resolveNotify, loadProjectOverride, saveProjectOverride, isQuieter } from "@squadrant/shared";
+import type { SquadrantConfig, TelegramConfig, NotifyConfig } from "@squadrant/shared";
+import { loadState, setNotify, topicKey, setTopic } from "./state.js";
+import { topicName } from "./format.js";
+import type { TelegramClient } from "./client.js";
+
+export interface TelegramStatusResult {
+  tokenSet: boolean;
+  supergroupId: number | null;
+  links: Array<{ project: string; scope: string; topicId: number }>;
+}
+
+export function runTelegramStatus(opts: {
+  config: SquadrantConfig;
+  stateRoot: string;
+  env?: NodeJS.ProcessEnv;
+}): TelegramStatusResult {
+  const tg = opts.config.telegram;
+  const env = opts.env ?? process.env;
+  const tokenSet = !!(tg?.botToken ?? env.TELEGRAM_BOT_TOKEN);
+  const links = Object.entries(loadState(opts.stateRoot).topics).map(([key, topicId]) => {
+    const sep = key.indexOf("::");
+    return { project: key.slice(0, sep), scope: key.slice(sep + 2), topicId };
+  });
+  return { tokenSet, supergroupId: tg?.supergroupId ?? null, links };
+}
+
+/** Set a project's notification flag in telegram-state.json. */
+export function runTelegramNotifySet(opts: { project: string; active: boolean; stateRoot: string }): void {
+  setNotify(opts.stateRoot, opts.project, opts.active);
+}
+
+/** Write a deliberate per-project notification preference (crew tier / cap) to
+ *  projects/<name>.json. Distinct from live on|off state (telegram-state.json). */
+export function runTelegramNotifyPref(
+  args: { project: string; dimension: "crew" | "cap"; value: string; root?: string },
+): { ok: true } | { ok: false; message: string } {
+  const { project, dimension, value, root } = args;
+  if (dimension === "crew") {
+    if (!["all", "alert_only", "done_only", "none"].includes(value))
+      return { ok: false, message: "crew must be all|alert_only|done_only|none" };
+    saveProjectOverride(project, { telegram: { notify: { crew: value as any } } }, root);
+    return { ok: true };
+  }
+  if (value !== "on" && value !== "off") return { ok: false, message: "cap must be on|off" };
+  saveProjectOverride(project, { telegram: { notify: { cap: value === "on" } } }, root);
+  return { ok: true };
+}
+
+/** List every known project (union of linked topics and notify keys) with its state. */
+export function runTelegramNotifyStatus(opts: { stateRoot: string }): Array<{ project: string; active: boolean }> {
+  const s = loadState(opts.stateRoot);
+  const projects = new Set<string>();
+  for (const key of Object.keys(s.topics)) {
+    const sep = key.indexOf("::");
+    projects.add(sep === -1 ? key : key.slice(0, sep));
+  }
+  for (const p of Object.keys(s.notify)) projects.add(p);
+  return [...projects].map((project) => ({ project, active: s.notify[project] === true }));
+}
+
+/** Resolved `cap` for a project — whether explicit captain messages may be sent.
+ *  `cap=false` is the deliberate "don't let the captain DM me" switch; live
+ *  idle-mute (active) is intentionally NOT consulted here (an explicit push
+ *  shouldn't be dropped just because the topic is idle-muted). */
+export function capAllowed(project: string, globalNotify: TelegramConfig["notify"], root?: string): boolean {
+  return resolveNotify(globalNotify, loadProjectOverride(project, root)).cap;
+}
+
+function confirmationText(project: string, before: NotifyConfig, after: NotifyConfig, dim: "active" | "cap" | "crew"): string {
+  if (dim === "active") return `🔕 ${project} — all notifications muted here. Unmute: squadrant telegram notify ${project} on`;
+  if (dim === "cap")    return `🔕 ${project} — captain messages muted here. Re-enable: squadrant telegram notify ${project} cap on`;
+  return `🔕 ${project} — crew notifications now '${after.crew}' (was '${before.crew}'). Re-enable: squadrant telegram notify ${project} crew ${before.crew}`;
+}
+
+/** Send a one-time mute confirmation directly to the project topic, bypassing all delivery gates.
+ *  Returns true if the message was sent, false if skipped (not quieter / no topic) or failed. */
+export async function runNotifyConfirmation(opts: {
+  project: string;
+  before: NotifyConfig;
+  after: NotifyConfig;
+  cfg: TelegramConfig;
+  client: TelegramClient;
+  stateRoot: string;
+}): Promise<boolean> {
+  const { quieter, dim } = isQuieter(opts.before, opts.after);
+  if (!quieter || dim === null) return false;
+  const topicId = loadState(opts.stateRoot).topics[topicKey(opts.project)];
+  if (topicId === undefined) return false;
+  const text = confirmationText(opts.project, opts.before, opts.after, dim);
+  try {
+    await opts.client.sendMessage(opts.cfg.supergroupId, topicId, text);
+    return true;
+  } catch {
+    console.warn(`[squadrant] mute-confirmation send failed for ${opts.project} — notification preference was still saved`);
+    return false;
+  }
+}
+
+/** Send a message to a project's linked Telegram topic. */
+export async function runTelegramSend(opts: {
+  project: string;
+  message: string;
+  cfg: TelegramConfig;
+  client: TelegramClient;
+  stateRoot: string;
+}): Promise<{ chatId: number; topicId: number }> {
+  const topicId = loadState(opts.stateRoot).topics[topicKey(opts.project)];
+  if (topicId === undefined) {
+    throw new Error(`project "${opts.project}" is not linked — run: squadrant telegram link ${opts.project}`);
+  }
+  await opts.client.sendMessage(opts.cfg.supergroupId, topicId, opts.message);
+  return { chatId: opts.cfg.supergroupId, topicId };
+}
+
+/** Bind a project to a forum topic, creating it on first link. Idempotent. */
+export async function runTelegramLink(opts: {
+  project: string;
+  cfg: TelegramConfig;
+  client: TelegramClient;
+  stateRoot: string;
+}): Promise<{ topicId: number; created: boolean }> {
+  const existing = loadState(opts.stateRoot).topics[topicKey(opts.project)];
+  if (existing !== undefined) return { topicId: existing, created: false };
+  const topicId = await opts.client.createForumTopic(opts.cfg.supergroupId, topicName(opts.project));
+  setTopic(opts.stateRoot, opts.project, topicId);
+  return { topicId, created: true };
+}

--- a/packages/core/src/telegram/setup.ts
+++ b/packages/core/src/telegram/setup.ts
@@ -3,6 +3,10 @@
 // getUpdates is single-consumer — setup runs before the daemon starts polling (#321).
 import fs from "node:fs";
 import type { TelegramClient } from "./client.js";
+import { loadState } from "./state.js";
+import { BOT_COMMANDS } from "./bot-commands.js";
+import { restartDaemonIfRunning } from "../restart-daemon.js";
+import type { RestartOutcome } from "../restart-daemon.js";
 
 /**
  * Decide whether to reuse an existing supergroup or re-detect via getUpdates.
@@ -51,6 +55,42 @@ export async function detectGroupId(
   opts: { timeoutMs?: number; sleep?: (ms: number) => Promise<void> } = {},
 ): Promise<number> {
   return (await detectGroupAndUser(client, opts)).supergroupId;
+}
+
+export function resolveSetupToken(
+  existingToken: string | undefined,
+  opts: { resetToken: boolean },
+): "prompt" | "try-reuse" {
+  if (opts.resetToken || !existingToken) return "prompt";
+  return "try-reuse";
+}
+
+/**
+ * Precedence: explicit --user-id flag > detected userId (first-run getUpdates) >
+ * lastUserId persisted in telegram-state.json by the bridge poll (passive capture).
+ */
+export function resolveSetupUserId(
+  flagUserId: number | undefined,
+  detectedUserId: number | undefined,
+  stateRoot: string,
+): number | undefined {
+  return flagUserId ?? detectedUserId ?? loadState(stateRoot).lastUserId;
+}
+
+export async function runRegisterCommands(opts: { client: TelegramClient }): Promise<void> {
+  await opts.client.setMyCommands(BOT_COMMANDS);
+}
+
+export function runTelegramPostSetup(opts: {
+  doRestart?: (o: { reason: string }) => RestartOutcome;
+}): void {
+  const doRestart = opts.doRestart ?? restartDaemonIfRunning;
+  const outcome = doRestart({ reason: "telegram config" });
+  if (outcome === "skipped-not-running") {
+    console.log("(daemon not running — change applies on next start)");
+  } else if (outcome === "skipped-opt-out") {
+    console.log("(run 'squadrant heal daemon' to apply)");
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Extracts 14 functions + 1 interface from `cli/commands/telegram.ts` into `@squadrant/core`
- New file `core/telegram/notify.ts`: `TelegramStatusResult`, `runTelegramStatus`, `runTelegramNotifySet`, `runTelegramNotifyPref`, `runTelegramNotifyStatus`, `capAllowed`, `runNotifyConfirmation`, `runTelegramSend`, `runTelegramLink`
- Extended `core/telegram/setup.ts`: `resolveSetupToken`, `resolveSetupUserId`, `runRegisterCommands`, `runTelegramPostSetup`
- `telegram.ts` shrinks from 565 → 307 LOC; re-exports keep existing CLI test imports working without changes
- ZERO behavior change — all 1555 tests pass at same count as develop baseline

References #367 (does NOT close — more slices remain).

## Function disposition

| Function | Destination |
|---|---|
| `runTelegramStatus`, `TelegramStatusResult` | `core/telegram/notify.ts` |
| `runTelegramNotifySet`, `runTelegramNotifyPref`, `runTelegramNotifyStatus` | `core/telegram/notify.ts` |
| `capAllowed`, `confirmationText` (private), `runNotifyConfirmation` | `core/telegram/notify.ts` |
| `runTelegramSend`, `runTelegramLink` | `core/telegram/notify.ts` |
| `resolveSetupToken`, `resolveSetupUserId` | `core/telegram/setup.ts` |
| `runRegisterCommands`, `runTelegramPostSetup` | `core/telegram/setup.ts` |
| `questionMasked`, `questionYesNo` | stayed in `cli/commands/telegram.ts` (stdin/tty) |
| `defaultStateRoot` | stayed in `cli/commands/telegram.ts` (CLI path derivation) |
| `telegramCommand` + all subcommand definitions | stayed in `cli/commands/telegram.ts` |

## Test plan

- [x] `pnpm build` green (both `dist/index.js` and `dist/squadrantd.js`)
- [x] `pnpm test --run`: 144 files / 1555 tests — exact baseline match
- [x] All existing CLI telegram tests pass via re-exports (`telegram.test.ts`, `telegram.notify.test.ts`, `telegram.send.test.ts`)