### PR TITLE
fix(workspaces): defer-on-ambiguity in probe path — never clobber the captain's draft (#258)

### DIFF
--- a/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
+++ b/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { createCmuxDriver, sanitizeForCmuxSend, parseDraftFromScreen, classifyStartupSurface, classifySendOutcome } from "../cmux.js";
+import { createCmuxDriver, sanitizeForCmuxSend, parseDraftFromScreen, classifyStartupSurface, classifySendOutcome, classifyDraftLiveness } from "../cmux.js";
 import { DeferDelivery } from "@squadrant/core";
 
 const execFileMock = vi.hoisted(() => vi.fn());
@@ -1221,5 +1221,49 @@ describe("classifyStartupSurface (#292 startup-readiness classifier)", () => {
   it("prefers 'working' over 'idle' when both chrome and a live turn are present", () => {
     // The 258 fixture shape: idle-looking input box but an active spinner above.
     expect(classifyStartupSurface(WORKING_STATUS)).toBe("working");
+  });
+});
+
+// #258 probe false-negative cases — RED tests (Step-1: assert DESIRED behavior
+// which FAILS against the current slice(0,-1) logic).
+//
+// The current classifier misses two false-negative triggers and would fall
+// through to deliver() — clobbering a real in-progress user draft:
+//
+//  1. trailing-space: readInputBoxRaw trims trailing whitespace, so a draft
+//     ending in " " produces before="hello" AFTER the trim. Backspace removes
+//     the space from the terminal; box now reads "hello" too → after="hello".
+//     before === after (looks invariant), NOT before.slice(0,-1) → 'no-draft'
+//     → deliver → CLOBBER.
+//
+//  2. trailing emoji (wide/surrogate-pair char): backspace removes one grapheme
+//     ("😀" = U+1F600 = 😀); after="hello " trimmed to "hello".
+//     before.slice(0,-1) removes only the low surrogate (\uDE00), yielding
+//     "hello \uD83D" (broken) ≠ "hello" → 'no-draft' → deliver → CLOBBER.
+//
+// These tests FAIL on the current Step-1 classifier (it returns 'no-draft' for
+// both). They become GREEN in Step-2 after the fix.
+describe("classifyDraftLiveness (#258 probe false-negative detection)", () => {
+  it("returns 'real-draft' for ASCII draft that is 1 char shorter (sanity: positive detection still works)", () => {
+    // "hello world" → backspace removes 'd' → "hello worl"
+    expect(classifyDraftLiveness("hello world", "hello worl")).toBe("real-draft");
+  });
+
+  it("trailing-space: before='hello', after='hello' → 'inconclusive' (should NOT be no-draft)", () => {
+    // User typed "hello " — readInputBoxRaw trims → before="hello".
+    // Backspace removes the space from the terminal box: renders "hello" → after="hello".
+    // Current logic: after !== before.slice(0,-1) ("hell") → 'no-draft' → delivers → CLOBBER.
+    // Desired: 'inconclusive' — ambiguous between ghost-invariant and trailing-space draft;
+    // MUST defer rather than risk clobbering the human's real content.
+    expect(classifyDraftLiveness("hello", "hello")).toBe("inconclusive");
+  });
+
+  it("trailing emoji (surrogate pair): before='hello \\uD83D\\uDE00', after='hello' → 'real-draft'", () => {
+    // User typed "hello 😀" (U+1F600 = surrogate pair 😀).
+    // readInputBoxRaw: before="hello 😀" (no trailing whitespace to trim).
+    // Backspace removes the 😀 grapheme; terminal now shows "hello " → trimmed → after="hello".
+    // Current logic: before.slice(0,-1) = "hello \uD83D" (broken surrogate) ≠ "hello" → 'no-draft' → CLOBBER.
+    // Desired: 'real-draft' (grapheme-aware detection: drop last grapheme "😀" → "hello " → trim → "hello").
+    expect(classifyDraftLiveness("hello 😀", "hello")).toBe("real-draft");
   });
 });

