### PR TITLE
fix(core): never stale-skip terminal/blocked events; fix null-draft defer escalation (#474)

### DIFF
--- a/packages/cli/src/__tests__/squadrantd-daemon-direct.test.ts
+++ b/packages/cli/src/__tests__/squadrantd-daemon-direct.test.ts
@@ -90,16 +90,18 @@ describe("squadrantd daemon-direct (#332)", () => {
     const inbox = join(stateRoot, "inbox");
     mkdirSync(inbox, { recursive: true });
 
-    // Seed two STALE entries (older than STALE_THRESHOLD_MS) followed by one
-    // FRESH entry, all written directly so we control the timestamps.
+    // Seed two STALE non-terminal entries followed by one FRESH terminal entry,
+    // written directly so we control timestamps and kinds.
+    // Non-terminal stale entries (task.started) are silently acked (#332 storm).
+    // Terminal stale entries would bypass the skip (#474 D1) — tested separately.
     const staleTs = new Date(Date.now() - STALE_THRESHOLD_MS - 60_000).toISOString();
     const freshTs = new Date().toISOString();
-    const line = (seq: number, ts: string, message: string) =>
-      JSON.stringify({ seq, ts, taskId: "t1", name: "test-crew", kind: "task.done", provider: "claude", payload: {}, message }) + "\n";
+    const mkLine = (seq: number, ts: string, kind: string, message: string) =>
+      JSON.stringify({ seq, ts, taskId: "t1", name: "test-crew", kind, provider: "claude", payload: {}, message }) + "\n";
     appendFileSync(join(inbox, "p.log"),
-      line(1, staleTs, "CREW DONE stale-1") +
-      line(2, staleTs, "CREW DONE stale-2") +
-      line(3, freshTs, "CREW DONE fresh-3"),
+      mkLine(1, staleTs, "task.started", "crew started stale-1") +
+      mkLine(2, staleTs, "task.started", "crew started stale-2") +
+      mkLine(3, freshTs, "task.done", "CREW DONE fresh-3"),
       "utf-8");
     await writeCursor({ stateRoot, project: "p", subscriber: "captain", lastAckedSeq: 0 });
 
@@ -458,6 +460,46 @@ describe("squadrantd daemon-direct (#332)", () => {
     // A subsequent (non-overlapping) tick must NOT re-deliver the already-acked entry.
     await handle.tickDelivery!();
     expect(sent.length).toBe(1);
+  });
+
+  // #474 D1: must-deliver events (task.done / task.blocked / task.failed)
+  // enqueued >5min before the daemon started must be DELIVERED, not stale-acked.
+  // task.blocked is especially critical: a dropped one leaves the captain waiting
+  // forever on a crew question. Today delivery-loop.ts:158 acks ALL stale entries
+  // regardless of kind — this test MUST FAIL until the D1 fix.
+  it("delivers stale must-deliver events (task.done + task.blocked) despite age on daemon restart (#474 / D1)", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-dd-474-"));
+    const sock = join(dir, "c.sock");
+    const stateRoot = join(dir, "state");
+    const inbox = join(stateRoot, "inbox");
+    mkdirSync(inbox, { recursive: true });
+
+    // Two must-deliver entries enqueued >5min before this daemon session:
+    //   seq 1 — task.done    (CREW DONE): terminal transition
+    //   seq 2 — task.blocked (CREW BLOCKED): crew waiting for captain input
+    const staleTs = new Date(Date.now() - STALE_THRESHOLD_MS - 60_000).toISOString();
+    const mkEntry = (seq: number, kind: string, message: string) =>
+      JSON.stringify({ seq, ts: staleTs, taskId: "t1", name: "test-crew", kind, provider: "claude", payload: {}, message }) + "\n";
+    appendFileSync(join(inbox, "p.log"),
+      mkEntry(1, "task.done",    "CREW DONE stale-terminal") +
+      mkEntry(2, "task.blocked", "CREW BLOCKED stale-blocked"),
+      "utf-8");
+    await writeCursor({ stateRoot, project: "p", subscriber: "captain", lastAckedSeq: 0 });
+
+    const cmux = fakeCmux();
+    const handle = startSquadrantd({
+      stateRoot, sockPath: sock, sweepMs: 0,
+      daemonCmux: cmux,
+      captainSurfaces: { p: { workspaceId: "ws:1", surfaceId: "surface:1", title: "captain" } },
+    });
+    stop = handle.stop;
+
+    if (handle.tickDelivery) await handle.tickDelivery();
+
+    // Both must-deliver events reach the captain regardless of staleness.
+    expect(cmux.sent.length).toBe(2);
+    expect(cmux.sent[0].text).toMatch(/CREW DONE stale-terminal/);
+    expect(cmux.sent[1].text).toMatch(/CREW BLOCKED stale-blocked/);
   });
 
   it("daemon-direct probe emits task.blocked when interactive crew pane shows a permission prompt", async () => {

--- a/packages/core/src/daemon/delivery-loop.ts
+++ b/packages/core/src/daemon/delivery-loop.ts
@@ -13,6 +13,11 @@ import type { DaemonContext } from "./context.js";
 const CURSOR_SUBSCRIBER = "captain";
 const CAPTAIN_GONE_STREAK_K = 3;
 
+// Must-deliver event kinds that bypass the stale-skip path (#474 D1).
+// Includes terminal transitions (done/failed/cancelled) AND task.blocked:
+// a dropped task.blocked leaves the captain waiting forever on a crew question.
+const TERMINAL_KINDS = new Set(["task.done", "task.failed", "task.cancelled", "task.blocked"]);
+
 /** Pure: find the captain surface by title in a surface list (#332). */
 export function discoverCaptainSurface(surfaces: PaneRef[], captainTitle: string): PaneRef | null {
   return surfaces.find((s) => s.title === captainTitle) ?? null;
@@ -156,15 +161,24 @@ export function createDelivery(
         // #332 storm BUG 3: silently ack entries that pre-date this daemon
         // session by more than STALE_THRESHOLD_MS.
         if (new Date(entry.ts).getTime() < sessionStartMs - STALE_THRESHOLD_MS) {
-          await writeCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER, lastAckedSeq: entry.seq });
-          continue;
+          // D1 (#474): terminal events must deliver regardless of age — an
+          // undelivered CREW DONE must reach the captain even after a daemon
+          // restart >5min after enqueue. Non-terminal backlog suppression stays.
+          if (!TERMINAL_KINDS.has(entry.kind)) {
+            log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=stale-skipped`);
+            await writeCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER, lastAckedSeq: entry.seq });
+            continue;
+          }
+          log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=stale-terminal-deliver`);
         }
         const result = await d.deliver(entry, (text, sendOpts) =>
           cmux.send(surface!, text, sendOpts),
         );
         if ("delivered" in result) {
+          log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=delivered`);
           await writeCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER, lastAckedSeq: entry.seq });
         } else {
+          log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=deferred`);
           break;
         }
       }

--- a/packages/core/src/delivery/__tests__/captain-delivery.test.ts
+++ b/packages/core/src/delivery/__tests__/captain-delivery.test.ts
@@ -45,4 +45,23 @@ describe("CaptainDelivery defer-while-typing (#258/#302)", () => {
     expect(result).toEqual({ delivered: true });
     expect(sent).toEqual([]);
   });
+
+  // #474 D2: DeferDelivery(null) means the captain pane has NO visible input box
+  // — this is NOT "captain typing", it means "pane not in input state".
+  // Null-draft defers must escalate to probe after stableProbePolls (3), not
+  // maxDefers (300). Today captain-delivery.ts:71 short-circuits on null content
+  // (`null && ...` = false) so stableCounts never increments and only the 300-
+  // defer backstop eventually fires. This test MUST FAIL until the D2 fix.
+  it("null-draft DeferDelivery escalates to probe after stableProbePolls, not maxDefers (#474 / D2)", async () => {
+    const probes: boolean[] = [];
+    const d = new CaptainDelivery({ maxDefers: 300, stableProbePolls: 3 });
+    const send = async (_t: string, opts?: { probe?: boolean }) => {
+      probes.push(!!opts?.probe);
+      if (!opts?.probe) throw new DeferDelivery(null); // null draft: pane not in input state
+    };
+    // Drive for stableProbePolls + 2 iterations; probe must fire by then.
+    for (let i = 0; i < 5; i++) await d.deliver({ seq: 1, message: "x" }, send);
+    // Probe must have fired well before maxDefers (300).
+    expect(probes.some((p) => p)).toBe(true);
+  });
 });

