### PR TITLE
fix: silent first-turn delivery drop under concurrent spawn load (#466)

### DIFF
--- a/packages/cli/src/__tests__/squadrantd-push.test.ts
+++ b/packages/cli/src/__tests__/squadrantd-push.test.ts
@@ -102,7 +102,8 @@ describe("squadrantd push notifications (#109)", () => {
   it("INTERACTIVE quiet (from sweep) triggers exactly one CREW QUIET notify, stays working (#354)", async () => {
     const store = createStore(dir);
     // rec() defaults to mode: "interactive"; no pendingTool → alive-thinking path.
-    store.put(rec("task-idle-1", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250 }));
+    // firstTurnConfirmedAt set: this crew received its task and is quietly thinking (#466).
+    store.put(rec("task-idle-1", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250, firstTurnConfirmedAt: 1 }));
     const n = fakeNotify();
     const d = createDaemon({ store, now: () => 5000, notify: n.notify });
     await d.sweep();
@@ -117,7 +118,7 @@ describe("squadrantd push notifications (#109)", () => {
 
   it("CREW QUIET fires once per quiet episode across repeated sweeps → no storm (#354)", async () => {
     const store = createStore(dir);
-    store.put(rec("task-idle-2", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250 }));
+    store.put(rec("task-idle-2", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250, firstTurnConfirmedAt: 1 }));
     const n = fakeNotify();
     const d = createDaemon({ store, now: () => 5000, notify: n.notify });
     await d.sweep(); // quiet → one CREW QUIET
@@ -129,7 +130,7 @@ describe("squadrantd push notifications (#109)", () => {
 
   it("awaiting-input + task.started (captain resumes) → working, no extra notify", async () => {
     const store = createStore(dir);
-    store.put(rec("task-idle-3", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250 }));
+    store.put(rec("task-idle-3", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250, firstTurnConfirmedAt: 1 }));
     const n = fakeNotify();
     const d = createDaemon({ store, now: () => 5000, notify: n.notify });
     await d.sweep(); // → awaiting-input, push #1 (CREW IDLE)

--- a/packages/cli/src/commands/__tests__/crew.test.ts
+++ b/packages/cli/src/commands/__tests__/crew.test.ts
@@ -9,6 +9,7 @@ const listSurfaces = vi.hoisted(() => vi.fn());
 const status = vi.hoisted(() => vi.fn());
 const buildCommand = vi.hoisted(() => vi.fn());
 const probe = vi.hoisted(() => vi.fn());
+const sendFirstTurnWhenReadyMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@squadrant/workspaces", () => ({
   createCmuxDriver: () => ({
@@ -53,11 +54,10 @@ vi.mock("@squadrant/workspaces", () => ({
     if (!ws) throw new Error(`Captain workspace '${proj.captainName}' is not running. Run 'squadrant launch ${project}' first.`);
     return { runtime: { newPane, closePane, sendToPane, readPaneScreen, listSurfaces, status }, workspaceId: ws.id };
   },
-  sendFirstTurnWhenReady: async (_runtime: unknown, pane: unknown, task: string) => {
-    await sendToPane(pane, task);
-  },
+  sendFirstTurnWhenReady: sendFirstTurnWhenReadyMock,
   confirmedSendToPane: async (_runtime: unknown, pane: unknown, msg: string) => {
     await sendToPane(pane, msg);
+    return { delivered: true };
   },
   getFreePort: vi.fn().mockResolvedValue(12345),
 }));
@@ -178,6 +178,11 @@ describe("squadrant crew spawn", () => {
     resolveCrewRoute.mockReset();
     // Default: no routing match (fall through to existing defaults).
     resolveCrewRoute.mockReturnValue(null);
+    sendFirstTurnWhenReadyMock.mockReset();
+    sendFirstTurnWhenReadyMock.mockImplementation(async (_: unknown, pane: unknown, task: string) => {
+      await sendToPane(pane, task);
+      return { delivered: true };
+    });
   });
 
   afterEach(() => {
@@ -205,7 +210,7 @@ describe("squadrant crew spawn", () => {
       cwd: "/tmp/brove/.worktrees/brove-crew-1",
       task: "do the thing",
     }));
-    expect(squadrantdCall).toHaveBeenCalledTimes(1);
+    expect(squadrantdCall).toHaveBeenCalledTimes(2); // dispatch + task.first-turn.confirmed
     // Squadrant hooks written to .claude/settings.local.json (auto-loaded source) inside the worktree.
     expect(writePerCrewSettingsLocal).toHaveBeenCalledWith(expect.objectContaining({
       projectCwd: "/tmp/brove/.worktrees/brove-crew-1",
@@ -411,7 +416,7 @@ describe("squadrant crew spawn", () => {
       task: "do the thing",
       budgetMs: 86400000,
     }));
-    expect(squadrantdCall).toHaveBeenCalledTimes(1);
+    expect(squadrantdCall).toHaveBeenCalledTimes(2); // dispatch + task.first-turn.confirmed
     // Per-crew opencode config uses the daemon-assigned taskId.
     expect(writePerCrewOpencodeConfig).toHaveBeenCalledWith(expect.objectContaining({
       project: "brove",
@@ -662,6 +667,53 @@ describe("squadrant crew spawn", () => {
     status.mockResolvedValue(null);
     await expect(runCrewSpawn({ project: "brove", task: "x" }))
       .rejects.toThrow(/captain workspace 'brove-captain' is not running/i);
+  });
+
+  it("delivered:false emits stderr warning and does NOT emit task.first-turn.confirmed (#466)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude ...");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-nd1" } }));
+    squadrantdCall.mockResolvedValue({ id: "task-nd1", project: "brove", provider: "claude", mode: "interactive" });
+    sendFirstTurnWhenReadyMock.mockResolvedValueOnce({ delivered: false });
+
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    const promise = runCrewSpawn({ project: "brove", task: "undelivered task" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("First turn not delivered"));
+    // emitEvent must NOT fire when delivery fails
+    const kinds = (squadrantdCall.mock.calls as Array<[{ kind: string; event?: { type: string } }]>)
+      .map(([r]) => r);
+    expect(kinds).not.toContainEqual(expect.objectContaining({ event: { type: "task.first-turn.confirmed", id: "task-nd1" } }));
+
+    stderrSpy.mockRestore();
+  });
+
+  it("delivered:true emits task.first-turn.confirmed event to daemon (#466)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude ...");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-dt1" } }));
+    squadrantdCall.mockResolvedValue({ id: "task-dt1", project: "brove", provider: "claude", mode: "interactive" });
+
+    const promise = runCrewSpawn({ project: "brove", task: "delivered task" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    // squadrantdCall fired twice: once for dispatch, once for task.first-turn.confirmed
+    expect(squadrantdCall).toHaveBeenCalledTimes(2);
+    expect(squadrantdCall).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      kind: "event",
+      project: "brove",
+      event: { type: "task.first-turn.confirmed", id: "task-dt1" },
+    }));
   });
 
   describe("leveled crew routing (#275)", () => {
@@ -1041,6 +1093,11 @@ describe("completion-protocol suffix in first turns (#278)", () => {
     existsSyncMock.mockReturnValue(false);
     resolveCrewRoute.mockReset();
     resolveCrewRoute.mockReturnValue(null);
+    sendFirstTurnWhenReadyMock.mockReset();
+    sendFirstTurnWhenReadyMock.mockImplementation(async (_: unknown, pane: unknown, task: string) => {
+      await sendToPane(pane, task);
+      return { delivered: true };
+    });
     let reads = 0;
     readPaneScreen.mockImplementation(async () => {
       reads++;

--- a/packages/cli/src/commands/__tests__/side.test.ts
+++ b/packages/cli/src/commands/__tests__/side.test.ts
@@ -57,6 +57,7 @@ vi.mock("@squadrant/workspaces", () => ({
   },
   sendFirstTurnWhenReady: async (_runtime: unknown, pane: unknown, task: string) => {
     await sendToPane(pane, task);
+    return { delivered: true };
   },
   getFreePort: async () => 12345,
 }));
@@ -560,7 +561,7 @@ describe("crew spawn regression — daemon path unchanged", () => {
     await vi.advanceTimersByTimeAsync(3000);
     await promise;
 
-    expect(squadrantdCall).toHaveBeenCalledTimes(1);
+    expect(squadrantdCall).toHaveBeenCalledTimes(2); // dispatch + task.first-turn.confirmed
     vi.useRealTimers();
   });
 });

--- a/packages/cli/src/commands/crew.ts
+++ b/packages/cli/src/commands/crew.ts
@@ -48,6 +48,8 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<{ title?: str
       sendFirstTurnWhenReady(runtime, pane, firstTurn, preLaunchScreen, opts),
     getFreePort,
     sendCodexFirstTurn,
+    // #466: wire delivery confirmation so the daemon stamps firstTurnConfirmedAt.
+    emitEvent: async (p, event) => { await squadrantdCall({ kind: "event", project: p, event }); },
     onRouted: (route) =>
       console.log(
         chalk.dim(

--- a/packages/core/src/__tests__/crew-spawn.test.ts
+++ b/packages/core/src/__tests__/crew-spawn.test.ts
@@ -644,7 +644,7 @@ describe("runCrewSend", () => {
   it("uses deps.sendToPane when provided, bypassing runtime.sendToPane", async () => {
     const existing = { ...makePaneRef("5"), title: "🔧 myproj:crew-1" };
     const runtime = makeRuntime("workspace:1", [existing]);
-    const injectedSend = vi.fn().mockResolvedValue(undefined);
+    const injectedSend = vi.fn().mockResolvedValue({ delivered: true });
     await runCrewSend(PROJECT, "crew-1", "big message", runtime, "workspace:1", {
       listTasks: vi.fn().mockResolvedValue([]),
       emitEvent: vi.fn(),

--- a/packages/core/src/__tests__/crew-spawn.test.ts
+++ b/packages/core/src/__tests__/crew-spawn.test.ts
@@ -136,7 +136,7 @@ function makeSpawnDeps(runtime: RuntimeDriver, agent: ResolvedAgent): CrewSpawnD
     dispatchCrew: vi.fn().mockResolvedValue(rec),
     writeSettingsLocal: vi.fn(),
     writeOpencodeConfig: vi.fn().mockReturnValue("/fake/opencode.json"),
-    sendFirstTurn: vi.fn().mockResolvedValue(undefined),
+    sendFirstTurn: vi.fn().mockResolvedValue({ delivered: true }),
     getFreePort: vi.fn().mockResolvedValue(9876),
     sendCodexFirstTurn: vi.fn().mockResolvedValue(undefined),
     onRouted: vi.fn(),
@@ -237,6 +237,61 @@ describe("runCrewSpawn", () => {
         expect.stringContaining("squadrant crew signal done"),
         expect.any(String),
       );
+    });
+
+    // #466: when sendFirstTurn resolves { delivered: false }, runCrewSpawn must NOT
+    // report clean success — the caller gets the pane ref (crew is usable via send)
+    // but the warning is surfaced via stderr so the captain knows to re-send.
+    it("writes stderr warning when sendFirstTurn returns { delivered: false } (#466)", async () => {
+      const config = makeConfig();
+      const runtime = makeRuntime();
+      const agent = makeAgent("claude");
+      const deps = makeSpawnDeps(runtime, agent);
+      deps.sendFirstTurn = vi.fn().mockResolvedValue({ delivered: false });
+
+      const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+      try {
+        await runCrewSpawn({ project: PROJECT, task: "fix the bug" }, config, deps);
+        const stderrOutput = stderrSpy.mock.calls.map((c) => c[0]).join("");
+        expect(stderrOutput).toMatch(/first turn.*not.*delivered|not.*delivered.*first turn/i);
+        expect(stderrOutput).toMatch(/crew send/i);
+      } finally {
+        stderrSpy.mockRestore();
+      }
+    });
+
+    // #466: when sendFirstTurn resolves { delivered: true }, emitEvent is called
+    // with task.first-turn.confirmed so the daemon can stamp firstTurnConfirmedAt.
+    it("emits task.first-turn.confirmed when sendFirstTurn returns { delivered: true } (#466)", async () => {
+      const config = makeConfig();
+      const runtime = makeRuntime();
+      const agent = makeAgent("claude");
+      const deps = makeSpawnDeps(runtime, agent);
+      deps.sendFirstTurn = vi.fn().mockResolvedValue({ delivered: true });
+      const emitEvent = vi.fn().mockResolvedValue(undefined);
+      deps.emitEvent = emitEvent;
+
+      await runCrewSpawn({ project: PROJECT, task: "fix the bug" }, config, deps);
+
+      expect(emitEvent).toHaveBeenCalledWith(
+        PROJECT,
+        expect.objectContaining({ type: "task.first-turn.confirmed", id: "task-001" }),
+      );
+    });
+
+    // #466: when emitEvent is absent (not wired), delivered=true is a no-op —
+    // the spawn still succeeds (backward-compat for callers without the dep).
+    it("succeeds without error when emitEvent is absent and delivered=true (#466)", async () => {
+      const config = makeConfig();
+      const runtime = makeRuntime();
+      const agent = makeAgent("claude");
+      const deps = makeSpawnDeps(runtime, agent);
+      deps.sendFirstTurn = vi.fn().mockResolvedValue({ delivered: true });
+      // emitEvent intentionally not set
+
+      await expect(
+        runCrewSpawn({ project: PROJECT, task: "fix the bug" }, config, deps),
+      ).resolves.toBeDefined();
     });
 
     it("respects permissionMode from config", async () => {

--- a/packages/core/src/__tests__/daemon.test.ts
+++ b/packages/core/src/__tests__/daemon.test.ts
@@ -119,17 +119,78 @@ describe("daemon handler", () => {
   // #354: a quiet INTERACTIVE crew with no tool in flight is alive-thinking, NOT
   // awaiting-input — the watchdog no longer flips it. It stays `working` and the
   // sweep emits a distinct, non-alarming CREW QUIET notify (once per episode).
+  // #466: firstTurnConfirmedAt must be SET to take the "deep thinking" path;
+  // unset means the first turn may not have landed → CREW UNDELIVERED instead.
   it("sweep: over-budget INTERACTIVE task with no tool in flight stays working + CREW QUIET (#354)", async () => {
     const store = createStore(dir);
     const calls: any[] = [];
     store.put(rec("s1i", { mode: "interactive", state: "working", lastHeartbeat: 0,
-      heartbeatBudgetMs: 100, attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 0 }] }));
+      heartbeatBudgetMs: 100, firstTurnConfirmedAt: 1,  // confirmed → "deep thinking" path
+      attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 0 }] }));
     const d = createDaemon({ store, now: () => 1000, notify: async (a) => { calls.push(a); } });
     await d.sweep();
     expect(store.get("p", "s1i")?.state).toBe("working");
     expect(calls.length).toBe(1);
     expect(calls[0].message).toMatch(/CREW QUIET/);
     expect(calls[0].event.type).toBe("task.quiet");
+  });
+
+  // #466: an interactive crew that is quiet past its budget but has NEVER had
+  // firstTurnConfirmedAt set must emit CREW UNDELIVERED — not "deep thinking".
+  // This catches the race where spawn sends the first turn into a not-yet-ready
+  // box and the crew sits idle at an empty prompt (0% ctx, $0.00).
+  it("sweep: interactive quiet task with NO firstTurnConfirmedAt → CREW UNDELIVERED (#466)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    // firstTurnConfirmedAt intentionally absent — first turn may not have landed
+    store.put(rec("u1", { mode: "interactive", state: "working", lastHeartbeat: 0,
+      heartbeatBudgetMs: 100, attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 0 }] }));
+    const d = createDaemon({ store, now: () => 1000, notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    expect(store.get("p", "u1")?.state).toBe("working"); // state unchanged
+    expect(calls.length).toBe(1);
+    expect(calls[0].message).toMatch(/CREW UNDELIVERED/);
+    expect(calls[0].message).toMatch(/re-send/i);
+    expect(calls[0].event.type).toBe("task.quiet"); // reuses task.quiet as notify vehicle
+  });
+
+  // #466: same crew but WITH firstTurnConfirmedAt set → normal "deep thinking" path.
+  it("sweep: interactive quiet task WITH firstTurnConfirmedAt → CREW QUIET, not UNDELIVERED (#466)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    store.put(rec("u2", { mode: "interactive", state: "working", lastHeartbeat: 0,
+      firstTurnConfirmedAt: 50,  // first turn landed
+      heartbeatBudgetMs: 100, attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 0 }] }));
+    const d = createDaemon({ store, now: () => 1000, notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    expect(store.get("p", "u2")?.state).toBe("working");
+    expect(calls.length).toBe(1);
+    expect(calls[0].message).toMatch(/CREW QUIET/);
+    expect(calls[0].message).not.toMatch(/UNDELIVERED/);
+  });
+
+  // #466: task within heartbeat budget — no UNDELIVERED (not yet timed out).
+  it("sweep: interactive task within budget with NO firstTurnConfirmedAt → no notification (#466)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    store.put(rec("u3", { mode: "interactive", state: "working", lastHeartbeat: 950,
+      heartbeatBudgetMs: 100, attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 950 }] }));
+    const d = createDaemon({ store, now: () => 1000, notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    expect(calls.length).toBe(0); // within budget → silent
+  });
+
+  // #466: task.first-turn.confirmed event stamps firstTurnConfirmedAt on the record.
+  it("task.first-turn.confirmed stamps firstTurnConfirmedAt on the record (#466)", async () => {
+    const store = createStore(dir);
+    store.put(rec("fc1", { state: "working" }));
+    const d = createDaemon({ store, now: () => 500 });
+    const updated = await d.handle({
+      kind: "event", project: "p",
+      event: { type: "task.first-turn.confirmed", id: "fc1" },
+    }) as import("@squadrant/shared").TaskRecord;
+    expect(updated.firstTurnConfirmedAt).toBe(500);
+    expect(store.get("p", "fc1")?.firstTurnConfirmedAt).toBe(500);
   });
 
   // #354: an interactive crew with a tool in flight (PreToolUse, no PostToolUse)

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -454,7 +454,7 @@ export async function runCrewSend(
     // runtime.sendToPane so the caller can inject paste-settle-Enter hardening.
     // Falls back to runtime.sendToPane when absent (preserves existing behaviour
     // for callers that don't inject it, e.g. unit tests).
-    sendToPane?: (pane: PaneRef, message: string) => Promise<void>;
+    sendToPane?: (pane: PaneRef, message: string) => Promise<{ delivered: boolean }>;
   },
 ): Promise<void> {
   const crew = await findCrewPane(runtime, workspaceId, project, name);
@@ -479,8 +479,11 @@ export async function runCrewSend(
     // Swallow daemon errors so crews without a daemon or offline daemon
     // still receive the sent message.
   }
-  const deliver = deps.sendToPane ?? ((pane, msg) => runtime.sendToPane(pane, msg));
-  await deliver(crew, message);
+  const deliver = deps.sendToPane ?? ((pane, msg) => runtime.sendToPane(pane, msg).then(() => ({ delivered: true })));
+  const { delivered } = await deliver(crew, message);
+  if (!delivered) {
+    process.stderr.write(`⚠️  Message not delivered to crew '${name}' — use 'squadrant crew send ${project} ${name}' to re-send.\n`);
+  }
 }
 
 export async function runCrewRead(

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -118,14 +118,19 @@ export interface CrewSpawnDeps {
   writeSettingsLocal(projectCwd: string): void;
   /** CLI-edge: write opencode permission config for an interactive crew. */
   writeOpencodeConfig(opts: { stateRoot: string; project: string; taskId: string; gateBash?: boolean }): string;
-  /** CLI-edge: deliver the first turn once the agent pane is ready. */
-  sendFirstTurn(pane: PaneRef, firstTurn: string, preLaunchScreen: string, opts?: TurnAcceptanceConfig): Promise<void>;
+  /** CLI-edge: deliver the first turn once the agent pane is ready. Returns
+   *  { delivered: true } when positively confirmed, { delivered: false } when
+   *  all retry paths exhausted without confirmation (#466). */
+  sendFirstTurn(pane: PaneRef, firstTurn: string, preLaunchScreen: string, opts?: TurnAcceptanceConfig): Promise<{ delivered: boolean }>;
   /** CLI-edge: reserve an ephemeral TCP port for opencode's embedded HTTP server. */
   getFreePort(): Promise<number>;
   /** CLI-edge: deliver the task to a freshly-dispatched codex thread. */
   sendCodexFirstTurn(taskId: string, task: string): Promise<void>;
   /** Optional: called after routing to log the selected route (e.g. chalk.dim(...)). */
   onRouted?(route: CrewRouteResult): void;
+  /** #466: optional — when provided, called with task.first-turn.confirmed after
+   *  positively confirmed delivery so the daemon can stamp firstTurnConfirmedAt. */
+  emitEvent?(project: string, event: ControlEvent): Promise<void>;
 }
 
 // ─── Private helpers ──────────────────────────────────────────────────────────
@@ -343,7 +348,13 @@ export async function runCrewSpawn(
     const envPrefix = `SQUADRANT_CREW_TASK_ID=${rec.id} SQUADRANT_CREW_PROJECT=${input.project}`;
     await deps.runtime.sendToPane(pane, `cd ${shellQuote(spawnCwd)} && ${envPrefix} ${cliCommand}`);
     const preLaunchScreen = (await deps.runtime.readPaneScreen(pane)) ?? "";
-    await deps.sendFirstTurn(pane, `${firstTurnTask}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen);
+    const claudeResult = await deps.sendFirstTurn(pane, `${firstTurnTask}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen);
+    // #466: surface non-delivery explicitly instead of silently returning success.
+    if (!claudeResult.delivered) {
+      process.stderr.write(`⚠️  First turn not delivered for crew '${name}' — use 'squadrant crew send ${input.project} ${name}' to re-send the task.\n`);
+    } else {
+      await deps.emitEvent?.(input.project, { type: "task.first-turn.confirmed", id: rec.id });
+    }
     return { ...pane, title };
   }
 
@@ -389,12 +400,18 @@ export async function runCrewSpawn(
     const envPrefix = `SQUADRANT_CREW_TASK_ID=${rec.id} SQUADRANT_CREW_PROJECT=${input.project}`;
     await deps.runtime.sendToPane(pane, `cd ${shellQuote(spawnCwd)} && ${envPrefix} OPENCODE_CONFIG=${opencodeConfigPath} ${cliCommand}`);
     const preLaunchScreen = (await deps.runtime.readPaneScreen(pane)) ?? "";
-    await deps.sendFirstTurn(pane, `${firstTurnTask}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen, {
+    const opencodeResult = await deps.sendFirstTurn(pane, `${firstTurnTask}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen, {
       // #235: confirm-on-delivery — sendFirstTurnWhenReady polls until "Ask
       // anything…" leaves the screen, re-sending every ~3s to cover slow boots
       // without duplicating the task. See crew-pane.ts SPLASH_MAX_CHECKS/EVERY_N.
       splashMarker: "Ask anything…",
     } satisfies TurnAcceptanceConfig);
+    // #466: surface non-delivery; emit confirmed event on success.
+    if (!opencodeResult.delivered) {
+      process.stderr.write(`⚠️  First turn not delivered for crew '${name}' — use 'squadrant crew send ${input.project} ${name}' to re-send the task.\n`);
+    } else {
+      await deps.emitEvent?.(input.project, { type: "task.first-turn.confirmed", id: rec.id });
+    }
     return { ...pane, title };
   }
 
@@ -413,7 +430,11 @@ export async function runCrewSpawn(
   await deps.runtime.sendToPane(pane, cliCommand);
   if (interactive) {
     const preLaunchScreen = (await deps.runtime.readPaneScreen(pane)) ?? "";
-    await deps.sendFirstTurn(pane, firstTurnTask, preLaunchScreen);
+    const genericResult = await deps.sendFirstTurn(pane, firstTurnTask, preLaunchScreen);
+    // Generic branch has no daemon task record — only warn on non-delivery.
+    if (!genericResult.delivered) {
+      process.stderr.write(`⚠️  First turn not delivered for crew '${name}' — use 'squadrant crew send ${input.project} ${name}' to re-send the task.\n`);
+    }
   }
   return { ...pane, title };
 }

--- a/packages/core/src/daemon/reduce.ts
+++ b/packages/core/src/daemon/reduce.ts
@@ -240,6 +240,7 @@ const KNOWN_EVENT_TYPES: ReadonlySet<string> = new Set([
   "task.reattached", "task.reopened",
   "task.stalled", "task.idle", "task.quiet", "task.timeout", "task.reconcile-failed",
   "task.cancelled", "task.session.ended",
+  "task.first-turn.confirmed",  // #466: delivery confirmation
 ]);
 
 export function createDaemon(deps: DaemonDeps) {
@@ -467,6 +468,8 @@ export function createDaemon(deps: DaemonDeps) {
         // during pure model thinking). Surface a distinct, non-alarming nudge —
         // NOT 'awaiting-input' (the turn never ended; real CREW IDLE comes only
         // from the Stop hook). State stays `working`; notify once per episode.
+        // #466: if firstTurnConfirmedAt is unset the crew may never have received
+        // its first task — emit CREW UNDELIVERED instead of "deep thinking".
         if (r.mode === "interactive" && r.state === "working" && !r.pendingTool) {
           const liveness = r.attempts.at(-1)?.lastHeartbeatAt ?? r.lastHeartbeat;
           const quiet = t - liveness;
@@ -474,9 +477,16 @@ export function createDaemon(deps: DaemonDeps) {
             if (deps.notify && quietNotifiedAt.get(r.id) !== liveness) {
               quietNotifiedAt.set(r.id, liveness);
               const tag = crewTag(r);
-              const mins = Math.max(1, Math.round(quiet / 60000));
-              const message = `CREW QUIET ${tag}: working ~${mins}min with no tool activity — likely deep thinking (no reply expected yet).`;
               const synthEvent: ControlEvent = { type: "task.quiet", id: r.id, quietMs: quiet };
+              let message: string;
+              if (!r.firstTurnConfirmedAt) {
+                // #466: no confirmed delivery → crew may be sitting at an empty
+                // prompt. Alert distinctly so the captain can re-send the task.
+                message = `⚠️ CREW UNDELIVERED ${tag}: first turn may not have landed (0 activity) — re-send the task or check the spawn.`;
+              } else {
+                const mins = Math.max(1, Math.round(quiet / 60000));
+                message = `CREW QUIET ${tag}: working ~${mins}min with no tool activity — likely deep thinking (no reply expected yet).`;
+              }
               try {
                 const p = deps.notify({ project: r.project, message, record: r, event: synthEvent });
                 if (p && typeof (p as Promise<void>).catch === "function") (p as Promise<void>).catch(() => {});

--- a/packages/core/src/side-session.ts
+++ b/packages/core/src/side-session.ts
@@ -93,7 +93,7 @@ export interface SideSpawnDeps {
    */
   agentCmdFactory: (spawnCwd: string) => string;
   /** CLI-edge: deliver the first turn when the agent pane is ready. */
-  sendFirstTurn: (pane: PaneRef, firstTurn: string, preLaunchScreen: string) => Promise<void>;
+  sendFirstTurn: (pane: PaneRef, firstTurn: string, preLaunchScreen: string) => Promise<{ delivered: boolean }>;
 }
 
 export async function runSideSpawn(

--- a/packages/core/src/state-machine.ts
+++ b/packages/core/src/state-machine.ts
@@ -127,6 +127,11 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
       return { ...stampAttempt(base, {}, now), state: "blocked", question: ev.question, pendingTool: undefined };
     case "task.reattached":
       return stampAttempt(base, {}, now);
+    case "task.first-turn.confirmed":
+      // #466: stamp the confirmed delivery timestamp. No state change — the crew
+      // stays `working`. The watchdog reads this field to distinguish a quiet-
+      // thinking crew from one that never received its first turn.
+      return { ...rec, firstTurnConfirmedAt: now, lastEvent: ev.type };
     case "task.stalled":
     case "task.idle":
     case "task.quiet":

--- a/packages/shared/src/types/control.ts
+++ b/packages/shared/src/types/control.ts
@@ -85,6 +85,12 @@ export interface TaskRecord {
    *  (no pendingTool → CREW QUIET). Auto-clears: the next PostToolUse recovers
    *  the record to `working` (state-machine + recoverStall). */
   pendingTool?: { name: string; since: number };
+  /** #466: epoch ms when the spawn path positively confirmed the first turn was
+   *  delivered (paste rendered in the box → box emptied = submitted). Unset means
+   *  either the crew was spawned before this field existed, OR delivery was never
+   *  confirmed. The watchdog uses this to emit CREW UNDELIVERED instead of the
+   *  misleading "deep thinking" message for a crew that never received its task. */
+  firstTurnConfirmedAt?: number;
 }
 
 export type ControlEvent =
@@ -131,6 +137,10 @@ export type ControlEvent =
   // task to the absorbing 'cancelled' state. Silent: captain initiated the close
   // so no CREW CANCELLED push is fired (not in ATTENTION_STATES).
   | { type: "task.cancelled"; id: string; reason?: string }
+  // #466: emitted by runCrewSpawn after positively confirming the first turn was
+  // delivered. Stamps firstTurnConfirmedAt on the record so the watchdog can
+  // distinguish a quiet-thinking crew from one that never received its task.
+  | { type: "task.first-turn.confirmed"; id: string }
   // #139: a claude crew's SessionEnd hook fired — the session is GONE. Unlike
   // the other turn-boundary hooks (PostToolUse/SubagentStop = liveness), a dead
   // session must NOT resume 'working' (nothing heartbeats → false CREW STALLED

--- a/packages/workspaces/src/__tests__/crew-pane.test.ts
+++ b/packages/workspaces/src/__tests__/crew-pane.test.ts
@@ -334,19 +334,211 @@ describe("sendFirstTurnWhenReady — large paste race (#455)", () => {
     expect(sendToPane).not.toHaveBeenCalled();
   });
 
-  // When the paste NEVER renders (e.g. paste-buffer loss), the function must re-paste
-  // once rather than silently declaring success on a never-populated box.
-  it("re-pastes once when paste never renders (never-populated box)", async () => {
+  // When the paste NEVER renders (e.g. paste-buffer loss), the function re-pastes
+  // once in the first path, then falls back to confirmedSendToPane which also
+  // re-pastes once — total 4 paste calls when the box never populates (#466).
+  it("re-pastes in first path then falls back to confirmedSendToPane when paste never renders (#455/#466)", async () => {
     readPaneScreen.mockResolvedValue(EMPTY_BOX);
 
     const promise = sendFirstTurnWhenReady(rt(), pane, "very large task", "$ launch");
+    await vi.advanceTimersByTimeAsync(18000); // first path (~7s) + confirmedSendToPane fallback (~5s)
+    await promise;
+
+    // First path: 1 initial paste + 1 repaste when sawDraft stays false.
+    // confirmedSendToPane fallback: 1 initial paste + 1 repaste = 4 total.
+    expect(pasteToPane.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(pasteToPane).toHaveBeenCalledWith(pane, "very large task");
+    expect(sendToPane).not.toHaveBeenCalled();
+  });
+});
+
+// ─── #466: boot-gate requires parseable input box ─────────────────────────────
+
+describe("sendFirstTurnWhenReady — boot gate requires parseable box (#466)", () => {
+  let readPaneScreen: ReturnType<typeof vi.fn>;
+  let sendToPane: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
+  const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, sendToPane, pasteToPane, sendKeyToPane });
+
+  // A stable screen with NO HR-bounded box — e.g. the claude-mem boot banner.
+  const BANNER_ONLY = "=== claude-mem: loading memories ===\n(0 memories loaded)";
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    readPaneScreen = vi.fn();
+    sendToPane = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
+  });
+  afterEach(() => { vi.useRealTimers(); });
+
+  // Core regression fix: the boot gate must NOT declare ready when the screen is
+  // stable but has no HR-bounded input box. Under load the claude-mem banner
+  // stabilises before the CC input box renders, causing paste into the wrong spot.
+  // After the box appears the paste renders immediately and confirms delivery.
+  it("does not paste while screen is stable but has no parseable input box", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n <= 4) return BANNER_ONLY;   // banner stable, no box — must NOT trigger paste
+      if (n <= 6) return EMPTY_BOX;     // CC box appeared, stabilises → triggers readiness
+      if (n <= 8) return DRAFT_BOX;     // paste renders in box during settle
+      return EMPTY_BOX;                 // box empties after Enter → submitted
+    });
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "task text", "$ launch");
     await vi.advanceTimersByTimeAsync(10000);
     await promise;
 
-    // Re-pasted exactly once after the initial paste failed to render.
-    expect(pasteToPane).toHaveBeenCalledTimes(2);
-    expect(pasteToPane).toHaveBeenCalledWith(pane, "very large task");
-    expect(sendToPane).not.toHaveBeenCalled();
+    // Paste must only happen AFTER the input box appeared — never during banner.
+    // Exactly one paste: the box was ready when we pasted, draft rendered, submitted.
+    expect(pasteToPane).toHaveBeenCalledTimes(1);
+    expect(pasteToPane).toHaveBeenCalledWith(pane, "task text");
+  });
+
+  // When the box appears, delivery succeeds normally.
+  it("returns { delivered: true } once the box appears and submission is confirmed", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n <= 3) return BANNER_ONLY;   // banner stable, no box yet
+      if (n <= 5) return EMPTY_BOX;     // box appeared + stability poll
+      if (n <= 7) return DRAFT_BOX;     // paste settled in box
+      return EMPTY_BOX;                 // box emptied after Enter → submitted
+    });
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "task text", "$ launch");
+    await vi.advanceTimersByTimeAsync(10000);
+    const result = await promise;
+
+    expect(result).toEqual({ delivered: true });
+    expect(pasteToPane).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── #466: delivery status + self-heal fallback ───────────────────────────────
+
+describe("sendFirstTurnWhenReady — delivery status and self-heal (#466)", () => {
+  let readPaneScreen: ReturnType<typeof vi.fn>;
+  let sendToPane: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
+  const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, sendToPane, pasteToPane, sendKeyToPane });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    readPaneScreen = vi.fn();
+    sendToPane = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
+  });
+  afterEach(() => { vi.useRealTimers(); });
+
+  // Happy path: normal delivery returns { delivered: true }.
+  it("returns { delivered: true } on normal paste-then-submit delivery", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n <= 3) return EMPTY_BOX;  // readiness + preSend
+      if (n <= 5) return DRAFT_BOX;  // settle: paste rendered
+      return EMPTY_BOX;              // post-Enter: submitted
+    });
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "do the thing", "$ launch");
+    await vi.advanceTimersByTimeAsync(6000);
+    const result = await promise;
+
+    expect(result).toEqual({ delivered: true });
+  });
+
+  // Self-heal: paste path exhausts (sawDraft=false → box never populated), but the
+  // confirmedSendToPane fallback succeeds. The outcome is { delivered: true }.
+  // This is the key #466 scenario: paste went into a not-yet-ready box (no HR),
+  // but by fallback time the box has settled and accepts the task.
+  it("returns { delivered: true } when fallback confirmedSendToPane succeeds (#466 self-heal)", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      // Boot: stable box from the start
+      if (n <= 2) return EMPTY_BOX;
+      // preSend + first paste attempt: paste never renders (race — box not ready)
+      if (n <= 10) return EMPTY_BOX;
+      // Fallback (confirmedSendToPane): box now ready, paste renders, then empties
+      if (n <= 12) return DRAFT_BOX;  // fallback settle: paste rendered
+      return EMPTY_BOX;               // fallback confirm: submitted
+    });
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "do the thing", "$ launch");
+    await vi.advanceTimersByTimeAsync(18000);
+    const result = await promise;
+
+    expect(result).toEqual({ delivered: true });
+    // At least 2 pastes: one in the first path (which failed), one in the fallback
+    expect(pasteToPane.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // Hard drop: paste path exhausts with sawDraft=false, AND the fallback also
+  // fails (box never populates). Returns { delivered: false }.
+  it("returns { delivered: false } when both paste path and fallback fail (#466 hard drop)", async () => {
+    readPaneScreen.mockResolvedValue(EMPTY_BOX);
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "do the thing", "$ launch");
+    await vi.advanceTimersByTimeAsync(18000);
+    const result = await promise;
+
+    expect(result).toEqual({ delivered: false });
+  });
+});
+
+// ─── #466: confirmedSendToPane delivery status ────────────────────────────────
+
+describe("confirmedSendToPane — delivery status (#466)", () => {
+  let readPaneScreen: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
+  const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, pasteToPane, sendKeyToPane });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    readPaneScreen = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
+  });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it("returns { delivered: true } when box empties after draft seen", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n === 1) return box("");     // preSendScreen
+      if (n <= 3) return DRAFT_BOX;   // settle: paste rendered
+      return EMPTY_BOX;               // post-Enter: submitted
+    });
+
+    const promise = confirmedSendToPane(rt(), pane, "message");
+    await vi.advanceTimersByTimeAsync(3000);
+    const result = await promise;
+
+    expect(result).toEqual({ delivered: true });
+  });
+
+  it("returns { delivered: false } when retry exhausts without confirmation", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n === 1) return box("");   // preSendScreen
+      return EMPTY_BOX;              // paste never renders, box stays empty
+    });
+
+    const promise = confirmedSendToPane(rt(), pane, "message");
+    await vi.advanceTimersByTimeAsync(8000);
+    const result = await promise;
+
+    expect(result).toEqual({ delivered: false });
   });
 });
 

