### PR TITLE
Back-merge v0.13.5 (main→develop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.5] - 2026-07-01
+
+### Fixed
+
+- **Daemon no longer auto-answers the captain's modal (#484):** delivery no longer auto-submits into the captain's `AskUserQuestion`/permission modal. A positive `N. Label` option-list detector (`hasModalOptionList`) defers delivery before the ghost/probe branches can mistake a modal's highlighted option for a live draft.
+
 ## [0.13.4] - 2026-06-30
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "squadrant",
   "packageManager": "pnpm@10.30.3",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "Multi-project orchestration for your coding agents (Claude, Codex, opencode, Gemini)",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Sync develop with the v0.13.5 release commit (package.json 0.13.5 + CHANGELOG). #484 fix already on develop via #485; this brings the version bump back.