### PR TITLE
fix: decouple launch-interactive tests from system clock (v0.13.0 release blocker)

### DIFF
--- a/packages/cli/src/commands/__tests__/launch-interactive.test.ts
+++ b/packages/cli/src/commands/__tests__/launch-interactive.test.ts
@@ -71,7 +71,7 @@ describe("selectCaptainsInteractive", () => {
     const yesterdayEntries = MOCK_ENTRIES.filter(e => e.lastLaunched === "2026-06-26");
     mockCheckbox.mockResolvedValue(["squadrant"]);
 
-    const result = await selectCaptainsInteractive(MOCK_ENTRIES);
+    const result = await selectCaptainsInteractive(MOCK_ENTRIES, "2026-06-26");
 
     expect(result).toEqual(["squadrant"]);
 
@@ -96,7 +96,7 @@ describe("selectCaptainsInteractive", () => {
       .mockResolvedValueOnce(["brove", "__show_all__"])
       .mockResolvedValueOnce(["brove", "park"]);
 
-    const result = await selectCaptainsInteractive(MOCK_ENTRIES);
+    const result = await selectCaptainsInteractive(MOCK_ENTRIES, "2026-06-26");
 
     expect(result).toEqual(["brove", "park"]);
     expect(mockCheckbox).toHaveBeenCalledTimes(2);
@@ -112,7 +112,7 @@ describe("selectCaptainsInteractive", () => {
     mockCheckbox.mockResolvedValue(["oneplan", "park"]);
 
     const entriesWithoutYesterday = MOCK_ENTRIES.map(e => ({ ...e, lastLaunched: null }));
-    const result = await selectCaptainsInteractive(entriesWithoutYesterday);
+    const result = await selectCaptainsInteractive(entriesWithoutYesterday, "2026-06-26");
 
     expect(result).toEqual(["oneplan", "park"]);
 
@@ -130,7 +130,7 @@ describe("selectCaptainsInteractive", () => {
     const allYesterday = MOCK_ENTRIES.map(e => ({ ...e, lastLaunched: "2026-06-26" }));
     mockCheckbox.mockResolvedValue(["squadrant", "brove"]);
 
-    const result = await selectCaptainsInteractive(allYesterday);
+    const result = await selectCaptainsInteractive(allYesterday, "2026-06-26");
 
     expect(result).toEqual(["squadrant", "brove"]);
 

--- a/packages/cli/src/commands/launch-interactive.ts
+++ b/packages/cli/src/commands/launch-interactive.ts
@@ -30,8 +30,8 @@ export function partitionByYesterday(
 
 export async function selectCaptainsInteractive(
   entries: CaptainEntry[],
+  yesterday: string = getYesterday(),
 ): Promise<string[]> {
-  const yesterday = getYesterday();
   const { yesterday: yesterdayEntries, rest: restEntries } = partitionByYesterday(entries, yesterday);
 
   if (yesterdayEntries.length === 0) {


### PR DESCRIPTION
Unblocks the v0.13.0 release. The 3 `selectCaptainsInteractive` tests in `launch-interactive.test.ts` were coupled to the system clock: `MOCK_ENTRIES` hardcode `lastLaunched: "2026-06-26"` but the function called the real `getYesterday()` internally, so they only passed on 2026-06-27. They never hit CI before (develop was unpushed; its green CI predated the `squad launch` feature), so the failure first surfaced on the release PR.

**Fix (DI, matching the existing `partitionByYesterday(entries, yesterday)` pattern):** `selectCaptainsInteractive(entries, yesterday = getYesterday())` now takes an optional injectable date; the 4 test calls pass `"2026-06-26"` explicitly. No runtime behavior change for real callers.

Full suite green: **150 files, 1720 tests, 0 failures** (commit 8515a17).