### PR TITLE
feat(dashboard): surface delivery-deferral, CREW UNDELIVERED, Telegram-bridge and LifecycleSource health

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (4438 symbols, 6712 relationships, 168 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (4506 symbols, 6820 relationships, 166 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (4438 symbols, 6712 relationships, 168 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (4506 symbols, 6820 relationships, 166 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/packages/agents/src/codex/__tests__/codex-app-server-source.test.ts
+++ b/packages/agents/src/codex/__tests__/codex-app-server-source.test.ts
@@ -251,3 +251,19 @@ describe("CodexAppServerSource — anti-#2576: never reports task.done", () => {
     expect(reports).toHaveLength(0);
   });
 });
+
+describe("CodexAppServerSource — health() (B4)", () => {
+  it("reports inactive before start()", () => {
+    const src = makeSource();
+    expect(src.health()).toEqual({ active: false, error: null });
+  });
+
+  it("reports active after start(), inactive after stop() (never errors — purely push-driven)", () => {
+    const { deps } = makeDeps();
+    const src = makeSource();
+    src.start(deps);
+    expect(src.health()).toEqual({ active: true, error: null });
+    src.stop();
+    expect(src.health()).toEqual({ active: false, error: null });
+  });
+});

--- a/packages/agents/src/codex/codex-app-server-source.ts
+++ b/packages/agents/src/codex/codex-app-server-source.ts
@@ -37,19 +37,27 @@ export class CodexAppServerSource implements LifecycleSource {
   private deps?: LifecycleSourceDeps;
   /** taskId → last reported snapshot (for snapshot() liveness floor). */
   private cache = new Map<string, LifecycleSnapshot>();
+  private active = false;
 
   start(deps: LifecycleSourceDeps): void {
     this.deps = deps;
+    this.active = true;
   }
 
   stop(): void {
     this.deps = undefined;
     this.cache.clear();
+    this.active = false;
   }
 
   /** Returns the last-reported snapshot for a known crew (liveness floor). */
   snapshot(taskId: string): LifecycleSnapshot | undefined {
     return this.cache.get(taskId);
+  }
+
+  /** Read-only source health (B4). Purely push-driven — never errors on its own. */
+  health(): { active: boolean; error: string | null } {
+    return { active: this.active, error: null };
   }
 
   /**

--- a/packages/cli/src/__tests__/squadrantd-telegram.test.ts
+++ b/packages/cli/src/__tests__/squadrantd-telegram.test.ts
@@ -57,7 +57,10 @@ describe("squadrantd telegram bridge wiring", () => {
   it("starts/stops the injected bridge and composes pushLifecycle onto notify", async () => {
     dir = mkdtempSync(join(tmpdir(), "cp-tg-wired-"));
     const notify = vi.fn();
-    const bridge = { start: vi.fn(), stop: vi.fn(), pushLifecycle: vi.fn() };
+    const bridge = {
+      start: vi.fn(), stop: vi.fn(), pushLifecycle: vi.fn(),
+      health: vi.fn(() => ({ polling: false, lastSuccessfulPollAt: null, lastError: null, lastErrorAt: null })),
+    };
     const handle = startSquadrantd({
       stateRoot: join(dir, "state"),
       sockPath: join(dir, "c.sock"),

--- a/packages/cli/src/squadrantd.ts
+++ b/packages/cli/src/squadrantd.ts
@@ -143,6 +143,10 @@ export function startSquadrantd(opts: import("@squadrant/core").SquadrantdOpts =
   ctx.codexDriver = codexDriver;
   ctx.opencodeBridge = opencodeBridge;
   ctx.cmuxEventsBridge = cmuxEventsBridge;
+  // B4: register for per-source health aggregation in the snapshot. Registering
+  // is inert (no I/O) — only start() below (VITEST-guarded) actually runs a
+  // source, so health() correctly reports inactive until then.
+  ctx.lifecycleSources = [cmuxStoreSource, nativeHookSource, codexAppServerSource];
 
   // ── Telegram bridge (opt-in #65) ──────────────────────────────────────────
   // Built only when config.telegram is present. Skipped under vitest because the

--- a/packages/core/src/__tests__/liveness.classify.test.ts
+++ b/packages/core/src/__tests__/liveness.classify.test.ts
@@ -81,4 +81,52 @@ describe("projectHealth (pure projection)", () => {
     const kinds = cs.map((c) => c.kind);
     expect(kinds).not.toContain("relay" as never);
   });
+
+  it("B2: flags a quiet-past-budget interactive crew with no confirmed first turn as undelivered", () => {
+    const cs = projectHealth({
+      ...base,
+      now: 100_000,
+      captainStopped: false,
+      crews: [
+        {
+          id: "a1", name: "alpha", state: "submitted", mode: "interactive",
+          lastHeartbeat: 0, heartbeatBudgetMs: 60_000, firstTurnConfirmedAt: undefined,
+        },
+      ],
+    });
+    const crew = find(cs, "crew")!;
+    expect(crew.detail).toMatch(/undelivered/i);
+  });
+
+  it("B2: a crew with a confirmed first turn is never flagged undelivered, even if quiet past budget", () => {
+    const cs = projectHealth({
+      ...base,
+      now: 100_000,
+      captainStopped: false,
+      crews: [
+        {
+          id: "a1", name: "alpha", state: "working", mode: "interactive",
+          lastHeartbeat: 0, heartbeatBudgetMs: 60_000, firstTurnConfirmedAt: 1,
+        },
+      ],
+    });
+    const crew = find(cs, "crew")!;
+    expect(crew.detail).not.toMatch(/undelivered/i);
+  });
+
+  it("B2: a crew still within its heartbeat budget is never flagged undelivered", () => {
+    const cs = projectHealth({
+      ...base,
+      now: 10_000,
+      captainStopped: false,
+      crews: [
+        {
+          id: "a1", name: "alpha", state: "submitted", mode: "interactive",
+          lastHeartbeat: 0, heartbeatBudgetMs: 60_000, firstTurnConfirmedAt: undefined,
+        },
+      ],
+    });
+    const crew = find(cs, "crew")!;
+    expect(crew.detail).not.toMatch(/undelivered/i);
+  });
 });

--- a/packages/core/src/__tests__/mailbox.test.ts
+++ b/packages/core/src/__tests__/mailbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { mkdtempSync, readFileSync, existsSync, writeFileSync, mkdirSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -327,5 +327,25 @@ describe("mailboxStats", () => {
     const stats = await mailboxStats(stateRoot, "demo");
     expect(stats.rotationCount).toBe(1);
     expect(stats.maxSeq).toBe(6);
+  });
+
+  it("counts rotated-archive bytes and oldest-entry age when the current log is empty (#322)", async () => {
+    vi.useFakeTimers();
+    try {
+      const stateRoot = freshState();
+      vi.setSystemTime(1_000_000);
+      for (let i = 0; i < 5; i++) {
+        await appendToMailbox({ stateRoot, project: "demo", taskRecord: sampleRecord, event: doneEvent });
+      }
+      await rotateIfNeeded({ stateRoot, project: "demo", maxBytes: 50, maxAgeMs: 999999999, keepCount: 3 });
+      // No append after rotation: current file is fresh/empty, all entries live in the rotated archive.
+      vi.setSystemTime(1_000_000 + 5000);
+      const stats = await mailboxStats(stateRoot, "demo");
+      expect(stats.rotationCount).toBe(1);
+      expect(stats.sizeBytes).toBeGreaterThan(0);
+      expect(stats.oldestEntryAgeMs).toBe(5000);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/core/src/__tests__/snapshot.test.ts
+++ b/packages/core/src/__tests__/snapshot.test.ts
@@ -127,4 +127,28 @@ describe("assembleDaemonSnapshot", () => {
     const snap = assembleDaemonSnapshot(inputs(), NOW);
     expect(snap.tier2.results).toEqual({ fileCount: 294, totalBytes: 18_000_000 });
   });
+
+  it("B1: defaults deferral stats to zero/not-stuck when the caller has none yet", () => {
+    const snap = assembleDaemonSnapshot(inputs(), NOW);
+    expect(snap.tier2.projects[0].deferral).toEqual({ maxDeferCount: 0, stuck: false });
+  });
+
+  it("B1: passes per-project deferral stats through when the caller supplies them", () => {
+    const snap = assembleDaemonSnapshot(
+      inputs({
+        projects: [
+          {
+            project: "squadrant",
+            mailbox: { maxSeq: 12, sizeBytes: 1300, oldestEntryAgeMs: 60_000, rotationCount: 0 },
+            lastAckedSeq: 12,
+            storeByState: { working: 3 },
+            corruptCount: 0,
+            deferral: { maxDeferCount: 47, stuck: false },
+          },
+        ],
+      }),
+      NOW,
+    );
+    expect(snap.tier2.projects[0].deferral).toEqual({ maxDeferCount: 47, stuck: false });
+  });
 });

--- a/packages/core/src/__tests__/snapshot.test.ts
+++ b/packages/core/src/__tests__/snapshot.test.ts
@@ -33,6 +33,7 @@ function inputs(over: Partial<DaemonSnapshotInputs> = {}): DaemonSnapshotInputs 
     lastSweepAt: 9_000,
     sweepCadenceMs: 30_000,
     log: { errorCount: 0, sizeBytes: 1234, windowMs: 3_600_000 },
+    telegram: { configured: false, polling: false, lastSuccessfulPollAt: null, lastError: null, lastErrorAt: null },
     health: HEALTH,
     projects: [
       {
@@ -150,5 +151,18 @@ describe("assembleDaemonSnapshot", () => {
       NOW,
     );
     expect(snap.tier2.projects[0].deferral).toEqual({ maxDeferCount: 47, stuck: false });
+  });
+
+  it("B3: passes telegram bridge health through to Tier 0 verbatim", () => {
+    const snap = assembleDaemonSnapshot(
+      inputs({ telegram: { configured: true, polling: true, lastSuccessfulPollAt: 9500, lastError: null, lastErrorAt: null } }),
+      NOW,
+    );
+    expect(snap.tier0.telegram).toEqual({ configured: true, polling: true, lastSuccessfulPollAt: 9500, lastError: null, lastErrorAt: null });
+  });
+
+  it("B3: reports not-configured when telegram isn't set up", () => {
+    const snap = assembleDaemonSnapshot(inputs(), NOW);
+    expect(snap.tier0.telegram).toEqual({ configured: false, polling: false, lastSuccessfulPollAt: null, lastError: null, lastErrorAt: null });
   });
 });

--- a/packages/core/src/__tests__/snapshot.test.ts
+++ b/packages/core/src/__tests__/snapshot.test.ts
@@ -34,6 +34,7 @@ function inputs(over: Partial<DaemonSnapshotInputs> = {}): DaemonSnapshotInputs 
     sweepCadenceMs: 30_000,
     log: { errorCount: 0, sizeBytes: 1234, windowMs: 3_600_000 },
     telegram: { configured: false, polling: false, lastSuccessfulPollAt: null, lastError: null, lastErrorAt: null },
+    lifecycleSources: [],
     health: HEALTH,
     projects: [
       {
@@ -164,5 +165,21 @@ describe("assembleDaemonSnapshot", () => {
   it("B3: reports not-configured when telegram isn't set up", () => {
     const snap = assembleDaemonSnapshot(inputs(), NOW);
     expect(snap.tier0.telegram).toEqual({ configured: false, polling: false, lastSuccessfulPollAt: null, lastError: null, lastErrorAt: null });
+  });
+
+  it("B4: passes per-source LifecycleSource health through to Tier 0 verbatim", () => {
+    const snap = assembleDaemonSnapshot(
+      inputs({ lifecycleSources: [{ name: "cmux-store", active: true, error: null }, { name: "native-hook", active: false, error: "boom" }] }),
+      NOW,
+    );
+    expect(snap.tier0.lifecycleSources).toEqual([
+      { name: "cmux-store", active: true, error: null },
+      { name: "native-hook", active: false, error: "boom" },
+    ]);
+  });
+
+  it("B4: defaults to an empty list when no sources are registered", () => {
+    const snap = assembleDaemonSnapshot(inputs(), NOW);
+    expect(snap.tier0.lifecycleSources).toEqual([]);
   });
 });

--- a/packages/core/src/daemon/context.ts
+++ b/packages/core/src/daemon/context.ts
@@ -16,6 +16,7 @@ import type { PaneRef } from "@squadrant/shared";
 import type { AgentDriver, OpencodeBridge, CmuxEventsBridge, DaemonSurfaceDriver } from "../interfaces.js";
 import type { TelegramBridge } from "../telegram/bridge.js";
 import type { AttachFrame } from "../protocol.js";
+import type { LifecycleSource } from "../lifecycle-source.js";
 
 // ── Public injectable options (equivalent of old squadrantd.ts SquadrantdOpts) ───
 
@@ -60,6 +61,9 @@ export interface SquadrantdOpts {
    *  builds the real one only when config.telegram is present (and not under vitest,
    *  since pushLifecycle is composed onto notify and would hit the network). */
   telegramBridge?: TelegramBridge;
+  /** B4: registered LifecycleSource instances (cmux-store/native-hook/codex-appserver),
+   *  for aggregating per-source health into the snapshot. Empty in tests unless injected. */
+  lifecycleSources?: LifecycleSource[];
   /** Inject a fake surface driver for testing daemon-direct delivery. */
   daemonCmux?: DaemonSurfaceDriver;
   /** Factory for constructing the surface driver in production. */
@@ -121,6 +125,8 @@ export interface DaemonContext {
   cmuxEventsBridge: CmuxEventsBridge;
   /** Resolved Telegram bridge — undefined when config.telegram is absent. */
   telegramBridge?: TelegramBridge;
+  /** B4: registered LifecycleSource instances for per-source health aggregation. */
+  lifecycleSources: LifecycleSource[];
   /** Fan-out to attach clients (set by createAttach). */
   broadcast: (taskId: string, f: AttachFrame) => void;
   /** Schedule gate promotion (set by createAttach). */
@@ -176,6 +182,7 @@ export function buildContext(opts: SquadrantdOpts): DaemonContext {
     opencodeBridge: null as unknown as OpencodeBridge,
     cmuxEventsBridge: null as unknown as CmuxEventsBridge,
     telegramBridge: undefined,
+    lifecycleSources: opts.lifecycleSources ?? [],
     broadcast: () => {},
     schedulePromotion: () => {},
     cancelPromotionsFor: () => {},

--- a/packages/core/src/daemon/delivery-loop.ts
+++ b/packages/core/src/daemon/delivery-loop.ts
@@ -1,7 +1,7 @@
 // src/control/daemon/delivery.ts
 // Mailbox notification + daemon-direct captain delivery loop (#332).
 import { appendToMailbox, readCursor, writeCursor, readFromCursor } from "../mailbox.js";
-import { CaptainDelivery } from "../delivery/captain-delivery.js";
+import { CaptainDelivery, type CaptainDeliveryStats } from "../delivery/captain-delivery.js";
 import { loadConfig, TERMINAL_STATES } from "@squadrant/shared";
 import { STALE_THRESHOLD_MS } from "./interactive-probe.js";
 import type { TaskRecord, ControlEvent } from "@squadrant/shared";
@@ -48,6 +48,9 @@ export interface DeliveryResult {
   defaultNotify: (args: { project: string; message: string; record: TaskRecord; event: ControlEvent }) => Promise<void>;
   /** Guarded delivery tick — undefined when daemon-direct mode is OFF. */
   deliveryTick: (() => Promise<void>) | undefined;
+  /** Read-only per-project deferral stats (B1). undefined when daemon-direct mode is OFF,
+   *  or when the project has no CaptainDelivery instance yet (no delivery attempted). */
+  deliveryStats: (project: string) => CaptainDeliveryStats | undefined;
 }
 
 export function createDelivery(
@@ -80,12 +83,13 @@ export function createDelivery(
 
   // ── Daemon-direct delivery loop ───────────────────────────────────────────
   if (!daemonCmux) {
-    return { defaultNotify, deliveryTick: undefined };
+    return { defaultNotify, deliveryTick: undefined, deliveryStats: () => undefined };
   }
 
   const cmux = daemonCmux;
   const cfg = loadConfig();
   const deliveries = new Map<string, CaptainDelivery>();
+  const deliveryStats = (project: string): CaptainDeliveryStats | undefined => deliveries.get(project)?.stats();
   // Captured once at delivery-loop setup. Entries older than
   // sessionStartMs - STALE_THRESHOLD_MS are silently acked (cursor advanced)
   // without delivery. This stops a fresh/empty cursor from re-delivering the
@@ -195,5 +199,5 @@ export function createDelivery(
     }
   };
 
-  return { defaultNotify, deliveryTick };
+  return { defaultNotify, deliveryTick, deliveryStats };
 }

--- a/packages/core/src/daemon/start.ts
+++ b/packages/core/src/daemon/start.ts
@@ -38,7 +38,7 @@ export function startDaemon(ctx: DaemonContext, opts: SquadrantdOpts, pkgVersion
   const { daemonCmux } = ctx;
 
   const probes = createProbes(ctx);
-  const { defaultNotify, deliveryTick: initialDeliveryTick } = createDelivery(ctx, daemonCmux);
+  const { defaultNotify, deliveryTick: initialDeliveryTick, deliveryStats } = createDelivery(ctx, daemonCmux);
   // Compose the Telegram outbound push onto the notify fan-out: a captain
   // notification also pushes to the project's Telegram topic. When no bridge is
   // configured, notify is the base function unchanged (zero behavior change).
@@ -128,6 +128,7 @@ export function startDaemon(ctx: DaemonContext, opts: SquadrantdOpts, pkgVersion
           lastAckedSeq: cursor?.lastAckedSeq ?? 0,
           storeByState: storeStats.byState,
           corruptCount: storeStats.corruptCount,
+          deferral: deliveryStats(project),
         };
       }),
     );

--- a/packages/core/src/daemon/start.ts
+++ b/packages/core/src/daemon/start.ts
@@ -143,6 +143,7 @@ export function startDaemon(ctx: DaemonContext, opts: SquadrantdOpts, pkgVersion
       telegram: ctx.telegramBridge
         ? { configured: true, ...ctx.telegramBridge.health() }
         : { configured: false, polling: false, lastSuccessfulPollAt: null, lastError: null, lastErrorAt: null },
+      lifecycleSources: ctx.lifecycleSources.map((s) => ({ name: s.name, ...(s.health?.() ?? { active: true, error: null }) })),
       health: buildHealth(),
       projects,
       results: gatherResults(resultsDir),

--- a/packages/core/src/daemon/start.ts
+++ b/packages/core/src/daemon/start.ts
@@ -140,6 +140,9 @@ export function startDaemon(ctx: DaemonContext, opts: SquadrantdOpts, pkgVersion
       lastSweepAt: ctx.lastSweepAt.value,
       sweepCadenceMs: opts.sweepMs ?? 30_000,
       log: gatherLogStats(logPath, now, SNAPSHOT_LOG_WINDOW_MS),
+      telegram: ctx.telegramBridge
+        ? { configured: true, ...ctx.telegramBridge.health() }
+        : { configured: false, polling: false, lastSuccessfulPollAt: null, lastError: null, lastErrorAt: null },
       health: buildHealth(),
       projects,
       results: gatherResults(resultsDir),

--- a/packages/core/src/delivery/__tests__/captain-delivery.test.ts
+++ b/packages/core/src/delivery/__tests__/captain-delivery.test.ts
@@ -66,3 +66,37 @@ describe("CaptainDelivery defer-while-typing (#258/#302)", () => {
     expect(probes.some((p) => p)).toBe(true);
   });
 });
+
+describe("CaptainDelivery.stats (B1 — read-only deferral visibility)", () => {
+  it("reports zero/not-stuck when nothing is in flight", () => {
+    const d = new CaptainDelivery({ maxDefers: 5, stableProbePolls: 3 });
+    expect(d.stats()).toEqual({ maxDeferCount: 0, stuck: false });
+  });
+
+  it("reports the max in-flight defer count across seqs, not stuck below the threshold", async () => {
+    const d = new CaptainDelivery({ maxDefers: 5, stableProbePolls: 999 });
+    const send = async () => { throw new DeferDelivery("draft"); };
+    await d.deliver({ seq: 1, message: "a" }, send);
+    await d.deliver({ seq: 1, message: "a" }, send);
+    await d.deliver({ seq: 2, message: "b" }, send);
+    expect(d.stats()).toEqual({ maxDeferCount: 2, stuck: false });
+  });
+
+  it("flags stuck once the max in-flight defer count reaches maxDefers", async () => {
+    const d = new CaptainDelivery({ maxDefers: 2, stableProbePolls: 999 });
+    const send = async () => { throw new DeferDelivery("draft"); };
+    await d.deliver({ seq: 1, message: "a" }, send);
+    await d.deliver({ seq: 1, message: "a" }, send);
+    expect(d.stats()).toEqual({ maxDeferCount: 2, stuck: true });
+  });
+
+  it("clears a seq's defer count once it delivers", async () => {
+    let fail = true;
+    const d = new CaptainDelivery({ maxDefers: 5, stableProbePolls: 999 });
+    const send = async () => { if (fail) throw new DeferDelivery("draft"); };
+    await d.deliver({ seq: 1, message: "a" }, send);
+    fail = false;
+    await d.deliver({ seq: 1, message: "a" }, send);
+    expect(d.stats()).toEqual({ maxDeferCount: 0, stuck: false });
+  });
+});

--- a/packages/core/src/delivery/captain-delivery.ts
+++ b/packages/core/src/delivery/captain-delivery.ts
@@ -16,6 +16,15 @@ export interface CaptainDeliveryOptions {
 export type SendFn = (text: string, opts?: { probe?: boolean }) => Promise<void>;
 export type DeliverResult = { delivered: true } | { deferred: true };
 
+/** Read-only deferral snapshot (B1 — dashboard visibility into #484/#466-class stalls). */
+export interface CaptainDeliveryStats {
+  /** Highest in-flight deferCount across all seqs currently being retried (0 when none). */
+  maxDeferCount: number;
+  /** true once maxDeferCount has reached the configured maxDefers threshold — the same
+   *  point at which delivery force-escalates to a probe send. */
+  stuck: boolean;
+}
+
 /**
  * Unified-formatter helper (#214/#210): the daemon's formatMessage is the single
  * source of truth for the captain-facing message. Returns null for entries the
@@ -79,5 +88,12 @@ export class CaptainDelivery {
       // Non-DeferDelivery errors: don't advance cursor, retry next poll.
       return { deferred: true };
     }
+  }
+
+  /** Read-only. Never mutates — safe to poll from the snapshot assembler every tick. */
+  stats(): CaptainDeliveryStats {
+    let maxDeferCount = 0;
+    for (const c of this.deferCounts.values()) if (c > maxDeferCount) maxDeferCount = c;
+    return { maxDeferCount, stuck: maxDeferCount >= this.opts.maxDefers };
   }
 }

--- a/packages/core/src/lifecycle-source.ts
+++ b/packages/core/src/lifecycle-source.ts
@@ -78,6 +78,12 @@ export interface LifecycleSource {
    * A poll result MUST set origin:"scan" and MUST NOT assert state:"needsInput".
    */
   snapshot?(taskId: string): LifecycleSnapshot | undefined;
+  /**
+   * Read-only source-level health (B4 — dashboard visibility into which sources
+   * are up). Optional: a source with no fallible startup can omit it and the
+   * daemon assumes {active: true, error: null} once registered.
+   */
+  health?(): { active: boolean; error: string | null };
 }
 
 // ── the one reducer all sources feed ────────────────────────────────────────

--- a/packages/core/src/liveness.ts
+++ b/packages/core/src/liveness.ts
@@ -66,6 +66,13 @@ export interface CrewLiveness {
   state: TaskState;
   lastHeartbeat: number;
   mode: Mode;
+  /** Set once the crew's first turn is confirmed delivered (#466). Absent/undefined
+   *  means "never confirmed" — combined with heartbeatBudgetMs below to detect a
+   *  dropped first turn (mirrors daemon/reduce.ts's CREW UNDELIVERED watchdog). */
+  firstTurnConfirmedAt?: number;
+  /** Per-task stall threshold. Omitted when the caller doesn't have it (older
+   *  callers) — undelivered detection is skipped in that case, never a hard error. */
+  heartbeatBudgetMs?: number;
 }
 
 /**
@@ -121,13 +128,21 @@ export function projectHealth(input: {
   // ── crews (one row per non-terminal crew) ────────────────────────────────
   for (const c of crews) {
     if (TERMINAL.has(c.state)) continue;
+    // #466/B2: promote the CREW UNDELIVERED watchdog condition (daemon/reduce.ts)
+    // to a first-class, grep-able detail so it doesn't wait for the heartbeat
+    // window to age the row into stale/gone before it's noticeable.
+    const undelivered =
+      c.mode === "interactive" &&
+      !c.firstTurnConfirmedAt &&
+      c.heartbeatBudgetMs != null &&
+      now - c.lastHeartbeat > c.heartbeatBudgetMs;
     out.push({
       kind: "crew",
       project,
       ref: c.name ?? c.id.slice(0, 8),
       state: classifyHealth(c.lastHeartbeat, now, CREW_STALE_MS, CREW_GONE_MS),
       lastSeenMs: c.lastHeartbeat,
-      detail: c.state,
+      detail: undelivered ? `undelivered (${c.state})` : c.state,
     });
   }
 

--- a/packages/core/src/mailbox.ts
+++ b/packages/core/src/mailbox.ts
@@ -275,14 +275,19 @@ export interface MailboxStats {
  */
 export async function mailboxStats(stateRoot: string, project: string): Promise<MailboxStats> {
   const file = logPath(stateRoot, project);
-  let sizeBytes = 0;
-  try { sizeBytes = (await fs.stat(file)).size; }
-  catch (e) { if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e; }
   const rotated = await listRotatedOldestFirst(stateRoot, project);
+  let sizeBytes = 0;
+  for (const f of [file, ...rotated]) {
+    try { sizeBytes += (await fs.stat(f)).size; }
+    catch (e) { if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e; }
+  }
+  // Oldest entry lives in the oldest rotated archive when one exists (listRotatedOldestFirst
+  // returns oldest-first), otherwise it's the current file.
+  const oldestFile = rotated[0] ?? file;
   return {
     maxSeq: await readMaxSeq(stateRoot, project),
     sizeBytes,
-    oldestEntryAgeMs: await oldestEntryAgeMs(file),
+    oldestEntryAgeMs: await oldestEntryAgeMs(oldestFile),
     rotationCount: rotated.length,
   };
 }

--- a/packages/core/src/snapshot.ts
+++ b/packages/core/src/snapshot.ts
@@ -18,6 +18,13 @@ export interface TelegramHealth extends TelegramBridgeHealth {
   configured: boolean;
 }
 
+/** B4: one registered LifecycleSource's health (cmux-store/native-hook/codex-appserver). */
+export interface LifecycleSourceHealth {
+  name: string;
+  active: boolean;
+  error: string | null;
+}
+
 export type BuildState = "fresh" | "stale";
 
 /**
@@ -41,6 +48,7 @@ export interface DaemonRoot {
   sweep: { lastSweepAt: number | null; ageMs: number | null; cadenceMs: number };
   log: { errorCount: number; sizeBytes: number; windowMs: number };
   telegram: TelegramHealth;
+  lifecycleSources: LifecycleSourceHealth[];
 }
 
 // ── Tier 2: per-project data plane + global results ───────────────────────────
@@ -92,6 +100,7 @@ export interface DaemonSnapshotInputs {
   sweepCadenceMs: number;
   log: { errorCount: number; sizeBytes: number; windowMs: number };
   telegram: TelegramHealth;
+  lifecycleSources: LifecycleSourceHealth[];
   health: ComponentHealth[];
   projects: Array<{
     project: string;
@@ -126,6 +135,7 @@ export function assembleDaemonSnapshot(input: DaemonSnapshotInputs, now: number)
       },
       log: input.log,
       telegram: input.telegram,
+      lifecycleSources: input.lifecycleSources,
     },
     tier1: input.health,
     tier2: {

--- a/packages/core/src/snapshot.ts
+++ b/packages/core/src/snapshot.ts
@@ -8,6 +8,7 @@
 // the gathered numbers in here; this module never touches the filesystem.
 import type { ComponentHealth } from "./liveness.js";
 import type { MailboxStats } from "./mailbox.js";
+import type { CaptainDeliveryStats } from "./delivery/captain-delivery.js";
 export type { MailboxStats };
 
 export type BuildState = "fresh" | "stale";
@@ -58,6 +59,8 @@ export interface ProjectDataPlane {
   mailbox: MailboxStats;
   delivery: DeliveryLag;
   store: StoreStats;
+  /** B1: read-only captain-delivery deferral visibility (#484/#466-class stalls). */
+  deferral: CaptainDeliveryStats;
 }
 
 export interface DaemonSnapshot {
@@ -87,6 +90,8 @@ export interface DaemonSnapshotInputs {
     lastAckedSeq: number;
     storeByState: Record<string, number>;
     corruptCount: number;
+    /** Omitted when the caller has no CaptainDelivery instance for this project yet. */
+    deferral?: CaptainDeliveryStats;
   }>;
   results: ResultArtifacts;
 }
@@ -123,6 +128,7 @@ export function assembleDaemonSnapshot(input: DaemonSnapshotInputs, now: number)
           behind: Math.max(0, p.mailbox.maxSeq - p.lastAckedSeq),
         },
         store: { byState: p.storeByState, corruptCount: p.corruptCount },
+        deferral: p.deferral ?? { maxDeferCount: 0, stuck: false },
       })),
       results: input.results,
     },

