### PR TITLE
release: v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-06-26
+
+### Fixed
+
+- Crew first-turn could silently strand unsubmitted: a large first-turn payload pushed Claude Code into bracketed-paste mode, so the submit Enter landed as a literal newline inside the paste instead of submitting — the crew sat at 0% with the task stuck in its input box. First-turn delivery now pastes, waits for the paste window to settle, sends a separate confirmed Enter, and re-issues only Enter (never re-pastes) if still unsubmitted. ([#339], [#447])
+- Large follow-up `squadrant crew send` messages could strand the same way (the atomic send path hit the identical paste race). The confirmed-submit sequence is now extracted into a shared helper and applied to the follow-up send path too. ([#448], [#449])
+
+### Changed
+
+- The built-in default crew model is now sonnet (was opus); opus remains opt-in via the extreme routing tier or an explicit `--model opus`. This matches the intended tokenomics, makes fresh installs default to sonnet, and resolves the recurring config-drift advisory on upgrade. ([#446])
+
 ## [0.12.0] - 2026-06-26
 
 ### Added
@@ -770,3 +781,9 @@ GitHub-driven automation.
 - P0 roadmap items marked complete; out-of-repo work moved out.
 
 [0.2.0]: https://github.com/tu11aa/claude-cockpit/releases/tag/v0.2.0
+
+[#339]: https://github.com/tu11aa/squadrant/issues/339
+[#446]: https://github.com/tu11aa/squadrant/pull/446
+[#447]: https://github.com/tu11aa/squadrant/pull/447
+[#448]: https://github.com/tu11aa/squadrant/issues/448
+[#449]: https://github.com/tu11aa/squadrant/pull/449

--- a/docs/reports/2026-06-26-dbg-339-enter-not-submitting-rootcause.md
+++ b/docs/reports/2026-06-26-dbg-339-enter-not-submitting-rootcause.md
@@ -1,0 +1,86 @@
+# #339 — first-turn Enter inserts a newline instead of submitting — ROOT CAUSE PROVEN ✅
+
+**Date:** 2026-06-26
+**Branch:** `crew/fix-339`
+**Method:** superpowers:systematic-debugging — live reproduction against a real Claude Code surface before any fix.
+
+---
+
+## Symptom
+
+A crew first-turn (or captain Enter) intermittently leaves the full payload sitting
+**unsubmitted** in the input box, prefixed `❯ [Pasted text #1][Pasted text #2][Pasted
+text #3]…` — multiple pastes, **zero submits**, `Ctx Used 0.0%`. The turn never runs.
+Reported several times a day. Prior triage (`2026-06-16-dbg-cmux-double-startup-and-enter-newline.md`)
+could not reproduce it in isolation and ruled out: content newlines, the plain
+send+Enter race (15/15 clean on short messages), working-state delivery, and the
+#302 backspace probe.
+
+## What the prior triage missed: the payload SIZE is the trigger
+
+Short messages (captain DONE, ≤200 char) submit 15/15 — they never enter Claude
+Code's **paste mode**. The first-turn *task* payload (`task + "\n\n" + completionProtocol`,
+collapsed to one line by `sanitizeForCmuxSend`) is **thousands of characters**. That
+is what triggers the bug. The differentiator is paste-mode, not content.
+
+## Delivery path
+
+`sendFirstTurnWhenReady` (`packages/workspaces/src/crew-pane.ts`) → `sendToPane`
+(`packages/workspaces/src/runtimes/cmux.ts:431`):
+
+```ts
+await cmux(["send",     ..., sanitizeForCmuxSend(message)]);  // socket write #1: the text
+await cmux(["send-key", ..., "Enter"]);                       // socket write #2: the CR
+```
+
+Two separate socket writes. On retry, `sendFirstTurnWhenReady` re-calls `sendToPane`
+— i.e. it **re-pastes the entire task** and issues another Enter.
+
+## Live experiments (real `claude --model sonnet` surface, driven via cmux CLI)
+
+| # | Stimulus | Result |
+|---|----------|--------|
+| 1 | 3 298-char single-line payload, immediate `send`+`send-key Enter` | Rendered **inline**, **submitted** cleanly. No paste mode at this size. |
+| 2 | 8 912-char payload, `send` only (no Enter) | Box shows `❯ … [Pasted text #2][Pasted text #3]…[Pasted text #9] …` — **paste-mode reproduced**. cmux/PTY chunks a big `send`; Claude Code coalesces the chunks into `[Pasted text #N]` placeholders. |
+| 3 | After #2, wait ~2 s for the box to settle, **then** `send-key Enter` | **Submitted** (box emptied, turn started). A settled Enter always submits. |
+| 4 | 8 912-char payload + trailing `\n` in **one** `cmux send` (CR coalesced into the paste burst) | **STRANDED.** Box not empty, not working; the CR landed as a literal newline *inside* the paste: `…[Pasted text\n  #82]…`. **Deterministic proof of the mechanism.** |
+| 5 | On the stranded box from #4, re-issue **only** `send-key Enter` (no re-paste) | **Submitted** — the box emptied. Validates the fix: re-issue the CR, never re-paste. |
+| 6 | Immediate `send`+`send-key Enter`, 8 912-char, ×10 trials, quiet machine | 9 submitted / 1 inconclusive / 0 stranded — the per-Enter race is **low-probability when unloaded** (matches "not reproducible in isolation"). |
+
+## Root cause
+
+The first-turn payload is large enough to put Claude Code into **paste mode**: cmux/PTY
+delivers the big `send` as multiple chunks and Claude Code coalesces them into
+`[Pasted text #N]` placeholders, keeping a short **paste-accumulation window** open.
+
+`sendToPane` issues the submit CR as a *separate* socket write immediately after the
+paste. When that CR is consumed by Claude Code **while the paste-accumulation window
+is still open** — which happens when the two socket writes land in a single PTY read
+under load, or when the CR simply arrives before the paste finishes rendering — Claude
+Code treats the CR as a **literal newline appended to the pasted text**, not as a
+submit. The payload is stranded (experiment #4 reproduces this exactly).
+
+The current **retry makes it worse**: it re-calls `sendToPane`, **re-pasting the whole
+task** (stacking another `[Pasted text]`) and racing another CR the same way. Once
+stranding conditions hold across the ~1.5 s retry window, every attempt strands →
+"3 pastes, 0 submits."
+
+This explains every observation: short messages never strand (below paste threshold,
+15/15), the large first-turn task strands under load, and all retries strand together.
+
+## Fix (see PR)
+
+Deliver the task and submit it as **two separated, confirmed** steps in the
+claude/codex first-turn path (`sendFirstTurnWhenReady`):
+
+1. **Paste only** (`pasteToPane`, no Enter).
+2. **Settle** — poll the input box until its content is stable across two reads (the
+   paste-accumulation window has closed).
+3. **Submit** with a separate `sendKeyToPane(pane, "Enter")`.
+4. **Confirm** via read-back: the input box is empty ⇒ submitted. If the box still
+   holds the draft, re-issue **only the Enter** (re-settle first) — **never re-paste**
+   (re-pasting is what stacks `[Pasted text]` placeholders). Bounded attempts.
+
+The opencode splash path (#235, recently live-verified) is **left unchanged**. The
+short shell-launch and crew-message `sendToPane` callers are **left unchanged** (they
+are below the paste threshold and rely on the atomic send+Enter).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "squadrant",
   "packageManager": "pnpm@10.30.3",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Multi-project orchestration for your coding agents (Claude, Codex, opencode, Gemini)",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/__tests__/config.test.ts
+++ b/packages/cli/src/commands/__tests__/config.test.ts
@@ -46,7 +46,7 @@ describe("runConfigCheck", () => {
   });
 
   it("--fix does NOT stamp when advisory/invalid drift remains", () => {
-    writeUser((c) => { (c.defaults.roles as any).crew = { agent: "claude", model: "sonnet" }; });
+    writeUser((c) => { (c.defaults.roles as any).crew = { agent: "claude", model: "opus" }; });
     const res = runConfigCheck({ configPath: cfgPath, pkgVersion: "0.5.3", fix: true, accept: false });
     const onDisk = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
     expect(onDisk._squadrantVersion).toBeUndefined();
@@ -54,11 +54,11 @@ describe("runConfigCheck", () => {
   });
 
   it("--accept stamps without changing config", () => {
-    writeUser((c) => { (c.defaults.roles as any).crew = { agent: "claude", model: "sonnet" }; });
+    writeUser((c) => { (c.defaults.roles as any).crew = { agent: "claude", model: "opus" }; });
     runConfigCheck({ configPath: cfgPath, pkgVersion: "0.5.3", fix: false, accept: true });
     const onDisk = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
     expect(onDisk._squadrantVersion).toBe("0.5.3");
-    expect(onDisk.defaults.roles.crew.model).toBe("sonnet");
+    expect(onDisk.defaults.roles.crew.model).toBe("opus");
   });
 });
 

--- a/packages/cli/src/commands/__tests__/crew.test.ts
+++ b/packages/cli/src/commands/__tests__/crew.test.ts
@@ -56,6 +56,9 @@ vi.mock("@squadrant/workspaces", () => ({
   sendFirstTurnWhenReady: async (_runtime: unknown, pane: unknown, task: string) => {
     await sendToPane(pane, task);
   },
+  confirmedSendToPane: async (_runtime: unknown, pane: unknown, msg: string) => {
+    await sendToPane(pane, msg);
+  },
   getFreePort: vi.fn().mockResolvedValue(12345),
 }));
 

--- a/packages/cli/src/commands/crew.ts
+++ b/packages/cli/src/commands/crew.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { loadConfig, resolveTextInput } from "@squadrant/shared";
 import type { PanePlacement } from "@squadrant/shared";
-import { createCmuxDriver, RuntimeRegistry, resolveCaptainWorkspace, sendFirstTurnWhenReady, getFreePort } from "@squadrant/workspaces";
+import { createCmuxDriver, RuntimeRegistry, resolveCaptainWorkspace, sendFirstTurnWhenReady, confirmedSendToPane, getFreePort } from "@squadrant/workspaces";
 import { CapabilityRegistry, createClaudeDriver, createCodexDriver, createGeminiDriver, createOpencodeDriver } from "@squadrant/agents";
 import {
   runCrewSpawn as coreRunCrewSpawn,
@@ -62,6 +62,9 @@ export async function runCrewSend(project: string, name: string, message: string
   return coreRunCrewSend(project, name, message, runtime, workspaceId, {
     listTasks: async (p) => (await squadrantdCall({ kind: "list", project: p })) as TaskRecord[],
     emitEvent: async (p, event) => { await squadrantdCall({ kind: "event", project: p, event }); },
+    // #448: use paste-settle-Enter confirmation for follow-up sends (same guard
+    // as first-turn #447) so large messages don't strand in paste mode.
+    sendToPane: (pane, msg) => confirmedSendToPane(runtime, pane, msg),
   });
 }
 

--- a/packages/core/src/__tests__/crew-spawn.test.ts
+++ b/packages/core/src/__tests__/crew-spawn.test.ts
@@ -462,6 +462,21 @@ describe("runCrewSend", () => {
     });
     expect(runtime.sendToPane).toHaveBeenCalledWith(expect.anything(), "msg");
   });
+
+  // #448: when deps.sendToPane is injected, it is used instead of runtime.sendToPane
+  // so the CLI can supply the paste-settle-Enter confirmed-submit helper.
+  it("uses deps.sendToPane when provided, bypassing runtime.sendToPane", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:crew-1" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    const injectedSend = vi.fn().mockResolvedValue(undefined);
+    await runCrewSend(PROJECT, "crew-1", "big message", runtime, "workspace:1", {
+      listTasks: vi.fn().mockResolvedValue([]),
+      emitEvent: vi.fn(),
+      sendToPane: injectedSend,
+    });
+    expect(injectedSend).toHaveBeenCalledWith(expect.anything(), "big message");
+    expect(runtime.sendToPane).not.toHaveBeenCalled();
+  });
 });
 
 // ─── runCrewRead ─────────────────────────────────────────────────────────────

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -404,6 +404,11 @@ export async function runCrewSend(
   deps: {
     listTasks(project: string): Promise<TaskRecord[]>;
     emitEvent(project: string, event: ControlEvent): Promise<void>;
+    // Optional confirmed-submit override (#448). When provided, used instead of
+    // runtime.sendToPane so the caller can inject paste-settle-Enter hardening.
+    // Falls back to runtime.sendToPane when absent (preserves existing behaviour
+    // for callers that don't inject it, e.g. unit tests).
+    sendToPane?: (pane: PaneRef, message: string) => Promise<void>;
   },
 ): Promise<void> {
   const crew = await findCrewPane(runtime, workspaceId, project, name);
@@ -428,7 +433,8 @@ export async function runCrewSend(
     // Swallow daemon errors so crews without a daemon or offline daemon
     // still receive the sent message.
   }
-  await runtime.sendToPane(crew, message);
+  const deliver = deps.sendToPane ?? ((pane, msg) => runtime.sendToPane(pane, msg));
+  await deliver(crew, message);
 }
 
 export async function runCrewRead(

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -150,14 +150,14 @@ export function getDefaultConfig(): SquadrantConfig {
       models: {
         command: "opus",
         captain: "opus",
-        crew: "opus",
+        crew: "sonnet",
         exploration: "haiku",
         review: "opus",
       },
       roles: {
         command: { agent: "claude", model: "opus" },
         captain: { agent: "claude", model: "opus" },
-        crew: { agent: "claude", model: "opus" },
+        crew: { agent: "claude", model: "sonnet" },
         exploration: { agent: "claude", model: "haiku" },
         side: { agent: "claude", model: "opus" },
       },

--- a/packages/shared/src/lib/__tests__/config-drift.test.ts
+++ b/packages/shared/src/lib/__tests__/config-drift.test.ts
@@ -50,12 +50,12 @@ describe("detectDrift \u2014 deprecated", () => {
 describe("detectDrift \u2014 changed-default", () => {
   it("flags a field whose value equals the OLD default but the default changed", () => {
     const u = userConfig();
-    (u.defaults.roles as any).crew = { agent: "claude", model: "sonnet" };
+    (u.defaults.roles as any).crew = { agent: "claude", model: "opus" };
     const items = detectDrift(u, getDefaultConfig());
     const cd = items.find((i) => i.kind === "changed-default" && i.path === "defaults.roles.crew.model");
     expect(cd).toBeDefined();
     expect(cd?.severity).toBe("advisory");
-    expect(cd?.suggested).toBe("opus");
+    expect(cd?.suggested).toBe("sonnet");
   });
 
   it("does NOT flag a field the user customized to a third value", () => {

--- a/packages/shared/src/lib/__tests__/config.test.ts
+++ b/packages/shared/src/lib/__tests__/config.test.ts
@@ -51,12 +51,12 @@ describe("config", () => {
     const config = getDefaultConfig();
     expect(config.defaults.roles).toBeDefined();
     expect(config.defaults.roles!.command).toEqual({ agent: "claude", model: "opus" });
-    expect(config.defaults.roles!.crew).toEqual({ agent: "claude", model: "opus" });
+    expect(config.defaults.roles!.crew).toEqual({ agent: "claude", model: "sonnet" });
   });
 
-  it("defaults crews to opus + auto permission mode", () => {
+  it("defaults crews to sonnet + auto permission mode", () => {
     const config = getDefaultConfig();
-    expect(config.defaults.models!.crew).toBe("opus");
+    expect(config.defaults.models!.crew).toBe("sonnet");
     expect(config.defaults.permissions.crew).toBe("auto");
   });
 

--- a/packages/shared/src/lib/config-drift.ts
+++ b/packages/shared/src/lib/config-drift.ts
@@ -35,7 +35,7 @@ const KNOWN_DEPRECATED: Array<{ path: string; when?: (u: SquadrantConfig) => boo
 ];
 
 const KNOWN_DEFAULT_HISTORY: Array<{ path: string; oldDefaults: unknown[] }> = [
-  { path: "defaults.roles.crew.model", oldDefaults: ["sonnet"] },
+  { path: "defaults.roles.crew.model", oldDefaults: ["opus"] },
   { path: "defaults.roles.captain.model", oldDefaults: ["sonnet"] },
 ];
 

--- a/packages/shared/src/types/runtime.ts
+++ b/packages/shared/src/types/runtime.ts
@@ -50,6 +50,13 @@ export interface RuntimeDriver {
   newPane(opts: RuntimePaneOptions): Promise<PaneRef>;
   closePane(pane: PaneRef): Promise<void>;
   sendToPane(pane: PaneRef, message: string): Promise<void>; // sends text + Enter
+  // Paste text into a pane WITHOUT committing it (no Enter). Pairs with
+  // sendKeyToPane to submit as a separate, settled keystroke — required for the
+  // #339 first-turn fix, where bundling the CR with a large paste lets Claude
+  // Code absorb it as a newline inside the [Pasted text] placeholder.
+  pasteToPane(pane: PaneRef, text: string): Promise<void>;
+  // Send a single literal key press to a pane (e.g. "Enter").
+  sendKeyToPane(pane: PaneRef, key: string): Promise<void>;
   readPaneScreen(pane: PaneRef): Promise<string>;
   // List all surfaces (tabs/panes) inside a workspace, with their titles.
   // Used to find named crews by tab title (#56).

--- a/packages/workspaces/src/__tests__/crew-pane.test.ts
+++ b/packages/workspaces/src/__tests__/crew-pane.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { sendFirstTurnWhenReady } from "../crew-pane.js";
+import { sendFirstTurnWhenReady, confirmedSendToPane } from "../crew-pane.js";
 import type { PaneRef } from "@squadrant/shared";
 
 // Realistic Claude-Code-style screen: the live input box is the region between the
@@ -200,5 +200,86 @@ describe("sendFirstTurnWhenReady — post-send acceptance retry", () => {
     // Initial send + 2 re-sends (at checks 3 and 7), then accepted at check 8
     expect(sendToPane).toHaveBeenCalledTimes(3);
     expect(sendToPane).toHaveBeenCalledWith(pane, "do the thing");
+  });
+});
+
+// ─── confirmedSendToPane (#448 follow-up send hardening) ─────────────────────
+
+describe("confirmedSendToPane — follow-up crew send (#448)", () => {
+  let readPaneScreen: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
+  const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, pasteToPane, sendKeyToPane });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    readPaneScreen = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Core contract: same as first-turn — paste once, separate Enter, no bundled CR.
+  it("pastes the message once and submits with a separate Enter — never via send+Enter", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n === 1) return box("");           // preSendScreen capture
+      if (n <= 3) return DRAFT_BOX;          // settle: paste landed
+      return EMPTY_BOX;                       // post-Enter: submitted
+    });
+
+    const promise = confirmedSendToPane(rt(), pane, "follow-up message");
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(pasteToPane).toHaveBeenCalledTimes(1);
+    expect(pasteToPane).toHaveBeenCalledWith(pane, "follow-up message");
+    expect(sendKeyToPane).toHaveBeenCalledWith(pane, "Enter");
+  });
+
+  // #448 regression: when the first Enter is absorbed (box still holds draft),
+  // re-issue ONLY Enter — never re-paste the message.
+  it("re-issues ONLY Enter when the first submit is stranded — never re-pastes", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n === 1) return box("");           // preSendScreen
+      if (n <= 3) return DRAFT_BOX;          // settle
+      if (n === 4) return DRAFT_BOX;         // post-Enter#1: stranded
+      if (n <= 6) return DRAFT_BOX;          // re-settle
+      return EMPTY_BOX;                       // post-Enter#2: submitted
+    });
+
+    const promise = confirmedSendToPane(rt(), pane, "big message");
+    await vi.advanceTimersByTimeAsync(5000);
+    await promise;
+
+    expect(pasteToPane).toHaveBeenCalledTimes(1);
+    expect(sendKeyToPane).toHaveBeenCalledTimes(2);
+    expect(sendKeyToPane).toHaveBeenCalledWith(pane, "Enter");
+  });
+
+  // Short sends must not block waiting for the settle window — the box goes
+  // empty immediately (no paste-mode coalescing) and we return on the first check.
+  it("submits a short message on the first confirmation check", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n === 1) return box("");           // preSendScreen
+      if (n === 2) return EMPTY_BOX;         // settle: no paste coalescing (empty = stable immediately)
+      return EMPTY_BOX;                       // post-Enter: submitted
+    });
+
+    const promise = confirmedSendToPane(rt(), pane, "hi");
+    await vi.advanceTimersByTimeAsync(2000);
+    await promise;
+
+    expect(pasteToPane).toHaveBeenCalledTimes(1);
+    expect(sendKeyToPane).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/workspaces/src/__tests__/crew-pane.test.ts
+++ b/packages/workspaces/src/__tests__/crew-pane.test.ts
@@ -2,148 +2,119 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { sendFirstTurnWhenReady } from "../crew-pane.js";
 import type { PaneRef } from "@squadrant/shared";
 
-describe("sendFirstTurnWhenReady", () => {
+// Realistic Claude-Code-style screen: the live input box is the region between the
+// last two horizontal rules. parseDraftFromScreen reads exactly that region, so the
+// #339 fix can use box-empty (submitted) vs box-holds-draft (stranded) as its
+// confirmation signal instead of the fragile "screen changed" heuristic.
+const HR = "─".repeat(60);
+const box = (content: string) =>
+  `…transcript…\n${HR}\n❯ ${content}\n${HR}\n   Model: Sonnet 4.6  Ctx Used: 0.0%`;
+const EMPTY_BOX = box("");                 // parseDraftFromScreen → "" (submitted)
+const DRAFT_BOX = box("[Pasted text #1]"); // parseDraftFromScreen → draft  (stranded)
+
+describe("sendFirstTurnWhenReady — claude/codex first-turn (#339)", () => {
   let readPaneScreen: ReturnType<typeof vi.fn>;
   let sendToPane: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
   const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, sendToPane, pasteToPane, sendKeyToPane });
 
   beforeEach(() => {
     vi.useFakeTimers();
     readPaneScreen = vi.fn();
     sendToPane = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
   });
 
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it("polls until pane stabilizes then sends the task once", async () => {
-    let callCount = 0;
+  // #339: the submit CR must be a SEPARATE keystroke issued after the paste settles —
+  // never bundled into the paste send (which is how the CR gets absorbed as a newline
+  // inside the [Pasted text] placeholder). The whole task is pasted exactly once.
+  it("pastes the task once, then submits with a separate Enter — never via send+Enter", async () => {
+    let n = 0;
     readPaneScreen.mockImplementation(async () => {
-      callCount++;
-      if (callCount <= 1) return "";
-      if (callCount <= 3) return "> ";        // stable prompt, advanced past launch
-      if (callCount === 4) return "> ";       // preSend snapshot
-      return "> do the thing";                // after-send: screen changed → no re-send
+      n++;
+      if (n <= 3) return EMPTY_BOX;  // readiness polls + preSend snapshot
+      if (n <= 5) return DRAFT_BOX;  // settle: paste rendered, box holds the draft
+      return EMPTY_BOX;              // post-Enter: box empty → submitted
     });
 
-    const promise = sendFirstTurnWhenReady(
-      { readPaneScreen, sendToPane },
-      pane,
-      "do the thing",
-      "$ launch",
-    );
-
-    await vi.advanceTimersByTimeAsync(4000);
+    const promise = sendFirstTurnWhenReady(rt(), pane, "do the big thing", "$ launch");
+    await vi.advanceTimersByTimeAsync(6000);
     await promise;
 
-    expect(sendToPane).toHaveBeenCalledTimes(1);
-    expect(sendToPane).toHaveBeenCalledWith(pane, "do the thing");
-  });
-
-  it("falls back to sending even if pane never stabilises", async () => {
-    readPaneScreen.mockResolvedValue("");
-
-    const promise = sendFirstTurnWhenReady(
-      { readPaneScreen, sendToPane },
-      pane,
-      "do the thing",
-      "$ launch",
-    );
-
-    await vi.advanceTimersByTimeAsync(21000);
-    await promise;
-
-    // Two calls: fallback send + one re-send (post-send check sees an unchanged screen)
-    expect(sendToPane).toHaveBeenCalledTimes(2);
-    expect(sendToPane).toHaveBeenNthCalledWith(1, pane, "do the thing");
-    expect(sendToPane).toHaveBeenNthCalledWith(2, pane, "do the thing");
-  }, 15000);
-
-  it("re-sends once when the screen is unchanged after the first send", async () => {
-    readPaneScreen.mockResolvedValue("> ");
-
-    const promise = sendFirstTurnWhenReady(
-      { readPaneScreen, sendToPane },
-      pane,
-      "do the thing",
-      "$ launch",
-    );
-
-    await vi.advanceTimersByTimeAsync(5000);
-    await promise;
-
-    // Two calls: initial send + one re-send (preSend === afterScreen)
-    expect(sendToPane).toHaveBeenCalledTimes(2);
-    expect(sendToPane).toHaveBeenNthCalledWith(1, pane, "do the thing");
-    expect(sendToPane).toHaveBeenNthCalledWith(2, pane, "do the thing");
-  });
-
-  // #168: sendToPane (since #136) collapses newlines to spaces, so a multi-line
-  // task never appears verbatim in the pane render. The old post-send check
-  // `!afterScreen.includes(task)` therefore always re-sent → duplicate first
-  // turn. The fix compares the screen before vs after sending instead.
-  it("does NOT re-send a multi-line task when the pane render collapses newlines", async () => {
-    const task = "line one\nline two\nline three";
-    let callCount = 0;
-    readPaneScreen.mockImplementation(async () => {
-      callCount++;
-      // reads 1-2: poll (stable), read 3: preSend snapshot — all the bare prompt.
-      if (callCount <= 3) return "> ";
-      return "> line one line two line three";               // after-send: collapsed render
-    });
-
-    const promise = sendFirstTurnWhenReady(
-      { readPaneScreen, sendToPane },
-      pane,
-      task,
-      "$ launch",
-    );
-
-    await vi.advanceTimersByTimeAsync(4000);
-    await promise;
-
-    // The screen changed after the send (task was received), so no re-send —
-    // even though `afterScreen.includes(task)` is false for the multi-line task.
-    expect(sendToPane).toHaveBeenCalledTimes(1);
-    expect(sendToPane).toHaveBeenCalledWith(pane, task);
-  });
-
-  // opencode boot-race: the screen can be momentarily static while the launch
-  // command still sits un-entered on the shell line. Sending then concatenates
-  // onto that line → shell parse error. The readiness gate must require the
-  // screen to ADVANCE past the launch-line snapshot, not merely be static.
-  it("does NOT send the first turn while the pane still shows the un-entered launch line", async () => {
-    const launchLine = "$ SQUADRANT_CREW_TASK_ID=t1 opencode";
-    readPaneScreen.mockResolvedValue(launchLine);
-
-    const promise = sendFirstTurnWhenReady(
-      { readPaneScreen, sendToPane },
-      pane,
-      "do the thing",
-      launchLine,
-    );
-
-    // Well under the 20s timeout: the screen never advanced past the launch
-    // line, so the readiness gate must not have fired yet.
-    await vi.advanceTimersByTimeAsync(5000);
+    expect(pasteToPane).toHaveBeenCalledTimes(1);
+    expect(pasteToPane).toHaveBeenCalledWith(pane, "do the big thing");
+    expect(sendKeyToPane).toHaveBeenCalledWith(pane, "Enter");
     expect(sendToPane).not.toHaveBeenCalled();
+  });
 
-    // Drain to the timeout so the fallback send fires and the promise resolves.
+  // #339 core regression: when the first Enter is absorbed as a newline (box still
+  // holds the paste), the retry re-issues ONLY the Enter — it must NOT re-paste the
+  // task (re-pasting is what stacks [Pasted text #1][#2][#3] and never submits).
+  it("re-issues ONLY Enter when the first submit is stranded — never re-pastes", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n <= 3) return EMPTY_BOX;  // readiness + preSend
+      if (n <= 5) return DRAFT_BOX;  // settle after paste
+      if (n === 6) return DRAFT_BOX; // post-Enter#1: STILL holds draft → stranded
+      if (n <= 8) return DRAFT_BOX;  // re-settle before Enter#2
+      return EMPTY_BOX;              // post-Enter#2: submitted
+    });
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "do the big thing", "$ launch");
+    await vi.advanceTimersByTimeAsync(8000);
+    await promise;
+
+    expect(pasteToPane).toHaveBeenCalledTimes(1); // paste exactly ONCE, ever
+    expect(sendKeyToPane).toHaveBeenCalledTimes(2); // Enter, then re-Enter
+    expect(sendKeyToPane).toHaveBeenCalledWith(pane, "Enter");
+    expect(sendToPane).not.toHaveBeenCalled();
+  });
+
+  // Submission is confirmed by the input box going empty, NOT by "screen changed" —
+  // the paste itself changes the screen, so screen-changed would falsely report a
+  // stranded paste as submitted.
+  it("does not treat the paste landing in the box as a successful submit", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n <= 3) return EMPTY_BOX;  // readiness + preSend
+      return DRAFT_BOX;              // paste landed but box NEVER empties → never submits
+    });
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "do the big thing", "$ launch");
     await vi.advanceTimersByTimeAsync(20000);
     await promise;
-  }, 15000);
+
+    // Box never empties, so the retry loop keeps re-issuing Enter (≥2) and still
+    // never re-pastes. The point: it did not early-return on the paste-changed screen.
+    expect(pasteToPane).toHaveBeenCalledTimes(1);
+    expect(sendKeyToPane.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(sendToPane).not.toHaveBeenCalled();
+  });
 });
 
 describe("sendFirstTurnWhenReady — post-send acceptance retry", () => {
   let readPaneScreen: ReturnType<typeof vi.fn>;
   let sendToPane: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
   const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, sendToPane, pasteToPane, sendKeyToPane });
 
   beforeEach(() => {
     vi.useFakeTimers();
     readPaneScreen = vi.fn();
     sendToPane = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
   });
 
   afterEach(() => {
@@ -158,7 +129,7 @@ describe("sendFirstTurnWhenReady — post-send acceptance retry", () => {
     readPaneScreen.mockResolvedValue("Ask anything…");
 
     const promise = sendFirstTurnWhenReady(
-      { readPaneScreen, sendToPane },
+      rt(),
       pane,
       "do the thing",
       "$ opencode",
@@ -185,7 +156,7 @@ describe("sendFirstTurnWhenReady — post-send acceptance retry", () => {
     });
 
     const promise = sendFirstTurnWhenReady(
-      { readPaneScreen, sendToPane },
+      rt(),
       pane,
       "do the thing",
       "booting…",
@@ -215,7 +186,7 @@ describe("sendFirstTurnWhenReady — post-send acceptance retry", () => {
     });
 
     const promise = sendFirstTurnWhenReady(
-      { readPaneScreen, sendToPane },
+      rt(),
       pane,
       "do the thing",
       "$ opencode",

--- a/packages/workspaces/src/crew-pane.ts
+++ b/packages/workspaces/src/crew-pane.ts
@@ -6,7 +6,7 @@ import net from "node:net";
 import { loadConfig } from "@squadrant/shared";
 import type { PaneRef, RuntimeDriver } from "@squadrant/shared";
 import { RuntimeRegistry } from "./runtimes/registry.js";
-import { createCmuxDriver } from "./runtimes/cmux.js";
+import { createCmuxDriver, parseDraftFromScreen } from "./runtimes/cmux.js";
 import { titleFor, isCrewTitle, isTurnAccepted } from "@squadrant/core";
 import type { TurnAcceptanceConfig } from "@squadrant/core";
 
@@ -22,6 +22,30 @@ const POST_SEND_CHECK_MS = 750;
 // slow to redraw after accepting.
 const SPLASH_MAX_CHECKS = 20;    // 20 × 750ms ≈ 15s confirmation window
 const SPLASH_RESEND_EVERY_N = 4; // re-send every 4 checks ≈ every 3s
+
+// #339 paste-then-submit constants for the claude/codex first-turn path.
+// SETTLE polls the input box after the paste until its content stops changing —
+// i.e. Claude Code's paste-accumulation window has closed — so the submit CR is a
+// separate keystroke that lands AFTER the [Pasted text] placeholder is final and
+// is therefore treated as a submit, not a literal newline inside the paste.
+const SETTLE_POLL_MS = 400;
+const SETTLE_MAX_POLLS = 8;        // up to 3.2s for a very large paste to render
+const SUBMIT_RETRY_LIMIT = 4;      // Enter-only re-issues if the box stays stranded
+
+/** Poll the pane until its input box stops changing across two consecutive reads
+ *  (paste fully rendered / accumulation window closed), or the cap is hit. */
+async function settleInputBox(
+  runtime: Pick<RuntimeDriver, "readPaneScreen">,
+  pane: PaneRef,
+): Promise<void> {
+  let prev = (await runtime.readPaneScreen(pane)) ?? "";
+  for (let i = 0; i < SETTLE_MAX_POLLS; i++) {
+    await new Promise((r) => setTimeout(r, SETTLE_POLL_MS));
+    const cur = (await runtime.readPaneScreen(pane)) ?? "";
+    if (cur === prev) return;
+    prev = cur;
+  }
+}
 
 /** Reserve an ephemeral TCP port for a crew's embedded HTTP server. Binds :0,
  *  reads the OS-assigned port, then releases it. A small TOCTOU window exists
@@ -79,7 +103,7 @@ export async function resolveCaptainWorkspace(project: string): Promise<{
 }
 
 export async function sendFirstTurnWhenReady(
-  runtime: Pick<RuntimeDriver, "readPaneScreen" | "sendToPane">,
+  runtime: Pick<RuntimeDriver, "readPaneScreen" | "sendToPane" | "pasteToPane" | "sendKeyToPane">,
   pane: PaneRef,
   task: string,
   preLaunchScreen: string,
@@ -115,7 +139,6 @@ export async function sendFirstTurnWhenReady(
   // multi-line task never appears verbatim in the single-line pane render and
   // the check would always re-send a duplicate first turn (#168).
   const preSendScreen = (await runtime.readPaneScreen(pane)) ?? "";
-  await runtime.sendToPane(pane, task);
 
   // Confirm-on-delivery (#235): poll until the TUI confirms it accepted the turn.
   if (acceptanceConfig?.splashMarker) {
@@ -123,6 +146,10 @@ export async function sendFirstTurnWhenReady(
     // consumes the message. We check every POST_SEND_CHECK_MS but re-send only
     // every SPLASH_RESEND_EVERY_N checks — a 3s de-dup guard that prevents
     // duplicate task execution when the TUI is slow to redraw after accepting.
+    // opencode's TUI does not collapse pastes into placeholders, so the atomic
+    // send+Enter (sendToPane) is correct here and must stay (it was just fixed
+    // and live-verified in #235). The #339 paste race is claude-specific.
+    await runtime.sendToPane(pane, task);
     for (let check = 0; check < SPLASH_MAX_CHECKS; check++) {
       await new Promise((r) => setTimeout(r, POST_SEND_CHECK_MS));
       const afterScreen = (await runtime.readPaneScreen(pane)) ?? "";
@@ -133,18 +160,34 @@ export async function sendFirstTurnWhenReady(
         await runtime.sendToPane(pane, task);
       }
     }
-  } else {
-    // Screen-changed path (claude/codex): acceptance = the screen changed.
-    const retryLimit = acceptanceConfig?.retryLimit ?? 2;
-    for (let attempt = 0; attempt < retryLimit; attempt++) {
-      await new Promise((r) => setTimeout(r, POST_SEND_CHECK_MS));
-      const afterScreen = (await runtime.readPaneScreen(pane)) ?? "";
-      if (isTurnAccepted(preSendScreen, afterScreen, acceptanceConfig)) {
-        return;
-      }
-      if (attempt < retryLimit - 1) {
-        await runtime.sendToPane(pane, task);
-      }
-    }
+    return;
+  }
+
+  // Claude/codex path (#339): paste the task, let the [Pasted text] placeholder
+  // settle, THEN submit with a separate Enter. Bundling the CR with the paste
+  // (the old sendToPane) lets Claude Code absorb it as a literal newline inside
+  // the placeholder under load, stranding the whole turn unsubmitted. We confirm
+  // the submit by the input box going empty — NOT by "screen changed", because
+  // the paste itself changes the screen. If the box is still holding the draft we
+  // re-issue ONLY the Enter (after re-settling) and NEVER re-paste — re-pasting is
+  // exactly what stacks [Pasted text #1][#2][#3] and never submits.
+  await runtime.pasteToPane(pane, task);
+  await settleInputBox(runtime, pane);
+  await runtime.sendKeyToPane(pane, "Enter");
+
+  const retryLimit = acceptanceConfig?.retryLimit ?? SUBMIT_RETRY_LIMIT;
+  for (let attempt = 0; attempt < retryLimit; attempt++) {
+    await new Promise((r) => setTimeout(r, POST_SEND_CHECK_MS));
+    const afterScreen = (await runtime.readPaneScreen(pane)) ?? "";
+    const draft = parseDraftFromScreen(afterScreen);
+    // Box confirmed empty → the draft left the input box → submitted.
+    if (draft === "") return;
+    // Box not parseable (e.g. an agent TUI without the HR-bounded box, or a
+    // transient overlay): fall back to the screen-changed signal so non-claude
+    // TUIs aren't worse off than before.
+    if (draft === null && afterScreen !== preSendScreen) return;
+    // Still stranded — re-settle and re-issue ONLY the Enter (never re-paste).
+    await settleInputBox(runtime, pane);
+    await runtime.sendKeyToPane(pane, "Enter");
   }
 }

--- a/packages/workspaces/src/crew-pane.ts
+++ b/packages/workspaces/src/crew-pane.ts
@@ -102,6 +102,36 @@ export async function resolveCaptainWorkspace(project: string): Promise<{
   return { runtime, workspaceId: captain.id };
 }
 
+/**
+ * Deliver a message to a crew pane with the paste-settle-Enter confirmation
+ * sequence from #447. Shared by the follow-up `crew send` path (#448) and
+ * available for first-turn use — both call the same submit hardening:
+ *   1. paste only (no bundled CR)
+ *   2. settle until the input box content stops changing (accumulation closed)
+ *   3. separate Enter keystroke
+ *   4. confirm box empty; re-issue ONLY Enter if stranded (never re-paste)
+ */
+export async function confirmedSendToPane(
+  runtime: Pick<RuntimeDriver, "readPaneScreen" | "pasteToPane" | "sendKeyToPane">,
+  pane: PaneRef,
+  message: string,
+): Promise<void> {
+  const preSendScreen = (await runtime.readPaneScreen(pane)) ?? "";
+  await runtime.pasteToPane(pane, message);
+  await settleInputBox(runtime, pane);
+  await runtime.sendKeyToPane(pane, "Enter");
+
+  for (let attempt = 0; attempt < SUBMIT_RETRY_LIMIT; attempt++) {
+    await new Promise((r) => setTimeout(r, POST_SEND_CHECK_MS));
+    const afterScreen = (await runtime.readPaneScreen(pane)) ?? "";
+    const draft = parseDraftFromScreen(afterScreen);
+    if (draft === "") return;
+    if (draft === null && afterScreen !== preSendScreen) return;
+    await settleInputBox(runtime, pane);
+    await runtime.sendKeyToPane(pane, "Enter");
+  }
+}
+
 export async function sendFirstTurnWhenReady(
   runtime: Pick<RuntimeDriver, "readPaneScreen" | "sendToPane" | "pasteToPane" | "sendKeyToPane">,
   pane: PaneRef,

--- a/packages/workspaces/src/index.ts
+++ b/packages/workspaces/src/index.ts
@@ -5,4 +5,4 @@ export * from "./workspaces/index.js";
 export { CmuxEventsBridge, deriveRunState } from "./cmux-daemon/events-bridge.js";
 export type { RunState, CmuxEventsChild, CmuxAgentHook, CmuxEventsBridgeDeps } from "./cmux-daemon/events-bridge.js";
 export { DaemonCmux } from "./cmux-daemon/daemon-cmux.js";
-export { getFreePort, listProjectCrews, findCrew, resolveCaptainWorkspace, sendFirstTurnWhenReady } from "./crew-pane.js";
+export { getFreePort, listProjectCrews, findCrew, resolveCaptainWorkspace, sendFirstTurnWhenReady, confirmedSendToPane } from "./crew-pane.js";

--- a/packages/workspaces/src/runtimes/__tests__/registry.test.ts
+++ b/packages/workspaces/src/runtimes/__tests__/registry.test.ts
@@ -17,6 +17,8 @@ function stubDriver(name: string): RuntimeDriver {
     newPane: vi.fn(async () => ({ workspaceId: "workspace:1", surfaceId: "surface:1" })),
     closePane: vi.fn(async () => {}),
     sendToPane: vi.fn(async () => {}),
+    pasteToPane: vi.fn(async () => {}),
+    sendKeyToPane: vi.fn(async () => {}),
     readPaneScreen: vi.fn(async () => ""),
     listSurfaces: vi.fn(async () => []),
     spawnInjector: vi.fn(async () => ({ workspaceId: "workspace:1", surfaceId: "surface:1" })),

--- a/packages/workspaces/src/runtimes/cmux.ts
+++ b/packages/workspaces/src/runtimes/cmux.ts
@@ -429,8 +429,16 @@ export function createCmuxDriver(): RuntimeDriver {
     },
 
     async sendToPane(pane: PaneRef, message: string): Promise<void> {
-      await cmux(["send", "--workspace", pane.workspaceId, "--surface", pane.surfaceId, sanitizeForCmuxSend(message)]);
-      await cmux(["send-key", "--workspace", pane.workspaceId, "--surface", pane.surfaceId, "Enter"]);
+      await this.pasteToPane(pane, message);
+      await this.sendKeyToPane(pane, "Enter");
+    },
+
+    async pasteToPane(pane: PaneRef, text: string): Promise<void> {
+      await cmux(["send", "--workspace", pane.workspaceId, "--surface", pane.surfaceId, sanitizeForCmuxSend(text)]);
+    },
+
+    async sendKeyToPane(pane: PaneRef, key: string): Promise<void> {
+      await cmux(["send-key", "--workspace", pane.workspaceId, "--surface", pane.surfaceId, key]);
     },
 
     async readPaneScreen(pane: PaneRef): Promise<string> {


### PR DESCRIPTION
## [0.12.1] - 2026-06-26

### Fixed

- Crew first-turn could silently strand unsubmitted: a large first-turn payload pushed Claude Code into bracketed-paste mode, so the submit Enter landed as a literal newline inside the paste instead of submitting — the crew sat at 0% with the task stuck in its input box. First-turn delivery now pastes, waits for the paste window to settle, sends a separate confirmed Enter, and re-issues only Enter (never re-pastes) if still unsubmitted. ([#339], [#447])
- Large follow-up `squadrant crew send` messages could strand the same way (the atomic send path hit the identical paste race). The confirmed-submit sequence is now extracted into a shared helper and applied to the follow-up send path too. ([#448], [#449])

### Changed

- The built-in default crew model is now sonnet (was opus); opus remains opt-in via the extreme routing tier or an explicit `--model opus`. This matches the intended tokenomics, makes fresh installs default to sonnet, and resolves the recurring config-drift advisory on upgrade. ([#446])

[#339]: https://github.com/tu11aa/squadrant/issues/339
[#446]: https://github.com/tu11aa/squadrant/pull/446
[#447]: https://github.com/tu11aa/squadrant/pull/447
[#448]: https://github.com/tu11aa/squadrant/issues/448
[#449]: https://github.com/tu11aa/squadrant/pull/449