### PR TITLE
Release v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-06-29
+
+### Fixed
+
+- Large first-turn paste-strand: spawning a crew with a large task description could strand the
+  crew's first turn unsubmitted — the big payload pushed Claude Code into bracketed-paste mode and
+  the submit Enter was swallowed before the paste finished rendering, so the task sat in the input
+  box and never started. An un-rendered large paste is no longer treated as submitted; delivery
+  settles the paste window first, then sends a separate confirmed Enter. ([#455](https://github.com/tu11aa/squadrant/issues/455))
+- Transient API retry mis-classified as CREW FAILED: when a crew's underlying CLI hit a transient
+  API error and entered its own retry loop, the pane classifier read the in-flight retry as a fatal
+  failure and fired a bogus CREW FAILED signal even though the crew recovered on its own. In-flight
+  retries are no longer classified as terminal failure. ([#459](https://github.com/tu11aa/squadrant/issues/459))
+- Crew spawn collision on stale branch: if a previous crew left its `crew/<name>` branch behind
+  (closed without cleanup), spawning a new crew with the same name hard-failed on the
+  branch-already-exists collision. Stale crew branches are now reused or uniquified on spawn instead
+  of erroring. ([#460](https://github.com/tu11aa/squadrant/issues/460))
+
 ## [0.13.0] - 2026-06-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "squadrant",
   "packageManager": "pnpm@10.30.3",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Multi-project orchestration for your coding agents (Claude, Codex, opencode, Gemini)",
   "type": "module",
   "bin": {

--- a/packages/agents/src/__tests__/pane-classifier.test.ts
+++ b/packages/agents/src/__tests__/pane-classifier.test.ts
@@ -177,4 +177,41 @@ describe("classifyPaneTail", () => {
     ].join("\n");
     expect(classifyPaneTail(numberedList)).toBeNull();
   });
+
+  // ── #459: active-retry banner must NOT be classified as fatal error ──────
+
+  it("returns null for an in-flight API retry banner (recoverable, not error)", () => {
+    const tail = [
+      "● Working on the implementation...",
+      "✻ API error · Retrying in 0s · attempt 1/10",
+      "╭────────────────────────────╮",
+      "│ >                          │",
+      "╰────────────────────────────╯",
+    ].join("\n");
+    expect(classifyPaneTail(tail)).toBeNull();
+  });
+
+  it("still classifies a bare API error with no retry indicator as fatal error", () => {
+    const tail = [
+      "● Calling the API...",
+      "API Error: 529 Overloaded",
+      "╭────────────────────────────╮",
+      "│ >                          │",
+      "╰────────────────────────────╯",
+    ].join("\n");
+    const r = classifyPaneTail(tail);
+    expect(r?.kind).toBe("error");
+  });
+
+  it("classifies exhausted retries as fatal error even when retry text is also present", () => {
+    const tail = [
+      "✻ API error · Retrying in 0s · attempt 10/10",
+      "retries exhausted — giving up",
+      "╭────────────────────────────╮",
+      "│ >                          │",
+      "╰────────────────────────────╯",
+    ].join("\n");
+    const r = classifyPaneTail(tail);
+    expect(r?.kind).toBe("error");
+  });
 });

--- a/packages/agents/src/interactive/pane-classifier.ts
+++ b/packages/agents/src/interactive/pane-classifier.ts
@@ -77,11 +77,19 @@ export function classifyPaneTail(
   // ── error: a fatal CLI error banner (#196), checked LAST so a recoverable
   // approval/question above always wins. Match the LAST banner line (the final
   // error after any retry chatter is the most informative).
+  // #459: suppress the error verdict when the tail shows an active retry in
+  // flight (e.g. "Retrying in 0s · attempt 1/10") but no exhaustion marker —
+  // Claude Code auto-retries up to 10× and the crew usually recovers.
   let errLine: string | null = null;
   for (const c of cleaned) {
     if (c != null && ERROR_BANNER_RE.some((re) => re.test(c))) errLine = c;
   }
-  if (errLine) return { kind: "error", text: errLine.slice(0, 200) };
+  if (errLine) {
+    const isRetrying = cleaned.some((c) => c != null && RETRYING_RE.test(c));
+    const isExhausted = cleaned.some((c) => c != null && EXHAUSTED_RE.test(c));
+    if (isRetrying && !isExhausted) return null;
+    return { kind: "error", text: errLine.slice(0, 200) };
+  }
 
   return null;
 }
@@ -98,6 +106,14 @@ const ERROR_BANNER_RE: RegExp[] = [
   /\bretr(?:y|ies)\s+(?:exhausted|limit\s+(?:reached|exceeded))\b/i,
   /\bmaximum\s+retries\b/i,
 ];
+
+// Active-retry indicator: the CLI is still retrying (not yet exhausted). Used
+// to suppress a false-fatal-error verdict for in-flight retries (#459).
+const RETRYING_RE = /\bRetrying\b|\battempt\s+\d+\s*\/\s*\d+/i;
+
+// Retry exhaustion: the final retry failed. When present alongside RETRYING_RE,
+// exhaustion wins and the error verdict is still emitted.
+const EXHAUSTED_RE = /\bretr(?:y|ies)\s+(?:exhausted|limit\s+(?:reached|exceeded))\b|\bmaximum\s+retries\b/i;
 
 // A numbered option line, after chrome stripping: an optional cursor marker
 // (❯ / > / ›), a number, a dot, then the label. e.g. "❯ 1. Yes".

--- a/packages/shared/src/lib/__tests__/git-worktree.test.ts
+++ b/packages/shared/src/lib/__tests__/git-worktree.test.ts
@@ -34,6 +34,10 @@ describe("addWorktree", () => {
   beforeEach(() => execFileSyncMock.mockReset());
 
   it("runs `git -C <repo> worktree add <path> -b crew/<name> <base>` and returns the path", () => {
+    // No existing branch: show-ref throws (not found), worktree add succeeds.
+    execFileSyncMock.mockImplementationOnce(() => { throw new Error("not found"); }); // show-ref
+    execFileSyncMock.mockReturnValue(Buffer.from("")); // worktree add
+
     const wt = addWorktree({
       repoRoot: "/tmp/brove",
       worktreeDir: ".worktrees",
@@ -47,6 +51,63 @@ describe("addWorktree", () => {
     expect(execFileSyncMock).toHaveBeenCalledWith(
       "git",
       ["-C", "/tmp/brove", "worktree", "add", expectedPath, "-b", "crew/crew-1", "develop"],
+      expect.objectContaining({ stdio: "pipe" }),
+    );
+  });
+
+  // ── #460: stale branch collision handling ──────────────────────────────────
+
+  it("deletes and recreates the branch when it exists but has no unique commits (merged)", () => {
+    // show-ref succeeds (branch exists), log returns empty (no unique commits),
+    // branch -D succeeds, worktree add succeeds.
+    execFileSyncMock.mockReturnValueOnce(Buffer.from(""));   // show-ref: branch exists
+    execFileSyncMock.mockReturnValueOnce(Buffer.from(""));   // log: no unique commits
+    execFileSyncMock.mockReturnValueOnce(Buffer.from(""));   // branch -D
+    execFileSyncMock.mockReturnValue(Buffer.from(""));       // worktree add
+
+    const spec = { repoRoot: "/tmp/brove", worktreeDir: ".worktrees", project: "brove", name: "fix-1", base: "develop" };
+    const wt = addWorktree(spec);
+
+    const expectedPath = path.resolve("/tmp/brove", ".worktrees", "brove-fix-1");
+    expect(wt).toBe(expectedPath);
+
+    // branch -D must have been called
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      "git",
+      ["-C", "/tmp/brove", "branch", "-D", "crew/fix-1"],
+      expect.objectContaining({ stdio: "pipe" }),
+    );
+    // worktree add must use the original branch name
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      "git",
+      ["-C", "/tmp/brove", "worktree", "add", expectedPath, "-b", "crew/fix-1", "develop"],
+      expect.objectContaining({ stdio: "pipe" }),
+    );
+  });
+
+  it("uniquifies the branch and path when the existing branch has unique commits (preserves history)", () => {
+    // show-ref for original branch: exists; log: has commits;
+    // show-ref for -2 branch: not found; worktree add with -2: succeeds.
+    execFileSyncMock.mockReturnValueOnce(Buffer.from(""));                            // show-ref crew/fix-1: exists
+    execFileSyncMock.mockReturnValueOnce(Buffer.from("abc123 some commit\n"));        // log: has commits
+    execFileSyncMock.mockImplementationOnce(() => { throw new Error("not found"); }); // show-ref crew/fix-1-2: not found
+    execFileSyncMock.mockReturnValue(Buffer.from(""));                                // worktree add
+
+    const spec = { repoRoot: "/tmp/brove", worktreeDir: ".worktrees", project: "brove", name: "fix-1", base: "develop" };
+    const wt = addWorktree(spec);
+
+    // Path and branch should be uniquified to -2
+    const expectedPath = path.resolve("/tmp/brove", ".worktrees", "brove-fix-1-2");
+    expect(wt).toBe(expectedPath);
+
+    // branch -D must NOT have been called (original branch with commits is untouched)
+    const deleteCalls = execFileSyncMock.mock.calls.filter((c) => Array.isArray(c[1]) && c[1].includes("-D"));
+    expect(deleteCalls).toHaveLength(0);
+
+    // worktree add uses the uniquified name
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      "git",
+      ["-C", "/tmp/brove", "worktree", "add", expectedPath, "-b", "crew/fix-1-2", "develop"],
       expect.objectContaining({ stdio: "pipe" }),
     );
   });

--- a/packages/shared/src/lib/git-worktree.ts
+++ b/packages/shared/src/lib/git-worktree.ts
@@ -54,16 +54,77 @@ export function resolveWorktreeBase(repoRoot: string, fallback = "develop"): str
 
 /**
  * Create the crew's worktree + branch and return its absolute path.
- * Fails loud (throws) if git refuses — e.g. the base branch is missing or the
- * branch/path already exists. The caller's name-uniqueness check already
- * prevents live duplicates; a re-spawned-after-close name can collide on the
- * existing branch (rare — pick a new --name).
+ * Handles a stale crew/<name> branch left by a previously-closed crew (#460):
+ * - No existing branch → unchanged behavior.
+ * - Existing branch with no unique commits (merged/empty) → delete and recreate fresh.
+ * - Existing branch with unique commits → uniquify to crew/<name>-2, -3, … so no
+ *   commits are lost and there is no collision. The returned path reflects the
+ *   uniquified name.
  */
 export function addWorktree(spec: WorktreeSpec): string {
-  const wt = worktreePath(spec.repoRoot, spec.worktreeDir, spec.project, spec.name);
+  const originalBranch = crewBranch(spec.name);
+
+  let targetName = spec.name;
+  let targetBranch = originalBranch;
+
+  // Check whether crew/<name> already exists from a prior closed crew.
+  let branchExists = false;
+  try {
+    execFileSync(
+      "git",
+      ["-C", spec.repoRoot, "show-ref", "--verify", "--quiet", `refs/heads/${originalBranch}`],
+      { stdio: "pipe" },
+    );
+    branchExists = true;
+  } catch {
+    // Branch does not exist — normal path, nothing to resolve.
+  }
+
+  if (branchExists) {
+    const log = execFileSync(
+      "git",
+      ["-C", spec.repoRoot, "log", "--oneline", `${spec.base}..${originalBranch}`],
+      { stdio: ["ignore", "pipe", "ignore"] },
+    ).toString().trim();
+
+    if (!log) {
+      // No unique commits: safe to delete and let the worktree add recreate it.
+      execFileSync(
+        "git",
+        ["-C", spec.repoRoot, "branch", "-D", originalBranch],
+        { stdio: "pipe" },
+      );
+    } else {
+      // Has unique commits: uniquify to crew/<name>-N so history is preserved.
+      let suffix = 2;
+      while (true) {
+        const candidate = `${spec.name}-${suffix}`;
+        const candidateBranch = crewBranch(candidate);
+        let candidateExists = false;
+        try {
+          execFileSync(
+            "git",
+            ["-C", spec.repoRoot, "show-ref", "--verify", "--quiet", `refs/heads/${candidateBranch}`],
+            { stdio: "pipe" },
+          );
+          candidateExists = true;
+        } catch {
+          // Candidate branch is free.
+        }
+        if (!candidateExists) {
+          targetName = candidate;
+          targetBranch = candidateBranch;
+          break;
+        }
+        suffix++;
+      }
+    }
+  }
+
+  const wt = worktreePath(spec.repoRoot, spec.worktreeDir, spec.project, targetName);
   execFileSync(
     "git",
-    ["-C", spec.repoRoot, "worktree", "add", wt, "-b", crewBranch(spec.name), spec.base],
+    ["-C", spec.repoRoot, "worktree", "add", wt, "-b", targetBranch, spec.base],
     { stdio: "pipe" },
   );
   return wt;

--- a/packages/workspaces/src/__tests__/crew-pane.test.ts
+++ b/packages/workspaces/src/__tests__/crew-pane.test.ts
@@ -264,15 +264,16 @@ describe("confirmedSendToPane — follow-up crew send (#448)", () => {
     expect(sendKeyToPane).toHaveBeenCalledWith(pane, "Enter");
   });
 
-  // Short sends must not block waiting for the settle window — the box goes
-  // empty immediately (no paste-mode coalescing) and we return on the first check.
+  // Short sends must not block waiting for the settle window. For short content CC
+  // renders the text directly in the box (no [Pasted text] placeholder), so settle
+  // sees actual content and sawDraft is set; empty box after Enter = submitted.
   it("submits a short message on the first confirmation check", async () => {
     let n = 0;
     readPaneScreen.mockImplementation(async () => {
       n++;
-      if (n === 1) return box("");           // preSendScreen
-      if (n === 2) return EMPTY_BOX;         // settle: no paste coalescing (empty = stable immediately)
-      return EMPTY_BOX;                       // post-Enter: submitted
+      if (n === 1) return box("");         // preSendScreen: idle box
+      if (n <= 3) return box("hi");        // settle: short text rendered immediately (no placeholder)
+      return EMPTY_BOX;                    // post-Enter: submitted
     });
 
     const promise = confirmedSendToPane(rt(), pane, "hi");
@@ -281,5 +282,151 @@ describe("confirmedSendToPane — follow-up crew send (#448)", () => {
 
     expect(pasteToPane).toHaveBeenCalledTimes(1);
     expect(sendKeyToPane).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── #455: large-paste race — empty box before paste renders ─────────────────
+
+describe("sendFirstTurnWhenReady — large paste race (#455)", () => {
+  let readPaneScreen: ReturnType<typeof vi.fn>;
+  let sendToPane: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
+  const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, sendToPane, pasteToPane, sendKeyToPane });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    readPaneScreen = vi.fn();
+    sendToPane = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // #455 core regression: for a large paste the [Pasted text] placeholder may not
+  // have rendered by the time settleInputBox first polls — the box appears stable-
+  // empty. The pre-fix code treats that as "submitted" and returns; the paste then
+  // lands in an unsubmitted state (strand). The fix: only accept empty-box-means-
+  // submitted after the draft was observed non-empty at least once.
+  it("does not declare submitted on leading empties before paste renders (#455 race)", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n <= 3) return EMPTY_BOX;  // stability polls + preSend snapshot
+      if (n <= 5) return EMPTY_BOX;  // settle: paste NOT rendered yet (stable-empty bug)
+      if (n === 6) return EMPTY_BOX; // post-Enter#1: still empty (paste in flight)
+      if (n <= 9) return DRAFT_BOX;  // paste finally renders during retry settle
+      return EMPTY_BOX;              // post-Enter#2: box empty → actually submitted
+    });
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "very large task", "$ launch");
+    await vi.advanceTimersByTimeAsync(8000);
+    await promise;
+
+    // Must NOT have returned on the leading empty reads before paste rendered.
+    // Paste issued exactly once; Enter issued at least twice (initial no-op + retry).
+    expect(pasteToPane).toHaveBeenCalledTimes(1);
+    expect(sendKeyToPane.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(sendToPane).not.toHaveBeenCalled();
+  });
+
+  // When the paste NEVER renders (e.g. paste-buffer loss), the function must re-paste
+  // once rather than silently declaring success on a never-populated box.
+  it("re-pastes once when paste never renders (never-populated box)", async () => {
+    readPaneScreen.mockResolvedValue(EMPTY_BOX);
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "very large task", "$ launch");
+    await vi.advanceTimersByTimeAsync(10000);
+    await promise;
+
+    // Re-pasted exactly once after the initial paste failed to render.
+    expect(pasteToPane).toHaveBeenCalledTimes(2);
+    expect(pasteToPane).toHaveBeenCalledWith(pane, "very large task");
+    expect(sendToPane).not.toHaveBeenCalled();
+  });
+});
+
+describe("confirmedSendToPane — large paste race (#455)", () => {
+  let readPaneScreen: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
+  const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, pasteToPane, sendKeyToPane });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    readPaneScreen = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Same race as sendFirstTurnWhenReady: settle sees stable-empty, Enter fires into
+  // empty box (no-op), retry-check sees empty → pre-fix BUG declares submitted.
+  it("does not declare submitted on leading empties before paste renders (#455 race)", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n === 1) return box("");   // preSendScreen
+      if (n <= 3) return EMPTY_BOX;  // settle: paste not rendered yet
+      if (n === 4) return EMPTY_BOX; // post-Enter#1: still empty
+      if (n <= 7) return DRAFT_BOX;  // paste renders during retry settle
+      return EMPTY_BOX;              // post-Enter#2: submitted
+    });
+
+    const promise = confirmedSendToPane(rt(), pane, "big follow-up");
+    await vi.advanceTimersByTimeAsync(6000);
+    await promise;
+
+    expect(pasteToPane).toHaveBeenCalledTimes(1);
+    expect(sendKeyToPane.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // Exactly ONE submit detected: the moment the box empties AFTER the draft was seen.
+  it("submits exactly once — no double-submit after seeing non-empty then empty", async () => {
+    let returned = false;
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n === 1) return box("");   // preSendScreen
+      if (n <= 3) return EMPTY_BOX;  // settle: paste not rendered
+      if (n === 4) return EMPTY_BOX; // post-Enter#1: empty (no-op)
+      if (n <= 7) return DRAFT_BOX;  // paste renders during retry settle
+      return EMPTY_BOX;              // post-Enter#2: submitted
+    });
+
+    const promise = confirmedSendToPane(rt(), pane, "big follow-up");
+    promise.then(() => { returned = true; });
+    await vi.advanceTimersByTimeAsync(6000);
+    await promise;
+
+    // Function returned exactly once (no double-submit loop).
+    expect(returned).toBe(true);
+    expect(pasteToPane).toHaveBeenCalledTimes(1);
+  });
+
+  // When paste never renders: re-paste once rather than silently returning on an
+  // empty box that was never populated.
+  it("re-pastes once when paste never renders (never-populated box)", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n === 1) return box("");  // preSendScreen
+      return EMPTY_BOX;             // everything else: paste never appears
+    });
+
+    const promise = confirmedSendToPane(rt(), pane, "big follow-up");
+    await vi.advanceTimersByTimeAsync(6000);
+    await promise;
+
+    expect(pasteToPane).toHaveBeenCalledTimes(2);
+    expect(pasteToPane).toHaveBeenCalledWith(pane, "big follow-up");
   });
 });

