### PR TITLE
Release v0.13.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (4232 symbols, 6257 relationships, 157 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (4438 symbols, 6712 relationships, 168 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.3] - 2026-06-29
+
+### Fixed
+
+- First-turn delivery could still silently drop on a **single** (non-concurrent) spawn of a large
+  multi-line `--agent claude` crew — the v0.13.2 fix only covered concurrent-spawn load. Three
+  interlocking causes: the `CREW UNDELIVERED` watchdog was unreachable for a crew whose first turn
+  never landed (it never leaves the `submitted` state), the boot-readiness gate could latch onto the
+  claude-mem startup banner (which has HR lines but no input-box prompt glyph) and paste before the
+  real input box rendered, and a screen change during boot could be mistaken for a confirmed submit.
+  The watchdog now also covers quiet `submitted` crews, the boot gate requires the actual Claude Code
+  input box (`❯` prompt), and a screen-change only counts as delivery when the paste was observed.
+  ([#466](https://github.com/tu11aa/squadrant/issues/466))
+
+### Changed
+
+- First-turn delivery confirmation is now **hook-driven** instead of inferred from the terminal
+  screen. A `UserPromptSubmit` Claude Code hook (registered per crew) fires when the prompt is
+  actually submitted and authoritatively stamps the first-turn-confirmed signal, ending the class of
+  bugs where a screen-scrape heuristic mis-read an opaque TUI. The confirmation is stamped once and
+  is the **sole** confirmation source for claude crews (the screen-scrape remains only as a fallback
+  when the hook cannot be installed). ([#470](https://github.com/tu11aa/squadrant/issues/470),
+  [#472](https://github.com/tu11aa/squadrant/issues/472))
+
 ## [0.13.2] - 2026-06-29
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (4232 symbols, 6257 relationships, 157 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (4438 symbols, 6712 relationships, 168 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "squadrant",
   "packageManager": "pnpm@10.30.3",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "Multi-project orchestration for your coding agents (Claude, Codex, opencode, Gemini)",
   "type": "module",
   "bin": {

--- a/packages/agents/src/__tests__/interactive-claude-hook.test.ts
+++ b/packages/agents/src/__tests__/interactive-claude-hook.test.ts
@@ -36,9 +36,13 @@ describe("mapClaudeHookToEvent", () => {
   });
 
   it("unknown event → null", () => {
-    expect(mapClaudeHookToEvent("UserPromptSubmit", {}, TID)).toBeNull();
     expect(mapClaudeHookToEvent("PreToolUse", {}, TID)).toBeNull();
     expect(mapClaudeHookToEvent("", {}, TID)).toBeNull();
+  });
+
+  it("UserPromptSubmit → task.first-turn.confirmed (#470)", () => {
+    const ev = mapClaudeHookToEvent("UserPromptSubmit", {}, TID);
+    expect(ev).toEqual({ type: "task.first-turn.confirmed", id: TID });
   });
 
   it("anti-#2576 invariant: NO input produces task.done or task.failed", () => {

--- a/packages/agents/src/__tests__/interactive-claude.test.ts
+++ b/packages/agents/src/__tests__/interactive-claude.test.ts
@@ -82,4 +82,11 @@ describe("claude interactive hook merge", () => {
     expect(out.hooks.Notification[0].hooks[0].command).toContain(HOOK_CMD);
     expect(out.hooks.Notification[0].hooks[0].command).toContain("Notification");
   });
+
+  it("registers a UserPromptSubmit hook for authoritative first-turn confirmation (#470)", () => {
+    const out = mergeClaudeHooks({}, HOOK_CMD);
+    expect(out.hooks.UserPromptSubmit).toBeDefined();
+    expect(out.hooks.UserPromptSubmit[0].hooks[0].command).toContain(HOOK_CMD);
+    expect(out.hooks.UserPromptSubmit[0].hooks[0].command).toContain("UserPromptSubmit");
+  });
 });

--- a/packages/agents/src/interactive/claude.ts
+++ b/packages/agents/src/interactive/claude.ts
@@ -14,7 +14,10 @@ import type { ControlEvent } from "@squadrant/shared";
 // while the parent agent still owns the turn. SessionEnd is NOT liveness: it
 // signals the session is gone (crash / Ctrl-C / /exit), so it terminalizes the
 // record (→ task.session.ended) rather than resuming 'working' (#139).
-const EVENTS = ["Stop", "SubagentStop", "SessionEnd", "PostToolUse", "Notification"] as const;
+// UserPromptSubmit fires before Claude processes each prompt submission, including
+// the first interactive turn — used as the authoritative first-turn confirmation
+// signal (#470), replacing the screen-scrape {delivered} heuristic.
+const EVENTS = ["Stop", "SubagentStop", "SessionEnd", "PostToolUse", "Notification", "UserPromptSubmit"] as const;
 
 /**
  * Probe whether the local Claude CLI supports `--settings <path>`. The
@@ -218,6 +221,11 @@ export function mapClaudeHookToEvent(
       // The only resume-liveness hooks: PostToolUse fires after every tool call
       // mid-turn; SubagentStop fires while the parent still owns the turn.
       return { type: "task.progress", id: taskId, note: event.toLowerCase() };
+    case "UserPromptSubmit":
+      // #470: fires before Claude processes each prompt, including the first.
+      // The reducer stamps firstTurnConfirmedAt only on the first occurrence;
+      // subsequent submits (captain crew send follow-ups) are treated as liveness.
+      return { type: "task.first-turn.confirmed", id: taskId };
     default:
       return null;
   }

--- a/packages/cli/src/commands/__tests__/crew.test.ts
+++ b/packages/cli/src/commands/__tests__/crew.test.ts
@@ -210,7 +210,9 @@ describe("squadrant crew spawn", () => {
       cwd: "/tmp/brove/.worktrees/brove-crew-1",
       task: "do the thing",
     }));
-    expect(squadrantdCall).toHaveBeenCalledTimes(2); // dispatch + task.first-turn.confirmed
+    // #472: hooks installed (writeSettingsLocal mock succeeds) → UserPromptSubmit is
+    // sole confirmation source; scrape does NOT emit task.first-turn.confirmed.
+    expect(squadrantdCall).toHaveBeenCalledTimes(1); // dispatch only
     // Squadrant hooks written to .claude/settings.local.json (auto-loaded source) inside the worktree.
     expect(writePerCrewSettingsLocal).toHaveBeenCalledWith(expect.objectContaining({
       projectCwd: "/tmp/brove/.worktrees/brove-crew-1",
@@ -694,7 +696,8 @@ describe("squadrant crew spawn", () => {
     stderrSpy.mockRestore();
   });
 
-  it("delivered:true emits task.first-turn.confirmed event to daemon (#466)", async () => {
+  // #472: hooks installed (writeSettingsLocal mock succeeds) → scrape does NOT emit.
+  it("delivered:true does NOT emit task.first-turn.confirmed from scrape when hooks installed (#472)", async () => {
     loadConfig.mockReturnValue(baseConfig);
     status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
     listSurfaces.mockResolvedValue([]);
@@ -702,17 +705,39 @@ describe("squadrant crew spawn", () => {
     buildCommand.mockReturnValue("claude ...");
     buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-dt1" } }));
     squadrantdCall.mockResolvedValue({ id: "task-dt1", project: "brove", provider: "claude", mode: "interactive" });
+    // writePerCrewSettingsLocal default mock returns undefined (no throw) → hooksInstalled=true
 
     const promise = runCrewSpawn({ project: "brove", task: "delivered task" });
     await vi.advanceTimersByTimeAsync(3000);
     await promise;
 
-    // squadrantdCall fired twice: once for dispatch, once for task.first-turn.confirmed
+    // dispatch only — hook is sole confirmation source
+    expect(squadrantdCall).toHaveBeenCalledTimes(1);
+    const calls = (squadrantdCall.mock.calls as Array<[{ kind: string; event?: { type: string } }]>).map(([r]) => r);
+    expect(calls).not.toContainEqual(expect.objectContaining({ event: { type: "task.first-turn.confirmed" } }));
+  });
+
+  // #472 fallback: when writeSettingsLocal throws, scrape emits task.first-turn.confirmed.
+  it("emits task.first-turn.confirmed from scrape when writeSettingsLocal fails (fallback) (#472)", async () => {
+    loadConfig.mockReturnValue(baseConfig);
+    status.mockResolvedValue({ id: "workspace:5", name: "brove-captain", status: "running" });
+    listSurfaces.mockResolvedValue([]);
+    newPane.mockResolvedValue({ workspaceId: "workspace:5", surfaceId: "surface:9" });
+    buildCommand.mockReturnValue("claude ...");
+    buildDispatchRequest.mockImplementation((o) => ({ kind: "dispatch", record: { ...o, id: "task-fb1" } }));
+    squadrantdCall.mockResolvedValue({ id: "task-fb1", project: "brove", provider: "claude", mode: "interactive" });
+    writePerCrewSettingsLocal.mockImplementationOnce(() => { throw new Error("ENOENT"); });
+
+    const promise = runCrewSpawn({ project: "brove", task: "fallback task" });
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    // dispatch + task.first-turn.confirmed from scrape
     expect(squadrantdCall).toHaveBeenCalledTimes(2);
     expect(squadrantdCall).toHaveBeenNthCalledWith(2, expect.objectContaining({
       kind: "event",
       project: "brove",
-      event: { type: "task.first-turn.confirmed", id: "task-dt1" },
+      event: { type: "task.first-turn.confirmed", id: "task-fb1" },
     }));
   });
 

--- a/packages/cli/src/commands/__tests__/side.test.ts
+++ b/packages/cli/src/commands/__tests__/side.test.ts
@@ -561,7 +561,8 @@ describe("crew spawn regression — daemon path unchanged", () => {
     await vi.advanceTimersByTimeAsync(3000);
     await promise;
 
-    expect(squadrantdCall).toHaveBeenCalledTimes(2); // dispatch + task.first-turn.confirmed
+    // #472: hooks installed (writePerCrewSettingsLocal mock succeeds) → dispatch only, no scrape emit
+    expect(squadrantdCall).toHaveBeenCalledTimes(1); // dispatch only
     vi.useRealTimers();
   });
 });

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -31,9 +31,12 @@ async function sendToSock(req: unknown): Promise<void> {
 function mapHookSub(sub: string, payload: unknown, taskId: string): ControlEvent | null {
   switch (sub) {
     case "session-start":
-    case "prompt-submit":
     case "pre-tool-use":
       return { type: "task.progress", id: taskId, note: sub };
+    case "prompt-submit":
+      // #470: NativeHookSource path mirrors the crew _hook UserPromptSubmit path.
+      // Reducer stamps firstTurnConfirmedAt only once; subsequent submits become liveness.
+      return { type: "task.first-turn.confirmed", id: taskId };
     case "stop":
       return mapClaudeHookToEvent("Stop", payload, taskId);
     case "notification":

--- a/packages/core/src/__tests__/crew-spawn.test.ts
+++ b/packages/core/src/__tests__/crew-spawn.test.ts
@@ -260,13 +260,31 @@ describe("runCrewSpawn", () => {
       }
     });
 
-    // #466: when sendFirstTurn resolves { delivered: true }, emitEvent is called
-    // with task.first-turn.confirmed so the daemon can stamp firstTurnConfirmedAt.
-    it("emits task.first-turn.confirmed when sendFirstTurn returns { delivered: true } (#466)", async () => {
+    // #472: when hooks are installed (writeSettingsLocal succeeds), the scrape must
+    // NOT emit task.first-turn.confirmed — UserPromptSubmit hook is the sole source.
+    it("does NOT emit task.first-turn.confirmed from scrape when hooks installed (#472)", async () => {
       const config = makeConfig();
       const runtime = makeRuntime();
       const agent = makeAgent("claude");
       const deps = makeSpawnDeps(runtime, agent);
+      deps.sendFirstTurn = vi.fn().mockResolvedValue({ delivered: true });
+      const emitEvent = vi.fn().mockResolvedValue(undefined);
+      deps.emitEvent = emitEvent;
+      // writeSettingsLocal succeeds (default mock returns undefined — no throw)
+
+      await runCrewSpawn({ project: PROJECT, task: "fix the bug" }, config, deps);
+
+      expect(emitEvent).not.toHaveBeenCalled();
+    });
+
+    // #472: when writeSettingsLocal throws (OS error / hook install failure),
+    // scrape confirmation is the fallback so the crew isn't silently lost.
+    it("emits task.first-turn.confirmed from scrape when writeSettingsLocal fails (fallback) (#472)", async () => {
+      const config = makeConfig();
+      const runtime = makeRuntime();
+      const agent = makeAgent("claude");
+      const deps = makeSpawnDeps(runtime, agent);
+      deps.writeSettingsLocal = vi.fn().mockImplementation(() => { throw new Error("ENOENT"); });
       deps.sendFirstTurn = vi.fn().mockResolvedValue({ delivered: true });
       const emitEvent = vi.fn().mockResolvedValue(undefined);
       deps.emitEvent = emitEvent;

--- a/packages/core/src/__tests__/daemon.test.ts
+++ b/packages/core/src/__tests__/daemon.test.ts
@@ -222,6 +222,26 @@ describe("daemon handler", () => {
     expect(store.get("p", "fc1")?.firstTurnConfirmedAt).toBe(500);
   });
 
+  // #470: UserPromptSubmit fires on every prompt (incl. captain crew send follow-ups).
+  // The reducer must NOT re-stamp firstTurnConfirmedAt on the second occurrence.
+  it("task.first-turn.confirmed is idempotent — second event does not re-stamp firstTurnConfirmedAt (#470)", async () => {
+    const store = createStore(dir);
+    store.put(rec("fc2", { state: "working" }));
+    let tick = 500;
+    const d = createDaemon({ store, now: () => tick });
+    // First confirmation stamps at 500.
+    await d.handle({ kind: "event", project: "p", event: { type: "task.first-turn.confirmed", id: "fc2" } });
+    expect(store.get("p", "fc2")?.firstTurnConfirmedAt).toBe(500);
+    // Second confirmation (e.g. from a captain crew send follow-up) must not change the field.
+    tick = 999;
+    const second = await d.handle({
+      kind: "event", project: "p",
+      event: { type: "task.first-turn.confirmed", id: "fc2" },
+    }) as import("@squadrant/shared").TaskRecord;
+    expect(second.firstTurnConfirmedAt).toBe(500);
+    expect(store.get("p", "fc2")?.firstTurnConfirmedAt).toBe(500);
+  });
+
   // #354: an interactive crew with a tool in flight (PreToolUse, no PostToolUse)
   // past the tool-stall budget IS a hung tool call → stalled, with a tool-named,
   // recoverable CREW STALLED warn.

--- a/packages/core/src/__tests__/daemon.test.ts
+++ b/packages/core/src/__tests__/daemon.test.ts
@@ -180,6 +180,35 @@ describe("daemon handler", () => {
     expect(calls.length).toBe(0); // within budget → silent
   });
 
+  // #466-single DEFECT 1: CREW UNDELIVERED must also fire for a spawned interactive
+  // crew still in `submitted` (never received task.started — the first turn was
+  // dropped before CC could process it). The prior fix only wired UNDELIVERED under
+  // `working`, so a silently-dropped crew was never flagged.
+  it("sweep: interactive `submitted` task past budget with no firstTurnConfirmedAt → CREW UNDELIVERED (#466-single)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    store.put(rec("s-undelivered", { mode: "interactive", state: "submitted", lastHeartbeat: 0,
+      heartbeatBudgetMs: 100, attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 0 }] }));
+    const d = createDaemon({ store, now: () => 1000, notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    expect(store.get("p", "s-undelivered")?.state).toBe("submitted"); // state unchanged
+    expect(calls.length).toBe(1);
+    expect(calls[0].message).toMatch(/CREW UNDELIVERED/);
+    expect(calls[0].message).toMatch(/re-send/i);
+    expect(calls[0].event.type).toBe("task.quiet");
+  });
+
+  // A `submitted` crew within the heartbeat budget must NOT fire (no false alarm).
+  it("sweep: interactive `submitted` task WITHIN budget → no notification (#466-single)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    store.put(rec("s-ok", { mode: "interactive", state: "submitted", lastHeartbeat: 950,
+      heartbeatBudgetMs: 100, attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 950 }] }));
+    const d = createDaemon({ store, now: () => 1000, notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    expect(calls.length).toBe(0);
+  });
+
   // #466: task.first-turn.confirmed event stamps firstTurnConfirmedAt on the record.
   it("task.first-turn.confirmed stamps firstTurnConfirmedAt on the record (#466)", async () => {
     const store = createStore(dir);

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -328,7 +328,16 @@ export async function runCrewSpawn(
     // Write squadrant hooks to <cwd>/.claude/settings.local.json so they are
     // auto-loaded as a project-local settings source. Merges with any existing
     // hooks — does not clobber the user's own personal hooks (#134).
-    deps.writeSettingsLocal(spawnCwd);
+    // #472: capture whether hook installation succeeded — when it does, the
+    // UserPromptSubmit hook is the SOLE first-turn confirmation source for
+    // claude crews. If the write fails (rare OS error), fall back to scrape.
+    let hooksInstalled = false;
+    try {
+      deps.writeSettingsLocal(spawnCwd);
+      hooksInstalled = true;
+    } catch {
+      // Hook file write failed — scrape confirmation remains as fallback.
+    }
     const cliCommand = agent.buildCommand({
       prompt: input.task,
       workdir: spawnCwd,
@@ -352,9 +361,11 @@ export async function runCrewSpawn(
     // #466: surface non-delivery explicitly instead of silently returning success.
     if (!claudeResult.delivered) {
       process.stderr.write(`⚠️  First turn not delivered for crew '${name}' — use 'squadrant crew send ${input.project} ${name}' to re-send the task.\n`);
-    } else {
+    } else if (!hooksInstalled) {
+      // #472: hooks unavailable — scrape is the only confirmation source for this crew.
       await deps.emitEvent?.(input.project, { type: "task.first-turn.confirmed", id: rec.id });
     }
+    // When hooksInstalled=true: UserPromptSubmit hook stamps firstTurnConfirmedAt.
     return { ...pane, title };
   }
 

--- a/packages/core/src/daemon/reduce.ts
+++ b/packages/core/src/daemon/reduce.ts
@@ -447,6 +447,27 @@ export function createDaemon(deps: DaemonDeps) {
             continue;
           }
         }
+        // #466-single: An interactive crew spawned but never started stays in
+        // `submitted` — no task.started hook ever fires, so the CREW QUIET/
+        // UNDELIVERED block below (which requires `working`) is unreachable.
+        // Surface CREW UNDELIVERED here for the quiet-past-budget submitted case
+        // so a silently-dropped first turn is caught regardless of state.
+        if (r.mode === "interactive" && r.state === "submitted" && !r.firstTurnConfirmedAt) {
+          const elapsed = t - r.lastHeartbeat;
+          if (elapsed > r.heartbeatBudgetMs) {
+            if (deps.notify && quietNotifiedAt.get(r.id) !== r.lastHeartbeat) {
+              quietNotifiedAt.set(r.id, r.lastHeartbeat);
+              const tag = crewTag(r);
+              const synthEvent: ControlEvent = { type: "task.quiet", id: r.id, quietMs: elapsed };
+              const message = `⚠️ CREW UNDELIVERED ${tag}: first turn may not have landed (crew never started) — re-send the task or check the spawn.`;
+              try {
+                const p = deps.notify({ project: r.project, message, record: r, event: synthEvent });
+                if (p && typeof (p as Promise<void>).catch === "function") (p as Promise<void>).catch(() => {});
+              } catch { /* swallowed */ }
+            }
+            continue;
+          }
+        }
         // #354: evaluateStall now only stalls a HEADLESS heartbeat timeout or a
         // hung INTERACTIVE tool call (PreToolUse with no PostToolUse past the
         // tool-stall budget). A quiet interactive thinking turn no longer stalls

--- a/packages/core/src/state-machine.ts
+++ b/packages/core/src/state-machine.ts
@@ -128,9 +128,12 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
     case "task.reattached":
       return stampAttempt(base, {}, now);
     case "task.first-turn.confirmed":
-      // #466: stamp the confirmed delivery timestamp. No state change — the crew
-      // stays `working`. The watchdog reads this field to distinguish a quiet-
-      // thinking crew from one that never received its first turn.
+      // #466/#470: stamp firstTurnConfirmedAt on the FIRST occurrence only.
+      // UserPromptSubmit fires on every prompt submit (incl. captain follow-ups);
+      // subsequent events are treated as liveness so the field is never re-stamped.
+      if (rec.firstTurnConfirmedAt) {
+        return { ...rec, lastEvent: "task.progress" };
+      }
       return { ...rec, firstTurnConfirmedAt: now, lastEvent: ev.type };
     case "task.stalled":
     case "task.idle":

--- a/packages/workspaces/src/__tests__/crew-pane.test.ts
+++ b/packages/workspaces/src/__tests__/crew-pane.test.ts
@@ -622,3 +622,161 @@ describe("confirmedSendToPane — large paste race (#455)", () => {
     expect(pasteToPane).toHaveBeenCalledWith(pane, "big follow-up");
   });
 });
+
+// ─── #466-single DEFECT 2: boot gate must reject HR-bounded banner (no ❯ prompt) ──
+
+describe("sendFirstTurnWhenReady — boot gate rejects HR banner without ❯ (#466-single defect 2)", () => {
+  let readPaneScreen: ReturnType<typeof vi.fn>;
+  let sendToPane: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
+  const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, sendToPane, pasteToPane, sendKeyToPane });
+
+  // The claude-mem banner that triggers the bug: has two HR lines but NO ❯ prompt
+  // between them. parseDraftFromScreen returns "" (≠ null) → old code treated this
+  // as "box present", boot gate fired, paste went into the banner and was lost.
+  // hasCCInputBox (new gate) requires a ❯ inside the box → correctly defers.
+  const HR = "─".repeat(60);
+  const BANNER_WITH_HR = `${HR}\nclaude-mem: initializing\nLoaded 42 memories\n${HR}`;
+  const EMPTY_BOX_LOCAL = `…transcript…\n${HR}\n❯ \n${HR}\n   Model: Sonnet 4.6  Ctx Used: 0.0%`;
+  const DRAFT_BOX_LOCAL = `…transcript…\n${HR}\n❯ [Pasted text #1]\n${HR}\n   Model: Sonnet 4.6`;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    readPaneScreen = vi.fn();
+    sendToPane = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
+  });
+  afterEach(() => { vi.useRealTimers(); });
+
+  // Core regression: paste must NOT fire while the HR banner (no ❯) is stable.
+  // We track which readPaneScreen call# triggered the first paste — it must be
+  // AFTER the banner period (n<=4). Before the fix the first paste fires at n=3
+  // (preSend captured during BANNER), which fails the > 4 assertion.
+  it("first paste fires AFTER banner period, not during HR banner stabilisation (#466-single defect 2)", async () => {
+    let firstPasteN = -1;
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n <= 4) return BANNER_WITH_HR;   // n=1..4: banner stable, no ❯
+      if (n <= 9) return EMPTY_BOX_LOCAL;  // n=5..9: CC box (has ❯) appears and stays
+      if (n <= 11) return DRAFT_BOX_LOCAL; // n=10..11: paste rendered
+      return EMPTY_BOX_LOCAL;              // n>=12: submitted
+    });
+    pasteToPane.mockImplementation(() => {
+      if (firstPasteN < 0) firstPasteN = n;
+    });
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "task text", "$ launch");
+    await vi.advanceTimersByTimeAsync(15000);
+    await promise;
+
+    // BEFORE fix: firstPasteN = 3 (paste during banner at n=3, ≤ 4) → fails
+    // AFTER fix:  firstPasteN = 7 (paste deferred to n=7, CC box stable) → passes
+    expect(firstPasteN).toBeGreaterThan(4);
+    expect(sendToPane).not.toHaveBeenCalled();
+  });
+
+  it("returns { delivered: true } when paste deferred until CC box is stable (#466-single defect 2)", async () => {
+    let firstPasteN = -1;
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n <= 4) return BANNER_WITH_HR;
+      if (n <= 9) return EMPTY_BOX_LOCAL;
+      if (n <= 11) return DRAFT_BOX_LOCAL;
+      return EMPTY_BOX_LOCAL;
+    });
+    pasteToPane.mockImplementation(() => {
+      if (firstPasteN < 0) firstPasteN = n;
+    });
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "task text", "$ launch");
+    await vi.advanceTimersByTimeAsync(15000);
+    const result = await promise;
+
+    expect(result).toEqual({ delivered: true });
+    expect(firstPasteN).toBeGreaterThan(4);
+  });
+});
+
+// ─── #466-single DEFECT 3: screen-changed must not declare delivery without sawDraft ─
+
+describe("sendFirstTurnWhenReady — screen change without sawDraft is NOT delivery (#466-single defect 3)", () => {
+  let readPaneScreen: ReturnType<typeof vi.fn>;
+  let sendToPane: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
+  const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, sendToPane, pasteToPane, sendKeyToPane });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    readPaneScreen = vi.fn();
+    sendToPane = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
+  });
+  afterEach(() => { vi.useRealTimers(); });
+
+  // Defect 3 scenario: paste is issued into the ready box, the box becomes
+  // non-parseable (CC TUI transitions mid-boot), and the screen changes — but the
+  // draft was never seen. The old code returned { delivered: true } on the screen-
+  // changed branch without requiring sawDraft. After the fix, it must return false.
+  it("returns { delivered: false } when screen changes but paste never rendered in box (#466-single defect 3)", async () => {
+    const NON_PARSEABLE = "CC transitioning — no HR box visible";
+    const HR = "─".repeat(60);
+    const EMPTY_BOX_LOCAL = `…transcript…\n${HR}\n❯ \n${HR}\n   Model: Sonnet 4.6  Ctx Used: 0.0%`;
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n <= 2) return EMPTY_BOX_LOCAL;  // readiness: stable CC box
+      if (n === 3) return EMPTY_BOX_LOCAL; // preSend snapshot
+      return NON_PARSEABLE;                 // post-paste: non-parseable, screen changed (boot transition)
+    });
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "big task", "$ launch");
+    await vi.advanceTimersByTimeAsync(25000);
+    const result = await promise;
+
+    // Screen changed but draft never rendered — NOT a delivery confirmation.
+    expect(result).toEqual({ delivered: false });
+    expect(sendToPane).not.toHaveBeenCalled();
+  });
+});
+
+describe("confirmedSendToPane — screen change without sawDraft is NOT delivery (#466-single defect 3)", () => {
+  let readPaneScreen: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
+  const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, pasteToPane, sendKeyToPane });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    readPaneScreen = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
+  });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it("returns { delivered: false } when paste never rendered but screen changed (#466-single defect 3)", async () => {
+    const HR = "─".repeat(60);
+    const IDLE_BOX = `…transcript…\n${HR}\n❯ \n${HR}\n   Model: Sonnet 4.6  Ctx Used: 0.0%`;
+    const NON_PARSEABLE = "CC transitioning — no HR box visible";
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n === 1) return IDLE_BOX;   // preSendScreen
+      return NON_PARSEABLE;            // after paste: no box, screen changed — draft never rendered
+    });
+
+    const promise = confirmedSendToPane(rt(), pane, "message");
+    await vi.advanceTimersByTimeAsync(8000);
+    const result = await promise;
+
+    expect(result).toEqual({ delivered: false });
+  });
+});