--- a/packages/core/src/delivery/captain-delivery.ts
+++ b/packages/core/src/delivery/captain-delivery.ts
@@ -68,7 +68,12 @@ export class CaptainDelivery {
         // Track content stability: byte-identical non-empty draft across
         // consecutive polls means the captain isn't actively typing (#302).
         const content = e.draft;
-        if (content && content === this.lastContent.get(seq)) {
+        const prev = this.lastContent.get(seq);
+        // D2 (#474): null-draft means the captain pane has no visible input
+        // box — NOT "captain typing". Consecutive nulls escalate like a stable
+        // draft so delivery isn't stuck for maxDefers (300) polls.
+        // Real-draft (byte-identical non-empty) path (#302/#258) is unchanged.
+        if (content === null ? prev === null : (!!content && content === prev)) {
           this.stableCounts.set(seq, (this.stableCounts.get(seq) ?? 0) + 1);
         } else {
           this.stableCounts.set(seq, 0);


### PR DESCRIPTION
Closes #474.

## Root cause (empirically proven via TDD red→green)
Daemon-direct delivery silently dropped an undelivered terminal lifecycle event (CREW DONE/BLOCKED/FAILED) when the daemon restarted >5min after the event was enqueued.

- **D1** `delivery-loop.ts:158` stale-skip silently acked any entry older than `sessionStartMs − 5min`, conflating historical backlog with a real never-delivered terminal signal.
- **D2** `captain-delivery.ts:71` `if (content && …)` short-circuited on null draft → `stableCounts` never incremented → null-draft defers never escalated, sitting the full ~5min `maxDefers` backstop (the window that let D1 drop them).
- **D3** the delivery loop logged nothing per decision — made the class undiagnosable.

## Fix
- **D3:** per-decision delivery logging (seq, kind, outcome: delivered | deferred | stale-skipped | stale-terminal-deliver).
- **D2:** consecutive null-drafts accumulate toward `stableProbePolls` and escalate promptly. Real-draft (#302/#258 captain-typing) path byte-for-byte unchanged.
- **D1:** terminal kinds `{task.done, task.failed, task.cancelled, task.blocked}` bypass stale-skip and always deliver regardless of age. A dropped `task.blocked` is the worst case (captain waits forever on a crew asking a question).

## Tests (TDD)
- 2 new tests reproduced both defects (RED), now green.
- D1 test covers stale `task.done` + `task.blocked` delivery post-restart.
- D2 test asserts escalation fires well before `maxDefers`.
- Full core+cli suite: 997/997.