--- a/packages/workspaces/src/crew-pane.ts
+++ b/packages/workspaces/src/crew-pane.ts
@@ -33,18 +33,25 @@ const SETTLE_MAX_POLLS = 8;        // up to 3.2s for a very large paste to rende
 const SUBMIT_RETRY_LIMIT = 4;      // Enter-only re-issues if the box stays stranded
 
 /** Poll the pane until its input box stops changing across two consecutive reads
- *  (paste fully rendered / accumulation window closed), or the cap is hit. */
+ *  (paste fully rendered / accumulation window closed), or the cap is hit.
+ *  Returns true if the box was observed with content at any point — the caller
+ *  uses this to distinguish "paste rendered then submitted" from "paste never
+ *  rendered, empty box is NOT a confirmation of submit" (#455). */
 async function settleInputBox(
   runtime: Pick<RuntimeDriver, "readPaneScreen">,
   pane: PaneRef,
-): Promise<void> {
+): Promise<boolean> {
   let prev = (await runtime.readPaneScreen(pane)) ?? "";
+  let sawContent = parseDraftFromScreen(prev) !== "" && parseDraftFromScreen(prev) !== null;
   for (let i = 0; i < SETTLE_MAX_POLLS; i++) {
     await new Promise((r) => setTimeout(r, SETTLE_POLL_MS));
     const cur = (await runtime.readPaneScreen(pane)) ?? "";
-    if (cur === prev) return;
+    const draft = parseDraftFromScreen(cur);
+    if (draft !== "" && draft !== null) sawContent = true;
+    if (cur === prev) return sawContent;
     prev = cur;
   }
+  return sawContent;
 }
 
 /** Reserve an ephemeral TCP port for a crew's embedded HTTP server. Binds :0,
@@ -118,16 +125,28 @@ export async function confirmedSendToPane(
 ): Promise<void> {
   const preSendScreen = (await runtime.readPaneScreen(pane)) ?? "";
   await runtime.pasteToPane(pane, message);
-  await settleInputBox(runtime, pane);
+  // #455: track whether the paste ever rendered so we don't treat an empty box
+  // that was NEVER populated as a successful submit (race: paste still in flight
+  // when settle fires, stable-empty → Enter into nothing → false "submitted").
+  let sawDraft = await settleInputBox(runtime, pane);
   await runtime.sendKeyToPane(pane, "Enter");
 
+  let repasted = false;
   for (let attempt = 0; attempt < SUBMIT_RETRY_LIMIT; attempt++) {
     await new Promise((r) => setTimeout(r, POST_SEND_CHECK_MS));
     const afterScreen = (await runtime.readPaneScreen(pane)) ?? "";
     const draft = parseDraftFromScreen(afterScreen);
-    if (draft === "") return;
+    if (draft !== "" && draft !== null) sawDraft = true;
+    // Box confirmed empty AND we observed the paste rendered first → submitted.
+    if (draft === "" && sawDraft) return;
     if (draft === null && afterScreen !== preSendScreen) return;
-    await settleInputBox(runtime, pane);
+    const settled = await settleInputBox(runtime, pane);
+    if (settled) sawDraft = true;
+    // #455: paste never rendered — re-paste once rather than issuing Enter into emptiness.
+    if (!sawDraft && !repasted) {
+      repasted = true;
+      await runtime.pasteToPane(pane, message);
+    }
     await runtime.sendKeyToPane(pane, "Enter");
   }
 }
@@ -202,22 +221,33 @@ export async function sendFirstTurnWhenReady(
   // re-issue ONLY the Enter (after re-settling) and NEVER re-paste — re-pasting is
   // exactly what stacks [Pasted text #1][#2][#3] and never submits.
   await runtime.pasteToPane(pane, task);
-  await settleInputBox(runtime, pane);
+  // #455: track whether the paste ever rendered so we don't treat an empty box
+  // that was NEVER populated as a successful submit (race: paste still in flight
+  // when settle fires, stable-empty → Enter into nothing → false "submitted").
+  let sawDraft = await settleInputBox(runtime, pane);
   await runtime.sendKeyToPane(pane, "Enter");
 
   const retryLimit = acceptanceConfig?.retryLimit ?? SUBMIT_RETRY_LIMIT;
+  let repasted = false;
   for (let attempt = 0; attempt < retryLimit; attempt++) {
     await new Promise((r) => setTimeout(r, POST_SEND_CHECK_MS));
     const afterScreen = (await runtime.readPaneScreen(pane)) ?? "";
     const draft = parseDraftFromScreen(afterScreen);
-    // Box confirmed empty → the draft left the input box → submitted.
-    if (draft === "") return;
+    if (draft !== "" && draft !== null) sawDraft = true;
+    // Box confirmed empty AND we observed the paste rendered first → submitted.
+    if (draft === "" && sawDraft) return;
     // Box not parseable (e.g. an agent TUI without the HR-bounded box, or a
     // transient overlay): fall back to the screen-changed signal so non-claude
     // TUIs aren't worse off than before.
     if (draft === null && afterScreen !== preSendScreen) return;
-    // Still stranded — re-settle and re-issue ONLY the Enter (never re-paste).
-    await settleInputBox(runtime, pane);
+    const settled = await settleInputBox(runtime, pane);
+    if (settled) sawDraft = true;
+    // #455: paste never rendered — re-paste once rather than issuing Enter into emptiness.
+    if (!sawDraft && !repasted) {
+      repasted = true;
+      await runtime.pasteToPane(pane, task);
+    }
+    // Still stranded — re-issue ONLY the Enter (re-paste only when never rendered).
     await runtime.sendKeyToPane(pane, "Enter");
   }
 }


### PR DESCRIPTION
## Release v0.13.1

Patch release with three crew-robustness bugfixes already merged to develop.

## Changes

- **#455** — Large first-turn paste-strand: a large task description could push Claude Code into bracketed-paste mode, swallowing the submit Enter so the crew's first turn never started. Delivery now settles the paste window before sending a confirmed Enter.
- **#459** — Transient API retry mis-classified as CREW FAILED: in-flight CLI retry loops were read by the pane classifier as fatal failures, firing bogus CREW FAILED signals even when the crew recovered. In-flight retries are no longer classified as terminal failure.
- **#460** — Crew spawn collision on stale branch: spawning a new crew whose `crew/<name>` branch already existed (left by a previously closed crew) hard-failed. Stale crew branches are now reused or uniquified on spawn instead of erroring.

## Diff

Only `CHANGELOG.md` and root `package.json` (version bump `0.13.0` → `0.13.1`) changed.

## Merging

Merging this PR into `main` triggers `release.yml` (tag + GitHub release + npm publish). Do NOT merge until captain/user approves.