### PR TITLE
fix(core,workspaces): single-spawn first-turn drop — 3 root causes (#466 reopen)

### DIFF
--- a/packages/core/src/__tests__/daemon.test.ts
+++ b/packages/core/src/__tests__/daemon.test.ts
@@ -180,6 +180,35 @@ describe("daemon handler", () => {
     expect(calls.length).toBe(0); // within budget → silent
   });
 
+  // #466-single DEFECT 1: CREW UNDELIVERED must also fire for a spawned interactive
+  // crew still in `submitted` (never received task.started — the first turn was
+  // dropped before CC could process it). The prior fix only wired UNDELIVERED under
+  // `working`, so a silently-dropped crew was never flagged.
+  it("sweep: interactive `submitted` task past budget with no firstTurnConfirmedAt → CREW UNDELIVERED (#466-single)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    store.put(rec("s-undelivered", { mode: "interactive", state: "submitted", lastHeartbeat: 0,
+      heartbeatBudgetMs: 100, attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 0 }] }));
+    const d = createDaemon({ store, now: () => 1000, notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    expect(store.get("p", "s-undelivered")?.state).toBe("submitted"); // state unchanged
+    expect(calls.length).toBe(1);
+    expect(calls[0].message).toMatch(/CREW UNDELIVERED/);
+    expect(calls[0].message).toMatch(/re-send/i);
+    expect(calls[0].event.type).toBe("task.quiet");
+  });
+
+  // A `submitted` crew within the heartbeat budget must NOT fire (no false alarm).
+  it("sweep: interactive `submitted` task WITHIN budget → no notification (#466-single)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    store.put(rec("s-ok", { mode: "interactive", state: "submitted", lastHeartbeat: 950,
+      heartbeatBudgetMs: 100, attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 950 }] }));
+    const d = createDaemon({ store, now: () => 1000, notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    expect(calls.length).toBe(0);
+  });
+
   // #466: task.first-turn.confirmed event stamps firstTurnConfirmedAt on the record.
   it("task.first-turn.confirmed stamps firstTurnConfirmedAt on the record (#466)", async () => {
     const store = createStore(dir);

--- a/packages/core/src/daemon/reduce.ts
+++ b/packages/core/src/daemon/reduce.ts
@@ -447,6 +447,27 @@ export function createDaemon(deps: DaemonDeps) {
             continue;
           }
         }
+        // #466-single: An interactive crew spawned but never started stays in
+        // `submitted` — no task.started hook ever fires, so the CREW QUIET/
+        // UNDELIVERED block below (which requires `working`) is unreachable.
+        // Surface CREW UNDELIVERED here for the quiet-past-budget submitted case
+        // so a silently-dropped first turn is caught regardless of state.
+        if (r.mode === "interactive" && r.state === "submitted" && !r.firstTurnConfirmedAt) {
+          const elapsed = t - r.lastHeartbeat;
+          if (elapsed > r.heartbeatBudgetMs) {
+            if (deps.notify && quietNotifiedAt.get(r.id) !== r.lastHeartbeat) {
+              quietNotifiedAt.set(r.id, r.lastHeartbeat);
+              const tag = crewTag(r);
+              const synthEvent: ControlEvent = { type: "task.quiet", id: r.id, quietMs: elapsed };
+              const message = `⚠️ CREW UNDELIVERED ${tag}: first turn may not have landed (crew never started) — re-send the task or check the spawn.`;
+              try {
+                const p = deps.notify({ project: r.project, message, record: r, event: synthEvent });
+                if (p && typeof (p as Promise<void>).catch === "function") (p as Promise<void>).catch(() => {});
+              } catch { /* swallowed */ }
+            }
+            continue;
+          }
+        }
         // #354: evaluateStall now only stalls a HEADLESS heartbeat timeout or a
         // hung INTERACTIVE tool call (PreToolUse with no PostToolUse past the
         // tool-stall budget). A quiet interactive thinking turn no longer stalls

--- a/packages/workspaces/src/__tests__/crew-pane.test.ts
+++ b/packages/workspaces/src/__tests__/crew-pane.test.ts
@@ -622,3 +622,161 @@ describe("confirmedSendToPane — large paste race (#455)", () => {
     expect(pasteToPane).toHaveBeenCalledWith(pane, "big follow-up");
   });
 });
