### PR TITLE
fix(workspaces): ghost/hint defers forever — deliver when backspace is a no-op (#258 regression)

### DIFF
--- a/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
+++ b/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
@@ -741,24 +741,69 @@ describe("sendToSurface draft-preservation", () => {
     expect(calls.some((a) => a.includes("send-key") && a.includes("Enter"))).toBe(true);
   });
 
-  // #258 fix: ghost-invariant (after===before) is now INCONCLUSIVE — it is
-  // indistinguishable from a real draft whose trailing space was trimmed away
-  // by readInputBoxRaw. Bias: protect the human, delay the bot. The ghost text
-  // is still never re-pasted (no materialization). Crew message deferred until
-  // a later probe sees after==="" (ghost dismissed) or a grapheme-aware match.
-  it("probe: ghost INVARIANT under backspace (stays identical) → defers (inconclusive — indistinguishable from trailing-space real draft, #258)", async () => {
+  // Ghost-invariant fix: when backspace is a true no-op on BOTH trimmed AND raw
+  // content (rawBefore===rawAfter), the box holds non-editable ghost/hint text —
+  // a real draft ALWAYS changes under backspace. Deliver immediately; never defer.
+  // Ghost text is still never re-pasted (no materialization vector).
+  it("probe: ghost INVARIANT under backspace (stays identical) → DELIVERS (ghost is non-editable, not a real draft)", async () => {
     const GHOST = "some persistent suggestion";
     probeMock(GHOST, (s) => s); // invariant: backspace is a no-op on non-buffer ghost
     await expect(
       driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done", { probe: true }),
+    ).resolves.toBeUndefined();
+    const calls = execFileMock.mock.calls.map(argvOf);
+    // Ghost text is never re-pasted
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("persistent suggestion")))).toBe(false);
+    // Crew message IS delivered
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")))).toBe(true);
+    // Enter is submitted
+    expect(calls.some((a) => a.includes("send-key") && a.includes("Enter"))).toBe(true);
+  });
+
+  // Ghost-defer regression (#258 anti-clobber introduced a regression where a
+  // history/hint ghost text — "go — publish it", "wait for both crews to finish" —
+  // that is invariant under the backspace probe (rawBefore===rawAfter) caused
+  // delivery to defer indefinitely. Because the ghost is non-editable the backspace
+  // is a true no-op on both trimmed AND untrimmed content, giving the clean
+  // discrimination: invariant ⇒ not a real draft ⇒ DELIVER.
+  //
+  // RED test: currently DEFERS (bug). Fix: DELIVERS.
+  it("probe: ghost hint invariant under backspace (rawBefore===rawAfter, non-empty box) → DELIVERS (not defers) [ghost-defer regression]", async () => {
+    const GHOST = "go — publish it";
+    // Ghost: backspace is a true no-op on raw AND trimmed content.
+    probeMock(GHOST, (s) => s);
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done", { probe: true }),
+    ).resolves.toBeUndefined(); // MUST deliver, not defer
+    const calls = execFileMock.mock.calls.map(argvOf);
+    // Crew message IS delivered
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")))).toBe(true);
+    // Ghost text is never typed back into the box (no materialization)
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("go — publish it")))).toBe(false);
+    // Enter is submitted
+    expect(calls.some((a) => a.includes("send-key") && a.includes("Enter"))).toBe(true);
+  });
+
+  // Regression guard: trailing-space real draft must still DEFER after the ghost fix.
+  // rawBefore="hello " (untrimmed) → backspace removes the space → rawAfter="hello"
+  // → rawBefore !== rawAfter → real editable content → restore + defer.
+  it("probe: trailing-space real draft (rawBefore !== rawAfter) → still DEFERS (no-clobber regression guard)", async () => {
+    let rawBox = "hello "; // trailing space removed by backspace
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return makeTestScreen(`❯ ${rawBox}`);
+      if (args.includes("send-key") && args.includes("backspace")) { rawBox = rawBox.slice(0, -1); return ""; }
+      return "";
+    });
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done", { probe: true }),
     ).rejects.toBeInstanceOf(DeferDelivery);
     const calls = execFileMock.mock.calls.map(argvOf);