--- a/packages/core/src/snapshot.ts
+++ b/packages/core/src/snapshot.ts
@@ -9,7 +9,14 @@
 import type { ComponentHealth } from "./liveness.js";
 import type { MailboxStats } from "./mailbox.js";
 import type { CaptainDeliveryStats } from "./delivery/captain-delivery.js";
+import type { TelegramBridgeHealth } from "./telegram/bridge.js";
 export type { MailboxStats };
+
+/** B3: Telegram bridge status. `configured: false` when no bridge is set up
+ *  (v.s. `configured: true` with a dead poll loop — a distinct, worse state). */
+export interface TelegramHealth extends TelegramBridgeHealth {
+  configured: boolean;
+}
 
 export type BuildState = "fresh" | "stale";
 
@@ -33,6 +40,7 @@ export interface DaemonRoot {
   /** lastSweepAt/ageMs are null until the first sweep has run. */
   sweep: { lastSweepAt: number | null; ageMs: number | null; cadenceMs: number };
   log: { errorCount: number; sizeBytes: number; windowMs: number };
+  telegram: TelegramHealth;
 }
 
 // ── Tier 2: per-project data plane + global results ───────────────────────────
@@ -83,6 +91,7 @@ export interface DaemonSnapshotInputs {
   lastSweepAt: number | null;
   sweepCadenceMs: number;
   log: { errorCount: number; sizeBytes: number; windowMs: number };
+  telegram: TelegramHealth;
   health: ComponentHealth[];
   projects: Array<{
     project: string;
@@ -116,6 +125,7 @@ export function assembleDaemonSnapshot(input: DaemonSnapshotInputs, now: number)
         cadenceMs: input.sweepCadenceMs,
       },
       log: input.log,
+      telegram: input.telegram,
     },
     tier1: input.health,
     tier2: {

--- a/packages/core/src/telegram/__tests__/bridge.test.ts
+++ b/packages/core/src/telegram/__tests__/bridge.test.ts
@@ -408,6 +408,93 @@ describe("inbound poll", () => {
   });
 });
 
