### PR TITLE
chore: refresh GitNexus index stamp post-#367

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (4074 symbols, 6036 relationships, 155 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (4154 symbols, 6159 relationships, 156 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (4074 symbols, 6036 relationships, 155 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (4154 symbols, 6159 relationships, 156 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 


### PR DESCRIPTION
Housekeeping after the structural refactor (#427/#429/#367). Reran `npx gitnexus analyze` on merged develop; restamps the GitNexus marker in AGENTS.md/CLAUDE.md to **4,154 symbols / 6,159 relationships / 156 flows** (was 4074/6036/155 — the post-S5 stamp). Docs-only, no code change.