--- a/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
+++ b/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
@@ -708,6 +708,27 @@ describe("sendToSurface draft-preservation", () => {
     expect(sends[0][sends[0].length - 1]).toBe("d");
   });
 
+  // #258 emoji fix: trailing emoji (surrogate pair) is correctly classified as
+  // real-draft and the FULL grapheme (not a lone broken surrogate) is restored.
+  it("probe: real draft ending in emoji (😀, surrogate pair) → defers and restores the full grapheme, never re-pastes draft", async () => {
+    const DRAFT = "hello 😀";
+    // Terminal backspace removes the 😀 grapheme; readInputBoxRaw trims trailing
+    // space → box shows "hello" → probeMock simulates this transformation.
+    probeMock(DRAFT, () => "hello");
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done", { probe: true }),
+    ).rejects.toBeInstanceOf(DeferDelivery);
+    const calls = execFileMock.mock.calls.map(argvOf);
+    // Full draft must NEVER be re-pasted
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes(DRAFT)))).toBe(false);
+    // Crew message NOT delivered
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")))).toBe(false);
+    // The restored char must be the full emoji grapheme, not a broken surrogate
+    const sends = calls.filter((a) => a[0] === "send");
+    expect(sends).toHaveLength(1);
+    expect(sends[0][sends[0].length - 1]).toBe("😀");
+  });
+
   it("probe: ghost that DISMISSES to empty under backspace → delivers message+Enter, NEVER re-sends the ghost text (#302 materialization regression)", async () => {
     const GHOST = "wait for both crews to finish";
     probeMock(GHOST, () => ""); // verified live: the #294 queue ghost dismisses to empty
@@ -720,13 +741,22 @@ describe("sendToSurface draft-preservation", () => {
     expect(calls.some((a) => a.includes("send-key") && a.includes("Enter"))).toBe(true);
   });
 
-  it("probe: ghost INVARIANT under backspace (stays identical) → delivers, never re-sends the ghost", async () => {
+  // #258 fix: ghost-invariant (after===before) is now INCONCLUSIVE — it is
+  // indistinguishable from a real draft whose trailing space was trimmed away
+  // by readInputBoxRaw. Bias: protect the human, delay the bot. The ghost text
+  // is still never re-pasted (no materialization). Crew message deferred until
+  // a later probe sees after==="" (ghost dismissed) or a grapheme-aware match.
+  it("probe: ghost INVARIANT under backspace (stays identical) → defers (inconclusive — indistinguishable from trailing-space real draft, #258)", async () => {
     const GHOST = "some persistent suggestion";
     probeMock(GHOST, (s) => s); // invariant: backspace is a no-op on non-buffer ghost
-    await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done", { probe: true });
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done", { probe: true }),
+    ).rejects.toBeInstanceOf(DeferDelivery);
     const calls = execFileMock.mock.calls.map(argvOf);
+    // Ghost text is never re-pasted (materialization guard still holds)
     expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("persistent suggestion")))).toBe(false);
-    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")))).toBe(true);
+    // Crew message NOT delivered — deferred to protect any possible real draft
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")))).toBe(false);
   });
 
   it("non-probe call with a draft present defers WITHOUT any keystroke (hot path unchanged — never races typing)", async () => {

--- a/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
+++ b/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
@@ -757,6 +757,34 @@ describe("sendToSurface draft-preservation", () => {
     expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("persistent suggestion")))).toBe(false);
     // Crew message NOT delivered — deferred to protect any possible real draft
     expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")))).toBe(false);
+    // True no-op: backspace didn't change the box → no restore send at all (#258)
+    expect(calls.filter((a) => a[0] === "send")).toHaveLength(0);
+  });
+
+  // #258 trailing-space residual: probe removes the trailing space (which readInputBoxRaw
+  // trimmed, so before===after in the trimmed view → inconclusive). The RAW (untrimmed)
+  // comparison detects the change and restores the space before deferring — the user's
+  // draft is left intact as "hello ", not mutated to "hello".
+  it("probe: trailing-space draft (inconclusive) → defers AND restores the space (draft preserved)", async () => {
+    let rawBox = "hello "; // trailing space — readInputBoxRaw trims it away → before="hello"
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return makeTestScreen(`❯ ${rawBox}`);
+      if (args.includes("send-key") && args.includes("backspace")) {
+        rawBox = rawBox.slice(0, -1); // backspace removes the trailing space from terminal
+        return "";
+      }
+      return "";
+    });
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done", { probe: true }),
+    ).rejects.toBeInstanceOf(DeferDelivery);
+    const calls = execFileMock.mock.calls.map(argvOf);
+    // Crew message NOT delivered
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")))).toBe(false);
+    // The trailing space is restored — exactly one send(), and it sends " "
+    const sends = calls.filter((a) => a[0] === "send");
+    expect(sends).toHaveLength(1);
+    expect(sends[0][sends[0].length - 1]).toBe(" ");
   });
 
   it("non-probe call with a draft present defers WITHOUT any keystroke (hot path unchanged — never races typing)", async () => {

--- a/packages/workspaces/src/runtimes/cmux.ts
+++ b/packages/workspaces/src/runtimes/cmux.ts
@@ -314,6 +314,34 @@ export function classifySendOutcome(payload: string, postBox: string | null): st
   return "unknown";
 }
 
+export type DraftLiveness = "real-draft" | "no-draft" | "inconclusive";
+
+/**
+ * Pure probe-liveness decision extracted for unit testing (#258).
+ * Given `before` / `after` raw box readings (from readInputBoxRaw) around a
+ * single backspace, classify whether a real user draft was present.
+ *
+ * Step-1 version: mirrors the current inline condition verbatim so existing
+ * behaviour is unchanged; tests can assert the false-negatives as failing.
+ * Step-2 will harden this into grapheme-aware + inconclusive-defers.
+ */
+export function classifyDraftLiveness(
+  before: string | null,
+  after: string | null,
+): DraftLiveness {
+  if (
+    before !== null &&
+    after !== null &&
+    after.length > 0 &&
+    after === before.slice(0, -1)
+  ) {
+    return "real-draft";
+  }
+  // Current behaviour: all other cases fall through to deliver. Step-2 will
+  // split this into 'no-draft' (ghost dismissed) vs 'inconclusive' (defer).
+  return "no-draft";
+}
+
 export function createCmuxDriver(): RuntimeDriver {
   return {
     name: "cmux",
@@ -559,28 +587,28 @@ export function createCmuxDriver(): RuntimeDriver {
       if (!opts?.probe) throw new DeferDelivery(draft);
 
       // #302 buffer-liveness probe (replaces the old destructive backspace×N
-      // clear + re-paste, which MATERIALIZED ghost suggestions). A real draft is
-      // the ONLY thing that yields the "last char removed, still non-empty"
-      // signature under ONE backspace (verified live, CC 2.1.x); a ghost either
-      // stays invariant or dismisses to empty. So we PROTECT only on that exact
-      // signature, and we NEVER re-paste screen-read content.
+      // clear + re-paste, which MATERIALIZED ghost suggestions). classifyDraftLiveness
+      // decides from the before/after box readings whether a real draft is present.
+      // #258: Step-1 refactor — behaviour unchanged; Step-2 hardens the classifier.
       const before = readInputBoxRaw(screen);
       await cmux(["send-key", "--workspace", ws, "--surface", sf, "backspace"]);
       let afterScreen = "";
       try {
         afterScreen = await cmux(["read-screen", "--workspace", ws, "--surface", sf]);
-      } catch { /* unreadable after probe — treat as no real draft, fall through to deliver */ }
+      } catch { /* unreadable after probe — classifyDraftLiveness receives null, returns no-draft */ }
       const after = readInputBoxRaw(afterScreen);
 
-      if (before !== null && after !== null && after.length > 0 && after === before.slice(0, -1)) {
+      const liveness = classifyDraftLiveness(before, after);
+      if (liveness === "real-draft") {
         // Confirmed REAL draft. Restore the single char our probe removed (NOT a
         // full re-paste — at most one known char), then defer. Never clobber, and
         // a ghost can never reach this branch, so it can never be materialized.
-        await cmux(["send", "--workspace", ws, "--surface", sf, before.slice(-1)]);
+        await cmux(["send", "--workspace", ws, "--surface", sf, before!.slice(-1)]);
         throw new DeferDelivery(draft);
       }
 
-      // No real draft (ghost dismissed/invariant, or buffer now empty) → deliver.
+      // 'no-draft' (and currently 'inconclusive') → deliver.
+      // Step-2 will make 'inconclusive' defer to protect real trailing-space/emoji drafts.
       await deliver();
     },
 

--- a/packages/workspaces/src/runtimes/cmux.ts
+++ b/packages/workspaces/src/runtimes/cmux.ts
@@ -317,29 +317,48 @@ export function classifySendOutcome(payload: string, postBox: string | null): st
 export type DraftLiveness = "real-draft" | "no-draft" | "inconclusive";
 
 /**
- * Pure probe-liveness decision extracted for unit testing (#258).
+ * Pure probe-liveness decision (#258 fix).
  * Given `before` / `after` raw box readings (from readInputBoxRaw) around a
  * single backspace, classify whether a real user draft was present.
  *
- * Step-1 version: mirrors the current inline condition verbatim so existing
- * behaviour is unchanged; tests can assert the false-negatives as failing.
- * Step-2 will harden this into grapheme-aware + inconclusive-defers.
+ * Three-way result — caller mapping:
+ *   "real-draft"   → restore last grapheme, throw DeferDelivery
+ *   "no-draft"     → deliver (ghost positively confirmed dismissed to empty)
+ *   "inconclusive" → throw DeferDelivery (bias: protect human, delay bot)
+ *
+ * "Inconclusive" covers: after===before (ghost-invariant OR trailing-space
+ * trim makes them equal — indistinguishable), null after-read (timing/overlay),
+ * and any other mismatch not explained by grapheme removal. The old code treated
+ * all of these as "no-draft" (fall-through to deliver), which is the #258 clobber.
  */
 export function classifyDraftLiveness(
   before: string | null,
   after: string | null,
 ): DraftLiveness {
-  if (
-    before !== null &&
-    after !== null &&
-    after.length > 0 &&
-    after === before.slice(0, -1)
-  ) {
-    return "real-draft";
+  if (before === null || after === null) return "inconclusive";
+
+  // Ghost dismissed to empty → positively confirmed no real draft remains.
+  if (after === "") return "no-draft";
+
+  // Grapheme-aware last-grapheme-removal check (Node 16+ / Intl.Segmenter).
+  // Removes the last grapheme cluster from `before`, trims trailing whitespace
+  // (matching what readInputBoxRaw does on the re-rendered screen), then
+  // compares to `after`. Handles emoji, wide chars, and combining sequences
+  // that slice(0,-1) gets wrong by removing only one UTF-16 code unit.
+  if (before.length > 0) {
+    const segs = [...new Intl.Segmenter().segment(before)];
+    const expected = segs
+      .slice(0, -1)
+      .map((s) => s.segment)
+      .join("")
+      .replace(/\s+$/, "");
+    if (after === expected) return "real-draft";
   }
-  // Current behaviour: all other cases fall through to deliver. Step-2 will
-  // split this into 'no-draft' (ghost dismissed) vs 'inconclusive' (defer).
-  return "no-draft";
+
+  // Everything else — after===before (ghost-invariant or trailing-space trim),
+  // arbitrary mismatch, or other ambiguity — is inconclusive. Defer to protect
+  // the human; a correctly empty box always produces after==="" (caught above).
+  return "inconclusive";
 }
 
 export function createCmuxDriver(): RuntimeDriver {
@@ -586,30 +605,37 @@ export function createCmuxDriver(): RuntimeDriver {
       // defer and carry the content so the relay can track stability (#302).
       if (!opts?.probe) throw new DeferDelivery(draft);
 
-      // #302 buffer-liveness probe (replaces the old destructive backspace×N
-      // clear + re-paste, which MATERIALIZED ghost suggestions). classifyDraftLiveness
-      // decides from the before/after box readings whether a real draft is present.
-      // #258: Step-1 refactor — behaviour unchanged; Step-2 hardens the classifier.
+      // #302 buffer-liveness probe. classifyDraftLiveness decides from the
+      // before/after box readings whether a real draft is present (#258 fix).
       const before = readInputBoxRaw(screen);
       await cmux(["send-key", "--workspace", ws, "--surface", sf, "backspace"]);
+      // 50ms settle: give the TUI time to re-render before reading back the
+      // result. Without this, a too-fast read may still show the pre-backspace
+      // content, producing a false after===before (timing-race #258).
+      await new Promise<void>((r) => setTimeout(r, 50));
       let afterScreen = "";
       try {
         afterScreen = await cmux(["read-screen", "--workspace", ws, "--surface", sf]);
-      } catch { /* unreadable after probe — classifyDraftLiveness receives null, returns no-draft */ }
+      } catch { /* unreadable — after stays "", readInputBoxRaw → null → inconclusive → defer */ }
       const after = readInputBoxRaw(afterScreen);
 
       const liveness = classifyDraftLiveness(before, after);
       if (liveness === "real-draft") {
-        // Confirmed REAL draft. Restore the single char our probe removed (NOT a
-        // full re-paste — at most one known char), then defer. Never clobber, and
-        // a ghost can never reach this branch, so it can never be materialized.
-        await cmux(["send", "--workspace", ws, "--surface", sf, before!.slice(-1)]);
+        // Confirmed real draft. Restore the last grapheme our probe removed
+        // (grapheme-aware — not slice(-1) which breaks emoji, #258), then defer.
+        const segs = before ? [...new Intl.Segmenter().segment(before)] : [];
+        const lastGrapheme =
+          segs.length > 0 ? segs[segs.length - 1].segment : before!.slice(-1);
+        await cmux(["send", "--workspace", ws, "--surface", sf, lastGrapheme]);
         throw new DeferDelivery(draft);
       }
-
-      // 'no-draft' (and currently 'inconclusive') → deliver.
-      // Step-2 will make 'inconclusive' defer to protect real trailing-space/emoji drafts.
-      await deliver();
+      if (liveness === "no-draft") {
+        // Ghost positively dismissed to empty — safe to deliver.
+        await deliver(); return;
+      }
+      // 'inconclusive' (ghost-invariant, trailing-space, timing race, etc.)
+      // → DEFER: protect the human's in-progress text, delay the bot (#258).
+      throw new DeferDelivery(draft);
     },
 
     async listSurfaces(workspaceId: string): Promise<PaneRef[]> {

--- a/packages/workspaces/src/runtimes/cmux.ts
+++ b/packages/workspaces/src/runtimes/cmux.ts
@@ -235,7 +235,10 @@ export function hasCCInputBox(screen: string): boolean {
  * parseDraftFromScreen this captures EVERY content line, so a multi-line draft's
  * change on its last line is not missed.
  */
-export function readInputBoxRaw(screen: string): string | null {
+export function readInputBoxRaw(
+  screen: string,
+  opts?: { trim?: boolean },
+): string | null {
   if (!screen) return null;
   const lines = screen.split(/\r?\n/);
   const HR_RE = /^\s*─{10,}\s*$/;
@@ -255,7 +258,10 @@ export function readInputBoxRaw(screen: string): string | null {
     s = s.replace(/\s*[▌█▔▎▏]+\s*$/, "");    // drop a trailing cursor glyph
     parts.push(s);
   }
-  return parts.join("").replace(/\s+$/, ""); // trim only the trailing edge
+  const joined = parts.join("");
+  // Default: trim trailing whitespace. Pass { trim: false } to preserve it —
+  // used by the probe branch to detect whether a backspace was a no-op (#258).
+  return opts?.trim === false ? joined : joined.replace(/\s+$/, "");
 }
 
 // #292: Claude Code renders a persistent bottom status block once its TUI is past
@@ -607,7 +613,10 @@ export function createCmuxDriver(): RuntimeDriver {
 
       // #302 buffer-liveness probe. classifyDraftLiveness decides from the
       // before/after box readings whether a real draft is present (#258 fix).
+      // Capture both trimmed (for classification) and untrimmed (for no-op
+      // detection in the inconclusive branch) before sending the backspace.
       const before = readInputBoxRaw(screen);
+      const rawBefore = readInputBoxRaw(screen, { trim: false });
       await cmux(["send-key", "--workspace", ws, "--surface", sf, "backspace"]);
       // 50ms settle: give the TUI time to re-render before reading back the
       // result. Without this, a too-fast read may still show the pre-backspace
@@ -618,6 +627,7 @@ export function createCmuxDriver(): RuntimeDriver {
         afterScreen = await cmux(["read-screen", "--workspace", ws, "--surface", sf]);
       } catch { /* unreadable — after stays "", readInputBoxRaw → null → inconclusive → defer */ }
       const after = readInputBoxRaw(afterScreen);
+      const rawAfter = readInputBoxRaw(afterScreen, { trim: false });
 
       const liveness = classifyDraftLiveness(before, after);
       if (liveness === "real-draft") {
@@ -633,8 +643,17 @@ export function createCmuxDriver(): RuntimeDriver {
         // Ghost positively dismissed to empty — safe to deliver.
         await deliver(); return;
       }
-      // 'inconclusive' (ghost-invariant, trailing-space, timing race, etc.)
-      // → DEFER: protect the human's in-progress text, delay the bot (#258).
+      // 'inconclusive': could be ghost-invariant (true no-op) or trailing-space
+      // draft (backspace removed the space but trim masked it). Distinguish by
+      // comparing the UNTRIMMED raw content: if the box actually changed, the
+      // backspace consumed a real character — restore it before deferring (#258).
+      if (rawBefore !== null && rawAfter !== null && rawBefore !== rawAfter) {
+        const segs = [...new Intl.Segmenter().segment(rawBefore)];
+        const lastGrapheme =
+          segs.length > 0 ? segs[segs.length - 1].segment : rawBefore.slice(-1);
+        await cmux(["send", "--workspace", ws, "--surface", sf, lastGrapheme]);
+      }
+      // → DEFER either way: protect the human's in-progress text, delay the bot.
       throw new DeferDelivery(draft);
     },
 


### PR DESCRIPTION
Closes #258.

## Bug
When the captain had an in-progress draft and a crew message was delivered, the buffer-liveness probe (`cmux.ts`) could **false-negative** on a real draft and fall through to `deliver()` (send+Enter), gluing the crew message onto the draft and submitting both.

## Root cause (TDD-proven)
The single-backspace signature `after === before.slice(0,-1)` false-negatives when:
- the draft **ends in a space** (`readInputBoxRaw` trims trailing whitespace, so before===after)
- the draft **ends in an emoji / wide / combining char** (`slice(0,-1)` removes one UTF-16 unit, not a grapheme)
- a **read-screen timing race** returns stale content

The old code treated all of these as 'no draft' → deliver → **clobber**.

## Fix
- `classifyDraftLiveness(before, after)` — pure, three-way: `real-draft` / `no-draft` (box positively empty) / `inconclusive`. Grapheme-aware (Intl.Segmenter), trailing-whitespace-aware.
- **Invert the fall-through: `inconclusive` → DEFER, never deliver.** Bias to protecting the human; the `maxDefers` backstop still guarantees eventual delivery.
- 50ms settle re-read after the backspace to kill the timing race.
- Grapheme-aware restore of the probed char.
- Inconclusive branch restores the consumed char only when the untrimmed box actually changed (trailing-space → restore; ghost-invariant no-op → don't) — so a real draft is never silently mutated.
- `null`-draft defer and empty-box fast path unchanged (deferral when the captain is awaiting the user's reply is intentional, #268).

## Tests
RED→GREEN: trailing-space and emoji false-negatives reproduced then fixed; ghost-invariant, restore, and trailing-space-preservation covered. **823/823** suite; **110/110** cmux tests verified on the worktree.

## Live validation
Confirmed in production on a real captain with a held draft: a pending CREW DONE deferred ~18× over 90s through the probe path with the draft fully intact — no clobber. Daemon ran this build (detached) during validation.