### PR TITLE
Release v0.13.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.5] - 2026-07-01
+
+### Fixed
+
+- **Daemon no longer auto-answers the captain's modal (#484):** delivery no longer auto-submits into the captain's `AskUserQuestion`/permission modal. A positive `N. Label` option-list detector (`hasModalOptionList`) defers delivery before the ghost/probe branches can mistake a modal's highlighted option for a live draft.
+
 ## [0.13.4] - 2026-06-30
 
 ### Fixed

--- a/docs/reports/484-askuserquestion-fixture.txt
+++ b/docs/reports/484-askuserquestion-fixture.txt
@@ -1,0 +1,35 @@
+
+  2f093fe9-a235-5d1c-9a62-3fae2cdf7eb1
+  7c3338c5-8eec-50ae-bc4a-1f6969419936
+  claude-501
+  claude-mcp-browser-bridge-q3labsadmin
+  cmux-last-socket-path
+  cmux-session-map.json
+  devio_semaphore_logi_hpp_OptionsPlus_A7D4B139-F9F9-44A6-9F5D-7BC0A9B8B80F
+  logi.optionsplus.updater.log
+  logitech_kiros_agent-1945cf41572893f0fec8b289fe959344
+  logitech_kiros_updater
+  oneplan-server-r1-pr-brief.md
+  powerlog
+  warp_service
+
+✻ Churned for 8s
+
+❯ Use the AskUserQuestion tool right now to ask me: 'Which color do you prefer?' with options Red, 
+  Blue, Green. Do this immediately, do not explain first.                                          
+───────────────────────────────────────────────────────────────────────────────────────────────────
+ ☐ Color 
+
+Which color do you prefer?
+
+❯ 1. Red
+     Red
+  2. Blue
+     Blue
+  3. Green
+     Green
+  4. Type something.
+───────────────────────────────────────────────────────────────────────────────────────────────────
+  5. Chat about this
+
+Enter to select · ↑/↓ to navigate · Esc to cancel

--- a/docs/reports/484-idle-fixture.txt
+++ b/docs/reports/484-idle-fixture.txt
@@ -1,0 +1,35 @@
+     ../../tmp/.cockpit-smoke.txt
+       #8476  11:59 PM  ✅  Created cockpit smoke test marker file
+ 
+     Jun 16, 2026
+
+     General
+       #18178  3:26 PM  🔄  Authentication system refactor with token rotation edge case fix
+     #S5243 Status notification about completed auth refactor work and casual interaction (Jun 16
+     at 3:27 PM)
+ 
+ 
+     Investigated: No active investigation occurring. Session received status notifications about
+     completed work on the opencode/refactor-auth branch.
+     
+     Learned: Authentication system refactor on opencode/refactor-auth branch is complete with all
+     tests passing and token rotation edge case now handled cleanly.
+
+     Completed: Auth refactor work completed on opencode/refactor-auth branch. Token rotation edge
+     case fix implemented. All tests passing.
+
+     Next Steps: Session is idle awaiting next task or direction from user.
+
+
+     Access 4k tokens of past research & decisions for just 350t. Use the claude-mem skill to 
+     access memories by ID.
+
+     View Observations Live @ http://localhost:37777
+
+───────────────────────────────────────────────────────────────────────────────────────────────────
+❯ 
+───────────────────────────────────────────────────────────────────────────────────────────────────
+   Model: Sonnet 5  Ctx Used: 0.0%  Cost: $0.00  Sessio...
+   Session ID: bcef7dd0-9d23-4bc9-a1e7-4210732e1857  Thin...
+   ⎇ no git  𖠰 no git 
+  ⏵⏵ auto mode on (shift+tab to cycle) · ← for agents

