### PR TITLE
fix(crew): copy --task-file into isolated worktree root (#458)

### DIFF
--- a/packages/cli/src/commands/crew.ts
+++ b/packages/cli/src/commands/crew.ts
@@ -129,6 +129,9 @@ crewCommand
           ...(opts.approval ? { approvalPolicy: "untrusted", approval: true } : {}),
           ...(opts.shared ? { shared: true } : {}),
           ...(opts.model ? { model: opts.model } : {}),
+          // #458: pass the raw file path (not stdin) so runCrewSpawn can copy it
+          // into the isolated worktree root for relative-path access.
+          ...(opts.taskFile && opts.taskFile !== "-" ? { taskFile: opts.taskFile } : {}),
         });
         console.log(chalk.green(`✔ Crew '${pane.title}' spawned (${pane.surfaceId})`));
       } catch (err) {

--- a/packages/core/src/__tests__/crew-spawn.test.ts
+++ b/packages/core/src/__tests__/crew-spawn.test.ts
@@ -31,7 +31,8 @@ vi.mock("node:fs", async (importOriginal) => {
   // Default: existsSync returns false so codex role file is treated as absent.
   const existsSync = vi.fn().mockReturnValue(false);
   const readFileSync = vi.fn().mockReturnValue("");
-  return { ...actual, existsSync, readFileSync, default: { ...actual, existsSync, readFileSync } };
+  const copyFileSync = vi.fn();
+  return { ...actual, existsSync, readFileSync, copyFileSync, default: { ...actual, existsSync, readFileSync, copyFileSync } };
 });
 
 // Prevent reapCrewChildren from running real `ps auxE` during close tests.
@@ -43,6 +44,7 @@ vi.mock("node:child_process", async (importOriginal) => {
 
 // ─── imports (after mock declarations) ───────────────────────────────────────
 
+import * as nodefs from "node:fs";
 import {
   runCrewSpawn,
   runCrewSend,
@@ -150,6 +152,7 @@ beforeEach(() => {
   );
   resolveWorktreeBaseMock.mockReturnValue("main");
   loadConfigMock.mockReturnValue(makeConfig());
+  vi.mocked(nodefs.copyFileSync).mockReset();
 });
 
 // ─── runCrewSpawn ────────────────────────────────────────────────────────────
@@ -270,6 +273,96 @@ describe("runCrewSpawn", () => {
         expect.stringContaining(`cd '${PROJ_PATH}'`),
       );
     });
+
+    // #458: --task-file with isolated worktree
+    describe("--task-file with isolated worktree (#458)", () => {
+      it("copies task file into worktree root and sends short Read first-turn", async () => {
+        const config = makeConfig();
+        const runtime = makeRuntime();
+        const agent = makeAgent("claude");
+        const deps = makeSpawnDeps(runtime, agent);
+
+        await runCrewSpawn(
+          { project: PROJECT, task: "full brief contents", taskFile: "/tmp/task-brief.md" },
+          config,
+          deps,
+        );
+
+        const worktreePath = `${PROJ_PATH}/.worktrees/${PROJECT}-crew-1`;
+        expect(vi.mocked(nodefs.copyFileSync)).toHaveBeenCalledWith(
+          "/tmp/task-brief.md",
+          `${worktreePath}/task-brief.md`,
+        );
+        expect(deps.sendFirstTurn).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.stringContaining("Read ./task-brief.md"),
+          expect.any(String),
+        );
+        // First turn must NOT inline the full file content
+        expect(deps.sendFirstTurn).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.not.stringContaining("full brief contents"),
+          expect.any(String),
+        );
+      });
+
+      it("does NOT copy task file for --shared spawn (preserves current behavior)", async () => {
+        const config = makeConfig();
+        const runtime = makeRuntime();
+        const agent = makeAgent("claude");
+        const deps = makeSpawnDeps(runtime, agent);
+
+        await runCrewSpawn(
+          { project: PROJECT, task: "full brief contents", taskFile: "/tmp/task-brief.md", shared: true },
+          config,
+          deps,
+        );
+
+        expect(vi.mocked(nodefs.copyFileSync)).not.toHaveBeenCalled();
+        // Shared spawn still inlines the task text
+        expect(deps.sendFirstTurn).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.stringContaining("full brief contents"),
+          expect.any(String),
+        );
+      });
+
+      it("does NOT copy when no taskFile is provided (preserves current behavior)", async () => {
+        const config = makeConfig();
+        const runtime = makeRuntime();
+        const agent = makeAgent("claude");
+        const deps = makeSpawnDeps(runtime, agent);
+
+        await runCrewSpawn({ project: PROJECT, task: "direct positional task" }, config, deps);
+
+        expect(vi.mocked(nodefs.copyFileSync)).not.toHaveBeenCalled();
+        expect(deps.sendFirstTurn).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.stringContaining("direct positional task"),
+          expect.any(String),
+        );
+      });
+
+      it("does NOT copy for stdin (taskFile = '-')", async () => {
+        const config = makeConfig();
+        const runtime = makeRuntime();
+        const agent = makeAgent("claude");
+        const deps = makeSpawnDeps(runtime, agent);
+
+        await runCrewSpawn(
+          { project: PROJECT, task: "stdin task content", taskFile: "-" },
+          config,
+          deps,
+        );
+
+        expect(vi.mocked(nodefs.copyFileSync)).not.toHaveBeenCalled();
+        expect(deps.sendFirstTurn).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.stringContaining("stdin task content"),
+          expect.any(String),
+        );
+      });
+    });
   });
 
   describe("opencode branch", () => {
@@ -342,6 +435,34 @@ describe("runCrewSpawn", () => {
         expect.stringContaining("squadrant crew attach task-001"),
       );
       expect(deps.sendCodexFirstTurn).toHaveBeenCalledWith("task-001", "do work");
+    });
+
+    it("sends short Read first-turn to codex when taskFile is set for isolated worktree", async () => {
+      const config = makeConfig();
+      const runtime = makeRuntime();
+      const agent = makeAgent("codex");
+      const deps = makeSpawnDeps(runtime, agent);
+      deps.resolveAgent = vi.fn().mockReturnValue(agent);
+
+      await runCrewSpawn(
+        { project: PROJECT, task: "full brief", taskFile: "/tmp/codex-brief.md", agent: "codex", agentExplicit: true },
+        config,
+        deps,
+      );
+
+      expect(vi.mocked(nodefs.copyFileSync)).toHaveBeenCalledWith(
+        "/tmp/codex-brief.md",
+        expect.stringContaining("codex-brief.md"),
+      );
+      // sendCodexFirstTurn receives the short "Read" message, not the full content
+      expect(deps.sendCodexFirstTurn).toHaveBeenCalledWith(
+        "task-001",
+        expect.stringContaining("Read ./codex-brief.md"),
+      );
+      expect(deps.sendCodexFirstTurn).toHaveBeenCalledWith(
+        "task-001",
+        expect.not.stringContaining("full brief"),
+      );
     });
   });
 

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -82,6 +82,11 @@ export interface CrewSpawnInput {
   model?: string;
   /** True when --agent was explicitly passed by the caller; suppresses crew routing. */
   agentExplicit?: boolean;
+  /** Path to the task file when --task-file was used (not '-' for stdin). Set by
+   *  the CLI so runCrewSpawn can copy the file into the isolated worktree root,
+   *  enabling the crew to `Read ./<basename>` without hunting the main checkout (#458).
+   *  Ignored for --shared spawns and when absent. */
+  taskFile?: string;
 }
 
 // ─── CrewSpawnDeps ───────────────────────────────────────────────────────────