-    // Ghost text is never re-pasted (materialization guard still holds)
-    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("persistent suggestion")))).toBe(false);
-    // Crew message NOT delivered — deferred to protect any possible real draft
+    // Crew message NOT delivered
     expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")))).toBe(false);
-    // True no-op: backspace didn't change the box → no restore send at all (#258)
-    expect(calls.filter((a) => a[0] === "send")).toHaveLength(0);
+    // The trailing space is restored
+    const sends = calls.filter((a) => a[0] === "send");
+    expect(sends).toHaveLength(1);
+    expect(sends[0][sends[0].length - 1]).toBe(" ");
   });
 
   // #258 trailing-space residual: probe removes the trailing space (which readInputBoxRaw

--- a/packages/workspaces/src/runtimes/cmux.ts
+++ b/packages/workspaces/src/runtimes/cmux.ts
@@ -645,15 +645,22 @@ export function createCmuxDriver(): RuntimeDriver {
       }
       // 'inconclusive': could be ghost-invariant (true no-op) or trailing-space
       // draft (backspace removed the space but trim masked it). Distinguish by
-      // comparing the UNTRIMMED raw content: if the box actually changed, the
-      // backspace consumed a real character — restore it before deferring (#258).
-      if (rawBefore !== null && rawAfter !== null && rawBefore !== rawAfter) {
-        const segs = [...new Intl.Segmenter().segment(rawBefore)];
-        const lastGrapheme =
-          segs.length > 0 ? segs[segs.length - 1].segment : rawBefore.slice(-1);
-        await cmux(["send", "--workspace", ws, "--surface", sf, lastGrapheme]);
+      // comparing the UNTRIMMED raw content.
+      if (rawBefore !== null && rawAfter !== null) {
+        if (rawBefore !== rawAfter) {
+          // Raw changed: real trailing-space (or similar) draft — backspace consumed
+          // a real character. Restore the removed grapheme then defer (#258).
+          const segs = [...new Intl.Segmenter().segment(rawBefore)];
+          const lastGrapheme =
+            segs.length > 0 ? segs[segs.length - 1].segment : rawBefore.slice(-1);
+          await cmux(["send", "--workspace", ws, "--surface", sf, lastGrapheme]);
+          throw new DeferDelivery(draft);
+        }
+        // rawBefore === rawAfter: backspace was a true no-op — the box holds ghost/hint
+        // text (non-editable). A real draft ALWAYS changes under backspace. Deliver.
+        await deliver(); return;
       }
-      // → DEFER either way: protect the human's in-progress text, delay the bot.
+      // Null raw reads: can't distinguish ghost from draft → defer (bias: protect human).
       throw new DeferDelivery(draft);
     },
 


### PR DESCRIPTION
Fixes a regression introduced by #258. A ghost/history hint in the captain input box (dim suggestion text, e.g. 'go — publish it') caused delivery to defer forever until the user manually typed+Entered.

## Cause
#258 made the probe's `inconclusive` outcome always defer. A ghost/hint is invariant under the probe's backspace (non-editable), so it landed in `inconclusive` → perpetual defer. Before #258 that case delivered.

## Fix
Split `inconclusive` by whether the backspace actually changed the untrimmed box:
- raw **changed** → a real char was consumed (trailing-space draft) → restore grapheme + defer (anti-clobber unchanged)
- raw **unchanged** → true no-op → box holds non-editable ghost/hint → **deliver** (a real draft always changes under backspace)
- null raw → defer (safe bias)

## Tests
RED→GREEN: ghost invariant under backspace now delivers; trailing-space real draft still defers (clobber guard). 112 cmux + 828 core+workspaces green.