--- a/docs/reports/484-permission-fixture.txt
+++ b/docs/reports/484-permission-fixture.txt
@@ -1,0 +1,52 @@
+     Apr 2, 2026
+
+     #S317 User requested Claude's identity in one sentence (Apr 2 at 12:15 PM)
+
+     #S316 Initial greeting exchange - user requested a simple hello (Apr 2 at 12:15 PM)
+
+     #S5242 Think step by step about the number 7 and execute bash command to finish (Apr 2 at 12:18 PM)
+
+
+     May 20, 2026
+
+     ../../tmp/.cockpit-smoke.txt
+       #8476  11:59 PM  ✅  Created cockpit smoke test marker file
+
+     Jun 16, 2026
+
+     General
+       #18178  3:26 PM  🔄  Authentication system refactor with token rotation edge case fix
+     #S5243 Status notification about completed auth refactor work and casual interaction (Jun 16 at 3:27 PM)
+
+
+     Investigated: No active investigation occurring. Session received status notifications about completed work on the opencode/refactor-auth branch.
+
+     Learned: Authentication system refactor on opencode/refactor-auth branch is complete with all tests passing and token rotation edge case now handled
+     cleanly.
+
+     Completed: Auth refactor work completed on opencode/refactor-auth branch. Token rotation edge case fix implemented. All tests passing.
+
+     Next Steps: Session is idle awaiting next task or direction from user.
+
+
+     Access 4k tokens of past research & decisions for just 350t. Use the claude-mem skill to access memories by ID.
+
+     View Observations Live @ http://localhost:37777
+
+❯ Use the Bash tool to run exactly: echo hi >> /tmp/squadrant-484-perm-test.txt                                                                                  
+
+  Running 1 shell command…
+  ⎿  $ echo hi >> /tmp/squadrant-484-perm-test.txt
+
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ Bash command
+
+   echo hi >> /tmp/squadrant-484-perm-test.txt
+   Append 'hi' to test file
+
+ Do you want to proceed?
+ ❯ 1. Yes
+   2. Yes, and always allow access to tmp/ from this project
+   3. No
+
+ Esc to cancel · Tab to amend · ctrl+e to explain

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "squadrant",
   "packageManager": "pnpm@10.30.3",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "Multi-project orchestration for your coding agents (Claude, Codex, opencode, Gemini)",
   "type": "module",
   "bin": {

--- a/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
+++ b/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { createCmuxDriver, sanitizeForCmuxSend, parseDraftFromScreen, classifyStartupSurface, classifySendOutcome, classifyDraftLiveness } from "../cmux.js";
+import { createCmuxDriver, sanitizeForCmuxSend, parseDraftFromScreen, hasModalOptionList, classifyStartupSurface, classifySendOutcome, classifyDraftLiveness } from "../cmux.js";
 import { DeferDelivery } from "@squadrant/core";
 
 const execFileMock = vi.hoisted(() => vi.fn());
@@ -1123,6 +1123,148 @@ describe("parseDraftFromScreen", () => {
       "utf-8",
     );
     expect(parseDraftFromScreen(fixture)).toBe("");
+  });
+});
+
+// #484: AskUserQuestion / permission-approval SELECTION modals draw their own
+// pair of ── HR borders around a numbered option list, and highlight the
+// selected option with the same ❯ glyph as the genuine CC input box. A real
+// captured frame (docs/reports/484-askuserquestion-fixture.txt) confirms
+// parseDraftFromScreen returns the highlighted option's label ("1. Red") —
+// NOT null and NOT "" — so hasCCInputBox (which only checks for *any* ❯/>
+// between the HRs) cannot tell the modal apart from a genuine draft-bearing
+// input box. hasModalOptionList is the positive modal detector: CC renders
+// every selectable option (AskUserQuestion AND the Bash-approval picker) as
+// a "N. Label" line, which a real typed draft or ghost/hint placeholder
+// never does.
+describe("hasModalOptionList (#484 AskUserQuestion / permission-picker detector)", () => {
+  it("returns true for a real captured AskUserQuestion modal frame (regression #484)", () => {
+    const fixture = readFileSync(
+      join(process.cwd(), "docs/reports/484-askuserquestion-fixture.txt"),
+      "utf-8",
+    );
+    expect(hasModalOptionList(fixture)).toBe(true);
+  });
+
+  it("returns false for a real captured permission-approval frame (only one HR — already deferred via the #268 null gate)", () => {
+    const fixture = readFileSync(
+      join(process.cwd(), "docs/reports/484-permission-fixture.txt"),
+      "utf-8",
+    );
+    expect(hasModalOptionList(fixture)).toBe(false);
+  });
+
+  it("returns false for a real captured genuine idle empty input box", () => {
+    const fixture = readFileSync(
+      join(process.cwd(), "docs/reports/484-idle-fixture.txt"),
+      "utf-8",
+    );
+    expect(hasModalOptionList(fixture)).toBe(false);
+  });
+
+  it("returns false for a genuine typed draft (regression guard for #258)", () => {
+    const screen = makeTestScreen("❯ my draft here", "Some history");
+    expect(hasModalOptionList(screen)).toBe(false);
+  });
+
+  it("returns false when HR boundaries are absent (overlay/scrolled — regression guard for #268)", () => {
+    const fixture = readFileSync(
+      join(process.cwd(), "docs/reports/268-overlay-fixture.txt"),
+      "utf-8",
+    );
+    expect(hasModalOptionList(fixture)).toBe(false);
+  });
+
+  it("returns false for ghost/hint placeholder text (regression guard for #294 ghost-defer)", () => {
+    const fixture = readFileSync(
+      join(process.cwd(), "docs/reports/294-ghost-placeholder-fixture.txt"),
+      "utf-8",
+    );
+    expect(hasModalOptionList(fixture)).toBe(false);
+  });
+});
+
+// #484: the DANGEROUS path is the #302 stable-content probe escalation. Once a
+// mailbox entry has been stable (same non-null draft) across stableProbePolls
+// polls, captain-delivery.ts retries with probe:true. The probe's backspace
+// classifier treats "backspace is a no-op on both raw and trimmed content" as
+// proof of a non-editable ghost/hint placeholder → safe to deliver. But
+// backspace is ALSO a no-op against a selection modal (it isn't a text field
+// at all) — without the #484 guard, the probe would misclassify the modal as
+// a ghost and call deliver(), typing the crew message + Enter into the
+// picker and auto-confirming whichever option happens to be highlighted.
+describe("sendToSurface #484 modal/permission-picker deferral", () => {
+  const driver = createCmuxDriver();
+
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  it("defers on a real captured AskUserQuestion modal frame, never types or presses Enter (non-probe path)", async () => {
+    const fixture = readFileSync(
+      join(process.cwd(), "docs/reports/484-askuserquestion-fixture.txt"),
+      "utf-8",
+    );
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return fixture;
+      return "";
+    });
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done"),
+    ).rejects.toBeInstanceOf(DeferDelivery);
+    const calls = execFileMock.mock.calls.map(argvOf);
+    expect(calls.some((a) => a[0] === "send")).toBe(false);
+    expect(calls.some((a) => a.includes("send-key") && a.includes("Enter"))).toBe(false);
+  });
+
+  it("defers on a real captured AskUserQuestion modal frame even when probe-escalated (stable-content path) — never sends backspace, never delivers [#484 regression]", async () => {
+    const fixture = readFileSync(
+      join(process.cwd(), "docs/reports/484-askuserquestion-fixture.txt"),
+      "utf-8",
+    );
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return fixture;
+      return "";
+    });
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done", { probe: true }),
+    ).rejects.toBeInstanceOf(DeferDelivery);
+    const calls = execFileMock.mock.calls.map(argvOf);
+    // The modal guard must trip BEFORE the probe ever sends a backspace.
+    expect(calls.some((a) => a.includes("send-key") && a.includes("backspace"))).toBe(false);
+    expect(calls.some((a) => a[0] === "send")).toBe(false);
+    expect(calls.some((a) => a.includes("send-key") && a.includes("Enter"))).toBe(false);
+  });
+
+  it("still defers on a real captured permission-approval frame (regression guard, already-safe via the #268 null gate)", async () => {
+    const fixture = readFileSync(
+      join(process.cwd(), "docs/reports/484-permission-fixture.txt"),
+      "utf-8",
+    );
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return fixture;
+      return "";
+    });
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done"),
+    ).rejects.toBeInstanceOf(DeferDelivery);
+    const calls = execFileMock.mock.calls.map(argvOf);
+    expect(calls.some((a) => a[0] === "send")).toBe(false);
+  });
+
+  it("still delivers on a real captured genuine idle empty input box (regression guard)", async () => {
+    const fixture = readFileSync(
+      join(process.cwd(), "docs/reports/484-idle-fixture.txt"),
+      "utf-8",
+    );
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return fixture;
+      return "";
+    });
+    await driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done");
+    const calls = execFileMock.mock.calls.map(argvOf);
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")))).toBe(true);
+    expect(calls.some((a) => a.includes("send-key") && a.includes("Enter"))).toBe(true);
   });
 });
 

