### PR TITLE
Release v0.13.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (4157 symbols, 6162 relationships, 156 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (4232 symbols, 6257 relationships, 157 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-06-28
+
+### Added
+
+- Native lifecycle ingestion (#333 Phase 1): squadrant now installs and owns its own Claude Code lifecycle hooks via a NativeHookSource (primary), registered namespaced and non-clobbering in `~/.claude/settings.json`, alongside a CodexAppServerSource adapter for the codex app-server and a CmuxStoreSource backup that reads `~/.cmuxterm`. A new internal `squadrant hooks claude <event>` CLI bridges Claude lifecycle events to the daemon. These run additively next to the existing cmux events bridge. ([#333](https://github.com/tu11aa/squadrant/issues/333))
+- Interactive no-arg `squad launch`: running `squad launch` with no project opens a multi-select and boots the chosen captains in parallel.
+
+### Fixed
+
+- First-turn drop regression (#333): AskUserQuestion was registered as an invalid top-level Claude hook event, which made Claude Code show a blocking "Settings Warning" modal at session start that swallowed a freshly spawned crew's first turn. It is now registered correctly as a PreToolUse hook with `matcher: "AskUserQuestion"`. ([#333](https://github.com/tu11aa/squadrant/issues/333))
+- opencode multi-option picker is now detected as CREW BLOCKED so the captain is prompted to choose, instead of the crew stalling silently while the daemon shows it as working.
+
 ## [0.12.1] - 2026-06-26
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (4157 symbols, 6162 relationships, 156 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (4232 symbols, 6257 relationships, 157 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/docs/reports/2026-06-26-cmux-hook-mechanism-for-c.md
+++ b/docs/reports/2026-06-26-cmux-hook-mechanism-for-c.md
@@ -1,0 +1,252 @@
+# cmux hook mechanism — implementation blueprint for NativeHookSource (C)
+
+**Date:** 2026-06-26  
+**Issue:** [#333](https://github.com/tu11aa/squadrant/issues/333)  
+**Purpose:** Read-only investigation of `~/.cmuxterm/` to give Phase 3's `NativeHookSource` a concrete spec to mimic cmux's proven approach.  
+**Scope:** `claude` agent only (the only agent with cmux hooks installed on this machine).
+
+---
+
+## 1. Files cmux writes
+
+Three files under `~/.cmuxterm/` (override via `CMUX_AGENT_HOOK_STATE_DIR`):
+
+| File | Written by | Format | Consumers |
+|---|---|---|---|
+| `claude-hook-sessions.json` | Every lifecycle-changing hook event | JSON (structured, version:1 implied) | `CmuxStoreSource`, daemon |
+| `events.jsonl` | Every cmux event (hooks, UI, notifications) | NDJSON, rotates to `events.jsonl.1` | `CmuxEventsBridge` cursor stream |
+| `workstream.jsonl` | Workstream-level events (session/tool/prompt) | NDJSON | Lower-level transcript, not lifecycle |
+
+---
+
+## 2. `claude-hook-sessions.json` — the primary surface for `CmuxStoreSource`
+
+### 2.1 Schema (live, captured 2026-06-26)
+
+```jsonc
+{
+  "sessions": {
+    "<sessionId-uuid>": {
+      // ── Lifecycle (the field CmuxStoreSource reads) ──
+      "agentLifecycle": "running" | "idle" | "needsInput" | "unknown",
+
+      // ── Identity ──
+      "sessionId": "<uuid>",          // cmux session UUID = claude session UUID (no prefix)
+      "surfaceId": "<UUID>",          // cmux terminal pane UUID
+
+      // ── Correlation ──
+      "pid": 89927,                   // OS pid of the agent process (always present)
+      "cwd": "/path/to/worktree",     // working directory at launch
+
+      // ── Human-readable lifecycle detail ──
+      "lastBody": "Claude needs your permission",
+      "lastSubtitle": "Permission",
+
+      // ── Timestamps (Unix float, not ISO) ──
+      "startedAt": 1782467161.876,
+      "updatedAt": 1782467498.596,    // updated on every hook write
+
+      // ── Hibernation ──
+      "isRestorable": true,           // present on all observed sessions; true when hibernatable
+
+      // ── Launch info ──
+      "launchCommand": {
+        "arguments": ["/path/to/claude", "--model", "sonnet", ...],
+        "capturedAt": 1782467161.873,
+        "executablePath": "/path/to/claude",
+        "launcher": "claude",
+        "source": "environment",
+        "workingDirectory": "/path/to/worktree"
+      },
+
+      // ── Other fields ──
+      "workspaceId": "<UUID>",
+      "transcriptPath": "/path/to/.claude/projects/.../{sessionId}.jsonl"
+    }
+  },
+  "activeSessionsBySurface": {
+    "<surfaceId>": {
+      "sessionId": "<uuid>",
+      "updatedAt": 1782453917.15,
+      "allowsNewSessionReplacement": true   // optional
+    }
+  }
+}
+```
+
+**28 sessions** observed on this machine; all have `pid`, `launchCommand`, `isRestorable`.
+
+### 2.2 Critical finding: `launchCommand` does NOT contain environment variables
+
+`launchCommand` fields are: `arguments`, `capturedAt`, `executablePath`, `launcher`, `source`, `workingDirectory`. There is no `environment` key-value dict. `source: "environment"` means the session was launched from the terminal environment, not a captured env-var map.
+
+**Implication for `CmuxStoreSource`:** `SQUADRANT_CREW_TASK_ID` is NOT directly available in the store file. Correlation must use:
+1. **`pid`** → read process environment via macOS `proc_pidinfo` / `KERN_PROCARGS2` to extract `SQUADRANT_CREW_TASK_ID` — this is the cleanest path.
+2. **`cwd`** fallback → match against `TaskRecord.cwd`; collision-prone when worktrees are shared (see #333 §2.4 warning).
+3. **`sessionId`** → the store's `sessionId` is the claude session UUID (same as the JSONL transcript filename, without the `claude-` prefix used in events.jsonl).
+
+### 2.3 `agentLifecycle` value set
+
+All four `LifecycleState` values are observed in the wild: `running`, `idle`, `needsInput`, `unknown`.
+
+---
+
+## 3. Hook events → `agentLifecycle` transitions
+
+cmux updates `agentLifecycle` in the store on every hook event. The mapping (derived from `events.jsonl` and cross-referenced with the spec):
+
+| `agent.hook.*` event | `agentLifecycle` after | Notes |
+|---|---|---|
+| `SessionStart` | `running` | Session just started |
+| `UserPromptSubmit` | `running` | User submitted a prompt; turn is live |
+| `PreToolUse` | `running` | A tool call is in flight |
+| `Stop` | `idle` | Turn ended; crew alive and quiescent |
+| `SubagentStop` | _(no change)_ | Subagent end ≠ turn end; cmux ignores this for lifecycle |
+| `Notification` | `needsInput` | Agent surfaced a notification (e.g. CREW BLOCKED) |
+| `AskUserQuestion` | `needsInput` | Agent asking a human question |
+| `SessionEnd` | _(teardown)_ | Session gone; cmux may remove or mark record |
+
+**Frequency from `events.jsonl` (this machine, all time):**
+```
+4307  agent.hook.PreToolUse       ← dominant (every tool call)
+ 664  agent.hook.Stop             ← turn-end signal
+ 394  agent.hook.UserPromptSubmit
+ 264  agent.hook.Notification
+ 242  agent.hook.SubagentStop     ← not lifecycle-changing
+ 120  agent.hook.SessionStart
+  86  agent.hook.SessionEnd
+  44  agent.hook.AskUserQuestion
+```
+
+---
+
+## 4. `events.jsonl` — the streaming wire (currently used by `CmuxEventsBridge`)
+
+### 4.1 Schema (one NDJSON object per line)
+
+```jsonc
+{
+  "boot_id": "<UUID>",
+  "category": "agent",              // or "feed", "notification", "sidebar", "surface", …
+  "id": "<boot_id>-<seq>",
+  "name": "agent.hook.PreToolUse",  // the event name
+  "occurred_at": "2026-06-25T09:20:18.756Z",
+  "pane_id": null,
+  "payload": {
+    "hook_event_name": "PreToolUse",
+    "phase": "received" | "completed",  // cmux processes hooks in two phases
+    "session_id": "claude-<uuid>",       // NOTE: has "claude-" prefix; strip for store lookup
+    "cwd": "/path/to/worktree",
+    "_source": "claude",
+    "_ppid": 67114,
+    "tool_name": "Bash",               // only on PreToolUse/PostToolUse
+    "context_length": 1236,
+    "redacted_fields": ["tool_input", "context"]
+  },
+  "protocol": "cmux-events",
+  "seq": 8775,
+  "source": "claude",
+  "surface_id": null,
+  "type": "event",
+  "version": 1,
+  "window_id": null,
+  "workspace_id": "<UUID>"
+}
+```
+
+**Key details:**
+- Each hook fires **two events**: `phase: "received"` then `phase: "completed"`. The existing `CmuxEventsBridge` acts on `phase: "completed"` only.
+- `payload.session_id` uses the `claude-<uuid>` format; the store's `sessionId` is the bare UUID.
+- The file rotates (`events.jsonl` → `events.jsonl.1`). `cmux events --cursor-file` handles rotation automatically.
+
+### 4.2 How `CmuxEventsBridge` consumes it
+
+`CmuxEventsBridge` runs a long-lived `cmux events --cursor-file <path>` child process, reading NDJSON frames and mapping `agent.hook.*` names to `RunState` via `deriveRunState()` (see `packages/workspaces/src/cmux-daemon/events-bridge.ts`). It resolves the crew by `payload.cwd`.
+
+**`NativeHookSource` does NOT need `events.jsonl`.** The store file is the right surface — `events.jsonl` is an internal wire that requires the `cmux events` process; the store is a stable, directly-readable external surface.
+
+---
+
+## 5. `workstream.jsonl` — transcript-level log (not for lifecycle)
+
+Lower-level per-turn content log. `kind` values: `toolUse` (18k+), `stop`, `userPrompt`, `toolResult`, `sessionStart`, `sessionEnd`, `question`. Fields: `workstreamId`, `payload`, `updatedAt`, `id`, `source`, `kind`, `cwd`, `ppid`.
+
+**`NativeHookSource` does NOT need `workstream.jsonl`** — it's a turn-content log, not a lifecycle signal.
+
+---
+
+## 6. Write triggers and timing
+
+cmux updates `claude-hook-sessions.json` **synchronously on each hook event** that changes lifecycle state. The `updatedAt` field advances with each write. The file is written as a whole (full JSON overwrite, not append), so consumers must:
+
+1. `fs.watch` the directory (debounced ~50ms for write bursts).
+2. Re-read and re-parse the full JSON on each change notification.
+3. Iterate sessions and compare `updatedAt` against a cached value to detect changes.
+
+The lock file `claude-hook-sessions.json.lock` is used by cmux during writes — consumers should retry or check the lock before reading to avoid torn reads.
+
+---
+
+## 7. `isRestorable` and the hibernation invariant
+
+All 27/28 sessions with `launchCommand` also have `isRestorable: true`. When cmux hibernates a session (RAM reclaim), the OS process may be suspended or gone, but the session is logically alive and resumable.
+
+**`CmuxStoreSource` MUST NOT emit `task.session.ended` for a session where `isRestorable: true` and `agentLifecycle: "idle"`.** A pid-verify failure on a restorable idle session means "hibernated", not "dead". Only pid-gone AND `isRestorable: false` (or field absent) should trigger `alive: false → task.session.ended`.
+
+---
+
+## 8. Correlation path for `CmuxStoreSource` — recommended implementation
+
+```typescript
+// Priority 1: pid → read KERN_PROCARGS2 / process env → SQUADRANT_CREW_TASK_ID
+async function resolveTaskId(session: StoreSession): Promise<string | undefined> {
+  const taskId = await readEnvFromPid(session.pid, "SQUADRANT_CREW_TASK_ID");
+  if (taskId) return taskId;
+
+  // Priority 2: cwd → match TaskRecord.cwd (collision-prone, use as fallback)
+  const byPath = store.findNonTerminal(r => r.cwd === session.cwd);
+  return byPath?.id;
+}
+
+// Priority 3: sessionId — strip "claude-" prefix if present and match TaskRecord.sessionId
+//   session.sessionId (store UUID) === TaskRecord.sessionId (when crews populate it)
+```
+
+For macOS `readEnvFromPid`:
+- Use `proc_pidinfo` with `PROC_PIDTASKALLINFO` or spawn `ps -E -p {pid}` as a fallback.
+- A cleaner approach: open `/proc/{pid}/environ` on Linux or use `sysctl KERN_PROCARGS2` on macOS (the design spec §4 describes this path for `NativeHookSource`).
+
+---
+
+## 9. What `NativeHookSource` should mimic
+
+`NativeHookSource` installs **squadrant-owned hooks** into each agent's native config, pointing at `squadrantd hooks <agent> <sub>`. Each hook invocation is fire-and-forget (`|| true`). The daemon receives it over the control socket and calls `report()` with `origin: "agent"`.
+
+Mirroring cmux's `CMUXCLI+AgentHookDefinitions.swift` pattern:
+
+| Hook event | `squadrantd hooks claude <sub>` | `LifecycleState` |
+|---|---|---|
+| `SessionStart` | `session-start` | `running` |
+| `UserPromptSubmit` | `prompt-submit` | `running` |
+| `PreToolUse` | `pre-tool-use` | `running` (+ tool name in detail) |
+| `Stop` | `stop` | `idle` |
+| `Notification` | `notification` | `needsInput` |
+| `AskUserQuestion` | `ask-question` | `needsInput` |
+| `SessionEnd` | `session-end` | _(teardown, emit `task.session.ended`)_ |
+
+The hook payload must include `SQUADRANT_CREW_TASK_ID` (available as an env var inside the hook's execution context, since it's set on the crew's process). This is the **only** reliable collision-proof correlation key and eliminates the need for KERN_PROCARGS2 in NativeHookSource (unlike CmuxStoreSource, which reads an external file).
+
+---
+
+## 10. Summary for implementers
+
+| Concern | CmuxStoreSource (Phase 1) | NativeHookSource (Phase 3) |
+|---|---|---|
+| Primary input | `~/.cmuxterm/claude-hook-sessions.json` | `squadrantd hooks <agent> <sub>` socket calls |
+| Watch mechanism | `fs.watch` directory (debounced) + lock-aware JSON parse | Control socket (existing daemon infra) |
+| Correlation key | `pid → KERN_PROCARGS2 → SQUADRANT_CREW_TASK_ID` + `cwd` fallback | `SQUADRANT_CREW_TASK_ID` in hook env (direct) |
+| `origin` on snapshots | `"agent"` (store carries agent-reported lifecycle) | `"agent"` |
+| Liveness floor | pid-verify (`process.kill(pid, 0)`) per session | KERN_PROCARGS2 process scan |
+| `needsInput` source | `agentLifecycle: "needsInput"` in store | `Notification` / `AskUserQuestion` hook events |
+| Hibernation guard | `isRestorable: true` → alive-idle (not dead) | Process suspended but taskId env survives |
+| cmux coupling | Yes — file vanishes without cmux | None — hooks in agent's own config |

--- a/docs/specs/2026-06-26-lifecycle-source-port-design.md
+++ b/docs/specs/2026-06-26-lifecycle-source-port-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-26
 **Issue:** [#333](https://github.com/tu11aa/squadrant/issues/333)
-**Status:** DESIGN — needs brainstorm + sign-off before any implementation
+**Status:** SIGNED-OFF (2026-06-26) — implementation proceeding per D1–D7 below
 **Research dossier:** `docs/research/2026-06-16-cmux-agent-lifecycle-and-daemon-architecture.md` (archived to hub-vault in #370; recover from git `be3230c`)
 **Related:** #328/#331 (claude event-bridge), #332 (daemon-direct, drop relay), #326 (compat backlog), #114 (native codex TUI + hooks), #329 (hibernation), #31 (multi-driver projection), #201 (codex first-turn hang)
 
@@ -228,68 +228,83 @@ plus a **`SQUADRANT_CREW_TASK_ID`-keyed `KERN_PROCARGS2` process scan** (libproc
 
 ## 5. Migration plan
 
-The refactor is **incremental and additive** — at no point is the daemon without a working lifecycle path. The same daemon work that drops the relay-proxy (#332) drops screen-scraping in one motion, because both fall out once the port owns lifecycle.
+The refactor is **incremental and additive** — at no point is the daemon without a working lifecycle path. Phase ordering follows the signed-off D1 decision: **C (`NativeHookSource`) is primary; A (`CmuxStoreSource`) ships as redundancy.** See § 6 for the signed-off decisions that shaped this plan.
 
-**Phase 0 — port scaffolding (no behaviour change).**
-Define `LifecycleSource`, `LifecycleSnapshot`, `reduceLifecycle`, and a `LifecycleReconciler` in `@squadrant/core` that fans `report()` into the existing `ctx.d.handle` pipeline. Wire the three existing bridges (`CmuxEventsBridge`, `OpencodeSseBridge`, `CodexInteractiveDriver`) to emit through it *unchanged in behaviour* — they become the first three adapters. This is the seam; everything downstream (reducer, watchdog, Telegram tiers) keeps working.
+**Phase 0 — scaffold interface + reducer + research hook mechanism (no behaviour change).**
+Define `LifecycleSource`, `LifecycleSnapshot`, `reduceLifecycle`, and a `LifecycleReconciler` in `@squadrant/core` that fans `report()` into the existing `ctx.d.handle` pipeline. Wire the three existing bridges (`CmuxEventsBridge`, `OpencodeSseBridge`, `CodexInteractiveDriver`) to emit through it *unchanged in behaviour* — they become the first three adapters. This is the seam; everything downstream (reducer, watchdog, Telegram tiers) keeps working. **Concurrently:** research cmux's `AgentHookDef` installer matrix (`CMUXCLI+AgentHookDefinitions.swift`, per-agent template shape, the `squadrantd hooks` subcommand design) to ground Phase 1 before implementation begins.
 
-**Phase 1 — `CmuxStoreSource` (ship A).**
-Add the store-file adapter for claude. Run it **alongside** `CmuxEventsBridge`; the reducer absorbs duplicates idempotently. Verify parity on claude crews (turn-end, working, needsInput). Once parity holds, **retire `CmuxEventsBridge`** (the #328/#331 socket subscription) — it becomes the first thing the port replaces. Extend `CmuxStoreSource` to opencode/codex store files *if* `cmux hooks setup` is run for them (free coverage).
+**Phase 1 — build C (primary, mimic cmux) + A (backup) + codex app-server wrapper.**
+Build `NativeHookSource` (C) mirroring cmux's proven hook mechanism, targeting claude first. Run alongside existing `CmuxEventsBridge`; the reducer absorbs duplicates idempotently. Concurrently ship `CmuxStoreSource` (A) as backup/redundancy — one file-watcher on `~/.cmuxterm/*-hook-sessions.json` + pid-verify, covering whichever agents have `cmux hooks setup` configured. Wrap the existing codex app-server driver as a `LifecycleSource` adapter (mechanism unchanged — see D5). Once C proves parity on claude crews, **retire `CmuxEventsBridge`** (the #328/#331 socket subscription).
 
-**Phase 2 — retire screen-scraping + fold into #332.**
-With `CmuxStoreSource` proving lifecycle for claude and the SSE/app-server sources owning opencode/codex, the ~14 `read-screen` lifecycle sites in `cmux.ts` lose their job. Delete them as part of the #332 daemon-direct refactor (same PR drops relay-proxy *and* scraping). Keep only the *delivery-time* read-screen the defer-while-typing logic needs (#258/#302) — that's input-box state, not lifecycle. (See decision D3 for timing.)
+**Phase 2 — parity + cleanup (deprecate scraping, retire relay when proven).**
+With C proving lifecycle for claude and A + app-server covering opencode/codex: **deprecate-in-place** the ~14 `read-screen` lifecycle sites in `cmux.ts` — mark `@deprecated`, leave as safety net; do **not** delete in this phase (see D3). Retire the relay-proxy fallback on the same parity gate once C + A are stable in production across all agents (see D7; **not in v0.13.0**). File the 'retire screen-scraping' follow-up issue. Keep delivery-time read-screen (#258/#302 defer-while-typing — input-box state, not lifecycle).
 
-**Phase 3 — `NativeHookSource` (build C, per agent).**
-Incrementally install squadrant-owned hooks, one agent at a time, behind a config flag. As each agent's native hooks prove out, that agent's `CorrelationHint` switches to `SQUADRANT_CREW_TASK_ID` and stops depending on cmux's store file. When all four agents are on native hooks, `CmuxStoreSource` becomes optional — the daemon's lifecycle no longer needs cmux at all.
+**Follow-ups post-v0.13.0:**
+- Gemini lifecycle driver (gemini has no driver today; out of scope for #333).
+- Persist/reconstruct schema if DEFER PERSIST (D6) proves insufficient at scale.
+- Full screen-scraping deletion (gated on real-world stability — see D3).
+- Full relay retirement if not completed in Phase 2 (see D7).
 
 **Reconcile with #329 (hibernation).**
 cmux hibernation reclaims RAM from `idle` crews (`allowsHibernation == idle`). A hibernated crew's pid may be gone or suspended while the crew is *logically alive*. The liveness floor must **not** emit `task.session.ended` for a hibernated-but-resumable crew. Rule: if the store/scan shows `idle` + `isRestorable` (cmux field) or a known resumeRef, treat as **alive-idle**, not dead. This is why the liveness layer is advisory (`origin:"scan"`) and never terminal on its own — terminal still needs an explicit signal or a confirmed process-gone-AND-not-restorable. Note hibernation is currently OFF by design (config doc: cmux 0.64.16 hibernation is global-only and would hibernate the captain), so this is a forward-compatibility rule, not a live concern yet.
 
 **Reconcile with #31 (multi-driver projection).**
-`LifecycleSource` slots cleanly under the existing **runtime** plugin seam (it's a property of the terminal/runtime driver, alongside cmux's `DaemonCmux`). `CmuxStoreSource` is the cmux-runtime's lifecycle adapter; a future runtime ships its own. `NativeHookSource` is runtime-independent and can be the default for any runtime that lacks a native lifecycle adapter.
+`LifecycleSource` slots cleanly under the existing **runtime** plugin seam (it's a property of the terminal/runtime driver, alongside cmux's `DaemonCmux`). `NativeHookSource` is runtime-independent and becomes the default for any runtime that lacks a native lifecycle adapter. `CmuxStoreSource` is the cmux-runtime's cmux-specific backup adapter; a future runtime ships its own equivalent. When both exist, the reducer resolves idempotently.
 
 ---
 
-## 6. DECISIONS NEEDING SIGN-OFF
+## 6. DECISIONS — SIGNED OFF 2026-06-26
 
-Each is a crisp choice with a recommendation. The captain + user brainstorm these before implementation.
+All seven decisions were brainstormed and signed off on 2026-06-26. Decisions that reversed the original recommendation are marked ⚠️ **FLIPPED**.
 
-### D1 — A-vs-C sequencing
-**Question:** Ship `CmuxStoreSource` (A) first and build `NativeHookSource` (C) later, or invest directly in C?
-- **(a) A first, then C incrementally.** ✅ *Recommended.* A is cheap (one file watcher + pid-verify), accurate, and covers 16 agents the moment cmux hooks are set up. It proves the port and reducer against real data before we sink effort into the per-agent installer matrix. C lands agent-by-agent behind the same port with zero re-architecture.
-- (b) C directly. Driver-agnostic from day one, but front-loads the entire installer + trust + collision problem and delays *any* improvement over today's claude-only path.
+### D1 — A-vs-C sequencing ⚠️ **FLIPPED**
+
+**SIGNED-OFF (2026-06-26): C-PRIMARY, A-BACKUP.**
+`NativeHookSource` (C) is the primary implementation — it mimics cmux's proven hook mechanism and is driver-agnostic by design. `CmuxStoreSource` (A) ships as backup/redundancy, watching `~/.cmuxterm/*-hook-sessions.json`. Both run under the same port; the reducer handles both idempotently.
+
+*(superseded) Original recommendation: (a) A first, then C incrementally — A is cheap (one file watcher + pid-verify), accurate, and proves the port and reducer against real data before investing in the per-agent installer matrix.*
 
 ### D2 — Event-driven vs poll
-**Question:** What's the port's primary paradigm?
-- **(a) Hybrid: push primary + low-frequency poll liveness floor.** ✅ *Recommended.* Matches reality (SSE/app-server push; store-file watch; process scan poll). Push gives latency and `needsInput`; poll guarantees we notice a dead/hung crew even when hooks fail silently. The `origin` discriminator + "explicit agent wins" reducer makes the two safe to combine.
-- (b) Push-only. Simpler interface, but a crew whose hooks never fire (install failure, sandbox) becomes invisible — no liveness floor.
-- (c) Poll-only. Robust liveness but loses `needsInput` entirely (hook-only signal) — regresses approvals/blocked detection.
 
-### D3 — Screen-scraping retirement timing
-**Question:** When do we delete the ~14 lifecycle `read-screen` sites in `cmux.ts`?
-- **(a) Retire only after A proves parity for claude AND opencode/codex have push sources (they do), folded into the #332 PR.** ✅ *Recommended.* Lowest risk: scraping stays as the safety net until the replacement is verified live across all three agents, then both scraping and relay-proxy die in one #332 refactor. Keep the delivery-time read-screen (#258/#302 defer-while-typing) — that's input-box state, not lifecycle.
-- (b) Retire immediately with Phase 1. Faster cleanup, but removes the fallback before A is battle-tested — risky given scraping's history of catching edge cases (#292).
-- (c) Keep scraping indefinitely as a tertiary fallback. Safest, but leaves the brittle cmux-coupled code we're trying to kill, defeating the point.
+**SIGNED-OFF (2026-06-26): HYBRID push + poll.**
+C pushes via hook (primary); low-frequency poll reconciles stuck state (liveness floor). Push gives latency and `needsInput`; poll guarantees detection of a dead/hung crew when hooks fail silently. The `origin` discriminator + "explicit agent wins" reducer makes the two safe to combine. A poll/scan can never assert `needsInput` — that is hook-only.
+
+*(original recommendation unchanged — option (a) confirmed)*
+
+### D3 — Screen-scraping retirement timing ⚠️ **FLIPPED**
+
+**SIGNED-OFF (2026-06-26): DEPRECATE-IN-PLACE.**
+Keep the ~14 `read-screen` lifecycle sites in `cmux.ts` as a safety net — mark `@deprecated` in the code, **do not delete in v0.13.0**. Retire only after several stable production versions on C + A, gated on real-world stability (not a synthetic test phase). A follow-up 'retire screen-scraping' issue will be filed and left open. Keep delivery-time read-screen (#258/#302) — input-box state, not lifecycle.
+
+*(superseded) Original recommendation: (a) Retire only after A proves parity for claude + opencode/codex, folded into the #332 PR — lowest risk; scraping and relay-proxy die in one motion.*
 
 ### D4 — Double-hook collision (cmux + squadrant both installed)
-**Question:** When `NativeHookSource` installs codex/gemini/opencode hooks that cmux *also* installs, how do we avoid double-processing / fighting?
-- **(a) Namespace squadrant's hooks + idempotent reducer; both fire harmlessly.** ✅ *Recommended.* The reducer already absorbs duplicates (anti-#2576). Squadrant's hook reports `SQUADRANT_CREW_TASK_ID`-keyed; cmux's writes its own store. They don't share state, so they can't corrupt each other. Simplest and most robust.
-- (b) Detect cmux hook presence and defer to `CmuxStoreSource` for that agent (install squadrant hooks only where cmux's are absent). Avoids redundant work but adds a detection/ordering dependency on cmux internals — re-couples C to cmux.
+
+**SIGNED-OFF (2026-06-26): NAMESPACE + IDEMPOTENT hook install.**
+Squadrant's hooks are namespaced and the installer is re-run-safe — it never clobbers pre-existing user hooks. The reducer already absorbs duplicates (anti-#2576). Both cmux and squadrant hooks can fire harmlessly; they write to separate stores and share no mutable state.
+
+*(original recommendation unchanged — option (a) confirmed, re-run-safe emphasis explicit)*
 
 ### D5 — Codex under the port (ties to #114)
-**Question:** Keep codex on the app-server, or move to TUI + native hooks?
-- **(a) Keep the app-server adapter now; revisit TUI+hooks under #114.** ✅ *Recommended.* The app-server already gives turn-end, approvals (`task.approval.requested`), and multi-turn `say()`/`steer()` — wrapping it as a `LifecycleSource` adapter is nearly free and loses nothing. Moving to TUI+hooks unlocks dropping the app-server complexity but reopens hook-trust (D's no-dangerous-flags constraint) and first-turn-hang (#201). Sequence it as its own #114 effort *after* the port exists.
-- (b) Move codex to TUI+native-hooks now, as the first `NativeHookSource` agent. Unifies codex with claude/opencode and kills app-server complexity, but front-loads hook-trust + #201 risk into the port work.
 
-### D6 — Hook-trust handling for codex (no "dangerously" flags)
-**Question:** How does squadrant get its codex hook trusted without `--dangerously-bypass-hook-trust`?
-- **(a) Persist trust once at `squadrantd hooks setup codex` time (mirror how cmux persists it), then run codex normally.** ✅ *Recommended* (pending a source check of how codex stores persisted trust). Honors the user's no-dangerous-flags rule and is a one-time setup cost.
-- (b) Defer codex native hooks entirely; keep codex on the app-server (= choosing D5a). Acceptable fallback if persisted trust proves unworkable.
+**SIGNED-OFF (2026-06-26): KEEP app-server for codex, wrapped as one `LifecycleSource`.**
+Keep the existing codex app-server driver; wrap it as a `LifecycleSource` adapter. Unified at the port interface; mechanism unchanged. Revisit TUI + native hooks under #114 after the port exists.
 
-### D7 — Relay-proxy disposition (#332 boundary)
-**Question:** When the port owns lifecycle, does the relay fully retire?
-- **(a) Fully retire relay-proxy; re-home defer-while-typing (#258/#302) into daemon-direct `cmux send`.** ✅ *Recommended.* The dossier confirms the daemon can call `cmux send/read-screen` directly (socket reachable from any process since 0.64.16), so the relay's reason to exist is gone. Lifecycle moves to the port; delivery moves to daemon-direct. One coherent #332 cut.
-- (b) Keep a thin in-process notification-delivery shim. Less migration risk, but leaves a vestigial component the port was meant to obviate.
+*(original recommendation unchanged — option (a) confirmed)*
+
+### D6 — Session persistence on daemon restart
+
+**SIGNED-OFF (2026-06-26): DEFER PERSIST / RECONSTRUCT.**
+No new persistence layer in v0.13.0. On daemon restart, reconstruct the live session set from the cmux store (`~/.cmuxterm/*-hook-sessions.json`) and live crew panes (analogous to `listCrewPanes`). Session identity is stable across all supported agents: claude exposes `session_id`, codex exposes `resume-id`, opencode exposes `ses_*`-prefixed IDs. Gemini has no driver (out of scope for #333). No standalone trust-handshake state was found in the codebase (verified).
+
+*(superseded) Original D6 question: "Hook-trust handling for codex (no 'dangerously' flags)" — how squadrant gets its codex hook trusted without `--dangerously-bypass-hook-trust`. Deferred: codex stays on app-server (D5), making hook-trust a non-issue for v0.13.0. Re-evaluate when #114 (codex TUI + native hooks) is scoped.*
+
+### D7 — Relay-proxy disposition (#332 boundary) ⚠️ **FLIPPED**
+
+**SIGNED-OFF (2026-06-26): RETIRE RELAY IN PHASE 2, GATED.**
+Verified: the relay main delivery path is gone as of #332, but a live fallback remains for opencode (`claude.ts:183`) and cmux-unreachable paths (`cmux-probe.ts`). Remove in Phase 2 once C + A prove stable in production across all agents, on the same parity gate as screen-scraping deprecation. **Not in v0.13.0.**
+
+*(superseded) Original recommendation: (a) Fully retire relay-proxy in the #332 PR — daemon-direct is the delivery path; relay's reason to exist is gone once lifecycle moves to the port.*
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "squadrant",
   "packageManager": "pnpm@10.30.3",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Multi-project orchestration for your coding agents (Claude, Codex, opencode, Gemini)",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "node": ">=18"
   },
   "dependencies": {
+    "@inquirer/checkbox": "^4.1.5",
     "chalk": "^5.4.0",
     "commander": "^13.0.0",
     "gray-matter": "^4.0.3",

--- a/packages/agents/src/__tests__/pane-classifier.test.ts
+++ b/packages/agents/src/__tests__/pane-classifier.test.ts
@@ -29,6 +29,32 @@ const WORKING_PANE = [
   "  accept edits on (shift+tab to cycle)                    ",
 ].join("\n");
 
+// opencode's native multi-option picker: question buried mid-paragraph, then a
+// ┃-bordered box with numbered options and a keyboard-hint footer.  The footer
+// ("↑↓ select  enter submit  esc dismiss") is the last content line, so the
+// trailing-question detector alone would never fire.
+const OPENCODE_PICKER = [
+  "I need to know how to proceed with the implementation.",
+  "The current approach has some tradeoffs to consider.",
+  "Which strategy should I use for the cache layer?",
+  "╭──────────────────────────────────────────────────────╮",
+  "┃ 1. Use Redis for distributed caching                 ┃",
+  "┃ 2. Use an in-memory LRU for local caching            ┃",
+  "┃ 3. Skip caching entirely                             ┃",
+  "┃ ↑↓ select  enter submit  esc dismiss                 ┃",
+  "╰──────────────────────────────────────────────────────╯",
+].join("\n");
+
+// Same shape but no "?"-terminated line above the options → fallback text.
+const OPENCODE_PICKER_NO_QUESTION = [
+  "Let me know your preference.",
+  "╭──────────────────────────────────────────────────────╮",
+  "┃ 1. Option A                                          ┃",
+  "┃ 2. Option B                                          ┃",
+  "┃ ↑↓ select  enter submit  esc dismiss                 ┃",
+  "╰──────────────────────────────────────────────────────╯",
+].join("\n");
+
 // A pane whose agent output ends in a direct question (mainly the opencode
 // path — opencode has no Stop hook so the daemon never sees a turn-end block).
 const QUESTION_PANE = [
@@ -124,6 +150,19 @@ describe("classifyPaneTail", () => {
       kind: "question",
       text: "Should I retry the request now?",
     });
+  });
+
+  it("classifies an opencode multi-option picker as question with extracted question text", () => {
+    const r = classifyPaneTail(OPENCODE_PICKER);
+    expect(r).toEqual({
+      kind: "question",
+      text: "Which strategy should I use for the cache layer?",
+    });
+  });
+
+  it("classifies an opencode picker with no '?' line above as question with fallback text", () => {
+    const r = classifyPaneTail(OPENCODE_PICKER_NO_QUESTION);
+    expect(r).toEqual({ kind: "question", text: "Crew is awaiting a choice." });
   });
 
   it("does not misfire approval on a numbered list that lacks a Yes/No block", () => {

--- a/packages/agents/src/codex/__tests__/codex-app-server-source.test.ts
+++ b/packages/agents/src/codex/__tests__/codex-app-server-source.test.ts
@@ -1,0 +1,253 @@
+// Tests for CodexAppServerSource — LifecycleSource adapter for codex app-server.
+//
+// All deps are injected; no real app-server is spawned.
+import { describe, it, expect, beforeEach } from "vitest";
+import { CodexAppServerSource } from "../codex-app-server-source.js";
+import type { LifecycleSnapshot, LifecycleSourceDeps } from "@squadrant/core";
+import type { ControlEvent } from "@squadrant/shared";
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+
+const TASK_ID = "task-abc123";
+const TURN_ID = "turn-001";
+
+function makeDeps() {
+  const reports: LifecycleSnapshot[] = [];
+  const deps: LifecycleSourceDeps = {
+    resolve: () => undefined,
+    report: (snap) => reports.push(snap),
+  };
+  return { deps, reports };
+}
+
+function makeSource() {
+  return new CodexAppServerSource();
+}
+
+// ── start / stop ─────────────────────────────────────────────────────────────
+
+describe("CodexAppServerSource — lifecycle", () => {
+  it("has name 'codex-appserver'", () => {
+    expect(makeSource().name).toBe("codex-appserver");
+  });
+
+  it("ignores observe() before start()", () => {
+    const src = makeSource();
+    // Should not throw; just drop the event.
+    src.observe({ type: "task.turn.completed", id: TASK_ID, turnId: TURN_ID });
+  });
+
+  it("stops reporting after stop()", () => {
+    const { deps, reports } = makeDeps();
+    const src = makeSource();
+    src.start(deps);
+    src.observe({ type: "task.turn.completed", id: TASK_ID, turnId: TURN_ID });
+    expect(reports).toHaveLength(1);
+    src.stop();
+    src.observe({ type: "task.turn.completed", id: TASK_ID, turnId: TURN_ID });
+    expect(reports).toHaveLength(1); // no new reports after stop
+  });
+
+  it("stop() clears the snapshot cache", () => {
+    const { deps } = makeDeps();
+    const src = makeSource();
+    src.start(deps);
+    src.observe({ type: "task.turn.completed", id: TASK_ID, turnId: TURN_ID });
+    expect(src.snapshot(TASK_ID)).toBeDefined();
+    src.stop();
+    expect(src.snapshot(TASK_ID)).toBeUndefined();
+  });
+});
+
+// ── running events ────────────────────────────────────────────────────────────
+
+describe("CodexAppServerSource — running state", () => {
+  let src: CodexAppServerSource;
+  let reports: LifecycleSnapshot[];
+
+  beforeEach(() => {
+    const fixture = makeDeps();
+    reports = fixture.reports;
+    src = makeSource();
+    src.start(fixture.deps);
+  });
+
+  it("task.started → running, alive:true, origin:agent", () => {
+    src.observe({ type: "task.started", id: TASK_ID });
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toMatchObject({ taskId: TASK_ID, state: "running", alive: true, origin: "agent" });
+  });
+
+  it("task.reattached → running, alive:true", () => {
+    src.observe({ type: "task.reattached", id: TASK_ID });
+    expect(reports[0]).toMatchObject({ taskId: TASK_ID, state: "running", alive: true });
+  });
+
+  it("task.turn.started → running", () => {
+    src.observe({ type: "task.turn.started", id: TASK_ID, turnId: TURN_ID });
+    expect(reports[0]).toMatchObject({ taskId: TASK_ID, state: "running" });
+  });
+
+  it("task.delta → running (liveness heartbeat)", () => {
+    src.observe({ type: "task.delta", id: TASK_ID, turnId: TURN_ID, chunk: "hi" });
+    expect(reports[0]).toMatchObject({ taskId: TASK_ID, state: "running" });
+  });
+
+  it("task.progress → running (liveness heartbeat)", () => {
+    src.observe({ type: "task.progress", id: TASK_ID, tool: "Bash" });
+    expect(reports[0]).toMatchObject({ taskId: TASK_ID, state: "running" });
+  });
+});
+
+// ── idle events ──────────────────────────────────────────────────────────────
+
+describe("CodexAppServerSource — idle state", () => {
+  let src: CodexAppServerSource;
+  let reports: LifecycleSnapshot[];
+
+  beforeEach(() => {
+    const fixture = makeDeps();
+    reports = fixture.reports;
+    src = makeSource();
+    src.start(fixture.deps);
+  });
+
+  it("task.turn.completed → idle, alive:true", () => {
+    src.observe({ type: "task.turn.completed", id: TASK_ID, turnId: TURN_ID });
+    expect(reports[0]).toMatchObject({ taskId: TASK_ID, state: "idle", alive: true, origin: "agent" });
+  });
+
+  it("task.failed → idle, alive:true (crew alive; turn ended with error)", () => {
+    src.observe({ type: "task.failed", id: TASK_ID, error: "boom" });
+    expect(reports[0]).toMatchObject({ taskId: TASK_ID, state: "idle", alive: true });
+  });
+
+  it("task.session.ended → idle, alive:false (process gone)", () => {
+    src.observe({ type: "task.session.ended", id: TASK_ID });
+    expect(reports[0]).toMatchObject({ taskId: TASK_ID, state: "idle", alive: false, origin: "agent" });
+  });
+});
+
+// ── needsInput events ─────────────────────────────────────────────────────────
+
+describe("CodexAppServerSource — needsInput state", () => {
+  let src: CodexAppServerSource;
+  let reports: LifecycleSnapshot[];
+
+  beforeEach(() => {
+    const fixture = makeDeps();
+    reports = fixture.reports;
+    src = makeSource();
+    src.start(fixture.deps);
+  });
+
+  it("task.approval.requested → needsInput with detail", () => {
+    src.observe({
+      type: "task.approval.requested",
+      id: TASK_ID,
+      requestId: 1,
+      question: "Allow shell?",
+      kind: "execCommandApproval",
+    });
+    expect(reports[0]).toMatchObject({
+      taskId: TASK_ID,
+      state: "needsInput",
+      alive: true,
+      origin: "agent",
+      detail: { note: "Allow shell?", reason: "execCommandApproval" },
+    });
+  });
+
+  it("task.input.requested → needsInput with detail", () => {
+    src.observe({
+      type: "task.input.requested",
+      id: TASK_ID,
+      requestId: 2,
+      question: "What next?",
+    });
+    expect(reports[0]).toMatchObject({
+      taskId: TASK_ID,
+      state: "needsInput",
+      alive: true,
+      detail: { note: "What next?" },
+    });
+  });
+});
+
+// ── ignored events ───────────────────────────────────────────────────────────
+
+describe("CodexAppServerSource — ignored (no report)", () => {
+  let src: CodexAppServerSource;
+  let reports: LifecycleSnapshot[];
+
+  beforeEach(() => {
+    const fixture = makeDeps();
+    reports = fixture.reports;
+    src = makeSource();
+    src.start(fixture.deps);
+  });
+
+  const ignoredEvents: ControlEvent[] = [
+    { type: "task.done", id: TASK_ID, resultRef: "/tmp/out.txt" },
+    { type: "task.blocked", id: TASK_ID, reason: "blocked", question: "?" },
+    { type: "task.cancelled", id: TASK_ID },
+    { type: "task.session", id: TASK_ID, resumeRef: "thread-xyz" },
+    { type: "task.stalled", id: TASK_ID, heartbeatBudgetMs: 60000 },
+    { type: "task.quiet", id: TASK_ID, quietMs: 30000 },
+    { type: "task.idle", id: TASK_ID, heartbeatBudgetMs: 60000 },
+    { type: "task.timeout", id: TASK_ID, taskTimeoutMs: 3600000 },
+    { type: "task.reconcile-failed", id: TASK_ID, reason: "no pane" },
+    { type: "task.reopened", id: TASK_ID },
+    { type: "heartbeat", id: TASK_ID },
+  ];
+
+  for (const ev of ignoredEvents) {
+    it(`${ev.type} → no report (terminal or notify-only)`, () => {
+      src.observe(ev);
+      expect(reports).toHaveLength(0);
+    });
+  }
+});
+
+// ── snapshot() liveness floor ─────────────────────────────────────────────────
+
+describe("CodexAppServerSource — snapshot()", () => {
+  it("returns undefined before any observation", () => {
+    const { deps } = makeDeps();
+    const src = makeSource();
+    src.start(deps);
+    expect(src.snapshot(TASK_ID)).toBeUndefined();
+  });
+
+  it("returns last observed snapshot", () => {
+    const { deps } = makeDeps();
+    const src = makeSource();
+    src.start(deps);
+    src.observe({ type: "task.turn.completed", id: TASK_ID, turnId: TURN_ID });
+    src.observe({ type: "task.approval.requested", id: TASK_ID, requestId: 1, question: "?", kind: "k" });
+    const snap = src.snapshot(TASK_ID);
+    expect(snap?.state).toBe("needsInput");
+  });
+
+  it("tracks multiple taskIds independently", () => {
+    const { deps } = makeDeps();
+    const src = makeSource();
+    src.start(deps);
+    src.observe({ type: "task.turn.completed", id: "task-A", turnId: TURN_ID });
+    src.observe({ type: "task.started", id: "task-B" });
+    expect(src.snapshot("task-A")?.state).toBe("idle");
+    expect(src.snapshot("task-B")?.state).toBe("running");
+  });
+});
+
+// ── anti-#2576 invariant ─────────────────────────────────────────────────────
+
+describe("CodexAppServerSource — anti-#2576: never reports task.done", () => {
+  it("task.done is ignored — no report emitted", () => {
+    const { deps, reports } = makeDeps();
+    const src = makeSource();
+    src.start(deps);
+    src.observe({ type: "task.done", id: TASK_ID, resultRef: "/out" });
+    expect(reports).toHaveLength(0);
+  });
+});

--- a/packages/agents/src/codex/codex-app-server-source.ts
+++ b/packages/agents/src/codex/codex-app-server-source.ts
@@ -1,0 +1,117 @@
+// codex-app-server-source.ts — LifecycleSource adapter for the codex app-server.
+//
+// Implements D5 from the #333 design: wraps the existing CodexInteractiveDriver
+// as a LifecycleSource without changing the driver's internals.
+//
+// Mechanism: the daemon emit path calls observe(ev) with every ControlEvent that
+// CodexInteractiveDriver emits. This source maps those events to LifecycleSnapshots
+// and feeds them into the reduceLifecycle pipeline via deps.report().
+//
+// Correlation: codex ControlEvents already carry ev.id (taskId), so no
+// deps.resolve() lookup is needed — taskId is known at the call site.
+//
+// NOT wired into the live daemon in Phase 1 (additive per D3/D7).
+// The sibling NativeHookSource crew wires both sources in after this file lands.
+
+import type { LifecycleSource, LifecycleSourceDeps, LifecycleSnapshot } from "@squadrant/core";
+import type { ControlEvent } from "@squadrant/shared";
+
+// ── CodexAppServerSource ─────────────────────────────────────────────────────
+
+/**
+ * LifecycleSource adapter for the codex app-server driver.
+ *
+ * Push-only source: the app-server is event-driven, not polled. snapshot()
+ * returns the last reported state for the liveness floor.
+ *
+ * Usage (daemon wiring, handled by sibling crew):
+ *   const source = new CodexAppServerSource();
+ *   source.start(deps);
+ *   // Wrap the driver's emit so every event also passes through the source:
+ *   const emit = (ev) => { source.observe(ev); handle(ev); };
+ *   const driver = new CodexInteractiveDriver({ emit, ... });
+ */
+export class CodexAppServerSource implements LifecycleSource {
+  readonly name = "codex-appserver";
+
+  private deps?: LifecycleSourceDeps;
+  /** taskId → last reported snapshot (for snapshot() liveness floor). */
+  private cache = new Map<string, LifecycleSnapshot>();
+
+  start(deps: LifecycleSourceDeps): void {
+    this.deps = deps;
+  }
+
+  stop(): void {
+    this.deps = undefined;
+    this.cache.clear();
+  }
+
+  /** Returns the last-reported snapshot for a known crew (liveness floor). */
+  snapshot(taskId: string): LifecycleSnapshot | undefined {
+    return this.cache.get(taskId);
+  }
+
+  /**
+   * Feed a ControlEvent from CodexInteractiveDriver into this source.
+   * The daemon wires: emit = (ev) => { source.observe(ev); handle(ev); }
+   *
+   * All events that carry lifecycle meaning for a codex crew are mapped to a
+   * LifecycleSnapshot and reported. Events that are terminal signals (task.done,
+   * task.cancelled, task.blocked) or notify-only (task.stalled, task.quiet, etc.)
+   * are ignored — terminal state still comes exclusively from `squadrant crew signal`
+   * (anti-#2576 invariant).
+   */
+  observe(ev: ControlEvent): void {
+    const snap = toSnapshot(ev);
+    if (!snap || !this.deps) return;
+    this.cache.set(snap.taskId, snap);
+    this.deps.report(snap);
+  }
+}
+
+// ── private: ControlEvent → LifecycleSnapshot ────────────────────────────────
+
+function toSnapshot(ev: ControlEvent): LifecycleSnapshot | null {
+  const now = Date.now();
+  switch (ev.type) {
+    // ── running: a turn is live ──────────────────────────────────────────────
+    case "task.started":
+    case "task.reattached":
+    case "task.turn.started":
+    case "task.delta":
+    case "task.progress":
+      return { taskId: ev.id, state: "running", alive: true, origin: "agent", at: now };
+
+    // ── idle: turn ended, crew alive, awaiting next input ────────────────────
+    // task.failed: the turn ended with an error, but the crew process is alive.
+    // task.session.ended: process is gone (alive:false) — signals liveness loss.
+    case "task.turn.completed":
+      return { taskId: ev.id, state: "idle", alive: true, origin: "agent", at: now };
+
+    case "task.failed":
+      return { taskId: ev.id, state: "idle", alive: true, origin: "agent", at: now };
+
+    case "task.session.ended":
+      return { taskId: ev.id, state: "idle", alive: false, origin: "agent", at: now };
+
+    // ── needsInput: crew is blocked on a human ───────────────────────────────
+    case "task.approval.requested":
+      return {
+        taskId: ev.id, state: "needsInput", alive: true, origin: "agent", at: now,
+        detail: { note: ev.question, reason: ev.kind },
+      };
+
+    case "task.input.requested":
+      return {
+        taskId: ev.id, state: "needsInput", alive: true, origin: "agent", at: now,
+        detail: { note: ev.question },
+      };
+
+    // ── terminal / notify-only — ignored ────────────────────────────────────
+    // task.done, task.blocked, task.cancelled: terminal state from crew signal only.
+    // task.session, task.stalled, task.quiet, task.idle, task.timeout, etc.: no-op.
+    default:
+      return null;
+  }
+}

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -2,6 +2,7 @@
 export * from "./drivers/index.js";
 export * from "./projection/index.js";
 export * from "./codex/app-server-client.js";
+export * from "./codex/codex-app-server-source.js";
 export * from "./codex/driver.js";
 export * from "./codex/normalize.js";
 export * from "./opencode/sse-bridge.js";

--- a/packages/agents/src/interactive/pane-classifier.ts
+++ b/packages/agents/src/interactive/pane-classifier.ts
@@ -55,6 +55,20 @@ export function classifyPaneTail(
     return { kind: "approval", text: "Crew is awaiting permission approval." };
   }
 
+  // ── generic picker: opencode's multi-option widget (no Yes/No) ───────────
+  // The question is buried mid-paragraph; the picker footer ("↑↓ select …")
+  // is the last content line, so detectTrailingQuestion never fires for it.
+  const hasPickerFooter = cleaned.some((c) => c != null && PICKER_FOOTER_RE.test(c));
+  if (options.length >= 2 && hasPickerFooter) {
+    const firstOptCi = options[0].ci;
+    for (let i = firstOptCi - 1; i >= 0; i--) {
+      const c = cleaned[i];
+      if (c == null) continue;
+      if (c.endsWith("?")) return { kind: "question", text: c };
+    }
+    return { kind: "question", text: "Crew is awaiting a choice." };
+  }
+
   // ── question: trailing question in the chrome-stripped agent output region ──
   const region = cleaned.filter((c): c is string => c != null).join("\n");
   const q = detectTrailingQuestion(region);
@@ -88,6 +102,10 @@ const ERROR_BANNER_RE: RegExp[] = [
 // A numbered option line, after chrome stripping: an optional cursor marker
 // (❯ / > / ›), a number, a dot, then the label. e.g. "❯ 1. Yes".
 const OPTION_RE = /^[❯>›]?\s*(\d+)\.\s+(.*\S)\s*$/;
+
+// Footer navigation hint line rendered by opencode's interactive picker widget.
+// The last content line of the picker box is the keyboard-shortcut legend.
+const PICKER_FOOTER_RE = /↑↓\s*select|enter\s+submit|esc\s+dismiss/i;
 
 // Box-drawing / rule characters that make up a pure-chrome line.
 const PURE_CHROME_RE = /^[\s─━│┃╭╮╰╯┌┐└┘├┤┬┴┼═║╔╗╚╝╠╣╦╩╬▁▂▃▄▅▆▇█▔▏▕]+$/;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": { "build": "tsc -b" },
   "dependencies": {
+    "@inquirer/checkbox": "^4.1.5",
     "@squadrant/agents": "workspace:*",
     "@squadrant/core": "workspace:*",
     "@squadrant/shared": "workspace:*",

--- a/packages/cli/src/commands/__tests__/launch-interactive.test.ts
+++ b/packages/cli/src/commands/__tests__/launch-interactive.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  partitionByYesterday,
+  getYesterday,
+  selectCaptainsInteractive,
+  type CaptainEntry,
+} from "../launch-interactive.js";
+
+const MOCK_ENTRIES: CaptainEntry[] = [
+  { projectName: "squadrant", captainName: "⚓ squadrant-captain", lastLaunched: "2026-06-26" },
+  { projectName: "brove", captainName: "⚓ brove-captain", lastLaunched: "2026-06-26" },
+  { projectName: "oneplan", captainName: "⚓ oneplan-captain", lastLaunched: "2026-06-25" },
+  { projectName: "park", captainName: "⚓ park-captain", lastLaunched: null },
+];
+
+describe("getYesterday", () => {
+  it("returns yesterday's date in YYYY-MM-DD format", () => {
+    const yesterday = getYesterday();
+    expect(yesterday).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    const d = new Date();
+    d.setDate(d.getDate() - 1);
+    expect(yesterday).toBe(d.toISOString().slice(0, 10));
+  });
+});
+
+describe("partitionByYesterday", () => {
+  it("separates yesterday-launched entries from the rest", () => {
+    const result = partitionByYesterday(MOCK_ENTRIES, "2026-06-26");
+    expect(result.yesterday).toEqual([
+      { projectName: "squadrant", captainName: "⚓ squadrant-captain", lastLaunched: "2026-06-26" },
+      { projectName: "brove", captainName: "⚓ brove-captain", lastLaunched: "2026-06-26" },
+    ]);
+    expect(result.rest).toEqual([
+      { projectName: "oneplan", captainName: "⚓ oneplan-captain", lastLaunched: "2026-06-25" },
+      { projectName: "park", captainName: "⚓ park-captain", lastLaunched: null },
+    ]);
+  });
+
+  it("returns empty yesterday array when none match", () => {
+    const result = partitionByYesterday(MOCK_ENTRIES, "2099-01-01");
+    expect(result.yesterday).toEqual([]);
+    expect(result.rest).toEqual(MOCK_ENTRIES);
+  });
+
+  it("returns empty rest array when all match", () => {
+    const allYesterday = MOCK_ENTRIES.map(e => ({ ...e, lastLaunched: "2026-06-26" }));
+    const result = partitionByYesterday(allYesterday, "2026-06-26");
+    expect(result.yesterday).toEqual(allYesterday);
+    expect(result.rest).toEqual([]);
+  });
+});
+
+describe("selectCaptainsInteractive", () => {
+  const mockCheckbox = vi.hoisted(() => vi.fn());
+  vi.mock("@inquirer/checkbox", () => {
+    class Separator {
+      separator: string;
+      constructor(separator: string) { this.separator = separator; }
+      toString() { return this.separator; }
+    }
+    const mod = mockCheckbox as typeof mockCheckbox & { Separator: typeof Separator };
+    mod.Separator = Separator;
+    return { default: mod, Separator };
+  });
+
+  beforeEach(() => {
+    mockCheckbox.mockReset();
+  });
+
+  it("shows yesterday's captains pre-checked and returns selection", async () => {
+    const yesterdayEntries = MOCK_ENTRIES.filter(e => e.lastLaunched === "2026-06-26");
+    mockCheckbox.mockResolvedValue(["squadrant"]);
+
+    const result = await selectCaptainsInteractive(MOCK_ENTRIES);
+
+    expect(result).toEqual(["squadrant"]);
+
+    // Verify the checkbox was called with yesterday's entries pre-checked + "Show all"
+    const callArgs = mockCheckbox.mock.calls[0][0];
+    expect(callArgs.message).toContain("Select captains to launch");
+    const choices = callArgs.choices;
+    // The "Show all" entry is present
+    expect(choices.some((c: { value: string }) => c.value === "__show_all__")).toBe(true);
+    // Each yesterday entry is pre-checked
+    for (const y of yesterdayEntries) {
+      const choice = choices.find((c: { value: string }) => c.value === y.projectName);
+      expect(choice).toBeDefined();
+      expect(choice.checked).toBe(true);
+    }
+  });
+
+  it("re-prompts with all projects when Show all is selected", async () => {
+    // First call: user selects "brove" + "__show_all__"
+    // Second call: user selects "brove" + "park"
+    mockCheckbox
+      .mockResolvedValueOnce(["brove", "__show_all__"])
+      .mockResolvedValueOnce(["brove", "park"]);
+
+    const result = await selectCaptainsInteractive(MOCK_ENTRIES);
+
+    expect(result).toEqual(["brove", "park"]);
+    expect(mockCheckbox).toHaveBeenCalledTimes(2);
+
+    // Second call should have ALL projects listed
+    const secondCallChoices = mockCheckbox.mock.calls[1][0].choices;
+    for (const e of MOCK_ENTRIES) {
+      expect(secondCallChoices.some((c: { value: string }) => c.value === e.projectName)).toBe(true);
+    }
+  });
+
+  it("shows all projects unchecked when none were launched yesterday", async () => {
+    mockCheckbox.mockResolvedValue(["oneplan", "park"]);
+
+    const entriesWithoutYesterday = MOCK_ENTRIES.map(e => ({ ...e, lastLaunched: null }));
+    const result = await selectCaptainsInteractive(entriesWithoutYesterday);
+
+    expect(result).toEqual(["oneplan", "park"]);
+
+    // All non-separator choices should be unchecked
+    const choices = mockCheckbox.mock.calls[0][0].choices.filter((c: { value?: string }) => c.value);
+    for (const c of choices) {
+      expect(c.checked).toBe(false);
+    }
+    // No "Show all" option when showing everything already
+    const values = choices.map((c: { value: string }) => c.value);
+    expect(values).not.toContain("__show_all__");
+  });
+
+  it("shows yesterday's captains pre-checked when all launched yesterday", async () => {
+    const allYesterday = MOCK_ENTRIES.map(e => ({ ...e, lastLaunched: "2026-06-26" }));
+    mockCheckbox.mockResolvedValue(["squadrant", "brove"]);
+
+    const result = await selectCaptainsInteractive(allYesterday);
+
+    expect(result).toEqual(["squadrant", "brove"]);
+
+    // Choices should include all entries pre-checked + "Show all"
+    const choices = mockCheckbox.mock.calls[0][0].choices.filter((c: { value?: string }) => c.value);
+    const values = choices.map((c: { value: string }) => c.value);
+    expect(values).toContain("__show_all__");
+    for (const c of choices.filter((c: { value: string }) => c.value !== "__show_all__")) {
+      expect(c.checked).toBe(true);
+    }
+  });
+});

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -1,0 +1,88 @@
+// hooks.ts — 'squadrant hooks <agent> <sub>' — lifecycle hook receiver for NativeHookSource.
+//
+// The NativeHookSource installer writes 'squadrant hooks claude <sub>' into
+// ~/.claude/settings.json. When claude fires a hook, this command:
+//   1. reads SQUADRANT_CREW_TASK_ID + SQUADRANT_CREW_PROJECT from the inherited env
+//   2. drains stdin for the JSON payload claude passes to every hook
+//   3. maps the sub-alias to the appropriate ControlEvent
+//   4. sends { kind: "event" } to the daemon via the existing IPC path
+//
+// Always exits 0 — claude's hook contract requires it (non-zero blocks the conversation).
+import { Command } from "commander";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { sendRequest } from "@squadrant/core";
+import { mapClaudeHookToEvent } from "@squadrant/agents";
+import type { ControlEvent } from "@squadrant/shared";
+
+const SOCK = join(homedir(), ".config", "squadrant", "squadrant.sock");
+
+async function sendToSock(req: unknown): Promise<void> {
+  await sendRequest(SOCK, req);
+}
+
+/**
+ * Map a NativeHookSource sub-alias to a ControlEvent.
+ *
+ * "stop", "notification", "session-end" delegate to mapClaudeHookToEvent (which
+ * handles detectTrailingQuestion and isPermissionNotification). The new subs
+ * not covered by the existing per-crew mapper are handled inline.
+ */
+function mapHookSub(sub: string, payload: unknown, taskId: string): ControlEvent | null {
+  switch (sub) {
+    case "session-start":
+    case "prompt-submit":
+    case "pre-tool-use":
+      return { type: "task.progress", id: taskId, note: sub };
+    case "stop":
+      return mapClaudeHookToEvent("Stop", payload, taskId);
+    case "notification":
+      return mapClaudeHookToEvent("Notification", payload, taskId);
+    case "ask-question": {
+      const q = typeof (payload as Record<string, unknown>)?.question === "string"
+        ? (payload as Record<string, unknown>).question as string
+        : "awaiting input";
+      return { type: "task.input.requested", id: taskId, requestId: 0, question: q };
+    }
+    case "session-end":
+      return mapClaudeHookToEvent("SessionEnd", payload, taskId);
+    default:
+      return null;
+  }
+}
+
+export function hooksCommand(): Command {
+  const hooks = new Command("hooks")
+    .description("(internal) receive lifecycle hook events from agent processes");
+
+  hooks
+    .command("claude <sub>", { hidden: true })
+    .description("internal: bridge a NativeHookSource claude hook to squadrantd")
+    .action(async (sub: string) => {
+      const taskId = process.env.SQUADRANT_CREW_TASK_ID;
+      const project = process.env.SQUADRANT_CREW_PROJECT;
+      // Not a crew session — no-op (hook fires for all claude processes).
+      if (!taskId || !project) { process.exit(0); }
+
+      let stdin = "";
+      try {
+        for await (const chunk of process.stdin) stdin += chunk as string;
+      } catch { /* ignore */ }
+      let payload: unknown = undefined;
+      if (stdin.trim()) {
+        try { payload = JSON.parse(stdin); } catch { /* ignore malformed */ }
+      }
+
+      const ev = mapHookSub(sub, payload, taskId);
+      if (!ev) { process.exit(0); }
+
+      try {
+        await sendToSock({ kind: "event", project, event: ev });
+      } catch {
+        // Daemon down: do NOT block claude. Hook contract requires exit 0.
+      }
+      process.exit(0);
+    });
+
+  return hooks;
+}

--- a/packages/cli/src/commands/launch-interactive.ts
+++ b/packages/cli/src/commands/launch-interactive.ts
@@ -1,0 +1,90 @@
+import checkbox, { Separator } from "@inquirer/checkbox";
+
+export interface CaptainEntry {
+  projectName: string;
+  captainName: string;
+  lastLaunched: string | null;
+}
+
+export function getYesterday(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  return d.toISOString().slice(0, 10);
+}
+
+export function partitionByYesterday(
+  entries: CaptainEntry[],
+  yesterday: string,
+): { yesterday: CaptainEntry[]; rest: CaptainEntry[] } {
+  const y: CaptainEntry[] = [];
+  const r: CaptainEntry[] = [];
+  for (const e of entries) {
+    if (e.lastLaunched === yesterday) {
+      y.push(e);
+    } else {
+      r.push(e);
+    }
+  }
+  return { yesterday: y, rest: r };
+}
+
+export async function selectCaptainsInteractive(
+  entries: CaptainEntry[],
+): Promise<string[]> {
+  const yesterday = getYesterday();
+  const { yesterday: yesterdayEntries, rest: restEntries } = partitionByYesterday(entries, yesterday);
+
+  if (yesterdayEntries.length === 0) {
+    const result = await checkbox({
+      message: "Select captains to launch:",
+      choices: entries.map(e => ({
+        name: `${e.captainName} (${e.projectName})`,
+        value: e.projectName,
+        checked: false,
+      })),
+      pageSize: 20,
+    });
+    return result;
+  }
+
+  const initialChoices = [
+    new Separator("── Opened yesterday ──"),
+    ...yesterdayEntries.map(e => ({
+      name: `${e.captainName} (${e.projectName})`,
+      value: e.projectName,
+      checked: true,
+    })),
+    new Separator(),
+    { name: "Show all projects", value: "__show_all__", checked: false },
+  ];
+
+  const result = await checkbox({
+    message: "Select captains to launch:",
+    choices: initialChoices,
+    pageSize: 20,
+  });
+
+  if (result.includes("__show_all__")) {
+    const allChecked = yesterdayEntries.map(e => e.projectName);
+    const result2 = await checkbox({
+      message: "Select captains to launch (all projects):",
+      choices: [
+        new Separator("── Opened yesterday ──"),
+        ...yesterdayEntries.map(e => ({
+          name: `${e.captainName} (${e.projectName})`,
+          value: e.projectName,
+          checked: allChecked.includes(e.projectName),
+        })),
+        ...restEntries.map(e => ({
+          name: `${e.captainName} (${e.projectName})`,
+          value: e.projectName,
+          checked: false,
+        })),
+      ],
+      pageSize: 30,
+    });
+    return result2;
+  }
+
+  return result;
+}

--- a/packages/cli/src/commands/launch.ts
+++ b/packages/cli/src/commands/launch.ts
@@ -19,7 +19,9 @@ import {
   RuntimeRegistry, createCmuxDriver, createObsidianDriver, WorkspaceRegistry,
   isInsideCmux, cmuxLocal, classifyStartupSurface,
 } from "@squadrant/workspaces";
-import { launchOneWorkspace } from "@squadrant/core";
+import { launchOneWorkspace, loadSessions } from "@squadrant/core";
+import { selectCaptainsInteractive } from "./launch-interactive.js";
+import type { CaptainEntry } from "./launch-interactive.js";
 
 // Re-export for test-import stability (launch.test.ts imports from ../launch.js).
 export { deliverStartupPrompt } from "@squadrant/core";
@@ -137,13 +139,53 @@ export const launchCommand = new Command("launch")
       }
       console.log("");
     } else if (!project) {
-      console.error(
-        chalk.red(
-          "\n  ✘ Specify a project name, or pass --all to launch every captain.\n" +
-            "    For one-shot Command tasks, use `squadrant command --task <briefing|learnings-review|wiki-aggregate>`.\n",
-        ),
-      );
-      process.exit(1);
+      // No args: interactive multi-select when TTY, error otherwise.
+      if (!process.stdin.isTTY || !process.stdout.isTTY) {
+        console.error(
+          chalk.red(
+            "\n  ✘ Specify a project name, or pass --all to launch every captain.\n" +
+              "    For one-shot Command tasks, use `squadrant command --task <briefing|learnings-review|wiki-aggregate>`.\n",
+          ),
+        );
+        process.exit(1);
+      }
+
+      // Interactive: pick captains, then launch in parallel.
+      ensureCmuxReady();
+
+      const sessions = loadSessions(SESSIONS_PATH);
+      const entries: CaptainEntry[] = Object.entries(config.projects).map(([name, proj]) => ({
+        projectName: name,
+        captainName: proj.captainName,
+        lastLaunched: sessions.workspaces[proj.captainName]?.lastLaunched ?? null,
+      }));
+
+      const selected = await selectCaptainsInteractive(entries);
+
+      if (selected.length === 0) {
+        console.log(chalk.yellow("\n  No captains selected.\n"));
+        return;
+      }
+
+      console.log(chalk.bold(`\nLaunching ${selected.length} captain workspace(s) in parallel\n`));
+
+      // Discover + create spoke vaults in parallel (different directories, safe).
+      await Promise.all(selected.map(async (name) => {
+        const proj = config.projects[name];
+        const projPath = resolveHome(proj.path);
+
+        const spokePath = resolveHome(proj.spokeVault);
+        if (!fs.existsSync(spokePath)) {
+          const spokeDriver = new WorkspaceRegistry({ obsidian: createObsidianDriver }).forProject(name, config);
+          await ensureSpokeLayout(spokeDriver);
+          console.log(chalk.cyan(`  ✔ Created spoke vault at ${spokePath}`));
+        }
+
+        console.log(chalk.bold(`\n  Captain: ${proj.captainName} (${name})`));
+        await launchOne(proj.captainName, "captain", projPath, config.defaults.permissions?.captain || "auto", false, true, name);
+      }));
+
+      console.log("");
     } else {
       // Launch captain workspace for a project
       if (!config.projects[project]) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -32,6 +32,7 @@ import { groupCommand } from "./commands/group.js";
 import { cmuxCommand } from "./commands/cmux.js";
 import { effortCommand } from "./commands/effort.js";
 import { telegramCommand } from "./commands/telegram.js";
+import { hooksCommand } from "./commands/hooks.js";
 import { detectDrift } from "@squadrant/shared";
 import { needsCheck, withStamp } from "@squadrant/shared";
 import { getDefaultConfig } from "@squadrant/shared";
@@ -118,6 +119,7 @@ program.addCommand(groupCommand);
 program.addCommand(cmuxCommand);
 program.addCommand(effortCommand);
 program.addCommand(telegramCommand);
+program.addCommand(hooksCommand());
 
 program.parseAsync().catch((e) => {
   process.stderr.write(`error: ${e instanceof Error ? e.message : String(e)}\n`);

--- a/packages/cli/src/squadrantd.ts
+++ b/packages/cli/src/squadrantd.ts
@@ -10,7 +10,9 @@ import { createAttach } from "@squadrant/core";
 import { startDaemon } from "@squadrant/core";
 import { isDaemonSocketLive } from "@squadrant/core";
 import { appendCaptainMessage, createTelegramClient, createTelegramBridge, createEnsureCaptainAlive } from "@squadrant/core";
+import { reduceLifecycle } from "@squadrant/core";
 import type { TelegramBridge } from "@squadrant/core";
+import type { LifecycleSnapshot, LifecycleSourceDeps } from "@squadrant/core";
 import type { TelegramConfig } from "@squadrant/shared";
 import { createRunCommand, createIsCaptainAlive, createLaunch } from "@squadrant/core";
 export type { SquadrantdOpts } from "@squadrant/core";
@@ -19,7 +21,7 @@ export { discoverCaptainSurface } from "@squadrant/core";
 import type { AttachFrame } from "@squadrant/core";
 import type { PaneRef } from "@squadrant/shared";
 import { runHeadless, CodexInteractiveDriver, OpencodeSseBridge } from "@squadrant/agents";
-import { CmuxEventsBridge, DaemonCmux } from "@squadrant/workspaces";
+import { CmuxEventsBridge, DaemonCmux, CmuxStoreSource } from "@squadrant/workspaces";
 import { loadConfig, TERMINAL_STATES } from "@squadrant/shared";
 import { createCmuxDriver } from "@squadrant/workspaces";
 
@@ -129,6 +131,8 @@ export function startSquadrantd(opts: import("@squadrant/core").SquadrantdOpts =
     log,
   });
 
+  const cmuxStoreSource = new CmuxStoreSource({ log });
+
   ctx.codexDriver = codexDriver;
   ctx.opencodeBridge = opencodeBridge;
   ctx.cmuxEventsBridge = cmuxEventsBridge;
@@ -162,7 +166,51 @@ export function startSquadrantd(opts: import("@squadrant/core").SquadrantdOpts =
     }
   });
 
-  return startDaemon(ctx, { ...opts, launchHeadless }, PKG_VERSION);
+  const h = startDaemon(ctx, { ...opts, launchHeadless }, PKG_VERSION);
+
+  // A1: start cmux store-file backup lifecycle source alongside CmuxEventsBridge (B1).
+  // startDaemon() guarantees ctx.d is set before returning. Skipped under vitest
+  // (mirrors the B1 guard in start.ts — real fs.watch would touch disk in tests).
+  if (!process.env.VITEST) {
+    const prevSnaps = new Map<string, LifecycleSnapshot>();
+    const storeDeps: LifecycleSourceDeps = {
+      resolve: (hint) => {
+        if (!hint.cwd) return undefined;
+        return store.listAll().find(
+          (r) => r.mode === "interactive" && !TERMINAL_STATES.has(r.state) && r.cwd === hint.cwd,
+        );
+      },
+      report: (snap) => {
+        const found = store.listAll().find((r) => r.id === snap.taskId);
+        if (!found) return;
+        const prev = prevSnaps.get(snap.taskId);
+        const newState = reduceLifecycle(prev, snap);
+        const changed = !prev || newState !== prev.state;
+        prevSnaps.set(snap.taskId, snap);
+        if (!snap.alive) {
+          void ctx.d.handle({ kind: "event", project: found.project, event: { type: "task.session.ended", id: snap.taskId } });
+          return;
+        }
+        if (!changed) return;
+        if (newState === "idle") {
+          void ctx.d.handle({ kind: "event", project: found.project, event: { type: "task.turn.completed", id: snap.taskId, turnId: "cmux-store" } });
+        } else if (newState === "running" || newState === "needsInput") {
+          void ctx.d.handle({ kind: "event", project: found.project, event: { type: "task.progress", id: snap.taskId } });
+        }
+      },
+      log,
+    };
+    try { cmuxStoreSource.start(storeDeps); }
+    catch (e) { log(`cmux store source start failed: ${(e as Error).message}`); }
+  }
+
+  const origStop = h.stop.bind(h);
+  h.stop = async () => {
+    try { cmuxStoreSource.stop(); } catch { /* best-effort */ }
+    return origStop();
+  };
+
+  return h;
 }
 
 // Executed by launchd (ProgramArguments → this file's compiled .js).

--- a/packages/cli/src/squadrantd.ts
+++ b/packages/cli/src/squadrantd.ts
@@ -20,8 +20,8 @@ export { defaultIsPidAlive } from "@squadrant/core";
 export { discoverCaptainSurface } from "@squadrant/core";
 import type { AttachFrame } from "@squadrant/core";
 import type { PaneRef } from "@squadrant/shared";
-import { runHeadless, CodexInteractiveDriver, OpencodeSseBridge } from "@squadrant/agents";
-import { CmuxEventsBridge, DaemonCmux, CmuxStoreSource } from "@squadrant/workspaces";
+import { runHeadless, CodexInteractiveDriver, OpencodeSseBridge, CodexAppServerSource } from "@squadrant/agents";
+import { CmuxEventsBridge, DaemonCmux, CmuxStoreSource, NativeHookSource } from "@squadrant/workspaces";
 import { loadConfig, TERMINAL_STATES } from "@squadrant/shared";
 import { createCmuxDriver } from "@squadrant/workspaces";
 
@@ -82,6 +82,11 @@ export function startSquadrantd(opts: import("@squadrant/core").SquadrantdOpts =
   // Emit callbacks close over ctx lazily: ctx.d, ctx.broadcast, and
   // ctx.schedulePromotion are late-bound by startDaemon before any emit fires.
 
+  // D5: codex app-server LifecycleSource — must be created before codexDriver
+  // so the emit closure can call observe(). start() is called in the VITEST-
+  // guarded block below after startDaemon() sets ctx.d.
+  const codexAppServerSource = new CodexAppServerSource();
+
   const codexDriver = opts.codexDriver ?? new CodexInteractiveDriver({
     emit: (ev) => {
       const found = ctx.store.listAll().find((r) => r.id === ev.id);
@@ -101,6 +106,7 @@ export function startSquadrantd(opts: import("@squadrant/core").SquadrantdOpts =
         ctx.schedulePromotion(ev.id, ev.requestId, "approval", ev.question);
       } else if (ev.type === "task.reattached")
         ctx.broadcast(ev.id, { type: "reattached", taskId: ev.id } as AttachFrame);
+      codexAppServerSource.observe(ev);
     },
   });
 
@@ -132,6 +138,7 @@ export function startSquadrantd(opts: import("@squadrant/core").SquadrantdOpts =
   });
 
   const cmuxStoreSource = new CmuxStoreSource({ log });
+  const nativeHookSource = new NativeHookSource({ log });
 
   ctx.codexDriver = codexDriver;
   ctx.opencodeBridge = opencodeBridge;
@@ -202,11 +209,76 @@ export function startSquadrantd(opts: import("@squadrant/core").SquadrantdOpts =
     };
     try { cmuxStoreSource.start(storeDeps); }
     catch (e) { log(`cmux store source start failed: ${(e as Error).message}`); }
+
+    // C1: start native hook source (primary LifecycleSource C). Installs squadrant-
+    // owned hooks into ~/.claude/settings.json (idempotent, namespaced per D4).
+    try { nativeHookSource.install(); }
+    catch (e) { log(`native hook install failed: ${(e as Error).message}`); }
+    const hookPrevSnaps = new Map<string, LifecycleSnapshot>();
+    const hookDeps: LifecycleSourceDeps = {
+      resolve: (hint) => {
+        if (!hint.cwd) return undefined;
+        return store.listAll().find(
+          (r) => r.mode === "interactive" && !TERMINAL_STATES.has(r.state) && r.cwd === hint.cwd,
+        );
+      },
+      report: (snap) => {
+        const found = store.listAll().find((r) => r.id === snap.taskId);
+        if (!found) return;
+        const prev = hookPrevSnaps.get(snap.taskId);
+        const newState = reduceLifecycle(prev, snap);
+        const changed = !prev || newState !== prev.state;
+        hookPrevSnaps.set(snap.taskId, snap);
+        if (!snap.alive) {
+          void ctx.d.handle({ kind: "event", project: found.project, event: { type: "task.session.ended", id: snap.taskId } });
+          return;
+        }
+        if (!changed) return;
+        if (newState === "idle") {
+          void ctx.d.handle({ kind: "event", project: found.project, event: { type: "task.turn.completed", id: snap.taskId, turnId: "native-hook" } });
+        } else if (newState === "running" || newState === "needsInput") {
+          void ctx.d.handle({ kind: "event", project: found.project, event: { type: "task.progress", id: snap.taskId } });
+        }
+      },
+      log,
+    };
+    try { nativeHookSource.start(hookDeps); }
+    catch (e) { log(`native hook source start failed: ${(e as Error).message}`); }
+
+    // D5: start codex app-server lifecycle source. codexAppServerSource.observe()
+    // is already wired into the codexDriver emit above; start() connects the deps.
+    const codexPrevSnaps = new Map<string, LifecycleSnapshot>();
+    const codexSourceDeps: LifecycleSourceDeps = {
+      resolve: () => undefined,  // taskId comes from ControlEvent.id; resolve() unused
+      report: (snap) => {
+        const found = store.listAll().find((r) => r.id === snap.taskId);
+        if (!found) return;
+        const prev = codexPrevSnaps.get(snap.taskId);
+        const newState = reduceLifecycle(prev, snap);
+        const changed = !prev || newState !== prev.state;
+        codexPrevSnaps.set(snap.taskId, snap);
+        if (!snap.alive) {
+          void ctx.d.handle({ kind: "event", project: found.project, event: { type: "task.session.ended", id: snap.taskId } });
+          return;
+        }
+        if (!changed) return;
+        if (newState === "idle") {
+          void ctx.d.handle({ kind: "event", project: found.project, event: { type: "task.turn.completed", id: snap.taskId, turnId: "codex-appserver" } });
+        } else if (newState === "running" || newState === "needsInput") {
+          void ctx.d.handle({ kind: "event", project: found.project, event: { type: "task.progress", id: snap.taskId } });
+        }
+      },
+      log,
+    };
+    try { codexAppServerSource.start(codexSourceDeps); }
+    catch (e) { log(`codex app-server source start failed: ${(e as Error).message}`); }
   }
 
   const origStop = h.stop.bind(h);
   h.stop = async () => {
     try { cmuxStoreSource.stop(); } catch { /* best-effort */ }
+    try { nativeHookSource.stop(); } catch { /* best-effort */ }
+    try { codexAppServerSource.stop(); } catch { /* best-effort */ }
     return origStop();
   };
 

--- a/packages/cli/src/squadrantd.ts
+++ b/packages/cli/src/squadrantd.ts
@@ -182,9 +182,10 @@ export function startSquadrantd(opts: import("@squadrant/core").SquadrantdOpts =
     const prevSnaps = new Map<string, LifecycleSnapshot>();
     const storeDeps: LifecycleSourceDeps = {
       resolve: (hint) => {
-        if (!hint.cwd) return undefined;
+        if (!hint.cwd && hint.pid == null) return undefined;
         return store.listAll().find(
-          (r) => r.mode === "interactive" && !TERMINAL_STATES.has(r.state) && r.cwd === hint.cwd,
+          (r) => r.mode === "interactive" && !TERMINAL_STATES.has(r.state) &&
+            (r.cwd === hint.cwd || (hint.pid != null && r.pid === hint.pid)),
         );
       },
       report: (snap) => {
@@ -201,8 +202,11 @@ export function startSquadrantd(opts: import("@squadrant/core").SquadrantdOpts =
         if (!changed) return;
         if (newState === "idle") {
           void ctx.d.handle({ kind: "event", project: found.project, event: { type: "task.turn.completed", id: snap.taskId, turnId: "cmux-store" } });
-        } else if (newState === "running" || newState === "needsInput") {
+        } else if (newState === "running") {
           void ctx.d.handle({ kind: "event", project: found.project, event: { type: "task.progress", id: snap.taskId } });
+        } else if (newState === "needsInput") {
+          const question = snap.detail?.note ?? snap.detail?.reason ?? "crew awaiting input";
+          void ctx.d.handle({ kind: "event", project: found.project, event: { type: "task.blocked", id: snap.taskId, reason: "needsInput", question } });
         }
       },
       log,
@@ -217,9 +221,10 @@ export function startSquadrantd(opts: import("@squadrant/core").SquadrantdOpts =
     const hookPrevSnaps = new Map<string, LifecycleSnapshot>();
     const hookDeps: LifecycleSourceDeps = {
       resolve: (hint) => {
-        if (!hint.cwd) return undefined;
+        if (!hint.cwd && hint.pid == null) return undefined;
         return store.listAll().find(
-          (r) => r.mode === "interactive" && !TERMINAL_STATES.has(r.state) && r.cwd === hint.cwd,
+          (r) => r.mode === "interactive" && !TERMINAL_STATES.has(r.state) &&
+            (r.cwd === hint.cwd || (hint.pid != null && r.pid === hint.pid)),
         );
       },
       report: (snap) => {
@@ -236,8 +241,11 @@ export function startSquadrantd(opts: import("@squadrant/core").SquadrantdOpts =
         if (!changed) return;
         if (newState === "idle") {
           void ctx.d.handle({ kind: "event", project: found.project, event: { type: "task.turn.completed", id: snap.taskId, turnId: "native-hook" } });
-        } else if (newState === "running" || newState === "needsInput") {
+        } else if (newState === "running") {
           void ctx.d.handle({ kind: "event", project: found.project, event: { type: "task.progress", id: snap.taskId } });
+        } else if (newState === "needsInput") {
+          const question = snap.detail?.note ?? snap.detail?.reason ?? "crew awaiting input";
+          void ctx.d.handle({ kind: "event", project: found.project, event: { type: "task.blocked", id: snap.taskId, reason: "needsInput", question } });
         }
       },
       log,
@@ -264,8 +272,11 @@ export function startSquadrantd(opts: import("@squadrant/core").SquadrantdOpts =
         if (!changed) return;
         if (newState === "idle") {
           void ctx.d.handle({ kind: "event", project: found.project, event: { type: "task.turn.completed", id: snap.taskId, turnId: "codex-appserver" } });
-        } else if (newState === "running" || newState === "needsInput") {
+        } else if (newState === "running") {
           void ctx.d.handle({ kind: "event", project: found.project, event: { type: "task.progress", id: snap.taskId } });
+        } else if (newState === "needsInput") {
+          const question = snap.detail?.note ?? snap.detail?.reason ?? "crew awaiting input";
+          void ctx.d.handle({ kind: "event", project: found.project, event: { type: "task.blocked", id: snap.taskId, reason: "needsInput", question } });
         }
       },
       log,

--- a/packages/core/src/__tests__/lifecycle-source.test.ts
+++ b/packages/core/src/__tests__/lifecycle-source.test.ts
@@ -1,0 +1,116 @@
+// packages/core/src/__tests__/lifecycle-source.test.ts
+//
+// Table-driven unit tests for the pure `reduceLifecycle` reducer.
+// These cover every transition rule from the FeedCoordinator spec (D1-D7):
+//   - agent-originated signals are authoritative
+//   - scan may NEVER assert needsInput
+//   - needsInput set by an agent only relaxes on an agent-originated running
+//   - a stale scan does not regress a more recent agent state
+import { describe, it, expect } from "vitest";
+import { reduceLifecycle } from "../lifecycle-source.js";
+import type { LifecycleSnapshot, LifecycleState } from "../lifecycle-source.js";
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+function snap(
+  state: LifecycleState,
+  origin: "agent" | "scan",
+  at = 100,
+  taskId = "t1",
+): LifecycleSnapshot {
+  return { taskId, state, alive: true, origin, at };
+}
+
+// ── table cases ─────────────────────────────────────────────────────────────
+
+// Case set 1: no prior state + agent signal — agent is authoritative.
+describe("reduceLifecycle — no prior + agent", () => {
+  it("undefined prev + agent running → running", () => {
+    expect(reduceLifecycle(undefined, snap("running", "agent"))).toBe("running");
+  });
+  it("undefined prev + agent idle → idle", () => {
+    expect(reduceLifecycle(undefined, snap("idle", "agent"))).toBe("idle");
+  });
+  it("undefined prev + agent needsInput → needsInput", () => {
+    expect(reduceLifecycle(undefined, snap("needsInput", "agent"))).toBe("needsInput");
+  });
+  it("undefined prev + agent unknown → unknown", () => {
+    expect(reduceLifecycle(undefined, snap("unknown", "agent"))).toBe("unknown");
+  });
+});
+
+// Case set 2: no prior state + scan signal — scan provides liveness only.
+describe("reduceLifecycle — no prior + scan", () => {
+  it("undefined prev + scan running → running", () => {
+    expect(reduceLifecycle(undefined, snap("running", "scan"))).toBe("running");
+  });
+  it("undefined prev + scan idle → idle", () => {
+    expect(reduceLifecycle(undefined, snap("idle", "scan"))).toBe("idle");
+  });
+  it("undefined prev + scan unknown → unknown", () => {
+    expect(reduceLifecycle(undefined, snap("unknown", "scan"))).toBe("unknown");
+  });
+  it("undefined prev + scan needsInput → unknown (scan cannot assert needsInput)", () => {
+    expect(reduceLifecycle(undefined, snap("needsInput", "scan"))).toBe("unknown");
+  });
+});
+
+// Case set 3: agent-set needsInput is sticky — scan cannot override it.
+describe("reduceLifecycle — needsInput sticky against scans", () => {
+  const prev = snap("needsInput", "agent", 10);
+
+  it("agent needsInput + scan running (newer) → needsInput", () => {
+    expect(reduceLifecycle(prev, snap("running", "scan", 20))).toBe("needsInput");
+  });
+  it("agent needsInput + scan idle (newer) → needsInput", () => {
+    expect(reduceLifecycle(prev, snap("idle", "scan", 20))).toBe("needsInput");
+  });
+  it("agent needsInput + scan unknown (newer) → needsInput", () => {
+    expect(reduceLifecycle(prev, snap("unknown", "scan", 20))).toBe("needsInput");
+  });
+  it("agent needsInput + scan needsInput (newer) → needsInput (invalid scan state preserved via stickiness)", () => {
+    expect(reduceLifecycle(prev, snap("needsInput", "scan", 20))).toBe("needsInput");
+  });
+});
+
+// Case set 4: agent CAN override any prior state including needsInput.
+describe("reduceLifecycle — agent overrides everything", () => {
+  it("agent needsInput prev + agent running → running", () => {
+    expect(reduceLifecycle(snap("needsInput", "agent", 10), snap("running", "agent", 20))).toBe("running");
+  });
+  it("agent needsInput prev + agent idle → idle", () => {
+    expect(reduceLifecycle(snap("needsInput", "agent", 10), snap("idle", "agent", 20))).toBe("idle");
+  });
+  it("agent needsInput prev + agent unknown → unknown", () => {
+    expect(reduceLifecycle(snap("needsInput", "agent", 10), snap("unknown", "agent", 20))).toBe("unknown");
+  });
+  it("scan idle prev + agent needsInput → needsInput", () => {
+    expect(reduceLifecycle(snap("idle", "scan", 10), snap("needsInput", "agent", 20))).toBe("needsInput");
+  });
+  it("agent running prev + agent needsInput → needsInput", () => {
+    expect(reduceLifecycle(snap("running", "agent", 10), snap("needsInput", "agent", 20))).toBe("needsInput");
+  });
+});
+
+// Case set 5: stale scan does not regress a more-recent agent state.
+describe("reduceLifecycle — timestamp precedence for scans", () => {
+  it("agent running (at=20) + scan idle (at=10, stale) → running", () => {
+    expect(reduceLifecycle(snap("running", "agent", 20), snap("idle", "scan", 10))).toBe("running");
+  });
+  it("agent running (at=10) + scan idle (at=20, newer) → idle", () => {
+    expect(reduceLifecycle(snap("running", "agent", 10), snap("idle", "scan", 20))).toBe("idle");
+  });
+  it("agent running (at=20) + scan unknown (at=20, same timestamp) → running (tie → agent wins)", () => {
+    expect(reduceLifecycle(snap("running", "agent", 20), snap("unknown", "scan", 20))).toBe("running");
+  });
+});
+
+// Case set 6: scan prev + agent next — agent is always authoritative regardless of timestamp.
+describe("reduceLifecycle — agent always wins against scan prev", () => {
+  it("scan idle (at=20) prev + agent running (at=10, older) → running", () => {
+    expect(reduceLifecycle(snap("idle", "scan", 20), snap("running", "agent", 10))).toBe("running");
+  });
+  it("scan running (at=100) prev + agent needsInput (at=1) → needsInput", () => {
+    expect(reduceLifecycle(snap("running", "scan", 100), snap("needsInput", "agent", 1))).toBe("needsInput");
+  });
+});

--- a/packages/core/src/daemon/interactive-probe.ts
+++ b/packages/core/src/daemon/interactive-probe.ts
@@ -37,6 +37,7 @@ const ERROR_BANNER_RE: RegExp[] = [
   /\bmaximum\s+retries\b/i,
 ];
 const OPTION_RE = /^[❯>›]?\s*(\d+)\.\s+(.*\S)\s*$/;
+const PICKER_FOOTER_RE = /↑↓\s*select|enter\s+submit|esc\s+dismiss/i;
 const PURE_CHROME_RE = /^[\s─━│┃╭╮╰╯┌┐└┘├┤┬┴┼═║╔╗╚╝╠╣╦╩╬▁▂▃▄▅▆▇█▔▏▕]+$/;
 const STATUS_LINE_RE = /accept edits on|shift\+tab|⏵⏵|\? for shortcuts|esc to interrupt|tokens? (used|left)|context left/i;
 
@@ -74,6 +75,16 @@ function classifyPaneTail(
       if (c.endsWith("?")) return { kind: "approval", text: c };
     }
     return { kind: "approval", text: "Crew is awaiting permission approval." };
+  }
+  const hasPickerFooter = cleaned.some((c) => c != null && PICKER_FOOTER_RE.test(c));
+  if (options.length >= 2 && hasPickerFooter) {
+    const firstOptCi = options[0].ci;
+    for (let i = firstOptCi - 1; i >= 0; i--) {
+      const c = cleaned[i];
+      if (c == null) continue;
+      if (c.endsWith("?")) return { kind: "question", text: c };
+    }
+    return { kind: "question", text: "Crew is awaiting a choice." };
   }
   const region = cleaned.filter((c): c is string => c != null).join("\n");
   const q = detectTrailingQuestion(region);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,3 +28,4 @@ export * from "./group-dispatch.js";
 export * from "./launch-workspace.js";
 export * from "./side-session.js";
 export * from "./crew-spawn.js";
+export * from "./lifecycle-source.js";

--- a/packages/core/src/lifecycle-source.ts
+++ b/packages/core/src/lifecycle-source.ts
@@ -1,0 +1,119 @@
+// packages/core/src/lifecycle-source.ts
+//
+// LifecycleSource port — phase 0 scaffold (issue #333).
+//
+// Defines the abstraction for normalizing agent lifecycle events from
+// heterogeneous sources (cmux store file, native hooks, SSE, app-server)
+// into a single 4-state model. NO concrete implementation lives here; this is
+// the interface + types + pure reducer only.
+//
+// WIRING CONSTRAINT: nothing in this file is imported by the live daemon or
+// delivery path. It compiles and tests but remains unwired until Phase 1.
+
+// ── normalized lifecycle vocabulary ─────────────────────────────────────────
+
+/** The four canonical crew lifecycle states (mirrors cmux AgentHibernationLifecycleState). */
+export type LifecycleState = "running" | "idle" | "needsInput" | "unknown";
+
+/** One observation about one crew, from one source. */
+export interface LifecycleSnapshot {
+  taskId: string;
+  state: LifecycleState;
+  /** Is the OS process actually alive (pid-verified)? */
+  alive: boolean;
+  /**
+   * Provenance — the reconciler's tie-breaker.
+   * "agent" = explicit hook / SSE / app-server transition (authoritative).
+   * "scan"  = inferred from a process/file sweep (liveness only; may NOT assert needsInput).
+   */
+  origin: "agent" | "scan";
+  /** Monotonic stamp (epoch ms) for last-writer reconciliation across sources. */
+  at: number;
+  pid?: number;
+  /** Optional human detail for surfacing CREW BLOCKED / CREW WORKING context. */
+  detail?: { note?: string; tool?: string; reason?: string };
+}
+
+/**
+ * Correlation hints a source passes when resolving a raw signal back to a crew.
+ * The daemon tries them in priority order: taskId > pid > cwd > sessionId.
+ */
+export interface CorrelationHint {
+  /** Strongest — SQUADRANT_CREW_TASK_ID injected into every crew's env at spawn. */
+  taskId?: string;
+  /** From the cmux store or process scan. */
+  pid?: number;
+  /** Weakest — collision-prone when a worktree is shared. */
+  cwd?: string;
+  /** Source-internal (cmux sessionId, codex threadId). */
+  sessionId?: string;
+}
+
+/** What the daemon hands every source: how to correlate + where to report. */
+export interface LifecycleSourceDeps {
+  /**
+   * Map a raw signal back to its owning crew TaskRecord, or undefined.
+   * Keeping it injected makes each source independently testable.
+   */
+  resolve(hint: CorrelationHint): { id: string } | undefined;
+  /** Normalized observation → reducer → ControlEvent pipeline. */
+  report(snap: LifecycleSnapshot): void;
+  log?(msg: string): void;
+}
+
+/**
+ * The port. Each adapter implements start/stop.
+ * Push sources call deps.report() on transition.
+ * Poll sources additionally expose snapshot() for the liveness floor sweep.
+ */
+export interface LifecycleSource {
+  /** Identifies the source in logs and the reconciler ("cmux-store" | "native-hook" | …). */
+  readonly name: string;
+  start(deps: LifecycleSourceDeps): void;
+  stop(): void;
+  /**
+   * Poll hook — optional.
+   * Returns the current liveness snapshot for a known crew, or undefined if
+   * this source has no view of it. Drives the liveness floor sweep.
+   * A poll result MUST set origin:"scan" and MUST NOT assert state:"needsInput".
+   */
+  snapshot?(taskId: string): LifecycleSnapshot | undefined;
+}
+
+// ── the one reducer all sources feed ────────────────────────────────────────
+
+/**
+ * Pure. Reconcile a new snapshot against the crew's last known state.
+ *
+ * Rules (from cmux FeedCoordinator.swift):
+ *   1. Agent-originated signals are authoritative — always trusted.
+ *   2. Scan signals can never assert needsInput (hook-only signal).
+ *   3. Agent-set needsInput is sticky — only an agent-originated running relaxes it.
+ *   4. A stale scan (at <= prev.at when prev is agent-set) does not regress state.
+ */
+export function reduceLifecycle(
+  prev: LifecycleSnapshot | undefined,
+  next: LifecycleSnapshot,
+): LifecycleState {
+  // Rule 1: agent-originated signals are authoritative.
+  if (next.origin === "agent") {
+    return next.state;
+  }
+
+  // Rule 2: scan signals can never assert needsInput.
+  if (next.state === "needsInput") {
+    return prev?.state ?? "unknown";
+  }
+
+  // Rule 3: agent-set needsInput is sticky against scans.
+  if (prev?.state === "needsInput") {
+    return "needsInput";
+  }
+
+  // Rule 4: a stale scan does not regress a more-recent agent state.
+  if (prev?.origin === "agent" && prev.at >= next.at) {
+    return prev.state;
+  }
+
+  return next.state;
+}

--- a/packages/workspaces/src/cmux-daemon/__tests__/cmux-store-source.test.ts
+++ b/packages/workspaces/src/cmux-daemon/__tests__/cmux-store-source.test.ts
@@ -186,15 +186,26 @@ describe("CmuxStoreSource — liveness + hibernation guard", () => {
     expect(reports[0].alive).toBe(false);
   });
 
-  it("sets alive:true when pid is dead but isRestorable:true (hibernated, not dead)", () => {
+  it("sets alive:true when pid is dead but isRestorable:true and agentLifecycle is idle (hibernated)", () => {
     const { deps, reports } = makeDeps();
     const src = makeSource({
-      storeContent: makeStoreFile({ [CREW_SESSION_ID]: makeSession({ isRestorable: true }) }),
+      storeContent: makeStoreFile({ [CREW_SESSION_ID]: makeSession({ isRestorable: true, agentLifecycle: "idle" }) }),
       pidAlive: false,
     });
     src.start(deps);
 
     expect(reports[0].alive).toBe(true);
+  });
+
+  it("sets alive:false when pid is dead, isRestorable:true, but agentLifecycle is not idle", () => {
+    const { deps, reports } = makeDeps();
+    const src = makeSource({
+      storeContent: makeStoreFile({ [CREW_SESSION_ID]: makeSession({ isRestorable: true, agentLifecycle: "running" }) }),
+      pidAlive: false,
+    });
+    src.start(deps);
+
+    expect(reports[0].alive).toBe(false);
   });
 
   it("sets alive:false when pid is dead and isRestorable is absent", () => {

--- a/packages/workspaces/src/cmux-daemon/__tests__/cmux-store-source.test.ts
+++ b/packages/workspaces/src/cmux-daemon/__tests__/cmux-store-source.test.ts
@@ -1,0 +1,413 @@
+// Tests for CmuxStoreSource — LifecycleSource adapter for ~/.cmuxterm
+//
+// All filesystem and process-kill deps are injected so tests run without
+// touching disk or real pids. Timer deps are injected for debounce tests.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { CmuxStoreSource } from "../cmux-store-source.js";
+import type { CmuxStoreSourceOpts } from "../cmux-store-source.js";
+import type { LifecycleSnapshot, LifecycleSourceDeps } from "@squadrant/core";
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+
+const CREW_CWD = "/home/user/worktrees/my-crew";
+const CREW_PID = 12345;
+const CREW_SESSION_ID = "a1b2c3d4-uuid";
+const CREW_TASK_ID = "task-001";
+const STORE_FILENAME = "claude-hook-sessions.json";
+
+function makeSession(overrides: Partial<{
+  agentLifecycle: string;
+  pid: number;
+  cwd: string;
+  sessionId: string;
+  isRestorable: boolean;
+  lastBody: string;
+  updatedAt: number;
+}> = {}) {
+  return {
+    agentLifecycle: "idle",
+    pid: CREW_PID,
+    cwd: CREW_CWD,
+    sessionId: CREW_SESSION_ID,
+    isRestorable: true,
+    updatedAt: 1782467498.596,
+    ...overrides,
+  };
+}
+
+function makeStoreFile(sessions: Record<string, ReturnType<typeof makeSession>>) {
+  return JSON.stringify({ sessions });
+}
+
+/** Build a deps object that resolves by cwd and captures reports. */
+function makeDeps(options: { resolveByTaskId?: string } = {}) {
+  const reports: LifecycleSnapshot[] = [];
+  const deps: LifecycleSourceDeps = {
+    resolve: (hint) => {
+      if (hint.cwd === CREW_CWD) return { id: options.resolveByTaskId ?? CREW_TASK_ID };
+      return undefined;
+    },
+    report: (snap) => reports.push(snap),
+    log: vi.fn(),
+  };
+  return { deps, reports };
+}
+
+/** Build CmuxStoreSource opts with all deps injected. */
+function makeSource(overrides: Partial<CmuxStoreSourceOpts> & {
+  storeContent?: string;
+  lockExists?: boolean;
+  pidAlive?: boolean;
+  watchCb?: { capture: (cb: () => void) => void };
+} = {}): CmuxStoreSource {
+  const {
+    storeContent = makeStoreFile({ [CREW_SESSION_ID]: makeSession() }),
+    lockExists = false,
+    pidAlive = true,
+    watchCb,
+    ...rest
+  } = overrides;
+
+  const timers: Array<{ fn: () => void; ms: number }> = [];
+  return new CmuxStoreSource({
+    stateDir: "/fake/.cmuxterm",
+    debounceMs: 10,
+    listFiles: () => [STORE_FILENAME],
+    readFile: (path) => {
+      if (path.endsWith(STORE_FILENAME)) return storeContent;
+      return undefined;
+    },
+    fileExists: (path) => {
+      if (path.endsWith(".lock")) return lockExists;
+      return false;
+    },
+    isPidAlive: () => pidAlive,
+    watchDir: (_, cb) => {
+      watchCb?.capture(cb);
+      return () => {};
+    },
+    scheduleTimer: (fn, ms) => {
+      const id = { fn, ms } as unknown as ReturnType<typeof setTimeout>;
+      timers.push({ fn, ms });
+      return id;
+    },
+    cancelTimer: (_id) => {
+      timers.pop();
+    },
+    log: () => {},
+    ...rest,
+  });
+}
+
+// ── test suites ───────────────────────────────────────────────────────────────
+
+describe("CmuxStoreSource — basic snapshot reporting", () => {
+  it("emits an agent snapshot for a running session", () => {
+    const { deps, reports } = makeDeps();
+    const src = makeSource({ storeContent: makeStoreFile({ [CREW_SESSION_ID]: makeSession({ agentLifecycle: "running" }) }) });
+    src.start(deps);
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toMatchObject({
+      taskId: CREW_TASK_ID,
+      state: "running",
+      origin: "agent",
+      alive: true,
+      pid: CREW_PID,
+    });
+  });
+
+  it("emits an agent snapshot for an idle session", () => {
+    const { deps, reports } = makeDeps();
+    const src = makeSource({ storeContent: makeStoreFile({ [CREW_SESSION_ID]: makeSession({ agentLifecycle: "idle" }) }) });
+    src.start(deps);
+
+    expect(reports[0]).toMatchObject({ state: "idle", origin: "agent" });
+  });
+
+  it("emits needsInput from store as origin:agent (authoritative, not filtered)", () => {
+    const { deps, reports } = makeDeps();
+    const src = makeSource({ storeContent: makeStoreFile({ [CREW_SESSION_ID]: makeSession({ agentLifecycle: "needsInput" }) }) });
+    src.start(deps);
+
+    expect(reports[0]).toMatchObject({ state: "needsInput", origin: "agent" });
+  });
+
+  it("emits unknown for an unrecognised agentLifecycle value", () => {
+    const { deps, reports } = makeDeps();
+    const src = makeSource({ storeContent: makeStoreFile({ [CREW_SESSION_ID]: makeSession({ agentLifecycle: "garbage" }) }) });
+    src.start(deps);
+
+    expect(reports[0]).toMatchObject({ state: "unknown", origin: "agent" });
+  });
+
+  it("includes lastBody in detail when present", () => {
+    const { deps, reports } = makeDeps();
+    const src = makeSource({ storeContent: makeStoreFile({ [CREW_SESSION_ID]: makeSession({ lastBody: "Claude needs your permission" }) }) });
+    src.start(deps);
+
+    expect(reports[0].detail?.note).toBe("Claude needs your permission");
+  });
+
+  it("converts updatedAt (Unix float s) to epoch ms in the at field", () => {
+    const { deps, reports } = makeDeps();
+    const src = makeSource({ storeContent: makeStoreFile({ [CREW_SESSION_ID]: makeSession({ updatedAt: 1782467498.596 }) }) });
+    src.start(deps);
+
+    expect(reports[0].at).toBe(1782467498596);
+  });
+
+  it("performs an initial scan on start() before any watch event", () => {
+    const { deps, reports } = makeDeps();
+    const src = makeSource();
+    src.start(deps);
+
+    expect(reports).toHaveLength(1);
+  });
+});
+
+describe("CmuxStoreSource — liveness + hibernation guard", () => {
+  it("sets alive:true when pid is alive", () => {
+    const { deps, reports } = makeDeps();
+    const src = makeSource({ pidAlive: true });
+    src.start(deps);
+
+    expect(reports[0].alive).toBe(true);
+  });
+
+  it("sets alive:false when pid is dead and isRestorable is false", () => {
+    const { deps, reports } = makeDeps();
+    const src = makeSource({
+      storeContent: makeStoreFile({ [CREW_SESSION_ID]: makeSession({ isRestorable: false }) }),
+      pidAlive: false,
+    });
+    src.start(deps);
+
+    expect(reports[0].alive).toBe(false);
+  });
+
+  it("sets alive:true when pid is dead but isRestorable:true (hibernated, not dead)", () => {
+    const { deps, reports } = makeDeps();
+    const src = makeSource({
+      storeContent: makeStoreFile({ [CREW_SESSION_ID]: makeSession({ isRestorable: true }) }),
+      pidAlive: false,
+    });
+    src.start(deps);
+
+    expect(reports[0].alive).toBe(true);
+  });
+
+  it("sets alive:false when pid is dead and isRestorable is absent", () => {
+    const { deps, reports } = makeDeps();
+    const session = makeSession() as Partial<ReturnType<typeof makeSession>>;
+    delete session.isRestorable;
+    const src = makeSource({
+      storeContent: makeStoreFile({ [CREW_SESSION_ID]: session as ReturnType<typeof makeSession> }),
+      pidAlive: false,
+    });
+    src.start(deps);
+
+    expect(reports[0].alive).toBe(false);
+  });
+});
+
+describe("CmuxStoreSource — correlation", () => {
+  it("skips sessions that cannot be resolved", () => {
+    const deps: LifecycleSourceDeps = {
+      resolve: () => undefined,  // resolves nothing
+      report: vi.fn(),
+    };
+    const src = makeSource();
+    src.start(deps);
+
+    expect(deps.report).not.toHaveBeenCalled();
+  });
+
+  it("emits for multiple sessions in the same file", () => {
+    const { deps, reports } = makeDeps();
+    const secondTaskId = "task-002";
+    const secondCwd = "/home/user/worktrees/crew-b";
+    const depsMulti: LifecycleSourceDeps = {
+      resolve: (hint) => {
+        if (hint.cwd === CREW_CWD) return { id: CREW_TASK_ID };
+        if (hint.cwd === secondCwd) return { id: secondTaskId };
+        return undefined;
+      },
+      report: (snap) => reports.push(snap),
+    };
+    const storeContent = makeStoreFile({
+      [CREW_SESSION_ID]: makeSession({ cwd: CREW_CWD }),
+      "other-session-id": makeSession({ cwd: secondCwd, sessionId: "other-session-id" }),
+    });
+    const src = makeSource({ storeContent });
+    src.start(depsMulti);
+
+    expect(reports).toHaveLength(2);
+    const taskIds = reports.map((r) => r.taskId);
+    expect(taskIds).toContain(CREW_TASK_ID);
+    expect(taskIds).toContain(secondTaskId);
+  });
+
+  it("skips sessions missing required fields (sessionId, cwd, pid)", () => {
+    const { deps, reports } = makeDeps();
+    const badSession = { agentLifecycle: "running" } as ReturnType<typeof makeSession>;
+    const src = makeSource({ storeContent: makeStoreFile({ bad: badSession }) });
+    src.start(deps);
+
+    expect(reports).toHaveLength(0);
+  });
+});
+
+describe("CmuxStoreSource — lock file", () => {
+  it("skips a store file when a .lock sibling exists", () => {
+    const { deps, reports } = makeDeps();
+    const src = makeSource({ lockExists: true });
+    src.start(deps);
+
+    expect(reports).toHaveLength(0);
+  });
+});
+
+describe("CmuxStoreSource — resilience", () => {
+  it("does not throw or emit when the store file is malformed JSON", () => {
+    const { deps, reports } = makeDeps();
+    const src = makeSource({ storeContent: "not-json-{{{" });
+    expect(() => src.start(deps)).not.toThrow();
+    expect(reports).toHaveLength(0);
+  });
+
+  it("does not throw when stateDir does not exist (listFiles returns [])", () => {
+    const { deps, reports } = makeDeps();
+    const src = makeSource({ listFiles: () => [] });
+    expect(() => src.start(deps)).not.toThrow();
+    expect(reports).toHaveLength(0);
+  });
+});
+
+describe("CmuxStoreSource — snapshot() liveness floor", () => {
+  it("returns cached snapshot for a known taskId", () => {
+    const { deps } = makeDeps();
+    const src = makeSource({ storeContent: makeStoreFile({ [CREW_SESSION_ID]: makeSession({ agentLifecycle: "idle" }) }) });
+    src.start(deps);
+
+    const snap = src.snapshot(CREW_TASK_ID);
+    expect(snap).toBeDefined();
+    expect(snap?.state).toBe("idle");
+    expect(snap?.taskId).toBe(CREW_TASK_ID);
+  });
+
+  it("returns undefined for an unknown taskId", () => {
+    const { deps } = makeDeps();
+    const src = makeSource();
+    src.start(deps);
+
+    expect(src.snapshot("unknown-task")).toBeUndefined();
+  });
+
+  it("cache is cleared on stop()", () => {
+    const { deps } = makeDeps();
+    const src = makeSource();
+    src.start(deps);
+    src.stop();
+
+    expect(src.snapshot(CREW_TASK_ID)).toBeUndefined();
+  });
+});
+
+describe("CmuxStoreSource — debounce and re-scan", () => {
+  it("debounces rapid watch callbacks into a single scan", () => {
+    const { deps, reports } = makeDeps();
+    let capturedCb!: () => void;
+
+    // Use a real setTimeout/clearTimeout pair but with controlled timing via vi
+    vi.useFakeTimers();
+    const src = new CmuxStoreSource({
+      stateDir: "/fake/.cmuxterm",
+      debounceMs: 50,
+      listFiles: () => [STORE_FILENAME],
+      readFile: () => makeStoreFile({ [CREW_SESSION_ID]: makeSession() }),
+      fileExists: () => false,
+      isPidAlive: () => true,
+      watchDir: (_, cb) => {
+        capturedCb = cb;
+        return () => {};
+      },
+    });
+    src.start(deps);
+
+    // Initial scan fires once synchronously.
+    const reportsAfterStart = reports.length;
+
+    // Fire 3 rapid watch events — only one debounced scan should result.
+    capturedCb();
+    capturedCb();
+    capturedCb();
+    vi.advanceTimersByTime(100);
+
+    vi.useRealTimers();
+    // The debounced scan adds exactly 1 more batch of snapshots.
+    expect(reports.length).toBe(reportsAfterStart + 1);
+  });
+
+  it("rescans when a watch event fires after debounce settles", () => {
+    const { deps, reports } = makeDeps();
+    let capturedCb!: () => void;
+
+    vi.useFakeTimers();
+    const src = new CmuxStoreSource({
+      stateDir: "/fake/.cmuxterm",
+      debounceMs: 50,
+      listFiles: () => [STORE_FILENAME],
+      readFile: () => makeStoreFile({ [CREW_SESSION_ID]: makeSession() }),
+      fileExists: () => false,
+      isPidAlive: () => true,
+      watchDir: (_, cb) => {
+        capturedCb = cb;
+        return () => {};
+      },
+    });
+    src.start(deps);
+    const after1 = reports.length;
+
+    capturedCb();
+    vi.advanceTimersByTime(100);
+    const after2 = reports.length;
+
+    capturedCb();
+    vi.advanceTimersByTime(100);
+
+    vi.useRealTimers();
+    expect(after2).toBe(after1 + 1);
+    expect(reports.length).toBe(after2 + 1);
+  });
+});
+
+describe("CmuxStoreSource — stop()", () => {
+  it("does not emit after stop()", () => {
+    const { deps, reports } = makeDeps();
+    let capturedCb!: () => void;
+
+    vi.useFakeTimers();
+    const src = new CmuxStoreSource({
+      stateDir: "/fake/.cmuxterm",
+      debounceMs: 50,
+      listFiles: () => [STORE_FILENAME],
+      readFile: () => makeStoreFile({ [CREW_SESSION_ID]: makeSession() }),
+      fileExists: () => false,
+      isPidAlive: () => true,
+      watchDir: (_, cb) => {
+        capturedCb = cb;
+        return () => {};
+      },
+    });
+    src.start(deps);
+    src.stop();
+    const reportsAtStop = reports.length;
+
+    capturedCb?.();
+    vi.advanceTimersByTime(200);
+    vi.useRealTimers();
+
+    expect(reports.length).toBe(reportsAtStop);
+  });
+});

--- a/packages/workspaces/src/cmux-daemon/cmux-store-source.ts
+++ b/packages/workspaces/src/cmux-daemon/cmux-store-source.ts
@@ -112,8 +112,8 @@ export class CmuxStoreSource implements LifecycleSource {
     this.readFile = opts.readFile ?? defaultReadFile;
     this.fileExists = opts.fileExists ?? existsSync;
     this.watchDir = opts.watchDir ?? defaultWatchDir;
-    this.scheduleTimer = opts.scheduleTimer ?? (setTimeout as CmuxStoreSourceOpts["scheduleTimer"]!);
-    this.cancelTimer = opts.cancelTimer ?? (clearTimeout as CmuxStoreSourceOpts["cancelTimer"]!);
+    this.scheduleTimer = opts.scheduleTimer ?? (setTimeout as NonNullable<CmuxStoreSourceOpts["scheduleTimer"]>);
+    this.cancelTimer = opts.cancelTimer ?? (clearTimeout as NonNullable<CmuxStoreSourceOpts["cancelTimer"]>);
     this.log = opts.log ?? (() => {});
   }
 

--- a/packages/workspaces/src/cmux-daemon/cmux-store-source.ts
+++ b/packages/workspaces/src/cmux-daemon/cmux-store-source.ts
@@ -205,10 +205,11 @@ export class CmuxStoreSource implements LifecycleSource {
     // Pid-verify liveness.
     let alive = this.isPidAlive(session.pid);
 
-    // Hibernation guard (research §7): a session with isRestorable:true may
-    // have its process suspended or reaped by cmux to reclaim RAM. The session
-    // is logically alive — do NOT emit alive:false or trigger task.session.ended.
-    if (!alive && session.isRestorable === true) {
+    // Hibernation guard (research §194): cmux reclaims RAM from idle crews by
+    // suspending or reaping the pid. Only treat a dead pid as logically alive
+    // when the session is restorable AND idle — a running/needsInput session
+    // with a dead pid is genuinely gone, not hibernated.
+    if (!alive && session.isRestorable === true && session.agentLifecycle === "idle") {
       alive = true;
     }
 

--- a/packages/workspaces/src/cmux-daemon/cmux-store-source.ts
+++ b/packages/workspaces/src/cmux-daemon/cmux-store-source.ts
@@ -1,0 +1,275 @@
+// cmux-store-source.ts — LifecycleSource adapter for ~/.cmuxterm/*-hook-sessions.json
+//
+// Implements the backup LifecycleSource (D1: A-backup) from the #333 design.
+// Watches the cmux state directory, reads each agent's hook-sessions.json, and
+// feeds LifecycleSnapshots into the reduceLifecycle pipeline via deps.report().
+//
+// NOT wired into the live daemon path in Phase 1 (additive per D3/D7).
+//
+// CORRELATION CONSTRAINT (research §2.2): launchCommand in the store has no
+// environment vars — SQUADRANT_CREW_TASK_ID is not available. Correlate by:
+//   1. cwd (primary for interactive crews — match against TaskRecord.cwd)
+//   2. pid (passed in hint; daemon can try KERN_PROCARGS2 lookup later)
+//   3. sessionId (cmux UUID; may match TaskRecord.sessionId if crew populates it)
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { watch, readdirSync, readFileSync, existsSync } from "node:fs";
+import type { LifecycleSource, LifecycleSourceDeps, LifecycleSnapshot, CorrelationHint, LifecycleState } from "@squadrant/core";
+
+// ── store file schema (version:1, live schema from research report §2.2) ─────
+
+interface StoreSession {
+  sessionId: string;
+  agentLifecycle: string;
+  pid: number;
+  cwd: string;
+  lastBody?: string;
+  isRestorable?: boolean;
+  updatedAt: number;  // Unix float (seconds)
+}
+
+interface StoreFile {
+  sessions?: Record<string, StoreSession>;
+}
+
+// ── injectable deps ──────────────────────────────────────────────────────────
+
+export interface CmuxStoreSourceOpts {
+  /** Directory to watch. Defaults to CMUX_AGENT_HOOK_STATE_DIR or ~/.cmuxterm. */
+  stateDir?: string;
+  /** Debounce delay between a watch event and the next scan (ms). Default 50. */
+  debounceMs?: number;
+  /** Returns true if the given pid is alive. Default: process.kill(pid, 0). */
+  isPidAlive?: (pid: number) => boolean;
+  /**
+   * Lists store files in the given directory.
+   * Default: readdirSync filtered to *-hook-sessions.json.
+   */
+  listFiles?: (dir: string) => string[];
+  /**
+   * Reads a file's content, returns undefined on any read error.
+   * Default: readFileSync.
+   */
+  readFile?: (path: string) => string | undefined;
+  /**
+   * Returns true if the given path exists (lock-file check).
+   * Default: existsSync.
+   */
+  fileExists?: (path: string) => boolean;
+  /**
+   * Starts a directory watcher. Calls cb on relevant file changes.
+   * Returns a stop function. Default: fs.watch.
+   */
+  watchDir?: (dir: string, cb: () => void) => () => void;
+  /** Injectable setTimeout for debouncing. Default: global setTimeout. */
+  scheduleTimer?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  /** Injectable clearTimeout for debouncing. Default: global clearTimeout. */
+  cancelTimer?: (id: ReturnType<typeof setTimeout>) => void;
+  log?: (msg: string) => void;
+}
+
+// ── CmuxStoreSource ──────────────────────────────────────────────────────────
+
+/**
+ * LifecycleSource that watches ~/.cmuxterm/*-hook-sessions.json.
+ *
+ * cmux writes the hook-sessions file on every lifecycle-changing hook event
+ * (SessionStart, UserPromptSubmit, PreToolUse, Stop, Notification, AskUserQuestion).
+ * Each session record carries `agentLifecycle` in the 4-state vocabulary that
+ * exactly matches LifecycleState, so no re-mapping is needed.
+ *
+ * Events carry origin:"agent" because the store is the agent's own reported
+ * lifecycle state — not inferred from a process scan.
+ */
+export class CmuxStoreSource implements LifecycleSource {
+  readonly name = "cmux-store";
+
+  private readonly stateDir: string;
+  private readonly debounceMs: number;
+  private readonly isPidAlive: (pid: number) => boolean;
+  private readonly listFiles: (dir: string) => string[];
+  private readonly readFile: (path: string) => string | undefined;
+  private readonly fileExists: (path: string) => boolean;
+  private readonly watchDir: (dir: string, cb: () => void) => () => void;
+  private readonly scheduleTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  private readonly cancelTimer: (id: ReturnType<typeof setTimeout>) => void;
+  private readonly log: (msg: string) => void;
+
+  private deps?: LifecycleSourceDeps;
+  private stopWatcher?: () => void;
+  private debounceTimer?: ReturnType<typeof setTimeout>;
+  /** taskId → last reported snapshot (for snapshot() liveness floor). */
+  private cache = new Map<string, LifecycleSnapshot>();
+
+  constructor(opts: CmuxStoreSourceOpts = {}) {
+    this.stateDir =
+      opts.stateDir ??
+      process.env.CMUX_AGENT_HOOK_STATE_DIR ??
+      join(homedir(), ".cmuxterm");
+    this.debounceMs = opts.debounceMs ?? 50;
+    this.isPidAlive = opts.isPidAlive ?? defaultIsPidAlive;
+    this.listFiles = opts.listFiles ?? defaultListFiles;
+    this.readFile = opts.readFile ?? defaultReadFile;
+    this.fileExists = opts.fileExists ?? existsSync;
+    this.watchDir = opts.watchDir ?? defaultWatchDir;
+    this.scheduleTimer = opts.scheduleTimer ?? (setTimeout as CmuxStoreSourceOpts["scheduleTimer"]!);
+    this.cancelTimer = opts.cancelTimer ?? (clearTimeout as CmuxStoreSourceOpts["cancelTimer"]!);
+    this.log = opts.log ?? (() => {});
+  }
+
+  start(deps: LifecycleSourceDeps): void {
+    this.deps = deps;
+    // Initial scan before any watch events fire.
+    this.scan();
+    // Watch for subsequent changes, debounced.
+    try {
+      this.stopWatcher = this.watchDir(this.stateDir, () => this.scheduleDebounced());
+    } catch (e) {
+      this.log(`cmux-store: failed to watch ${this.stateDir}: ${(e as Error).message}`);
+    }
+  }
+
+  stop(): void {
+    if (this.debounceTimer !== undefined) {
+      this.cancelTimer(this.debounceTimer);
+      this.debounceTimer = undefined;
+    }
+    this.stopWatcher?.();
+    this.stopWatcher = undefined;
+    this.deps = undefined;
+    this.cache.clear();
+  }
+
+  /** Returns the last-reported snapshot for a known crew (liveness floor). */
+  snapshot(taskId: string): LifecycleSnapshot | undefined {
+    return this.cache.get(taskId);
+  }
+
+  // ── private ─────────────────────────────────────────────────────────────────
+
+  private scheduleDebounced(): void {
+    if (this.debounceTimer !== undefined) {
+      this.cancelTimer(this.debounceTimer);
+    }
+    this.debounceTimer = this.scheduleTimer(() => {
+      this.debounceTimer = undefined;
+      this.scan();
+    }, this.debounceMs);
+  }
+
+  private scan(): void {
+    if (!this.deps) return;
+    for (const filename of this.listFiles(this.stateDir)) {
+      this.scanFile(filename);
+    }
+  }
+
+  private scanFile(filename: string): void {
+    const deps = this.deps!;
+    const filePath = join(this.stateDir, filename);
+    const lockPath = `${filePath}.lock`;
+
+    // Skip files that cmux is currently writing.
+    if (this.fileExists(lockPath)) {
+      this.log(`cmux-store: skipping ${filename} (locked)`);
+      return;
+    }
+
+    const raw = this.readFile(filePath);
+    if (!raw) return;
+
+    let parsed: StoreFile;
+    try {
+      parsed = JSON.parse(raw) as StoreFile;
+    } catch {
+      this.log(`cmux-store: failed to parse ${filename}`);
+      return;
+    }
+
+    for (const session of Object.values(parsed.sessions ?? {})) {
+      this.processSession(session, deps);
+    }
+  }
+
+  private processSession(session: StoreSession, deps: LifecycleSourceDeps): void {
+    if (!session.sessionId || !session.cwd || typeof session.pid !== "number") return;
+
+    const hint: CorrelationHint = {
+      cwd: session.cwd,
+      pid: session.pid,
+      sessionId: session.sessionId,
+    };
+    const resolved = deps.resolve(hint);
+    if (!resolved) return;
+
+    // Pid-verify liveness.
+    let alive = this.isPidAlive(session.pid);
+
+    // Hibernation guard (research §7): a session with isRestorable:true may
+    // have its process suspended or reaped by cmux to reclaim RAM. The session
+    // is logically alive — do NOT emit alive:false or trigger task.session.ended.
+    if (!alive && session.isRestorable === true) {
+      alive = true;
+    }
+
+    const snap: LifecycleSnapshot = {
+      taskId: resolved.id,
+      state: parseLifecycleState(session.agentLifecycle),
+      alive,
+      // "agent": the store carries the agent's own reported lifecycle state,
+      // not a scan inference. needsInput from the store is authoritative.
+      origin: "agent",
+      at: Math.floor((session.updatedAt ?? 0) * 1000),
+      pid: session.pid,
+      ...(session.lastBody ? { detail: { note: session.lastBody } } : {}),
+    };
+
+    this.cache.set(resolved.id, snap);
+    deps.report(snap);
+  }
+}
+
+// ── private helpers ──────────────────────────────────────────────────────────
+
+function parseLifecycleState(s: string | undefined): LifecycleState {
+  if (s === "running" || s === "idle" || s === "needsInput" || s === "unknown") {
+    return s;
+  }
+  return "unknown";
+}
+
+function defaultIsPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function defaultListFiles(dir: string): string[] {
+  try {
+    return readdirSync(dir).filter(
+      (f) => f.endsWith("-hook-sessions.json") && !f.endsWith(".lock"),
+    );
+  } catch {
+    return [];
+  }
+}
+
+function defaultReadFile(path: string): string | undefined {
+  try {
+    return readFileSync(path, "utf-8");
+  } catch {
+    return undefined;
+  }
+}
+
+function defaultWatchDir(dir: string, cb: () => void): () => void {
+  const w = watch(dir, (_event, filename) => {
+    if (typeof filename === "string" && filename.endsWith("-hook-sessions.json")) {
+      cb();
+    }
+  });
+  return () => w.close();
+}

--- a/packages/workspaces/src/index.ts
+++ b/packages/workspaces/src/index.ts
@@ -5,4 +5,6 @@ export * from "./workspaces/index.js";
 export { CmuxEventsBridge, deriveRunState } from "./cmux-daemon/events-bridge.js";
 export type { RunState, CmuxEventsChild, CmuxAgentHook, CmuxEventsBridgeDeps } from "./cmux-daemon/events-bridge.js";
 export { DaemonCmux } from "./cmux-daemon/daemon-cmux.js";
+export { CmuxStoreSource } from "./cmux-daemon/cmux-store-source.js";
+export type { CmuxStoreSourceOpts } from "./cmux-daemon/cmux-store-source.js";
 export { getFreePort, listProjectCrews, findCrew, resolveCaptainWorkspace, sendFirstTurnWhenReady, confirmedSendToPane } from "./crew-pane.js";

--- a/packages/workspaces/src/index.ts
+++ b/packages/workspaces/src/index.ts
@@ -7,4 +7,6 @@ export type { RunState, CmuxEventsChild, CmuxAgentHook, CmuxEventsBridgeDeps } f
 export { DaemonCmux } from "./cmux-daemon/daemon-cmux.js";
 export { CmuxStoreSource } from "./cmux-daemon/cmux-store-source.js";
 export type { CmuxStoreSourceOpts } from "./cmux-daemon/cmux-store-source.js";
+export { NativeHookSource, installClaudeHooks, mapSubToLifecycle } from "./native-hooks/native-hook-source.js";
+export type { NativeHookSourceOpts, ClaudeHooksInstallOpts } from "./native-hooks/native-hook-source.js";
 export { getFreePort, listProjectCrews, findCrew, resolveCaptainWorkspace, sendFirstTurnWhenReady, confirmedSendToPane } from "./crew-pane.js";

--- a/packages/workspaces/src/native-hooks/__tests__/native-hook-source.test.ts
+++ b/packages/workspaces/src/native-hooks/__tests__/native-hook-source.test.ts
@@ -61,21 +61,22 @@ function makeSource(installOverrides: Parameters<typeof makeInstallOpts>[0] = {}
 // ── installClaudeHooks ────────────────────────────────────────────────────────
 
 describe("installClaudeHooks — basic installation", () => {
-  it("installs hooks for all 7 lifecycle-relevant events", () => {
+  it("installs hooks for all 7 lifecycle-relevant subs across 6 event keys", () => {
     const { opts, written } = makeInstallOpts();
     installClaudeHooks(opts);
 
     expect(written).toHaveLength(1);
     const result = JSON.parse(written[0].content);
-    const eventNames = [
-      "SessionStart", "UserPromptSubmit", "PreToolUse",
-      "Stop", "Notification", "AskUserQuestion", "SessionEnd",
-    ];
-    for (const ev of eventNames) {
+    // 6 unique event keys (PreToolUse appears twice: catch-all + AskUserQuestion matcher)
+    for (const ev of ["SessionStart", "UserPromptSubmit", "PreToolUse", "Stop", "Notification", "SessionEnd"]) {
       expect(result.hooks[ev]).toBeDefined();
       expect(Array.isArray(result.hooks[ev])).toBe(true);
       expect(result.hooks[ev].length).toBeGreaterThan(0);
     }
+    // AskUserQuestion is a TOOL not an event — must never be a top-level hook key
+    expect(result.hooks["AskUserQuestion"]).toBeUndefined();
+    // PreToolUse carries both the catch-all and the AskUserQuestion-specific entry
+    expect(result.hooks.PreToolUse).toHaveLength(2);
   });
 
   it("each installed hook entry uses the correct sub-command alias", () => {
@@ -83,19 +84,34 @@ describe("installClaudeHooks — basic installation", () => {
     installClaudeHooks(opts);
 
     const result = JSON.parse(written[0].content);
-    const expectations: Array<[string, string]> = [
+    // Single-entry events: first (and only) entry carries the sub-command
+    const singleEntryExpectations: Array<[string, string]> = [
       ["SessionStart", "session-start"],
       ["UserPromptSubmit", "prompt-submit"],
-      ["PreToolUse", "pre-tool-use"],
       ["Stop", "stop"],
       ["Notification", "notification"],
-      ["AskUserQuestion", "ask-question"],
       ["SessionEnd", "session-end"],
     ];
-    for (const [ev, sub] of expectations) {
+    for (const [ev, sub] of singleEntryExpectations) {
       const entry = result.hooks[ev][0];
       expect(entry.hooks[0].command).toBe(`${HOOK_CMD} claude ${sub}`);
     }
+    // PreToolUse: catch-all (matcher "") and AskUserQuestion-specific (matcher "AskUserQuestion")
+    const hasCmd = (entries: unknown[], cmd: string): boolean =>
+      entries.some(
+        (e) =>
+          Array.isArray((e as Record<string, unknown>).hooks) &&
+          ((e as Record<string, unknown>).hooks as unknown[]).some(
+            (h) => (h as Record<string, unknown>).command === cmd,
+          ),
+      );
+    expect(hasCmd(result.hooks.PreToolUse, `${HOOK_CMD} claude pre-tool-use`)).toBe(true);
+    expect(hasCmd(result.hooks.PreToolUse, `${HOOK_CMD} claude ask-question`)).toBe(true);
+    // ask-question entry must carry the AskUserQuestion tool matcher
+    const askEntry = (result.hooks.PreToolUse as unknown[]).find(
+      (e) => hasCmd([e], `${HOOK_CMD} claude ask-question`),
+    ) as Record<string, unknown> | undefined;
+    expect(askEntry?.matcher).toBe("AskUserQuestion");
   });
 
   it("returns the settings file path", () => {

--- a/packages/workspaces/src/native-hooks/__tests__/native-hook-source.test.ts
+++ b/packages/workspaces/src/native-hooks/__tests__/native-hook-source.test.ts
@@ -1,0 +1,505 @@
+// Tests for NativeHookSource — LifecycleSource C (primary, #333 Phase 1)
+//
+// All I/O deps are injected so tests run without touching disk or real processes.
+import { describe, it, expect, vi } from "vitest";
+import {
+  NativeHookSource,
+  installClaudeHooks,
+  mapSubToLifecycle,
+} from "../native-hook-source.js";
+import type { ClaudeHooksInstallOpts, NativeHookSourceOpts } from "../native-hook-source.js";
+import type { LifecycleSnapshot, LifecycleSourceDeps } from "@squadrant/core";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const TASK_ID = "task-abc-123";
+const HOOK_CMD = "squadrant hooks";
+const SETTINGS_PATH = "/fake/.claude/settings.json";
+
+/** Build a LifecycleSourceDeps that captures reports. */
+function makeDeps() {
+  const reports: LifecycleSnapshot[] = [];
+  const deps: LifecycleSourceDeps = {
+    resolve: (hint) => (hint.taskId === TASK_ID ? { id: TASK_ID } : undefined),
+    report: (snap) => reports.push(snap),
+    log: vi.fn(),
+  };
+  return { deps, reports };
+}
+
+/** Build ClaudeHooksInstallOpts with injectable I/O. */
+function makeInstallOpts(overrides: {
+  existingSettings?: Record<string, unknown>;
+  existingRaw?: string;
+} = {}): { opts: ClaudeHooksInstallOpts; written: Array<{ path: string; content: string }> } {
+  const written: Array<{ path: string; content: string }> = [];
+  const opts: ClaudeHooksInstallOpts = {
+    settingsPath: SETTINGS_PATH,
+    hookCmd: HOOK_CMD,
+    readFile: () => {
+      if (overrides.existingRaw !== undefined) return overrides.existingRaw;
+      if (overrides.existingSettings !== undefined) return JSON.stringify(overrides.existingSettings);
+      return undefined;
+    },
+    writeFile: (path, content) => written.push({ path, content }),
+    log: vi.fn(),
+  };
+  return { opts, written };
+}
+
+/** Build a NativeHookSource with injectable install opts. */
+function makeSource(installOverrides: Parameters<typeof makeInstallOpts>[0] = {}): {
+  src: NativeHookSource;
+  installOpts: ClaudeHooksInstallOpts;
+  written: Array<{ path: string; content: string }>;
+} {
+  const { opts, written } = makeInstallOpts(installOverrides);
+  const src = new NativeHookSource({ hookInstall: opts });
+  return { src, installOpts: opts, written };
+}
+
+// ── installClaudeHooks ────────────────────────────────────────────────────────
+
+describe("installClaudeHooks — basic installation", () => {
+  it("installs hooks for all 7 lifecycle-relevant events", () => {
+    const { opts, written } = makeInstallOpts();
+    installClaudeHooks(opts);
+
+    expect(written).toHaveLength(1);
+    const result = JSON.parse(written[0].content);
+    const eventNames = [
+      "SessionStart", "UserPromptSubmit", "PreToolUse",
+      "Stop", "Notification", "AskUserQuestion", "SessionEnd",
+    ];
+    for (const ev of eventNames) {
+      expect(result.hooks[ev]).toBeDefined();
+      expect(Array.isArray(result.hooks[ev])).toBe(true);
+      expect(result.hooks[ev].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("each installed hook entry uses the correct sub-command alias", () => {
+    const { opts, written } = makeInstallOpts();
+    installClaudeHooks(opts);
+
+    const result = JSON.parse(written[0].content);
+    const expectations: Array<[string, string]> = [
+      ["SessionStart", "session-start"],
+      ["UserPromptSubmit", "prompt-submit"],
+      ["PreToolUse", "pre-tool-use"],
+      ["Stop", "stop"],
+      ["Notification", "notification"],
+      ["AskUserQuestion", "ask-question"],
+      ["SessionEnd", "session-end"],
+    ];
+    for (const [ev, sub] of expectations) {
+      const entry = result.hooks[ev][0];
+      expect(entry.hooks[0].command).toBe(`${HOOK_CMD} claude ${sub}`);
+    }
+  });
+
+  it("returns the settings file path", () => {
+    const { opts } = makeInstallOpts();
+    const returned = installClaudeHooks(opts);
+    expect(returned).toBe(SETTINGS_PATH);
+  });
+
+  it("writes when settings file is absent (creates fresh)", () => {
+    const { opts, written } = makeInstallOpts({ existingSettings: undefined });
+    installClaudeHooks(opts);
+    expect(written).toHaveLength(1);
+  });
+});
+
+describe("installClaudeHooks — idempotency (D4: re-run-safe)", () => {
+  it("does not write the file on a second call when hooks are already present", () => {
+    const { opts, written } = makeInstallOpts();
+    installClaudeHooks(opts);
+    const contentAfterFirst = written[0].content;
+
+    // Second call: feed the first-call output back as existing content.
+    const { opts: opts2, written: written2 } = makeInstallOpts({ existingRaw: contentAfterFirst });
+    installClaudeHooks(opts2);
+
+    expect(written2).toHaveLength(0);
+  });
+
+  it("does not duplicate hook entries on repeated calls", () => {
+    const { opts, written } = makeInstallOpts();
+    installClaudeHooks(opts);
+    const afterFirst = written[0].content;
+
+    const { opts: opts2, written: written2 } = makeInstallOpts({ existingRaw: afterFirst });
+    installClaudeHooks(opts2);
+
+    // No second write means no change.
+    expect(written2).toHaveLength(0);
+    // And the first result has exactly one entry per event (no duplication).
+    const result = JSON.parse(afterFirst);
+    expect(result.hooks.Stop).toHaveLength(1);
+    expect(result.hooks.SessionEnd).toHaveLength(1);
+  });
+});
+
+describe("installClaudeHooks — non-clobbering (D4: preserves existing hooks)", () => {
+  it("preserves existing non-squadrant hooks in the same event array", () => {
+    const userHook = { matcher: "*", hooks: [{ type: "command", command: "my-tool hook-stop" }] };
+    const { opts, written } = makeInstallOpts({
+      existingSettings: { hooks: { Stop: [userHook] } },
+    });
+    installClaudeHooks(opts);
+
+    const result = JSON.parse(written[0].content);
+    const stopEntries = result.hooks.Stop;
+    expect(stopEntries.some((e: unknown) =>
+      (e as Record<string, unknown>).hooks &&
+      ((e as Record<string, unknown>).hooks as unknown[]).some(
+        (h: unknown) => (h as Record<string, unknown>).command === "my-tool hook-stop",
+      ),
+    )).toBe(true);
+  });
+
+  it("preserves unrelated top-level settings fields (model, permissions, etc.)", () => {
+    const { opts, written } = makeInstallOpts({
+      existingSettings: { model: "claude-sonnet-4-6", permissions: { allow: ["Bash(git:*)"] } },
+    });
+    installClaudeHooks(opts);
+
+    const result = JSON.parse(written[0].content);
+    expect(result.model).toBe("claude-sonnet-4-6");
+    expect(result.permissions).toEqual({ allow: ["Bash(git:*)"] });
+  });
+
+  it("preserves hooks from other tools under the same event (namespacing)", () => {
+    const cmuxHook = { matcher: "", hooks: [{ type: "command", command: "cmux hooks claude stop" }] };
+    const { opts, written } = makeInstallOpts({
+      existingSettings: { hooks: { Stop: [cmuxHook] } },
+    });
+    installClaudeHooks(opts);
+
+    const result = JSON.parse(written[0].content);
+    const stopEntries = result.hooks.Stop;
+    // cmux hook preserved
+    expect(stopEntries.some((e: unknown) =>
+      (e as Record<string, unknown>).hooks &&
+      ((e as Record<string, unknown>).hooks as unknown[]).some(
+        (h: unknown) => (h as Record<string, unknown>).command === "cmux hooks claude stop",
+      ),
+    )).toBe(true);
+    // squadrant hook also added
+    expect(stopEntries.some((e: unknown) =>
+      (e as Record<string, unknown>).hooks &&
+      ((e as Record<string, unknown>).hooks as unknown[]).some(
+        (h: unknown) => (h as Record<string, unknown>).command === `${HOOK_CMD} claude stop`,
+      ),
+    )).toBe(true);
+  });
+
+  it("handles malformed JSON in settings file gracefully (resets hooks section)", () => {
+    const { opts, written } = makeInstallOpts({ existingRaw: "not-valid-json{{" });
+    expect(() => installClaudeHooks(opts)).not.toThrow();
+    expect(written).toHaveLength(1);
+    const result = JSON.parse(written[0].content);
+    expect(result.hooks.Stop).toBeDefined();
+  });
+
+  it("resets hooks when existing value is a non-object (e.g. null)", () => {
+    const { opts, written } = makeInstallOpts({
+      existingSettings: { hooks: null },
+    });
+    expect(() => installClaudeHooks(opts)).not.toThrow();
+    expect(written).toHaveLength(1);
+    const result = JSON.parse(written[0].content);
+    expect(result.hooks.Stop).toBeDefined();
+  });
+});
+
+// ── mapSubToLifecycle ─────────────────────────────────────────────────────────
+
+describe("mapSubToLifecycle — pure mapping", () => {
+  it("maps session-start → running", () => expect(mapSubToLifecycle("session-start")).toBe("running"));
+  it("maps prompt-submit → running", () => expect(mapSubToLifecycle("prompt-submit")).toBe("running"));
+  it("maps pre-tool-use → running", () => expect(mapSubToLifecycle("pre-tool-use")).toBe("running"));
+  it("maps stop → idle", () => expect(mapSubToLifecycle("stop")).toBe("idle"));
+  it("maps notification → needsInput", () => expect(mapSubToLifecycle("notification")).toBe("needsInput"));
+  it("maps ask-question → needsInput", () => expect(mapSubToLifecycle("ask-question")).toBe("needsInput"));
+  it("maps session-end → 'session-end' (teardown sentinel)", () => expect(mapSubToLifecycle("session-end")).toBe("session-end"));
+  it("maps unknown sub → null (no-op)", () => {
+    expect(mapSubToLifecycle("")).toBeNull();
+    expect(mapSubToLifecycle("unknown-event")).toBeNull();
+    expect(mapSubToLifecycle("Stop")).toBeNull();  // case-sensitive: Claude names vs aliases
+  });
+});
+
+// ── NativeHookSource.handleHook ───────────────────────────────────────────────
+
+describe("NativeHookSource — handleHook lifecycle state mapping", () => {
+  it("session-start → state:running, alive:true, origin:agent", () => {
+    const { src } = makeSource();
+    const { deps, reports } = makeDeps();
+    src.start(deps);
+    src.handleHook("session-start", TASK_ID);
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toMatchObject({ taskId: TASK_ID, state: "running", alive: true, origin: "agent" });
+  });
+
+  it("prompt-submit → state:running, alive:true", () => {
+    const { src } = makeSource();
+    const { deps, reports } = makeDeps();
+    src.start(deps);
+    src.handleHook("prompt-submit", TASK_ID);
+    expect(reports[0]).toMatchObject({ state: "running", alive: true });
+  });
+
+  it("stop → state:idle, alive:true", () => {
+    const { src } = makeSource();
+    const { deps, reports } = makeDeps();
+    src.start(deps);
+    src.handleHook("stop", TASK_ID);
+    expect(reports[0]).toMatchObject({ state: "idle", alive: true });
+  });
+
+  it("notification → state:needsInput, alive:true", () => {
+    const { src } = makeSource();
+    const { deps, reports } = makeDeps();
+    src.start(deps);
+    src.handleHook("notification", TASK_ID);
+    expect(reports[0]).toMatchObject({ state: "needsInput", alive: true });
+  });
+
+  it("ask-question → state:needsInput, alive:true", () => {
+    const { src } = makeSource();
+    const { deps, reports } = makeDeps();
+    src.start(deps);
+    src.handleHook("ask-question", TASK_ID);
+    expect(reports[0]).toMatchObject({ state: "needsInput", alive: true });
+  });
+
+  it("session-end → state:unknown, alive:false (teardown — anti-#2576)", () => {
+    const { src } = makeSource();
+    const { deps, reports } = makeDeps();
+    src.start(deps);
+    src.handleHook("session-end", TASK_ID);
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toMatchObject({ state: "unknown", alive: false, origin: "agent" });
+  });
+
+  it("unknown sub → no report emitted", () => {
+    const { src } = makeSource();
+    const { deps, reports } = makeDeps();
+    src.start(deps);
+    src.handleHook("Stop", TASK_ID);   // wrong case — should be 'stop'
+    src.handleHook("garbage", TASK_ID);
+    src.handleHook("", TASK_ID);
+    expect(reports).toHaveLength(0);
+  });
+
+  it("all reported snapshots carry origin:agent (never scan)", () => {
+    const { src } = makeSource();
+    const { deps, reports } = makeDeps();
+    src.start(deps);
+    for (const sub of ["session-start", "prompt-submit", "pre-tool-use", "stop", "notification", "ask-question", "session-end"]) {
+      src.handleHook(sub, TASK_ID);
+    }
+    for (const snap of reports) {
+      expect(snap.origin).toBe("agent");
+    }
+  });
+});
+
+describe("NativeHookSource — handleHook payload extraction", () => {
+  it("notification with payload.message → detail.note", () => {
+    const { src } = makeSource();
+    const { deps, reports } = makeDeps();
+    src.start(deps);
+    src.handleHook("notification", TASK_ID, undefined, { message: "Claude needs your permission" });
+
+    expect(reports[0].detail?.note).toBe("Claude needs your permission");
+  });
+
+  it("notification with no message → no detail", () => {
+    const { src } = makeSource();
+    const { deps, reports } = makeDeps();
+    src.start(deps);
+    src.handleHook("notification", TASK_ID, undefined, {});
+
+    expect(reports[0].detail).toBeUndefined();
+  });
+
+  it("pre-tool-use with payload.tool_name → detail.tool", () => {
+    const { src } = makeSource();
+    const { deps, reports } = makeDeps();
+    src.start(deps);
+    src.handleHook("pre-tool-use", TASK_ID, undefined, { tool_name: "Bash" });
+
+    expect(reports[0].detail?.tool).toBe("Bash");
+  });
+
+  it("pre-tool-use with no tool_name → no detail", () => {
+    const { src } = makeSource();
+    const { deps, reports } = makeDeps();
+    src.start(deps);
+    src.handleHook("pre-tool-use", TASK_ID, undefined, {});
+
+    expect(reports[0].detail).toBeUndefined();
+  });
+
+  it("stop with any payload → no detail (only notification and pre-tool-use extract detail)", () => {
+    const { src } = makeSource();
+    const { deps, reports } = makeDeps();
+    src.start(deps);
+    src.handleHook("stop", TASK_ID, undefined, { message: "some message" });
+
+    expect(reports[0].detail).toBeUndefined();
+  });
+
+  it("null payload → no detail, no throw", () => {
+    const { src } = makeSource();
+    const { deps, reports } = makeDeps();
+    src.start(deps);
+    expect(() => src.handleHook("notification", TASK_ID, undefined, null)).not.toThrow();
+    expect(reports[0].detail).toBeUndefined();
+  });
+});
+
+describe("NativeHookSource — handleHook pid", () => {
+  it("carries pid when provided", () => {
+    const { src } = makeSource();
+    const { deps, reports } = makeDeps();
+    src.start(deps);
+    src.handleHook("stop", TASK_ID, 99001);
+
+    expect(reports[0].pid).toBe(99001);
+  });
+
+  it("omits pid when not provided", () => {
+    const { src } = makeSource();
+    const { deps, reports } = makeDeps();
+    src.start(deps);
+    src.handleHook("stop", TASK_ID);
+
+    expect(reports[0].pid).toBeUndefined();
+  });
+});
+
+describe("NativeHookSource — handleHook before start() (no deps)", () => {
+  it("is a no-op — does not throw", () => {
+    const { src } = makeSource();
+    expect(() => src.handleHook("stop", TASK_ID)).not.toThrow();
+  });
+});
+
+describe("NativeHookSource — at timestamp", () => {
+  it("snapshot at field is a positive number (epoch ms)", () => {
+    const { src } = makeSource();
+    const { deps, reports } = makeDeps();
+    src.start(deps);
+    const before = Date.now();
+    src.handleHook("stop", TASK_ID);
+    const after = Date.now();
+
+    expect(reports[0].at).toBeGreaterThanOrEqual(before);
+    expect(reports[0].at).toBeLessThanOrEqual(after);
+  });
+});
+
+// ── NativeHookSource — snapshot() liveness floor ─────────────────────────────
+
+describe("NativeHookSource — snapshot()", () => {
+  it("returns the last-reported snapshot for a known taskId", () => {
+    const { src } = makeSource();
+    const { deps } = makeDeps();
+    src.start(deps);
+    src.handleHook("stop", TASK_ID);
+
+    const snap = src.snapshot(TASK_ID);
+    expect(snap).toBeDefined();
+    expect(snap?.state).toBe("idle");
+    expect(snap?.taskId).toBe(TASK_ID);
+  });
+
+  it("returns undefined for an unknown taskId", () => {
+    const { src } = makeSource();
+    const { deps } = makeDeps();
+    src.start(deps);
+
+    expect(src.snapshot("never-seen")).toBeUndefined();
+  });
+
+  it("reflects the latest handleHook call when called multiple times", () => {
+    const { src } = makeSource();
+    const { deps } = makeDeps();
+    src.start(deps);
+    src.handleHook("session-start", TASK_ID);
+    src.handleHook("stop", TASK_ID);
+
+    expect(src.snapshot(TASK_ID)?.state).toBe("idle");
+  });
+
+  it("cache is cleared on stop()", () => {
+    const { src } = makeSource();
+    const { deps } = makeDeps();
+    src.start(deps);
+    src.handleHook("stop", TASK_ID);
+    src.stop();
+
+    expect(src.snapshot(TASK_ID)).toBeUndefined();
+  });
+});
+
+// ── NativeHookSource — LifecycleSource interface: start/stop ─────────────────
+
+describe("NativeHookSource — start/stop", () => {
+  it("does not report after stop()", () => {
+    const { src } = makeSource();
+    const { deps, reports } = makeDeps();
+    src.start(deps);
+    src.stop();
+    src.handleHook("stop", TASK_ID);
+
+    expect(reports).toHaveLength(0);
+  });
+
+  it("resumes reporting after start() is called again", () => {
+    const { src } = makeSource();
+    const { deps, reports } = makeDeps();
+    src.start(deps);
+    src.stop();
+    src.start(deps);
+    src.handleHook("stop", TASK_ID);
+
+    expect(reports).toHaveLength(1);
+  });
+
+  it("name is 'native-hook'", () => {
+    const { src } = makeSource();
+    expect(src.name).toBe("native-hook");
+  });
+});
+
+// ── NativeHookSource — install() ─────────────────────────────────────────────
+
+describe("NativeHookSource — install()", () => {
+  it("delegates to installClaudeHooks and returns the settings path", () => {
+    const { src, written } = makeSource();
+    const returned = src.install();
+
+    expect(returned).toBe(SETTINGS_PATH);
+    expect(written).toHaveLength(1);
+  });
+
+  it("install() is idempotent when called twice", () => {
+    const { opts, written } = makeInstallOpts();
+    const src1 = new NativeHookSource({ hookInstall: opts });
+    src1.install();
+    const afterFirst = written[0].content;
+
+    const { opts: opts2, written: written2 } = makeInstallOpts({ existingRaw: afterFirst });
+    const src2 = new NativeHookSource({ hookInstall: opts2 });
+    src2.install();
+
+    expect(written2).toHaveLength(0);
+  });
+});

--- a/packages/workspaces/src/native-hooks/native-hook-source.ts
+++ b/packages/workspaces/src/native-hooks/native-hook-source.ts
@@ -14,16 +14,19 @@ import type { LifecycleSource, LifecycleSourceDeps, LifecycleSnapshot, Lifecycle
 
 // ── Hook event matrix ─────────────────────────────────────────────────────────
 
-// Claude hook event name → sub-command alias (blueprint §9).
+// Claude hook event name → sub-command alias → optional tool matcher (blueprint §9).
 // Non-lifecycle hooks (PostToolUse, SubagentStop) are intentionally excluded;
 // they feed the existing crew._hook bridge and are not part of the 4-state model.
-const CLAUDE_HOOK_EVENTS: ReadonlyArray<readonly [string, string]> = [
+//
+// Third element (matcher) is passed as the hook entry's "matcher" field.
+// AskUserQuestion is a TOOL, not an event — hook it via PreToolUse with a tool matcher.
+const CLAUDE_HOOK_EVENTS: ReadonlyArray<readonly [string, string, string?]> = [
   ["SessionStart",     "session-start"],
   ["UserPromptSubmit", "prompt-submit"],
   ["PreToolUse",       "pre-tool-use"],
   ["Stop",             "stop"],
   ["Notification",     "notification"],
-  ["AskUserQuestion",  "ask-question"],
+  ["PreToolUse",       "ask-question", "AskUserQuestion"],
   ["SessionEnd",       "session-end"],
 ];
 
@@ -79,12 +82,13 @@ export function installClaudeHooks(opts: ClaudeHooksInstallOpts = {}): string {
   const hooks = settings.hooks as Record<string, unknown>;
 
   let changed = false;
-  for (const [eventName, sub] of CLAUDE_HOOK_EVENTS) {
+  for (const [eventName, sub, matcher] of CLAUDE_HOOK_EVENTS) {
     if (!Array.isArray(hooks[eventName])) {
       hooks[eventName] = [];
     }
     const entries = hooks[eventName] as unknown[];
     const command = `${hookCmd} claude ${sub}`;
+    const hookMatcher = matcher ?? "";
 
     // Idempotency check: skip if our exact command is already registered.
     const alreadyPresent = entries.some(
@@ -97,7 +101,7 @@ export function installClaudeHooks(opts: ClaudeHooksInstallOpts = {}): string {
         ),
     );
     if (!alreadyPresent) {
-      entries.push({ matcher: "", hooks: [{ type: "command", command, timeout: 10 }] });
+      entries.push({ matcher: hookMatcher, hooks: [{ type: "command", command, timeout: 10 }] });
       changed = true;
     }
   }

--- a/packages/workspaces/src/native-hooks/native-hook-source.ts
+++ b/packages/workspaces/src/native-hooks/native-hook-source.ts
@@ -1,0 +1,261 @@
+// native-hook-source.ts — LifecycleSource C: squadrant-owned claude hooks
+//
+// PRIMARY LifecycleSource (#333 Phase 1, D1). Installs namespaced hooks into
+// claude's native config and receives hook events pushed by the daemon.
+//
+// NOT wired into the live daemon in Phase 1 (additive per D3/D7).
+// The sibling wiring crew adds 'squadrant hooks claude <sub>' to the CLI,
+// reads SQUADRANT_CREW_TASK_ID from the hook process env, and calls handleHook().
+
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import type { LifecycleSource, LifecycleSourceDeps, LifecycleSnapshot, LifecycleState } from "@squadrant/core";
+
+// ── Hook event matrix ─────────────────────────────────────────────────────────
+
+// Claude hook event name → sub-command alias (blueprint §9).
+// Non-lifecycle hooks (PostToolUse, SubagentStop) are intentionally excluded;
+// they feed the existing crew._hook bridge and are not part of the 4-state model.
+const CLAUDE_HOOK_EVENTS: ReadonlyArray<readonly [string, string]> = [
+  ["SessionStart",     "session-start"],
+  ["UserPromptSubmit", "prompt-submit"],
+  ["PreToolUse",       "pre-tool-use"],
+  ["Stop",             "stop"],
+  ["Notification",     "notification"],
+  ["AskUserQuestion",  "ask-question"],
+  ["SessionEnd",       "session-end"],
+];
+
+const DEFAULT_HOOK_CMD = "squadrant hooks";
+
+// ── Hook installer ────────────────────────────────────────────────────────────
+
+export interface ClaudeHooksInstallOpts {
+  /** Path to ~/.claude/settings.json. Injectable for tests. */
+  settingsPath?: string;
+  /**
+   * Base hook command — final command is '<hookCmd> claude <sub>'.
+   * Default: 'squadrant hooks' (the CLI subcommand wired by the daemon crew).
+   */
+  hookCmd?: string;
+  /** Injectable: read file content, undefined on any read error. */
+  readFile?: (path: string) => string | undefined;
+  /** Injectable: write file (caller responsible for creating parent dirs). */
+  writeFile?: (path: string, content: string) => void;
+  log?: (msg: string) => void;
+}
+
+/**
+ * Idempotent, non-clobbering installer for squadrant-owned hooks in ~/.claude/settings.json.
+ *
+ * Installs one hook entry per lifecycle-relevant Claude hook event (D4: namespaced,
+ * re-run-safe). Hooks from cmux, the user, or other tools with different commands
+ * are left untouched. A second call with the same hookCmd is a complete no-op.
+ * Returns the path to the settings file (which may or may not have been written).
+ */
+export function installClaudeHooks(opts: ClaudeHooksInstallOpts = {}): string {
+  const settingsPath = opts.settingsPath ?? join(homedir(), ".claude", "settings.json");
+  const hookCmd = opts.hookCmd ?? DEFAULT_HOOK_CMD;
+  const readFile = opts.readFile ?? defaultReadFile;
+  const writeFile = opts.writeFile ?? defaultWriteFile;
+  const log = opts.log ?? (() => {});
+
+  // Parse existing settings (start fresh if absent or malformed).
+  let settings: Record<string, unknown> = {};
+  const raw = readFile(settingsPath);
+  if (raw) {
+    try {
+      settings = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      log(`native-hook: failed to parse ${settingsPath} — hooks section will be reset`);
+    }
+  }
+
+  // Ensure hooks is a plain object.
+  if (typeof settings.hooks !== "object" || settings.hooks === null || Array.isArray(settings.hooks)) {
+    settings.hooks = {};
+  }
+  const hooks = settings.hooks as Record<string, unknown>;
+
+  let changed = false;
+  for (const [eventName, sub] of CLAUDE_HOOK_EVENTS) {
+    if (!Array.isArray(hooks[eventName])) {
+      hooks[eventName] = [];
+    }
+    const entries = hooks[eventName] as unknown[];
+    const command = `${hookCmd} claude ${sub}`;
+
+    // Idempotency check: skip if our exact command is already registered.
+    const alreadyPresent = entries.some(
+      (m) =>
+        Array.isArray((m as Record<string, unknown>).hooks) &&
+        ((m as Record<string, unknown>).hooks as unknown[]).some(
+          (h) =>
+            typeof (h as Record<string, unknown>).command === "string" &&
+            (h as Record<string, unknown>).command === command,
+        ),
+    );
+    if (!alreadyPresent) {
+      entries.push({ matcher: "", hooks: [{ type: "command", command, timeout: 10 }] });
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    writeFile(settingsPath, JSON.stringify(settings, null, 2));
+  }
+  return settingsPath;
+}
+
+// ── Sub-event → lifecycle state mapping ──────────────────────────────────────
+
+/**
+ * Pure: map a sub-event alias to its LifecycleState.
+ * Returns "session-end" for the teardown alias (not a LifecycleState value — the
+ * caller emits alive:false + state:"unknown" and the daemon wiring translates to
+ * task.session.ended). Returns null for unknown subs (caller no-ops).
+ */
+export function mapSubToLifecycle(sub: string): LifecycleState | "session-end" | null {
+  switch (sub) {
+    case "session-start":  return "running";
+    case "prompt-submit":  return "running";
+    case "pre-tool-use":   return "running";
+    case "stop":           return "idle";
+    case "notification":   return "needsInput";
+    case "ask-question":   return "needsInput";
+    case "session-end":    return "session-end";
+    default:               return null;
+  }
+}
+
+// ── NativeHookSource ─────────────────────────────────────────────────────────
+
+export interface NativeHookSourceOpts {
+  /** Options forwarded to installClaudeHooks(). Useful for testing. */
+  hookInstall?: ClaudeHooksInstallOpts;
+  log?: (msg: string) => void;
+}
+
+/**
+ * LifecycleSource C — primary, driver-agnostic (#333 D1).
+ *
+ * Two seams:
+ *   1. install() — writes squadrant-owned hooks into ~/.claude/settings.json
+ *      (idempotent, namespaced, non-clobbering per D4).
+ *   2. handleHook(sub, taskId, pid?, payload?) — called by the daemon when a
+ *      claude hook fires; maps the sub-event to a LifecycleSnapshot and feeds
+ *      it into deps.report().
+ *
+ * Unlike CmuxStoreSource (file-watcher), NativeHookSource is purely push-driven:
+ * every snapshot arrives via handleHook() from the daemon's 'squadrant hooks'
+ * CLI subcommand. The snapshot() method serves the liveness floor from the cache.
+ */
+export class NativeHookSource implements LifecycleSource {
+  readonly name = "native-hook";
+
+  private readonly hookInstall: ClaudeHooksInstallOpts;
+  private readonly log: (msg: string) => void;
+
+  private deps?: LifecycleSourceDeps;
+  /** taskId → last-reported snapshot, for snapshot() liveness floor. */
+  private cache = new Map<string, LifecycleSnapshot>();
+
+  constructor(opts: NativeHookSourceOpts = {}) {
+    this.hookInstall = opts.hookInstall ?? {};
+    this.log = opts.log ?? (() => {});
+  }
+
+  start(deps: LifecycleSourceDeps): void {
+    this.deps = deps;
+  }
+
+  stop(): void {
+    this.deps = undefined;
+    this.cache.clear();
+  }
+
+  /** Returns the last-reported snapshot for a known crew (liveness floor poll). */
+  snapshot(taskId: string): LifecycleSnapshot | undefined {
+    return this.cache.get(taskId);
+  }
+
+  /**
+   * Install squadrant-owned hooks into ~/.claude/settings.json.
+   * Idempotent — safe to call on every project init or crew spawn.
+   * Returns the path to the settings file.
+   */
+  install(): string {
+    return installClaudeHooks(this.hookInstall);
+  }
+
+  /**
+   * Receive a lifecycle hook event from the daemon and report a LifecycleSnapshot.
+   *
+   * The daemon's 'squadrant hooks claude <sub>' CLI subcommand calls this after
+   * reading SQUADRANT_CREW_TASK_ID from the hook's process environment — the only
+   * collision-proof correlation key (blueprint §2.2 priority 1).
+   *
+   * @param sub     Sub-event alias: "session-start" | "prompt-submit" | "stop" | …
+   * @param taskId  SQUADRANT_CREW_TASK_ID extracted from the hook process env.
+   * @param pid     Optional: OS pid from the hook's process env or argv.
+   * @param payload Optional: parsed JSON payload from hook stdin (best-effort detail).
+   */
+  handleHook(sub: string, taskId: string, pid?: number, payload?: unknown): void {
+    if (!this.deps) return;
+
+    const mapped = mapSubToLifecycle(sub);
+    if (mapped === null) {
+      this.log(`native-hook: unknown sub '${sub}' for task ${taskId} — ignored`);
+      return;
+    }
+
+    // session-end signals teardown: alive:false lets the daemon wiring emit
+    // task.session.ended (anti-#2576: never task.done from a lifecycle hook).
+    const isSessionEnd = mapped === "session-end";
+    const state: LifecycleState = isSessionEnd ? "unknown" : mapped;
+
+    const detail = extractDetail(sub, payload);
+    const snap: LifecycleSnapshot = {
+      taskId,
+      state,
+      alive: !isSessionEnd,
+      origin: "agent",
+      at: Date.now(),
+      ...(pid !== undefined ? { pid } : {}),
+      ...(detail ? { detail } : {}),
+    };
+
+    this.cache.set(taskId, snap);
+    this.deps.report(snap);
+  }
+}
+
+// ── Private helpers ───────────────────────────────────────────────────────────
+
+function extractDetail(sub: string, payload: unknown): LifecycleSnapshot["detail"] | undefined {
+  if (!payload || typeof payload !== "object") return undefined;
+  const p = payload as Record<string, unknown>;
+  if (sub === "notification") {
+    const note = typeof p.message === "string" ? p.message : undefined;
+    return note ? { note } : undefined;
+  }
+  if (sub === "pre-tool-use") {
+    const tool = typeof p.tool_name === "string" ? p.tool_name : undefined;
+    return tool ? { tool } : undefined;
+  }
+  return undefined;
+}
+
+function defaultReadFile(path: string): string | undefined {
+  try {
+    return readFileSync(path, "utf-8");
+  } catch {
+    return undefined;
+  }
+}
+
+function defaultWriteFile(path: string, content: string): void {
+  mkdirSync(path.replace(/\/[^/]+$/, ""), { recursive: true });
+  writeFileSync(path, content, "utf-8");
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@inquirer/checkbox':
+        specifier: ^4.1.5
+        version: 4.3.2(@types/node@22.19.21)
       '@squadrant/agents':
         specifier: workspace:*
         version: link:../agents
@@ -281,6 +284,41 @@ packages:
   '@grammyjs/types@3.28.0':
     resolution: {integrity: sha512-4JvXCdxRZHCje0M4gHzLwtB4bLno3WD28xd8CNfk4POWIu73BFnSvGeW6OQ5gPem4eYTEwkD9yDaXssixl6tMQ==}
 
+  '@inquirer/ansi@1.0.2':
+    resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/checkbox@4.3.2':
+    resolution: {integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.3.2':
+    resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.15':
+    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
+    engines: {node: '>=18'}
+
+  '@inquirer/type@3.0.10':
+    resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -478,6 +516,14 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -514,6 +560,17 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
@@ -541,6 +598,9 @@ packages:
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -591,6 +651,10 @@ packages:
     resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
     engines: {node: '>=0.10.0'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -631,6 +695,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -707,6 +775,10 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -723,6 +795,14 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-bom-string@1.0.0:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
@@ -880,6 +960,14 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
+  yoctocolors-cjs@2.1.3:
+    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
+    engines: {node: '>=18'}
+
 snapshots:
 
   '@esbuild/aix-ppc64@0.27.7':
@@ -961,6 +1049,37 @@ snapshots:
     optional: true
 
   '@grammyjs/types@3.28.0': {}
+
+  '@inquirer/ansi@1.0.2': {}
+
+  '@inquirer/checkbox@4.3.2(@types/node@22.19.21)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.21)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.21)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.21
+
+  '@inquirer/core@10.3.2(@types/node@22.19.21)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.21)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.21
+
+  '@inquirer/figures@1.0.15': {}
+
+  '@inquirer/type@3.0.10(@types/node@22.19.21)':
+    optionalDependencies:
+      '@types/node': 22.19.21
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -1108,6 +1227,12 @@ snapshots:
 
   acorn@8.17.0: {}
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
   any-promise@1.3.0: {}
 
   argparse@1.0.10:
@@ -1139,6 +1264,14 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  cli-width@4.1.0: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
   commander@13.1.0: {}
 
   commander@4.1.1: {}
@@ -1152,6 +1285,8 @@ snapshots:
       ms: 2.1.3
 
   deep-eql@5.0.2: {}
+
+  emoji-regex@8.0.0: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -1218,6 +1353,8 @@ snapshots:
 
   is-extendable@0.1.1: {}
 
+  is-fullwidth-code-point@3.0.0: {}
+
   joycon@3.1.1: {}
 
   js-tokens@9.0.1: {}
@@ -1251,6 +1388,8 @@ snapshots:
       ufo: 1.6.4
 
   ms@2.1.3: {}
+
+  mute-stream@2.0.0: {}
 
   mz@2.7.0:
     dependencies:
@@ -1332,6 +1471,8 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@4.1.0: {}
+
   source-map-js@1.2.1: {}
 
   source-map@0.7.6: {}
@@ -1341,6 +1482,16 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
 
   strip-bom-string@1.0.0: {}
 
@@ -1497,3 +1648,11 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  yoctocolors-cjs@2.1.3: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@inquirer/checkbox':
+        specifier: ^4.1.5
+        version: 4.3.2(@types/node@22.19.21)
       chalk:
         specifier: ^5.4.0
         version: 5.6.2


### PR DESCRIPTION
## v0.13.0

Ships #333 Phase 1 (LifecycleSource port) and the first-turn-drop fix, plus interactive launch and the opencode-picker-blocked fix.

### Added
- **Native lifecycle ingestion (#333 Phase 1):** squadrant-owned Claude hooks via `NativeHookSource` (primary, namespaced/non-clobbering install), `CodexAppServerSource` adapter, and `CmuxStoreSource` backup; new internal `squadrant hooks claude <event>` CLI. Additive next to the cmux events bridge.
- Interactive no-arg `squad launch` (multi-select, parallel boot).

### Fixed
- **First-turn drop (#333):** `AskUserQuestion` was registered as an invalid top-level hook event → blocking Settings Warning modal swallowed crew first turns. Now a `PreToolUse` hook with `matcher: "AskUserQuestion"`.
- opencode multi-option picker now detected as CREW BLOCKED (captain no longer blind to it).

Deployed + verified end-to-end live before this release: daemon on new build, hook matcher present in settings, claude crew first-turn delivery confirmed.