### PR TITLE
ci: fail release when npm publish fails (+ verify step)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,22 @@ jobs:
 
       - name: Publish to npm
         if: steps.check.outputs.should_release == 'true' && steps.npmtok.outputs.has_token == 'true'
-        continue-on-error: true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public
+
+      - name: Verify npm publish
+        if: steps.check.outputs.should_release == 'true' && steps.npmtok.outputs.has_token == 'true'
+        run: |
+          VERSION="${{ steps.ver.outputs.version }}"
+          for i in 1 2 3 4 5; do
+            PUBLISHED=$(curl -fsSL "https://registry.npmjs.org/squadrant/$VERSION" | node -p "JSON.parse(require('fs').readFileSync(0)).version" 2>/dev/null || true)
+            if [ "$PUBLISHED" = "$VERSION" ]; then
+              echo "✓ squadrant@$VERSION confirmed live on npm"
+              exit 0
+            fi
+            echo "registry not yet showing $VERSION (attempt $i/5), retrying…"
+            sleep 10
+          done
+          echo "::error::squadrant@$VERSION did NOT appear on the npm registry after publish"
+          exit 1


### PR DESCRIPTION
## Summary

- Removes `continue-on-error: true` from the "Publish to npm" step so a failed `npm publish` (e.g. expired `NPM_TOKEN` → E404) now fails the release job instead of silently reporting success.
- Adds a "Verify npm publish" step that polls `registry.npmjs.org` directly (not `npm view`, which CDN-caches) up to 5×10s and fails the job if the version isn't confirmed live.

## Context

This silent-failure pattern bit us on v0.13.1 (2026-06-29) — the job showed green while npm was still at the previous version. Caught only by a manual `curl registry.npmjs.org/squadrant` check.

## Test plan

- [ ] Verify `git diff` shows only the removed `continue-on-error` line and the new verify step
- [ ] Confirm YAML is valid (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`)
- [ ] On next real release, confirm the job fails loudly if publish fails