### PR TITLE
chore: refresh GitNexus index after #428/#235

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (4154 symbols, 6159 relationships, 156 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (4157 symbols, 6162 relationships, 156 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (4154 symbols, 6159 relationships, 156 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (4157 symbols, 6162 relationships, 156 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 


### PR DESCRIPTION
## Summary

- Re-ran `npx gitnexus analyze --embeddings` after the S4 naming refactor (#428) and opencode first-turn fix (#235)
- Symbols: 4154 → 4157 | Relationships: 6159 → 6162 | Flows: 156 (unchanged)
- Updated stamps in `CLAUDE.md` and `AGENTS.md`

## Gate

- `git diff` limited to stamp lines in `AGENTS.md` and `CLAUDE.md` only — no source changes