### PR TITLE
fix(core): remove inert D2 null-draft escalation (#477)

### DIFF
--- a/packages/core/src/delivery/__tests__/captain-delivery.test.ts
+++ b/packages/core/src/delivery/__tests__/captain-delivery.test.ts
@@ -46,22 +46,23 @@ describe("CaptainDelivery defer-while-typing (#258/#302)", () => {
     expect(sent).toEqual([]);
   });
 
-  // #474 D2: DeferDelivery(null) means the captain pane has NO visible input box
-  // — this is NOT "captain typing", it means "pane not in input state".
-  // Null-draft defers must escalate to probe after stableProbePolls (3), not
-  // maxDefers (300). Today captain-delivery.ts:71 short-circuits on null content
-  // (`null && ...` = false) so stableCounts never increments and only the 300-
-  // defer backstop eventually fires. This test MUST FAIL until the D2 fix.
-  it("null-draft DeferDelivery escalates to probe after stableProbePolls, not maxDefers (#474 / D2)", async () => {
+  // #477: null-draft means the captain pane has no visible input box — delivery
+  // MUST keep deferring (safe). stableCounts never accumulates on null content
+  // so the probe-escalation path (#302) is never triggered. Only the maxDefers
+  // backstop eventually forces delivery.
+  it("null-draft DeferDelivery never escalates early — maxDefers backstop only (#477)", async () => {
     const probes: boolean[] = [];
-    const d = new CaptainDelivery({ maxDefers: 300, stableProbePolls: 3 });
+    const d = new CaptainDelivery({ maxDefers: 5, stableProbePolls: 3 });
     const send = async (_t: string, opts?: { probe?: boolean }) => {
       probes.push(!!opts?.probe);
-      if (!opts?.probe) throw new DeferDelivery(null); // null draft: pane not in input state
+      if (!opts?.probe) throw new DeferDelivery(null);
     };
-    // Drive for stableProbePolls + 2 iterations; probe must fire by then.
-    for (let i = 0; i < 5; i++) await d.deliver({ seq: 1, message: "x" }, send);
-    // Probe must have fired well before maxDefers (300).
+    // After stableProbePolls+1 polls, probe must NOT have fired (stableCounts stays 0 on null)
+    for (let i = 0; i < 4; i++) await d.deliver({ seq: 1, message: "x" }, send);
+    expect(probes.every((p) => !p)).toBe(true);
+    // maxDefers backstop fires at poll 6 (deferCount reaches maxDefers=5)
+    await d.deliver({ seq: 1, message: "x" }, send);
+    await d.deliver({ seq: 1, message: "x" }, send);
     expect(probes.some((p) => p)).toBe(true);
   });
 });

--- a/packages/core/src/delivery/captain-delivery.ts
+++ b/packages/core/src/delivery/captain-delivery.ts
@@ -68,12 +68,7 @@ export class CaptainDelivery {
         // Track content stability: byte-identical non-empty draft across
         // consecutive polls means the captain isn't actively typing (#302).
         const content = e.draft;
-        const prev = this.lastContent.get(seq);
-        // D2 (#474): null-draft means the captain pane has no visible input
-        // box — NOT "captain typing". Consecutive nulls escalate like a stable
-        // draft so delivery isn't stuck for maxDefers (300) polls.
-        // Real-draft (byte-identical non-empty) path (#302/#258) is unchanged.
-        if (content === null ? prev === null : (!!content && content === prev)) {
+        if (content && content === this.lastContent.get(seq)) {
           this.stableCounts.set(seq, (this.stableCounts.get(seq) ?? 0) + 1);
         } else {
           this.stableCounts.set(seq, 0);


### PR DESCRIPTION
Closes #477.

The D2 change from PR #476 made `CaptainDelivery` escalate null-drafts to `probe:true`, but the real cmux driver throws `DeferDelivery(null)` before the probe branch (`cmux.ts:552`) — so probe is ignored for null-drafts and the escalation was inert in production. Deferring null-drafts is also *correct and intentional* (#268): when the captain pane shows a question/overlay awaiting the user's reply, delivery must defer.

- Revert `captain-delivery.ts` to the original #302 logic (null content resets `stableCounts`, never accumulates toward the probe escalation → null-drafts keep deferring until the input box is visible).
- Replace the misleading D2 test with a #477 safety test: a persistent null-draft does NOT escalate early; only the `maxDefers` backstop fires.
- #474 D1 (terminal/blocked bypass stale-skip) in `delivery-loop.ts` is untouched and remains the operative #474 fix.

563/563 core tests pass.