--- a/packages/workspaces/src/crew-pane.ts
+++ b/packages/workspaces/src/crew-pane.ts
@@ -117,12 +117,16 @@ export async function resolveCaptainWorkspace(project: string): Promise<{
  *   2. settle until the input box content stops changing (accumulation closed)
  *   3. separate Enter keystroke
  *   4. confirm box empty; re-issue ONLY Enter if stranded (never re-paste)
+ *
+ * Returns `{ delivered: true }` when the box empties after the draft was seen
+ * (positive submit confirmation), or `{ delivered: false }` if the retry loop
+ * exhausts without confirmation (#466: callers surface non-delivery explicitly).
  */
 export async function confirmedSendToPane(
   runtime: Pick<RuntimeDriver, "readPaneScreen" | "pasteToPane" | "sendKeyToPane">,
   pane: PaneRef,
   message: string,
-): Promise<void> {
+): Promise<{ delivered: boolean }> {
   const preSendScreen = (await runtime.readPaneScreen(pane)) ?? "";
   await runtime.pasteToPane(pane, message);
   // #455: track whether the paste ever rendered so we don't treat an empty box
@@ -138,8 +142,8 @@ export async function confirmedSendToPane(
     const draft = parseDraftFromScreen(afterScreen);
     if (draft !== "" && draft !== null) sawDraft = true;
     // Box confirmed empty AND we observed the paste rendered first → submitted.
-    if (draft === "" && sawDraft) return;
-    if (draft === null && afterScreen !== preSendScreen) return;
+    if (draft === "" && sawDraft) return { delivered: true };
+    if (draft === null && afterScreen !== preSendScreen) return { delivered: true };
     const settled = await settleInputBox(runtime, pane);
     if (settled) sawDraft = true;
     // #455: paste never rendered — re-paste once rather than issuing Enter into emptiness.
@@ -149,6 +153,7 @@ export async function confirmedSendToPane(
     }
     await runtime.sendKeyToPane(pane, "Enter");
   }
+  return { delivered: false };
 }
 
 export async function sendFirstTurnWhenReady(
@@ -157,7 +162,7 @@ export async function sendFirstTurnWhenReady(
   task: string,
   preLaunchScreen: string,
   acceptanceConfig?: TurnAcceptanceConfig,
-): Promise<void> {
+): Promise<{ delivered: boolean }> {
   await new Promise((r) => setTimeout(r, SEND_FIRST_TURN_FLOOR_MS));
 
   const maxPolls = Math.floor(
@@ -169,12 +174,14 @@ export async function sendFirstTurnWhenReady(
   for (let i = 0; i < maxPolls && !stable; i++) {
     const screen = (await runtime.readPaneScreen(pane)) ?? "";
     // Ready = the agent prompt is actually up: screen is non-empty, settled
-    // (unchanged between two consecutive reads), AND has advanced past the
-    // un-entered launch command line. The last condition prevents sending the
-    // task onto the shell line before the TUI takes over — which concatenates
-    // onto the launch command and triggers a shell parse error (opencode
-    // boot-race). A momentarily static launch line is not readiness.
-    if (screen.length > 0 && screen === previousScreen && screen !== preLaunchScreen) {
+    // (unchanged between two consecutive reads), has advanced past the un-entered
+    // launch command line, AND (for the claude/codex path) the HR-bounded input
+    // box is actually rendered. The last check prevents pasting into the claude-mem
+    // boot banner which can stabilise BEFORE the CC input box appears under load
+    // (#466 root cause). For the opencode splash path, parseDraftFromScreen would
+    // return null (no HR box), so we skip that check to preserve existing behaviour.
+    const hasInputBox = !!acceptanceConfig?.splashMarker || parseDraftFromScreen(screen) !== null;
+    if (screen.length > 0 && screen === previousScreen && screen !== preLaunchScreen && hasInputBox) {
       stable = true;
     } else {
       previousScreen = screen;
@@ -203,13 +210,20 @@ export async function sendFirstTurnWhenReady(
       await new Promise((r) => setTimeout(r, POST_SEND_CHECK_MS));
       const afterScreen = (await runtime.readPaneScreen(pane)) ?? "";
       if (isTurnAccepted(preSendScreen, afterScreen, acceptanceConfig)) {
-        return;
+        return { delivered: true };
       }
       if ((check + 1) % SPLASH_RESEND_EVERY_N === 0 && check < SPLASH_MAX_CHECKS - 1) {
         await runtime.sendToPane(pane, task);
       }
     }
-    return;
+    return { delivered: false };
+  }
+
+  // #466: if the box never appeared in the boot window, skip the paste path and
+  // go directly to the settled-box fallback (confirmedSendToPane). By the time we
+  // get here, more time has passed and the box is likely ready.
+  if (!stable) {
+    return confirmedSendToPane(runtime, pane, task);
   }
 
   // Claude/codex path (#339): paste the task, let the [Pasted text] placeholder
@@ -235,11 +249,11 @@ export async function sendFirstTurnWhenReady(
     const draft = parseDraftFromScreen(afterScreen);
     if (draft !== "" && draft !== null) sawDraft = true;
     // Box confirmed empty AND we observed the paste rendered first → submitted.
-    if (draft === "" && sawDraft) return;
+    if (draft === "" && sawDraft) return { delivered: true };
     // Box not parseable (e.g. an agent TUI without the HR-bounded box, or a
     // transient overlay): fall back to the screen-changed signal so non-claude
     // TUIs aren't worse off than before.
-    if (draft === null && afterScreen !== preSendScreen) return;
+    if (draft === null && afterScreen !== preSendScreen) return { delivered: true };
     const settled = await settleInputBox(runtime, pane);
     if (settled) sawDraft = true;
     // #455: paste never rendered — re-paste once rather than issuing Enter into emptiness.
@@ -250,4 +264,14 @@ export async function sendFirstTurnWhenReady(
     // Still stranded — re-issue ONLY the Enter (re-paste only when never rendered).
     await runtime.sendKeyToPane(pane, "Enter");
   }
+
+  // #466: retry loop exhausted — if the paste never rendered (sawDraft=false),
+  // the box was likely not ready when we pasted (the #466 timing race). Fall back
+  // once to confirmedSendToPane which starts fresh on a now-settled box.
+  // When sawDraft=true (paste rendered, Enter repeatedly failed), re-pasting would
+  // stack [Pasted text] entries — do not retry, just report non-delivery.
+  if (!sawDraft) {
+    return confirmedSendToPane(runtime, pane, task);
+  }
+  return { delivered: false };
 }


### PR DESCRIPTION
## Problem

Under concurrent load (3+ `--agent claude` spawns), ~1/3 of crews silently drop their first-turn task prompt. The crew boots to an empty `❯` prompt (0% ctx/$0.00) and the watchdog mislabels it as "deep thinking" instead of undelivered.

**Root cause (confirmed repro):** The claude-mem banner stabilises before the Claude Code input box renders under load. The boot-readiness gate was keying on screen stability alone — so it fired and pasted into the banner, not the box. The task text was swallowed silently.

## Changes (3 atomic commits)

### Part 1 — Boot gate + delivery status (`packages/workspaces`)
- `sendFirstTurnWhenReady`: gate now requires `parseDraftFromScreen(screen) !== null` (a parseable HR-bounded input box) before declaring ready — prevents paste into the banner
- Both `sendFirstTurnWhenReady` and `confirmedSendToPane` return `{ delivered: boolean }` — callers can surface non-delivery explicitly
- Auto-fallback: when the paste path exhausts retries with `sawDraft=false`, fall through to `confirmedSendToPane` for a fresh attempt on the now-settled box

### Part 2 — Spawn surfaces non-delivery (`packages/core`, `packages/cli`)
- `CrewSpawnDeps.sendFirstTurn` return type updated to `Promise<{ delivered: boolean }>`
- Optional `emitEvent?` added to `CrewSpawnDeps` (backward-compat — no error when absent)
- claude + opencode spawn branches: write `⚠️ First turn not delivered` to stderr on `!delivered`; emit `task.first-turn.confirmed` on success so the daemon can stamp `firstTurnConfirmedAt`
- Wire `emitEvent` in CLI `crew.ts`

### Part 3 — Watchdog CREW UNDELIVERED (`packages/shared`, `packages/core`)
- `firstTurnConfirmedAt?: number` added to `TaskRecord`
- `task.first-turn.confirmed` added to `ControlEvent` union + `KNOWN_EVENT_TYPES`
- State machine handles `task.first-turn.confirmed`: stamps the field, no state transition
- `sweep()` CREW QUIET block: emits `CREW UNDELIVERED` (re-send prompt) when `!firstTurnConfirmedAt`, `CREW QUIET / deep thinking` when confirmed

## Tests

- 21 tests in `crew-pane.test.ts` (7 new #466 scenarios)
- 40 tests in `crew-spawn.test.ts` (4 new #466 scenarios)
- 5 new daemon tests (UNDELIVERED/QUIET branching, state-machine stamp)
- 809/809 across `packages/core` + `packages/workspaces`

## Test plan
- [ ] Spawn 3 concurrent large multi-line `--agent claude` crews — all should confirm delivery or emit stderr warning
- [ ] Watchdog shows `CREW UNDELIVERED` for an unconfirmed crew (not "deep thinking")
- [ ] `squadrant crew send` still works as follow-up recovery path
- [ ] opencode spawn path unaffected (splash-marker bypass preserves existing behaviour)

Closes #466