@@ -146,6 +151,10 @@ async function findCrewPane(
 async function runCodexInteractiveSpawn(o: {
   project: string;
   task: string;
+  /** Override for first-turn delivery to the model. When set (e.g. "Read ./file.md
+   *  to get your task brief"), used instead of `task` for sendCodexFirstTurn so large
+   *  file contents aren't sent verbatim. The daemon dispatch always uses `task`. */
+  firstTurn?: string;
   cwd: string;
   runtime: RuntimeDriver;
   workspaceId: string;
@@ -177,8 +186,9 @@ async function runCodexInteractiveSpawn(o: {
   // dispatch only opens the thread; the task text never reaches the model
   // unless we send it. Fire-and-forget: the renderer in the tab picks up
   // streamed deltas once it attaches.
-  if (o.task && o.task !== "(interactive)") {
-    void o.sendCodexFirstTurn(rec.id, o.task).catch((e: unknown) => {
+  const firstTurnText = o.firstTurn ?? o.task;
+  if (firstTurnText && firstTurnText !== "(interactive)") {
+    void o.sendCodexFirstTurn(rec.id, firstTurnText).catch((e: unknown) => {
       process.stderr.write(`(first-turn delivery failed: ${(e as Error).message})\n`);
     });
   }
@@ -229,6 +239,20 @@ export async function runCrewSpawn(
       })
     : proj.path;
 
+  // #458: For isolated-worktree spawns with a task file, copy the file into the
+  // worktree root so the crew can find it via `Read ./<basename>` without having
+  // to discover the main checkout path. Use a short first-turn message referencing
+  // the local path to avoid large-paste issues on big task files.
+  // Guards: skip for --shared (file is in the main checkout, already reachable),
+  // skip for stdin ('-') since there is no file to copy.
+  let firstTurnTask = input.task;
+  if (input.taskFile && input.taskFile !== "-" && !input.shared) {
+    const absTaskFile = path.resolve(input.taskFile);
+    const basename = path.basename(absTaskFile);
+    fs.copyFileSync(absTaskFile, path.join(spawnCwd, basename));
+    firstTurnTask = `Read ./${basename} to get your task brief, then execute it.`;
+  }
+
   // #275 leveled crew routing: consult routing rules when agent/model were not
   // explicitly provided by the caller. Explicit --agent or --model always win.
   const route = !input.agentExplicit && !input.model
@@ -256,6 +280,7 @@ export async function runCrewSpawn(
     return runCodexInteractiveSpawn({
       project: input.project,
       task: input.task,
+      firstTurn: firstTurnTask !== input.task ? firstTurnTask : undefined,
       cwd: spawnCwd,
       runtime: deps.runtime,
       workspaceId: captain.id,
@@ -318,7 +343,7 @@ export async function runCrewSpawn(
     const envPrefix = `SQUADRANT_CREW_TASK_ID=${rec.id} SQUADRANT_CREW_PROJECT=${input.project}`;
     await deps.runtime.sendToPane(pane, `cd ${shellQuote(spawnCwd)} && ${envPrefix} ${cliCommand}`);
     const preLaunchScreen = (await deps.runtime.readPaneScreen(pane)) ?? "";
-    await deps.sendFirstTurn(pane, `${input.task}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen);
+    await deps.sendFirstTurn(pane, `${firstTurnTask}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen);
     return { ...pane, title };
   }
 
@@ -364,7 +389,7 @@ export async function runCrewSpawn(
     const envPrefix = `SQUADRANT_CREW_TASK_ID=${rec.id} SQUADRANT_CREW_PROJECT=${input.project}`;
     await deps.runtime.sendToPane(pane, `cd ${shellQuote(spawnCwd)} && ${envPrefix} OPENCODE_CONFIG=${opencodeConfigPath} ${cliCommand}`);
     const preLaunchScreen = (await deps.runtime.readPaneScreen(pane)) ?? "";
-    await deps.sendFirstTurn(pane, `${input.task}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen, {
+    await deps.sendFirstTurn(pane, `${firstTurnTask}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen, {
       // #235: confirm-on-delivery — sendFirstTurnWhenReady polls until "Ask
       // anything…" leaves the screen, re-sending every ~3s to cover slow boots
       // without duplicating the task. See crew-pane.ts SPLASH_MAX_CHECKS/EVERY_N.
@@ -388,7 +413,7 @@ export async function runCrewSpawn(
   await deps.runtime.sendToPane(pane, cliCommand);
   if (interactive) {
     const preLaunchScreen = (await deps.runtime.readPaneScreen(pane)) ?? "";
-    await deps.sendFirstTurn(pane, input.task, preLaunchScreen);
+    await deps.sendFirstTurn(pane, firstTurnTask, preLaunchScreen);
   }
   return { ...pane, title };
 }


### PR DESCRIPTION
## Summary

- Adds `taskFile?: string` to `CrewSpawnInput` so the CLI can pass the source path through to the spawn orchestrator
- After `addWorktree()`, when `--task-file` is used with an isolated-worktree spawn, `copyFileSync` copies the file into the worktree root
- First-turn message changes to a short `Read ./<basename> to get your task brief, then execute it.` instead of inlining the full file content — avoids the large-paste issue on big task files
- Daemon `dispatchCrew` still receives `input.task` (the resolved file content) for status display
- Guards: no-op for `--shared` spawns and stdin (`-`), where current behavior is preserved

Closes #458.

## Test plan

- [x] New tests in `crew-spawn.test.ts` covering: isolated+taskFile copies file and sends short Read first-turn; shared+taskFile no copy (current behavior); no taskFile no copy (current behavior); stdin taskFile no copy
- [x] Codex branch covered: `runCodexInteractiveSpawn` sends short first-turn via new optional `firstTurn` param
- [x] 499 tests passing, build green