### PR TITLE
fix: daemon task-ledger cruft + ghost lifecycle notifications (#457)

### DIFF
--- a/packages/cli/src/commands/crew-control.ts
+++ b/packages/cli/src/commands/crew-control.ts
@@ -8,6 +8,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { sendRequest } from "@squadrant/core";
 import { ensureDaemon } from "@squadrant/core";
 import type { ControlEvent, Mode, Provider, TaskRecord } from "@squadrant/shared";
+import { TERMINAL_STATES } from "@squadrant/shared";
 import { mapClaudeHookToEvent } from "@squadrant/agents";
 import { filterTasks, formatCompactTasks } from "./crew-output.js";
 import { crewAttachCommand } from "./crew-attach.js";
@@ -210,7 +211,17 @@ export function addControlPlaneCrewCommands(crew: Command): void {
     .option("--state-only <taskId>", "Print just the state string for a single task")
     .option("--purge <taskId>", "Purge a task record from the store (default: only terminal records)")
     .option("--force", "Force-purge a non-terminal record (use with --purge)")
-    .action(async (project: string, opts: { json?: boolean; id?: string; state?: string; stateOnly?: string; purge?: string; force?: boolean }) => {
+    .option("--all-terminal", "Purge all terminal (done/cancelled/failed) records for the project")
+    .action(async (project: string, opts: { json?: boolean; id?: string; state?: string; stateOnly?: string; purge?: string; force?: boolean; allTerminal?: boolean }) => {
+      if (opts.allTerminal) {
+        const tasks = (await squadrantdCall({ kind: "list", project })) as TaskRecord[];
+        const terminal = tasks.filter((t) => TERMINAL_STATES.has(t.state as any));
+        for (const t of terminal) {
+          await squadrantdCall({ kind: "purge", project, id: t.id, force: false });
+        }
+        console.log(`purged ${terminal.length} terminal record(s)`);
+        return;
+      }
       if (opts.purge) {
         const r = await squadrantdCall({ kind: "purge", project, id: opts.purge, force: opts.force ?? false }) as TaskRecord;
         console.log(`purged ${r.provider}/${r.id} (was ${r.state})`);

--- a/packages/core/src/__tests__/daemon.test.ts
+++ b/packages/core/src/__tests__/daemon.test.ts
@@ -985,7 +985,170 @@ describe("crewTag (#378)", () => {
   });
 });
 
-// ── Issue #378: purge request kind ──────────────────────────────────────────
+// ── Issue #457: auto-prune terminal records (keep last K per project) ─────────
+
+describe("sweep: terminal record overflow prune (#457)", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "cp-prune-")); });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("keeps the most-recent K terminal records when count exceeds the limit", async () => {
+    const store = createStore(dir);
+    const NOW = 1_000_000_000;
+    // Create 22 terminal records with staggered lastHeartbeat values — all recent
+    // (within minutes of NOW) so the 7-day TTL does NOT eat them; only the
+    // overflow prune should act.
+    for (let i = 0; i < 22; i++) {
+      store.put(rec(`term-${String(i).padStart(2, "0")}`, {
+        state: "done", resultRef: "/r",
+        lastHeartbeat: NOW - 600_000 + i * 1000, // oldest: -600s, newest: -578s
+        heartbeatBudgetMs: 86_400_000,
+        createdAt: NOW - 600_000, // 10 min ago, well within any TTL
+      }));
+    }
+    const d = createDaemon({ store, now: () => NOW, taskTimeoutMs: 999_999_999 });
+    await d.sweep();
+    const remaining = store.list("p").filter((r) => r.state === "done");
+    // Should keep exactly 20 (the default TERMINAL_RECORD_KEEP_PER_PROJECT)
+    expect(remaining.length).toBe(20);
+    // The 2 oldest (term-00 and term-01) should be gone
+    expect(store.get("p", "term-00")).toBeUndefined();
+    expect(store.get("p", "term-01")).toBeUndefined();
+    // The most recent (term-21) should remain
+    expect(store.get("p", "term-21")).toBeDefined();
+  });
+
+  it("does NOT prune when terminal count is at or below the limit", async () => {
+    const store = createStore(dir);
+    const NOW = 1_000_000_000;
+    for (let i = 0; i < 20; i++) {
+      store.put(rec(`term-${i}`, {
+        state: "cancelled", lastHeartbeat: NOW - 600_000 + i * 1000,
+        heartbeatBudgetMs: 86_400_000, createdAt: NOW - 600_000,
+      }));
+    }
+    const d = createDaemon({ store, now: () => NOW, taskTimeoutMs: 999_999_999 });
+    await d.sweep();
+    expect(store.list("p").length).toBe(20);
+  });
+
+  it("never prunes non-terminal records regardless of count", async () => {
+    const store = createStore(dir);
+    const NOW = 1_000_000_000;
+    for (let i = 0; i < 25; i++) {
+      store.put(rec(`live-${i}`, {
+        state: "working", lastHeartbeat: NOW - 600_000 + i * 1000,
+        heartbeatBudgetMs: 86_400_000, createdAt: NOW - 600_000,
+        mode: "headless",
+      }));
+    }
+    const d = createDaemon({ store, now: () => NOW, taskTimeoutMs: 999_999_999 });
+    await d.sweep();
+    expect(store.list("p").length).toBe(25);
+  });
+
+  it("prunes per-project independently — overflow in one project does not affect another", async () => {
+    const store = createStore(dir);
+    const NOW = 1_000_000_000;
+    // proj A: 22 terminal records (2 should be pruned)
+    for (let i = 0; i < 22; i++) {
+      store.put(rec(`a-${i}`, {
+        project: "projA", state: "done", resultRef: "/r",
+        lastHeartbeat: NOW - 600_000 + i * 1000, heartbeatBudgetMs: 86_400_000, createdAt: NOW - 600_000,
+      }));
+    }
+    // proj B: 5 terminal records (none should be pruned)
+    for (let i = 0; i < 5; i++) {
+      store.put(rec(`b-${i}`, {
+        project: "projB", state: "done", resultRef: "/r",
+        lastHeartbeat: NOW - 600_000 + i * 1000, heartbeatBudgetMs: 86_400_000, createdAt: NOW - 600_000,
+      }));
+    }
+    const d = createDaemon({ store, now: () => NOW, taskTimeoutMs: 999_999_999 });
+    await d.sweep();
+    expect(store.list("projA").filter((r) => r.state === "done").length).toBe(20);
+    expect(store.list("projB").filter((r) => r.state === "done").length).toBe(5);
+  });
+});
+
+// ── Issue #457: suppress ghost CREW TIMEOUT when surface is gone ────────────
+
+describe("sweep: ghost CREW TIMEOUT suppression (#457)", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "cp-ghost-")); });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("interactive task with GONE surface: task is cancelled but notify is NOT called (silent)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    store.put(rec("ghost-gone", {
+      mode: "interactive", state: "awaiting-input",
+      createdAt: 0, lastHeartbeat: 1000, heartbeatBudgetMs: 86_400_000,
+    }));
+    const d = createDaemon({
+      store, now: () => 2000, taskTimeoutMs: 1_000,
+      isSurfaceAlive: async () => "gone",
+      notify: async (a) => { calls.push(a); },
+    });
+    await d.sweep();
+    expect(store.get("p", "ghost-gone")?.state).toBe("cancelled");
+    expect(calls.filter((c) => c.message.includes("CREW TIMEOUT"))).toHaveLength(0);
+  });
+
+  it("interactive task with ALIVE surface: task is cancelled AND notify IS called", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    store.put(rec("ghost-alive", {
+      mode: "interactive", state: "working",
+      createdAt: 0, lastHeartbeat: 1000, heartbeatBudgetMs: 86_400_000,
+    }));
+    const d = createDaemon({
+      store, now: () => 2000, taskTimeoutMs: 1_000,
+      isSurfaceAlive: async () => "alive",
+      notify: async (a) => { calls.push(a); },
+    });
+    await d.sweep();
+    expect(store.get("p", "ghost-alive")?.state).toBe("cancelled");
+    expect(calls.filter((c) => c.message.includes("CREW TIMEOUT"))).toHaveLength(1);
+  });
+
+  it("interactive task with UNKNOWN surface liveness: task is cancelled AND notify IS called (conservative)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    store.put(rec("ghost-unknown", {
+      mode: "interactive", state: "working",
+      createdAt: 0, lastHeartbeat: 1000, heartbeatBudgetMs: 86_400_000,
+    }));
+    const d = createDaemon({
+      store, now: () => 2000, taskTimeoutMs: 1_000,
+      isSurfaceAlive: async () => "unknown",
+      notify: async (a) => { calls.push(a); },
+    });
+    await d.sweep();
+    expect(store.get("p", "ghost-unknown")?.state).toBe("cancelled");
+    expect(calls.filter((c) => c.message.includes("CREW TIMEOUT"))).toHaveLength(1);
+  });
+
+  it("HEADLESS task: notify IS called regardless of isSurfaceAlive (headless has no cmux surface)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    store.put(rec("ghost-headless", {
+      mode: "headless", state: "working",
+      createdAt: 0, lastHeartbeat: 1000, heartbeatBudgetMs: 86_400_000,
+    }));
+    // isSurfaceAlive returns "gone" — should be ignored for headless
+    const d = createDaemon({
+      store, now: () => 2000, taskTimeoutMs: 1_000,
+      isSurfaceAlive: async () => "gone",
+      notify: async (a) => { calls.push(a); },
+    });
+    await d.sweep();
+    expect(store.get("p", "ghost-headless")?.state).toBe("cancelled");
+    expect(calls.filter((c) => c.message.includes("CREW TIMEOUT"))).toHaveLength(1);
+  });
+});
+
+// ── Issue #457: purge request kind ──────────────────────────────────────────
 describe("purge (#378)", () => {
   let dir: string;
   beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "cp-purge-")); });

