### PR TITLE
fix(spawn): reliable first-turn submit — root-cause #339

### DIFF
--- a/docs/reports/2026-06-26-dbg-339-enter-not-submitting-rootcause.md
+++ b/docs/reports/2026-06-26-dbg-339-enter-not-submitting-rootcause.md
@@ -1,0 +1,86 @@
+# #339 — first-turn Enter inserts a newline instead of submitting — ROOT CAUSE PROVEN ✅
+
+**Date:** 2026-06-26
+**Branch:** `crew/fix-339`
+**Method:** superpowers:systematic-debugging — live reproduction against a real Claude Code surface before any fix.
+
+---
+
+## Symptom
+
+A crew first-turn (or captain Enter) intermittently leaves the full payload sitting
+**unsubmitted** in the input box, prefixed `❯ [Pasted text #1][Pasted text #2][Pasted
+text #3]…` — multiple pastes, **zero submits**, `Ctx Used 0.0%`. The turn never runs.
+Reported several times a day. Prior triage (`2026-06-16-dbg-cmux-double-startup-and-enter-newline.md`)
+could not reproduce it in isolation and ruled out: content newlines, the plain
+send+Enter race (15/15 clean on short messages), working-state delivery, and the
+#302 backspace probe.
+
+## What the prior triage missed: the payload SIZE is the trigger
+
+Short messages (captain DONE, ≤200 char) submit 15/15 — they never enter Claude
+Code's **paste mode**. The first-turn *task* payload (`task + "\n\n" + completionProtocol`,
+collapsed to one line by `sanitizeForCmuxSend`) is **thousands of characters**. That
+is what triggers the bug. The differentiator is paste-mode, not content.
+
+## Delivery path
+
+`sendFirstTurnWhenReady` (`packages/workspaces/src/crew-pane.ts`) → `sendToPane`
+(`packages/workspaces/src/runtimes/cmux.ts:431`):
+
+```ts
+await cmux(["send",     ..., sanitizeForCmuxSend(message)]);  // socket write #1: the text
+await cmux(["send-key", ..., "Enter"]);                       // socket write #2: the CR
+```
+
+Two separate socket writes. On retry, `sendFirstTurnWhenReady` re-calls `sendToPane`
+— i.e. it **re-pastes the entire task** and issues another Enter.
+
+## Live experiments (real `claude --model sonnet` surface, driven via cmux CLI)
+
+| # | Stimulus | Result |
+|---|----------|--------|
+| 1 | 3 298-char single-line payload, immediate `send`+`send-key Enter` | Rendered **inline**, **submitted** cleanly. No paste mode at this size. |
+| 2 | 8 912-char payload, `send` only (no Enter) | Box shows `❯ … [Pasted text #2][Pasted text #3]…[Pasted text #9] …` — **paste-mode reproduced**. cmux/PTY chunks a big `send`; Claude Code coalesces the chunks into `[Pasted text #N]` placeholders. |
+| 3 | After #2, wait ~2 s for the box to settle, **then** `send-key Enter` | **Submitted** (box emptied, turn started). A settled Enter always submits. |
+| 4 | 8 912-char payload + trailing `\n` in **one** `cmux send` (CR coalesced into the paste burst) | **STRANDED.** Box not empty, not working; the CR landed as a literal newline *inside* the paste: `…[Pasted text\n  #82]…`. **Deterministic proof of the mechanism.** |
+| 5 | On the stranded box from #4, re-issue **only** `send-key Enter` (no re-paste) | **Submitted** — the box emptied. Validates the fix: re-issue the CR, never re-paste. |
+| 6 | Immediate `send`+`send-key Enter`, 8 912-char, ×10 trials, quiet machine | 9 submitted / 1 inconclusive / 0 stranded — the per-Enter race is **low-probability when unloaded** (matches "not reproducible in isolation"). |
+
+## Root cause
+
+The first-turn payload is large enough to put Claude Code into **paste mode**: cmux/PTY
+delivers the big `send` as multiple chunks and Claude Code coalesces them into
+`[Pasted text #N]` placeholders, keeping a short **paste-accumulation window** open.
+
+`sendToPane` issues the submit CR as a *separate* socket write immediately after the
+paste. When that CR is consumed by Claude Code **while the paste-accumulation window
+is still open** — which happens when the two socket writes land in a single PTY read
+under load, or when the CR simply arrives before the paste finishes rendering — Claude
+Code treats the CR as a **literal newline appended to the pasted text**, not as a
+submit. The payload is stranded (experiment #4 reproduces this exactly).
+
+The current **retry makes it worse**: it re-calls `sendToPane`, **re-pasting the whole
+task** (stacking another `[Pasted text]`) and racing another CR the same way. Once
+stranding conditions hold across the ~1.5 s retry window, every attempt strands →
+"3 pastes, 0 submits."
+
+This explains every observation: short messages never strand (below paste threshold,
+15/15), the large first-turn task strands under load, and all retries strand together.
+
+## Fix (see PR)
+
+Deliver the task and submit it as **two separated, confirmed** steps in the
+claude/codex first-turn path (`sendFirstTurnWhenReady`):
+
+1. **Paste only** (`pasteToPane`, no Enter).
+2. **Settle** — poll the input box until its content is stable across two reads (the
+   paste-accumulation window has closed).
+3. **Submit** with a separate `sendKeyToPane(pane, "Enter")`.
+4. **Confirm** via read-back: the input box is empty ⇒ submitted. If the box still
+   holds the draft, re-issue **only the Enter** (re-settle first) — **never re-paste**
+   (re-pasting is what stacks `[Pasted text]` placeholders). Bounded attempts.
+
+The opencode splash path (#235, recently live-verified) is **left unchanged**. The
+short shell-launch and crew-message `sendToPane` callers are **left unchanged** (they
+are below the paste threshold and rely on the atomic send+Enter).

--- a/packages/shared/src/types/runtime.ts
+++ b/packages/shared/src/types/runtime.ts
@@ -50,6 +50,13 @@ export interface RuntimeDriver {
   newPane(opts: RuntimePaneOptions): Promise<PaneRef>;
   closePane(pane: PaneRef): Promise<void>;
   sendToPane(pane: PaneRef, message: string): Promise<void>; // sends text + Enter
+  // Paste text into a pane WITHOUT committing it (no Enter). Pairs with
+  // sendKeyToPane to submit as a separate, settled keystroke — required for the
+  // #339 first-turn fix, where bundling the CR with a large paste lets Claude
+  // Code absorb it as a newline inside the [Pasted text] placeholder.
+  pasteToPane(pane: PaneRef, text: string): Promise<void>;
+  // Send a single literal key press to a pane (e.g. "Enter").
+  sendKeyToPane(pane: PaneRef, key: string): Promise<void>;
   readPaneScreen(pane: PaneRef): Promise<string>;
   // List all surfaces (tabs/panes) inside a workspace, with their titles.
   // Used to find named crews by tab title (#56).

--- a/packages/workspaces/src/__tests__/crew-pane.test.ts
+++ b/packages/workspaces/src/__tests__/crew-pane.test.ts
@@ -2,148 +2,119 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { sendFirstTurnWhenReady } from "../crew-pane.js";
 import type { PaneRef } from "@squadrant/shared";
 
-describe("sendFirstTurnWhenReady", () => {
+// Realistic Claude-Code-style screen: the live input box is the region between the
+// last two horizontal rules. parseDraftFromScreen reads exactly that region, so the
+// #339 fix can use box-empty (submitted) vs box-holds-draft (stranded) as its
+// confirmation signal instead of the fragile "screen changed" heuristic.
+const HR = "─".repeat(60);
+const box = (content: string) =>
+  `…transcript…\n${HR}\n❯ ${content}\n${HR}\n   Model: Sonnet 4.6  Ctx Used: 0.0%`;
+const EMPTY_BOX = box("");                 // parseDraftFromScreen → "" (submitted)
+const DRAFT_BOX = box("[Pasted text #1]"); // parseDraftFromScreen → draft  (stranded)
+
+describe("sendFirstTurnWhenReady — claude/codex first-turn (#339)", () => {
   let readPaneScreen: ReturnType<typeof vi.fn>;
   let sendToPane: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
   const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, sendToPane, pasteToPane, sendKeyToPane });
 
   beforeEach(() => {
     vi.useFakeTimers();
     readPaneScreen = vi.fn();
     sendToPane = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
   });
 
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it("polls until pane stabilizes then sends the task once", async () => {
-    let callCount = 0;
+  // #339: the submit CR must be a SEPARATE keystroke issued after the paste settles —
+  // never bundled into the paste send (which is how the CR gets absorbed as a newline
+  // inside the [Pasted text] placeholder). The whole task is pasted exactly once.
+  it("pastes the task once, then submits with a separate Enter — never via send+Enter", async () => {
+    let n = 0;
     readPaneScreen.mockImplementation(async () => {
-      callCount++;
-      if (callCount <= 1) return "";
-      if (callCount <= 3) return "> ";        // stable prompt, advanced past launch
-      if (callCount === 4) return "> ";       // preSend snapshot
-      return "> do the thing";                // after-send: screen changed → no re-send
+      n++;
+      if (n <= 3) return EMPTY_BOX;  // readiness polls + preSend snapshot
+      if (n <= 5) return DRAFT_BOX;  // settle: paste rendered, box holds the draft
+      return EMPTY_BOX;              // post-Enter: box empty → submitted
     });
 
-    const promise = sendFirstTurnWhenReady(
-      { readPaneScreen, sendToPane },
-      pane,
-      "do the thing",
-      "$ launch",
-    );
-
-    await vi.advanceTimersByTimeAsync(4000);
+    const promise = sendFirstTurnWhenReady(rt(), pane, "do the big thing", "$ launch");
+    await vi.advanceTimersByTimeAsync(6000);
     await promise;
 
-    expect(sendToPane).toHaveBeenCalledTimes(1);
-    expect(sendToPane).toHaveBeenCalledWith(pane, "do the thing");
-  });
-
-  it("falls back to sending even if pane never stabilises", async () => {
-    readPaneScreen.mockResolvedValue("");
-
-    const promise = sendFirstTurnWhenReady(
-      { readPaneScreen, sendToPane },
-      pane,
-      "do the thing",
-      "$ launch",
-    );
-
-    await vi.advanceTimersByTimeAsync(21000);
-    await promise;
-
-    // Two calls: fallback send + one re-send (post-send check sees an unchanged screen)
-    expect(sendToPane).toHaveBeenCalledTimes(2);
-    expect(sendToPane).toHaveBeenNthCalledWith(1, pane, "do the thing");
-    expect(sendToPane).toHaveBeenNthCalledWith(2, pane, "do the thing");
-  }, 15000);
-
-  it("re-sends once when the screen is unchanged after the first send", async () => {
-    readPaneScreen.mockResolvedValue("> ");
-
-    const promise = sendFirstTurnWhenReady(
-      { readPaneScreen, sendToPane },
-      pane,
-      "do the thing",
-      "$ launch",
-    );
-
-    await vi.advanceTimersByTimeAsync(5000);
-    await promise;
-
-    // Two calls: initial send + one re-send (preSend === afterScreen)
-    expect(sendToPane).toHaveBeenCalledTimes(2);
-    expect(sendToPane).toHaveBeenNthCalledWith(1, pane, "do the thing");
-    expect(sendToPane).toHaveBeenNthCalledWith(2, pane, "do the thing");
-  });
-
-  // #168: sendToPane (since #136) collapses newlines to spaces, so a multi-line
-  // task never appears verbatim in the pane render. The old post-send check
-  // `!afterScreen.includes(task)` therefore always re-sent → duplicate first
-  // turn. The fix compares the screen before vs after sending instead.
-  it("does NOT re-send a multi-line task when the pane render collapses newlines", async () => {
-    const task = "line one\nline two\nline three";
-    let callCount = 0;
-    readPaneScreen.mockImplementation(async () => {
-      callCount++;
-      // reads 1-2: poll (stable), read 3: preSend snapshot — all the bare prompt.
-      if (callCount <= 3) return "> ";
-      return "> line one line two line three";               // after-send: collapsed render
-    });
-
-    const promise = sendFirstTurnWhenReady(
-      { readPaneScreen, sendToPane },
-      pane,
-      task,
-      "$ launch",
-    );
-
-    await vi.advanceTimersByTimeAsync(4000);
-    await promise;
-
-    // The screen changed after the send (task was received), so no re-send —
-    // even though `afterScreen.includes(task)` is false for the multi-line task.
-    expect(sendToPane).toHaveBeenCalledTimes(1);
-    expect(sendToPane).toHaveBeenCalledWith(pane, task);
-  });
-
-  // opencode boot-race: the screen can be momentarily static while the launch
-  // command still sits un-entered on the shell line. Sending then concatenates
-  // onto that line → shell parse error. The readiness gate must require the
-  // screen to ADVANCE past the launch-line snapshot, not merely be static.
-  it("does NOT send the first turn while the pane still shows the un-entered launch line", async () => {
-    const launchLine = "$ SQUADRANT_CREW_TASK_ID=t1 opencode";
-    readPaneScreen.mockResolvedValue(launchLine);
-
-    const promise = sendFirstTurnWhenReady(
-      { readPaneScreen, sendToPane },
-      pane,
-      "do the thing",
-      launchLine,
-    );
-
-    // Well under the 20s timeout: the screen never advanced past the launch
-    // line, so the readiness gate must not have fired yet.
-    await vi.advanceTimersByTimeAsync(5000);
+    expect(pasteToPane).toHaveBeenCalledTimes(1);
+    expect(pasteToPane).toHaveBeenCalledWith(pane, "do the big thing");
+    expect(sendKeyToPane).toHaveBeenCalledWith(pane, "Enter");
     expect(sendToPane).not.toHaveBeenCalled();
+  });
 
-    // Drain to the timeout so the fallback send fires and the promise resolves.
+  // #339 core regression: when the first Enter is absorbed as a newline (box still
+  // holds the paste), the retry re-issues ONLY the Enter — it must NOT re-paste the
+  // task (re-pasting is what stacks [Pasted text #1][#2][#3] and never submits).
+  it("re-issues ONLY Enter when the first submit is stranded — never re-pastes", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n <= 3) return EMPTY_BOX;  // readiness + preSend
+      if (n <= 5) return DRAFT_BOX;  // settle after paste
+      if (n === 6) return DRAFT_BOX; // post-Enter#1: STILL holds draft → stranded
+      if (n <= 8) return DRAFT_BOX;  // re-settle before Enter#2
+      return EMPTY_BOX;              // post-Enter#2: submitted
+    });
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "do the big thing", "$ launch");
+    await vi.advanceTimersByTimeAsync(8000);
+    await promise;
+
+    expect(pasteToPane).toHaveBeenCalledTimes(1); // paste exactly ONCE, ever
+    expect(sendKeyToPane).toHaveBeenCalledTimes(2); // Enter, then re-Enter
+    expect(sendKeyToPane).toHaveBeenCalledWith(pane, "Enter");
+    expect(sendToPane).not.toHaveBeenCalled();
+  });
+
+  // Submission is confirmed by the input box going empty, NOT by "screen changed" —
+  // the paste itself changes the screen, so screen-changed would falsely report a
+  // stranded paste as submitted.
+  it("does not treat the paste landing in the box as a successful submit", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n <= 3) return EMPTY_BOX;  // readiness + preSend
+      return DRAFT_BOX;              // paste landed but box NEVER empties → never submits
+    });
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "do the big thing", "$ launch");
     await vi.advanceTimersByTimeAsync(20000);
     await promise;