--- a/packages/workspaces/src/crew-pane.ts
+++ b/packages/workspaces/src/crew-pane.ts
@@ -6,7 +6,7 @@ import net from "node:net";
 import { loadConfig } from "@squadrant/shared";
 import type { PaneRef, RuntimeDriver } from "@squadrant/shared";
 import { RuntimeRegistry } from "./runtimes/registry.js";
-import { createCmuxDriver, parseDraftFromScreen } from "./runtimes/cmux.js";
+import { createCmuxDriver, parseDraftFromScreen, hasCCInputBox } from "./runtimes/cmux.js";
 import { titleFor, isCrewTitle, isTurnAccepted } from "@squadrant/core";
 import type { TurnAcceptanceConfig } from "@squadrant/core";
 
@@ -143,7 +143,7 @@ export async function confirmedSendToPane(
     if (draft !== "" && draft !== null) sawDraft = true;
     // Box confirmed empty AND we observed the paste rendered first → submitted.
     if (draft === "" && sawDraft) return { delivered: true };
-    if (draft === null && afterScreen !== preSendScreen) return { delivered: true };
+    if (draft === null && afterScreen !== preSendScreen && sawDraft) return { delivered: true };
     const settled = await settleInputBox(runtime, pane);
     if (settled) sawDraft = true;
     // #455: paste never rendered — re-paste once rather than issuing Enter into emptiness.
@@ -175,12 +175,15 @@ export async function sendFirstTurnWhenReady(
     const screen = (await runtime.readPaneScreen(pane)) ?? "";
     // Ready = the agent prompt is actually up: screen is non-empty, settled
     // (unchanged between two consecutive reads), has advanced past the un-entered
-    // launch command line, AND (for the claude/codex path) the HR-bounded input
-    // box is actually rendered. The last check prevents pasting into the claude-mem
-    // boot banner which can stabilise BEFORE the CC input box appears under load
-    // (#466 root cause). For the opencode splash path, parseDraftFromScreen would
-    // return null (no HR box), so we skip that check to preserve existing behaviour.
-    const hasInputBox = !!acceptanceConfig?.splashMarker || parseDraftFromScreen(screen) !== null;
+    // launch command line, AND (for the claude/codex path) the CC input box is
+    // rendered with its ❯ prompt glyph. hasCCInputBox is stricter than the old
+    // parseDraftFromScreen(screen)!==null check: the claude-mem startup banner can
+    // produce HR-bounded regions without a ❯ inside — parseDraftFromScreen returns
+    // "" (≠ null) for those, falsely satisfying the old gate. hasCCInputBox
+    // requires the ❯ to be present, so banners do not trigger a premature paste
+    // (#466-single root cause). For the opencode splash path the splashMarker
+    // short-circuits before this check, preserving existing behaviour.
+    const hasInputBox = !!acceptanceConfig?.splashMarker || hasCCInputBox(screen);
     if (screen.length > 0 && screen === previousScreen && screen !== preLaunchScreen && hasInputBox) {
       stable = true;
     } else {
@@ -253,7 +256,7 @@ export async function sendFirstTurnWhenReady(
     // Box not parseable (e.g. an agent TUI without the HR-bounded box, or a
     // transient overlay): fall back to the screen-changed signal so non-claude
     // TUIs aren't worse off than before.
-    if (draft === null && afterScreen !== preSendScreen) return { delivered: true };
+    if (draft === null && afterScreen !== preSendScreen && sawDraft) return { delivered: true };
     const settled = await settleInputBox(runtime, pane);
     if (settled) sawDraft = true;
     // #455: paste never rendered — re-paste once rather than issuing Enter into emptiness.

--- a/packages/workspaces/src/runtimes/cmux.ts
+++ b/packages/workspaces/src/runtimes/cmux.ts
@@ -203,6 +203,30 @@ export function parseDraftFromScreen(screen: string): string | null {
 }
 
 /**
+ * True when the screen contains a real Claude Code input box — two HR boundaries
+ * AND at least one line between them with the CC prompt glyph (❯ or >). This
+ * distinguishes the CC input box from the claude-mem startup banner, which can
+ * produce HR-bounded regions WITHOUT a prompt glyph and stabilise before CC
+ * renders its own TUI. parseDraftFromScreen returns "" for both cases (two HRs
+ * found, no ❯ inside), so !==null does not distinguish them (#466-single fix).
+ */
+export function hasCCInputBox(screen: string): boolean {
+  if (!screen) return false;
+  const lines = screen.split(/\r?\n/);
+  const HR_RE = /^\s*─{10,}\s*$/;
+  let bottomHR = -1;
+  let topHR = -1;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (HR_RE.test(lines[i])) {
+      if (bottomHR === -1) bottomHR = i;
+      else { topHR = i; break; }
+    }
+  }
+  if (topHR === -1) return false;
+  return lines.slice(topHR + 1, bottomHR).some((l) => /[>❯]/.test(l));
+}
+
+/**
  * Extract the RAW input-box content for the #302 buffer-liveness probe — all
  * content lines between the last two HRs, joined, with the prompt glyph and any
  * trailing cursor glyph stripped (but NOT the #294 ghost heuristics: the probe


### PR DESCRIPTION
Release v0.13.3 — fully verified stable (1770/1770 + live single + 4× concurrent large-spawn + idempotency).

## Fixes
- **#466 reopen** (#469): single large multi-line `--agent claude` spawn no longer drops the first turn (banner-vs-box boot gate, submitted-state UNDELIVERED watchdog, sawDraft delivery guard).
- **#470** (#471): first-turn confirmation is now hook-driven via `UserPromptSubmit`, not screen-scraped — ends the recurring first-turn-drop class.
- **#472** (#473): `UserPromptSubmit` is the sole confirmation source for claude crews (scrape fallback only when the hook can't install).

## Verification (live, on the merged develop build)
- Full suite: 1770/1770 local.
- Single 1.3KB multi-line claude spawn: landed, hook-confirmed.
- 4× concurrent large multi-line claude spawns: 4/4 landed, 0 drops, all hook-confirmed.
- Stamp-once idempotency held across a follow-up send.

Merging to main triggers tag v0.13.3 + GitHub release + npm publish (guarded + curl-verified per #463).

Note: #474 (daemon-restart stale-skip delivery drop) is tracked separately and NOT in this release.