### PR TITLE
fix(#459,#460): suppress false CREW FAILED on API retry + handle stale crew branch on spawn

### DIFF
--- a/packages/agents/src/__tests__/pane-classifier.test.ts
+++ b/packages/agents/src/__tests__/pane-classifier.test.ts
@@ -177,4 +177,41 @@ describe("classifyPaneTail", () => {
     ].join("\n");
     expect(classifyPaneTail(numberedList)).toBeNull();
   });
+
+  // ── #459: active-retry banner must NOT be classified as fatal error ──────
+
+  it("returns null for an in-flight API retry banner (recoverable, not error)", () => {
+    const tail = [
+      "● Working on the implementation...",
+      "✻ API error · Retrying in 0s · attempt 1/10",
+      "╭────────────────────────────╮",
+      "│ >                          │",
+      "╰────────────────────────────╯",
+    ].join("\n");
+    expect(classifyPaneTail(tail)).toBeNull();
+  });
+
+  it("still classifies a bare API error with no retry indicator as fatal error", () => {
+    const tail = [
+      "● Calling the API...",
+      "API Error: 529 Overloaded",
+      "╭────────────────────────────╮",
+      "│ >                          │",
+      "╰────────────────────────────╯",
+    ].join("\n");
+    const r = classifyPaneTail(tail);
+    expect(r?.kind).toBe("error");
+  });
+
+  it("classifies exhausted retries as fatal error even when retry text is also present", () => {
+    const tail = [
+      "✻ API error · Retrying in 0s · attempt 10/10",
+      "retries exhausted — giving up",
+      "╭────────────────────────────╮",
+      "│ >                          │",
+      "╰────────────────────────────╯",
+    ].join("\n");
+    const r = classifyPaneTail(tail);
+    expect(r?.kind).toBe("error");
+  });
 });

--- a/packages/agents/src/interactive/pane-classifier.ts
+++ b/packages/agents/src/interactive/pane-classifier.ts
@@ -77,11 +77,19 @@ export function classifyPaneTail(
   // ── error: a fatal CLI error banner (#196), checked LAST so a recoverable
   // approval/question above always wins. Match the LAST banner line (the final
   // error after any retry chatter is the most informative).
+  // #459: suppress the error verdict when the tail shows an active retry in
+  // flight (e.g. "Retrying in 0s · attempt 1/10") but no exhaustion marker —
+  // Claude Code auto-retries up to 10× and the crew usually recovers.
   let errLine: string | null = null;
   for (const c of cleaned) {
     if (c != null && ERROR_BANNER_RE.some((re) => re.test(c))) errLine = c;
   }
-  if (errLine) return { kind: "error", text: errLine.slice(0, 200) };
+  if (errLine) {
+    const isRetrying = cleaned.some((c) => c != null && RETRYING_RE.test(c));
+    const isExhausted = cleaned.some((c) => c != null && EXHAUSTED_RE.test(c));
+    if (isRetrying && !isExhausted) return null;
+    return { kind: "error", text: errLine.slice(0, 200) };
+  }
 
   return null;
 }
@@ -98,6 +106,14 @@ const ERROR_BANNER_RE: RegExp[] = [
   /\bretr(?:y|ies)\s+(?:exhausted|limit\s+(?:reached|exceeded))\b/i,
   /\bmaximum\s+retries\b/i,
 ];
+
+// Active-retry indicator: the CLI is still retrying (not yet exhausted). Used
+// to suppress a false-fatal-error verdict for in-flight retries (#459).
+const RETRYING_RE = /\bRetrying\b|\battempt\s+\d+\s*\/\s*\d+/i;
+
+// Retry exhaustion: the final retry failed. When present alongside RETRYING_RE,
+// exhaustion wins and the error verdict is still emitted.
+const EXHAUSTED_RE = /\bretr(?:y|ies)\s+(?:exhausted|limit\s+(?:reached|exceeded))\b|\bmaximum\s+retries\b/i;
 
 // A numbered option line, after chrome stripping: an optional cursor marker
 // (❯ / > / ›), a number, a dot, then the label. e.g. "❯ 1. Yes".