-  }, 15000);
+
+    // Box never empties, so the retry loop keeps re-issuing Enter (≥2) and still
+    // never re-pastes. The point: it did not early-return on the paste-changed screen.
+    expect(pasteToPane).toHaveBeenCalledTimes(1);
+    expect(sendKeyToPane.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(sendToPane).not.toHaveBeenCalled();
+  });
 });
 
 describe("sendFirstTurnWhenReady — post-send acceptance retry", () => {
   let readPaneScreen: ReturnType<typeof vi.fn>;
   let sendToPane: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
   const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, sendToPane, pasteToPane, sendKeyToPane });
 
   beforeEach(() => {
     vi.useFakeTimers();
     readPaneScreen = vi.fn();
     sendToPane = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
   });
 
   afterEach(() => {
@@ -158,7 +129,7 @@ describe("sendFirstTurnWhenReady — post-send acceptance retry", () => {
     readPaneScreen.mockResolvedValue("Ask anything…");
 
     const promise = sendFirstTurnWhenReady(
-      { readPaneScreen, sendToPane },
+      rt(),
       pane,
       "do the thing",
       "$ opencode",
@@ -185,7 +156,7 @@ describe("sendFirstTurnWhenReady — post-send acceptance retry", () => {
     });
 
     const promise = sendFirstTurnWhenReady(
-      { readPaneScreen, sendToPane },
+      rt(),
       pane,
       "do the thing",
       "booting…",
@@ -215,7 +186,7 @@ describe("sendFirstTurnWhenReady — post-send acceptance retry", () => {
     });
 
     const promise = sendFirstTurnWhenReady(
-      { readPaneScreen, sendToPane },
+      rt(),
       pane,
       "do the thing",
       "$ opencode",

--- a/packages/workspaces/src/crew-pane.ts
+++ b/packages/workspaces/src/crew-pane.ts
@@ -6,7 +6,7 @@ import net from "node:net";
 import { loadConfig } from "@squadrant/shared";
 import type { PaneRef, RuntimeDriver } from "@squadrant/shared";
 import { RuntimeRegistry } from "./runtimes/registry.js";
-import { createCmuxDriver } from "./runtimes/cmux.js";
+import { createCmuxDriver, parseDraftFromScreen } from "./runtimes/cmux.js";
 import { titleFor, isCrewTitle, isTurnAccepted } from "@squadrant/core";
 import type { TurnAcceptanceConfig } from "@squadrant/core";
 
@@ -22,6 +22,30 @@ const POST_SEND_CHECK_MS = 750;
 // slow to redraw after accepting.
 const SPLASH_MAX_CHECKS = 20;    // 20 × 750ms ≈ 15s confirmation window
 const SPLASH_RESEND_EVERY_N = 4; // re-send every 4 checks ≈ every 3s
+
+// #339 paste-then-submit constants for the claude/codex first-turn path.
+// SETTLE polls the input box after the paste until its content stops changing —
+// i.e. Claude Code's paste-accumulation window has closed — so the submit CR is a
+// separate keystroke that lands AFTER the [Pasted text] placeholder is final and
+// is therefore treated as a submit, not a literal newline inside the paste.
+const SETTLE_POLL_MS = 400;
+const SETTLE_MAX_POLLS = 8;        // up to 3.2s for a very large paste to render
+const SUBMIT_RETRY_LIMIT = 4;      // Enter-only re-issues if the box stays stranded
+
+/** Poll the pane until its input box stops changing across two consecutive reads
+ *  (paste fully rendered / accumulation window closed), or the cap is hit. */
+async function settleInputBox(
+  runtime: Pick<RuntimeDriver, "readPaneScreen">,
+  pane: PaneRef,
+): Promise<void> {
+  let prev = (await runtime.readPaneScreen(pane)) ?? "";
+  for (let i = 0; i < SETTLE_MAX_POLLS; i++) {
+    await new Promise((r) => setTimeout(r, SETTLE_POLL_MS));
+    const cur = (await runtime.readPaneScreen(pane)) ?? "";
+    if (cur === prev) return;
+    prev = cur;
+  }
+}
 
 /** Reserve an ephemeral TCP port for a crew's embedded HTTP server. Binds :0,
  *  reads the OS-assigned port, then releases it. A small TOCTOU window exists
@@ -79,7 +103,7 @@ export async function resolveCaptainWorkspace(project: string): Promise<{
 }
 
 export async function sendFirstTurnWhenReady(
-  runtime: Pick<RuntimeDriver, "readPaneScreen" | "sendToPane">,
+  runtime: Pick<RuntimeDriver, "readPaneScreen" | "sendToPane" | "pasteToPane" | "sendKeyToPane">,
   pane: PaneRef,
   task: string,
   preLaunchScreen: string,
@@ -115,7 +139,6 @@ export async function sendFirstTurnWhenReady(
   // multi-line task never appears verbatim in the single-line pane render and
   // the check would always re-send a duplicate first turn (#168).
   const preSendScreen = (await runtime.readPaneScreen(pane)) ?? "";
-  await runtime.sendToPane(pane, task);
 
   // Confirm-on-delivery (#235): poll until the TUI confirms it accepted the turn.
   if (acceptanceConfig?.splashMarker) {
@@ -123,6 +146,10 @@ export async function sendFirstTurnWhenReady(
     // consumes the message. We check every POST_SEND_CHECK_MS but re-send only
     // every SPLASH_RESEND_EVERY_N checks — a 3s de-dup guard that prevents
     // duplicate task execution when the TUI is slow to redraw after accepting.
+    // opencode's TUI does not collapse pastes into placeholders, so the atomic
+    // send+Enter (sendToPane) is correct here and must stay (it was just fixed
+    // and live-verified in #235). The #339 paste race is claude-specific.
+    await runtime.sendToPane(pane, task);
     for (let check = 0; check < SPLASH_MAX_CHECKS; check++) {
       await new Promise((r) => setTimeout(r, POST_SEND_CHECK_MS));
       const afterScreen = (await runtime.readPaneScreen(pane)) ?? "";
@@ -133,18 +160,34 @@ export async function sendFirstTurnWhenReady(
         await runtime.sendToPane(pane, task);
       }
     }
-  } else {
-    // Screen-changed path (claude/codex): acceptance = the screen changed.
-    const retryLimit = acceptanceConfig?.retryLimit ?? 2;
-    for (let attempt = 0; attempt < retryLimit; attempt++) {
-      await new Promise((r) => setTimeout(r, POST_SEND_CHECK_MS));
-      const afterScreen = (await runtime.readPaneScreen(pane)) ?? "";
-      if (isTurnAccepted(preSendScreen, afterScreen, acceptanceConfig)) {
-        return;
-      }
-      if (attempt < retryLimit - 1) {
-        await runtime.sendToPane(pane, task);
-      }
-    }
+    return;
+  }
+
+  // Claude/codex path (#339): paste the task, let the [Pasted text] placeholder
+  // settle, THEN submit with a separate Enter. Bundling the CR with the paste
+  // (the old sendToPane) lets Claude Code absorb it as a literal newline inside
+  // the placeholder under load, stranding the whole turn unsubmitted. We confirm
+  // the submit by the input box going empty — NOT by "screen changed", because
+  // the paste itself changes the screen. If the box is still holding the draft we
+  // re-issue ONLY the Enter (after re-settling) and NEVER re-paste — re-pasting is
+  // exactly what stacks [Pasted text #1][#2][#3] and never submits.
+  await runtime.pasteToPane(pane, task);
+  await settleInputBox(runtime, pane);
+  await runtime.sendKeyToPane(pane, "Enter");
+
+  const retryLimit = acceptanceConfig?.retryLimit ?? SUBMIT_RETRY_LIMIT;
+  for (let attempt = 0; attempt < retryLimit; attempt++) {
+    await new Promise((r) => setTimeout(r, POST_SEND_CHECK_MS));
+    const afterScreen = (await runtime.readPaneScreen(pane)) ?? "";
+    const draft = parseDraftFromScreen(afterScreen);
+    // Box confirmed empty → the draft left the input box → submitted.
+    if (draft === "") return;
+    // Box not parseable (e.g. an agent TUI without the HR-bounded box, or a
+    // transient overlay): fall back to the screen-changed signal so non-claude
+    // TUIs aren't worse off than before.
+    if (draft === null && afterScreen !== preSendScreen) return;
+    // Still stranded — re-settle and re-issue ONLY the Enter (never re-paste).
+    await settleInputBox(runtime, pane);
+    await runtime.sendKeyToPane(pane, "Enter");
   }
 }

--- a/packages/workspaces/src/runtimes/__tests__/registry.test.ts
+++ b/packages/workspaces/src/runtimes/__tests__/registry.test.ts
@@ -17,6 +17,8 @@ function stubDriver(name: string): RuntimeDriver {
     newPane: vi.fn(async () => ({ workspaceId: "workspace:1", surfaceId: "surface:1" })),
     closePane: vi.fn(async () => {}),
     sendToPane: vi.fn(async () => {}),
+    pasteToPane: vi.fn(async () => {}),
+    sendKeyToPane: vi.fn(async () => {}),
     readPaneScreen: vi.fn(async () => ""),
     listSurfaces: vi.fn(async () => []),
     spawnInjector: vi.fn(async () => ({ workspaceId: "workspace:1", surfaceId: "surface:1" })),

--- a/packages/workspaces/src/runtimes/cmux.ts
+++ b/packages/workspaces/src/runtimes/cmux.ts
@@ -429,8 +429,16 @@ export function createCmuxDriver(): RuntimeDriver {
     },
 
     async sendToPane(pane: PaneRef, message: string): Promise<void> {
-      await cmux(["send", "--workspace", pane.workspaceId, "--surface", pane.surfaceId, sanitizeForCmuxSend(message)]);
-      await cmux(["send-key", "--workspace", pane.workspaceId, "--surface", pane.surfaceId, "Enter"]);
+      await this.pasteToPane(pane, message);
+      await this.sendKeyToPane(pane, "Enter");
+    },
+
+    async pasteToPane(pane: PaneRef, text: string): Promise<void> {
+      await cmux(["send", "--workspace", pane.workspaceId, "--surface", pane.surfaceId, sanitizeForCmuxSend(text)]);
+    },
+
+    async sendKeyToPane(pane: PaneRef, key: string): Promise<void> {
+      await cmux(["send-key", "--workspace", pane.workspaceId, "--surface", pane.surfaceId, key]);
     },
 
     async readPaneScreen(pane: PaneRef): Promise<string> {


### PR DESCRIPTION
Fixes #339.

## Root cause (proven, not guessed)

The first-turn payload (`task + "\n\n" + completionProtocol`) is **large** — thousands of characters. `sanitizeForCmuxSend` collapses it to one line, then `sendToPane` delivers it as `cmux send <payload>` followed by a **separate** `cmux send-key Enter`.

A large `send` is **chunked** by cmux/the PTY, and Claude Code coalesces the chunks into `[Pasted text #N]` placeholders, holding a short **paste-accumulation window** open. When the submit CR is consumed by Claude Code **while that window is still open** — the two socket writes landing in one PTY read under load, or the CR simply arriving before the paste finishes rendering — Claude Code treats the CR as a **literal newline appended to the pasted text**, not as a submit. The turn is stranded, unsubmitted, `Ctx 0.0%`.

The old **retry made it worse**: it re-called `sendToPane`, **re-pasting the whole task** (stacking another `[Pasted text]`) and racing another CR the same way → the reported "3 pastes, 0 submits".

This is exactly why **short** messages never strand (captain DONE, follow-up `crew send` — both below the paste threshold, both use the same `sendToPane`), while only the **big first turn** fails. The submit-CR mechanism is identical across the two paths; the trigger is payload size → paste mode.

### Evidence (live, against a real `claude` surface)

| Stimulus | Result |
|---|---|
| 3 298-char single-line payload, immediate send+Enter | inline render, **submits** (no paste mode at this size) |
| 8 912-char payload, send only | `[Pasted text #2]…[Pasted text #9]` — paste mode reproduced |
| paste, **wait to settle**, then a separate Enter | **submits** |
| paste + CR in **one** burst (CR coalesced into the paste) | **STRANDED** — CR became a newline inside the paste: `…[Pasted text\n  #82]…` (deterministic) |
| re-issue **only** Enter on the stranded box (no re-paste) | **submits** |

Full write-up: `docs/reports/2026-06-26-dbg-339-enter-not-submitting-rootcause.md`.

## Fix

In the claude/codex first-turn path (`sendFirstTurnWhenReady`), deliver and submit as two **separated, confirmed** steps:

1. **Paste only** — new `pasteToPane` primitive (no Enter).
2. **Settle** — poll the input box until its content stops changing across two reads (the paste-accumulation window has closed).
3. **Submit** — a separate `sendKeyToPane(pane, "Enter")`.
4. **Confirm** by read-back: input box empty ⇒ submitted. If it still holds the draft, re-issue **only the Enter** (after re-settling) — **never re-paste** (re-pasting is what stacks placeholders). Bounded attempts.

Submission is confirmed by the **input box going empty**, not by "screen changed" — the paste itself changes the screen, so the old screen-changed check would mistake a stranded paste for a submit.

`sendToPane` is refactored to `pasteToPane` + `sendKeyToPane("Enter")` — behaviour identical for its existing callers (short shell-launch, `crew send`). The **opencode splash path (#235)** is unchanged.

## Tests & gates

- New unit tests in `crew-pane.test.ts`: pastes once + submits via a separate Enter; re-issues **only** Enter when stranded (never re-pastes); does not treat the paste landing as a submit. opencode splash tests unchanged and green.
- `tsc -b` clean · `tsup` clean · `node dist/index.js --help` works.
- Full suite: **1585 passed**.
- **Live proof (real built code via `sendFirstTurnWhenReady`, fresh claude surface per spawn, large multi-line first-turn payload):** 5/5 submitted, **0 stuck-in-box**.

## Scope note

opencode (different TUI, no `[Pasted text]` coalescing) keeps its #235 splash logic. A *large* follow-up `crew send` could in theory hit the same paste race (it uses the unchanged atomic `sendToPane`), but follow-up sends are short in practice and submit reliably; generalizing the confirmed-submit primitive to all sends is a possible follow-up.
