### PR TITLE
fix(#455): don't treat un-rendered large paste as submitted (first-turn strand)

### DIFF
--- a/packages/workspaces/src/__tests__/crew-pane.test.ts
+++ b/packages/workspaces/src/__tests__/crew-pane.test.ts
@@ -264,15 +264,16 @@ describe("confirmedSendToPane — follow-up crew send (#448)", () => {
     expect(sendKeyToPane).toHaveBeenCalledWith(pane, "Enter");
   });
 
-  // Short sends must not block waiting for the settle window — the box goes
-  // empty immediately (no paste-mode coalescing) and we return on the first check.
+  // Short sends must not block waiting for the settle window. For short content CC
+  // renders the text directly in the box (no [Pasted text] placeholder), so settle
+  // sees actual content and sawDraft is set; empty box after Enter = submitted.
   it("submits a short message on the first confirmation check", async () => {
     let n = 0;
     readPaneScreen.mockImplementation(async () => {
       n++;
-      if (n === 1) return box("");           // preSendScreen
-      if (n === 2) return EMPTY_BOX;         // settle: no paste coalescing (empty = stable immediately)
-      return EMPTY_BOX;                       // post-Enter: submitted
+      if (n === 1) return box("");         // preSendScreen: idle box
+      if (n <= 3) return box("hi");        // settle: short text rendered immediately (no placeholder)
+      return EMPTY_BOX;                    // post-Enter: submitted
     });
 
     const promise = confirmedSendToPane(rt(), pane, "hi");
@@ -281,5 +282,151 @@ describe("confirmedSendToPane — follow-up crew send (#448)", () => {
 
     expect(pasteToPane).toHaveBeenCalledTimes(1);
     expect(sendKeyToPane).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── #455: large-paste race — empty box before paste renders ─────────────────
+
+describe("sendFirstTurnWhenReady — large paste race (#455)", () => {
+  let readPaneScreen: ReturnType<typeof vi.fn>;
+  let sendToPane: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
+  const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, sendToPane, pasteToPane, sendKeyToPane });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    readPaneScreen = vi.fn();
+    sendToPane = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // #455 core regression: for a large paste the [Pasted text] placeholder may not
+  // have rendered by the time settleInputBox first polls — the box appears stable-
+  // empty. The pre-fix code treats that as "submitted" and returns; the paste then
+  // lands in an unsubmitted state (strand). The fix: only accept empty-box-means-
+  // submitted after the draft was observed non-empty at least once.
+  it("does not declare submitted on leading empties before paste renders (#455 race)", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n <= 3) return EMPTY_BOX;  // stability polls + preSend snapshot
+      if (n <= 5) return EMPTY_BOX;  // settle: paste NOT rendered yet (stable-empty bug)
+      if (n === 6) return EMPTY_BOX; // post-Enter#1: still empty (paste in flight)
+      if (n <= 9) return DRAFT_BOX;  // paste finally renders during retry settle
+      return EMPTY_BOX;              // post-Enter#2: box empty → actually submitted
+    });
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "very large task", "$ launch");
+    await vi.advanceTimersByTimeAsync(8000);
+    await promise;
+
+    // Must NOT have returned on the leading empty reads before paste rendered.
+    // Paste issued exactly once; Enter issued at least twice (initial no-op + retry).
+    expect(pasteToPane).toHaveBeenCalledTimes(1);
+    expect(sendKeyToPane.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(sendToPane).not.toHaveBeenCalled();
+  });
+
+  // When the paste NEVER renders (e.g. paste-buffer loss), the function must re-paste
+  // once rather than silently declaring success on a never-populated box.
+  it("re-pastes once when paste never renders (never-populated box)", async () => {
+    readPaneScreen.mockResolvedValue(EMPTY_BOX);
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "very large task", "$ launch");
+    await vi.advanceTimersByTimeAsync(10000);
+    await promise;
+
+    // Re-pasted exactly once after the initial paste failed to render.
+    expect(pasteToPane).toHaveBeenCalledTimes(2);
+    expect(pasteToPane).toHaveBeenCalledWith(pane, "very large task");
+    expect(sendToPane).not.toHaveBeenCalled();
+  });
+});
+
+describe("confirmedSendToPane — large paste race (#455)", () => {
+  let readPaneScreen: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
+  const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, pasteToPane, sendKeyToPane });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    readPaneScreen = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Same race as sendFirstTurnWhenReady: settle sees stable-empty, Enter fires into
+  // empty box (no-op), retry-check sees empty → pre-fix BUG declares submitted.
+  it("does not declare submitted on leading empties before paste renders (#455 race)", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n === 1) return box("");   // preSendScreen
+      if (n <= 3) return EMPTY_BOX;  // settle: paste not rendered yet
+      if (n === 4) return EMPTY_BOX; // post-Enter#1: still empty
+      if (n <= 7) return DRAFT_BOX;  // paste renders during retry settle
+      return EMPTY_BOX;              // post-Enter#2: submitted
+    });
+
+    const promise = confirmedSendToPane(rt(), pane, "big follow-up");
+    await vi.advanceTimersByTimeAsync(6000);
+    await promise;
+
+    expect(pasteToPane).toHaveBeenCalledTimes(1);
+    expect(sendKeyToPane.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // Exactly ONE submit detected: the moment the box empties AFTER the draft was seen.
+  it("submits exactly once — no double-submit after seeing non-empty then empty", async () => {
+    let returned = false;
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n === 1) return box("");   // preSendScreen
+      if (n <= 3) return EMPTY_BOX;  // settle: paste not rendered
+      if (n === 4) return EMPTY_BOX; // post-Enter#1: empty (no-op)
+      if (n <= 7) return DRAFT_BOX;  // paste renders during retry settle
+      return EMPTY_BOX;              // post-Enter#2: submitted
+    });
+
+    const promise = confirmedSendToPane(rt(), pane, "big follow-up");
+    promise.then(() => { returned = true; });
+    await vi.advanceTimersByTimeAsync(6000);
+    await promise;
+
+    // Function returned exactly once (no double-submit loop).
+    expect(returned).toBe(true);
+    expect(pasteToPane).toHaveBeenCalledTimes(1);
+  });
+
+  // When paste never renders: re-paste once rather than silently returning on an
+  // empty box that was never populated.
+  it("re-pastes once when paste never renders (never-populated box)", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n === 1) return box("");  // preSendScreen
+      return EMPTY_BOX;             // everything else: paste never appears
+    });
+
+    const promise = confirmedSendToPane(rt(), pane, "big follow-up");
+    await vi.advanceTimersByTimeAsync(6000);
+    await promise;
+
+    expect(pasteToPane).toHaveBeenCalledTimes(2);
+    expect(pasteToPane).toHaveBeenCalledWith(pane, "big follow-up");
   });
 });