+describe("health() (B3 — dashboard visibility into the poll loop)", () => {
+  it("reports not-polling with no poll history before start()", () => {
+    const client: TelegramClient = {
+      sendMessage: async () => {},
+      createForumTopic: async () => 1,
+      getUpdates: async () => [],
+      getMe: async () => ({ id: 0, username: "" }),
+      setMyCommands: async () => {},
+      answerCallbackQuery: async () => {},
+      editMessageReplyMarkup: async () => {},
+      sendChatAction: async () => {},
+    };
+    const bridge = createTelegramBridge({ cfg, stateRoot: freshRoot(), client, appendCaptainMessage: async () => {}, log: () => {} });
+    active = bridge;
+    expect(bridge.health()).toEqual({ polling: false, lastSuccessfulPollAt: null, lastError: null, lastErrorAt: null });
+  });
+
+  it("stamps lastSuccessfulPollAt after a clean poll and reports polling=true", async () => {
+    const root = freshRoot();
+    let n = 0;
+    const polled = deferred();
+    const client: TelegramClient = {
+      sendMessage: async () => {},
+      createForumTopic: async () => 1,
+      getUpdates: async () => { n++; if (n === 1) polled.resolve(); return []; },
+      getMe: async () => ({ id: 0, username: "" }),
+      setMyCommands: async () => {},
+      answerCallbackQuery: async () => {},
+      editMessageReplyMarkup: async () => {},
+      sendChatAction: async () => {},
+    };
+    const bridge = createTelegramBridge({ cfg, stateRoot: root, client, appendCaptainMessage: async () => {}, log: () => {} });
+    active = bridge;
+    bridge.start();
+    await polled.promise;
+    await waitFor(() => bridge.health().lastSuccessfulPollAt !== null);
+    const h = bridge.health();
+    expect(h.polling).toBe(true);
+    expect(h.lastError).toBeNull();
+    expect(typeof h.lastSuccessfulPollAt).toBe("number");
+  });
+
+  it("stamps lastError/lastErrorAt on a failing poll without clearing polling", async () => {
+    const root = freshRoot();
+    const failed = deferred();
+    const client: TelegramClient = {
+      sendMessage: async () => {},
+      createForumTopic: async () => 1,
+      getUpdates: async () => { failed.resolve(); throw new Error("getUpdates boom"); },
+      getMe: async () => ({ id: 0, username: "" }),
+      setMyCommands: async () => {},
+      answerCallbackQuery: async () => {},
+      editMessageReplyMarkup: async () => {},
+      sendChatAction: async () => {},
+    };
+    const bridge = createTelegramBridge({ cfg, stateRoot: root, client, appendCaptainMessage: async () => {}, log: () => {} });
+    active = bridge;
+    bridge.start();
+    await failed.promise;
+    await waitFor(() => bridge.health().lastError !== null);
+    const h = bridge.health();
+    expect(h.polling).toBe(true);
+    expect(h.lastError).toContain("getUpdates boom");
+    expect(typeof h.lastErrorAt).toBe("number");
+  });
+
+  it("reports polling=false after stop()", async () => {
+    const root = freshRoot();
+    const client: TelegramClient = {
+      sendMessage: async () => {},
+      createForumTopic: async () => 1,
+      getUpdates: async () => [],
+      getMe: async () => ({ id: 0, username: "" }),
+      setMyCommands: async () => {},
+      answerCallbackQuery: async () => {},
+      editMessageReplyMarkup: async () => {},
+      sendChatAction: async () => {},
+    };
+    const bridge = createTelegramBridge({ cfg, stateRoot: root, client, appendCaptainMessage: async () => {}, log: () => {} });
+    active = bridge;
+    bridge.start();
+    await waitFor(() => bridge.health().lastSuccessfulPollAt !== null);
+    bridge.stop();
+    expect(bridge.health().polling).toBe(false);
+  });
+});
+
 describe("lastUserId passive capture", () => {
   it("records m.from.id to state on an allowlisted inbound message", async () => {
     const root = freshRoot();

--- a/packages/core/src/telegram/bridge.ts
+++ b/packages/core/src/telegram/bridge.ts
@@ -22,11 +22,21 @@ interface CallbackQuery {
   data?: string;
 }
 
+/** Read-only poll-loop health (B3 — dashboard visibility). A silently-dying
+ *  getUpdates loop otherwise looks identical to a healthy quiet one from outside. */
+export interface TelegramBridgeHealth {
+  polling: boolean;
+  lastSuccessfulPollAt: number | null;
+  lastError: string | null;
+  lastErrorAt: number | null;
+}
+
 export interface TelegramBridge {
   start(): void;
   stop(): void;
   /** Outbound, best-effort: a Telegram failure is swallowed (logged), never thrown. */
   pushLifecycle(project: string, ev: ControlEvent): void;
+  health(): TelegramBridgeHealth;
 }
 
 export interface TelegramBridgeOptions {
@@ -94,6 +104,9 @@ export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridg
   const configRoot = opts.configRoot ?? path.join(os.homedir(), ".config", "squadrant");
   const pollMs = cfg.pollMs ?? 1000;
   let running = false;
+  let lastSuccessfulPollAt: number | null = null;
+  let lastError: string | null = null;
+  let lastErrorAt: number | null = null;
 
   function persistOffset(next: number): void {
     const s = loadState(stateRoot);
@@ -451,7 +464,10 @@ export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridg
           await handleUpdate(u);
           persistOffset(u.update_id + 1);
         }
+        lastSuccessfulPollAt = Date.now();
       } catch (e) {
+        lastError = (e as Error).message;
+        lastErrorAt = Date.now();
         log(`telegram inbound poll failed: ${(e as Error).message}`);
       }
       if (running) await sleep(pollMs);
@@ -473,6 +489,9 @@ export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridg
       void deliverOutbound(project, ev).catch((e) => {
         log(`telegram outbound failed project=${project}: ${(e as Error).message}`);
       });
+    },
+    health() {
+      return { polling: running, lastSuccessfulPollAt, lastError, lastErrorAt };
     },
   };
 }

--- a/packages/web/src/__tests__/snapshot-merge.test.ts
+++ b/packages/web/src/__tests__/snapshot-merge.test.ts
@@ -17,6 +17,7 @@ const daemon: DaemonSnapshot = {
     sweep: { lastSweepAt: 1, ageMs: 4, cadenceMs: 30_000 },
     log: { errorCount: 0, sizeBytes: 0, windowMs: 3_600_000 },
     telegram: { configured: false, polling: false, lastSuccessfulPollAt: null, lastError: null, lastErrorAt: null },
+    lifecycleSources: [],
   },
   tier1: [],
   tier2: { projects: [], results: { fileCount: 0, totalBytes: 0 } },

--- a/packages/web/src/__tests__/snapshot-merge.test.ts
+++ b/packages/web/src/__tests__/snapshot-merge.test.ts
@@ -16,6 +16,7 @@ const daemon: DaemonSnapshot = {
     build: { state: "fresh", processStartedAt: 1, distBuiltAt: 0 },
     sweep: { lastSweepAt: 1, ageMs: 4, cadenceMs: 30_000 },
     log: { errorCount: 0, sizeBytes: 0, windowMs: 3_600_000 },
+    telegram: { configured: false, polling: false, lastSuccessfulPollAt: null, lastError: null, lastErrorAt: null },
   },
   tier1: [],
   tier2: { projects: [], results: { fileCount: 0, totalBytes: 0 } },

--- a/packages/web/src/__tests__/web-render.test.ts
+++ b/packages/web/src/__tests__/web-render.test.ts
@@ -24,6 +24,7 @@ function daemon(over: Partial<DaemonSnapshot["tier0"]> = {}, tier1: DaemonSnapsh
       sweep: { lastSweepAt: 1000, ageMs: 8000, cadenceMs: 30_000 },
       log: { errorCount: 0, sizeBytes: 100, windowMs: 3_600_000 },
       telegram: { configured: false, polling: false, lastSuccessfulPollAt: null, lastError: null, lastErrorAt: null },
+      lifecycleSources: [],
       ...over,
     },
     tier1,
@@ -226,6 +227,36 @@ describe("telegram bridge health (B3)", () => {
       telegram: { configured: true, polling: true, lastSuccessfulPollAt: 900_000, lastError: "getUpdates 401 Unauthorized", lastErrorAt: 950_000 },
     })));
     expect(out).toContain("getUpdates 401 Unauthorized");
