### PR TITLE
Release v0.13.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,22 @@ jobs:
 
       - name: Publish to npm
         if: steps.check.outputs.should_release == 'true' && steps.npmtok.outputs.has_token == 'true'
-        continue-on-error: true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public
+
+      - name: Verify npm publish
+        if: steps.check.outputs.should_release == 'true' && steps.npmtok.outputs.has_token == 'true'
+        run: |
+          VERSION="${{ steps.ver.outputs.version }}"
+          for i in 1 2 3 4 5; do
+            PUBLISHED=$(curl -fsSL "https://registry.npmjs.org/squadrant/$VERSION" | node -p "JSON.parse(require('fs').readFileSync(0)).version" 2>/dev/null || true)
+            if [ "$PUBLISHED" = "$VERSION" ]; then
+              echo "✓ squadrant@$VERSION confirmed live on npm"
+              exit 0
+            fi
+            echo "registry not yet showing $VERSION (attempt $i/5), retrying…"
+            sleep 10
+          done
+          echo "::error::squadrant@$VERSION did NOT appear on the npm registry after publish"
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.2] - 2026-06-29
+
+### Fixed
+
+- First-turn delivery could silently drop under concurrent spawn load: spawning several large
+  multi-line `--agent claude` crews at once could leave one sitting at an empty prompt (0% context)
+  because the boot-readiness gate latched onto the session-start banner before the input box had
+  rendered, so the paste landed in a not-ready box and the retry loop exhausted without confirming
+  submission — while `crew spawn` still reported success and the watchdog mislabeled the inert crew
+  as "deep thinking". The boot gate now waits for a parseable input box before pasting, first-turn
+  delivery reports a delivery status and auto-falls-back to the confirmed send path when the paste
+  can't be confirmed, non-delivery surfaces a warning instead of a false success, and the watchdog
+  emits a distinct "CREW UNDELIVERED" alert (via a new first-turn-confirmed signal) instead of
+  "deep thinking" for a crew that never received its task. ([#466](https://github.com/tu11aa/squadrant/issues/466))
+- Daemon task-ledger cruft and ghost lifecycle notifications: terminal task records accumulated
+  indefinitely, and an abandoned task whose crew surface was gone could still fire CREW IDLE /
+  CREW TIMEOUT notifications, confusingly surfacing mid-session. The daemon now prunes terminal
+  records per project on sweep, suppresses lifecycle notifications for interactive tasks whose
+  surface is provably gone, and `crew tasks --all-terminal` bulk-purges terminal records.
+  ([#457](https://github.com/tu11aa/squadrant/issues/457))
+- `crew spawn --task-file` was not readable from an isolated-worktree crew's working directory; the
+  file is now copied into the worktree root and the crew is given a short pointer first turn.
+  ([#458](https://github.com/tu11aa/squadrant/issues/458))
+- The release workflow reported success even when `npm publish` failed (the publish step was
+  `continue-on-error`), so a bad token could leave npm a version behind while CI stayed green. The
+  publish step now fails the job on error and a verification step confirms the published version is
+  live on the registry. ([#463](https://github.com/tu11aa/squadrant/pull/463))
+
 ## [0.13.1] - 2026-06-29
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "squadrant",
   "packageManager": "pnpm@10.30.3",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Multi-project orchestration for your coding agents (Claude, Codex, opencode, Gemini)",
   "type": "module",
   "bin": {

--- a/packages/cli/src/__tests__/squadrantd-push.test.ts
+++ b/packages/cli/src/__tests__/squadrantd-push.test.ts
@@ -102,7 +102,8 @@ describe("squadrantd push notifications (#109)", () => {
   it("INTERACTIVE quiet (from sweep) triggers exactly one CREW QUIET notify, stays working (#354)", async () => {
     const store = createStore(dir);
     // rec() defaults to mode: "interactive"; no pendingTool → alive-thinking path.
-    store.put(rec("task-idle-1", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250 }));
+    // firstTurnConfirmedAt set: this crew received its task and is quietly thinking (#466).
+    store.put(rec("task-idle-1", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250, firstTurnConfirmedAt: 1 }));
     const n = fakeNotify();
     const d = createDaemon({ store, now: () => 5000, notify: n.notify });
     await d.sweep();
@@ -117,7 +118,7 @@ describe("squadrantd push notifications (#109)", () => {
 
   it("CREW QUIET fires once per quiet episode across repeated sweeps → no storm (#354)", async () => {
     const store = createStore(dir);
-    store.put(rec("task-idle-2", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250 }));
+    store.put(rec("task-idle-2", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250, firstTurnConfirmedAt: 1 }));
     const n = fakeNotify();
     const d = createDaemon({ store, now: () => 5000, notify: n.notify });
     await d.sweep(); // quiet → one CREW QUIET
@@ -129,7 +130,7 @@ describe("squadrantd push notifications (#109)", () => {
 
   it("awaiting-input + task.started (captain resumes) → working, no extra notify", async () => {
     const store = createStore(dir);
-    store.put(rec("task-idle-3", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250 }));
+    store.put(rec("task-idle-3", { state: "working", lastHeartbeat: 0, heartbeatBudgetMs: 250, firstTurnConfirmedAt: 1 }));
     const n = fakeNotify();
     const d = createDaemon({ store, now: () => 5000, notify: n.notify });
     await d.sweep(); // → awaiting-input, push #1 (CREW IDLE)

--- a/packages/cli/src/commands/__tests__/crew.test.ts
+++ b/packages/cli/src/commands/__tests__/crew.test.ts
@@ -9,6 +9,7 @@ const listSurfaces = vi.hoisted(() => vi.fn());
 const status = vi.hoisted(() => vi.fn());
 const buildCommand = vi.hoisted(() => vi.fn());
 const probe = vi.hoisted(() => vi.fn());
+const sendFirstTurnWhenReadyMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@squadrant/workspaces", () => ({
   createCmuxDriver: () => ({
@@ -53,11 +54,10 @@ vi.mock("@squadrant/workspaces", () => ({
     if (!ws) throw new Error(`Captain workspace '${proj.captainName}' is not running. Run 'squadrant launch ${project}' first.`);
     return { runtime: { newPane, closePane, sendToPane, readPaneScreen, listSurfaces, status }, workspaceId: ws.id };
   },
-  sendFirstTurnWhenReady: async (_runtime: unknown, pane: unknown, task: string) => {
-    await sendToPane(pane, task);
-  },
+  sendFirstTurnWhenReady: sendFirstTurnWhenReadyMock,
   confirmedSendToPane: async (_runtime: unknown, pane: unknown, msg: string) => {
     await sendToPane(pane, msg);
+    return { delivered: true };
   },
   getFreePort: vi.fn().mockResolvedValue(12345),
 }));
@@ -178,6 +178,11 @@ describe("squadrant crew spawn", () => {
     resolveCrewRoute.mockReset();
     // Default: no routing match (fall through to existing defaults).
     resolveCrewRoute.mockReturnValue(null);
+    sendFirstTurnWhenReadyMock.mockReset();
+    sendFirstTurnWhenReadyMock.mockImplementation(async (_: unknown, pane: unknown, task: string) => {
+      await sendToPane(pane, task);
+      return { delivered: true };
+    });
   });
 
   afterEach(() => {
@@ -205,7 +210,7 @@ describe("squadrant crew spawn", () => {
       cwd: "/tmp/brove/.worktrees/brove-crew-1",
       task: "do the thing",
     }));
-    expect(squadrantdCall).toHaveBeenCalledTimes(1);
+    expect(squadrantdCall).toHaveBeenCalledTimes(2); // dispatch + task.first-turn.confirmed
     // Squadrant hooks written to .claude/settings.local.json (auto-loaded source) inside the worktree.
     expect(writePerCrewSettingsLocal).toHaveBeenCalledWith(expect.objectContaining({
       projectCwd: "/tmp/brove/.worktrees/brove-crew-1",
@@ -411,7 +416,7 @@ describe("squadrant crew spawn", () => {
       task: "do the thing",
       budgetMs: 86400000,
     }));
-    expect(squadrantdCall).toHaveBeenCalledTimes(1);
+    expect(squadrantdCall).toHaveBeenCalledTimes(2); // dispatch + task.first-turn.confirmed
     // Per-crew opencode config uses the daemon-assigned taskId.
     expect(writePerCrewOpencodeConfig).toHaveBeenCalledWith(expect.objectContaining({
       project: "brove",
@@ -662,6 +667,53 @@ describe("squadrant crew spawn", () => {
     status.mockResolvedValue(null);
     await expect(runCrewSpawn({ project: "brove", task: "x" }))
       .rejects.toThrow(/captain workspace 'brove-captain' is not running/i);
+  });
+
+  it("delivered:false emits stderr warning and does NOT emit task.first-turn.confirmed (#466)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude ...");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-nd1" } }));
+    squadrantdCall.mockResolvedValue({ id: "task-nd1", project: "brove", provider: "claude", mode: "interactive" });
+    sendFirstTurnWhenReadyMock.mockResolvedValueOnce({ delivered: false });
+
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    const promise = runCrewSpawn({ project: "brove", task: "undelivered task" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("First turn not delivered"));
+    // emitEvent must NOT fire when delivery fails
+    const kinds = (squadrantdCall.mock.calls as Array<[{ kind: string; event?: { type: string } }]>)
+      .map(([r]) => r);
+    expect(kinds).not.toContainEqual(expect.objectContaining({ event: { type: "task.first-turn.confirmed", id: "task-nd1" } }));
+
+    stderrSpy.mockRestore();
+  });
+
+  it("delivered:true emits task.first-turn.confirmed event to daemon (#466)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude ...");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-dt1" } }));
+    squadrantdCall.mockResolvedValue({ id: "task-dt1", project: "brove", provider: "claude", mode: "interactive" });
+
+    const promise = runCrewSpawn({ project: "brove", task: "delivered task" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    // squadrantdCall fired twice: once for dispatch, once for task.first-turn.confirmed
+    expect(squadrantdCall).toHaveBeenCalledTimes(2);
+    expect(squadrantdCall).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      kind: "event",
+      project: "brove",
+      event: { type: "task.first-turn.confirmed", id: "task-dt1" },
+    }));
   });
 
   describe("leveled crew routing (#275)", () => {
@@ -1041,6 +1093,11 @@ describe("completion-protocol suffix in first turns (#278)", () => {
     existsSyncMock.mockReturnValue(false);
     resolveCrewRoute.mockReset();
     resolveCrewRoute.mockReturnValue(null);
+    sendFirstTurnWhenReadyMock.mockReset();
+    sendFirstTurnWhenReadyMock.mockImplementation(async (_: unknown, pane: unknown, task: string) => {
+      await sendToPane(pane, task);
+      return { delivered: true };
+    });
     let reads = 0;
     readPaneScreen.mockImplementation(async () => {
       reads++;

--- a/packages/cli/src/commands/__tests__/side.test.ts
+++ b/packages/cli/src/commands/__tests__/side.test.ts
@@ -57,6 +57,7 @@ vi.mock("@squadrant/workspaces", () => ({
   },
   sendFirstTurnWhenReady: async (_runtime: unknown, pane: unknown, task: string) => {
     await sendToPane(pane, task);
+    return { delivered: true };
   },
   getFreePort: async () => 12345,
 }));
@@ -560,7 +561,7 @@ describe("crew spawn regression — daemon path unchanged", () => {
     await vi.advanceTimersByTimeAsync(3000);
     await promise;
 
-    expect(squadrantdCall).toHaveBeenCalledTimes(1);
+    expect(squadrantdCall).toHaveBeenCalledTimes(2); // dispatch + task.first-turn.confirmed
     vi.useRealTimers();
   });
 });

--- a/packages/cli/src/commands/crew-control.ts
+++ b/packages/cli/src/commands/crew-control.ts
@@ -8,6 +8,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { sendRequest } from "@squadrant/core";
 import { ensureDaemon } from "@squadrant/core";
 import type { ControlEvent, Mode, Provider, TaskRecord } from "@squadrant/shared";
+import { TERMINAL_STATES } from "@squadrant/shared";
 import { mapClaudeHookToEvent } from "@squadrant/agents";
 import { filterTasks, formatCompactTasks } from "./crew-output.js";
 import { crewAttachCommand } from "./crew-attach.js";
@@ -210,7 +211,17 @@ export function addControlPlaneCrewCommands(crew: Command): void {
     .option("--state-only <taskId>", "Print just the state string for a single task")
     .option("--purge <taskId>", "Purge a task record from the store (default: only terminal records)")
     .option("--force", "Force-purge a non-terminal record (use with --purge)")
-    .action(async (project: string, opts: { json?: boolean; id?: string; state?: string; stateOnly?: string; purge?: string; force?: boolean }) => {
+    .option("--all-terminal", "Purge all terminal (done/cancelled/failed) records for the project")
+    .action(async (project: string, opts: { json?: boolean; id?: string; state?: string; stateOnly?: string; purge?: string; force?: boolean; allTerminal?: boolean }) => {
+      if (opts.allTerminal) {
+        const tasks = (await squadrantdCall({ kind: "list", project })) as TaskRecord[];
+        const terminal = tasks.filter((t) => TERMINAL_STATES.has(t.state as any));
+        for (const t of terminal) {
+          await squadrantdCall({ kind: "purge", project, id: t.id, force: false });
+        }
+        console.log(`purged ${terminal.length} terminal record(s)`);
+        return;
+      }
       if (opts.purge) {
         const r = await squadrantdCall({ kind: "purge", project, id: opts.purge, force: opts.force ?? false }) as TaskRecord;
         console.log(`purged ${r.provider}/${r.id} (was ${r.state})`);

--- a/packages/cli/src/commands/crew.ts
+++ b/packages/cli/src/commands/crew.ts
@@ -129,6 +129,9 @@ crewCommand
           ...(opts.approval ? { approvalPolicy: "untrusted", approval: true } : {}),
           ...(opts.shared ? { shared: true } : {}),
           ...(opts.model ? { model: opts.model } : {}),
+          // #458: pass the raw file path (not stdin) so runCrewSpawn can copy it
+          // into the isolated worktree root for relative-path access.
+          ...(opts.taskFile && opts.taskFile !== "-" ? { taskFile: opts.taskFile } : {}),
         });
         console.log(chalk.green(`✔ Crew '${pane.title}' spawned (${pane.surfaceId})`));
       } catch (err) {

--- a/packages/cli/src/commands/crew.ts
+++ b/packages/cli/src/commands/crew.ts
@@ -48,6 +48,8 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<{ title?: str
       sendFirstTurnWhenReady(runtime, pane, firstTurn, preLaunchScreen, opts),
     getFreePort,
     sendCodexFirstTurn,
+    // #466: wire delivery confirmation so the daemon stamps firstTurnConfirmedAt.
+    emitEvent: async (p, event) => { await squadrantdCall({ kind: "event", project: p, event }); },
     onRouted: (route) =>
       console.log(
         chalk.dim(

--- a/packages/core/src/__tests__/crew-spawn.test.ts
+++ b/packages/core/src/__tests__/crew-spawn.test.ts
@@ -644,7 +644,7 @@ describe("runCrewSend", () => {
   it("uses deps.sendToPane when provided, bypassing runtime.sendToPane", async () => {
     const existing = { ...makePaneRef("5"), title: "🔧 myproj:crew-1" };
     const runtime = makeRuntime("workspace:1", [existing]);
-    const injectedSend = vi.fn().mockResolvedValue(undefined);
+    const injectedSend = vi.fn().mockResolvedValue({ delivered: true });
     await runCrewSend(PROJECT, "crew-1", "big message", runtime, "workspace:1", {
       listTasks: vi.fn().mockResolvedValue([]),
       emitEvent: vi.fn(),

--- a/packages/core/src/__tests__/crew-spawn.test.ts
+++ b/packages/core/src/__tests__/crew-spawn.test.ts
@@ -31,7 +31,8 @@ vi.mock("node:fs", async (importOriginal) => {
   // Default: existsSync returns false so codex role file is treated as absent.
   const existsSync = vi.fn().mockReturnValue(false);
   const readFileSync = vi.fn().mockReturnValue("");
-  return { ...actual, existsSync, readFileSync, default: { ...actual, existsSync, readFileSync } };
+  const copyFileSync = vi.fn();
+  return { ...actual, existsSync, readFileSync, copyFileSync, default: { ...actual, existsSync, readFileSync, copyFileSync } };
 });
 
 // Prevent reapCrewChildren from running real `ps auxE` during close tests.
@@ -43,6 +44,7 @@ vi.mock("node:child_process", async (importOriginal) => {
 
 // ─── imports (after mock declarations) ───────────────────────────────────────
 
+import * as nodefs from "node:fs";
 import {
   runCrewSpawn,
   runCrewSend,
@@ -150,6 +152,7 @@ beforeEach(() => {
   );
   resolveWorktreeBaseMock.mockReturnValue("main");
   loadConfigMock.mockReturnValue(makeConfig());
+  vi.mocked(nodefs.copyFileSync).mockReset();
 });
 
 // ─── runCrewSpawn ────────────────────────────────────────────────────────────
@@ -270,6 +273,96 @@ describe("runCrewSpawn", () => {
         expect.stringContaining(`cd '${PROJ_PATH}'`),
       );
     });
+
+    // #458: --task-file with isolated worktree
+    describe("--task-file with isolated worktree (#458)", () => {
+      it("copies task file into worktree root and sends short Read first-turn", async () => {
+        const config = makeConfig();
+        const runtime = makeRuntime();
+        const agent = makeAgent("claude");
+        const deps = makeSpawnDeps(runtime, agent);
+
+        await runCrewSpawn(
+          { project: PROJECT, task: "full brief contents", taskFile: "/tmp/task-brief.md" },
+          config,
+          deps,
+        );
+
+        const worktreePath = `${PROJ_PATH}/.worktrees/${PROJECT}-crew-1`;
+        expect(vi.mocked(nodefs.copyFileSync)).toHaveBeenCalledWith(
+          "/tmp/task-brief.md",
+          `${worktreePath}/task-brief.md`,
+        );
+        expect(deps.sendFirstTurn).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.stringContaining("Read ./task-brief.md"),
+          expect.any(String),
+        );
+        // First turn must NOT inline the full file content
+        expect(deps.sendFirstTurn).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.not.stringContaining("full brief contents"),
+          expect.any(String),
+        );
+      });
+
+      it("does NOT copy task file for --shared spawn (preserves current behavior)", async () => {
+        const config = makeConfig();
+        const runtime = makeRuntime();
+        const agent = makeAgent("claude");
+        const deps = makeSpawnDeps(runtime, agent);
+
+        await runCrewSpawn(
+          { project: PROJECT, task: "full brief contents", taskFile: "/tmp/task-brief.md", shared: true },
+          config,
+          deps,
+        );
+
+        expect(vi.mocked(nodefs.copyFileSync)).not.toHaveBeenCalled();
+        // Shared spawn still inlines the task text
+        expect(deps.sendFirstTurn).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.stringContaining("full brief contents"),
+          expect.any(String),
+        );
+      });
+
+      it("does NOT copy when no taskFile is provided (preserves current behavior)", async () => {
+        const config = makeConfig();
+        const runtime = makeRuntime();
+        const agent = makeAgent("claude");
+        const deps = makeSpawnDeps(runtime, agent);
+
+        await runCrewSpawn({ project: PROJECT, task: "direct positional task" }, config, deps);
+
+        expect(vi.mocked(nodefs.copyFileSync)).not.toHaveBeenCalled();
+        expect(deps.sendFirstTurn).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.stringContaining("direct positional task"),
+          expect.any(String),
+        );
+      });
+
+      it("does NOT copy for stdin (taskFile = '-')", async () => {
+        const config = makeConfig();
+        const runtime = makeRuntime();
+        const agent = makeAgent("claude");
+        const deps = makeSpawnDeps(runtime, agent);
+
+        await runCrewSpawn(
+          { project: PROJECT, task: "stdin task content", taskFile: "-" },
+          config,
+          deps,
+        );
+
+        expect(vi.mocked(nodefs.copyFileSync)).not.toHaveBeenCalled();
+        expect(deps.sendFirstTurn).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.stringContaining("stdin task content"),
+          expect.any(String),
+        );
+      });
+    });
   });
 
   describe("opencode branch", () => {
@@ -342,6 +435,34 @@ describe("runCrewSpawn", () => {
         expect.stringContaining("squadrant crew attach task-001"),
       );
       expect(deps.sendCodexFirstTurn).toHaveBeenCalledWith("task-001", "do work");
+    });
+
+    it("sends short Read first-turn to codex when taskFile is set for isolated worktree", async () => {
+      const config = makeConfig();
+      const runtime = makeRuntime();
+      const agent = makeAgent("codex");
+      const deps = makeSpawnDeps(runtime, agent);
+      deps.resolveAgent = vi.fn().mockReturnValue(agent);
+
+      await runCrewSpawn(
+        { project: PROJECT, task: "full brief", taskFile: "/tmp/codex-brief.md", agent: "codex", agentExplicit: true },
+        config,
+        deps,
+      );
+
+      expect(vi.mocked(nodefs.copyFileSync)).toHaveBeenCalledWith(
+        "/tmp/codex-brief.md",
+        expect.stringContaining("codex-brief.md"),
+      );
+      // sendCodexFirstTurn receives the short "Read" message, not the full content
+      expect(deps.sendCodexFirstTurn).toHaveBeenCalledWith(
+        "task-001",
+        expect.stringContaining("Read ./codex-brief.md"),
+      );
+      expect(deps.sendCodexFirstTurn).toHaveBeenCalledWith(
+        "task-001",
+        expect.not.stringContaining("full brief"),
+      );
     });
   });
 

--- a/packages/core/src/__tests__/crew-spawn.test.ts
+++ b/packages/core/src/__tests__/crew-spawn.test.ts
@@ -136,7 +136,7 @@ function makeSpawnDeps(runtime: RuntimeDriver, agent: ResolvedAgent): CrewSpawnD
     dispatchCrew: vi.fn().mockResolvedValue(rec),
     writeSettingsLocal: vi.fn(),
     writeOpencodeConfig: vi.fn().mockReturnValue("/fake/opencode.json"),
-    sendFirstTurn: vi.fn().mockResolvedValue(undefined),
+    sendFirstTurn: vi.fn().mockResolvedValue({ delivered: true }),
     getFreePort: vi.fn().mockResolvedValue(9876),
     sendCodexFirstTurn: vi.fn().mockResolvedValue(undefined),
     onRouted: vi.fn(),
@@ -237,6 +237,61 @@ describe("runCrewSpawn", () => {
         expect.stringContaining("squadrant crew signal done"),
         expect.any(String),
       );
+    });
+
+    // #466: when sendFirstTurn resolves { delivered: false }, runCrewSpawn must NOT
+    // report clean success — the caller gets the pane ref (crew is usable via send)
+    // but the warning is surfaced via stderr so the captain knows to re-send.
+    it("writes stderr warning when sendFirstTurn returns { delivered: false } (#466)", async () => {
+      const config = makeConfig();
+      const runtime = makeRuntime();
+      const agent = makeAgent("claude");
+      const deps = makeSpawnDeps(runtime, agent);
+      deps.sendFirstTurn = vi.fn().mockResolvedValue({ delivered: false });
+
+      const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+      try {
+        await runCrewSpawn({ project: PROJECT, task: "fix the bug" }, config, deps);
+        const stderrOutput = stderrSpy.mock.calls.map((c) => c[0]).join("");
+        expect(stderrOutput).toMatch(/first turn.*not.*delivered|not.*delivered.*first turn/i);
+        expect(stderrOutput).toMatch(/crew send/i);
+      } finally {
+        stderrSpy.mockRestore();
+      }
+    });
+
+    // #466: when sendFirstTurn resolves { delivered: true }, emitEvent is called
+    // with task.first-turn.confirmed so the daemon can stamp firstTurnConfirmedAt.
+    it("emits task.first-turn.confirmed when sendFirstTurn returns { delivered: true } (#466)", async () => {
+      const config = makeConfig();
+      const runtime = makeRuntime();
+      const agent = makeAgent("claude");
+      const deps = makeSpawnDeps(runtime, agent);
+      deps.sendFirstTurn = vi.fn().mockResolvedValue({ delivered: true });
+      const emitEvent = vi.fn().mockResolvedValue(undefined);
+      deps.emitEvent = emitEvent;
+
+      await runCrewSpawn({ project: PROJECT, task: "fix the bug" }, config, deps);
+
+      expect(emitEvent).toHaveBeenCalledWith(
+        PROJECT,
+        expect.objectContaining({ type: "task.first-turn.confirmed", id: "task-001" }),
+      );
+    });
+
+    // #466: when emitEvent is absent (not wired), delivered=true is a no-op —
+    // the spawn still succeeds (backward-compat for callers without the dep).
+    it("succeeds without error when emitEvent is absent and delivered=true (#466)", async () => {
+      const config = makeConfig();
+      const runtime = makeRuntime();
+      const agent = makeAgent("claude");
+      const deps = makeSpawnDeps(runtime, agent);
+      deps.sendFirstTurn = vi.fn().mockResolvedValue({ delivered: true });
+      // emitEvent intentionally not set
+
+      await expect(
+        runCrewSpawn({ project: PROJECT, task: "fix the bug" }, config, deps),
+      ).resolves.toBeDefined();
     });
 
     it("respects permissionMode from config", async () => {

--- a/packages/core/src/__tests__/daemon.test.ts
+++ b/packages/core/src/__tests__/daemon.test.ts
@@ -985,7 +985,170 @@ describe("crewTag (#378)", () => {
   });
 });
 
-// ── Issue #378: purge request kind ──────────────────────────────────────────
+// ── Issue #457: auto-prune terminal records (keep last K per project) ─────────
+
+describe("sweep: terminal record overflow prune (#457)", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "cp-prune-")); });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("keeps the most-recent K terminal records when count exceeds the limit", async () => {
+    const store = createStore(dir);
+    const NOW = 1_000_000_000;
+    // Create 22 terminal records with staggered lastHeartbeat values — all recent
+    // (within minutes of NOW) so the 7-day TTL does NOT eat them; only the
+    // overflow prune should act.
+    for (let i = 0; i < 22; i++) {
+      store.put(rec(`term-${String(i).padStart(2, "0")}`, {
+        state: "done", resultRef: "/r",
+        lastHeartbeat: NOW - 600_000 + i * 1000, // oldest: -600s, newest: -578s
+        heartbeatBudgetMs: 86_400_000,
+        createdAt: NOW - 600_000, // 10 min ago, well within any TTL
+      }));
+    }
+    const d = createDaemon({ store, now: () => NOW, taskTimeoutMs: 999_999_999 });
+    await d.sweep();
+    const remaining = store.list("p").filter((r) => r.state === "done");
+    // Should keep exactly 20 (the default TERMINAL_RECORD_KEEP_PER_PROJECT)
+    expect(remaining.length).toBe(20);
+    // The 2 oldest (term-00 and term-01) should be gone
+    expect(store.get("p", "term-00")).toBeUndefined();
+    expect(store.get("p", "term-01")).toBeUndefined();
+    // The most recent (term-21) should remain
+    expect(store.get("p", "term-21")).toBeDefined();
+  });
+
+  it("does NOT prune when terminal count is at or below the limit", async () => {
+    const store = createStore(dir);
+    const NOW = 1_000_000_000;
+    for (let i = 0; i < 20; i++) {
+      store.put(rec(`term-${i}`, {
+        state: "cancelled", lastHeartbeat: NOW - 600_000 + i * 1000,
+        heartbeatBudgetMs: 86_400_000, createdAt: NOW - 600_000,
+      }));
+    }
+    const d = createDaemon({ store, now: () => NOW, taskTimeoutMs: 999_999_999 });
+    await d.sweep();
+    expect(store.list("p").length).toBe(20);
+  });
+
+  it("never prunes non-terminal records regardless of count", async () => {
+    const store = createStore(dir);
+    const NOW = 1_000_000_000;
+    for (let i = 0; i < 25; i++) {
+      store.put(rec(`live-${i}`, {
+        state: "working", lastHeartbeat: NOW - 600_000 + i * 1000,
+        heartbeatBudgetMs: 86_400_000, createdAt: NOW - 600_000,
+        mode: "headless",
+      }));
+    }
+    const d = createDaemon({ store, now: () => NOW, taskTimeoutMs: 999_999_999 });
+    await d.sweep();
+    expect(store.list("p").length).toBe(25);
+  });
+
+  it("prunes per-project independently — overflow in one project does not affect another", async () => {
+    const store = createStore(dir);
+    const NOW = 1_000_000_000;
+    // proj A: 22 terminal records (2 should be pruned)
+    for (let i = 0; i < 22; i++) {
+      store.put(rec(`a-${i}`, {
+        project: "projA", state: "done", resultRef: "/r",
+        lastHeartbeat: NOW - 600_000 + i * 1000, heartbeatBudgetMs: 86_400_000, createdAt: NOW - 600_000,
+      }));
+    }
+    // proj B: 5 terminal records (none should be pruned)
+    for (let i = 0; i < 5; i++) {
+      store.put(rec(`b-${i}`, {
+        project: "projB", state: "done", resultRef: "/r",
+        lastHeartbeat: NOW - 600_000 + i * 1000, heartbeatBudgetMs: 86_400_000, createdAt: NOW - 600_000,
+      }));
+    }
+    const d = createDaemon({ store, now: () => NOW, taskTimeoutMs: 999_999_999 });
+    await d.sweep();
+    expect(store.list("projA").filter((r) => r.state === "done").length).toBe(20);
+    expect(store.list("projB").filter((r) => r.state === "done").length).toBe(5);
+  });
+});
+
+// ── Issue #457: suppress ghost CREW TIMEOUT when surface is gone ────────────
+
+describe("sweep: ghost CREW TIMEOUT suppression (#457)", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "cp-ghost-")); });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("interactive task with GONE surface: task is cancelled but notify is NOT called (silent)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    store.put(rec("ghost-gone", {
+      mode: "interactive", state: "awaiting-input",
+      createdAt: 0, lastHeartbeat: 1000, heartbeatBudgetMs: 86_400_000,
+    }));
+    const d = createDaemon({
+      store, now: () => 2000, taskTimeoutMs: 1_000,
+      isSurfaceAlive: async () => "gone",
+      notify: async (a) => { calls.push(a); },
+    });
+    await d.sweep();
+    expect(store.get("p", "ghost-gone")?.state).toBe("cancelled");
+    expect(calls.filter((c) => c.message.includes("CREW TIMEOUT"))).toHaveLength(0);
+  });
+
+  it("interactive task with ALIVE surface: task is cancelled AND notify IS called", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    store.put(rec("ghost-alive", {
+      mode: "interactive", state: "working",
+      createdAt: 0, lastHeartbeat: 1000, heartbeatBudgetMs: 86_400_000,
+    }));
+    const d = createDaemon({
+      store, now: () => 2000, taskTimeoutMs: 1_000,
+      isSurfaceAlive: async () => "alive",
+      notify: async (a) => { calls.push(a); },
+    });
+    await d.sweep();
+    expect(store.get("p", "ghost-alive")?.state).toBe("cancelled");
+    expect(calls.filter((c) => c.message.includes("CREW TIMEOUT"))).toHaveLength(1);
+  });
+
+  it("interactive task with UNKNOWN surface liveness: task is cancelled AND notify IS called (conservative)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    store.put(rec("ghost-unknown", {
+      mode: "interactive", state: "working",
+      createdAt: 0, lastHeartbeat: 1000, heartbeatBudgetMs: 86_400_000,
+    }));
+    const d = createDaemon({
+      store, now: () => 2000, taskTimeoutMs: 1_000,
+      isSurfaceAlive: async () => "unknown",
+      notify: async (a) => { calls.push(a); },
+    });
+    await d.sweep();
+    expect(store.get("p", "ghost-unknown")?.state).toBe("cancelled");
+    expect(calls.filter((c) => c.message.includes("CREW TIMEOUT"))).toHaveLength(1);
+  });
+
+  it("HEADLESS task: notify IS called regardless of isSurfaceAlive (headless has no cmux surface)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    store.put(rec("ghost-headless", {
+      mode: "headless", state: "working",
+      createdAt: 0, lastHeartbeat: 1000, heartbeatBudgetMs: 86_400_000,
+    }));
+    // isSurfaceAlive returns "gone" — should be ignored for headless
+    const d = createDaemon({
+      store, now: () => 2000, taskTimeoutMs: 1_000,
+      isSurfaceAlive: async () => "gone",
+      notify: async (a) => { calls.push(a); },
+    });
+    await d.sweep();
+    expect(store.get("p", "ghost-headless")?.state).toBe("cancelled");
+    expect(calls.filter((c) => c.message.includes("CREW TIMEOUT"))).toHaveLength(1);
+  });
+});
+
+// ── Issue #457: purge request kind ──────────────────────────────────────────
 describe("purge (#378)", () => {
   let dir: string;
   beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "cp-purge-")); });

--- a/packages/core/src/__tests__/daemon.test.ts
+++ b/packages/core/src/__tests__/daemon.test.ts
@@ -119,17 +119,78 @@ describe("daemon handler", () => {
   // #354: a quiet INTERACTIVE crew with no tool in flight is alive-thinking, NOT
   // awaiting-input — the watchdog no longer flips it. It stays `working` and the
   // sweep emits a distinct, non-alarming CREW QUIET notify (once per episode).
+  // #466: firstTurnConfirmedAt must be SET to take the "deep thinking" path;
+  // unset means the first turn may not have landed → CREW UNDELIVERED instead.
   it("sweep: over-budget INTERACTIVE task with no tool in flight stays working + CREW QUIET (#354)", async () => {
     const store = createStore(dir);
     const calls: any[] = [];
     store.put(rec("s1i", { mode: "interactive", state: "working", lastHeartbeat: 0,
-      heartbeatBudgetMs: 100, attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 0 }] }));
+      heartbeatBudgetMs: 100, firstTurnConfirmedAt: 1,  // confirmed → "deep thinking" path
+      attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 0 }] }));
     const d = createDaemon({ store, now: () => 1000, notify: async (a) => { calls.push(a); } });
     await d.sweep();
     expect(store.get("p", "s1i")?.state).toBe("working");
     expect(calls.length).toBe(1);
     expect(calls[0].message).toMatch(/CREW QUIET/);
     expect(calls[0].event.type).toBe("task.quiet");
