### PR TITLE
fix(workspaces): defer captain delivery into AskUserQuestion/permission modals

### DIFF
--- a/docs/reports/484-askuserquestion-fixture.txt
+++ b/docs/reports/484-askuserquestion-fixture.txt
@@ -1,0 +1,35 @@
+
+  2f093fe9-a235-5d1c-9a62-3fae2cdf7eb1
+  7c3338c5-8eec-50ae-bc4a-1f6969419936
+  claude-501
+  claude-mcp-browser-bridge-q3labsadmin
+  cmux-last-socket-path
+  cmux-session-map.json
+  devio_semaphore_logi_hpp_OptionsPlus_A7D4B139-F9F9-44A6-9F5D-7BC0A9B8B80F
+  logi.optionsplus.updater.log
+  logitech_kiros_agent-1945cf41572893f0fec8b289fe959344
+  logitech_kiros_updater
+  oneplan-server-r1-pr-brief.md
+  powerlog
+  warp_service
+
+✻ Churned for 8s
+
+❯ Use the AskUserQuestion tool right now to ask me: 'Which color do you prefer?' with options Red, 
+  Blue, Green. Do this immediately, do not explain first.                                          
+───────────────────────────────────────────────────────────────────────────────────────────────────
+ ☐ Color 
+
+Which color do you prefer?
+
+❯ 1. Red
+     Red
+  2. Blue
+     Blue
+  3. Green
+     Green
+  4. Type something.
+───────────────────────────────────────────────────────────────────────────────────────────────────
+  5. Chat about this
+
+Enter to select · ↑/↓ to navigate · Esc to cancel

--- a/docs/reports/484-idle-fixture.txt
+++ b/docs/reports/484-idle-fixture.txt
@@ -1,0 +1,35 @@
+     ../../tmp/.cockpit-smoke.txt
+       #8476  11:59 PM  ✅  Created cockpit smoke test marker file
+ 
+     Jun 16, 2026
+
+     General
+       #18178  3:26 PM  🔄  Authentication system refactor with token rotation edge case fix
+     #S5243 Status notification about completed auth refactor work and casual interaction (Jun 16
+     at 3:27 PM)
+ 
+ 
+     Investigated: No active investigation occurring. Session received status notifications about
+     completed work on the opencode/refactor-auth branch.
+     
+     Learned: Authentication system refactor on opencode/refactor-auth branch is complete with all
+     tests passing and token rotation edge case now handled cleanly.
+
+     Completed: Auth refactor work completed on opencode/refactor-auth branch. Token rotation edge
+     case fix implemented. All tests passing.
+
+     Next Steps: Session is idle awaiting next task or direction from user.
+
+
+     Access 4k tokens of past research & decisions for just 350t. Use the claude-mem skill to 
+     access memories by ID.
+
+     View Observations Live @ http://localhost:37777
+
+───────────────────────────────────────────────────────────────────────────────────────────────────
+❯ 
+───────────────────────────────────────────────────────────────────────────────────────────────────
+   Model: Sonnet 5  Ctx Used: 0.0%  Cost: $0.00  Sessio...
+   Session ID: bcef7dd0-9d23-4bc9-a1e7-4210732e1857  Thin...
+   ⎇ no git  𖠰 no git 
+  ⏵⏵ auto mode on (shift+tab to cycle) · ← for agents

--- a/docs/reports/484-permission-fixture.txt
+++ b/docs/reports/484-permission-fixture.txt
@@ -1,0 +1,52 @@
+     Apr 2, 2026
+
+     #S317 User requested Claude's identity in one sentence (Apr 2 at 12:15 PM)
+
+     #S316 Initial greeting exchange - user requested a simple hello (Apr 2 at 12:15 PM)
+
+     #S5242 Think step by step about the number 7 and execute bash command to finish (Apr 2 at 12:18 PM)
+
+
+     May 20, 2026
+
+     ../../tmp/.cockpit-smoke.txt
+       #8476  11:59 PM  ✅  Created cockpit smoke test marker file
+
+     Jun 16, 2026
+
+     General
+       #18178  3:26 PM  🔄  Authentication system refactor with token rotation edge case fix
+     #S5243 Status notification about completed auth refactor work and casual interaction (Jun 16 at 3:27 PM)
+
+
+     Investigated: No active investigation occurring. Session received status notifications about completed work on the opencode/refactor-auth branch.
+
+     Learned: Authentication system refactor on opencode/refactor-auth branch is complete with all tests passing and token rotation edge case now handled
+     cleanly.
+
+     Completed: Auth refactor work completed on opencode/refactor-auth branch. Token rotation edge case fix implemented. All tests passing.
+
+     Next Steps: Session is idle awaiting next task or direction from user.
+
+
+     Access 4k tokens of past research & decisions for just 350t. Use the claude-mem skill to access memories by ID.
+
+     View Observations Live @ http://localhost:37777
+
+❯ Use the Bash tool to run exactly: echo hi >> /tmp/squadrant-484-perm-test.txt                                                                                  
+
+  Running 1 shell command…
+  ⎿  $ echo hi >> /tmp/squadrant-484-perm-test.txt
+
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ Bash command
+
+   echo hi >> /tmp/squadrant-484-perm-test.txt
+   Append 'hi' to test file
+
+ Do you want to proceed?
+ ❯ 1. Yes
+   2. Yes, and always allow access to tmp/ from this project
+   3. No
+
+ Esc to cancel · Tab to amend · ctrl+e to explain