--- a/packages/workspaces/src/crew-pane.ts
+++ b/packages/workspaces/src/crew-pane.ts
@@ -33,18 +33,25 @@ const SETTLE_MAX_POLLS = 8;        // up to 3.2s for a very large paste to rende
 const SUBMIT_RETRY_LIMIT = 4;      // Enter-only re-issues if the box stays stranded
 
 /** Poll the pane until its input box stops changing across two consecutive reads
- *  (paste fully rendered / accumulation window closed), or the cap is hit. */
+ *  (paste fully rendered / accumulation window closed), or the cap is hit.
+ *  Returns true if the box was observed with content at any point — the caller
+ *  uses this to distinguish "paste rendered then submitted" from "paste never
+ *  rendered, empty box is NOT a confirmation of submit" (#455). */
 async function settleInputBox(
   runtime: Pick<RuntimeDriver, "readPaneScreen">,
   pane: PaneRef,
-): Promise<void> {
+): Promise<boolean> {
   let prev = (await runtime.readPaneScreen(pane)) ?? "";
+  let sawContent = parseDraftFromScreen(prev) !== "" && parseDraftFromScreen(prev) !== null;
   for (let i = 0; i < SETTLE_MAX_POLLS; i++) {
     await new Promise((r) => setTimeout(r, SETTLE_POLL_MS));
     const cur = (await runtime.readPaneScreen(pane)) ?? "";
-    if (cur === prev) return;
+    const draft = parseDraftFromScreen(cur);
+    if (draft !== "" && draft !== null) sawContent = true;
+    if (cur === prev) return sawContent;
     prev = cur;
   }
+  return sawContent;
 }
 
 /** Reserve an ephemeral TCP port for a crew's embedded HTTP server. Binds :0,
@@ -118,16 +125,28 @@ export async function confirmedSendToPane(
 ): Promise<void> {
   const preSendScreen = (await runtime.readPaneScreen(pane)) ?? "";
   await runtime.pasteToPane(pane, message);
-  await settleInputBox(runtime, pane);
+  // #455: track whether the paste ever rendered so we don't treat an empty box
+  // that was NEVER populated as a successful submit (race: paste still in flight
+  // when settle fires, stable-empty → Enter into nothing → false "submitted").
+  let sawDraft = await settleInputBox(runtime, pane);
   await runtime.sendKeyToPane(pane, "Enter");
 
+  let repasted = false;
   for (let attempt = 0; attempt < SUBMIT_RETRY_LIMIT; attempt++) {
     await new Promise((r) => setTimeout(r, POST_SEND_CHECK_MS));
     const afterScreen = (await runtime.readPaneScreen(pane)) ?? "";
     const draft = parseDraftFromScreen(afterScreen);
-    if (draft === "") return;
+    if (draft !== "" && draft !== null) sawDraft = true;
+    // Box confirmed empty AND we observed the paste rendered first → submitted.
+    if (draft === "" && sawDraft) return;
     if (draft === null && afterScreen !== preSendScreen) return;
-    await settleInputBox(runtime, pane);
+    const settled = await settleInputBox(runtime, pane);
+    if (settled) sawDraft = true;
+    // #455: paste never rendered — re-paste once rather than issuing Enter into emptiness.
+    if (!sawDraft && !repasted) {
+      repasted = true;
+      await runtime.pasteToPane(pane, message);
+    }
     await runtime.sendKeyToPane(pane, "Enter");
   }
 }
@@ -202,22 +221,33 @@ export async function sendFirstTurnWhenReady(
   // re-issue ONLY the Enter (after re-settling) and NEVER re-paste — re-pasting is
   // exactly what stacks [Pasted text #1][#2][#3] and never submits.
   await runtime.pasteToPane(pane, task);
-  await settleInputBox(runtime, pane);
+  // #455: track whether the paste ever rendered so we don't treat an empty box
+  // that was NEVER populated as a successful submit (race: paste still in flight
+  // when settle fires, stable-empty → Enter into nothing → false "submitted").
+  let sawDraft = await settleInputBox(runtime, pane);
   await runtime.sendKeyToPane(pane, "Enter");
 
   const retryLimit = acceptanceConfig?.retryLimit ?? SUBMIT_RETRY_LIMIT;
+  let repasted = false;
   for (let attempt = 0; attempt < retryLimit; attempt++) {
     await new Promise((r) => setTimeout(r, POST_SEND_CHECK_MS));
     const afterScreen = (await runtime.readPaneScreen(pane)) ?? "";
     const draft = parseDraftFromScreen(afterScreen);
-    // Box confirmed empty → the draft left the input box → submitted.
-    if (draft === "") return;
+    if (draft !== "" && draft !== null) sawDraft = true;
+    // Box confirmed empty AND we observed the paste rendered first → submitted.
+    if (draft === "" && sawDraft) return;
     // Box not parseable (e.g. an agent TUI without the HR-bounded box, or a
     // transient overlay): fall back to the screen-changed signal so non-claude
     // TUIs aren't worse off than before.
     if (draft === null && afterScreen !== preSendScreen) return;
-    // Still stranded — re-settle and re-issue ONLY the Enter (never re-paste).
-    await settleInputBox(runtime, pane);
+    const settled = await settleInputBox(runtime, pane);
+    if (settled) sawDraft = true;
+    // #455: paste never rendered — re-paste once rather than issuing Enter into emptiness.
+    if (!sawDraft && !repasted) {
+      repasted = true;
+      await runtime.pasteToPane(pane, task);
+    }
+    // Still stranded — re-issue ONLY the Enter (re-paste only when never rendered).
     await runtime.sendKeyToPane(pane, "Enter");
   }
 }


### PR DESCRIPTION
Fixes #455.

## Root cause
The first-turn submit-confirmation treated `parseDraftFromScreen(screen) === ""` as "submitted", but for a slow/large paste an empty box also means "the paste hasn't rendered yet". The two are indistinguishable, so a large first-turn could: `settleInputBox` catches the stable-empty window before the paste renders → returns → `Enter` fires into an empty box → the retry loop reads an empty box → returns claiming success while the paste lands afterward and strands (or never lands → empty box, 0% ctx). Observed live on the v0.13.0 release-prep crew.

## Fix (`packages/workspaces/src/crew-pane.ts`)
- `settleInputBox` now returns `boolean` — whether the box was observed with content at any point.
- `confirmedSendToPane` and `sendFirstTurnWhenReady` (claude/codex path) track a `sawDraft` flag (seeded from settle, updated each retry poll). An empty box is accepted as "submitted" **only when `sawDraft` is true** (the paste was seen to render first).
- If the paste never renders (`sawDraft` never set), re-paste **exactly once** (`repasted` guard) instead of firing Enter into emptiness. Preserves the original #339 invariant: never re-paste a *rendered-but-stranded* box (avoids `[Pasted #1][#2]` stacking).
- Non-claude TUI fallback (`draft === null && screen changed`) and the opencode splash path are unchanged.

## Tests
5 new tests in `crew-pane.test.ts`: the leading-empty race + never-renders re-paste, for **both** `sendFirstTurnWhenReady` and `confirmedSendToPane`, plus an exact-one-submit guard. Updated the "short message submits" mock to render realistic content.

**1725/1725 tests pass, build green.** Related: #339, #447, #448, #449.