### PR TITLE
fix(spawn): confirm-on-delivery for opencode first turn (#235)

### DIFF
--- a/packages/core/src/__tests__/crew-spawn.test.ts
+++ b/packages/core/src/__tests__/crew-spawn.test.ts
@@ -297,7 +297,7 @@ describe("runCrewSpawn", () => {
         expect.anything(),
         expect.any(String),
         expect.any(String),
-        expect.objectContaining({ splashMarker: "Ask anything…", retryLimit: 3 }),
+        expect.objectContaining({ splashMarker: "Ask anything…" }),
       );
     });
 

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -365,14 +365,10 @@ export async function runCrewSpawn(
     await deps.runtime.sendToPane(pane, `cd ${shellQuote(spawnCwd)} && ${envPrefix} OPENCODE_CONFIG=${opencodeConfigPath} ${cliCommand}`);
     const preLaunchScreen = (await deps.runtime.readPaneScreen(pane)) ?? "";
     await deps.sendFirstTurn(pane, `${input.task}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen, {
-      // #235: opencode's idle splash ("Ask anything…") keeps mutating (cursor
-      // blink, status line toggle), so the old screen-changed check would always
-      // see a *different* screen and never re-send a dropped turn. The splashMarker
-      // confirms the TUI actually left splash before declaring acceptance.
+      // #235: confirm-on-delivery — sendFirstTurnWhenReady polls until "Ask
+      // anything…" leaves the screen, re-sending every ~3s to cover slow boots
+      // without duplicating the task. See crew-pane.ts SPLASH_MAX_CHECKS/EVERY_N.
       splashMarker: "Ask anything…",
-      // opencode has a wider boot-race window than claude, so allow 3 retries
-      // instead of the default 2.
-      retryLimit: 3,
     } satisfies TurnAcceptanceConfig);
     return { ...pane, title };
   }

--- a/packages/workspaces/src/__tests__/crew-pane.test.ts
+++ b/packages/workspaces/src/__tests__/crew-pane.test.ts
@@ -150,26 +150,31 @@ describe("sendFirstTurnWhenReady — post-send acceptance retry", () => {
     vi.useRealTimers();
   });
 
-  it("retries up to retryLimit when opencode splash persists (splashMarker set)", async () => {
+  // #235: confirm-on-delivery — when the splash persists, sendFirstTurnWhenReady
+  // polls every 750ms but re-sends only every 4 checks (≈3s de-dup guard).
+  // Over a 15s window (SPLASH_MAX_CHECKS=20), at most 4 re-sends are issued on
+  // top of the initial send (at check 3, 7, 11, 15 → 5 total sends).
+  it("uses time-bounded confirm-on-delivery when opencode splash persists", async () => {
     readPaneScreen.mockResolvedValue("Ask anything…");
 
     const promise = sendFirstTurnWhenReady(
       { readPaneScreen, sendToPane },
       pane,
       "do the thing",
-      "$ opencode",       // preLaunchScreen
-      { splashMarker: "Ask anything…", retryLimit: 3 },
+      "$ opencode",
+      { splashMarker: "Ask anything…" },
     );
 
-    // Floor (1500) + 2 poll cycles (1500) + 3 retry checks (2250) = 5250ms
-    await vi.advanceTimersByTimeAsync(6000);
+    // Floor (1500) + 2 stability polls (1500) + 20 confirm checks (15000) = 18000ms
+    await vi.advanceTimersByTimeAsync(18500);
     await promise;
 
-    // 3 full retry rounds: initial send + 2 re-sends = 3 total
-    expect(sendToPane).toHaveBeenCalledTimes(3);
-  });
+    // 1 initial send + 4 re-sends at checks 3, 7, 11, 15 = 5 total
+    expect(sendToPane).toHaveBeenCalledTimes(5);
+    expect(sendToPane).toHaveBeenCalledWith(pane, "do the thing");
+  }, 15000);
 
-  it("exits early on acceptance instead of exhausting retries", async () => {
+  it("exits early on acceptance instead of exhausting the confirm window", async () => {
     let callCount = 0;
     readPaneScreen.mockImplementation(async () => {
       callCount++;
@@ -184,13 +189,45 @@ describe("sendFirstTurnWhenReady — post-send acceptance retry", () => {
       pane,
       "do the thing",
       "booting…",
-      { splashMarker: "Ask anything…", retryLimit: 3 },
+      { splashMarker: "Ask anything…" },
     );
 
     await vi.advanceTimersByTimeAsync(5000);
     await promise;
 
-    // 1 send only: acceptance detected on first retry check
+    // 1 send only: acceptance detected on first confirm check
     expect(sendToPane).toHaveBeenCalledTimes(1);
+  });
+
+  // #235: slow boot — opencode accepts after 6s (8 checks × 750ms). The
+  // confirm-on-delivery loop must keep trying until splash clears, not give up
+  // after a fixed count as the old retryLimit:3 path did.
+  it("confirms delivery after slow boot (splash clears after 6s of checks)", async () => {
+    let checkCount = 0;
+    readPaneScreen.mockImplementation(async () => {
+      checkCount++;
+      // stability reads 1-2: both "Ask anything…" → stable detected
+      if (checkCount <= 2) return "Ask anything…";
+      if (checkCount === 3) return "Ask anything…";  // preSend snapshot
+      // 8 post-send checks (8 × 750ms = 6s) with splash still showing
+      if (checkCount <= 11) return "Ask anything…";
+      return "> processing your task";               // accepted!
+    });
+
+    const promise = sendFirstTurnWhenReady(
+      { readPaneScreen, sendToPane },
+      pane,
+      "do the thing",
+      "$ opencode",
+      { splashMarker: "Ask anything…" },
+    );
+
+    // Floor(1500) + 2 polls(1500) + 9 checks(6750) = ~9750ms
+    await vi.advanceTimersByTimeAsync(12000);
+    await promise;
+
+    // Initial send + 2 re-sends (at checks 3 and 7), then accepted at check 8
+    expect(sendToPane).toHaveBeenCalledTimes(3);
+    expect(sendToPane).toHaveBeenCalledWith(pane, "do the thing");
   });
 });

--- a/packages/workspaces/src/crew-pane.ts
+++ b/packages/workspaces/src/crew-pane.ts
@@ -16,6 +16,13 @@ const POLL_INTERVAL_MS = 750;
 const SEND_FIRST_TURN_TIMEOUT_MS = 20000;
 const POST_SEND_CHECK_MS = 750;
 
+// #235 Confirm-on-delivery constants for splash-gated agents (opencode).
+// We poll every POST_SEND_CHECK_MS but only re-send every SPLASH_RESEND_EVERY_N
+// checks — a 3s de-dup guard that prevents double-execution when the TUI is
+// slow to redraw after accepting.
+const SPLASH_MAX_CHECKS = 20;    // 20 × 750ms ≈ 15s confirmation window
+const SPLASH_RESEND_EVERY_N = 4; // re-send every 4 checks ≈ every 3s
+
 /** Reserve an ephemeral TCP port for a crew's embedded HTTP server. Binds :0,
  *  reads the OS-assigned port, then releases it. A small TOCTOU window exists
  *  between release and the crew binding the port; acceptable for local
@@ -110,17 +117,34 @@ export async function sendFirstTurnWhenReady(
   const preSendScreen = (await runtime.readPaneScreen(pane)) ?? "";
   await runtime.sendToPane(pane, task);
 
-  // Bounded retry loop (#235): after sending, poll the pane for evidence that
-  // the TUI actually accepted the turn.
-  const retryLimit = acceptanceConfig?.retryLimit ?? 2;
-  for (let attempt = 0; attempt < retryLimit; attempt++) {
-    await new Promise((r) => setTimeout(r, POST_SEND_CHECK_MS));
-    const afterScreen = (await runtime.readPaneScreen(pane)) ?? "";
-    if (isTurnAccepted(preSendScreen, afterScreen, acceptanceConfig)) {
-      return;
+  // Confirm-on-delivery (#235): poll until the TUI confirms it accepted the turn.
+  if (acceptanceConfig?.splashMarker) {
+    // Splash path (opencode): the "Ask anything…" splash clears once the TUI
+    // consumes the message. We check every POST_SEND_CHECK_MS but re-send only
+    // every SPLASH_RESEND_EVERY_N checks — a 3s de-dup guard that prevents
+    // duplicate task execution when the TUI is slow to redraw after accepting.
+    for (let check = 0; check < SPLASH_MAX_CHECKS; check++) {
+      await new Promise((r) => setTimeout(r, POST_SEND_CHECK_MS));
+      const afterScreen = (await runtime.readPaneScreen(pane)) ?? "";
+      if (isTurnAccepted(preSendScreen, afterScreen, acceptanceConfig)) {
+        return;
+      }
+      if ((check + 1) % SPLASH_RESEND_EVERY_N === 0 && check < SPLASH_MAX_CHECKS - 1) {
+        await runtime.sendToPane(pane, task);
+      }
     }
-    if (attempt < retryLimit - 1) {
-      await runtime.sendToPane(pane, task);
+  } else {
+    // Screen-changed path (claude/codex): acceptance = the screen changed.
+    const retryLimit = acceptanceConfig?.retryLimit ?? 2;
+    for (let attempt = 0; attempt < retryLimit; attempt++) {
+      await new Promise((r) => setTimeout(r, POST_SEND_CHECK_MS));
+      const afterScreen = (await runtime.readPaneScreen(pane)) ?? "";
+      if (isTurnAccepted(preSendScreen, afterScreen, acceptanceConfig)) {
+        return;
+      }
+      if (attempt < retryLimit - 1) {
+        await runtime.sendToPane(pane, task);
+      }
     }
   }
 }


### PR DESCRIPTION
## Root cause

`sendFirstTurnWhenReady` used a fixed retry count for the splash-based opencode path: 3 retries × 750ms = **2.25s total**. When opencode's boot took longer than this, all retries exhausted silently and the function returned with the task marked `working` but nothing delivered — the worst failure class (false-healthy).

The splash keeps mutating (status-line toggle), so the stability check can fire early (two consecutive reads happened to catch the same state), triggering the send before opencode's internal initialization is complete. The 2.25s retry window was simply not wide enough to cover the full boot tail.

## Fix

Time-bounded confirm-on-delivery loop for the `splashMarker` path:

- Poll every **750ms** to detect splash clearance (fast acceptance detection)
- Re-send only every **4 checks ≈ 3s** (de-dup guard — prevents duplicate execution when the TUI is slow to redraw after accepting)
- Total confirmation window: **15s** (20 × 750ms) — covers any reasonable opencode boot

The `else` branch (claude/codex screen-changed path) is unchanged.

## Changes

| File | Change |
|------|--------|
| `packages/workspaces/src/crew-pane.ts` | Add `SPLASH_MAX_CHECKS`/`SPLASH_RESEND_EVERY_N` constants; split retry into splash-path (time-bounded) and screen-changed path (count-based) |
| `packages/core/src/crew-spawn.ts` | Remove unused `retryLimit: 3` from opencode spawn (splash path drives its own timing now) |
| `packages/workspaces/src/__tests__/crew-pane.test.ts` | Update existing splash test; add slow-boot test that proves old code would fail, new code confirms delivery |
| `packages/core/src/__tests__/crew-spawn.test.ts` | Remove `retryLimit: 3` from opencode sendFirstTurn assertion |

## Test plan

- [x] `pnpm test` 1586/1586 green
- [x] `pnpm build` clean
- [x] `node dist/index.js --help` works (NodeNext .js gate)
- [x] New test "confirms delivery after slow boot" — simulates opencode accepting after 8 post-send checks (6s); proves retries fire at 3s intervals and delivery is confirmed when splash clears
- [x] claude/codex spawn paths untouched (no `splashMarker` → `else` branch, same behavior)