### PR TITLE
chore(config): default crew model opus→sonnet (tokenomics)

### DIFF
--- a/packages/cli/src/commands/__tests__/config.test.ts
+++ b/packages/cli/src/commands/__tests__/config.test.ts
@@ -46,7 +46,7 @@ describe("runConfigCheck", () => {
   });
 
   it("--fix does NOT stamp when advisory/invalid drift remains", () => {
-    writeUser((c) => { (c.defaults.roles as any).crew = { agent: "claude", model: "sonnet" }; });
+    writeUser((c) => { (c.defaults.roles as any).crew = { agent: "claude", model: "opus" }; });
     const res = runConfigCheck({ configPath: cfgPath, pkgVersion: "0.5.3", fix: true, accept: false });
     const onDisk = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
     expect(onDisk._squadrantVersion).toBeUndefined();
@@ -54,11 +54,11 @@ describe("runConfigCheck", () => {
   });
 
   it("--accept stamps without changing config", () => {
-    writeUser((c) => { (c.defaults.roles as any).crew = { agent: "claude", model: "sonnet" }; });
+    writeUser((c) => { (c.defaults.roles as any).crew = { agent: "claude", model: "opus" }; });
     runConfigCheck({ configPath: cfgPath, pkgVersion: "0.5.3", fix: false, accept: true });
     const onDisk = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
     expect(onDisk._squadrantVersion).toBe("0.5.3");
-    expect(onDisk.defaults.roles.crew.model).toBe("sonnet");
+    expect(onDisk.defaults.roles.crew.model).toBe("opus");
   });
 });
 

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -150,14 +150,14 @@ export function getDefaultConfig(): SquadrantConfig {
       models: {
         command: "opus",
         captain: "opus",
-        crew: "opus",
+        crew: "sonnet",
         exploration: "haiku",
         review: "opus",
       },
       roles: {
         command: { agent: "claude", model: "opus" },
         captain: { agent: "claude", model: "opus" },
-        crew: { agent: "claude", model: "opus" },
+        crew: { agent: "claude", model: "sonnet" },
         exploration: { agent: "claude", model: "haiku" },
         side: { agent: "claude", model: "opus" },
       },

--- a/packages/shared/src/lib/__tests__/config-drift.test.ts
+++ b/packages/shared/src/lib/__tests__/config-drift.test.ts
@@ -50,12 +50,12 @@ describe("detectDrift \u2014 deprecated", () => {
 describe("detectDrift \u2014 changed-default", () => {
   it("flags a field whose value equals the OLD default but the default changed", () => {
     const u = userConfig();
-    (u.defaults.roles as any).crew = { agent: "claude", model: "sonnet" };
+    (u.defaults.roles as any).crew = { agent: "claude", model: "opus" };
     const items = detectDrift(u, getDefaultConfig());
     const cd = items.find((i) => i.kind === "changed-default" && i.path === "defaults.roles.crew.model");
     expect(cd).toBeDefined();
     expect(cd?.severity).toBe("advisory");
-    expect(cd?.suggested).toBe("opus");
+    expect(cd?.suggested).toBe("sonnet");
   });
 
   it("does NOT flag a field the user customized to a third value", () => {

--- a/packages/shared/src/lib/__tests__/config.test.ts
+++ b/packages/shared/src/lib/__tests__/config.test.ts
@@ -51,12 +51,12 @@ describe("config", () => {
     const config = getDefaultConfig();
     expect(config.defaults.roles).toBeDefined();
     expect(config.defaults.roles!.command).toEqual({ agent: "claude", model: "opus" });
-    expect(config.defaults.roles!.crew).toEqual({ agent: "claude", model: "opus" });
+    expect(config.defaults.roles!.crew).toEqual({ agent: "claude", model: "sonnet" });
   });
 
-  it("defaults crews to opus + auto permission mode", () => {
+  it("defaults crews to sonnet + auto permission mode", () => {
     const config = getDefaultConfig();
-    expect(config.defaults.models!.crew).toBe("opus");
+    expect(config.defaults.models!.crew).toBe("sonnet");
     expect(config.defaults.permissions.crew).toBe("auto");
   });
 

--- a/packages/shared/src/lib/config-drift.ts
+++ b/packages/shared/src/lib/config-drift.ts
@@ -35,7 +35,7 @@ const KNOWN_DEPRECATED: Array<{ path: string; when?: (u: SquadrantConfig) => boo
 ];
 
 const KNOWN_DEFAULT_HISTORY: Array<{ path: string; oldDefaults: unknown[] }> = [
-  { path: "defaults.roles.crew.model", oldDefaults: ["sonnet"] },
+  { path: "defaults.roles.crew.model", oldDefaults: ["opus"] },
   { path: "defaults.roles.captain.model", oldDefaults: ["sonnet"] },
 ];
 


### PR DESCRIPTION
## Summary

- Flips `defaults.roles.crew.model` and `defaults.models.crew` in `getDefaultConfig()` from `opus` to `sonnet`
- Matches the live config override already on all running instances (deliberate tokenomics: opus is opt-in via the `extreme` routing tier or `--model opus`)
- Stops the recurring `changed-default` drift advisory that fires every version bump because the repo default diverged from the live value
- Updates `KNOWN_DEFAULT_HISTORY` in `config-drift.ts` so the advisory now correctly fires for configs still carrying the OLD `opus` default (nudging them toward `sonnet`)
- Updates 3 test assertions that verified the `opus` crew default

## What was NOT changed

- `command` / `captain` / `side` / `exploration` / `review` role defaults — untouched
- `crewRouting` rules including the `extreme` tier (`opus`) — untouched
- The `captain.model` drift history entry — it was already `oldDefaults: ["sonnet"]` which is unrelated to crew and was left as-is

## Gates

- `pnpm build` ✅ clean
- `vitest run` on affected test files ✅ 21/21 passed
- `node dist/index.js --help` ✅ works
- `gitnexus_detect_changes` ✅ only the 4 intended files changed