+  });
+
+  // #466: an interactive crew that is quiet past its budget but has NEVER had
+  // firstTurnConfirmedAt set must emit CREW UNDELIVERED — not "deep thinking".
+  // This catches the race where spawn sends the first turn into a not-yet-ready
+  // box and the crew sits idle at an empty prompt (0% ctx, $0.00).
+  it("sweep: interactive quiet task with NO firstTurnConfirmedAt → CREW UNDELIVERED (#466)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    // firstTurnConfirmedAt intentionally absent — first turn may not have landed
+    store.put(rec("u1", { mode: "interactive", state: "working", lastHeartbeat: 0,
+      heartbeatBudgetMs: 100, attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 0 }] }));
+    const d = createDaemon({ store, now: () => 1000, notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    expect(store.get("p", "u1")?.state).toBe("working"); // state unchanged
+    expect(calls.length).toBe(1);
+    expect(calls[0].message).toMatch(/CREW UNDELIVERED/);
+    expect(calls[0].message).toMatch(/re-send/i);
+    expect(calls[0].event.type).toBe("task.quiet"); // reuses task.quiet as notify vehicle
+  });
+
+  // #466: same crew but WITH firstTurnConfirmedAt set → normal "deep thinking" path.
+  it("sweep: interactive quiet task WITH firstTurnConfirmedAt → CREW QUIET, not UNDELIVERED (#466)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    store.put(rec("u2", { mode: "interactive", state: "working", lastHeartbeat: 0,
+      firstTurnConfirmedAt: 50,  // first turn landed
+      heartbeatBudgetMs: 100, attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 0 }] }));
+    const d = createDaemon({ store, now: () => 1000, notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    expect(store.get("p", "u2")?.state).toBe("working");
+    expect(calls.length).toBe(1);
+    expect(calls[0].message).toMatch(/CREW QUIET/);
+    expect(calls[0].message).not.toMatch(/UNDELIVERED/);
+  });
+
+  // #466: task within heartbeat budget — no UNDELIVERED (not yet timed out).
+  it("sweep: interactive task within budget with NO firstTurnConfirmedAt → no notification (#466)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    store.put(rec("u3", { mode: "interactive", state: "working", lastHeartbeat: 950,
+      heartbeatBudgetMs: 100, attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 950 }] }));
+    const d = createDaemon({ store, now: () => 1000, notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    expect(calls.length).toBe(0); // within budget → silent
+  });
+
+  // #466: task.first-turn.confirmed event stamps firstTurnConfirmedAt on the record.
+  it("task.first-turn.confirmed stamps firstTurnConfirmedAt on the record (#466)", async () => {
+    const store = createStore(dir);
+    store.put(rec("fc1", { state: "working" }));
+    const d = createDaemon({ store, now: () => 500 });
+    const updated = await d.handle({
+      kind: "event", project: "p",
+      event: { type: "task.first-turn.confirmed", id: "fc1" },
+    }) as import("@squadrant/shared").TaskRecord;
+    expect(updated.firstTurnConfirmedAt).toBe(500);
+    expect(store.get("p", "fc1")?.firstTurnConfirmedAt).toBe(500);
   });
 
   // #354: an interactive crew with a tool in flight (PreToolUse, no PostToolUse)

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -454,7 +454,7 @@ export async function runCrewSend(
     // runtime.sendToPane so the caller can inject paste-settle-Enter hardening.
     // Falls back to runtime.sendToPane when absent (preserves existing behaviour
     // for callers that don't inject it, e.g. unit tests).
-    sendToPane?: (pane: PaneRef, message: string) => Promise<void>;
+    sendToPane?: (pane: PaneRef, message: string) => Promise<{ delivered: boolean }>;
   },
 ): Promise<void> {
   const crew = await findCrewPane(runtime, workspaceId, project, name);
@@ -479,8 +479,11 @@ export async function runCrewSend(
     // Swallow daemon errors so crews without a daemon or offline daemon
     // still receive the sent message.
   }
-  const deliver = deps.sendToPane ?? ((pane, msg) => runtime.sendToPane(pane, msg));
-  await deliver(crew, message);
+  const deliver = deps.sendToPane ?? ((pane, msg) => runtime.sendToPane(pane, msg).then(() => ({ delivered: true })));
+  const { delivered } = await deliver(crew, message);
+  if (!delivered) {
+    process.stderr.write(`⚠️  Message not delivered to crew '${name}' — use 'squadrant crew send ${project} ${name}' to re-send.\n`);
+  }
 }
 
 export async function runCrewRead(

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -82,6 +82,11 @@ export interface CrewSpawnInput {
   model?: string;
   /** True when --agent was explicitly passed by the caller; suppresses crew routing. */
   agentExplicit?: boolean;
+  /** Path to the task file when --task-file was used (not '-' for stdin). Set by
+   *  the CLI so runCrewSpawn can copy the file into the isolated worktree root,
+   *  enabling the crew to `Read ./<basename>` without hunting the main checkout (#458).
+   *  Ignored for --shared spawns and when absent. */
+  taskFile?: string;
 }
 
 // ─── CrewSpawnDeps ───────────────────────────────────────────────────────────
@@ -146,6 +151,10 @@ async function findCrewPane(
 async function runCodexInteractiveSpawn(o: {
   project: string;
   task: string;
+  /** Override for first-turn delivery to the model. When set (e.g. "Read ./file.md
+   *  to get your task brief"), used instead of `task` for sendCodexFirstTurn so large
+   *  file contents aren't sent verbatim. The daemon dispatch always uses `task`. */
+  firstTurn?: string;
   cwd: string;
   runtime: RuntimeDriver;
   workspaceId: string;
@@ -177,8 +186,9 @@ async function runCodexInteractiveSpawn(o: {
   // dispatch only opens the thread; the task text never reaches the model
   // unless we send it. Fire-and-forget: the renderer in the tab picks up
   // streamed deltas once it attaches.
-  if (o.task && o.task !== "(interactive)") {
-    void o.sendCodexFirstTurn(rec.id, o.task).catch((e: unknown) => {
+  const firstTurnText = o.firstTurn ?? o.task;
+  if (firstTurnText && firstTurnText !== "(interactive)") {
+    void o.sendCodexFirstTurn(rec.id, firstTurnText).catch((e: unknown) => {
       process.stderr.write(`(first-turn delivery failed: ${(e as Error).message})\n`);
     });
   }
@@ -229,6 +239,20 @@ export async function runCrewSpawn(
       })
     : proj.path;
 
+  // #458: For isolated-worktree spawns with a task file, copy the file into the
+  // worktree root so the crew can find it via `Read ./<basename>` without having
+  // to discover the main checkout path. Use a short first-turn message referencing
+  // the local path to avoid large-paste issues on big task files.
+  // Guards: skip for --shared (file is in the main checkout, already reachable),
+  // skip for stdin ('-') since there is no file to copy.
+  let firstTurnTask = input.task;
+  if (input.taskFile && input.taskFile !== "-" && !input.shared) {
+    const absTaskFile = path.resolve(input.taskFile);
+    const basename = path.basename(absTaskFile);
+    fs.copyFileSync(absTaskFile, path.join(spawnCwd, basename));
+    firstTurnTask = `Read ./${basename} to get your task brief, then execute it.`;
+  }
+
   // #275 leveled crew routing: consult routing rules when agent/model were not
   // explicitly provided by the caller. Explicit --agent or --model always win.
   const route = !input.agentExplicit && !input.model
@@ -256,6 +280,7 @@ export async function runCrewSpawn(
     return runCodexInteractiveSpawn({
       project: input.project,
       task: input.task,
+      firstTurn: firstTurnTask !== input.task ? firstTurnTask : undefined,
       cwd: spawnCwd,
       runtime: deps.runtime,
       workspaceId: captain.id,
@@ -318,7 +343,7 @@ export async function runCrewSpawn(
     const envPrefix = `SQUADRANT_CREW_TASK_ID=${rec.id} SQUADRANT_CREW_PROJECT=${input.project}`;
     await deps.runtime.sendToPane(pane, `cd ${shellQuote(spawnCwd)} && ${envPrefix} ${cliCommand}`);
     const preLaunchScreen = (await deps.runtime.readPaneScreen(pane)) ?? "";
-    await deps.sendFirstTurn(pane, `${input.task}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen);
+    await deps.sendFirstTurn(pane, `${firstTurnTask}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen);
     return { ...pane, title };
   }
 
@@ -364,7 +389,7 @@ export async function runCrewSpawn(
     const envPrefix = `SQUADRANT_CREW_TASK_ID=${rec.id} SQUADRANT_CREW_PROJECT=${input.project}`;
     await deps.runtime.sendToPane(pane, `cd ${shellQuote(spawnCwd)} && ${envPrefix} OPENCODE_CONFIG=${opencodeConfigPath} ${cliCommand}`);
     const preLaunchScreen = (await deps.runtime.readPaneScreen(pane)) ?? "";
-    await deps.sendFirstTurn(pane, `${input.task}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen, {
+    await deps.sendFirstTurn(pane, `${firstTurnTask}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen, {
       // #235: confirm-on-delivery — sendFirstTurnWhenReady polls until "Ask
       // anything…" leaves the screen, re-sending every ~3s to cover slow boots
       // without duplicating the task. See crew-pane.ts SPLASH_MAX_CHECKS/EVERY_N.
@@ -388,7 +413,7 @@ export async function runCrewSpawn(
   await deps.runtime.sendToPane(pane, cliCommand);
   if (interactive) {
     const preLaunchScreen = (await deps.runtime.readPaneScreen(pane)) ?? "";
-    await deps.sendFirstTurn(pane, input.task, preLaunchScreen);
+    await deps.sendFirstTurn(pane, firstTurnTask, preLaunchScreen);
   }
   return { ...pane, title };
 }

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -118,14 +118,19 @@ export interface CrewSpawnDeps {
   writeSettingsLocal(projectCwd: string): void;
   /** CLI-edge: write opencode permission config for an interactive crew. */
   writeOpencodeConfig(opts: { stateRoot: string; project: string; taskId: string; gateBash?: boolean }): string;
-  /** CLI-edge: deliver the first turn once the agent pane is ready. */
-  sendFirstTurn(pane: PaneRef, firstTurn: string, preLaunchScreen: string, opts?: TurnAcceptanceConfig): Promise<void>;
+  /** CLI-edge: deliver the first turn once the agent pane is ready. Returns
+   *  { delivered: true } when positively confirmed, { delivered: false } when
+   *  all retry paths exhausted without confirmation (#466). */
+  sendFirstTurn(pane: PaneRef, firstTurn: string, preLaunchScreen: string, opts?: TurnAcceptanceConfig): Promise<{ delivered: boolean }>;
   /** CLI-edge: reserve an ephemeral TCP port for opencode's embedded HTTP server. */
   getFreePort(): Promise<number>;
   /** CLI-edge: deliver the task to a freshly-dispatched codex thread. */
   sendCodexFirstTurn(taskId: string, task: string): Promise<void>;
   /** Optional: called after routing to log the selected route (e.g. chalk.dim(...)). */
   onRouted?(route: CrewRouteResult): void;
+  /** #466: optional — when provided, called with task.first-turn.confirmed after
+   *  positively confirmed delivery so the daemon can stamp firstTurnConfirmedAt. */
+  emitEvent?(project: string, event: ControlEvent): Promise<void>;
 }
 
 // ─── Private helpers ──────────────────────────────────────────────────────────
@@ -343,7 +348,13 @@ export async function runCrewSpawn(
     const envPrefix = `SQUADRANT_CREW_TASK_ID=${rec.id} SQUADRANT_CREW_PROJECT=${input.project}`;
     await deps.runtime.sendToPane(pane, `cd ${shellQuote(spawnCwd)} && ${envPrefix} ${cliCommand}`);
     const preLaunchScreen = (await deps.runtime.readPaneScreen(pane)) ?? "";
-    await deps.sendFirstTurn(pane, `${firstTurnTask}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen);
+    const claudeResult = await deps.sendFirstTurn(pane, `${firstTurnTask}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen);
+    // #466: surface non-delivery explicitly instead of silently returning success.
+    if (!claudeResult.delivered) {
+      process.stderr.write(`⚠️  First turn not delivered for crew '${name}' — use 'squadrant crew send ${input.project} ${name}' to re-send the task.\n`);
+    } else {
+      await deps.emitEvent?.(input.project, { type: "task.first-turn.confirmed", id: rec.id });
+    }
     return { ...pane, title };
   }
 
@@ -389,12 +400,18 @@ export async function runCrewSpawn(
     const envPrefix = `SQUADRANT_CREW_TASK_ID=${rec.id} SQUADRANT_CREW_PROJECT=${input.project}`;
     await deps.runtime.sendToPane(pane, `cd ${shellQuote(spawnCwd)} && ${envPrefix} OPENCODE_CONFIG=${opencodeConfigPath} ${cliCommand}`);
     const preLaunchScreen = (await deps.runtime.readPaneScreen(pane)) ?? "";
-    await deps.sendFirstTurn(pane, `${firstTurnTask}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen, {
+    const opencodeResult = await deps.sendFirstTurn(pane, `${firstTurnTask}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen, {
       // #235: confirm-on-delivery — sendFirstTurnWhenReady polls until "Ask
       // anything…" leaves the screen, re-sending every ~3s to cover slow boots
       // without duplicating the task. See crew-pane.ts SPLASH_MAX_CHECKS/EVERY_N.
       splashMarker: "Ask anything…",
     } satisfies TurnAcceptanceConfig);
+    // #466: surface non-delivery; emit confirmed event on success.
+    if (!opencodeResult.delivered) {
+      process.stderr.write(`⚠️  First turn not delivered for crew '${name}' — use 'squadrant crew send ${input.project} ${name}' to re-send the task.\n`);
+    } else {
+      await deps.emitEvent?.(input.project, { type: "task.first-turn.confirmed", id: rec.id });
+    }
     return { ...pane, title };
   }
 
@@ -413,7 +430,11 @@ export async function runCrewSpawn(
   await deps.runtime.sendToPane(pane, cliCommand);
   if (interactive) {
     const preLaunchScreen = (await deps.runtime.readPaneScreen(pane)) ?? "";
-    await deps.sendFirstTurn(pane, firstTurnTask, preLaunchScreen);
+    const genericResult = await deps.sendFirstTurn(pane, firstTurnTask, preLaunchScreen);
+    // Generic branch has no daemon task record — only warn on non-delivery.
+    if (!genericResult.delivered) {
+      process.stderr.write(`⚠️  First turn not delivered for crew '${name}' — use 'squadrant crew send ${input.project} ${name}' to re-send the task.\n`);
+    }
   }
   return { ...pane, title };
 }

--- a/packages/core/src/daemon/reduce.ts
+++ b/packages/core/src/daemon/reduce.ts
@@ -73,6 +73,10 @@ export const DEFAULT_TASK_TIMEOUT_MS = 8 * 60 * 60 * 1000;
 // than this are pruned from the store during sweep().
 export const TERMINAL_RECORD_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
+// #457: Max terminal records to keep per project. Bounds accumulation for
+// short-lived test sessions where many tasks finish before the 7-day TTL.
+export const TERMINAL_RECORD_KEEP_PER_PROJECT = 20;
+
 // 'awaiting-input' is an attention state: entering it (idle watchdog OR a
 // Stop-hook turn boundary) fires exactly one accurate CREW IDLE push. The
 // firePush prev===next guard keeps it from re-firing while the task sits idle.
@@ -370,6 +374,20 @@ export function createDaemon(deps: DaemonDeps) {
     async sweep(): Promise<void> {
       const t = now();
       const surfaceAlive = deps.isSurfaceAlive ?? (async () => "unknown" as const);
+
+      // #457: Per-project overflow prune — keep only the most-recent K terminal
+      // records. Bounds accumulation for short-lived sessions where many tasks
+      // finish before the 7-day TTL expires.
+      const projects = new Set(store.listAll().map((r) => r.project));
+      for (const project of projects) {
+        const terminal = store.list(project)
+          .filter((r) => TERMINAL_STATES.has(r.state))
+          .sort((a, b) => b.lastHeartbeat - a.lastHeartbeat);
+        for (const r of terminal.slice(TERMINAL_RECORD_KEEP_PER_PROJECT)) {
+          store.delete(r.project, r.id);
+        }
+      }
+
       for (const r of store.listAll()) {
         // #378: GC terminal records whose last heartbeat is older than the TTL.
         if (TERMINAL_STATES.has(r.state) && t - r.lastHeartbeat > TERMINAL_RECORD_TTL_MS) {
@@ -391,7 +409,16 @@ export function createDaemon(deps: DaemonDeps) {
             // Terminalize first — persisted to store so any future daemon instance
             // sees a terminal record and skips it (flood-proof across restarts).
             store.put({ ...r, state: "cancelled", lastEvent: "sweep.task-timeout" });
-            if (deps.notify) {
+            // #457: suppress ghost CREW TIMEOUT for interactive tasks whose surface
+            // is provably gone — they were already abandoned; terminalize silently.
+            // Headless tasks have no cmux surface so always notify.
+            // "unknown" (cmux down / transient) → notify conservatively.
+            let shouldNotify = true;
+            if (r.mode === "interactive") {
+              const liveness = await surfaceAlive(r);
+              if (liveness === "gone") shouldNotify = false;
+            }
+            if (deps.notify && shouldNotify) {
               try {
                 const p = deps.notify({ project: r.project, message: msg, record: r, event: synthEvent });
                 if (p && typeof (p as Promise<void>).catch === "function") {

--- a/packages/core/src/daemon/reduce.ts
+++ b/packages/core/src/daemon/reduce.ts
@@ -240,6 +240,7 @@ const KNOWN_EVENT_TYPES: ReadonlySet<string> = new Set([
   "task.reattached", "task.reopened",
   "task.stalled", "task.idle", "task.quiet", "task.timeout", "task.reconcile-failed",
   "task.cancelled", "task.session.ended",
+  "task.first-turn.confirmed",  // #466: delivery confirmation
 ]);
 
 export function createDaemon(deps: DaemonDeps) {
@@ -467,6 +468,8 @@ export function createDaemon(deps: DaemonDeps) {
         // during pure model thinking). Surface a distinct, non-alarming nudge —
         // NOT 'awaiting-input' (the turn never ended; real CREW IDLE comes only
         // from the Stop hook). State stays `working`; notify once per episode.
+        // #466: if firstTurnConfirmedAt is unset the crew may never have received
+        // its first task — emit CREW UNDELIVERED instead of "deep thinking".
         if (r.mode === "interactive" && r.state === "working" && !r.pendingTool) {
           const liveness = r.attempts.at(-1)?.lastHeartbeatAt ?? r.lastHeartbeat;
           const quiet = t - liveness;
@@ -474,9 +477,16 @@ export function createDaemon(deps: DaemonDeps) {
             if (deps.notify && quietNotifiedAt.get(r.id) !== liveness) {
               quietNotifiedAt.set(r.id, liveness);
               const tag = crewTag(r);
-              const mins = Math.max(1, Math.round(quiet / 60000));
-              const message = `CREW QUIET ${tag}: working ~${mins}min with no tool activity — likely deep thinking (no reply expected yet).`;
               const synthEvent: ControlEvent = { type: "task.quiet", id: r.id, quietMs: quiet };
+              let message: string;
+              if (!r.firstTurnConfirmedAt) {
+                // #466: no confirmed delivery → crew may be sitting at an empty
+                // prompt. Alert distinctly so the captain can re-send the task.
+                message = `⚠️ CREW UNDELIVERED ${tag}: first turn may not have landed (0 activity) — re-send the task or check the spawn.`;
+              } else {
+                const mins = Math.max(1, Math.round(quiet / 60000));
+                message = `CREW QUIET ${tag}: working ~${mins}min with no tool activity — likely deep thinking (no reply expected yet).`;
+              }
               try {
                 const p = deps.notify({ project: r.project, message, record: r, event: synthEvent });
                 if (p && typeof (p as Promise<void>).catch === "function") (p as Promise<void>).catch(() => {});

--- a/packages/core/src/side-session.ts
+++ b/packages/core/src/side-session.ts
@@ -93,7 +93,7 @@ export interface SideSpawnDeps {
    */
   agentCmdFactory: (spawnCwd: string) => string;
   /** CLI-edge: deliver the first turn when the agent pane is ready. */
-  sendFirstTurn: (pane: PaneRef, firstTurn: string, preLaunchScreen: string) => Promise<void>;
+  sendFirstTurn: (pane: PaneRef, firstTurn: string, preLaunchScreen: string) => Promise<{ delivered: boolean }>;
 }
 
 export async function runSideSpawn(

--- a/packages/core/src/state-machine.ts
+++ b/packages/core/src/state-machine.ts
@@ -127,6 +127,11 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
       return { ...stampAttempt(base, {}, now), state: "blocked", question: ev.question, pendingTool: undefined };
     case "task.reattached":
       return stampAttempt(base, {}, now);
+    case "task.first-turn.confirmed":
+      // #466: stamp the confirmed delivery timestamp. No state change — the crew
+      // stays `working`. The watchdog reads this field to distinguish a quiet-
+      // thinking crew from one that never received its first turn.
+      return { ...rec, firstTurnConfirmedAt: now, lastEvent: ev.type };
     case "task.stalled":
     case "task.idle":
     case "task.quiet":

--- a/packages/shared/src/types/control.ts
+++ b/packages/shared/src/types/control.ts
@@ -85,6 +85,12 @@ export interface TaskRecord {
    *  (no pendingTool → CREW QUIET). Auto-clears: the next PostToolUse recovers
    *  the record to `working` (state-machine + recoverStall). */
   pendingTool?: { name: string; since: number };
+  /** #466: epoch ms when the spawn path positively confirmed the first turn was
+   *  delivered (paste rendered in the box → box emptied = submitted). Unset means
+   *  either the crew was spawned before this field existed, OR delivery was never
+   *  confirmed. The watchdog uses this to emit CREW UNDELIVERED instead of the
+   *  misleading "deep thinking" message for a crew that never received its task. */
+  firstTurnConfirmedAt?: number;
 }
 
 export type ControlEvent =
@@ -131,6 +137,10 @@ export type ControlEvent =
   // task to the absorbing 'cancelled' state. Silent: captain initiated the close
   // so no CREW CANCELLED push is fired (not in ATTENTION_STATES).
   | { type: "task.cancelled"; id: string; reason?: string }
+  // #466: emitted by runCrewSpawn after positively confirming the first turn was
+  // delivered. Stamps firstTurnConfirmedAt on the record so the watchdog can
+  // distinguish a quiet-thinking crew from one that never received its task.
+  | { type: "task.first-turn.confirmed"; id: string }
   // #139: a claude crew's SessionEnd hook fired — the session is GONE. Unlike
   // the other turn-boundary hooks (PostToolUse/SubagentStop = liveness), a dead
   // session must NOT resume 'working' (nothing heartbeats → false CREW STALLED

--- a/packages/workspaces/src/__tests__/crew-pane.test.ts
+++ b/packages/workspaces/src/__tests__/crew-pane.test.ts
@@ -334,19 +334,211 @@ describe("sendFirstTurnWhenReady — large paste race (#455)", () => {
     expect(sendToPane).not.toHaveBeenCalled();
   });
 
-  // When the paste NEVER renders (e.g. paste-buffer loss), the function must re-paste
-  // once rather than silently declaring success on a never-populated box.
-  it("re-pastes once when paste never renders (never-populated box)", async () => {
+  // When the paste NEVER renders (e.g. paste-buffer loss), the function re-pastes
+  // once in the first path, then falls back to confirmedSendToPane which also
+  // re-pastes once — total 4 paste calls when the box never populates (#466).
+  it("re-pastes in first path then falls back to confirmedSendToPane when paste never renders (#455/#466)", async () => {
     readPaneScreen.mockResolvedValue(EMPTY_BOX);
 
     const promise = sendFirstTurnWhenReady(rt(), pane, "very large task", "$ launch");
+    await vi.advanceTimersByTimeAsync(18000); // first path (~7s) + confirmedSendToPane fallback (~5s)
+    await promise;
+
+    // First path: 1 initial paste + 1 repaste when sawDraft stays false.
+    // confirmedSendToPane fallback: 1 initial paste + 1 repaste = 4 total.
+    expect(pasteToPane.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(pasteToPane).toHaveBeenCalledWith(pane, "very large task");
+    expect(sendToPane).not.toHaveBeenCalled();
+  });
+});
+
+// ─── #466: boot-gate requires parseable input box ─────────────────────────────
+
+describe("sendFirstTurnWhenReady — boot gate requires parseable box (#466)", () => {
+  let readPaneScreen: ReturnType<typeof vi.fn>;
+  let sendToPane: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
+  const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, sendToPane, pasteToPane, sendKeyToPane });
+
+  // A stable screen with NO HR-bounded box — e.g. the claude-mem boot banner.
+  const BANNER_ONLY = "=== claude-mem: loading memories ===\n(0 memories loaded)";
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    readPaneScreen = vi.fn();
+    sendToPane = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
+  });
+  afterEach(() => { vi.useRealTimers(); });
+
+  // Core regression fix: the boot gate must NOT declare ready when the screen is
+  // stable but has no HR-bounded input box. Under load the claude-mem banner
+  // stabilises before the CC input box renders, causing paste into the wrong spot.
+  // After the box appears the paste renders immediately and confirms delivery.
+  it("does not paste while screen is stable but has no parseable input box", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n <= 4) return BANNER_ONLY;   // banner stable, no box — must NOT trigger paste
+      if (n <= 6) return EMPTY_BOX;     // CC box appeared, stabilises → triggers readiness
+      if (n <= 8) return DRAFT_BOX;     // paste renders in box during settle
+      return EMPTY_BOX;                 // box empties after Enter → submitted
+    });
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "task text", "$ launch");
     await vi.advanceTimersByTimeAsync(10000);
     await promise;
 
-    // Re-pasted exactly once after the initial paste failed to render.
-    expect(pasteToPane).toHaveBeenCalledTimes(2);
-    expect(pasteToPane).toHaveBeenCalledWith(pane, "very large task");
-    expect(sendToPane).not.toHaveBeenCalled();
+    // Paste must only happen AFTER the input box appeared — never during banner.
+    // Exactly one paste: the box was ready when we pasted, draft rendered, submitted.
+    expect(pasteToPane).toHaveBeenCalledTimes(1);
+    expect(pasteToPane).toHaveBeenCalledWith(pane, "task text");
+  });
+
+  // When the box appears, delivery succeeds normally.
+  it("returns { delivered: true } once the box appears and submission is confirmed", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n <= 3) return BANNER_ONLY;   // banner stable, no box yet
+      if (n <= 5) return EMPTY_BOX;     // box appeared + stability poll
+      if (n <= 7) return DRAFT_BOX;     // paste settled in box
+      return EMPTY_BOX;                 // box emptied after Enter → submitted
+    });
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "task text", "$ launch");
+    await vi.advanceTimersByTimeAsync(10000);
+    const result = await promise;
+
+    expect(result).toEqual({ delivered: true });
+    expect(pasteToPane).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── #466: delivery status + self-heal fallback ───────────────────────────────
+
+describe("sendFirstTurnWhenReady — delivery status and self-heal (#466)", () => {
+  let readPaneScreen: ReturnType<typeof vi.fn>;
+  let sendToPane: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
+  const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, sendToPane, pasteToPane, sendKeyToPane });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    readPaneScreen = vi.fn();
+    sendToPane = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
+  });
+  afterEach(() => { vi.useRealTimers(); });
+
+  // Happy path: normal delivery returns { delivered: true }.
+  it("returns { delivered: true } on normal paste-then-submit delivery", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n <= 3) return EMPTY_BOX;  // readiness + preSend
+      if (n <= 5) return DRAFT_BOX;  // settle: paste rendered
+      return EMPTY_BOX;              // post-Enter: submitted
+    });
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "do the thing", "$ launch");
+    await vi.advanceTimersByTimeAsync(6000);
+    const result = await promise;
+
+    expect(result).toEqual({ delivered: true });
+  });
+
+  // Self-heal: paste path exhausts (sawDraft=false → box never populated), but the
+  // confirmedSendToPane fallback succeeds. The outcome is { delivered: true }.
+  // This is the key #466 scenario: paste went into a not-yet-ready box (no HR),
+  // but by fallback time the box has settled and accepts the task.
+  it("returns { delivered: true } when fallback confirmedSendToPane succeeds (#466 self-heal)", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      // Boot: stable box from the start
+      if (n <= 2) return EMPTY_BOX;
+      // preSend + first paste attempt: paste never renders (race — box not ready)
+      if (n <= 10) return EMPTY_BOX;
+      // Fallback (confirmedSendToPane): box now ready, paste renders, then empties
+      if (n <= 12) return DRAFT_BOX;  // fallback settle: paste rendered
+      return EMPTY_BOX;               // fallback confirm: submitted
+    });
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "do the thing", "$ launch");
+    await vi.advanceTimersByTimeAsync(18000);
+    const result = await promise;
+
+    expect(result).toEqual({ delivered: true });
+    // At least 2 pastes: one in the first path (which failed), one in the fallback
+    expect(pasteToPane.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // Hard drop: paste path exhausts with sawDraft=false, AND the fallback also
+  // fails (box never populates). Returns { delivered: false }.
+  it("returns { delivered: false } when both paste path and fallback fail (#466 hard drop)", async () => {
+    readPaneScreen.mockResolvedValue(EMPTY_BOX);
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "do the thing", "$ launch");
+    await vi.advanceTimersByTimeAsync(18000);
+    const result = await promise;
+
+    expect(result).toEqual({ delivered: false });
+  });
+});
+
+// ─── #466: confirmedSendToPane delivery status ────────────────────────────────
+
+describe("confirmedSendToPane — delivery status (#466)", () => {
+  let readPaneScreen: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
+  const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, pasteToPane, sendKeyToPane });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    readPaneScreen = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
+  });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it("returns { delivered: true } when box empties after draft seen", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n === 1) return box("");     // preSendScreen
+      if (n <= 3) return DRAFT_BOX;   // settle: paste rendered
+      return EMPTY_BOX;               // post-Enter: submitted
+    });
+
+    const promise = confirmedSendToPane(rt(), pane, "message");
+    await vi.advanceTimersByTimeAsync(3000);
+    const result = await promise;
+
+    expect(result).toEqual({ delivered: true });
+  });
+
+  it("returns { delivered: false } when retry exhausts without confirmation", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n === 1) return box("");   // preSendScreen
+      return EMPTY_BOX;              // paste never renders, box stays empty
+    });
+
+    const promise = confirmedSendToPane(rt(), pane, "message");
+    await vi.advanceTimersByTimeAsync(8000);
+    const result = await promise;
+
+    expect(result).toEqual({ delivered: false });
   });
 });
 