--- a/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
+++ b/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { createCmuxDriver, sanitizeForCmuxSend, parseDraftFromScreen, classifyStartupSurface, classifySendOutcome, classifyDraftLiveness } from "../cmux.js";
+import { createCmuxDriver, sanitizeForCmuxSend, parseDraftFromScreen, hasModalOptionList, classifyStartupSurface, classifySendOutcome, classifyDraftLiveness } from "../cmux.js";
 import { DeferDelivery } from "@squadrant/core";
 
 const execFileMock = vi.hoisted(() => vi.fn());
@@ -1123,6 +1123,148 @@ describe("parseDraftFromScreen", () => {
       "utf-8",
     );
     expect(parseDraftFromScreen(fixture)).toBe("");
+  });
+});
+
+// #484: AskUserQuestion / permission-approval SELECTION modals draw their own
+// pair of ── HR borders around a numbered option list, and highlight the
+// selected option with the same ❯ glyph as the genuine CC input box. A real
+// captured frame (docs/reports/484-askuserquestion-fixture.txt) confirms
+// parseDraftFromScreen returns the highlighted option's label ("1. Red") —
+// NOT null and NOT "" — so hasCCInputBox (which only checks for *any* ❯/>
+// between the HRs) cannot tell the modal apart from a genuine draft-bearing
+// input box. hasModalOptionList is the positive modal detector: CC renders
+// every selectable option (AskUserQuestion AND the Bash-approval picker) as
+// a "N. Label" line, which a real typed draft or ghost/hint placeholder
+// never does.
+describe("hasModalOptionList (#484 AskUserQuestion / permission-picker detector)", () => {
+  it("returns true for a real captured AskUserQuestion modal frame (regression #484)", () => {
+    const fixture = readFileSync(
+      join(process.cwd(), "docs/reports/484-askuserquestion-fixture.txt"),
+      "utf-8",
+    );
+    expect(hasModalOptionList(fixture)).toBe(true);
+  });
+
+  it("returns false for a real captured permission-approval frame (only one HR — already deferred via the #268 null gate)", () => {
+    const fixture = readFileSync(
+      join(process.cwd(), "docs/reports/484-permission-fixture.txt"),
+      "utf-8",
+    );
+    expect(hasModalOptionList(fixture)).toBe(false);
+  });
+
+  it("returns false for a real captured genuine idle empty input box", () => {
+    const fixture = readFileSync(
+      join(process.cwd(), "docs/reports/484-idle-fixture.txt"),
+      "utf-8",
+    );
+    expect(hasModalOptionList(fixture)).toBe(false);
+  });
+
+  it("returns false for a genuine typed draft (regression guard for #258)", () => {
+    const screen = makeTestScreen("❯ my draft here", "Some history");
+    expect(hasModalOptionList(screen)).toBe(false);
+  });
+
+  it("returns false when HR boundaries are absent (overlay/scrolled — regression guard for #268)", () => {
+    const fixture = readFileSync(
+      join(process.cwd(), "docs/reports/268-overlay-fixture.txt"),
+      "utf-8",
+    );
+    expect(hasModalOptionList(fixture)).toBe(false);
+  });
+
+  it("returns false for ghost/hint placeholder text (regression guard for #294 ghost-defer)", () => {
+    const fixture = readFileSync(
+      join(process.cwd(), "docs/reports/294-ghost-placeholder-fixture.txt"),
+      "utf-8",
+    );
+    expect(hasModalOptionList(fixture)).toBe(false);
+  });
+});
+
+// #484: the DANGEROUS path is the #302 stable-content probe escalation. Once a
+// mailbox entry has been stable (same non-null draft) across stableProbePolls
+// polls, captain-delivery.ts retries with probe:true. The probe's backspace
+// classifier treats "backspace is a no-op on both raw and trimmed content" as
+// proof of a non-editable ghost/hint placeholder → safe to deliver. But
+// backspace is ALSO a no-op against a selection modal (it isn't a text field
+// at all) — without the #484 guard, the probe would misclassify the modal as
+// a ghost and call deliver(), typing the crew message + Enter into the
+// picker and auto-confirming whichever option happens to be highlighted.
+describe("sendToSurface #484 modal/permission-picker deferral", () => {
+  const driver = createCmuxDriver();
+
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  it("defers on a real captured AskUserQuestion modal frame, never types or presses Enter (non-probe path)", async () => {
+    const fixture = readFileSync(
+      join(process.cwd(), "docs/reports/484-askuserquestion-fixture.txt"),
+      "utf-8",
+    );
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return fixture;
+      return "";
+    });
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done"),
+    ).rejects.toBeInstanceOf(DeferDelivery);
+    const calls = execFileMock.mock.calls.map(argvOf);
+    expect(calls.some((a) => a[0] === "send")).toBe(false);
+    expect(calls.some((a) => a.includes("send-key") && a.includes("Enter"))).toBe(false);
+  });
+
+  it("defers on a real captured AskUserQuestion modal frame even when probe-escalated (stable-content path) — never sends backspace, never delivers [#484 regression]", async () => {
+    const fixture = readFileSync(
+      join(process.cwd(), "docs/reports/484-askuserquestion-fixture.txt"),
+      "utf-8",
+    );
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return fixture;
+      return "";
+    });
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done", { probe: true }),
+    ).rejects.toBeInstanceOf(DeferDelivery);
+    const calls = execFileMock.mock.calls.map(argvOf);
+    // The modal guard must trip BEFORE the probe ever sends a backspace.
+    expect(calls.some((a) => a.includes("send-key") && a.includes("backspace"))).toBe(false);
+    expect(calls.some((a) => a[0] === "send")).toBe(false);
+    expect(calls.some((a) => a.includes("send-key") && a.includes("Enter"))).toBe(false);
+  });
+
+  it("still defers on a real captured permission-approval frame (regression guard, already-safe via the #268 null gate)", async () => {
+    const fixture = readFileSync(
+      join(process.cwd(), "docs/reports/484-permission-fixture.txt"),
+      "utf-8",
+    );
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return fixture;
+      return "";
+    });
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done"),
+    ).rejects.toBeInstanceOf(DeferDelivery);
+    const calls = execFileMock.mock.calls.map(argvOf);
+    expect(calls.some((a) => a[0] === "send")).toBe(false);
+  });
+
+  it("still delivers on a real captured genuine idle empty input box (regression guard)", async () => {
+    const fixture = readFileSync(
+      join(process.cwd(), "docs/reports/484-idle-fixture.txt"),
+      "utf-8",
+    );
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return fixture;
+      return "";
+    });
+    await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done");
+    const calls = execFileMock.mock.calls.map(argvOf);
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")))).toBe(true);
+    expect(calls.some((a) => a.includes("send-key") && a.includes("Enter"))).toBe(true);
   });
 });
 