--- a/packages/core/src/daemon/reduce.ts
+++ b/packages/core/src/daemon/reduce.ts
@@ -73,6 +73,10 @@ export const DEFAULT_TASK_TIMEOUT_MS = 8 * 60 * 60 * 1000;
 // than this are pruned from the store during sweep().
 export const TERMINAL_RECORD_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
+// #457: Max terminal records to keep per project. Bounds accumulation for
+// short-lived test sessions where many tasks finish before the 7-day TTL.
+export const TERMINAL_RECORD_KEEP_PER_PROJECT = 20;
+
 // 'awaiting-input' is an attention state: entering it (idle watchdog OR a
 // Stop-hook turn boundary) fires exactly one accurate CREW IDLE push. The
 // firePush prev===next guard keeps it from re-firing while the task sits idle.
@@ -370,6 +374,20 @@ export function createDaemon(deps: DaemonDeps) {
     async sweep(): Promise<void> {
       const t = now();
       const surfaceAlive = deps.isSurfaceAlive ?? (async () => "unknown" as const);
+
+      // #457: Per-project overflow prune — keep only the most-recent K terminal
+      // records. Bounds accumulation for short-lived sessions where many tasks
+      // finish before the 7-day TTL expires.
+      const projects = new Set(store.listAll().map((r) => r.project));
+      for (const project of projects) {
+        const terminal = store.list(project)
+          .filter((r) => TERMINAL_STATES.has(r.state))
+          .sort((a, b) => b.lastHeartbeat - a.lastHeartbeat);
+        for (const r of terminal.slice(TERMINAL_RECORD_KEEP_PER_PROJECT)) {
+          store.delete(r.project, r.id);
+        }
+      }
+
       for (const r of store.listAll()) {
         // #378: GC terminal records whose last heartbeat is older than the TTL.
         if (TERMINAL_STATES.has(r.state) && t - r.lastHeartbeat > TERMINAL_RECORD_TTL_MS) {
@@ -391,7 +409,16 @@ export function createDaemon(deps: DaemonDeps) {
             // Terminalize first — persisted to store so any future daemon instance
             // sees a terminal record and skips it (flood-proof across restarts).
             store.put({ ...r, state: "cancelled", lastEvent: "sweep.task-timeout" });
-            if (deps.notify) {
+            // #457: suppress ghost CREW TIMEOUT for interactive tasks whose surface
+            // is provably gone — they were already abandoned; terminalize silently.
+            // Headless tasks have no cmux surface so always notify.
+            // "unknown" (cmux down / transient) → notify conservatively.
+            let shouldNotify = true;
+            if (r.mode === "interactive") {
+              const liveness = await surfaceAlive(r);
+              if (liveness === "gone") shouldNotify = false;
+            }
+            if (deps.notify && shouldNotify) {
               try {
                 const p = deps.notify({ project: r.project, message: msg, record: r, event: synthEvent });
                 if (p && typeof (p as Promise<void>).catch === "function") {


### PR DESCRIPTION
## Summary

Fixes issue #457 — three coordinated changes to clean up the daemon task ledger and stop ghost lifecycle notifications.

- **Auto-prune terminal records** (`TERMINAL_RECORD_KEEP_PER_PROJECT = 20`): `sweep()` now prunes the oldest terminal records beyond the per-project cap before its per-record loop. This bounds accumulation for short-lived test sessions where many tasks finish before the existing 7-day TTL.

- **Suppress ghost CREW TIMEOUT notifications**: Before firing a CREW TIMEOUT notification for an interactive task, `sweep()` now checks `isSurfaceAlive`. If the surface is provably gone, the task is terminalized silently — no alarming push to the captain. Headless tasks and `unknown` liveness still notify (conservative). Fixes the 8h-old abandoned probe that fired a confusing CREW TIMEOUT in an unrelated live test session.

- **`crew tasks --all-terminal` bulk purge**: Extends the `squadrant crew tasks <project>` command with `--all-terminal` to clear every terminal record in one call. The existing `--purge <taskId>` single-id behavior is unchanged.

## Test plan

- [ ] All 376 core package tests pass (`vitest run packages/core/src/__tests__/`)
- [ ] Build is green (`pnpm build`)
- [ ] New tests cover:
  - Overflow prune: keeps 20 most-recent terminal records, drops oldest beyond cap, per-project independently, non-terminal records never pruned
  - Ghost suppression: CREW TIMEOUT for interactive/gone surface → silent (no notify); alive/unknown surface → notify; headless always notifies
  - CLI `--all-terminal` wired through existing `purge` handler (logic is trivially correct, covered by existing purge tests)