+
+// ─── #466-single DEFECT 2: boot gate must reject HR-bounded banner (no ❯ prompt) ──
+
+describe("sendFirstTurnWhenReady — boot gate rejects HR banner without ❯ (#466-single defect 2)", () => {
+  let readPaneScreen: ReturnType<typeof vi.fn>;
+  let sendToPane: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
+  const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, sendToPane, pasteToPane, sendKeyToPane });
+
+  // The claude-mem banner that triggers the bug: has two HR lines but NO ❯ prompt
+  // between them. parseDraftFromScreen returns "" (≠ null) → old code treated this
+  // as "box present", boot gate fired, paste went into the banner and was lost.
+  // hasCCInputBox (new gate) requires a ❯ inside the box → correctly defers.
+  const HR = "─".repeat(60);
+  const BANNER_WITH_HR = `${HR}\nclaude-mem: initializing\nLoaded 42 memories\n${HR}`;
+  const EMPTY_BOX_LOCAL = `…transcript…\n${HR}\n❯ \n${HR}\n   Model: Sonnet 4.6  Ctx Used: 0.0%`;
+  const DRAFT_BOX_LOCAL = `…transcript…\n${HR}\n❯ [Pasted text #1]\n${HR}\n   Model: Sonnet 4.6`;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    readPaneScreen = vi.fn();
+    sendToPane = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
+  });
+  afterEach(() => { vi.useRealTimers(); });
+
+  // Core regression: paste must NOT fire while the HR banner (no ❯) is stable.
+  // We track which readPaneScreen call# triggered the first paste — it must be
+  // AFTER the banner period (n<=4). Before the fix the first paste fires at n=3
+  // (preSend captured during BANNER), which fails the > 4 assertion.
+  it("first paste fires AFTER banner period, not during HR banner stabilisation (#466-single defect 2)", async () => {
+    let firstPasteN = -1;
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n <= 4) return BANNER_WITH_HR;   // n=1..4: banner stable, no ❯
+      if (n <= 9) return EMPTY_BOX_LOCAL;  // n=5..9: CC box (has ❯) appears and stays
+      if (n <= 11) return DRAFT_BOX_LOCAL; // n=10..11: paste rendered
+      return EMPTY_BOX_LOCAL;              // n>=12: submitted
+    });
+    pasteToPane.mockImplementation(() => {
+      if (firstPasteN < 0) firstPasteN = n;
+    });
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "task text", "$ launch");
+    await vi.advanceTimersByTimeAsync(15000);
+    await promise;
+
+    // BEFORE fix: firstPasteN = 3 (paste during banner at n=3, ≤ 4) → fails
+    // AFTER fix:  firstPasteN = 7 (paste deferred to n=7, CC box stable) → passes
+    expect(firstPasteN).toBeGreaterThan(4);
+    expect(sendToPane).not.toHaveBeenCalled();
+  });
+
+  it("returns { delivered: true } when paste deferred until CC box is stable (#466-single defect 2)", async () => {
+    let firstPasteN = -1;
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n <= 4) return BANNER_WITH_HR;
+      if (n <= 9) return EMPTY_BOX_LOCAL;
+      if (n <= 11) return DRAFT_BOX_LOCAL;
+      return EMPTY_BOX_LOCAL;
+    });
+    pasteToPane.mockImplementation(() => {
+      if (firstPasteN < 0) firstPasteN = n;
+    });
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "task text", "$ launch");
+    await vi.advanceTimersByTimeAsync(15000);
+    const result = await promise;
+
+    expect(result).toEqual({ delivered: true });
+    expect(firstPasteN).toBeGreaterThan(4);
+  });
+});
+
+// ─── #466-single DEFECT 3: screen-changed must not declare delivery without sawDraft ─
+
+describe("sendFirstTurnWhenReady — screen change without sawDraft is NOT delivery (#466-single defect 3)", () => {
+  let readPaneScreen: ReturnType<typeof vi.fn>;
+  let sendToPane: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
+  const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, sendToPane, pasteToPane, sendKeyToPane });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    readPaneScreen = vi.fn();
+    sendToPane = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
+  });
+  afterEach(() => { vi.useRealTimers(); });
+
+  // Defect 3 scenario: paste is issued into the ready box, the box becomes
+  // non-parseable (CC TUI transitions mid-boot), and the screen changes — but the
+  // draft was never seen. The old code returned { delivered: true } on the screen-
+  // changed branch without requiring sawDraft. After the fix, it must return false.
+  it("returns { delivered: false } when screen changes but paste never rendered in box (#466-single defect 3)", async () => {
+    const NON_PARSEABLE = "CC transitioning — no HR box visible";
+    const HR = "─".repeat(60);
+    const EMPTY_BOX_LOCAL = `…transcript…\n${HR}\n❯ \n${HR}\n   Model: Sonnet 4.6  Ctx Used: 0.0%`;
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n <= 2) return EMPTY_BOX_LOCAL;  // readiness: stable CC box
+      if (n === 3) return EMPTY_BOX_LOCAL; // preSend snapshot
+      return NON_PARSEABLE;                 // post-paste: non-parseable, screen changed (boot transition)
+    });
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "big task", "$ launch");
+    await vi.advanceTimersByTimeAsync(25000);
+    const result = await promise;
+
+    // Screen changed but draft never rendered — NOT a delivery confirmation.
+    expect(result).toEqual({ delivered: false });
+    expect(sendToPane).not.toHaveBeenCalled();
+  });
+});
+
+describe("confirmedSendToPane — screen change without sawDraft is NOT delivery (#466-single defect 3)", () => {
+  let readPaneScreen: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
+  const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, pasteToPane, sendKeyToPane });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    readPaneScreen = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
+  });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it("returns { delivered: false } when paste never rendered but screen changed (#466-single defect 3)", async () => {
+    const HR = "─".repeat(60);
+    const IDLE_BOX = `…transcript…\n${HR}\n❯ \n${HR}\n   Model: Sonnet 4.6  Ctx Used: 0.0%`;
+    const NON_PARSEABLE = "CC transitioning — no HR box visible";
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n === 1) return IDLE_BOX;   // preSendScreen
+      return NON_PARSEABLE;            // after paste: no box, screen changed — draft never rendered
+    });
+
+    const promise = confirmedSendToPane(rt(), pane, "message");
+    await vi.advanceTimersByTimeAsync(8000);
+    const result = await promise;
+
+    expect(result).toEqual({ delivered: false });
+  });
+});

