### PR TITLE
fix(workspaces): crew first-turn gate on CC-initialized + 90s budget for under-load cold-init (#466)

### DIFF
--- a/packages/workspaces/src/__tests__/crew-pane.test.ts
+++ b/packages/workspaces/src/__tests__/crew-pane.test.ts
@@ -747,6 +747,89 @@ describe("sendFirstTurnWhenReady — screen change without sawDraft is NOT deliv
   });
 });
 
+// ─── #466 RESIDUAL: gate on CC-initialized (not just ❯ box) + realistic budget ──
+// The prod repro (ci-indexer-38): the ❯ input box renders during cold-init while
+// claude-mem's MCP server is still loading — a window where keystrokes are silently
+// dropped (#235/#292). The old gate (hasCCInputBox = just a ❯ between two HRs)
+// declares "ready" in that window and pastes into a box that drops the keystrokes,
+// so the first turn never lands (firstTurnConfirmedAt was stamped 60s later, on the
+// operator's manual `crew send`). The captain startup path already solved this by
+// gating on CC_INITIALIZED_RE (Ctx Used / ⏵⏵ / for shortcuts / accept edits) via
+// classifyStartupSurface. The crew first-turn path must adopt the same contract.
+
+describe("sendFirstTurnWhenReady — gate requires CC initialized, not just ❯ box (#466 residual)", () => {
+  let readPaneScreen: ReturnType<typeof vi.fn>;
+  let sendToPane: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
+  const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, sendToPane, pasteToPane, sendKeyToPane });
+
+  const HR2 = "─".repeat(60);
+  // ❯ box present but CC NOT initialized — no Ctx Used / ⏵⏵ / shortcuts / accept-edits.
+  // This is the cold-init window (claude-mem MCP loading) where keystrokes are dropped.
+  const COLD_BOX = `…booting…\n${HR2}\n❯ \n${HR2}`;
+  // CC fully initialized: the persistent bottom status block is present.
+  const READY_BOX = `…transcript…\n${HR2}\n❯ \n${HR2}\n   Model: Sonnet 4.6  Ctx Used: 0.0%`;
+  const DRAFT_READY = `…transcript…\n${HR2}\n❯ [Pasted text #1]\n${HR2}\n   Model: Sonnet 4.6  Ctx Used: 0.0%`;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    readPaneScreen = vi.fn();
+    sendToPane = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
+  });
+  afterEach(() => { vi.useRealTimers(); });
+
+  // Core root-cause regression: paste must NOT fire while the ❯ box is up but CC
+  // has not yet rendered its initialized status block (keystrokes are dropped here).
+  it("does not paste while the ❯ box is up but CC is not yet initialized (cold-init drop window)", async () => {
+    let firstPasteN = -1;
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n <= 6) return COLD_BOX;     // ❯ visible but NOT initialized — keystrokes dropped
+      if (n <= 9) return READY_BOX;    // CC initialized (Ctx Used) — input accepted
+      if (n <= 11) return DRAFT_READY; // paste rendered in box
+      return READY_BOX;                // box empties after Enter → submitted
+    });
+    pasteToPane.mockImplementation(() => { if (firstPasteN < 0) firstPasteN = n; });
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "task text", "$ launch");
+    await vi.advanceTimersByTimeAsync(20000);
+    const result = await promise;
+
+    // BEFORE fix: firstPasteN = 3 (pasted into the cold box) → fails ( ≤ 6 ).
+    // AFTER fix:  paste deferred until CC initialized (firstPasteN > 6).
+    expect(firstPasteN).toBeGreaterThan(6);
+    expect(result).toEqual({ delivered: true });
+    expect(sendToPane).not.toHaveBeenCalled();
+  });
+
+  // Realistic budget: a slow boot under load reaches the initialized state only
+  // after the old 20s/24-poll window. The gated readiness wait must give it time
+  // instead of timing out and blind-firing into a still-cold box.
+  it("waits past the old 20s window for a slow boot to initialize (realistic budget)", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n <= 28) return COLD_BOX;     // long cold-init (~24s of polls): box up, not initialized
+      if (n <= 31) return READY_BOX;    // finally initialized
+      if (n <= 33) return DRAFT_READY;  // paste rendered
+      return READY_BOX;                 // submitted
+    });
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "task text", "$ launch");
+    await vi.advanceTimersByTimeAsync(40000);
+    const result = await promise;
+
+    // BEFORE fix: 20s budget times out into the cold box → blind fallback → dropped.
+    // AFTER fix:  extended budget reaches the initialized box → delivered.
+    expect(result).toEqual({ delivered: true });
+  });
+});
+
 describe("confirmedSendToPane — screen change without sawDraft is NOT delivery (#466-single defect 3)", () => {
   let readPaneScreen: ReturnType<typeof vi.fn>;
   let pasteToPane: ReturnType<typeof vi.fn>;

--- a/packages/workspaces/src/__tests__/crew-pane.test.ts
+++ b/packages/workspaces/src/__tests__/crew-pane.test.ts
@@ -828,6 +828,32 @@ describe("sendFirstTurnWhenReady — gate requires CC initialized, not just ❯ 
     // AFTER fix:  extended budget reaches the initialized box → delivered.
     expect(result).toEqual({ delivered: true });
   });
+
+  // pact-network's ACTUAL case: crews cold-init UNDER LOAD, so CC can take 30–60s to
+  // become input-ready (captains boot unloaded in 5–15s — captain parity is too short
+  // here). CC initializes at ~60s of polls. The readiness wait must reach it BEFORE
+  // the confirmedSendToPane fallback blind-fires into a still-cold box. The strong
+  // CC-initialized gate makes a long budget safe: it only waits as long as CC actually
+  // needs, and a crashed/never-ready CC still caps out at the budget.
+  it("delivers when a slow-under-load crew becomes CC-initialized at ~60s (#466 pact-network case)", async () => {
+    let n = 0;
+    readPaneScreen.mockImplementation(async () => {
+      n++;
+      if (n <= 78) return COLD_BOX;     // ~60s of cold-init under load: box up, NOT initialized
+      if (n <= 81) return READY_BOX;    // CC finally initialized (Ctx Used) → readiness + preSend
+      if (n <= 83) return DRAFT_READY;  // paste rendered in box
+      return READY_BOX;                 // box empties after Enter → submitted
+    });
+
+    const promise = sendFirstTurnWhenReady(rt(), pane, "task text", "$ launch");
+    await vi.advanceTimersByTimeAsync(95000);
+    const result = await promise;
+
+    // BEFORE fix: 30s budget times out at ~poll 38 → confirmedSendToPane fires while
+    //             CC is still cold → keystrokes dropped → delivered:false.
+    // AFTER fix:  90s budget reaches the initialized box at ~poll 80 → delivered.
+    expect(result).toEqual({ delivered: true });
+  });
 });
 
 describe("confirmedSendToPane — screen change without sawDraft is NOT delivery (#466-single defect 3)", () => {

--- a/packages/workspaces/src/crew-pane.ts
+++ b/packages/workspaces/src/crew-pane.ts
@@ -13,13 +13,17 @@ import type { TurnAcceptanceConfig } from "@squadrant/core";
 // Poll-based first-turn delivery timing constants.
 const SEND_FIRST_TURN_FLOOR_MS = 1500;
 const POLL_INTERVAL_MS = 750;
-// #466 residual: 30s matches the captain startup path's readyTimeoutMs
-// (deliverStartupPrompt). A crew in a fresh worktree with claude-mem's MCP server
-// loading under machine load can take >20s to reach the input-ready state; the old
-// 20s budget timed out into the cold-init box and blind-fired keystrokes that were
-// dropped. The gate below (CC-initialized, not just a ❯ box) needs this headroom to
-// observe the surface actually become ready instead of giving up early.
-const SEND_FIRST_TURN_TIMEOUT_MS = 30000;
+// #466 residual: 90s readiness cap. Captains boot UNLOADED (5–15s, hence their
+// 30s readyTimeoutMs), but crews cold-init UNDER LOAD in a fresh worktree with
+// claude-mem's MCP server loading — that can take 30–60s to reach input-ready
+// (pact-network's actual case). A captain-parity 30s budget timed out into the
+// still-cold box and the confirmedSendToPane fallback blind-fired keystrokes that
+// were dropped. The strong CC-initialized gate below makes a generous cap safe: it
+// only ever waits as long as CC actually needs (delivery fires the instant the
+// surface is ready), and a crashed/never-ready CC still caps out here. 90s sits
+// well under the daemon's 5min CREW UNDELIVERED watchdog, so a genuine failure is
+// still surfaced.
+const SEND_FIRST_TURN_TIMEOUT_MS = 90000;
 const POST_SEND_CHECK_MS = 750;
 
 // #235 Confirm-on-delivery constants for splash-gated agents (opencode).

--- a/packages/workspaces/src/crew-pane.ts
+++ b/packages/workspaces/src/crew-pane.ts
@@ -6,14 +6,20 @@ import net from "node:net";
 import { loadConfig } from "@squadrant/shared";
 import type { PaneRef, RuntimeDriver } from "@squadrant/shared";
 import { RuntimeRegistry } from "./runtimes/registry.js";
-import { createCmuxDriver, parseDraftFromScreen, hasCCInputBox } from "./runtimes/cmux.js";
+import { createCmuxDriver, parseDraftFromScreen, hasCCInputBox, classifyStartupSurface } from "./runtimes/cmux.js";
 import { titleFor, isCrewTitle, isTurnAccepted } from "@squadrant/core";
 import type { TurnAcceptanceConfig } from "@squadrant/core";
 
 // Poll-based first-turn delivery timing constants.
 const SEND_FIRST_TURN_FLOOR_MS = 1500;
 const POLL_INTERVAL_MS = 750;
-const SEND_FIRST_TURN_TIMEOUT_MS = 20000;
+// #466 residual: 30s matches the captain startup path's readyTimeoutMs
+// (deliverStartupPrompt). A crew in a fresh worktree with claude-mem's MCP server
+// loading under machine load can take >20s to reach the input-ready state; the old
+// 20s budget timed out into the cold-init box and blind-fired keystrokes that were
+// dropped. The gate below (CC-initialized, not just a ❯ box) needs this headroom to
+// observe the surface actually become ready instead of giving up early.
+const SEND_FIRST_TURN_TIMEOUT_MS = 30000;
 const POST_SEND_CHECK_MS = 750;
 
 // #235 Confirm-on-delivery constants for splash-gated agents (opencode).
@@ -183,8 +189,20 @@ export async function sendFirstTurnWhenReady(
     // requires the ❯ to be present, so banners do not trigger a premature paste
     // (#466-single root cause). For the opencode splash path the splashMarker
     // short-circuits before this check, preserving existing behaviour.
-    const hasInputBox = !!acceptanceConfig?.splashMarker || hasCCInputBox(screen);
-    if (screen.length > 0 && screen === previousScreen && screen !== preLaunchScreen && hasInputBox) {
+    // #466 residual: the ❯ input box renders during cold-init while claude-mem's
+    // MCP server is still loading — a window where keystrokes are silently dropped
+    // (#235/#292). hasCCInputBox alone (just a ❯ between two HRs) is satisfied in
+    // that window, so the old gate pasted into a box that dropped the keystrokes and
+    // the first turn never landed. Adopt the captain startup contract: require the
+    // surface to be CC-INITIALIZED (classifyStartupSurface === "idle", i.e. the
+    // persistent bottom status block — Ctx Used / ⏵⏵ / shortcuts / accept edits — is
+    // present and no turn is in flight), in addition to the ❯ box (keeps #469's
+    // banner rejection). The opencode splash path is unchanged: its splashMarker
+    // short-circuits below, so we leave its readiness as "box present".
+    const ready = acceptanceConfig?.splashMarker
+      ? true
+      : hasCCInputBox(screen) && classifyStartupSurface(screen) === "idle";
+    if (screen.length > 0 && screen === previousScreen && screen !== preLaunchScreen && ready) {
       stable = true;
     } else {
       previousScreen = screen;


### PR DESCRIPTION
Closes #466 (residual slow-boot first-turn drop).

## Root cause (authoritative, evidence-backed)
Crew first-turn delivery (`sendFirstTurnWhenReady`) gated on `hasCCInputBox` — just the `❯` box between two HRs. That box renders **during claude-mem MCP cold-init, a window where keystrokes are silently dropped** (#235/#292). The gate declared ready too early (or its 20s budget expired and blind-fired), so the paste landed in a not-ready box and the first turn never arrived → empty box, `Ctx 0.0%`. Smoking gun: `firstTurnConfirmedAt = createdAt + 60.7s` proved the auto-delivery submitted nothing; the hook only fired on manual `crew send` recovery.

The captain startup path (`deliverStartupPrompt`) already solved this — it gates on `CC_INITIALIZED_RE` (the persistent bottom status block), not the bare box.

## Fix
- Gate crew first-turn on `hasCCInputBox(screen) && classifyStartupSurface(screen) === 'idle'` — adopt the captain's proven CC-initialized contract instead of a new heuristic. Keeps #469's banner rejection (still requires `❯`) and the opencode `splashMarker` short-circuit.
- Extend the readiness budget 30s→90s: captains boot **unloaded**, but crews cold-init **under load** (other crews running) and can take 30–60s — pact-network's actual case. The old budget timed out into the still-cold box and the `confirmedSendToPane` fallback fired before CC was ready. 90s is well under the 5-min watchdog.

## Tests (TDD, 2 RED→GREEN pairs)
- Gate requires CC-initialized, not just `❯` (cold-init drop reproduced → fixed).
- Slow-under-load crew becomes CC-initialized at ~60s → first turn **delivered** (pact-network case; `delivered:false` before, `true` after).
- Full suite **1780** green; opencode splash, #469 banner, `confirmedSendToPane` unchanged.

This is the first fix in the first-turn-drop class to target **delivery readiness** rather than post-hoc confirmation.