### PR TITLE
feat(#333): scaffold LifecycleSource interface + reducer (no-op) + cmux hook research

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (4157 symbols, 6162 relationships, 156 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (4232 symbols, 6257 relationships, 157 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (4157 symbols, 6162 relationships, 156 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (4232 symbols, 6257 relationships, 157 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/docs/reports/2026-06-26-cmux-hook-mechanism-for-c.md
+++ b/docs/reports/2026-06-26-cmux-hook-mechanism-for-c.md
@@ -1,0 +1,252 @@
+# cmux hook mechanism — implementation blueprint for NativeHookSource (C)
+
+**Date:** 2026-06-26  
+**Issue:** [#333](https://github.com/tu11aa/squadrant/issues/333)  
+**Purpose:** Read-only investigation of `~/.cmuxterm/` to give Phase 3's `NativeHookSource` a concrete spec to mimic cmux's proven approach.  
+**Scope:** `claude` agent only (the only agent with cmux hooks installed on this machine).
+
+---
+
+## 1. Files cmux writes
+
+Three files under `~/.cmuxterm/` (override via `CMUX_AGENT_HOOK_STATE_DIR`):
+
+| File | Written by | Format | Consumers |
+|---|---|---|---|
+| `claude-hook-sessions.json` | Every lifecycle-changing hook event | JSON (structured, version:1 implied) | `CmuxStoreSource`, daemon |
+| `events.jsonl` | Every cmux event (hooks, UI, notifications) | NDJSON, rotates to `events.jsonl.1` | `CmuxEventsBridge` cursor stream |
+| `workstream.jsonl` | Workstream-level events (session/tool/prompt) | NDJSON | Lower-level transcript, not lifecycle |
+
+---
+
+## 2. `claude-hook-sessions.json` — the primary surface for `CmuxStoreSource`
+
+### 2.1 Schema (live, captured 2026-06-26)
+
+```jsonc
+{
+  "sessions": {
+    "<sessionId-uuid>": {
+      // ── Lifecycle (the field CmuxStoreSource reads) ──
+      "agentLifecycle": "running" | "idle" | "needsInput" | "unknown",
+
+      // ── Identity ──
+      "sessionId": "<uuid>",          // cmux session UUID = claude session UUID (no prefix)
+      "surfaceId": "<UUID>",          // cmux terminal pane UUID
+
+      // ── Correlation ──
+      "pid": 89927,                   // OS pid of the agent process (always present)
+      "cwd": "/path/to/worktree",     // working directory at launch
+
+      // ── Human-readable lifecycle detail ──
+      "lastBody": "Claude needs your permission",
+      "lastSubtitle": "Permission",
+
+      // ── Timestamps (Unix float, not ISO) ──
+      "startedAt": 1782467161.876,
+      "updatedAt": 1782467498.596,    // updated on every hook write
+
+      // ── Hibernation ──
+      "isRestorable": true,           // present on all observed sessions; true when hibernatable
+
+      // ── Launch info ──
+      "launchCommand": {
+        "arguments": ["/path/to/claude", "--model", "sonnet", ...],
+        "capturedAt": 1782467161.873,
+        "executablePath": "/path/to/claude",
+        "launcher": "claude",
+        "source": "environment",
+        "workingDirectory": "/path/to/worktree"
+      },
+
+      // ── Other fields ──
+      "workspaceId": "<UUID>",
+      "transcriptPath": "/path/to/.claude/projects/.../{sessionId}.jsonl"
+    }
+  },
+  "activeSessionsBySurface": {
+    "<surfaceId>": {
+      "sessionId": "<uuid>",
+      "updatedAt": 1782453917.15,
+      "allowsNewSessionReplacement": true   // optional
+    }
+  }
+}
+```
+
+**28 sessions** observed on this machine; all have `pid`, `launchCommand`, `isRestorable`.
+
+### 2.2 Critical finding: `launchCommand` does NOT contain environment variables
+
+`launchCommand` fields are: `arguments`, `capturedAt`, `executablePath`, `launcher`, `source`, `workingDirectory`. There is no `environment` key-value dict. `source: "environment"` means the session was launched from the terminal environment, not a captured env-var map.
+
+**Implication for `CmuxStoreSource`:** `SQUADRANT_CREW_TASK_ID` is NOT directly available in the store file. Correlation must use:
+1. **`pid`** → read process environment via macOS `proc_pidinfo` / `KERN_PROCARGS2` to extract `SQUADRANT_CREW_TASK_ID` — this is the cleanest path.
+2. **`cwd`** fallback → match against `TaskRecord.cwd`; collision-prone when worktrees are shared (see #333 §2.4 warning).
+3. **`sessionId`** → the store's `sessionId` is the claude session UUID (same as the JSONL transcript filename, without the `claude-` prefix used in events.jsonl).
+
+### 2.3 `agentLifecycle` value set
+
+All four `LifecycleState` values are observed in the wild: `running`, `idle`, `needsInput`, `unknown`.
+
+---
+
+## 3. Hook events → `agentLifecycle` transitions
+
+cmux updates `agentLifecycle` in the store on every hook event. The mapping (derived from `events.jsonl` and cross-referenced with the spec):
+
+| `agent.hook.*` event | `agentLifecycle` after | Notes |
+|---|---|---|
+| `SessionStart` | `running` | Session just started |
+| `UserPromptSubmit` | `running` | User submitted a prompt; turn is live |
+| `PreToolUse` | `running` | A tool call is in flight |
+| `Stop` | `idle` | Turn ended; crew alive and quiescent |
+| `SubagentStop` | _(no change)_ | Subagent end ≠ turn end; cmux ignores this for lifecycle |
+| `Notification` | `needsInput` | Agent surfaced a notification (e.g. CREW BLOCKED) |
+| `AskUserQuestion` | `needsInput` | Agent asking a human question |
+| `SessionEnd` | _(teardown)_ | Session gone; cmux may remove or mark record |
+
+**Frequency from `events.jsonl` (this machine, all time):**
+```
+4307  agent.hook.PreToolUse       ← dominant (every tool call)
+ 664  agent.hook.Stop             ← turn-end signal
+ 394  agent.hook.UserPromptSubmit
+ 264  agent.hook.Notification
+ 242  agent.hook.SubagentStop     ← not lifecycle-changing
+ 120  agent.hook.SessionStart
+  86  agent.hook.SessionEnd
+  44  agent.hook.AskUserQuestion
+```
+
+---
+
+## 4. `events.jsonl` — the streaming wire (currently used by `CmuxEventsBridge`)
+
+### 4.1 Schema (one NDJSON object per line)
+
+```jsonc
+{
+  "boot_id": "<UUID>",
+  "category": "agent",              // or "feed", "notification", "sidebar", "surface", …
+  "id": "<boot_id>-<seq>",
+  "name": "agent.hook.PreToolUse",  // the event name
+  "occurred_at": "2026-06-25T09:20:18.756Z",
+  "pane_id": null,
+  "payload": {
+    "hook_event_name": "PreToolUse",
+    "phase": "received" | "completed",  // cmux processes hooks in two phases
+    "session_id": "claude-<uuid>",       // NOTE: has "claude-" prefix; strip for store lookup
+    "cwd": "/path/to/worktree",
+    "_source": "claude",
+    "_ppid": 67114,
+    "tool_name": "Bash",               // only on PreToolUse/PostToolUse
+    "context_length": 1236,
+    "redacted_fields": ["tool_input", "context"]
+  },
+  "protocol": "cmux-events",
+  "seq": 8775,
+  "source": "claude",
+  "surface_id": null,
+  "type": "event",
+  "version": 1,
+  "window_id": null,
+  "workspace_id": "<UUID>"
+}
+```
+
+**Key details:**
+- Each hook fires **two events**: `phase: "received"` then `phase: "completed"`. The existing `CmuxEventsBridge` acts on `phase: "completed"` only.
+- `payload.session_id` uses the `claude-<uuid>` format; the store's `sessionId` is the bare UUID.
+- The file rotates (`events.jsonl` → `events.jsonl.1`). `cmux events --cursor-file` handles rotation automatically.
+
+### 4.2 How `CmuxEventsBridge` consumes it
+
+`CmuxEventsBridge` runs a long-lived `cmux events --cursor-file <path>` child process, reading NDJSON frames and mapping `agent.hook.*` names to `RunState` via `deriveRunState()` (see `packages/workspaces/src/cmux-daemon/events-bridge.ts`). It resolves the crew by `payload.cwd`.
+
+**`NativeHookSource` does NOT need `events.jsonl`.** The store file is the right surface — `events.jsonl` is an internal wire that requires the `cmux events` process; the store is a stable, directly-readable external surface.
+
+---
+
+## 5. `workstream.jsonl` — transcript-level log (not for lifecycle)
+
+Lower-level per-turn content log. `kind` values: `toolUse` (18k+), `stop`, `userPrompt`, `toolResult`, `sessionStart`, `sessionEnd`, `question`. Fields: `workstreamId`, `payload`, `updatedAt`, `id`, `source`, `kind`, `cwd`, `ppid`.
+
+**`NativeHookSource` does NOT need `workstream.jsonl`** — it's a turn-content log, not a lifecycle signal.
+
+---
+
+## 6. Write triggers and timing
+
+cmux updates `claude-hook-sessions.json` **synchronously on each hook event** that changes lifecycle state. The `updatedAt` field advances with each write. The file is written as a whole (full JSON overwrite, not append), so consumers must:
+
+1. `fs.watch` the directory (debounced ~50ms for write bursts).
+2. Re-read and re-parse the full JSON on each change notification.
+3. Iterate sessions and compare `updatedAt` against a cached value to detect changes.
+
+The lock file `claude-hook-sessions.json.lock` is used by cmux during writes — consumers should retry or check the lock before reading to avoid torn reads.
+
+---
+
+## 7. `isRestorable` and the hibernation invariant
+
+All 27/28 sessions with `launchCommand` also have `isRestorable: true`. When cmux hibernates a session (RAM reclaim), the OS process may be suspended or gone, but the session is logically alive and resumable.
+
+**`CmuxStoreSource` MUST NOT emit `task.session.ended` for a session where `isRestorable: true` and `agentLifecycle: "idle"`.** A pid-verify failure on a restorable idle session means "hibernated", not "dead". Only pid-gone AND `isRestorable: false` (or field absent) should trigger `alive: false → task.session.ended`.
+
+---
+
+## 8. Correlation path for `CmuxStoreSource` — recommended implementation
+
+```typescript
+// Priority 1: pid → read KERN_PROCARGS2 / process env → SQUADRANT_CREW_TASK_ID
+async function resolveTaskId(session: StoreSession): Promise<string | undefined> {
+  const taskId = await readEnvFromPid(session.pid, "SQUADRANT_CREW_TASK_ID");
+  if (taskId) return taskId;
+
+  // Priority 2: cwd → match TaskRecord.cwd (collision-prone, use as fallback)
+  const byPath = store.findNonTerminal(r => r.cwd === session.cwd);
+  return byPath?.id;
+}
+
+// Priority 3: sessionId — strip "claude-" prefix if present and match TaskRecord.sessionId
+//   session.sessionId (store UUID) === TaskRecord.sessionId (when crews populate it)
+```
+
+For macOS `readEnvFromPid`:
+- Use `proc_pidinfo` with `PROC_PIDTASKALLINFO` or spawn `ps -E -p {pid}` as a fallback.
+- A cleaner approach: open `/proc/{pid}/environ` on Linux or use `sysctl KERN_PROCARGS2` on macOS (the design spec §4 describes this path for `NativeHookSource`).
+
+---
+
+## 9. What `NativeHookSource` should mimic
+
+`NativeHookSource` installs **squadrant-owned hooks** into each agent's native config, pointing at `squadrantd hooks <agent> <sub>`. Each hook invocation is fire-and-forget (`|| true`). The daemon receives it over the control socket and calls `report()` with `origin: "agent"`.
+
+Mirroring cmux's `CMUXCLI+AgentHookDefinitions.swift` pattern:
+
+| Hook event | `squadrantd hooks claude <sub>` | `LifecycleState` |
+|---|---|---|
+| `SessionStart` | `session-start` | `running` |
+| `UserPromptSubmit` | `prompt-submit` | `running` |
+| `PreToolUse` | `pre-tool-use` | `running` (+ tool name in detail) |
+| `Stop` | `stop` | `idle` |
+| `Notification` | `notification` | `needsInput` |
+| `AskUserQuestion` | `ask-question` | `needsInput` |
+| `SessionEnd` | `session-end` | _(teardown, emit `task.session.ended`)_ |
+
+The hook payload must include `SQUADRANT_CREW_TASK_ID` (available as an env var inside the hook's execution context, since it's set on the crew's process). This is the **only** reliable collision-proof correlation key and eliminates the need for KERN_PROCARGS2 in NativeHookSource (unlike CmuxStoreSource, which reads an external file).
+
+---
+
+## 10. Summary for implementers
+
+| Concern | CmuxStoreSource (Phase 1) | NativeHookSource (Phase 3) |
+|---|---|---|
+| Primary input | `~/.cmuxterm/claude-hook-sessions.json` | `squadrantd hooks <agent> <sub>` socket calls |
+| Watch mechanism | `fs.watch` directory (debounced) + lock-aware JSON parse | Control socket (existing daemon infra) |
+| Correlation key | `pid → KERN_PROCARGS2 → SQUADRANT_CREW_TASK_ID` + `cwd` fallback | `SQUADRANT_CREW_TASK_ID` in hook env (direct) |
+| `origin` on snapshots | `"agent"` (store carries agent-reported lifecycle) | `"agent"` |
+| Liveness floor | pid-verify (`process.kill(pid, 0)`) per session | KERN_PROCARGS2 process scan |
+| `needsInput` source | `agentLifecycle: "needsInput"` in store | `Notification` / `AskUserQuestion` hook events |
+| Hibernation guard | `isRestorable: true` → alive-idle (not dead) | Process suspended but taskId env survives |
+| cmux coupling | Yes — file vanishes without cmux | None — hooks in agent's own config |

--- a/packages/core/src/__tests__/lifecycle-source.test.ts
+++ b/packages/core/src/__tests__/lifecycle-source.test.ts
@@ -1,0 +1,116 @@
+// packages/core/src/__tests__/lifecycle-source.test.ts
+//
+// Table-driven unit tests for the pure `reduceLifecycle` reducer.
+// These cover every transition rule from the FeedCoordinator spec (D1-D7):
+//   - agent-originated signals are authoritative
+//   - scan may NEVER assert needsInput
+//   - needsInput set by an agent only relaxes on an agent-originated running
+//   - a stale scan does not regress a more recent agent state
+import { describe, it, expect } from "vitest";
+import { reduceLifecycle } from "../lifecycle-source.js";
+import type { LifecycleSnapshot, LifecycleState } from "../lifecycle-source.js";
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+function snap(
+  state: LifecycleState,
+  origin: "agent" | "scan",
+  at = 100,
+  taskId = "t1",
+): LifecycleSnapshot {
+  return { taskId, state, alive: true, origin, at };
+}
+
+// ── table cases ─────────────────────────────────────────────────────────────
+
+// Case set 1: no prior state + agent signal — agent is authoritative.
+describe("reduceLifecycle — no prior + agent", () => {
+  it("undefined prev + agent running → running", () => {
+    expect(reduceLifecycle(undefined, snap("running", "agent"))).toBe("running");
+  });
+  it("undefined prev + agent idle → idle", () => {
+    expect(reduceLifecycle(undefined, snap("idle", "agent"))).toBe("idle");
+  });
+  it("undefined prev + agent needsInput → needsInput", () => {
+    expect(reduceLifecycle(undefined, snap("needsInput", "agent"))).toBe("needsInput");
+  });
+  it("undefined prev + agent unknown → unknown", () => {
+    expect(reduceLifecycle(undefined, snap("unknown", "agent"))).toBe("unknown");
+  });
+});
+
+// Case set 2: no prior state + scan signal — scan provides liveness only.
+describe("reduceLifecycle — no prior + scan", () => {
+  it("undefined prev + scan running → running", () => {
+    expect(reduceLifecycle(undefined, snap("running", "scan"))).toBe("running");
+  });
+  it("undefined prev + scan idle → idle", () => {
+    expect(reduceLifecycle(undefined, snap("idle", "scan"))).toBe("idle");
+  });
+  it("undefined prev + scan unknown → unknown", () => {
+    expect(reduceLifecycle(undefined, snap("unknown", "scan"))).toBe("unknown");
+  });
+  it("undefined prev + scan needsInput → unknown (scan cannot assert needsInput)", () => {
+    expect(reduceLifecycle(undefined, snap("needsInput", "scan"))).toBe("unknown");
+  });
+});
+
+// Case set 3: agent-set needsInput is sticky — scan cannot override it.
+describe("reduceLifecycle — needsInput sticky against scans", () => {
+  const prev = snap("needsInput", "agent", 10);
+
+  it("agent needsInput + scan running (newer) → needsInput", () => {
+    expect(reduceLifecycle(prev, snap("running", "scan", 20))).toBe("needsInput");
+  });
+  it("agent needsInput + scan idle (newer) → needsInput", () => {
+    expect(reduceLifecycle(prev, snap("idle", "scan", 20))).toBe("needsInput");
+  });
+  it("agent needsInput + scan unknown (newer) → needsInput", () => {
+    expect(reduceLifecycle(prev, snap("unknown", "scan", 20))).toBe("needsInput");
+  });
+  it("agent needsInput + scan needsInput (newer) → needsInput (invalid scan state preserved via stickiness)", () => {
+    expect(reduceLifecycle(prev, snap("needsInput", "scan", 20))).toBe("needsInput");
+  });
+});
+
+// Case set 4: agent CAN override any prior state including needsInput.
+describe("reduceLifecycle — agent overrides everything", () => {
+  it("agent needsInput prev + agent running → running", () => {
+    expect(reduceLifecycle(snap("needsInput", "agent", 10), snap("running", "agent", 20))).toBe("running");
+  });
+  it("agent needsInput prev + agent idle → idle", () => {
+    expect(reduceLifecycle(snap("needsInput", "agent", 10), snap("idle", "agent", 20))).toBe("idle");
+  });
+  it("agent needsInput prev + agent unknown → unknown", () => {
+    expect(reduceLifecycle(snap("needsInput", "agent", 10), snap("unknown", "agent", 20))).toBe("unknown");
+  });
+  it("scan idle prev + agent needsInput → needsInput", () => {
+    expect(reduceLifecycle(snap("idle", "scan", 10), snap("needsInput", "agent", 20))).toBe("needsInput");
+  });
+  it("agent running prev + agent needsInput → needsInput", () => {
+    expect(reduceLifecycle(snap("running", "agent", 10), snap("needsInput", "agent", 20))).toBe("needsInput");
+  });
+});
+
+// Case set 5: stale scan does not regress a more-recent agent state.
+describe("reduceLifecycle — timestamp precedence for scans", () => {
+  it("agent running (at=20) + scan idle (at=10, stale) → running", () => {
+    expect(reduceLifecycle(snap("running", "agent", 20), snap("idle", "scan", 10))).toBe("running");
+  });
+  it("agent running (at=10) + scan idle (at=20, newer) → idle", () => {
+    expect(reduceLifecycle(snap("running", "agent", 10), snap("idle", "scan", 20))).toBe("idle");
+  });
+  it("agent running (at=20) + scan unknown (at=20, same timestamp) → running (tie → agent wins)", () => {
+    expect(reduceLifecycle(snap("running", "agent", 20), snap("unknown", "scan", 20))).toBe("running");
+  });
+});
+
+// Case set 6: scan prev + agent next — agent is always authoritative regardless of timestamp.
+describe("reduceLifecycle — agent always wins against scan prev", () => {
+  it("scan idle (at=20) prev + agent running (at=10, older) → running", () => {
+    expect(reduceLifecycle(snap("idle", "scan", 20), snap("running", "agent", 10))).toBe("running");
+  });
+  it("scan running (at=100) prev + agent needsInput (at=1) → needsInput", () => {
+    expect(reduceLifecycle(snap("running", "scan", 100), snap("needsInput", "agent", 1))).toBe("needsInput");
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,3 +28,4 @@ export * from "./group-dispatch.js";
 export * from "./launch-workspace.js";
 export * from "./side-session.js";
 export * from "./crew-spawn.js";
+export * from "./lifecycle-source.js";

--- a/packages/core/src/lifecycle-source.ts
+++ b/packages/core/src/lifecycle-source.ts
@@ -1,0 +1,119 @@
+// packages/core/src/lifecycle-source.ts
+//
+// LifecycleSource port — phase 0 scaffold (issue #333).
+//
+// Defines the abstraction for normalizing agent lifecycle events from
+// heterogeneous sources (cmux store file, native hooks, SSE, app-server)
+// into a single 4-state model. NO concrete implementation lives here; this is
+// the interface + types + pure reducer only.
+//
+// WIRING CONSTRAINT: nothing in this file is imported by the live daemon or
+// delivery path. It compiles and tests but remains unwired until Phase 1.
+
+// ── normalized lifecycle vocabulary ─────────────────────────────────────────
+
+/** The four canonical crew lifecycle states (mirrors cmux AgentHibernationLifecycleState). */
+export type LifecycleState = "running" | "idle" | "needsInput" | "unknown";
+
+/** One observation about one crew, from one source. */
+export interface LifecycleSnapshot {
+  taskId: string;
+  state: LifecycleState;
+  /** Is the OS process actually alive (pid-verified)? */
+  alive: boolean;
+  /**
+   * Provenance — the reconciler's tie-breaker.
+   * "agent" = explicit hook / SSE / app-server transition (authoritative).
+   * "scan"  = inferred from a process/file sweep (liveness only; may NOT assert needsInput).
+   */
+  origin: "agent" | "scan";
+  /** Monotonic stamp (epoch ms) for last-writer reconciliation across sources. */
+  at: number;
+  pid?: number;
+  /** Optional human detail for surfacing CREW BLOCKED / CREW WORKING context. */
+  detail?: { note?: string; tool?: string; reason?: string };
+}
+
+/**
+ * Correlation hints a source passes when resolving a raw signal back to a crew.
+ * The daemon tries them in priority order: taskId > pid > cwd > sessionId.
+ */
+export interface CorrelationHint {
+  /** Strongest — SQUADRANT_CREW_TASK_ID injected into every crew's env at spawn. */
+  taskId?: string;
+  /** From the cmux store or process scan. */
+  pid?: number;
+  /** Weakest — collision-prone when a worktree is shared. */
+  cwd?: string;
+  /** Source-internal (cmux sessionId, codex threadId). */
+  sessionId?: string;
+}
+
+/** What the daemon hands every source: how to correlate + where to report. */
+export interface LifecycleSourceDeps {
+  /**
+   * Map a raw signal back to its owning crew TaskRecord, or undefined.
+   * Keeping it injected makes each source independently testable.
+   */
+  resolve(hint: CorrelationHint): { id: string } | undefined;
+  /** Normalized observation → reducer → ControlEvent pipeline. */
+  report(snap: LifecycleSnapshot): void;
+  log?(msg: string): void;
+}
+
+/**
+ * The port. Each adapter implements start/stop.
+ * Push sources call deps.report() on transition.
+ * Poll sources additionally expose snapshot() for the liveness floor sweep.
+ */
+export interface LifecycleSource {
+  /** Identifies the source in logs and the reconciler ("cmux-store" | "native-hook" | …). */
+  readonly name: string;
+  start(deps: LifecycleSourceDeps): void;
+  stop(): void;
+  /**
+   * Poll hook — optional.
+   * Returns the current liveness snapshot for a known crew, or undefined if
+   * this source has no view of it. Drives the liveness floor sweep.
+   * A poll result MUST set origin:"scan" and MUST NOT assert state:"needsInput".
+   */
+  snapshot?(taskId: string): LifecycleSnapshot | undefined;
+}
+
+// ── the one reducer all sources feed ────────────────────────────────────────
+
+/**
+ * Pure. Reconcile a new snapshot against the crew's last known state.
+ *
+ * Rules (from cmux FeedCoordinator.swift):
+ *   1. Agent-originated signals are authoritative — always trusted.
+ *   2. Scan signals can never assert needsInput (hook-only signal).
+ *   3. Agent-set needsInput is sticky — only an agent-originated running relaxes it.
+ *   4. A stale scan (at <= prev.at when prev is agent-set) does not regress state.
+ */
+export function reduceLifecycle(
+  prev: LifecycleSnapshot | undefined,
+  next: LifecycleSnapshot,
+): LifecycleState {
+  // Rule 1: agent-originated signals are authoritative.
+  if (next.origin === "agent") {
+    return next.state;
+  }
+
+  // Rule 2: scan signals can never assert needsInput.
+  if (next.state === "needsInput") {
+    return prev?.state ?? "unknown";
+  }
+
+  // Rule 3: agent-set needsInput is sticky against scans.
+  if (prev?.state === "needsInput") {
+    return "needsInput";
+  }
+
+  // Rule 4: a stale scan does not regress a more-recent agent state.
+  if (prev?.origin === "agent" && prev.at >= next.at) {
+    return prev.state;
+  }
+
+  return next.state;
+}


### PR DESCRIPTION
## Summary

Phase 0 of issue #333 — port scaffolding with zero behavior change. Nothing in the live daemon/delivery path imports the new module.

- **`packages/core/src/lifecycle-source.ts`** — `LifecycleSource` interface, `LifecycleSnapshot`, `CorrelationHint`, `LifecycleSourceDeps` types, and the pure `reduceLifecycle` reducer implementing the 4 FeedCoordinator rules from the spec
- **`packages/core/src/__tests__/lifecycle-source.test.ts`** — 22 table-driven unit tests, TDD (red→green verified)
- **`packages/core/src/index.ts`** — one added `export *` line (additive only)
- **`docs/reports/2026-06-26-cmux-hook-mechanism-for-c.md`** — read-only investigation of `~/.cmuxterm/` documenting the hook→agentLifecycle mapping, store schema (28 live sessions), write triggers, and correlation path; serves as the Phase 3 `NativeHookSource` blueprint

### Reducer state transitions (the heart of the abstraction)

| Scenario | Result |
|---|---|
| Any `origin:"agent"` signal | Trust it — returns `next.state` |
| `origin:"scan"` claiming `needsInput` | Invalid — falls back to `prev.state ?? "unknown"` |
| `origin:"scan"` when prev is agent-set `needsInput` | Sticky — returns `"needsInput"` |
| `origin:"scan"` older than agent-set prev (`prev.at >= next.at`) | Stale scan ignored — returns `prev.state` |
| `origin:"scan"` newer than prev, prev not `needsInput` | Accepted — returns `next.state` |

### Key research finding (cmux hook mechanism)

`launchCommand` in `claude-hook-sessions.json` does **not** contain env vars — `SQUADRANT_CREW_TASK_ID` is not directly available in the store file. `CmuxStoreSource` (Phase 1) must correlate by `pid → KERN_PROCARGS2` first, with `cwd` as fallback. `NativeHookSource` (Phase 3) gets `SQUADRANT_CREW_TASK_ID` directly from the hook's env context.

## Test plan

- [x] `npx vitest run packages/core` — 538/538 pass (22 new lifecycle-source tests)
- [x] `node dist/index.js --help` — CLI unaffected
- [x] `grep -r lifecycle-source packages/cli packages/workspaces packages/agents` — zero imports in live path (NO-OP constraint verified)
- [x] `gitnexus_impact` on `index.ts` — LOW risk, 0 affected processes
- [x] `gitnexus_detect_changes` before commit — 0 changed symbols in live paths