--- a/packages/workspaces/src/crew-pane.ts
+++ b/packages/workspaces/src/crew-pane.ts
@@ -6,7 +6,7 @@ import net from "node:net";
 import { loadConfig } from "@squadrant/shared";
 import type { PaneRef, RuntimeDriver } from "@squadrant/shared";
 import { RuntimeRegistry } from "./runtimes/registry.js";
-import { createCmuxDriver, parseDraftFromScreen } from "./runtimes/cmux.js";
+import { createCmuxDriver, parseDraftFromScreen, hasCCInputBox } from "./runtimes/cmux.js";
 import { titleFor, isCrewTitle, isTurnAccepted } from "@squadrant/core";
 import type { TurnAcceptanceConfig } from "@squadrant/core";
 
@@ -143,7 +143,7 @@ export async function confirmedSendToPane(
     if (draft !== "" && draft !== null) sawDraft = true;
     // Box confirmed empty AND we observed the paste rendered first → submitted.
     if (draft === "" && sawDraft) return { delivered: true };
-    if (draft === null && afterScreen !== preSendScreen) return { delivered: true };
+    if (draft === null && afterScreen !== preSendScreen && sawDraft) return { delivered: true };
     const settled = await settleInputBox(runtime, pane);
     if (settled) sawDraft = true;
     // #455: paste never rendered — re-paste once rather than issuing Enter into emptiness.
@@ -175,12 +175,15 @@ export async function sendFirstTurnWhenReady(
     const screen = (await runtime.readPaneScreen(pane)) ?? "";
     // Ready = the agent prompt is actually up: screen is non-empty, settled
     // (unchanged between two consecutive reads), has advanced past the un-entered
-    // launch command line, AND (for the claude/codex path) the HR-bounded input
-    // box is actually rendered. The last check prevents pasting into the claude-mem
-    // boot banner which can stabilise BEFORE the CC input box appears under load
-    // (#466 root cause). For the opencode splash path, parseDraftFromScreen would
-    // return null (no HR box), so we skip that check to preserve existing behaviour.
-    const hasInputBox = !!acceptanceConfig?.splashMarker || parseDraftFromScreen(screen) !== null;
+    // launch command line, AND (for the claude/codex path) the CC input box is
+    // rendered with its ❯ prompt glyph. hasCCInputBox is stricter than the old
+    // parseDraftFromScreen(screen)!==null check: the claude-mem startup banner can
+    // produce HR-bounded regions without a ❯ inside — parseDraftFromScreen returns
+    // "" (≠ null) for those, falsely satisfying the old gate. hasCCInputBox
+    // requires the ❯ to be present, so banners do not trigger a premature paste
+    // (#466-single root cause). For the opencode splash path the splashMarker
+    // short-circuits before this check, preserving existing behaviour.
+    const hasInputBox = !!acceptanceConfig?.splashMarker || hasCCInputBox(screen);
     if (screen.length > 0 && screen === previousScreen && screen !== preLaunchScreen && hasInputBox) {
       stable = true;
     } else {
@@ -253,7 +256,7 @@ export async function sendFirstTurnWhenReady(
     // Box not parseable (e.g. an agent TUI without the HR-bounded box, or a
     // transient overlay): fall back to the screen-changed signal so non-claude
     // TUIs aren't worse off than before.
-    if (draft === null && afterScreen !== preSendScreen) return { delivered: true };
+    if (draft === null && afterScreen !== preSendScreen && sawDraft) return { delivered: true };
     const settled = await settleInputBox(runtime, pane);
     if (settled) sawDraft = true;
     // #455: paste never rendered — re-paste once rather than issuing Enter into emptiness.

--- a/packages/workspaces/src/runtimes/cmux.ts
+++ b/packages/workspaces/src/runtimes/cmux.ts
@@ -203,6 +203,30 @@ export function parseDraftFromScreen(screen: string): string | null {
 }
 
 /**
+ * True when the screen contains a real Claude Code input box — two HR boundaries
+ * AND at least one line between them with the CC prompt glyph (❯ or >). This
+ * distinguishes the CC input box from the claude-mem startup banner, which can
+ * produce HR-bounded regions WITHOUT a prompt glyph and stabilise before CC
+ * renders its own TUI. parseDraftFromScreen returns "" for both cases (two HRs
+ * found, no ❯ inside), so !==null does not distinguish them (#466-single fix).
+ */
+export function hasCCInputBox(screen: string): boolean {
+  if (!screen) return false;
+  const lines = screen.split(/\r?\n/);
+  const HR_RE = /^\s*─{10,}\s*$/;
+  let bottomHR = -1;
+  let topHR = -1;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (HR_RE.test(lines[i])) {
+      if (bottomHR === -1) bottomHR = i;
+      else { topHR = i; break; }
+    }
+  }
+  if (topHR === -1) return false;
+  return lines.slice(topHR + 1, bottomHR).some((l) => /[>❯]/.test(l));
+}
+
+/**
  * Extract the RAW input-box content for the #302 buffer-liveness probe — all
  * content lines between the last two HRs, joined, with the prompt glyph and any
  * trailing cursor glyph stripped (but NOT the #294 ghost heuristics: the probe


### PR DESCRIPTION
## Summary

Fixes the reopened #466: a **single** large `--agent claude` spawn can silently drop its first turn. The prior fix (#467) only handled concurrent-spawn load. Three interlocking root causes remain.

### Defect 1 — CREW UNDELIVERED watchdog unreachable for truly dropped crew (`reduce.ts`)

The `⚠️ CREW UNDELIVERED` alert was gated on `state === "working"`, but a crew whose first turn is dropped never receives `task.started` and stays in `state = "submitted"` forever. Added a parallel check in the sweep loop for `submitted` interactive crews that have been quiet past their heartbeat budget.

### Defect 2 — Boot gate matches claude-mem banner (has HR lines, no `❯`) (`cmux.ts`, `crew-pane.ts`)

The readiness gate used `parseDraftFromScreen(screen) !== null`, which returns `""` (not null) when two HR lines are found — even when there is no `❯` prompt inside. The claude-mem startup banner produces HR-bounded regions without a prompt glyph, so the gate falsely fired during boot and the paste landed in the banner, not the CC input box. Added `hasCCInputBox()` which requires the `❯` inside the bounded region, and used it as the boot-gate predicate.

### Defect 3 — Screen-change falsely reports delivery when paste was never seen (`crew-pane.ts`)

Both `confirmedSendToPane` and `sendFirstTurnWhenReady` had:
```
if (draft === null && afterScreen !== preSendScreen) return { delivered: true }
```
CC finishing its boot changes the screen for unrelated reasons. This branch fired even when `sawDraft` was false (paste never rendered), suppressing the `⚠️` warning and never stamping `firstTurnConfirmedAt`. Added `&& sawDraft` guard so screen-change only counts as delivery when the paste was actually observed in the box.

## Test plan

- [ ] All 4 new unit tests (2 × Defect 1 in `daemon.test.ts`, 2 × Defect 2 + 2 × Defect 3 in `crew-pane.test.ts`) fail before the fix and pass after
- [ ] Full `pnpm build` clean (tsc + tsup)
- [ ] Full `pnpm test` passes: **1765/1765**
- [ ] CI `build-and-test` green on this PR