--- a/packages/workspaces/src/runtimes/cmux.ts
+++ b/packages/workspaces/src/runtimes/cmux.ts
@@ -227,6 +227,34 @@ export function hasCCInputBox(screen: string): boolean {
 }
 
 /**
+ * True when the HR-bounded region is an AskUserQuestion / permission-approval
+ * SELECTION MODAL rather than the genuine CC input box (#484). Both draw their
+ * own pair of ── borders and highlight the selected option with the same ❯
+ * glyph as a real draft, so neither parseDraftFromScreen nor hasCCInputBox can
+ * tell them apart — a live-captured frame confirms parseDraftFromScreen
+ * returns the highlighted option's own label ("1. Red"), not "" or null (see
+ * docs/reports/484-askuserquestion-fixture.txt). CC renders every selectable
+ * option (AskUserQuestion AND the Bash-approval picker) as a "N. Label" line,
+ * which a real typed draft or ghost/hint placeholder never does — that's the
+ * positive signal used here.
+ */
+export function hasModalOptionList(screen: string): boolean {
+  if (!screen) return false;
+  const lines = screen.split(/\r?\n/);
+  const HR_RE = /^\s*─{10,}\s*$/;
+  let bottomHR = -1;
+  let topHR = -1;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (HR_RE.test(lines[i])) {
+      if (bottomHR === -1) bottomHR = i;
+      else { topHR = i; break; }
+    }
+  }
+  if (topHR === -1) return false;
+  return lines.slice(topHR + 1, bottomHR).some((l) => /^\s*\d+\.\s/.test(l));
+}
+
+/**
  * Extract the RAW input-box content for the #302 buffer-liveness probe — all
  * content lines between the last two HRs, joined, with the prompt glyph and any
  * trailing cursor glyph stripped (but NOT the #294 ghost heuristics: the probe
@@ -603,6 +631,16 @@ export function createCmuxDriver(): RuntimeDriver {
 
       // null = box not confirmed visible → never keystroke into an overlay (#268).
       if (draft === null) throw new DeferDelivery(null);
+
+      // #484: an AskUserQuestion / permission-approval SELECTION MODAL — never
+      // deliver into it, regardless of what parseDraftFromScreen returned or
+      // whether this call is probe-escalated. Checked before the probe branch
+      // below because the probe's backspace-no-op check can't tell "ghost
+      // placeholder" apart from "selection list" (backspace is a no-op
+      // against both) and would otherwise call deliver(), typing the message
+      // and pressing Enter into the picker — auto-confirming whichever option
+      // is highlighted.
+      if (hasModalOptionList(screen)) throw new DeferDelivery(null);
 
       // Empty input — nothing to protect, deliver directly.
       if (draft === "") { await deliver(); return; }


### PR DESCRIPTION
## Summary
- Fixes #484: the captain delivery gate could auto-answer an AskUserQuestion / permission-approval modal once its content went "stable" and the #302 probe escalation kicked in.
- Adds `hasModalOptionList` (`packages/workspaces/src/runtimes/cmux.ts`) — a positive selection-modal detector — and wires it into `sendToSurface` ahead of both the empty-deliver branch and the probe/backspace path.
- Adds 3 real cmux `read-screen` fixtures under `docs/reports/` (AskUserQuestion modal, permission-approval prompt, genuine idle box) captured live for this fix, plus RED→GREEN regression tests in `cmux.test.ts`.

## Root cause (empirically verified, refines the issue write-up)
Live capture showed the AskUserQuestion modal's highlighted option renders as `❯ 1. Red` — so `parseDraftFromScreen` actually returns the option's own label (e.g. `"1. Red"`), not `""` as the issue assumed. That non-empty, non-null draft already defers on the **first** delivery attempt.

The real hole is the **#302 stable-content probe escalation**: once that "draft" is byte-identical across `stableProbePolls` polls, `captain-delivery.ts` retries with `probe: true`. The probe's backspace-liveness check can't tell "non-editable ghost/hint text" (backspace no-op → deliver) apart from "non-editable selection list" (backspace is *also* a no-op) — so it misclassifies the modal as a ghost and calls `deliver()`, typing the crew message and pressing Enter into the picker, auto-confirming whichever option is highlighted.

The real permission-approval prompt (`Do you want to proceed? ❯ 1. Yes / 2. Yes always / 3. No`) only renders **one** HR border in the current CC version, so it was already safe via the existing `null`-draft gate (#268) — confirmed with a fixture and regression test.

## Discriminator
`hasCCInputBox` alone is insufficient here (task's step-2 warning confirmed): the modal's highlighted option uses the same `❯` glyph as a real prompt. Instead, `hasModalOptionList` checks the same HR-bounded region for a numbered `"N. Label"` line — every CC selection UI (AskUserQuestion *and* the Bash-approval picker) renders options this way, and neither a real draft nor ghost/hint text ever does.

## Test plan
- [x] New RED tests (`hasModalOptionList` unit tests + `sendToSurface #484 modal/permission-picker deferral`) failed before the fix — the probe-escalation test specifically reproduced the live exploit (`resolved "undefined" instead of rejecting`).
- [x] All tests GREEN after the fix; existing regression suites (#258 draft-preservation/ghost-defer, #268 overlay, #294 ghost-placeholder) still pass unmodified.
- [x] `npm run build` — clean build, all packages + CLI bundle.
- [x] `npx vitest run` — 150 test files / 1792 tests passed.
- [x] `gitnexus_impact` on `sendToSurface`/`parseDraftFromScreen` — LOW risk both.
- [x] `gitnexus_detect_changes` — only `hasModalOptionList` (new) and `sendToSurface` touched; one affected process (`SendToSurface → CmuxTimeoutError`, step 1), expected.