--- a/packages/workspaces/src/runtimes/cmux.ts
+++ b/packages/workspaces/src/runtimes/cmux.ts
@@ -227,6 +227,34 @@ export function hasCCInputBox(screen: string): boolean {
 }
 
 /**
+ * True when the HR-bounded region is an AskUserQuestion / permission-approval
+ * SELECTION MODAL rather than the genuine CC input box (#484). Both draw their
+ * own pair of ── borders and highlight the selected option with the same ❯
+ * glyph as a real draft, so neither parseDraftFromScreen nor hasCCInputBox can
+ * tell them apart — a live-captured frame confirms parseDraftFromScreen
+ * returns the highlighted option's own label ("1. Red"), not "" or null (see
+ * docs/reports/484-askuserquestion-fixture.txt). CC renders every selectable
+ * option (AskUserQuestion AND the Bash-approval picker) as a "N. Label" line,
+ * which a real typed draft or ghost/hint placeholder never does — that's the
+ * positive signal used here.
+ */
+export function hasModalOptionList(screen: string): boolean {
+  if (!screen) return false;
+  const lines = screen.split(/\r?\n/);
+  const HR_RE = /^\s*─{10,}\s*$/;
+  let bottomHR = -1;
+  let topHR = -1;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (HR_RE.test(lines[i])) {
+      if (bottomHR === -1) bottomHR = i;
+      else { topHR = i; break; }
+    }
+  }
+  if (topHR === -1) return false;
+  return lines.slice(topHR + 1, bottomHR).some((l) => /^\s*\d+\.\s/.test(l));
+}
+
+/**
  * Extract the RAW input-box content for the #302 buffer-liveness probe — all
  * content lines between the last two HRs, joined, with the prompt glyph and any
  * trailing cursor glyph stripped (but NOT the #294 ghost heuristics: the probe
@@ -603,6 +631,16 @@ export function createCmuxDriver(): RuntimeDriver {
 
       // null = box not confirmed visible → never keystroke into an overlay (#268).
       if (draft === null) throw new DeferDelivery(null);
+
+      // #484: an AskUserQuestion / permission-approval SELECTION MODAL — never
+      // deliver into it, regardless of what parseDraftFromScreen returned or
+      // whether this call is probe-escalated. Checked before the probe branch
+      // below because the probe's backspace-no-op check can't tell "ghost
+      // placeholder" apart from "selection list" (backspace is a no-op
+      // against both) and would otherwise call deliver(), typing the message
+      // and pressing Enter into the picker — auto-confirming whichever option
+      // is highlighted.
+      if (hasModalOptionList(screen)) throw new DeferDelivery(null);
 
       // Empty input — nothing to protect, deliver directly.
       if (draft === "") { await deliver(); return; }


### PR DESCRIPTION
## Summary

Patch release. The only change over v0.13.4 is the already-merged #484 fix (PR #485):

- **Daemon no longer auto-answers the captain's modal (#484):** delivery no longer auto-submits into the captain's `AskUserQuestion`/permission modal. A positive `N. Label` option-list detector (`hasModalOptionList`) defers delivery before the ghost/probe branches can mistake a modal's highlighted option for a live draft.

## Test plan

- [x] `pnpm run build` — succeeds
- [x] `pnpm test` — 150 test files / 1792 tests passed
- [x] Version bump matches the v0.13.4 precedent exactly: root `package.json` + `CHANGELOG.md` only (workspace packages stay pinned at `0.0.0`)

Merging this PR to `main` triggers the tag + GitHub release + guarded npm publish via `.github/workflows/release.yml`.