+  });
+});
+
+describe("lifecycle source health (B4)", () => {
+  it("renders no source rows when none are registered", () => {
+    const out = renderContent(full(daemon({ lifecycleSources: [] })));
+    expect(out).not.toContain("cmux-store");
+  });
+
+  it("renders an active source as healthy", () => {
+    const out = renderContent(full(daemon({
+      lifecycleSources: [{ name: "cmux-store", active: true, error: null }],
+    })));
+    expect(out).toContain("cmux-store");
+    expect(out).toMatch(/cmux-store[\s\S]*?s-alive/);
+  });
+
+  it("flags an inactive source as a fault", () => {
+    const out = renderContent(full(daemon({
+      lifecycleSources: [{ name: "native-hook", active: false, error: null }],
+    })));
+    expect(out).toMatch(/native-hook[\s\S]*?s-gone/);
+  });
+
+  it("flags an active-but-errored source as a caution and shows the error text", () => {
+    const out = renderContent(full(daemon({
+      lifecycleSources: [{ name: "cmux-store", active: true, error: "ENOSPC: watch failed" }],
+    })));
+    expect(out).toMatch(/cmux-store[\s\S]*?s-stale/);
+    expect(out).toContain("ENOSPC: watch failed");
   });
 });
 

--- a/packages/web/src/__tests__/web-render.test.ts
+++ b/packages/web/src/__tests__/web-render.test.ts
@@ -23,6 +23,7 @@ function daemon(over: Partial<DaemonSnapshot["tier0"]> = {}, tier1: DaemonSnapsh
       build: { state: "fresh", processStartedAt: 2000, distBuiltAt: 1000 },
       sweep: { lastSweepAt: 1000, ageMs: 8000, cadenceMs: 30_000 },
       log: { errorCount: 0, sizeBytes: 100, windowMs: 3_600_000 },
+      telegram: { configured: false, polling: false, lastSuccessfulPollAt: null, lastError: null, lastErrorAt: null },
       ...over,
     },
     tier1,