--- a/packages/workspaces/src/crew-pane.ts
+++ b/packages/workspaces/src/crew-pane.ts
@@ -117,12 +117,16 @@ export async function resolveCaptainWorkspace(project: string): Promise<{
  *   2. settle until the input box content stops changing (accumulation closed)
  *   3. separate Enter keystroke
  *   4. confirm box empty; re-issue ONLY Enter if stranded (never re-paste)
+ *
+ * Returns `{ delivered: true }` when the box empties after the draft was seen
+ * (positive submit confirmation), or `{ delivered: false }` if the retry loop
+ * exhausts without confirmation (#466: callers surface non-delivery explicitly).
  */
 export async function confirmedSendToPane(
   runtime: Pick<RuntimeDriver, "readPaneScreen" | "pasteToPane" | "sendKeyToPane">,
   pane: PaneRef,
   message: string,
-): Promise<void> {
+): Promise<{ delivered: boolean }> {
   const preSendScreen = (await runtime.readPaneScreen(pane)) ?? "";
   await runtime.pasteToPane(pane, message);
   // #455: track whether the paste ever rendered so we don't treat an empty box
@@ -138,8 +142,8 @@ export async function confirmedSendToPane(
     const draft = parseDraftFromScreen(afterScreen);
     if (draft !== "" && draft !== null) sawDraft = true;
     // Box confirmed empty AND we observed the paste rendered first → submitted.
-    if (draft === "" && sawDraft) return;
-    if (draft === null && afterScreen !== preSendScreen) return;
+    if (draft === "" && sawDraft) return { delivered: true };
+    if (draft === null && afterScreen !== preSendScreen) return { delivered: true };
     const settled = await settleInputBox(runtime, pane);
     if (settled) sawDraft = true;
     // #455: paste never rendered — re-paste once rather than issuing Enter into emptiness.
@@ -149,6 +153,7 @@ export async function confirmedSendToPane(
     }
     await runtime.sendKeyToPane(pane, "Enter");
   }
+  return { delivered: false };
 }
 
 export async function sendFirstTurnWhenReady(
@@ -157,7 +162,7 @@ export async function sendFirstTurnWhenReady(
   task: string,
   preLaunchScreen: string,
   acceptanceConfig?: TurnAcceptanceConfig,
-): Promise<void> {
+): Promise<{ delivered: boolean }> {
   await new Promise((r) => setTimeout(r, SEND_FIRST_TURN_FLOOR_MS));
 
   const maxPolls = Math.floor(
@@ -169,12 +174,14 @@ export async function sendFirstTurnWhenReady(
   for (let i = 0; i < maxPolls && !stable; i++) {
     const screen = (await runtime.readPaneScreen(pane)) ?? "";
     // Ready = the agent prompt is actually up: screen is non-empty, settled
-    // (unchanged between two consecutive reads), AND has advanced past the
-    // un-entered launch command line. The last condition prevents sending the
-    // task onto the shell line before the TUI takes over — which concatenates
-    // onto the launch command and triggers a shell parse error (opencode
-    // boot-race). A momentarily static launch line is not readiness.
-    if (screen.length > 0 && screen === previousScreen && screen !== preLaunchScreen) {
+    // (unchanged between two consecutive reads), has advanced past the un-entered
+    // launch command line, AND (for the claude/codex path) the HR-bounded input
+    // box is actually rendered. The last check prevents pasting into the claude-mem
+    // boot banner which can stabilise BEFORE the CC input box appears under load
+    // (#466 root cause). For the opencode splash path, parseDraftFromScreen would
+    // return null (no HR box), so we skip that check to preserve existing behaviour.
+    const hasInputBox = !!acceptanceConfig?.splashMarker || parseDraftFromScreen(screen) !== null;
+    if (screen.length > 0 && screen === previousScreen && screen !== preLaunchScreen && hasInputBox) {
       stable = true;
     } else {
       previousScreen = screen;
@@ -203,13 +210,20 @@ export async function sendFirstTurnWhenReady(
       await new Promise((r) => setTimeout(r, POST_SEND_CHECK_MS));
       const afterScreen = (await runtime.readPaneScreen(pane)) ?? "";
       if (isTurnAccepted(preSendScreen, afterScreen, acceptanceConfig)) {
-        return;
+        return { delivered: true };
       }
       if ((check + 1) % SPLASH_RESEND_EVERY_N === 0 && check < SPLASH_MAX_CHECKS - 1) {
         await runtime.sendToPane(pane, task);
       }
     }
-    return;
+    return { delivered: false };
+  }
+
+  // #466: if the box never appeared in the boot window, skip the paste path and
+  // go directly to the settled-box fallback (confirmedSendToPane). By the time we
+  // get here, more time has passed and the box is likely ready.
+  if (!stable) {
+    return confirmedSendToPane(runtime, pane, task);
   }
 
   // Claude/codex path (#339): paste the task, let the [Pasted text] placeholder
@@ -235,11 +249,11 @@ export async function sendFirstTurnWhenReady(
     const draft = parseDraftFromScreen(afterScreen);
     if (draft !== "" && draft !== null) sawDraft = true;
     // Box confirmed empty AND we observed the paste rendered first → submitted.
-    if (draft === "" && sawDraft) return;
+    if (draft === "" && sawDraft) return { delivered: true };
     // Box not parseable (e.g. an agent TUI without the HR-bounded box, or a
     // transient overlay): fall back to the screen-changed signal so non-claude
     // TUIs aren't worse off than before.
-    if (draft === null && afterScreen !== preSendScreen) return;
+    if (draft === null && afterScreen !== preSendScreen) return { delivered: true };
     const settled = await settleInputBox(runtime, pane);
     if (settled) sawDraft = true;
     // #455: paste never rendered — re-paste once rather than issuing Enter into emptiness.
@@ -250,4 +264,14 @@ export async function sendFirstTurnWhenReady(
     // Still stranded — re-issue ONLY the Enter (re-paste only when never rendered).
     await runtime.sendKeyToPane(pane, "Enter");
   }
+
+  // #466: retry loop exhausted — if the paste never rendered (sawDraft=false),
+  // the box was likely not ready when we pasted (the #466 timing race). Fall back
+  // once to confirmedSendToPane which starts fresh on a now-settled box.
+  // When sawDraft=true (paste rendered, Enter repeatedly failed), re-pasting would
+  // stack [Pasted text] entries — do not retry, just report non-delivery.
+  if (!sawDraft) {
+    return confirmedSendToPane(runtime, pane, task);
+  }
+  return { delivered: false };
 }


### PR DESCRIPTION
## Release v0.13.2

Four bug fixes merged since v0.13.1.

### Fixed

- **#466** — First-turn delivery silently dropped under concurrent spawn load: large multi-line `--agent claude` crews could land in an unrendered input box, exhaust the retry loop, and sit inert while `crew spawn` reported success and the watchdog mislabeled the crew as "deep thinking". Boot gate now waits for a parseable input box; delivery reports status and auto-falls back to confirmed-send; non-delivery surfaces a warning; watchdog emits distinct "CREW UNDELIVERED" alert.
- **#457** — Daemon task-ledger cruft and ghost lifecycle notifications: terminal records accumulated indefinitely and abandoned tasks could still fire CREW IDLE / CREW TIMEOUT. Daemon now prunes terminal records on sweep, suppresses notifications for tasks whose surface is gone, and `crew tasks --all-terminal` bulk-purges.
- **#458** — `crew spawn --task-file` was unreadable from an isolated-worktree crew's working directory. File is now copied into the worktree root with a short pointer on first turn.
- **#463** — Release workflow silently green-lit a failed `npm publish` (`continue-on-error` masked bad token). Publish step now fails the job on error; a verification step confirms the version is live on the registry.

## Diff

Only `CHANGELOG.md` and root `package.json` (version bump `0.13.1` → `0.13.2`) — no source changes.

Merging this PR triggers `release.yml` → tag + gh-release + npm publish + publish-verify.