### PR TITLE
fix(core): make UserPromptSubmit sole first-turn confirmation for claude (#472)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (4232 symbols, 6257 relationships, 157 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (4438 symbols, 6712 relationships, 168 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (4232 symbols, 6257 relationships, 157 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (4438 symbols, 6712 relationships, 168 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/packages/cli/src/commands/__tests__/crew.test.ts
+++ b/packages/cli/src/commands/__tests__/crew.test.ts
@@ -210,7 +210,9 @@ describe("squadrant crew spawn", () => {
       cwd: "/tmp/brove/.worktrees/brove-crew-1",
       task: "do the thing",
     }));
-    expect(squadrantdCall).toHaveBeenCalledTimes(2); // dispatch + task.first-turn.confirmed
+    // #472: hooks installed (writeSettingsLocal mock succeeds) → UserPromptSubmit is
+    // sole confirmation source; scrape does NOT emit task.first-turn.confirmed.
+    expect(squadrantdCall).toHaveBeenCalledTimes(1); // dispatch only
     // Squadrant hooks written to .claude/settings.local.json (auto-loaded source) inside the worktree.
     expect(writePerCrewSettingsLocal).toHaveBeenCalledWith(expect.objectContaining({
       projectCwd: "/tmp/brove/.worktrees/brove-crew-1",
@@ -694,7 +696,8 @@ describe("squadrant crew spawn", () => {
     stderrSpy.mockRestore();
   });
 
-  it("delivered:true emits task.first-turn.confirmed event to daemon (#466)", async () => {
+  // #472: hooks installed (writeSettingsLocal mock succeeds) → scrape does NOT emit.
+  it("delivered:true does NOT emit task.first-turn.confirmed from scrape when hooks installed (#472)", async () => {
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
     listSurfaces.mockResolvedValue([]);
@@ -702,17 +705,39 @@ describe("squadrant crew spawn", () => {
     buildCommand.mockReturnValue("claude ...");
     buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-dt1" } }));
     squadrantdCall.mockResolvedValue({ id: "task-dt1", project: "brove", provider: "claude", mode: "interactive" });
+    // writePerCrewSettingsLocal default mock returns undefined (no throw) → hooksInstalled=true
 
     const promise = runCrewSpawn({ project: "brove", task: "delivered task" });
     await vi.advanceTimersByTimeAsync(3000);
     await promise;
 
-    // squadrantdCall fired twice: once for dispatch, once for task.first-turn.confirmed
+    // dispatch only — hook is sole confirmation source
+    expect(squadrantdCall).toHaveBeenCalledTimes(1);
+    const calls = (squadrantdCall.mock.calls as Array<[{ kind: string; event?: { type: string } }]>).map(([r]) => r);
+    expect(calls).not.toContainEqual(expect.objectContaining({ event: { type: "task.first-turn.confirmed" } }));
+  });
+
+  // #472 fallback: when writeSettingsLocal throws, scrape emits task.first-turn.confirmed.
+  it("emits task.first-turn.confirmed from scrape when writeSettingsLocal fails (fallback) (#472)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude ...");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-fb1" } }));
+    squadrantdCall.mockResolvedValue({ id: "task-fb1", project: "brove", provider: "claude", mode: "interactive" });
+    writePerCrewSettingsLocal.mockImplementationOnce(() => { throw new Error("ENOENT"); });
+
+    const promise = runCrewSpawn({ project: "brove", task: "fallback task" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    // dispatch + task.first-turn.confirmed from scrape
     expect(squadrantdCall).toHaveBeenCalledTimes(2);
     expect(squadrantdCall).toHaveBeenNthCalledWith(2, expect.objectContaining({
       kind: "event",
       project: "brove",
-      event: { type: "task.first-turn.confirmed", id: "task-dt1" },
+      event: { type: "task.first-turn.confirmed", id: "task-fb1" },
     }));
   });
 

--- a/packages/cli/src/commands/__tests__/side.test.ts
+++ b/packages/cli/src/commands/__tests__/side.test.ts
@@ -561,7 +561,8 @@ describe("crew spawn regression — daemon path unchanged", () => {
     await vi.advanceTimersByTimeAsync(3000);
     await promise;
 
-    expect(squadrantdCall).toHaveBeenCalledTimes(2); // dispatch + task.first-turn.confirmed
+    // #472: hooks installed (writePerCrewSettingsLocal mock succeeds) → dispatch only, no scrape emit
+    expect(squadrantdCall).toHaveBeenCalledTimes(1); // dispatch only
     vi.useRealTimers();
   });
 });

--- a/packages/core/src/__tests__/crew-spawn.test.ts
+++ b/packages/core/src/__tests__/crew-spawn.test.ts
@@ -260,13 +260,31 @@ describe("runCrewSpawn", () => {
       }
     });
 
-    // #466: when sendFirstTurn resolves { delivered: true }, emitEvent is called
-    // with task.first-turn.confirmed so the daemon can stamp firstTurnConfirmedAt.
-    it("emits task.first-turn.confirmed when sendFirstTurn returns { delivered: true } (#466)", async () => {
+    // #472: when hooks are installed (writeSettingsLocal succeeds), the scrape must
+    // NOT emit task.first-turn.confirmed — UserPromptSubmit hook is the sole source.
+    it("does NOT emit task.first-turn.confirmed from scrape when hooks installed (#472)", async () => {
       const config = makeConfig();
       const runtime = makeRuntime();
       const agent = makeAgent("claude");
       const deps = makeSpawnDeps(runtime, agent);
+      deps.sendFirstTurn = vi.fn().mockResolvedValue({ delivered: true });
+      const emitEvent = vi.fn().mockResolvedValue(undefined);
+      deps.emitEvent = emitEvent;
+      // writeSettingsLocal succeeds (default mock returns undefined — no throw)
+
+      await runCrewSpawn({ project: PROJECT, task: "fix the bug" }, config, deps);
+
+      expect(emitEvent).not.toHaveBeenCalled();
+    });
+
+    // #472: when writeSettingsLocal throws (OS error / hook install failure),
+    // scrape confirmation is the fallback so the crew isn't silently lost.
+    it("emits task.first-turn.confirmed from scrape when writeSettingsLocal fails (fallback) (#472)", async () => {
+      const config = makeConfig();
+      const runtime = makeRuntime();
+      const agent = makeAgent("claude");
+      const deps = makeSpawnDeps(runtime, agent);
+      deps.writeSettingsLocal = vi.fn().mockImplementation(() => { throw new Error("ENOENT"); });
       deps.sendFirstTurn = vi.fn().mockResolvedValue({ delivered: true });
       const emitEvent = vi.fn().mockResolvedValue(undefined);
       deps.emitEvent = emitEvent;

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -328,7 +328,16 @@ export async function runCrewSpawn(
     // Write squadrant hooks to <cwd>/.claude/settings.local.json so they are
     // auto-loaded as a project-local settings source. Merges with any existing
     // hooks — does not clobber the user's own personal hooks (#134).
-    deps.writeSettingsLocal(spawnCwd);
+    // #472: capture whether hook installation succeeded — when it does, the
+    // UserPromptSubmit hook is the SOLE first-turn confirmation source for
+    // claude crews. If the write fails (rare OS error), fall back to scrape.
+    let hooksInstalled = false;
+    try {
+      deps.writeSettingsLocal(spawnCwd);
+      hooksInstalled = true;
+    } catch {
+      // Hook file write failed — scrape confirmation remains as fallback.
+    }
     const cliCommand = agent.buildCommand({
       prompt: input.task,
       workdir: spawnCwd,
@@ -352,9 +361,11 @@ export async function runCrewSpawn(
     // #466: surface non-delivery explicitly instead of silently returning success.
     if (!claudeResult.delivered) {
       process.stderr.write(`⚠️  First turn not delivered for crew '${name}' — use 'squadrant crew send ${input.project} ${name}' to re-send the task.\n`);
-    } else {
+    } else if (!hooksInstalled) {
+      // #472: hooks unavailable — scrape is the only confirmation source for this crew.
       await deps.emitEvent?.(input.project, { type: "task.first-turn.confirmed", id: rec.id });
     }
+    // When hooksInstalled=true: UserPromptSubmit hook stamps firstTurnConfirmedAt.
     return { ...pane, title };
   }
 


### PR DESCRIPTION
## Summary

- **Closes #472** — removes the scrape-emitter (`task.first-turn.confirmed`) from the claude branch of `runCrewSpawn` so a screen heuristic can never silence the UNDELIVERED watchdog on a true first-turn drop
- The `UserPromptSubmit` hook (installed via `settings.local.json` since #470/#471) is now the **sole** confirmation source for claude crews
- Hook-availability fallback: if `writeSettingsLocal` throws (rare OS error / disk fault), the scrape path retains the `emitEvent` call for that crew so no healthy spawn loses its confirmation signal
- opencode and codex confirmation paths are **untouched**

## Changes

- `packages/core/src/crew-spawn.ts` — wrap `writeSettingsLocal` in try/catch to capture `hooksInstalled`; gate scrape `emitEvent` behind `!hooksInstalled` in the claude branch only
- `packages/core/src/__tests__/crew-spawn.test.ts` — update existing test to assert scrape does NOT emit on delivery (hooks installed); add fallback test for `writeSettingsLocal` failure path

## Test plan

- [ ] `npx vitest run` — 1769 tests all green (150 test files)
- [ ] `pnpm build` — clean TypeScript compile + tsup bundle
- [ ] claude branch: `writeSettingsLocal` succeeds → `emitEvent` NOT called on delivery
- [ ] claude branch: `writeSettingsLocal` throws → `emitEvent` IS called on delivery (scrape fallback)
- [ ] opencode branch: `emitEvent` still called on delivery (unchanged)
- [ ] Reducer idempotency (#471) still verified by daemon.test.ts