@@ -194,6 +195,37 @@ describe("daemon log error metric (fix b)", () => {
     // 7 log errors must NOT push the master annunciator to CRITICAL.
     expect(out).toContain('class="annunciator a-warn');
     expect(out).not.toContain('class="annunciator a-crit');
+  });
+});
+
+describe("telegram bridge health (B3)", () => {
+  it("shows 'not configured' (unknown) when no bridge is set up", () => {
+    const out = renderContent(full(daemon({
+      telegram: { configured: false, polling: false, lastSuccessfulPollAt: null, lastError: null, lastErrorAt: null },
+    })));
+    expect(out).toContain("telegram");
+    expect(out).toContain("not configured");
+  });
+
+  it("shows a healthy polling state when configured with no error", () => {
+    const out = renderContent(full(daemon({
+      telegram: { configured: true, polling: true, lastSuccessfulPollAt: 999_900, lastError: null, lastErrorAt: null },
+    })));
+    expect(out).toMatch(/polling/i);
+  });
+
+  it("flags a dead poll loop (configured but not polling) as a fault, not a false green", () => {
+    const out = renderContent(full(daemon({
+      telegram: { configured: true, polling: false, lastSuccessfulPollAt: 500_000, lastError: null, lastErrorAt: null },
+    })));
+    expect(out).toMatch(/data-panel="daemon"[\s\S]*telegram[\s\S]*?s-gone/);
+  });
+
+  it("shows the last poll error as a caution while still polling", () => {
+    const out = renderContent(full(daemon({
+      telegram: { configured: true, polling: true, lastSuccessfulPollAt: 900_000, lastError: "getUpdates 401 Unauthorized", lastErrorAt: 950_000 },
+    })));
+    expect(out).toContain("getUpdates 401 Unauthorized");
   });
 });
 

--- a/packages/web/src/__tests__/web-render.test.ts
+++ b/packages/web/src/__tests__/web-render.test.ts
@@ -33,6 +33,7 @@ function daemon(over: Partial<DaemonSnapshot["tier0"]> = {}, tier1: DaemonSnapsh
           mailbox: { maxSeq: 12, sizeBytes: 1300, oldestEntryAgeMs: 60_000, rotationCount: 0 },
           delivery: { maxSeq: 12, lastAckedSeq: 12, behind: 0 },
           store: { byState: { working: 3, blocked: 1 }, corruptCount: 0 },
+          deferral: { maxDeferCount: 0, stuck: false },
         },
       ],
       results: { fileCount: 294, totalBytes: 18_000_000 },
@@ -251,6 +252,7 @@ describe("stopped distinguished from fault (#324/#323)", () => {
       mailbox: { maxSeq: 10, sizeBytes: 100, oldestEntryAgeMs: 60_000, rotationCount: 0 },
       delivery: { maxSeq: 10, lastAckedSeq: 2, behind: 8 },
       store: { byState: { cancelled: 2 }, corruptCount: 0 },
+      deferral: { maxDeferCount: 0, stuck: false },
     }];
     const out = renderContent(full(d));
     // The card stays 'stopped' — delivery lag behind a closed captain is expected.
