### PR TITLE
refactor(cli): thin crew.ts — extract spawn orchestration to core (S2, #367)

### DIFF
--- a/packages/cli/src/commands/__tests__/crew.test.ts
+++ b/packages/cli/src/commands/__tests__/crew.test.ts
@@ -662,42 +662,51 @@ describe("squadrant crew spawn", () => {
   });
 
   describe("leveled crew routing (#275)", () => {
+    // routing now runs inside @squadrant/core (crew-spawn.ts) via internal relative import;
+    // the @squadrant/core mock does NOT intercept it. Tests verify outcome (buildCommand model)
+    // and use real config rules so the real resolveCrewRoute returns the expected route.
+    const routingConfig = {
+      ...baseConfig,
+      defaults: {
+        ...baseConfig.defaults,
+        crewRouting: { rules: [{ match: "refactor", agent: "claude", tier: "hard", model: "sonnet" }] },
+      },
+    };
+
     it("uses routed agent+model when no explicit agent/model provided and routing matches", async () => {
-      loadConfig.mockReturnValue(baseConfig);
+      loadConfig.mockReturnValue(routingConfig);
       status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
       listSurfaces.mockResolvedValue([]);
       newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
       buildCommand.mockReturnValue("claude --model sonnet ...");
       buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-route1" } }));
       squadrantdCall.mockResolvedValue({ id: "task-route1" });
-      resolveCrewRoute.mockReturnValue({ agent: "claude", model: "sonnet", tier: "hard", matchedRule: "refactor|implement" });
 
       const promise = runCrewSpawn({ project: "brove", task: "refactor the daemon" });
       await vi.advanceTimersByTimeAsync(3000);
       await promise;
 
-      expect(resolveCrewRoute).toHaveBeenCalledWith("refactor the daemon", baseConfig);
+      // real resolveCrewRoute (in core) matches the rule and applies model=sonnet
       expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ model: "sonnet" }));
     });
 
     it("explicit --agent overrides routing when agentExplicit=true", async () => {
-      loadConfig.mockReturnValue(baseConfig);
+      // use routingConfig so routing WOULD fire if not suppressed
+      loadConfig.mockReturnValue(routingConfig);
       status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
       listSurfaces.mockResolvedValue([]);
       newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
       buildCommand.mockReturnValue("gemini ...");
-      // routing would suggest claude/sonnet but agentExplicit=true suppresses it
-      resolveCrewRoute.mockReturnValue({ agent: "claude", model: "sonnet", tier: "hard", matchedRule: "refactor" });
 
       await runCrewSpawn({ project: "brove", task: "refactor the daemon", agent: "gemini", agentExplicit: true });
 
-      // routing should NOT have been consulted
-      expect(resolveCrewRoute).not.toHaveBeenCalled();
+      // agentExplicit=true suppresses routing — model stays undefined (no override applied)
       expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ model: undefined }));
     });
 
     it("explicit --model overrides routing model even when agentExplicit is false", async () => {
-      loadConfig.mockReturnValue(baseConfig);
+      // use routingConfig so routing WOULD fire if not suppressed
+      loadConfig.mockReturnValue(routingConfig);
       status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
       listSurfaces.mockResolvedValue([]);
       newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
@@ -709,8 +718,7 @@ describe("squadrant crew spawn", () => {
       await vi.advanceTimersByTimeAsync(3000);
       await promise;
 
-      // model passed explicitly → routing skipped entirely
-      expect(resolveCrewRoute).not.toHaveBeenCalled();
+      // explicit model=opus → routing skipped; buildCommand receives the explicit model
       expect(buildCommand).toHaveBeenCalledWith(expect.objectContaining({ model: "opus" }));
     });
 

--- a/packages/cli/src/commands/crew.ts
+++ b/packages/cli/src/commands/crew.ts
@@ -1,452 +1,90 @@
 import { Command } from "commander";
-import fs from "node:fs";
-import path from "node:path";
-import os from "node:os";
 import chalk from "chalk";
-import { loadConfig } from "@squadrant/shared";
-import { addWorktree, removeWorktree, resolveWorktreeBase, resolveTextInput, TERMINAL_STATES } from "@squadrant/shared";
-import type { TaskRecord } from "@squadrant/shared";
-import { resolveCrewRoute } from "@squadrant/core";
-import { createCmuxDriver, RuntimeRegistry } from "@squadrant/workspaces";
-import { listProjectCrews, findCrew, resolveCaptainWorkspace, sendFirstTurnWhenReady, getFreePort } from "@squadrant/workspaces";
-import type { PaneRef, PanePlacement, RuntimeDriver } from "@squadrant/workspaces";
+import { loadConfig, resolveTextInput } from "@squadrant/shared";
+import type { PanePlacement } from "@squadrant/shared";
+import { createCmuxDriver, RuntimeRegistry, resolveCaptainWorkspace, sendFirstTurnWhenReady, getFreePort } from "@squadrant/workspaces";
+import { CapabilityRegistry, createClaudeDriver, createCodexDriver, createGeminiDriver, createOpencodeDriver } from "@squadrant/agents";
 import {
-  createClaudeDriver,
-  createCodexDriver,
-  createGeminiDriver,
-  createOpencodeDriver,
-  CapabilityRegistry,
-} from "@squadrant/agents";
+  runCrewSpawn as coreRunCrewSpawn,
+  runCrewSend as coreRunCrewSend,
+  runCrewRead as coreRunCrewRead,
+  runCrewClose as coreRunCrewClose,
+  runCrewList as coreRunCrewList,
+  type CrewSpawnInput,
+  type ResolvedAgent,
+} from "@squadrant/core";
+import type { TaskRecord } from "@squadrant/shared";
 import { buildDispatchRequest, squadrantdCall, sendCodexFirstTurn } from "./crew-control.js";
 import { tailLines } from "./crew-output.js";
 import { writePerCrewSettingsLocal, writePerCrewOpencodeConfig } from "../lib/per-crew-settings.js";
-import { buildCompletionProtocol, shellQuote, titleFor, nameFromTitle, nextAutoName, reapCrewChildren } from "@squadrant/core";
-import type { TurnAcceptanceConfig } from "@squadrant/core";
 
-const TEMPLATES_DIR = path.join(os.homedir(), ".config", "squadrant", "templates");
+export type { CrewSpawnInput };
 
-// Base branch for `--worktree` crew branches is derived at spawn time from
-// origin/HEAD so repos using main, trunk, etc. work out of the box (#359).
-// Still avoids "current HEAD" deliberately — basing off the captain's volatile
-// HEAD would reintroduce the coupling this isolation feature exists to remove.
+// ─── thin wrappers ────────────────────────────────────────────────────────────
+// Each function constructs CLI-edge deps (concrete drivers, daemon closures,
+// settings writers) and delegates the orchestration algorithm to @squadrant/core.
 
-export interface CrewSpawnInput {
-  project: string;
-  task: string;
-  name?: string;
-  direction?: PanePlacement;
-  agent?: string;
-  approvalPolicy?: string;
-  /** Opt-out (#296): run this crew in the root checkout instead of an isolated
-   *  worktree. Pass true for small/one-off tasks that don't need branch isolation.
-   *  Default (undefined/false) = isolated worktree — parallel-safe. */
-  shared?: boolean;
-  /** CP3 opt-in: gate risky tools (bash) so the captain approves them.
-   *  codex maps this to approvalPolicy='untrusted'; opencode maps it to a
-   *  bash:"ask" per-crew config. Default (false) = fully autonomous. */
-  approval?: boolean;
-  /** Per-spawn model override — takes precedence over defaults.roles.crew.model.
-   *  Agent-specific alias (e.g. "sonnet", "opus" for claude; "gpt-5.5" for codex). */
-  model?: string;
-  /** True when --agent was explicitly passed by the caller; suppresses crew routing. */
-  agentExplicit?: boolean;
-}
-
-export async function runCrewSpawn(input: CrewSpawnInput): Promise<PaneRef> {
+export async function runCrewSpawn(input: CrewSpawnInput): Promise<{ title?: string; surfaceId: string; workspaceId: string }> {
   const config = loadConfig();
-  const proj = config.projects[input.project];
-  if (!proj) {
-    throw new Error(`Project '${input.project}' not found. Run 'squadrant projects list'.`);
-  }
-
   const runtime = new RuntimeRegistry({ cmux: createCmuxDriver() }).forProject(input.project, config);
-  const captain = await runtime.status(proj.captainName);
-  if (!captain) {
-    throw new Error(
-      `Captain workspace '${proj.captainName}' is not running. Run 'squadrant launch ${input.project}' first.`,
-    );
-  }
-
-  const existing = await listProjectCrews(runtime, captain.id, input.project);
-  const existingTitles = existing.map((s) => s.title!);
-  if (input.name) {
-    const wantTitle = titleFor(input.project, input.name);
-    if (existingTitles.includes(wantTitle)) {
-      throw new Error(
-        `Crew '${input.name}' already exists for ${input.project}. Use 'squadrant crew send ${input.project} ${input.name}' to send a follow-up, or pick a different --name.`,
-      );
-    }
-  }
-  const name = input.name ?? nextAutoName(existingTitles, input.project);
-
-  // Crews run in an isolated worktree+branch by default so multiple parallel
-  // crews never collide on a shared HEAD (#296). Pass shared:true (CLI: --shared)
-  // for small/one-off tasks that should run on the root checkout.
-  // Build/daemon still run from the MAIN checkout's dist (#216): worktrees edit
-  // source only. The worktree path becomes the crew's cwd via the existing cwd
-  // plumbing (dispatch record + buildCommand workdir).
-  const spawnCwd = !input.shared
-    ? addWorktree({
-        repoRoot: proj.path,
-        worktreeDir: config.defaults.worktreeDir ?? ".worktrees",
-        project: input.project,
-        name,
-        base: resolveWorktreeBase(proj.path),
-      })
-    : proj.path;
-
-  // #275 leveled crew routing: consult routing rules when agent/model were not
-  // explicitly provided by the caller. Explicit --agent or --model always win.
-  const route = !input.agentExplicit && !input.model
-    ? resolveCrewRoute(input.task, config)
-    : null;
-  if (route) {
-    console.log(chalk.dim(`routed: tier=${route.tier} → ${route.agent}${route.model ? `/${route.model}` : ""} (rule: "${route.matchedRule}")`));
-  }
-
   const agents = new CapabilityRegistry({
     claude: createClaudeDriver(),
     codex: createCodexDriver(),
     gemini: createGeminiDriver(),
     opencode: createOpencodeDriver(),
   });
-  const agentName = route?.agent ?? input.agent ?? "claude";
-  const agent = agents.get(agentName);
-  if (!agent) {
-    throw new Error(`Unknown agent '${agentName}'. Known: claude, codex, gemini, opencode.`);
-  }
-
-  // Codex: route through the interactive control-plane daemon (PR #98) instead
-  // of the print-mode CLI path. The dispatched task is driven via the
-  // crew-attach renderer running in the captain tab, so 'crew send' / 'crew
-  // read' / 'crew close' work identically to the Claude crew UX.
-  if (agentName === "codex") {
-    // Mirror claude's --append-system-prompt-file: read the crew role template
-    // and forward it to codex via thread/start.developerInstructions so the
-    // session knows it's a crew member, not a bare shell.
-    const codexRoleFile = path.join(TEMPLATES_DIR, `crew.${agent.templateSuffix}.md`);
-    const roleInstructions = fs.existsSync(codexRoleFile)
-      ? fs.readFileSync(codexRoleFile, "utf8")
-      : undefined;
-    return runCodexInteractiveSpawn({
-      project: input.project,
-      task: input.task,
-      cwd: spawnCwd,
-      runtime,
-      workspaceId: captain.id,
-      name,
-      direction: input.direction ?? "tab",
-      approvalPolicy: input.approvalPolicy,
-      roleInstructions,
-    });
-  }
-
-  const promptFile = path.join(TEMPLATES_DIR, `crew.${agent.templateSuffix}.md`);
-  // Claude crews run interactively (no -p) so the session stays alive between
-  // turns; the task is sent via cmux after the CLI boots. Other agents that
-  // don't yet honor `interactive` will keep their existing print-mode shape —
-  // a known limitation tracked for future work.
-  const interactive = agent.name === "claude" || agent.name === "opencode";
-  // Honor configured model routing only when the spawn agent matches the
-  // configured role agent — model names are agent-specific (e.g. "sonnet" is
-  // a Claude alias; codex/gemini have their own routing). Cross-agent crews
-  // fall back to the agent's own default to avoid passing an invalid model arg.
-  const crewRole = config.defaults.roles?.crew;
-  const configModel = crewRole && crewRole.agent === agent.name ? crewRole.model : undefined;
-  const crewModel = input.model ?? route?.model ?? configModel;
-
-  // Claude crews route through the control-plane daemon (PR #85 + this spec)
-  // so the captain learns terminal state via `squadrant crew status` instead
-  // of scraping the pane. The cmux tab still does the actual CLI launch —
-  // the daemon doesn't own Claude's PID (Approach 3 boundary). Hook bridge
-  // (per-crew settings.json with Stop/SubagentStop/SessionEnd → squadrant
-  // crew _hook) keeps the daemon's heartbeat fresh; explicit
-  // `squadrant crew signal done` from the crew template emits terminal state.
-  if (agentName === "claude") {
-    const req = buildDispatchRequest({
-      provider: "claude",
-      mode: "interactive",
-      project: input.project,
-      cwd: spawnCwd,
-      task: input.task,
-      name,
-    });
-    // Fail loud if daemon unreachable — refusal-to-degrade.
-    const rec = (await squadrantdCall(req)) as TaskRecord;
-    // Write squadrant hooks to <cwd>/.claude/settings.local.json so they are
-    // auto-loaded as a project-local settings source. The cmux claude wrapper
-    // injects its own hooks via --settings (level 2 precedence), but hooks
-    // merge across *different* settings sources — only multiple --settings
-    // flags collide. .claude/settings.local.json is gitignored and merges
-    // with any existing user hooks (#134).
-    writePerCrewSettingsLocal({ projectCwd: spawnCwd });
-    const cliCommand = agent.buildCommand({
-      prompt: input.task,
-      workdir: spawnCwd,
-      role: "crew",
-      promptFile,
-      interactive: true,
-      // Permission mode is config-driven (defaults.permissions.crew) so squadrant
-      // can default crews to 'auto' or keep the semi-automatic 'acceptEdits'
-      // gate (auto-accept edits, still prompt for risky ops). Falls back to
-      // 'acceptEdits' when unset.
-      permissionMode: config.defaults.permissions?.crew ?? "acceptEdits",
-      ...(crewModel ? { model: crewModel } : {}),
-    });
-    const direction: PanePlacement = input.direction ?? "tab";
-    const title = titleFor(input.project, name);
-    const pane = await runtime.newPane({ workspaceId: captain.id, direction, title });
-    // Prefix the CLI command with env so the hook bridge + signal verb
-    // running inside the crew's cmux tab can identify their task.
-    const envPrefix = `SQUADRANT_CREW_TASK_ID=${rec.id} SQUADRANT_CREW_PROJECT=${input.project}`;
-    await runtime.sendToPane(pane, `cd ${shellQuote(spawnCwd)} && ${envPrefix} ${cliCommand}`);
-    const preLaunchScreen = (await runtime.readPaneScreen(pane)) ?? "";
-    await sendFirstTurnWhenReady(runtime, pane, `${input.task}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen);
-    return { ...pane, title };
-  }
-
-  // Opencode crews route through the control-plane daemon so the captain
-  // learns terminal state via `squadrant crew status` instead of scraping the
-  // pane. Same approach as claude: daemon owns the state ledger, cmux tab
-  // does the actual CLI launch. No hook bridge (opencode has no hooks); the
-  // crew template instructs explicit `squadrant crew signal done|blocked|failed`.
-  if (agentName === "opencode") {
-    // Bind the crew's embedded opencode HTTP server on a known port so the
-    // daemon's SSE bridge can subscribe to /event for turn-end detection.
-    const serverPort = await getFreePort();
-    const req = buildDispatchRequest({
-      provider: "opencode",
-      mode: "interactive",
-      project: input.project,
-      cwd: spawnCwd,
-      task: input.task,
-      name,
-      // opencode has no heartbeat hook, so a normal budget would false-stall
-      // every crew after 5min; use a 24h budget to effectively disable stall
-      // detection. The SSE bridge (serverPort) provides turn-end liveness.
-      budgetMs: 86400000,
-      serverPort,
-    });
-    const rec = (await squadrantdCall(req)) as TaskRecord;
-    const opencodeConfigPath = writePerCrewOpencodeConfig({
-      stateRoot: path.join(os.homedir(), ".config", "squadrant", "state"),
-      project: input.project,
-      taskId: rec.id,
-      // CP3 opt-in: --approval gates bash so the captain approves shell commands.
-      // Without it, bash stays auto-approved (default behavior unchanged).
-      ...(input.approval ? { gateBash: true } : {}),
-    });
-    const cliCommand = agent.buildCommand({
-      prompt: input.task,
-      workdir: spawnCwd,
-      role: "crew",
-      promptFile,
-      interactive: true,
-      model: crewModel,
-      port: serverPort,
-    });
-    const direction: PanePlacement = input.direction ?? "tab";
-    const title = titleFor(input.project, name);
-    const pane = await runtime.newPane({ workspaceId: captain.id, direction, title });
-    const envPrefix = `SQUADRANT_CREW_TASK_ID=${rec.id} SQUADRANT_CREW_PROJECT=${input.project}`;
-    await runtime.sendToPane(pane, `cd ${shellQuote(spawnCwd)} && ${envPrefix} OPENCODE_CONFIG=${opencodeConfigPath} ${cliCommand}`);
-    const preLaunchScreen = (await runtime.readPaneScreen(pane)) ?? "";
-    await sendFirstTurnWhenReady(runtime, pane, `${input.task}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen, {
-      // #235: opencode's idle splash ("Ask anything…") keeps mutating (cursor
-      // blink, status line toggle), so the old screen-changed check would always
-      // see a *different* screen and never re-send a dropped turn. The splashMarker
-      // confirms the TUI actually left splash before declaring acceptance.
-      splashMarker: "Ask anything…",
-      // opencode has a wider boot-race window than claude, so allow 3 retries
-      // instead of the default 2.
-      retryLimit: 3,
-    } satisfies TurnAcceptanceConfig);
-    return { ...pane, title };
-  }
-
-  const cliCommand = agent.buildCommand({
-    prompt: input.task,
-    workdir: spawnCwd,
-    role: "crew",
-    promptFile,
-    interactive,
-    model: crewModel,
+  return coreRunCrewSpawn(input, config, {
+    runtime,
+    // AgentDriver satisfies ResolvedAgent structurally; `role: any` in ResolvedAgent
+    // bridges the Role vs string gap — only "crew" is ever passed at call sites.
+    resolveAgent: (name) => (agents.get(name) as unknown as ResolvedAgent) ?? null,
+    dispatchCrew: async (o) => {
+      const req = buildDispatchRequest(o);
+      return (await squadrantdCall(req)) as TaskRecord;
+    },
+    writeSettingsLocal: (cwd) => writePerCrewSettingsLocal({ projectCwd: cwd }),
+    writeOpencodeConfig: writePerCrewOpencodeConfig,
+    sendFirstTurn: (pane, firstTurn, preLaunchScreen, opts) =>
+      sendFirstTurnWhenReady(runtime, pane, firstTurn, preLaunchScreen, opts),
+    getFreePort,
+    sendCodexFirstTurn,
+    onRouted: (route) =>
+      console.log(
+        chalk.dim(
+          `routed: tier=${route.tier} → ${route.agent}${route.model ? `/${route.model}` : ""} (rule: "${route.matchedRule}")`,
+        ),
+      ),
   });
-
-  const direction: PanePlacement = input.direction ?? "tab";
-  const title = titleFor(input.project, name);
-  const pane = await runtime.newPane({ workspaceId: captain.id, direction, title });
-
-  // Step 1: launch the CLI in the new tab.
-  await runtime.sendToPane(pane, cliCommand);
-
-  // Step 2: for interactive sessions, poll until the CLI is ready, then send
-  // the task as the first prompt. For non-interactive (legacy) the prompt is
-  // already baked into cliCommand, so we're done.
-  if (interactive) {
-    const preLaunchScreen = (await runtime.readPaneScreen(pane)) ?? "";
-    await sendFirstTurnWhenReady(runtime, pane, input.task, preLaunchScreen);
-  }
-
-  return { ...pane, title };
-}
-
-async function runCodexInteractiveSpawn(o: {
-  project: string;
-  task: string;
-  cwd: string;
-  runtime: RuntimeDriver;
-  workspaceId: string;
-  name: string;
-  direction: PanePlacement;
-  approvalPolicy?: string;
-  roleInstructions?: string;
-}): Promise<PaneRef> {
-  const req = buildDispatchRequest({
-    provider: "codex",
-    mode: "interactive",
-    project: o.project,
-    cwd: o.cwd,
-    task: o.task,
-    name: o.name,
-    ...(o.approvalPolicy ? { approvalPolicy: o.approvalPolicy } : {}),
-    ...(o.roleInstructions ? { roleInstructions: o.roleInstructions } : {}),
-  });
-  const rec = (await squadrantdCall(req)) as TaskRecord;
-  const title = titleFor(o.project, o.name);
-  const pane = await o.runtime.newPane({
-    workspaceId: o.workspaceId,
-    direction: o.direction,
-    title,
-  });
-  await o.runtime.sendToPane(pane, `squadrant crew attach ${rec.id}`);
-  // Match the claude UX where the task arg becomes the first turn. The codex
-  // dispatch only opens the thread; the task text never reaches the model
-  // unless we send it. Fire-and-forget: the renderer in the tab will pick up
-  // streamed deltas once it attaches. Skip the deprecated "(interactive)"
-  // placeholder which `crew chat` passes when no task was provided.
-  if (o.task && o.task !== "(interactive)") {
-    void sendCodexFirstTurn(rec.id, o.task).catch((e: unknown) => {
-      process.stderr.write(`(first-turn delivery failed: ${(e as Error).message})\n`);
-    });
-  }
-  return { ...pane, title };
 }
 
 export async function runCrewSend(project: string, name: string, message: string): Promise<void> {
   const { runtime, workspaceId } = await resolveCaptainWorkspace(project);
-  const crew = await findCrew(runtime, workspaceId, project, name);
-  if (!crew) {
-    throw new Error(`Crew '${name}' not found for ${project}. Run 'squadrant crew list ${project}'.`);
-  }
-  // Best-effort attention-state handling before delivering the captain's answer.
-  // Terminal task (done/failed): reopen so the next signal done fires CREW DONE (#148).
-  // Blocked task: emit task.started to clear blocked→working so a subsequent real
-  // permission prompt re-fires CREW BLOCKED (#182). Without this the second block
-  // hits the idempotency guard (state-machine:69) and the captain misses it.
-  // Awaiting-input task: same resume — crew re-enters working so the next block fires.
-  try {
-    const tasks = (await squadrantdCall({ kind: "list", project })) as TaskRecord[];
-    const task = tasks.find((t) => t.name === name);
-    if (task) {
-      if (TERMINAL_STATES.has(task.state)) {
-        await squadrantdCall({ kind: "event", project, event: { type: "task.reopened", id: task.id } });
-      } else if (task.state === "blocked" || task.state === "awaiting-input") {
-        await squadrantdCall({ kind: "event", project, event: { type: "task.started", id: task.id } });
-      }
-    }
-  } catch {
-    // Swallow daemon errors so crews without a daemon or offline daemon
-    // still receive the sent message.
-  }
-  await runtime.sendToPane(crew, message);
+  return coreRunCrewSend(project, name, message, runtime, workspaceId, {
+    listTasks: async (p) => (await squadrantdCall({ kind: "list", project: p })) as TaskRecord[],
+    emitEvent: async (p, event) => { await squadrantdCall({ kind: "event", project: p, event }); },
+  });
 }
 
 export async function runCrewRead(project: string, name: string): Promise<string> {
   const { runtime, workspaceId } = await resolveCaptainWorkspace(project);
-  const crew = await findCrew(runtime, workspaceId, project, name);
-  if (!crew) {
-    throw new Error(`Crew '${name}' not found for ${project}. Run 'squadrant crew list ${project}'.`);
-  }
-  return runtime.readPaneScreen(crew);
+  return coreRunCrewRead(project, name, runtime, workspaceId);
 }
 
 export async function runCrewClose(project: string, name: string): Promise<void> {
   const { runtime, workspaceId } = await resolveCaptainWorkspace(project);
-  // resolveCaptainWorkspace already validated the project exists; reload for its
-  // root path so we can tell a worktree crew (cwd != root) from a root crew.
-  const projRoot = loadConfig().projects[project]?.path;
-  // Terminalize the daemon task FIRST — before (and independent of) finding the
-  // cmux pane (#184, hardened for #139). Without this, non-terminal tasks
-  // (blocked/working/awaiting-input) linger in the daemon ledger and keep firing
-  // phantom CREW BLOCKED/IDLE/STALLED pushes. Crucially, a DEAD crew's pane is
-  // already gone, so gating terminalization on findCrew (the old order) left that
-  // zombie record dangling forever. 'cancelled' is terminal but NOT in
-  // ATTENTION_STATES, so firePush stays silent — captain initiated the close.
-  let taskId: string | undefined;
-  // Worktree to clean up after the pane closes — set only when this crew ran in
-  // its own worktree (cwd recorded by the daemon differs from the root checkout).
-  // A non-worktree crew has cwd === root (or unset), so this stays undefined and
-  // close is unaffected (#216).
-  let worktreeCwd: string | undefined;
-  try {
-    const tasks = (await squadrantdCall({ kind: "list", project })) as TaskRecord[];
-    const task = tasks.find((t) => t.name === name);
-    if (task) {
-      taskId = task.id;
-      if (task.cwd && projRoot && task.cwd !== projRoot) {
-        worktreeCwd = task.cwd;
-      }
-      if (!TERMINAL_STATES.has(task.state)) {
-        await squadrantdCall({ kind: "event", project, event: { type: "task.cancelled", id: task.id, reason: "closed by captain" } });
-      }
-      // Codex teardown: the pane only hosts the `crew attach` renderer; the thread
-      // (and its per-thread MCP servers) live on the shared app-server, so closing
-      // the pane alone leaks them. Tell the daemon to archive the thread. Fires for
-      // terminal and non-terminal crews alike (a finished codex crew still holds a
-      // live thread until archived).
-      if (task.provider === "codex") {
-        await squadrantdCall({ kind: "codex-close", taskId: task.id });
-      }
-    }
-  } catch {
-    // Swallow daemon errors — a crew without a daemon must still close.
-  }
-  // Close the cmux pane if it still exists. A dead crew's pane is already gone —
-  // that is not an error (the record is terminalized above); proceed to reap
-  // children / clean the worktree. Only a genuine miss (no pane AND no daemon
-  // task) is a typo → surface the not-found error.
-  const crew = await findCrew(runtime, workspaceId, project, name);
-  if (crew) {
-    await runtime.closePane(crew);
-  } else if (taskId === undefined) {
-    throw new Error(`Crew '${name}' not found for ${project}. Run 'squadrant crew list ${project}'.`);
-  }
-  // Reap any surviving child processes (vitest workers, node subprocs, etc.)
-  // that the cmux pane-close cascade may have missed.
-  if (taskId !== undefined) {
-    await reapCrewChildren(taskId);
-  }
-  // Auto-clean the crew's worktree AFTER its processes are gone, so we don't
-  // yank a dir out from under a live shell. Best-effort: a failed removal must
-  // not break close (the branch is preserved regardless).
-  if (worktreeCwd && projRoot) {
-    try {
-      removeWorktree(projRoot, worktreeCwd);
-    } catch (e) {
-      process.stderr.write(`(worktree remove failed: ${(e as Error).message})\n`);
-    }
-  }
+  return coreRunCrewClose(project, name, runtime, workspaceId, {
+    listTasks: async (p) => (await squadrantdCall({ kind: "list", project: p })) as TaskRecord[],
+    emitEvent: async (p, event) => { await squadrantdCall({ kind: "event", project: p, event }); },
+    closeCodexThread: async (taskId) => { await squadrantdCall({ kind: "codex-close", taskId }); },
+  });
 }
 
 export async function runCrewList(project: string): Promise<Array<{ name: string; surfaceId: string }>> {
   const { runtime, workspaceId } = await resolveCaptainWorkspace(project);
-  const crews = await listProjectCrews(runtime, workspaceId, project);
-  return crews.map((c) => ({
-    name: nameFromTitle(project, c.title!),
-    surfaceId: c.surfaceId,
-  }));
+  return coreRunCrewList(project, runtime, workspaceId);
 }
+
+// ─── CLI command definitions ──────────────────────────────────────────────────
 
 export const crewCommand = new Command("crew").description(
   "Spawn and manage interactive crew sessions next to the project's captain",

--- a/packages/core/src/__tests__/crew-spawn.test.ts
+++ b/packages/core/src/__tests__/crew-spawn.test.ts
@@ -1,0 +1,605 @@
+// Unit tests for crew-spawn.ts orchestration logic.
+// Uses mock deps and module mocks — no daemon, no workspaces, no agents, no git.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── module mocks (hoisted before imports) ───────────────────────────────────
+
+const addWorktreeMock = vi.hoisted(() =>
+  vi.fn().mockImplementation(
+    (spec: { repoRoot: string; project: string; name: string }) =>
+      `${spec.repoRoot}/.worktrees/${spec.project}-${spec.name}`,
+  ),
+);
+const resolveWorktreeBaseMock = vi.hoisted(() => vi.fn().mockReturnValue("main"));
+const removeWorktreeMock = vi.hoisted(() => vi.fn());
+const loadConfigMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@squadrant/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@squadrant/shared")>();
+  return {
+    ...actual,
+    addWorktree: addWorktreeMock,
+    resolveWorktreeBase: resolveWorktreeBaseMock,
+    removeWorktree: removeWorktreeMock,
+    loadConfig: loadConfigMock,
+  };
+});
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  // Default: existsSync returns false so codex role file is treated as absent.
+  const existsSync = vi.fn().mockReturnValue(false);
+  const readFileSync = vi.fn().mockReturnValue("");
+  return { ...actual, existsSync, readFileSync, default: { ...actual, existsSync, readFileSync } };
+});
+
+// Prevent reapCrewChildren from running real `ps auxE` during close tests.
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  const exec = vi.fn((_cmd: string, _opts: unknown, cb: (e: null, out: string) => void) => cb(null, ""));
+  return { ...actual, exec, default: { ...actual, exec } };
+});
+
+// ─── imports (after mock declarations) ───────────────────────────────────────
+
+import {
+  runCrewSpawn,
+  runCrewSend,
+  runCrewRead,
+  runCrewClose,
+  runCrewList,
+  type CrewSpawnInput,
+  type CrewSpawnDeps,
+  type ResolvedAgent,
+} from "../crew-spawn.js";
+import type { SquadrantConfig, RuntimeDriver, PaneRef, ControlEvent, TaskRecord } from "@squadrant/shared";
+
+// ─── fixtures ────────────────────────────────────────────────────────────────
+
+const PROJ_PATH = "/fake/repo";
+const PROJECT = "myproj";
+const CAPTAIN_NAME = "myproj-captain";
+
+function makeConfig(overrides?: Partial<SquadrantConfig["defaults"]>): SquadrantConfig {
+  return {
+    version: 1,
+    projects: {
+      [PROJECT]: {
+        path: PROJ_PATH,
+        captainName: CAPTAIN_NAME,
+        spokeVault: "/fake/vault",
+      },
+    },
+    defaults: {
+      worktreeDir: ".worktrees",
+      permissions: { command: "acceptEdits", captain: "acceptEdits", crew: "acceptEdits" },
+      ...overrides,
+    },
+    runtime: "cmux",
+  } as unknown as SquadrantConfig;
+}
+
+function makePaneRef(suffix = "42"): PaneRef {
+  return { workspaceId: "workspace:1", surfaceId: `surface:${suffix}` };
+}
+
+function makeRuntime(captainId = "workspace:1", existingSurfaces: PaneRef[] = []): RuntimeDriver {
+  return {
+    name: "mock",
+    probe: vi.fn(),
+    list: vi.fn(),
+    status: vi.fn().mockResolvedValue({ id: captainId, name: CAPTAIN_NAME, status: "running" }),
+    spawn: vi.fn(),
+    send: vi.fn(),
+    sendKey: vi.fn(),
+    readScreen: vi.fn(),
+    stop: vi.fn(),
+    newPane: vi.fn().mockImplementation(({ title }) => Promise.resolve({ ...makePaneRef(), title })),
+    closePane: vi.fn().mockResolvedValue(undefined),
+    sendToPane: vi.fn().mockResolvedValue(undefined),
+    readPaneScreen: vi.fn().mockResolvedValue(""),
+    listSurfaces: vi.fn().mockResolvedValue(existingSurfaces),
+    spawnInjector: vi.fn(),
+    sendToSurface: vi.fn(),
+  } as unknown as RuntimeDriver;
+}
+
+function makeAgent(name = "claude"): ResolvedAgent {
+  return {
+    name,
+    templateSuffix: name,
+    buildCommand: vi.fn().mockReturnValue(`${name}-cli --interactive`),
+  };
+}
+
+function makeSpawnDeps(runtime: RuntimeDriver, agent: ResolvedAgent): CrewSpawnDeps {
+  const rec: TaskRecord = {
+    id: "task-001",
+    project: PROJECT,
+    provider: "claude",
+    mode: "interactive",
+    state: "submitted",
+    task: "do work",
+    cwd: PROJ_PATH,
+    createdAt: 0,
+    lastHeartbeat: 0,
+    lastEvent: "dispatch",
+    heartbeatBudgetMs: 300000,
+    attempts: [],
+  };
+  return {
+    runtime,
+    resolveAgent: vi.fn().mockReturnValue(agent),
+    dispatchCrew: vi.fn().mockResolvedValue(rec),
+    writeSettingsLocal: vi.fn(),
+    writeOpencodeConfig: vi.fn().mockReturnValue("/fake/opencode.json"),
+    sendFirstTurn: vi.fn().mockResolvedValue(undefined),
+    getFreePort: vi.fn().mockResolvedValue(9876),
+    sendCodexFirstTurn: vi.fn().mockResolvedValue(undefined),
+    onRouted: vi.fn(),
+  };
+}
+
+// Reset call counts between tests; restore implementations that vi.clearAllMocks() clears.
+beforeEach(() => {
+  vi.clearAllMocks();
+  addWorktreeMock.mockImplementation(
+    (spec: { repoRoot: string; project: string; name: string }) =>
+      `${spec.repoRoot}/.worktrees/${spec.project}-${spec.name}`,
+  );
+  resolveWorktreeBaseMock.mockReturnValue("main");
+  loadConfigMock.mockReturnValue(makeConfig());
+});
+
+// ─── runCrewSpawn ────────────────────────────────────────────────────────────
+
+describe("runCrewSpawn", () => {
+  it("throws when project is not in config", async () => {
+    const config = makeConfig();
+    const runtime = makeRuntime();
+    const deps = makeSpawnDeps(runtime, makeAgent());
+    await expect(runCrewSpawn({ project: "unknown", task: "do work" }, config, deps)).rejects.toThrow(
+      "Project 'unknown' not found",
+    );
+  });
+
+  it("throws when captain is not running", async () => {
+    const config = makeConfig();
+    const runtime = makeRuntime();
+    vi.mocked(runtime.status).mockResolvedValue(null);
+    const deps = makeSpawnDeps(runtime, makeAgent());
+    await expect(runCrewSpawn({ project: PROJECT, task: "do work" }, config, deps)).rejects.toThrow(
+      "is not running",
+    );
+  });
+
+  it("throws when crew name is already taken", async () => {
+    const config = makeConfig();
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:crew-1" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    const deps = makeSpawnDeps(runtime, makeAgent());
+    await expect(
+      runCrewSpawn({ project: PROJECT, task: "do work", name: "crew-1" }, config, deps),
+    ).rejects.toThrow("already exists");
+  });
+
+  it("auto-names to crew-1 when no crews exist", async () => {
+    const config = makeConfig();
+    const runtime = makeRuntime();
+    const deps = makeSpawnDeps(runtime, makeAgent());
+    const pane = await runCrewSpawn({ project: PROJECT, task: "do work" }, config, deps);
+    expect(pane.title).toBe("🔧 myproj:crew-1");
+  });
+
+  it("auto-names to crew-2 when crew-1 already exists", async () => {
+    const config = makeConfig();
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:crew-1" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    const deps = makeSpawnDeps(runtime, makeAgent());
+    const pane = await runCrewSpawn({ project: PROJECT, task: "do work" }, config, deps);
+    expect(pane.title).toBe("🔧 myproj:crew-2");
+  });
+
+  it("throws for unknown agent", async () => {
+    const config = makeConfig();
+    const runtime = makeRuntime();
+    const deps = makeSpawnDeps(runtime, makeAgent());
+    deps.resolveAgent = vi.fn().mockReturnValue(null);
+    await expect(
+      runCrewSpawn({ project: PROJECT, task: "do work", agent: "bogus" }, config, deps),
+    ).rejects.toThrow("Unknown agent 'bogus'");
+  });
+
+  describe("claude branch", () => {
+    it("dispatches, writes settings, launches pane, sends first turn", async () => {
+      const config = makeConfig();
+      const runtime = makeRuntime();
+      const agent = makeAgent("claude");
+      const deps = makeSpawnDeps(runtime, agent);
+
+      await runCrewSpawn({ project: PROJECT, task: "fix the bug" }, config, deps);
+
+      expect(deps.dispatchCrew).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: "claude", mode: "interactive", project: PROJECT }),
+      );
+      expect(deps.writeSettingsLocal).toHaveBeenCalledWith(expect.stringContaining(PROJ_PATH));
+      expect(runtime.newPane).toHaveBeenCalledOnce();
+      expect(runtime.sendToPane).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining("SQUADRANT_CREW_TASK_ID=task-001"),
+      );
+      expect(deps.sendFirstTurn).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining("squadrant crew signal done"),
+        expect.any(String),
+      );
+    });
+
+    it("respects permissionMode from config", async () => {
+      const config = makeConfig({ permissions: { command: "auto", captain: "auto", crew: "auto" } });
+      const runtime = makeRuntime();
+      const agent = makeAgent("claude");
+      const deps = makeSpawnDeps(runtime, agent);
+      await runCrewSpawn({ project: PROJECT, task: "t" }, config, deps);
+      expect(agent.buildCommand).toHaveBeenCalledWith(
+        expect.objectContaining({ permissionMode: "auto" }),
+      );
+    });
+
+    it("uses worktree cwd by default (no --shared)", async () => {
+      const config = makeConfig();
+      const runtime = makeRuntime();
+      const agent = makeAgent("claude");
+      const deps = makeSpawnDeps(runtime, agent);
+      await runCrewSpawn({ project: PROJECT, task: "t" }, config, deps);
+      expect(addWorktreeMock).toHaveBeenCalledWith(
+        expect.objectContaining({ repoRoot: PROJ_PATH, project: PROJECT }),
+      );
+    });
+
+    it("uses proj.path for --shared (no addWorktree)", async () => {
+      const config = makeConfig();
+      const runtime = makeRuntime();
+      const agent = makeAgent("claude");
+      const deps = makeSpawnDeps(runtime, agent);
+      await runCrewSpawn({ project: PROJECT, task: "t", shared: true }, config, deps);
+      expect(addWorktreeMock).not.toHaveBeenCalled();
+      expect(runtime.sendToPane).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining(`cd '${PROJ_PATH}'`),
+      );
+    });
+  });
+
+  describe("opencode branch", () => {
+    it("gets free port, dispatches with budgetMs 86400000, writes opencode config", async () => {
+      const config = makeConfig();
+      const runtime = makeRuntime();
+      const agent = makeAgent("opencode");
+      const deps = makeSpawnDeps(runtime, agent);
+      deps.resolveAgent = vi.fn().mockReturnValue(agent);
+
+      await runCrewSpawn(
+        { project: PROJECT, task: "do work", agent: "opencode", agentExplicit: true },
+        config,
+        deps,
+      );
+
+      expect(deps.getFreePort).toHaveBeenCalledOnce();
+      expect(deps.dispatchCrew).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: "opencode", budgetMs: 86400000, serverPort: 9876 }),
+      );
+      expect(deps.writeOpencodeConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ project: PROJECT, taskId: "task-001" }),
+      );
+      expect(deps.sendFirstTurn).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(String),
+        expect.any(String),
+        expect.objectContaining({ splashMarker: "Ask anything…", retryLimit: 3 }),
+      );
+    });
+
+    it("sets gateBash when approval flag is set", async () => {
+      const config = makeConfig();
+      const runtime = makeRuntime();
+      const agent = makeAgent("opencode");
+      const deps = makeSpawnDeps(runtime, agent);
+      deps.resolveAgent = vi.fn().mockReturnValue(agent);
+
+      await runCrewSpawn(
+        { project: PROJECT, task: "t", agent: "opencode", agentExplicit: true, approval: true },
+        config,
+        deps,
+      );
+
+      expect(deps.writeOpencodeConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ gateBash: true }),
+      );
+    });
+  });
+
+  describe("codex branch", () => {
+    it("dispatches codex, creates pane with attach command, sends first turn fire-and-forget", async () => {
+      const config = makeConfig();
+      const runtime = makeRuntime();
+      const agent = makeAgent("codex");
+      const deps = makeSpawnDeps(runtime, agent);
+      deps.resolveAgent = vi.fn().mockReturnValue(agent);
+
+      await runCrewSpawn(
+        { project: PROJECT, task: "do work", agent: "codex", agentExplicit: true },
+        config,
+        deps,
+      );
+
+      expect(deps.dispatchCrew).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: "codex", mode: "interactive" }),
+      );
+      expect(runtime.sendToPane).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining("squadrant crew attach task-001"),
+      );
+      expect(deps.sendCodexFirstTurn).toHaveBeenCalledWith("task-001", "do work");
+    });
+  });
+
+  describe("routing", () => {
+    it("suppresses routing when agentExplicit is true", async () => {
+      const config = makeConfig();
+      const runtime = makeRuntime();
+      const agent = makeAgent("claude");
+      const deps = makeSpawnDeps(runtime, agent);
+      deps.resolveAgent = vi.fn().mockReturnValue(agent);
+
+      await runCrewSpawn(
+        { project: PROJECT, task: "do work", agent: "claude", agentExplicit: true },
+        config,
+        deps,
+      );
+
+      expect(deps.onRouted).not.toHaveBeenCalled();
+      expect(deps.resolveAgent).toHaveBeenCalledWith("claude");
+    });
+
+    it("fires onRouted and applies model when routing matches", async () => {
+      const config = {
+        ...makeConfig(),
+        defaults: {
+          ...makeConfig().defaults,
+          crewRouting: {
+            rules: [{ match: "daemon", agent: "opencode", tier: "standard", model: "gpt-4" }],
+          },
+        },
+      } as unknown as SquadrantConfig;
+      const runtime = makeRuntime();
+      const agent = makeAgent("opencode");
+      const deps = makeSpawnDeps(runtime, agent);
+      deps.resolveAgent = vi.fn().mockReturnValue(agent);
+
+      await runCrewSpawn({ project: PROJECT, task: "fix daemon bug" }, config, deps);
+
+      expect(deps.onRouted).toHaveBeenCalledWith(
+        expect.objectContaining({ agent: "opencode", tier: "standard" }),
+      );
+      expect(agent.buildCommand).toHaveBeenCalledWith(
+        expect.objectContaining({ model: "gpt-4" }),
+      );
+    });
+
+    it("suppresses routing when model is explicitly provided", async () => {
+      const config = makeConfig();
+      const runtime = makeRuntime();
+      const agent = makeAgent("claude");
+      const deps = makeSpawnDeps(runtime, agent);
+      deps.resolveAgent = vi.fn().mockReturnValue(agent);
+
+      await runCrewSpawn({ project: PROJECT, task: "do work", model: "opus" }, config, deps);
+
+      expect(deps.onRouted).not.toHaveBeenCalled();
+      expect(agent.buildCommand).toHaveBeenCalledWith(
+        expect.objectContaining({ model: "opus" }),
+      );
+    });
+  });
+});
+
+// ─── runCrewSend ─────────────────────────────────────────────────────────────
+
+describe("runCrewSend", () => {
+  it("throws when crew pane not found", async () => {
+    const runtime = makeRuntime("ws:1", []);
+    await expect(
+      runCrewSend(PROJECT, "crew-1", "hello", runtime, "ws:1", {
+        listTasks: vi.fn().mockResolvedValue([]),
+        emitEvent: vi.fn(),
+      }),
+    ).rejects.toThrow("Crew 'crew-1' not found");
+  });
+
+  it("sends message to found crew pane", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:crew-1" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    await runCrewSend(PROJECT, "crew-1", "hello", runtime, "workspace:1", {
+      listTasks: vi.fn().mockResolvedValue([]),
+      emitEvent: vi.fn(),
+    });
+    expect(runtime.sendToPane).toHaveBeenCalledWith(expect.anything(), "hello");
+  });
+
+  it("emits task.reopened for terminal task before sending", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:crew-1" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    const emitEvent = vi.fn().mockResolvedValue(undefined);
+    const task = { id: "t1", name: "crew-1", state: "done" } as Partial<TaskRecord>;
+    await runCrewSend(PROJECT, "crew-1", "msg", runtime, "workspace:1", {
+      listTasks: vi.fn().mockResolvedValue([task]),
+      emitEvent,
+    });
+    expect(emitEvent).toHaveBeenCalledWith(PROJECT, { type: "task.reopened", id: "t1" });
+    expect(runtime.sendToPane).toHaveBeenCalledWith(expect.anything(), "msg");
+  });
+
+  it("emits task.started for blocked task before sending", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:crew-1" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    const emitEvent = vi.fn().mockResolvedValue(undefined);
+    const task = { id: "t1", name: "crew-1", state: "blocked" } as Partial<TaskRecord>;
+    await runCrewSend(PROJECT, "crew-1", "msg", runtime, "workspace:1", {
+      listTasks: vi.fn().mockResolvedValue([task]),
+      emitEvent,
+    });
+    expect(emitEvent).toHaveBeenCalledWith(PROJECT, { type: "task.started", id: "t1" });
+  });
+
+  it("swallows daemon errors and still delivers the message", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:crew-1" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    await runCrewSend(PROJECT, "crew-1", "msg", runtime, "workspace:1", {
+      listTasks: vi.fn().mockRejectedValue(new Error("daemon down")),
+      emitEvent: vi.fn(),
+    });
+    expect(runtime.sendToPane).toHaveBeenCalledWith(expect.anything(), "msg");
+  });
+});
+
+// ─── runCrewRead ─────────────────────────────────────────────────────────────
+
+describe("runCrewRead", () => {
+  it("throws when crew pane not found", async () => {
+    const runtime = makeRuntime("ws:1", []);
+    await expect(runCrewRead(PROJECT, "crew-1", runtime, "ws:1")).rejects.toThrow(
+      "Crew 'crew-1' not found",
+    );
+  });
+
+  it("returns pane screen for found crew", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:crew-1" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    vi.mocked(runtime.readPaneScreen).mockResolvedValue("screen content");
+    const result = await runCrewRead(PROJECT, "crew-1", runtime, "workspace:1");
+    expect(result).toBe("screen content");
+  });
+});
+
+// ─── runCrewList ─────────────────────────────────────────────────────────────
+
+describe("runCrewList", () => {
+  it("returns empty array when no crew panes", async () => {
+    const runtime = makeRuntime("ws:1", []);
+    const result = await runCrewList(PROJECT, runtime, "ws:1");
+    expect(result).toEqual([]);
+  });
+
+  it("returns crew names from titles, excluding non-crew panes", async () => {
+    const panes = [
+      { ...makePaneRef("1"), title: "🔧 myproj:crew-1" },
+      { ...makePaneRef("2"), title: "🔧 myproj:crew-2" },
+      { ...makePaneRef("3"), title: "🗒 myproj:side-1" }, // side session — excluded
+    ];
+    const runtime = makeRuntime("ws:1", panes);
+    const result = await runCrewList(PROJECT, runtime, "ws:1");
+    expect(result).toEqual([
+      { name: "crew-1", surfaceId: "surface:1" },
+      { name: "crew-2", surfaceId: "surface:2" },
+    ]);
+  });
+});
+
+// ─── runCrewClose ────────────────────────────────────────────────────────────
+
+describe("runCrewClose", () => {
+  it("throws when neither pane nor daemon task found", async () => {
+    const runtime = makeRuntime("ws:1", []);
+    await expect(
+      runCrewClose(PROJECT, "crew-1", runtime, "ws:1", {
+        listTasks: vi.fn().mockResolvedValue([]),
+        emitEvent: vi.fn(),
+        closeCodexThread: vi.fn(),
+      }),
+    ).rejects.toThrow("Crew 'crew-1' not found");
+  });
+
+  it("closes pane and emits task.cancelled for non-terminal task", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:crew-1" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    const emitEvent = vi.fn().mockResolvedValue(undefined);
+    const task = { id: "t1", name: "crew-1", state: "working", provider: "claude", cwd: PROJ_PATH } as Partial<TaskRecord>;
+
+    await runCrewClose(PROJECT, "crew-1", runtime, "workspace:1", {
+      listTasks: vi.fn().mockResolvedValue([task]),
+      emitEvent,
+      closeCodexThread: vi.fn(),
+    });
+
+    expect(emitEvent).toHaveBeenCalledWith(
+      PROJECT,
+      expect.objectContaining({ type: "task.cancelled", id: "t1" }),
+    );
+    expect(runtime.closePane).toHaveBeenCalledOnce();
+  });
+
+  it("calls closeCodexThread for codex tasks", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:crew-1" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    const closeCodexThread = vi.fn().mockResolvedValue(undefined);
+    const task = { id: "t1", name: "crew-1", state: "working", provider: "codex", cwd: PROJ_PATH } as Partial<TaskRecord>;
+
+    await runCrewClose(PROJECT, "crew-1", runtime, "workspace:1", {
+      listTasks: vi.fn().mockResolvedValue([task]),
+      emitEvent: vi.fn().mockResolvedValue(undefined),
+      closeCodexThread,
+    });
+
+    expect(closeCodexThread).toHaveBeenCalledWith("t1");
+  });
+
+  it("does not emit task.cancelled for already-terminal task", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:crew-1" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    const emitEvent = vi.fn().mockResolvedValue(undefined);
+    const task = { id: "t1", name: "crew-1", state: "done", provider: "claude", cwd: PROJ_PATH } as Partial<TaskRecord>;
+
+    await runCrewClose(PROJECT, "crew-1", runtime, "workspace:1", {
+      listTasks: vi.fn().mockResolvedValue([task]),
+      emitEvent,
+      closeCodexThread: vi.fn(),
+    });
+
+    expect(emitEvent).not.toHaveBeenCalledWith(
+      PROJECT,
+      expect.objectContaining({ type: "task.cancelled" }),
+    );
+    expect(runtime.closePane).toHaveBeenCalledOnce();
+  });
+
+  it("succeeds without throwing when pane is gone but daemon task exists (dead crew)", async () => {
+    const runtime = makeRuntime("workspace:1", []);
+    const task = { id: "t1", name: "crew-1", state: "done", provider: "claude", cwd: PROJ_PATH } as Partial<TaskRecord>;
+
+    await expect(
+      runCrewClose(PROJECT, "crew-1", runtime, "workspace:1", {
+        listTasks: vi.fn().mockResolvedValue([task]),
+        emitEvent: vi.fn().mockResolvedValue(undefined),
+        closeCodexThread: vi.fn(),
+      }),
+    ).resolves.not.toThrow();
+
+    expect(runtime.closePane).not.toHaveBeenCalled();
+  });
+
+  it("swallows daemon errors and still closes the pane", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:crew-1" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+
+    await runCrewClose(PROJECT, "crew-1", runtime, "workspace:1", {
+      listTasks: vi.fn().mockRejectedValue(new Error("daemon down")),
+      emitEvent: vi.fn(),
+      closeCodexThread: vi.fn(),
+    });
+
+    // pane found, pane closed; no throw despite daemon error
+    expect(runtime.closePane).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -1,0 +1,534 @@
+// Crew spawn and session orchestration — driver-agnostic algorithm (#367 command-thinning).
+// CLI-edge concerns (concrete driver construction, daemon calls, settings writers,
+// agent commands) are injected as closures; core only imports from @squadrant/shared
+// and core-internal modules. The algorithm is IDENTICAL to the prior crew.ts
+// implementation — zero behavior change.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type SquadrantConfig,
+  loadConfig,
+  type TaskRecord,
+  type Provider,
+  type PaneRef,
+  type PanePlacement,
+  type RuntimeDriver,
+  type ControlEvent,
+  addWorktree,
+  resolveWorktreeBase,
+  removeWorktree,
+  TERMINAL_STATES,
+} from "@squadrant/shared";
+import { resolveCrewRoute, type CrewRouteResult } from "./crew-routing.js";
+import {
+  buildCompletionProtocol,
+  shellQuote,
+  titleFor,
+  isCrewTitle,
+  nameFromTitle,
+  nextAutoName,
+  type TurnAcceptanceConfig,
+} from "./crew-protocol.js";
+import { reapCrewChildren } from "./crew-lifecycle.js";
+
+const TEMPLATES_DIR = path.join(os.homedir(), ".config", "squadrant", "templates");
+const STATE_ROOT = path.join(os.homedir(), ".config", "squadrant", "state");
+
+// ─── ResolvedAgent ────────────────────────────────────────────────────────────
+
+/** Minimal agent shape needed by spawn orchestration. CLI constructs from AgentDriver.
+ *
+ *  Note on `buildCommand` typing: AgentDriver (from @squadrant/agents) declares
+ *  role as Role (a union); this interface uses `string` to avoid importing from
+ *  agents in core. The only value ever passed at the call sites is "crew", which
+ *  satisfies Role at runtime. CLI callers use `as unknown as ResolvedAgent` to
+ *  bridge the type gap safely. */
+export interface ResolvedAgent {
+  name: string;
+  templateSuffix: string;
+  buildCommand(opts: {
+    prompt: string;
+    workdir: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    role: any;
+    promptFile: string;
+    interactive: boolean;
+    permissionMode?: string;
+    model?: string;
+    port?: number;
+  }): string;
+}
+
+// ─── CrewSpawnInput ───────────────────────────────────────────────────────────
+
+export interface CrewSpawnInput {
+  project: string;
+  task: string;
+  name?: string;
+  direction?: PanePlacement;
+  agent?: string;
+  approvalPolicy?: string;
+  /** Opt-out (#296): run this crew in the root checkout instead of an isolated
+   *  worktree. Pass true for small/one-off tasks that don't need branch isolation.
+   *  Default (undefined/false) = isolated worktree — parallel-safe. */
+  shared?: boolean;
+  /** CP3 opt-in: gate risky tools (bash) so the captain approves them.
+   *  codex maps this to approvalPolicy='untrusted'; opencode maps it to a
+   *  bash:"ask" per-crew config. Default (false) = fully autonomous. */
+  approval?: boolean;
+  /** Per-spawn model override — takes precedence over defaults.roles.crew.model. */
+  model?: string;
+  /** True when --agent was explicitly passed by the caller; suppresses crew routing. */
+  agentExplicit?: boolean;
+}
+
+// ─── CrewSpawnDeps ───────────────────────────────────────────────────────────
+
+export interface CrewSpawnDeps {
+  runtime: RuntimeDriver;
+  /**
+   * CLI-edge: look up a resolved agent by name. Returns null if unknown.
+   * Wraps CapabilityRegistry.get() from @squadrant/agents.
+   */
+  resolveAgent(name: string): ResolvedAgent | null;
+  /**
+   * CLI-edge: dispatch a crew task via the daemon.
+   * Wraps buildDispatchRequest + squadrantdCall from crew-control.ts.
+   */
+  dispatchCrew(opts: {
+    provider: Provider;
+    mode: "interactive";
+    project: string;
+    cwd: string;
+    task: string;
+    name: string;
+    budgetMs?: number;
+    serverPort?: number;
+    approvalPolicy?: string;
+    roleInstructions?: string;
+  }): Promise<TaskRecord>;
+  /** CLI-edge: write squadrant hooks to <cwd>/.claude/settings.local.json (#134). */
+  writeSettingsLocal(projectCwd: string): void;
+  /** CLI-edge: write opencode permission config for an interactive crew. */
+  writeOpencodeConfig(opts: { stateRoot: string; project: string; taskId: string; gateBash?: boolean }): string;
+  /** CLI-edge: deliver the first turn once the agent pane is ready. */
+  sendFirstTurn(pane: PaneRef, firstTurn: string, preLaunchScreen: string, opts?: TurnAcceptanceConfig): Promise<void>;
+  /** CLI-edge: reserve an ephemeral TCP port for opencode's embedded HTTP server. */
+  getFreePort(): Promise<number>;
+  /** CLI-edge: deliver the task to a freshly-dispatched codex thread. */
+  sendCodexFirstTurn(taskId: string, task: string): Promise<void>;
+  /** Optional: called after routing to log the selected route (e.g. chalk.dim(...)). */
+  onRouted?(route: CrewRouteResult): void;
+}
+
+// ─── Private helpers ──────────────────────────────────────────────────────────
+
+async function listCrewPanes(runtime: RuntimeDriver, workspaceId: string, project: string): Promise<PaneRef[]> {
+  const surfaces = await runtime.listSurfaces(workspaceId);
+  return surfaces.filter((s) => s.title && isCrewTitle(project, s.title));
+}
+
+async function findCrewPane(
+  runtime: RuntimeDriver,
+  workspaceId: string,
+  project: string,
+  name: string,
+): Promise<PaneRef | null> {
+  const want = titleFor(project, name);
+  const surfaces = await runtime.listSurfaces(workspaceId);
+  return surfaces.find((s) => s.title === want) ?? null;
+}
+
+// ─── Codex interactive spawn (private) ───────────────────────────────────────
+
+async function runCodexInteractiveSpawn(o: {
+  project: string;
+  task: string;
+  cwd: string;
+  runtime: RuntimeDriver;
+  workspaceId: string;
+  name: string;
+  direction: PanePlacement;
+  approvalPolicy?: string;
+  roleInstructions?: string;
+  dispatchCrew: CrewSpawnDeps["dispatchCrew"];
+  sendCodexFirstTurn: CrewSpawnDeps["sendCodexFirstTurn"];
+}): Promise<PaneRef> {
+  const rec = await o.dispatchCrew({
+    provider: "codex",
+    mode: "interactive",
+    project: o.project,
+    cwd: o.cwd,
+    task: o.task,
+    name: o.name,
+    ...(o.approvalPolicy ? { approvalPolicy: o.approvalPolicy } : {}),
+    ...(o.roleInstructions ? { roleInstructions: o.roleInstructions } : {}),
+  });
+  const title = titleFor(o.project, o.name);
+  const pane = await o.runtime.newPane({
+    workspaceId: o.workspaceId,
+    direction: o.direction,
+    title,
+  });
+  await o.runtime.sendToPane(pane, `squadrant crew attach ${rec.id}`);
+  // Match the claude UX where the task arg becomes the first turn. The codex
+  // dispatch only opens the thread; the task text never reaches the model
+  // unless we send it. Fire-and-forget: the renderer in the tab picks up
+  // streamed deltas once it attaches.
+  if (o.task && o.task !== "(interactive)") {
+    void o.sendCodexFirstTurn(rec.id, o.task).catch((e: unknown) => {
+      process.stderr.write(`(first-turn delivery failed: ${(e as Error).message})\n`);
+    });
+  }
+  return { ...pane, title };
+}
+
+// ─── runCrewSpawn ─────────────────────────────────────────────────────────────
+
+export async function runCrewSpawn(
+  input: CrewSpawnInput,
+  config: SquadrantConfig,
+  deps: CrewSpawnDeps,
+): Promise<PaneRef> {
+  const proj = config.projects[input.project];
+  if (!proj) {
+    throw new Error(`Project '${input.project}' not found. Run 'squadrant projects list'.`);
+  }
+
+  const captain = await deps.runtime.status(proj.captainName);
+  if (!captain) {
+    throw new Error(
+      `Captain workspace '${proj.captainName}' is not running. Run 'squadrant launch ${input.project}' first.`,
+    );
+  }
+
+  const existing = await listCrewPanes(deps.runtime, captain.id, input.project);
+  const existingTitles = existing.map((s) => s.title!);
+  if (input.name) {
+    const wantTitle = titleFor(input.project, input.name);
+    if (existingTitles.includes(wantTitle)) {
+      throw new Error(
+        `Crew '${input.name}' already exists for ${input.project}. Use 'squadrant crew send ${input.project} ${input.name}' to send a follow-up, or pick a different --name.`,
+      );
+    }
+  }
+  const name = input.name ?? nextAutoName(existingTitles, input.project);
+
+  // Crews run in an isolated worktree+branch by default so multiple parallel
+  // crews never collide on a shared HEAD (#296). Pass shared:true (CLI: --shared)
+  // for small/one-off tasks that should run on the root checkout.
+  const spawnCwd = !input.shared
+    ? addWorktree({
+        repoRoot: proj.path,
+        worktreeDir: config.defaults.worktreeDir ?? ".worktrees",
+        project: input.project,
+        name,
+        base: resolveWorktreeBase(proj.path),
+      })
+    : proj.path;
+
+  // #275 leveled crew routing: consult routing rules when agent/model were not
+  // explicitly provided by the caller. Explicit --agent or --model always win.
+  const route = !input.agentExplicit && !input.model
+    ? resolveCrewRoute(input.task, config)
+    : null;
+  if (route) {
+    deps.onRouted?.(route);
+  }
+
+  const agentName = route?.agent ?? input.agent ?? "claude";
+  const agent = deps.resolveAgent(agentName);
+  if (!agent) {
+    throw new Error(`Unknown agent '${agentName}'. Known: claude, codex, gemini, opencode.`);
+  }
+
+  // Codex: route through the interactive control-plane daemon (PR #98) instead
+  // of the print-mode CLI path. The dispatched task is driven via the
+  // crew-attach renderer running in the captain tab, so 'crew send' / 'crew
+  // read' / 'crew close' work identically to the Claude crew UX.
+  if (agentName === "codex") {
+    const codexRoleFile = path.join(TEMPLATES_DIR, `crew.${agent.templateSuffix}.md`);
+    const roleInstructions = fs.existsSync(codexRoleFile)
+      ? fs.readFileSync(codexRoleFile, "utf8")
+      : undefined;
+    return runCodexInteractiveSpawn({
+      project: input.project,
+      task: input.task,
+      cwd: spawnCwd,
+      runtime: deps.runtime,
+      workspaceId: captain.id,
+      name,
+      direction: input.direction ?? "tab",
+      approvalPolicy: input.approvalPolicy,
+      roleInstructions,
+      dispatchCrew: deps.dispatchCrew,
+      sendCodexFirstTurn: deps.sendCodexFirstTurn,
+    });
+  }
+
+  const promptFile = path.join(TEMPLATES_DIR, `crew.${agent.templateSuffix}.md`);
+  // Claude crews run interactively (no -p) so the session stays alive between
+  // turns; the task is sent via cmux after the CLI boots. Other agents that
+  // don't yet honor `interactive` will keep their existing print-mode shape.
+  const interactive = agent.name === "claude" || agent.name === "opencode";
+  // Honor configured model routing only when the spawn agent matches the
+  // configured role agent — model names are agent-specific. Cross-agent crews
+  // fall back to the agent's own default to avoid passing an invalid model arg.
+  const crewRole = config.defaults.roles?.crew;
+  const configModel = crewRole && crewRole.agent === agent.name ? crewRole.model : undefined;
+  const crewModel = input.model ?? route?.model ?? configModel;
+
+  // Claude crews route through the control-plane daemon (PR #85) so the captain
+  // learns terminal state via `squadrant crew status`. The cmux tab still does
+  // the actual CLI launch — the daemon doesn't own Claude's PID. Hook bridge
+  // (per-crew settings.json → Stop/SubagentStop/SessionEnd → squadrant crew _hook)
+  // keeps the daemon's heartbeat fresh; `squadrant crew signal done` emits
+  // terminal state.
+  if (agentName === "claude") {
+    const rec = await deps.dispatchCrew({
+      provider: "claude",
+      mode: "interactive",
+      project: input.project,
+      cwd: spawnCwd,
+      task: input.task,
+      name,
+    });
+    // Write squadrant hooks to <cwd>/.claude/settings.local.json so they are
+    // auto-loaded as a project-local settings source. Merges with any existing
+    // hooks — does not clobber the user's own personal hooks (#134).
+    deps.writeSettingsLocal(spawnCwd);
+    const cliCommand = agent.buildCommand({
+      prompt: input.task,
+      workdir: spawnCwd,
+      role: "crew",
+      promptFile,
+      interactive: true,
+      // Permission mode is config-driven so squadrant can default crews to 'auto'
+      // or keep the semi-automatic 'acceptEdits' gate. Falls back to 'acceptEdits'.
+      permissionMode: config.defaults.permissions?.crew ?? "acceptEdits",
+      ...(crewModel ? { model: crewModel } : {}),
+    });
+    const direction: PanePlacement = input.direction ?? "tab";
+    const title = titleFor(input.project, name);
+    const pane = await deps.runtime.newPane({ workspaceId: captain.id, direction, title });
+    // Prefix the CLI command with env so the hook bridge + signal verb running
+    // inside the crew's cmux tab can identify their task.
+    const envPrefix = `SQUADRANT_CREW_TASK_ID=${rec.id} SQUADRANT_CREW_PROJECT=${input.project}`;
+    await deps.runtime.sendToPane(pane, `cd ${shellQuote(spawnCwd)} && ${envPrefix} ${cliCommand}`);
+    const preLaunchScreen = (await deps.runtime.readPaneScreen(pane)) ?? "";
+    await deps.sendFirstTurn(pane, `${input.task}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen);
+    return { ...pane, title };
+  }
+
+  // Opencode crews route through the control-plane daemon so the captain learns
+  // terminal state via `squadrant crew status`. No hook bridge (opencode has no
+  // hooks); the crew template instructs explicit `squadrant crew signal done|blocked|failed`.
+  if (agentName === "opencode") {
+    // Bind the crew's embedded opencode HTTP server on a known port so the
+    // daemon's SSE bridge can subscribe to /event for turn-end detection.
+    const serverPort = await deps.getFreePort();
+    const rec = await deps.dispatchCrew({
+      provider: "opencode",
+      mode: "interactive",
+      project: input.project,
+      cwd: spawnCwd,
+      task: input.task,
+      name,
+      // opencode has no heartbeat hook, so a normal budget would false-stall
+      // every crew after 5min; use a 24h budget to effectively disable stall
+      // detection. The SSE bridge (serverPort) provides turn-end liveness.
+      budgetMs: 86400000,
+      serverPort,
+    });
+    const opencodeConfigPath = deps.writeOpencodeConfig({
+      stateRoot: STATE_ROOT,
+      project: input.project,
+      taskId: rec.id,
+      // CP3 opt-in: --approval gates bash so the captain approves shell commands.
+      ...(input.approval ? { gateBash: true } : {}),
+    });
+    const cliCommand = agent.buildCommand({
+      prompt: input.task,
+      workdir: spawnCwd,
+      role: "crew",
+      promptFile,
+      interactive: true,
+      model: crewModel,
+      port: serverPort,
+    });
+    const direction: PanePlacement = input.direction ?? "tab";
+    const title = titleFor(input.project, name);
+    const pane = await deps.runtime.newPane({ workspaceId: captain.id, direction, title });
+    const envPrefix = `SQUADRANT_CREW_TASK_ID=${rec.id} SQUADRANT_CREW_PROJECT=${input.project}`;
+    await deps.runtime.sendToPane(pane, `cd ${shellQuote(spawnCwd)} && ${envPrefix} OPENCODE_CONFIG=${opencodeConfigPath} ${cliCommand}`);
+    const preLaunchScreen = (await deps.runtime.readPaneScreen(pane)) ?? "";
+    await deps.sendFirstTurn(pane, `${input.task}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen, {
+      // #235: opencode's idle splash ("Ask anything…") keeps mutating (cursor
+      // blink, status line toggle), so the old screen-changed check would always
+      // see a *different* screen and never re-send a dropped turn. The splashMarker
+      // confirms the TUI actually left splash before declaring acceptance.
+      splashMarker: "Ask anything…",
+      // opencode has a wider boot-race window than claude, so allow 3 retries
+      // instead of the default 2.
+      retryLimit: 3,
+    } satisfies TurnAcceptanceConfig);
+    return { ...pane, title };
+  }
+
+  // Generic / fallback branch — agents that don't yet have a first-class branch.
+  const cliCommand = agent.buildCommand({
+    prompt: input.task,
+    workdir: spawnCwd,
+    role: "crew",
+    promptFile,
+    interactive,
+    model: crewModel,
+  });
+  const direction: PanePlacement = input.direction ?? "tab";
+  const title = titleFor(input.project, name);
+  const pane = await deps.runtime.newPane({ workspaceId: captain.id, direction, title });
+  await deps.runtime.sendToPane(pane, cliCommand);
+  if (interactive) {
+    const preLaunchScreen = (await deps.runtime.readPaneScreen(pane)) ?? "";
+    await deps.sendFirstTurn(pane, input.task, preLaunchScreen);
+  }
+  return { ...pane, title };
+}
+
+// ─── crew session operations ──────────────────────────────────────────────────
+
+export async function runCrewSend(
+  project: string,
+  name: string,
+  message: string,
+  runtime: RuntimeDriver,
+  workspaceId: string,
+  deps: {
+    listTasks(project: string): Promise<TaskRecord[]>;
+    emitEvent(project: string, event: ControlEvent): Promise<void>;
+  },
+): Promise<void> {
+  const crew = await findCrewPane(runtime, workspaceId, project, name);
+  if (!crew) {
+    throw new Error(`Crew '${name}' not found for ${project}. Run 'squadrant crew list ${project}'.`);
+  }
+  // Best-effort attention-state handling before delivering the captain's answer.
+  // Terminal task (done/failed): reopen so the next signal done fires CREW DONE (#148).
+  // Blocked task: emit task.started to clear blocked→working so a subsequent real
+  // permission prompt re-fires CREW BLOCKED (#182).
+  try {
+    const tasks = await deps.listTasks(project);
+    const task = tasks.find((t) => t.name === name);
+    if (task) {
+      if (TERMINAL_STATES.has(task.state)) {
+        await deps.emitEvent(project, { type: "task.reopened", id: task.id });
+      } else if (task.state === "blocked" || task.state === "awaiting-input") {
+        await deps.emitEvent(project, { type: "task.started", id: task.id });
+      }
+    }
+  } catch {
+    // Swallow daemon errors so crews without a daemon or offline daemon
+    // still receive the sent message.
+  }
+  await runtime.sendToPane(crew, message);
+}
+
+export async function runCrewRead(
+  project: string,
+  name: string,
+  runtime: RuntimeDriver,
+  workspaceId: string,
+): Promise<string> {
+  const crew = await findCrewPane(runtime, workspaceId, project, name);
+  if (!crew) {
+    throw new Error(`Crew '${name}' not found for ${project}. Run 'squadrant crew list ${project}'.`);
+  }
+  return runtime.readPaneScreen(crew);
+}
+
+export async function runCrewClose(
+  project: string,
+  name: string,
+  runtime: RuntimeDriver,
+  workspaceId: string,
+  deps: {
+    listTasks(project: string): Promise<TaskRecord[]>;
+    emitEvent(project: string, event: ControlEvent): Promise<void>;
+    closeCodexThread(taskId: string): Promise<void>;
+  },
+): Promise<void> {
+  // resolveCaptainWorkspace already validated the project exists; reload for its
+  // root path so we can tell a worktree crew (cwd != root) from a root crew.
+  const projRoot = loadConfig().projects[project]?.path;
+  // Terminalize the daemon task FIRST — before (and independent of) finding the
+  // cmux pane (#184, hardened for #139). Without this, non-terminal tasks
+  // (blocked/working/awaiting-input) linger in the daemon ledger and keep firing
+  // phantom CREW BLOCKED/IDLE/STALLED pushes. A DEAD crew's pane is already gone,
+  // so gating terminalization on findCrew (the old order) left zombie records
+  // dangling forever. 'cancelled' is terminal but NOT in ATTENTION_STATES, so
+  // firePush stays silent — captain initiated the close.
+  let taskId: string | undefined;
+  // Worktree to clean up after the pane closes — set only when this crew ran in
+  // its own worktree (cwd recorded by the daemon differs from the root checkout).
+  let worktreeCwd: string | undefined;
+  try {
+    const tasks = await deps.listTasks(project);
+    const task = tasks.find((t) => t.name === name);
+    if (task) {
+      taskId = task.id;
+      if (task.cwd && projRoot && task.cwd !== projRoot) {
+        worktreeCwd = task.cwd;
+      }
+      if (!TERMINAL_STATES.has(task.state)) {
+        await deps.emitEvent(project, { type: "task.cancelled", id: task.id, reason: "closed by captain" });
+      }
+      // Codex teardown: the pane only hosts the `crew attach` renderer; the thread
+      // (and its per-thread MCP servers) live on the shared app-server, so closing
+      // the pane alone leaks them. Tell the daemon to archive the thread.
+      if (task.provider === "codex") {
+        await deps.closeCodexThread(task.id);
+      }
+    }
+  } catch {
+    // Swallow daemon errors — a crew without a daemon must still close.
+  }
+  // Close the cmux pane if it still exists. A dead crew's pane is already gone —
+  // that is not an error (the record is terminalized above); proceed to reap
+  // children / clean the worktree. Only a genuine miss (no pane AND no daemon
+  // task) is a typo → surface the not-found error.
+  const crew = await findCrewPane(runtime, workspaceId, project, name);
+  if (crew) {
+    await runtime.closePane(crew);
+  } else if (taskId === undefined) {
+    throw new Error(`Crew '${name}' not found for ${project}. Run 'squadrant crew list ${project}'.`);
+  }
+  // Reap any surviving child processes (vitest workers, node subprocs, etc.)
+  // that the cmux pane-close cascade may have missed.
+  if (taskId !== undefined) {
+    await reapCrewChildren(taskId);
+  }
+  // Auto-clean the crew's worktree AFTER its processes are gone, so we don't
+  // yank a dir out from under a live shell. Best-effort: a failed removal must
+  // not break close (the branch is preserved regardless).
+  if (worktreeCwd && projRoot) {
+    try {
+      removeWorktree(projRoot, worktreeCwd);
+    } catch (e) {
+      process.stderr.write(`(worktree remove failed: ${(e as Error).message})\n`);
+    }
+  }
+}
+
+export async function runCrewList(
+  project: string,
+  runtime: RuntimeDriver,
+  workspaceId: string,
+): Promise<Array<{ name: string; surfaceId: string }>> {
+  const crews = await listCrewPanes(runtime, workspaceId, project);
+  return crews.map((c) => ({
+    name: nameFromTitle(project, c.title!),
+    surfaceId: c.surfaceId,
+  }));
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,3 +27,4 @@ export * from "./restart-daemon.js";
 export * from "./group-dispatch.js";
 export * from "./launch-workspace.js";
 export * from "./side-session.js";
+export * from "./crew-spawn.js";


### PR DESCRIPTION
## Summary

- Extracts the full spawn/send/read/close/list orchestration (569 LOC) from `packages/cli/src/commands/crew.ts` into `packages/core/src/crew-spawn.ts`
- All CLI-edge deps injected as closures via `CrewSpawnDeps` interface — core imports only `@squadrant/shared` and intra-core modules (agents/workspaces/cli stay clean)
- `crew.ts` drops to 207 LOC: thin parse → construct deps → delegate wrappers + Command definitions
- Follows the 5×-proven injection pattern: `core/group-dispatch.ts`, `core/launch-workspace.ts`, `core/side-session.ts`, `core/telegram/notify.ts`

## Hard invariants preserved (zero behavior change)

- Worktree isolation (#296): `addWorktree` + `resolveWorktreeBase` called identically
- Leveled routing (#275): real `resolveCrewRoute` still called from within core on the same config
- All agent branches preserved: claude / opencode / codex / generic
- Env prefix: `SQUADRANT_CREW_TASK_ID` / `SQUADRANT_CREW_PROJECT` set identically
- `settings.local.json` hook bridge (#134): `writeSettingsLocal` injected, called at same point
- Completion protocol: `buildCompletionProtocol` still appended to first turn

## Tests

- Adds `packages/core/src/__tests__/crew-spawn.test.ts`: 31 unit tests covering all branches (claude/opencode/codex), routing suppression, auto-naming, send/read/close/list
- `packages/cli/src/commands/__tests__/crew.test.ts`: routing tests updated — real `resolveCrewRoute` is now called inside core (not interceptable by `@squadrant/core` mock), tests updated to use real routing config and assert on observable outcome (`buildCommand` model)
- All 145 test files / 1586 tests pass; `pnpm build` green

## Test plan

- [ ] `pnpm build` — green (ESM dist/index.js + dist/squadrantd.js)
- [ ] `pnpm test run` — 145 files / 1586 tests pass, same as develop baseline
- [ ] `squadrant crew spawn <project> <task>` still works end-to-end in a live session