--- a/packages/shared/src/lib/__tests__/git-worktree.test.ts
+++ b/packages/shared/src/lib/__tests__/git-worktree.test.ts
@@ -34,6 +34,10 @@ describe("addWorktree", () => {
   beforeEach(() => execFileSyncMock.mockReset());
 
   it("runs `git -C <repo> worktree add <path> -b crew/<name> <base>` and returns the path", () => {
+    // No existing branch: show-ref throws (not found), worktree add succeeds.
+    execFileSyncMock.mockImplementationOnce(() => { throw new Error("not found"); }); // show-ref
+    execFileSyncMock.mockReturnValue(Buffer.from("")); // worktree add
+
     const wt = addWorktree({
       repoRoot: "/tmp/brove",
       worktreeDir: ".worktrees",
@@ -47,6 +51,63 @@ describe("addWorktree", () => {
     expect(execFileSyncMock).toHaveBeenCalledWith(
       "git",
       ["-C", "/tmp/brove", "worktree", "add", expectedPath, "-b", "crew/crew-1", "develop"],
+      expect.objectContaining({ stdio: "pipe" }),
+    );
+  });
+
+  // ── #460: stale branch collision handling ──────────────────────────────────
+
+  it("deletes and recreates the branch when it exists but has no unique commits (merged)", () => {
+    // show-ref succeeds (branch exists), log returns empty (no unique commits),
+    // branch -D succeeds, worktree add succeeds.
+    execFileSyncMock.mockReturnValueOnce(Buffer.from(""));   // show-ref: branch exists
+    execFileSyncMock.mockReturnValueOnce(Buffer.from(""));   // log: no unique commits
+    execFileSyncMock.mockReturnValueOnce(Buffer.from(""));   // branch -D
+    execFileSyncMock.mockReturnValue(Buffer.from(""));       // worktree add
+
+    const spec = { repoRoot: "/tmp/brove", worktreeDir: ".worktrees", project: "brove", name: "fix-1", base: "develop" };
+    const wt = addWorktree(spec);
+
+    const expectedPath = path.resolve("/tmp/brove", ".worktrees", "brove-fix-1");
+    expect(wt).toBe(expectedPath);
+
+    // branch -D must have been called
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      "git",
+      ["-C", "/tmp/brove", "branch", "-D", "crew/fix-1"],
+      expect.objectContaining({ stdio: "pipe" }),
+    );
+    // worktree add must use the original branch name
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      "git",
+      ["-C", "/tmp/brove", "worktree", "add", expectedPath, "-b", "crew/fix-1", "develop"],
+      expect.objectContaining({ stdio: "pipe" }),
+    );
+  });
+
+  it("uniquifies the branch and path when the existing branch has unique commits (preserves history)", () => {
+    // show-ref for original branch: exists; log: has commits;
+    // show-ref for -2 branch: not found; worktree add with -2: succeeds.
+    execFileSyncMock.mockReturnValueOnce(Buffer.from(""));                            // show-ref crew/fix-1: exists
+    execFileSyncMock.mockReturnValueOnce(Buffer.from("abc123 some commit\n"));        // log: has commits
+    execFileSyncMock.mockImplementationOnce(() => { throw new Error("not found"); }); // show-ref crew/fix-1-2: not found
+    execFileSyncMock.mockReturnValue(Buffer.from(""));                                // worktree add
+
+    const spec = { repoRoot: "/tmp/brove", worktreeDir: ".worktrees", project: "brove", name: "fix-1", base: "develop" };
+    const wt = addWorktree(spec);
+
+    // Path and branch should be uniquified to -2
+    const expectedPath = path.resolve("/tmp/brove", ".worktrees", "brove-fix-1-2");
+    expect(wt).toBe(expectedPath);
+
+    // branch -D must NOT have been called (original branch with commits is untouched)
+    const deleteCalls = execFileSyncMock.mock.calls.filter((c) => Array.isArray(c[1]) && c[1].includes("-D"));
+    expect(deleteCalls).toHaveLength(0);
+
+    // worktree add uses the uniquified name
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      "git",
+      ["-C", "/tmp/brove", "worktree", "add", expectedPath, "-b", "crew/fix-1-2", "develop"],
       expect.objectContaining({ stdio: "pipe" }),
     );
   });

--- a/packages/shared/src/lib/git-worktree.ts
+++ b/packages/shared/src/lib/git-worktree.ts
@@ -54,16 +54,77 @@ export function resolveWorktreeBase(repoRoot: string, fallback = "develop"): str
 
 /**
  * Create the crew's worktree + branch and return its absolute path.
- * Fails loud (throws) if git refuses — e.g. the base branch is missing or the
- * branch/path already exists. The caller's name-uniqueness check already
- * prevents live duplicates; a re-spawned-after-close name can collide on the
- * existing branch (rare — pick a new --name).
+ * Handles a stale crew/<name> branch left by a previously-closed crew (#460):
+ * - No existing branch → unchanged behavior.
+ * - Existing branch with no unique commits (merged/empty) → delete and recreate fresh.
+ * - Existing branch with unique commits → uniquify to crew/<name>-2, -3, … so no
+ *   commits are lost and there is no collision. The returned path reflects the
+ *   uniquified name.
  */
 export function addWorktree(spec: WorktreeSpec): string {
-  const wt = worktreePath(spec.repoRoot, spec.worktreeDir, spec.project, spec.name);
+  const originalBranch = crewBranch(spec.name);
+
+  let targetName = spec.name;
+  let targetBranch = originalBranch;
+
+  // Check whether crew/<name> already exists from a prior closed crew.
+  let branchExists = false;
+  try {
+    execFileSync(
+      "git",
+      ["-C", spec.repoRoot, "show-ref", "--verify", "--quiet", `refs/heads/${originalBranch}`],
+      { stdio: "pipe" },
+    );
+    branchExists = true;
+  } catch {
+    // Branch does not exist — normal path, nothing to resolve.
+  }
+
+  if (branchExists) {
+    const log = execFileSync(
+      "git",
+      ["-C", spec.repoRoot, "log", "--oneline", `${spec.base}..${originalBranch}`],
+      { stdio: ["ignore", "pipe", "ignore"] },
+    ).toString().trim();
+
+    if (!log) {
+      // No unique commits: safe to delete and let the worktree add recreate it.
+      execFileSync(
+        "git",
+        ["-C", spec.repoRoot, "branch", "-D", originalBranch],
+        { stdio: "pipe" },
+      );
+    } else {
+      // Has unique commits: uniquify to crew/<name>-N so history is preserved.
+      let suffix = 2;
+      while (true) {
+        const candidate = `${spec.name}-${suffix}`;
+        const candidateBranch = crewBranch(candidate);
+        let candidateExists = false;
+        try {
+          execFileSync(
+            "git",
+            ["-C", spec.repoRoot, "show-ref", "--verify", "--quiet", `refs/heads/${candidateBranch}`],
+            { stdio: "pipe" },
+          );
+          candidateExists = true;
+        } catch {
+          // Candidate branch is free.
+        }
+        if (!candidateExists) {
+          targetName = candidate;
+          targetBranch = candidateBranch;
+          break;
+        }
+        suffix++;
+      }
+    }
+  }
+
+  const wt = worktreePath(spec.repoRoot, spec.worktreeDir, spec.project, targetName);
   execFileSync(
     "git",
-    ["-C", spec.repoRoot, "worktree", "add", wt, "-b", crewBranch(spec.name), spec.base],
+    ["-C", spec.repoRoot, "worktree", "add", wt, "-b", targetBranch, spec.base],
     { stdio: "pipe" },
   );
   return wt;


### PR DESCRIPTION
Two small crew/daemon robustness fixes. Closes #459, closes #460.

### #459 — transient API retry no longer reported as CREW FAILED
`classifyPaneTail` (`pane-classifier.ts`) matched `/\bAPI Error\b/i` on the **actively-retrying** banner (`API error · Retrying in 0s · attempt 1/10`) and emitted `task.failed`. Now suppresses the `error` verdict when an active-retry indicator is present **and** no exhaustion marker — genuine fatal banners and retry-exhaustion still fire. Added `RETRYING_RE` + `EXHAUSTED_RE`.

### #460 — crew spawn no longer collides on a stale `crew/<name>` branch
`addWorktree` (`git-worktree.ts`) failed `fatal: a branch named 'crew/<name>' already exists` when a closed crew left the branch. Now: no-unique-commits branch → delete + recreate fresh; branch-with-commits → uniquify to `crew/<name>-N` (commits preserved); no branch → unchanged.

### Verification
- **1730/1730 tests pass** (+5 new: classifier retry/exhaustion cases; worktree no-branch/merged/with-commits cases). Build green.
- **#460 verified LIVE**: built the branch, spawned `--name vcollide`, closed it (branch persisted), re-spawned the same name → succeeded (pre-fix: hard-failed). Branch recreated fresh as expected.
- **#459**: pure-function classifier covered deterministically by the exact observed banner (an in-flight API retry can't be forced live).

Related: #196 (error-banner detection), #216 (worktree isolation).