@@ -264,6 +266,7 @@ describe("stopped distinguished from fault (#324/#323)", () => {
       mailbox: { maxSeq: 10, sizeBytes: 100, oldestEntryAgeMs: 60_000, rotationCount: 0 },
       delivery: { maxSeq: 10, lastAckedSeq: 10, behind: 0 },
       store: { byState: {}, corruptCount: 1 },
+      deferral: { maxDeferCount: 0, stuck: false },
     }];
     const out = renderContent(full(d));
     expect(out).toMatch(/data-rollup="gone"/);
@@ -291,6 +294,58 @@ describe("CREW UNDELIVERED headline (B2/#466)", () => {
   it("Projects tab still shows the raw detail text for the flagged crew row", () => {
     const out = renderContent(full(daemon({}, undeliveredCrew)));
     expect(out).toContain("undelivered (submitted)");
+  });
+});
+
+describe("delivery deferral visibility (B1/#484/#466)", () => {
+  it("renders the in-flight defer count in the project's delivery block", () => {
+    const d = daemon();
+    d.tier2.projects[0].deferral = { maxDeferCount: 47, stuck: false };
+    const out = renderContent(full(d));
+    expect(out).toContain("47");
+    expect(out).toMatch(/defer/i);
+  });
+
+  it("does not roll up or flag a project with zero in-flight defers", () => {
+    const d = daemon();
+    d.tier2.projects[0].deferral = { maxDeferCount: 0, stuck: false };
+    const out = renderContent(full(d));
+    expect(out).toMatch(/data-rollup="alive"/);
+    expect(out).not.toMatch(/delivery stuck/i);
+  });
+
+  it("rolls a project with in-flight (but not yet stuck) defers up to 'stale'", () => {
+    const d = daemon();
+    d.tier2.projects[0].deferral = { maxDeferCount: 5, stuck: false };
+    const out = renderContent(full(d));
+    expect(out).toMatch(/data-rollup="stale"/);
+  });
+
+  it("rolls a stuck project (deferCount crossed threshold) up to 'gone' with a headline flag", () => {
+    const d = daemon();
+    d.tier2.projects[0].deferral = { maxDeferCount: 300, stuck: true };
+    const out = renderContent(full(d));
+    expect(out).toMatch(/data-rollup="gone"/);
+    expect(out).toMatch(/delivery stuck/i);
+  });
+
+  it("shows the global max in-flight defer count as an Overview trend", () => {
+    const d = daemon();
+    d.tier2.projects[0].deferral = { maxDeferCount: 47, stuck: false };
+    const out = renderContent(full(d));
+    expect(out).toContain('data-spark="defers"');
+    expect(out).toMatch(/Delivery defers/i);
+  });
+
+  it("a stopped captain's leftover deferral does not false-alarm (#324/#323 pattern)", () => {
+    const stoppedCaptain: DaemonSnapshot["tier1"] = [
+      { kind: "captain", project: "squadrant", ref: "squadrant-captain", state: "stopped", lastSeenMs: null },
+    ];
+    const d = daemon({}, stoppedCaptain);
+    d.tier2.projects[0].deferral = { maxDeferCount: 300, stuck: true };
+    const out = renderContent(full(d));
+    expect(out).toMatch(/data-rollup="stopped"/);
+    expect(out).not.toMatch(/data-rollup="gone"/);
   });
 });
 

--- a/packages/web/src/__tests__/web-render.test.ts
+++ b/packages/web/src/__tests__/web-render.test.ts
@@ -270,6 +270,30 @@ describe("stopped distinguished from fault (#324/#323)", () => {
   });
 });
 
