### PR TITLE
fix: hook-driven first-turn confirmation via UserPromptSubmit (#470)

### DIFF
--- a/packages/agents/src/__tests__/interactive-claude-hook.test.ts
+++ b/packages/agents/src/__tests__/interactive-claude-hook.test.ts
@@ -36,9 +36,13 @@ describe("mapClaudeHookToEvent", () => {
   });
 
   it("unknown event → null", () => {
-    expect(mapClaudeHookToEvent("UserPromptSubmit", {}, TID)).toBeNull();
     expect(mapClaudeHookToEvent("PreToolUse", {}, TID)).toBeNull();
     expect(mapClaudeHookToEvent("", {}, TID)).toBeNull();
+  });
+
+  it("UserPromptSubmit → task.first-turn.confirmed (#470)", () => {
+    const ev = mapClaudeHookToEvent("UserPromptSubmit", {}, TID);
+    expect(ev).toEqual({ type: "task.first-turn.confirmed", id: TID });
   });
 
   it("anti-#2576 invariant: NO input produces task.done or task.failed", () => {

--- a/packages/agents/src/__tests__/interactive-claude.test.ts
+++ b/packages/agents/src/__tests__/interactive-claude.test.ts
@@ -82,4 +82,11 @@ describe("claude interactive hook merge", () => {
     expect(out.hooks.Notification[0].hooks[0].command).toContain(HOOK_CMD);
     expect(out.hooks.Notification[0].hooks[0].command).toContain("Notification");
   });
+
+  it("registers a UserPromptSubmit hook for authoritative first-turn confirmation (#470)", () => {
+    const out = mergeClaudeHooks({}, HOOK_CMD);
+    expect(out.hooks.UserPromptSubmit).toBeDefined();
+    expect(out.hooks.UserPromptSubmit[0].hooks[0].command).toContain(HOOK_CMD);
+    expect(out.hooks.UserPromptSubmit[0].hooks[0].command).toContain("UserPromptSubmit");
+  });
 });

--- a/packages/agents/src/interactive/claude.ts
+++ b/packages/agents/src/interactive/claude.ts
@@ -14,7 +14,10 @@ import type { ControlEvent } from "@squadrant/shared";
 // while the parent agent still owns the turn. SessionEnd is NOT liveness: it
 // signals the session is gone (crash / Ctrl-C / /exit), so it terminalizes the
 // record (→ task.session.ended) rather than resuming 'working' (#139).
-const EVENTS = ["Stop", "SubagentStop", "SessionEnd", "PostToolUse", "Notification"] as const;
+// UserPromptSubmit fires before Claude processes each prompt submission, including
+// the first interactive turn — used as the authoritative first-turn confirmation
+// signal (#470), replacing the screen-scrape {delivered} heuristic.
+const EVENTS = ["Stop", "SubagentStop", "SessionEnd", "PostToolUse", "Notification", "UserPromptSubmit"] as const;
 
 /**
  * Probe whether the local Claude CLI supports `--settings <path>`. The
@@ -218,6 +221,11 @@ export function mapClaudeHookToEvent(
       // The only resume-liveness hooks: PostToolUse fires after every tool call
       // mid-turn; SubagentStop fires while the parent still owns the turn.
       return { type: "task.progress", id: taskId, note: event.toLowerCase() };
+    case "UserPromptSubmit":
+      // #470: fires before Claude processes each prompt, including the first.
+      // The reducer stamps firstTurnConfirmedAt only on the first occurrence;
+      // subsequent submits (captain crew send follow-ups) are treated as liveness.
+      return { type: "task.first-turn.confirmed", id: taskId };
     default:
       return null;
   }

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -31,9 +31,12 @@ async function sendToSock(req: unknown): Promise<void> {
 function mapHookSub(sub: string, payload: unknown, taskId: string): ControlEvent | null {
   switch (sub) {
     case "session-start":
-    case "prompt-submit":
     case "pre-tool-use":
       return { type: "task.progress", id: taskId, note: sub };
+    case "prompt-submit":
+      // #470: NativeHookSource path mirrors the crew _hook UserPromptSubmit path.
+      // Reducer stamps firstTurnConfirmedAt only once; subsequent submits become liveness.
+      return { type: "task.first-turn.confirmed", id: taskId };
     case "stop":
       return mapClaudeHookToEvent("Stop", payload, taskId);
     case "notification":

--- a/packages/core/src/__tests__/daemon.test.ts
+++ b/packages/core/src/__tests__/daemon.test.ts
@@ -222,6 +222,26 @@ describe("daemon handler", () => {
     expect(store.get("p", "fc1")?.firstTurnConfirmedAt).toBe(500);
   });
 
+  // #470: UserPromptSubmit fires on every prompt (incl. captain crew send follow-ups).
+  // The reducer must NOT re-stamp firstTurnConfirmedAt on the second occurrence.
+  it("task.first-turn.confirmed is idempotent — second event does not re-stamp firstTurnConfirmedAt (#470)", async () => {
+    const store = createStore(dir);
+    store.put(rec("fc2", { state: "working" }));
+    let tick = 500;
+    const d = createDaemon({ store, now: () => tick });
+    // First confirmation stamps at 500.
+    await d.handle({ kind: "event", project: "p", event: { type: "task.first-turn.confirmed", id: "fc2" } });
+    expect(store.get("p", "fc2")?.firstTurnConfirmedAt).toBe(500);
+    // Second confirmation (e.g. from a captain crew send follow-up) must not change the field.
+    tick = 999;
+    const second = await d.handle({
+      kind: "event", project: "p",
+      event: { type: "task.first-turn.confirmed", id: "fc2" },
+    }) as import("@squadrant/shared").TaskRecord;
+    expect(second.firstTurnConfirmedAt).toBe(500);
+    expect(store.get("p", "fc2")?.firstTurnConfirmedAt).toBe(500);
+  });
+
   // #354: an interactive crew with a tool in flight (PreToolUse, no PostToolUse)
   // past the tool-stall budget IS a hung tool call → stalled, with a tool-named,
   // recoverable CREW STALLED warn.

--- a/packages/core/src/state-machine.ts
+++ b/packages/core/src/state-machine.ts
@@ -128,9 +128,12 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
     case "task.reattached":
       return stampAttempt(base, {}, now);
     case "task.first-turn.confirmed":
-      // #466: stamp the confirmed delivery timestamp. No state change — the crew
-      // stays `working`. The watchdog reads this field to distinguish a quiet-
-      // thinking crew from one that never received its first turn.
+      // #466/#470: stamp firstTurnConfirmedAt on the FIRST occurrence only.
+      // UserPromptSubmit fires on every prompt submit (incl. captain follow-ups);
+      // subsequent events are treated as liveness so the field is never re-stamped.
+      if (rec.firstTurnConfirmedAt) {
+        return { ...rec, lastEvent: "task.progress" };
+      }
       return { ...rec, firstTurnConfirmedAt: now, lastEvent: ev.type };
     case "task.stalled":
     case "task.idle":


### PR DESCRIPTION
## Summary

Closes #470. Makes `firstTurnConfirmedAt` hook-driven via `UserPromptSubmit`, ending the recurring screen-scrape first-turn-drop bug class (7 fixes, same pipeline).

- **`packages/agents/src/interactive/claude.ts`** — Add `UserPromptSubmit` to `EVENTS` so `mergeClaudeHooks` installs it into every crew's per-crew settings. Map `UserPromptSubmit` → `task.first-turn.confirmed` in `mapClaudeHookToEvent`.
- **`packages/cli/src/commands/hooks.ts`** — NativeHookSource `prompt-submit` sub now also → `task.first-turn.confirmed` (was `task.progress`). Both hook paths now emit the same authoritative confirmation consistently.
- **`packages/core/src/state-machine.ts`** — Guard `task.first-turn.confirmed` in the reducer: stamps `firstTurnConfirmedAt` only on the **first** occurrence. Subsequent submits (captain `crew send` follow-ups) fall through to liveness (`task.progress`) — field is never re-stamped.
- Screen-scrape `{delivered}` delivery loop (`crew-spawn.ts`, #469 fixes) **left intact** as the delivery driver and fallback. This adds hook confirmation on top; it does not replace the delivery mechanism.

## Tests

- `mapClaudeHookToEvent("UserPromptSubmit", …)` → `task.first-turn.confirmed`
- `mergeClaudeHooks` output includes a `UserPromptSubmit` hook entry
- Reducer: first `task.first-turn.confirmed` stamps `firstTurnConfirmedAt`; second does **not** re-stamp it
- All 1768 existing tests green (`pnpm build` + `pnpm test` clean)

## POC evidence (branch `poc/userpromptsubmit-firstturn`)

Hook fired end-to-end before this PR: `/tmp/uops-poc.log` showed `UserPromptSubmit task=e2f54357…` at first-turn time, daemon stamped `firstTurnConfirmedAt` from the hook signal.

## Out of scope / follow-up

`UserPromptSubmit` is claude-only. codex (app-server) and opencode (SSE) need equivalent authoritative first-turn signals for parity — file a follow-up per the multi-agent direction docs.