+describe("CREW UNDELIVERED headline (B2/#466)", () => {
+  const undeliveredCrew: DaemonSnapshot["tier1"] = [
+    { kind: "crew", project: "pact", ref: "pact-crew-1", state: "stale", lastSeenMs: 1, detail: "undelivered (submitted)" },
+  ];
+
+  it("shows a headline banner on Overview counting undelivered crews", () => {
+    const out = renderContent(full(daemon({}, undeliveredCrew)));
+    expect(out).toMatch(/1 CREW UNDELIVERED/i);
+  });
+
+  it("does not show the undelivered banner when no crew is flagged", () => {
+    const normalCrew: DaemonSnapshot["tier1"] = [
+      { kind: "crew", project: "pact", ref: "pact-crew-1", state: "alive", lastSeenMs: 1, detail: "working" },
+    ];
+    const out = renderContent(full(daemon({}, normalCrew)));
+    expect(out).not.toMatch(/undelivered/i);
+  });
+
+  it("Projects tab still shows the raw detail text for the flagged crew row", () => {
+    const out = renderContent(full(daemon({}, undeliveredCrew)));
+    expect(out).toContain("undelivered (submitted)");
+  });
+});
+
 describe("delivery lag bar", () => {
   it("renders an SVG-free delivery bar with acked + behind segments", () => {
     const d = daemon();

--- a/packages/web/src/web-render.ts
+++ b/packages/web/src/web-render.ts
@@ -157,7 +157,7 @@ function liveDeliveryBehind(d: DaemonSnapshot): number {
 interface Collected {
   now: number;
   daemonT: Tally; projT: Tally; envT: Tally; overall: Tally;
-  errors: number; behind: number; crewAgeMs: number;
+  errors: number; behind: number; crewAgeMs: number; undelivered: number;
 }
 
 function collect(snap: FullSnapshot): Collected {
@@ -174,7 +174,7 @@ function collect(snap: FullSnapshot): Collected {
   ];
   const daemonStates: AnyState[] = [];
   const projStates: AnyState[] = [];
-  let errors = 0, behind = 0, crewAgeMs = 0;
+  let errors = 0, behind = 0, crewAgeMs = 0, undelivered = 0;
   if (snap.daemon !== "unreachable") {
     const t0 = snap.daemon.tier0;
     daemonStates.push("alive"); // the daemon process itself is up
@@ -184,6 +184,8 @@ function collect(snap: FullSnapshot): Collected {
     for (const c of snap.daemon.tier1) {
       projStates.push(c.state);
       if (c.kind === "crew" && c.lastSeenMs != null) crewAgeMs = Math.max(crewAgeMs, now - c.lastSeenMs);
+      // B2/#466: promoted CREW UNDELIVERED signal — see liveness.ts projectHealth.
+      if (c.kind === "crew" && c.detail?.startsWith("undelivered")) undelivered++;
     }
     for (const p of snap.daemon.tier2.projects) {
       if (p.delivery.behind > 0) projStates.push("stale");
@@ -197,7 +199,7 @@ function collect(snap: FullSnapshot): Collected {
     projT: tally(projStates),
     envT: tally(envStates),
     overall: tally([...daemonStates, ...projStates, ...envStates]),
-    errors, behind, crewAgeMs,
+    errors, behind, crewAgeMs, undelivered,
   };
 }
 
@@ -240,6 +242,12 @@ function renderOverview(snap: FullSnapshot, col: Collected): string {
     "System Health",
     `${col.overall.alive} of ${col.overall.total} monitored components are alive — the ring shows the full breakdown by state.`,
   ));
+  if (col.undelivered > 0) {
+    out.push(banner(
+      "warn",
+      `⚠ ${col.undelivered} CREW${col.undelivered > 1 ? "S" : ""} UNDELIVERED — first turn may not have landed; re-send the task or check the spawn (see Projects tab)`,
+    ));
+  }
   out.push(
     `<div class="hero a-${mc}">`,
     `<div class="gauge">`,

--- a/packages/web/src/web-render.ts
+++ b/packages/web/src/web-render.ts
@@ -398,12 +398,26 @@ function renderDaemon(snap: FullSnapshot): string {
   // caution at most, with a trend sparkline, never a red master alarm.
   const logState: AnyState = t0.log.errorCount > 0 ? "stale" : "alive";
 
+  // B3: not configured is a calm "unknown" (nothing to alarm on); a dead poll
+  // loop (configured but not polling) is the false-green risk the report called
+  // out, so it bubbles a fault rather than looking indistinguishable from idle.
+  const tg = t0.telegram;
+  const tgState: AnyState = !tg.configured ? "unknown" : !tg.polling ? "gone" : tg.lastError ? "stale" : "alive";
+  const tgLabel = !tg.configured
+    ? "not configured"
+    : !tg.polling
+      ? "poll loop stopped"
+      : tg.lastError
+        ? `polling · ${tg.lastError}`
+        : `polling · last ok ${fmtAge(tg.lastSuccessfulPollAt == null ? null : snap.generatedAt - tg.lastSuccessfulPollAt)}`;
+
   out.push(
     `<div class="instr-grid">`,
     instr("process", `<span class="mono">squadrantd</span> ${statePill("alive")}`, `<span class="instr-sub">pid ${t0.pid} · v${esc(t0.version)}</span>`),
     instr("uptime", `<span class="mono">${fmtDur(t0.uptimeMs)}</span>`),
     instr("build", `${pill(buildState, t0.build.state)}`, t0.build.state === "stale" ? remediation("npm run build && squadrant heal daemon") : ""),
     instr("sweep", `${pill(sweepState, sweep)}`),
+    instr("telegram", `${pill(tgState, tgLabel)}`),
     `</div>`,
   );
 

--- a/packages/web/src/web-render.ts
+++ b/packages/web/src/web-render.ts
@@ -157,7 +157,7 @@ function liveDeliveryBehind(d: DaemonSnapshot): number {
 interface Collected {
   now: number;
   daemonT: Tally; projT: Tally; envT: Tally; overall: Tally;
-  errors: number; behind: number; crewAgeMs: number; undelivered: number;
+  errors: number; behind: number; crewAgeMs: number; undelivered: number; maxDeferCount: number;
 }
 
 function collect(snap: FullSnapshot): Collected {
@@ -174,7 +174,7 @@ function collect(snap: FullSnapshot): Collected {
   ];
   const daemonStates: AnyState[] = [];
   const projStates: AnyState[] = [];
-  let errors = 0, behind = 0, crewAgeMs = 0, undelivered = 0;
+  let errors = 0, behind = 0, crewAgeMs = 0, undelivered = 0, maxDeferCount = 0;
   if (snap.daemon !== "unreachable") {
     const t0 = snap.daemon.tier0;
     daemonStates.push("alive"); // the daemon process itself is up
@@ -190,6 +190,7 @@ function collect(snap: FullSnapshot): Collected {
     for (const p of snap.daemon.tier2.projects) {
       if (p.delivery.behind > 0) projStates.push("stale");
       if (p.store.corruptCount > 0) projStates.push("gone");
+      maxDeferCount = Math.max(maxDeferCount, p.deferral.maxDeferCount);
     }
     behind = liveDeliveryBehind(snap.daemon);
   }
@@ -199,7 +200,7 @@ function collect(snap: FullSnapshot): Collected {
     projT: tally(projStates),
     envT: tally(envStates),
     overall: tally([...daemonStates, ...projStates, ...envStates]),
-    errors, behind, crewAgeMs, undelivered,
+    errors, behind, crewAgeMs, undelivered, maxDeferCount,
   };
 }
 
@@ -279,6 +280,7 @@ function renderOverview(snap: FullSnapshot, col: Collected): string {
     trendCard("errors", "Daemon log", `${col.errors}`, "errors the daemon logged in the last window"),
     trendCard("behind", "Delivery lag", `${col.behind}`, "messages captains have not read yet"),
     trendCard("crewAge", "Crew heartbeat", linkLost ? "—" : fmtDur(col.crewAgeMs), "time since the quietest crew was last seen"),
+    trendCard("defers", "Delivery defers", `${col.maxDeferCount}`, "highest in-flight retry count for any project's captain delivery (#484/#466)"),
     `</div>`,
   );
 
@@ -331,10 +333,18 @@ function renderProjects(snap: FullSnapshot, now: number): string {
     // contribute a `stale` to the rollup (#324/#323). A genuine fault (corrupt
     // store) still bubbles `gone` and out-ranks the stopped headline.
     const captainStopped = comps.some((c) => c.kind === "captain" && c.state === "stopped");
+    // B1: an in-flight defer is a caution; crossing the maxDefers threshold ("stuck") is
+    // the exact #484/#466-class incident this session spent all day fixing, so it bubbles
+    // a fault. Guarded on !captainStopped so a closed captain's stale leftover counts never
+    // false-alarm (#324/#323 pattern).
+    const deferralState: AnyState =
+      !captainStopped && dp && dp.deferral.stuck ? "gone" :
+      !captainStopped && dp && dp.deferral.maxDeferCount > 0 ? "stale" : "alive";
     const rollupStates: AnyState[] = [
       ...comps.map((c) => c.state),
       !captainStopped && dp && dp.delivery.behind > 0 ? "stale" : "alive",
       dp && dp.store.corruptCount > 0 ? "gone" : "alive",
+      deferralState,
     ];
     const rollup = worst(rollupStates);
     out.push(`<article class="card" data-rollup="${rollup}">`);
@@ -353,7 +363,7 @@ function renderProjects(snap: FullSnapshot, now: number): string {
       out.push(
         `<div class="dp-grid">`,
         `<div class="dp-block"><span class="dp-l">mailbox</span><span class="dp-v"><span class="mono">${dp.mailbox.maxSeq}</span> entries · ${fmtBytes(dp.mailbox.sizeBytes)} · rotated ${dp.mailbox.rotationCount} · oldest ${fmtAge(dp.mailbox.oldestEntryAgeMs)}</span></div>`,
-        `<div class="dp-block"><span class="dp-l">captain delivery</span>${deliveryBar(dp.delivery.behind, dp.mailbox.maxSeq)}<span class="dp-v"><span class="mono">${dp.delivery.behind}</span> behind</span></div>`,
+        `<div class="dp-block"><span class="dp-l">captain delivery</span>${deliveryBar(dp.delivery.behind, dp.mailbox.maxSeq)}<span class="dp-v"><span class="mono">${dp.delivery.behind}</span> behind${dp.deferral.maxDeferCount > 0 ? ` · <span class="mono">${dp.deferral.maxDeferCount}</span> deferred${dp.deferral.stuck ? ` ${pill("gone", "delivery stuck")}` : ""}` : ""}</span></div>`,
         `<div class="dp-block"><span class="dp-l">task store</span><span class="chips">${counts || `<span class="dim small">no tasks</span>`}${dp.store.corruptCount > 0 ? pill("gone", `${dp.store.corruptCount} corrupt`) : ""}</span></div>`,
         `</div>`,
       );
@@ -477,6 +487,7 @@ function metricsBlob(col: Collected, linkLost: boolean): string {
     errors: linkLost ? 0 : col.errors,
     behind: linkLost ? 0 : col.behind,
     crewAgeMs: linkLost ? 0 : col.crewAgeMs,
+    maxDeferCount: linkLost ? 0 : col.maxDeferCount,
     alive: col.overall.alive, stale: col.overall.stale, gone: col.overall.gone, stopped: col.overall.stopped, unknown: col.overall.unknown,
   };
   // Escape `</` defensively so the JSON can never close the <script> early.
@@ -715,7 +726,7 @@ const CLIENT_JS = `
 (function(){
   var activeTab='overview';var hist={};var prev={};
   function pushHist(k,v,t){var a=hist[k]||(hist[k]=[]);if(a.length&&a[a.length-1].t===t)return;a.push({t:t,v:v});if(a.length>48)a.shift();}
-  function ingest(){var el=document.getElementById('squadrant-metrics');if(!el)return;var m;try{m=JSON.parse(el.textContent);}catch(e){return;}pushHist('errors',m.errors,m.t);pushHist('behind',m.behind,m.t);pushHist('crewAge',Math.round(m.crewAgeMs/1000),m.t);}
+  function ingest(){var el=document.getElementById('squadrant-metrics');if(!el)return;var m;try{m=JSON.parse(el.textContent);}catch(e){return;}pushHist('errors',m.errors,m.t);pushHist('behind',m.behind,m.t);pushHist('crewAge',Math.round(m.crewAgeMs/1000),m.t);pushHist('defers',m.maxDeferCount,m.t);}
   function sparkSVG(a){var W=100,H=28,p=2;if(!a.length)return'';var vs=a.map(function(x){return x.v;});var mx=Math.max.apply(null,vs),mn=Math.min.apply(null,vs);if(mx===mn)mx=mn+1;var n=a.length;var pts=a.map(function(x,i){var px=n>1?p+i/(n-1)*(W-2*p):W/2;var py=H-p-(x.v-mn)/(mx-mn)*(H-2*p);return[px,py];});var d=pts.map(function(pt,i){return(i?'L':'M')+pt[0].toFixed(1)+' '+pt[1].toFixed(1);}).join(' ');var last=pts[pts.length-1];var area=d+' L'+last[0].toFixed(1)+' '+H+' L'+pts[0][0].toFixed(1)+' '+H+' Z';return'<path class="spark-area" d="'+area+'"/><path class="spark-line" d="'+d+'"/><circle class="spark-dot" cx="'+last[0].toFixed(1)+'" cy="'+last[1].toFixed(1)+'" r="2"/>';}
   function drawSparks(){var ns=document.querySelectorAll('[data-spark]');for(var i=0;i<ns.length;i++){ns[i].innerHTML=sparkSVG(hist[ns[i].getAttribute('data-spark')]||[]);}}
   function applyTab(){var ts=document.querySelectorAll('[data-tab]');for(var i=0;i<ts.length;i++){var on=ts[i].getAttribute('data-tab')===activeTab;ts[i].setAttribute('aria-selected',on?'true':'false');ts[i].classList.toggle('on',on);}var ps=document.querySelectorAll('[data-panel]');for(var j=0;j<ps.length;j++){var on2=ps[j].getAttribute('data-panel')===activeTab;ps[j].hidden=!on2;}}

--- a/packages/web/src/web-render.ts
+++ b/packages/web/src/web-render.ts
@@ -418,6 +418,14 @@ function renderDaemon(snap: FullSnapshot): string {
     instr("build", `${pill(buildState, t0.build.state)}`, t0.build.state === "stale" ? remediation("npm run build && squadrant heal daemon") : ""),
     instr("sweep", `${pill(sweepState, sweep)}`),
     instr("telegram", `${pill(tgState, tgLabel)}`),
+    ...t0.lifecycleSources.map((s) => {
+      // B4: architecture-internal debugging aid — a source going dark usually
+      // already manifests as a stale/gone crew via the heartbeat classification;
+      // this just explains WHY without a daemon-log dive.
+      const state: AnyState = !s.active ? "gone" : s.error ? "stale" : "alive";
+      const label = !s.active ? "inactive" : s.error ? s.error : "active";
+      return instr(s.name, `${pill(state, label)}`);
+    }),
     `</div>`,
   );
 

--- a/packages/workspaces/src/cmux-daemon/__tests__/cmux-store-source.test.ts
+++ b/packages/workspaces/src/cmux-daemon/__tests__/cmux-store-source.test.ts
@@ -422,3 +422,36 @@ describe("CmuxStoreSource — stop()", () => {
     expect(reports.length).toBe(reportsAtStop);
   });
 });
+
+describe("CmuxStoreSource — health() (B4)", () => {
+  it("reports inactive with no error before start()", () => {
+    const src = makeSource();
+    expect(src.health()).toEqual({ active: false, error: null });
+  });
+
+  it("reports active after start()", () => {
+    const { deps } = makeDeps();
+    const src = makeSource();
+    src.start(deps);
+    expect(src.health()).toEqual({ active: true, error: null });
+  });
+
+  it("reports inactive again after stop()", () => {
+    const { deps } = makeDeps();
+    const src = makeSource();
+    src.start(deps);
+    src.stop();
+    expect(src.health()).toEqual({ active: false, error: null });
+  });
+
+  it("captures a watchDir failure as an error while staying active (initial scan still ran)", () => {
+    const { deps } = makeDeps();
+    const src = makeSource({
+      watchDir: () => { throw new Error("ENOSPC: watch failed"); },
+    });
+    src.start(deps);
+    const h = src.health();
+    expect(h.active).toBe(true);
+    expect(h.error).toContain("ENOSPC");
+  });
+});

--- a/packages/workspaces/src/cmux-daemon/cmux-store-source.ts
+++ b/packages/workspaces/src/cmux-daemon/cmux-store-source.ts
@@ -100,6 +100,8 @@ export class CmuxStoreSource implements LifecycleSource {
   private debounceTimer?: ReturnType<typeof setTimeout>;
   /** taskId → last reported snapshot (for snapshot() liveness floor). */
   private cache = new Map<string, LifecycleSnapshot>();
+  private active = false;
+  private lastError: string | null = null;
 
   constructor(opts: CmuxStoreSourceOpts = {}) {
     this.stateDir =
@@ -119,12 +121,15 @@ export class CmuxStoreSource implements LifecycleSource {
 
   start(deps: LifecycleSourceDeps): void {
     this.deps = deps;
+    this.active = true;
+    this.lastError = null;
     // Initial scan before any watch events fire.
     this.scan();
     // Watch for subsequent changes, debounced.
     try {
       this.stopWatcher = this.watchDir(this.stateDir, () => this.scheduleDebounced());
     } catch (e) {
+      this.lastError = (e as Error).message;
       this.log(`cmux-store: failed to watch ${this.stateDir}: ${(e as Error).message}`);
     }
   }
@@ -138,11 +143,17 @@ export class CmuxStoreSource implements LifecycleSource {
     this.stopWatcher = undefined;
     this.deps = undefined;
     this.cache.clear();
+    this.active = false;
   }
 
   /** Returns the last-reported snapshot for a known crew (liveness floor). */
   snapshot(taskId: string): LifecycleSnapshot | undefined {
     return this.cache.get(taskId);
+  }
+
+  /** Read-only source health (B4 — dashboard visibility into which sources are up). */
+  health(): { active: boolean; error: string | null } {
+    return { active: this.active, error: this.lastError };
   }
 
   // ── private ─────────────────────────────────────────────────────────────────

--- a/packages/workspaces/src/native-hooks/__tests__/native-hook-source.test.ts
+++ b/packages/workspaces/src/native-hooks/__tests__/native-hook-source.test.ts
@@ -519,3 +519,19 @@ describe("NativeHookSource — install()", () => {
     expect(written2).toHaveLength(0);
   });
 });
+
+describe("NativeHookSource — health() (B4)", () => {
+  it("reports inactive before start()", () => {
+    const { src } = makeSource();
+    expect(src.health()).toEqual({ active: false, error: null });
+  });
+
+  it("reports active after start(), inactive after stop() (never errors — purely push-driven)", () => {
+    const { src } = makeSource();
+    const { deps } = makeDeps();
+    src.start(deps);
+    expect(src.health()).toEqual({ active: true, error: null });
+    src.stop();
+    expect(src.health()).toEqual({ active: false, error: null });
+  });
+});

--- a/packages/workspaces/src/native-hooks/native-hook-source.ts
+++ b/packages/workspaces/src/native-hooks/native-hook-source.ts
@@ -164,6 +164,7 @@ export class NativeHookSource implements LifecycleSource {
   private deps?: LifecycleSourceDeps;
   /** taskId → last-reported snapshot, for snapshot() liveness floor. */
   private cache = new Map<string, LifecycleSnapshot>();
+  private active = false;
 
   constructor(opts: NativeHookSourceOpts = {}) {
     this.hookInstall = opts.hookInstall ?? {};
@@ -172,16 +173,23 @@ export class NativeHookSource implements LifecycleSource {
 
   start(deps: LifecycleSourceDeps): void {
     this.deps = deps;
+    this.active = true;
   }
 
   stop(): void {
     this.deps = undefined;
     this.cache.clear();
+    this.active = false;
   }
 
   /** Returns the last-reported snapshot for a known crew (liveness floor poll). */
   snapshot(taskId: string): LifecycleSnapshot | undefined {
     return this.cache.get(taskId);
+  }
+
+  /** Read-only source health (B4). Purely push-driven — never errors on its own. */
+  health(): { active: boolean; error: string | null } {
+    return { active: this.active, error: null };
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes #322. Implements the approved B1–B4 gap-report items from `2026-07-01-dashboard-gap-report.md` — the four highest-value missing health signals on the web dashboard. #315 (clickable heal/restart actions) is explicitly **not** included, per the report's own scoping (deferred, read-only beta).

- **#322** — `mailboxStats` now includes rotated archives in `sizeBytes`/`oldestEntryAgeMs` (previously only the current un-rotated log file), reusing the existing `listRotatedOldestFirst`.
- **B2** — Promotes the existing CREW UNDELIVERED watchdog condition (`daemon/reduce.ts`) to a first-class `ComponentHealth.detail = "undelivered (<state>)"` via `projectHealth`, instead of only firing as a notification side-channel. Dashboard Overview gets a headline banner + count; Projects tab already surfaces the per-row detail.
- **B1** (highest incident-relevance — today's #484/#466/#474/#477 class) — `CaptainDelivery.stats()` exposes a read-only max in-flight defer count + a `stuck` flag once it crosses `maxDefers`. Threaded through `DaemonSnapshotInputs`/`DaemonSnapshot` as `ProjectDataPlane.deferral`. Dashboard renders a per-project cell + an Overview "Delivery defers" trend, rolling a project card up to caution/fault (guarded on `!captainStopped` so a closed captain's leftover counts never false-alarm, per #324/#323).
- **B3** — `TelegramBridge.health()` tracks `polling`, `lastSuccessfulPollAt`, and the last poll error, closing the "false green while the poll loop is silently dead" gap. Surfaced as a Daemon-tab instrument row (`tier0.telegram`).
- **B4** (lowest value, architecture-internal) — Adds an optional `health()` to the `LifecycleSource` port, implemented on all three concrete sources (`CmuxStoreSource`, `NativeHookSource`, `CodexAppServerSource`), aggregated into `tier0.lifecycleSources` and rendered as per-source instrument rows on the Daemon tab.

## GitNexus

- Ran `gitnexus_impact` (upstream) on every modified symbol before editing — all LOW risk (`mailboxStats`, `CaptainDelivery`, `ComponentHealth`, `TelegramBridge`, `assembleDaemonSnapshot`).
- `gitnexus_detect_changes(scope=compare, base_ref=develop)` reports 63 changed symbols / 27 files / `risk_level: critical` — this reflects the cumulative scope of extending five shared interfaces (`DaemonSnapshot`, `DaemonContext`, `LifecycleSource`, `TelegramBridge`, `CaptainDelivery`) across a full feature branch, not a dangerous side-effect. Every changed symbol traces 1:1 to one of the five listed items; nothing unexpected was touched.

## Test plan
- [x] TDD (RED→GREEN) for every change: mailbox rotation test, `projectHealth` undelivered tests, `CaptainDelivery.stats()` tests, `assembleDaemonSnapshot` Tier-0/Tier-2 threading tests, `web-render` rendering tests, `TelegramBridge.health()` tests, per-source `health()` tests.
- [x] Full clean build (`npm run build`) — passes.
- [x] Full test suite (`npx vitest run`) — 150 files / 1835 tests passing.
- [x] No orphan vitest/dev-server processes left running.