### PR TITLE
fix(core): CREW IDLE flood — don't trust turn.completed while a tool is in flight (#492)

### DIFF
--- a/packages/core/src/__tests__/daemon.test.ts
+++ b/packages/core/src/__tests__/daemon.test.ts
@@ -699,6 +699,40 @@ describe("daemon – blocked crew resume path (#183)", () => {
       await d.handle({ kind: "event", project: "p", event: { type: "task.blocked", id: "t-blk", reason: "r", question: "q" } });
       expect(calls.filter((c) => c.message.includes("CREW BLOCKED"))).toHaveLength(1);
     });
+
+    // #492: a long tool-executing turn floods the captain with CREW IDLE ~once
+    // per watchdog tick while the daemon's own task state stays 'working'. Root
+    // cause: squadrant's daemon wires THREE parallel lifecycle sources for the
+    // same interactive crew (cmux-store file-watch, native claude hooks, cmux's
+    // forwarded event stream) — any one of them can independently (and
+    // erroneously) report task.turn.completed while a real tool call is still
+    // open. Reproduced here at the daemon/notify level (not just state-machine)
+    // to prove the flood is silenced end-to-end.
+    it("a genuinely in-flight tool call absorbs repeated turn.completed flaps with ZERO CREW IDLE fires (#492)", async () => {
+      const store = createStore(dir);
+      store.put(rec("t-flood", { state: "working" }));
+      const calls: any[] = [];
+      let nowMs = 100_000; // long past any captain-turn debounce window
+      const d = createDaemon({ store, now: () => nowMs, notify: async (a) => { calls.push(a); } });
+      // The real tool call starts (PreToolUse) — pendingTool opens.
+      await d.handle({ kind: "event", project: "p", event: { type: "task.progress", id: "t-flood", note: "agent.hook.PreToolUse", tool: "Bash" } });
+      // Three independent lifecycle sources each flap turn.completed on their
+      // own watchdog tick while the SAME tool call is still outstanding.
+      for (const t of [110_000, 130_000, 150_000, 170_000]) {
+        nowMs = t;
+        await d.handle({ kind: "event", project: "p", event: { type: "task.turn.completed", id: "t-flood", turnId: "racy-source" } });
+      }
+      expect(store.get("p", "t-flood")?.state).toBe("working");
+      expect(calls.filter((c) => c.message.includes("CREW IDLE"))).toHaveLength(0);
+
+      // Once the tool genuinely returns, the NEXT turn-end is real and delivers.
+      nowMs = 180_000;
+      await d.handle({ kind: "event", project: "p", event: { type: "task.progress", id: "t-flood", note: "posttooluse" } });
+      nowMs = 190_000;
+      await d.handle({ kind: "event", project: "p", event: { type: "task.turn.completed", id: "t-flood", turnId: "racy-source" } });
+      expect(store.get("p", "t-flood")?.state).toBe("awaiting-input");
+      expect(calls.filter((c) => c.message.includes("CREW IDLE"))).toHaveLength(1);
+    });
   });
 
   it("awaiting-input + task.started → working + subsequent task.blocked fires CREW BLOCKED (#183)", async () => {

--- a/packages/core/src/__tests__/state-machine.test.ts
+++ b/packages/core/src/__tests__/state-machine.test.ts
@@ -202,13 +202,45 @@ describe("state-machine reduce", () => {
     expect(still.pendingTool).toEqual({ name: "Bash", since: 7000 });
   });
 
-  it("turn boundaries clear pendingTool (turn.completed / task.started)", () => {
-    const open = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Bash" }, 7000);
-    const ended = reduce(open, { type: "task.turn.completed", id: "t1", turnId: "x" }, 8000);
-    expect(ended.pendingTool).toBeUndefined();
-    const started = reduce(reduce(open, { type: "task.blocked", id: "t1", reason: "r", question: "q?" }, 8000),
+  it("a genuine turn boundary (no tool in flight) clears pendingTool on turn.completed / task.started", () => {
+    const started = reduce(reduce(rec({ state: "working" }), { type: "task.blocked", id: "t1", reason: "r", question: "q?" }, 8000),
       { type: "task.started", id: "t1" }, 9000);
     expect(started.pendingTool).toBeUndefined();
+  });
+
+  // ── #492: CREW IDLE flood — turn.completed contradicted by an in-flight tool ──
+  // Multiple parallel lifecycle sources (cmux-store file-watch, native claude
+  // hooks, cmux's forwarded event stream) independently report turn-end for the
+  // same crew. A stale/heuristic report can assert task.turn.completed while a
+  // real tool call is still open (pendingTool set from its own PreToolUse) — that
+  // is self-contradictory (the daemon's own evidence says a tool never returned),
+  // so it must not be trusted as a genuine turn boundary.
+  it("task.turn.completed while a tool is genuinely in flight is NOT trusted as a turn boundary (#492)", () => {
+    const open = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Bash" }, 7000);
+    const stillOpen = reduce(open, { type: "task.turn.completed", id: "t1", turnId: "x" }, 8000);
+    expect(stillOpen.state).toBe("working"); // never flips to awaiting-input
+    expect(stillOpen.pendingTool).toEqual({ name: "Bash", since: 7000 }); // tool window untouched
+    expect(stillOpen.lastHeartbeat).toBe(8000); // still counts as liveness
+  });
+
+  it("repeated contradicted task.turn.completed reports never re-enter awaiting-input (flood guard)", () => {
+    const open = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Bash" }, 7000);
+    // Simulate several racing lifecycle sources each independently re-asserting
+    // turn-end on every watchdog tick while the same tool call is still open.
+    let cur = open;
+    for (const t of [8000, 9000, 10000, 11000]) {
+      cur = reduce(cur, { type: "task.turn.completed", id: "t1", turnId: "x" }, t);
+      expect(cur.state).toBe("working");
+    }
+  });
+
+  it("once the tool genuinely returns (PostToolUse), a subsequent task.turn.completed IS a real boundary", () => {
+    const open = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Bash" }, 7000);
+    const closed = reduce(open, { type: "task.progress", id: "t1", note: "posttooluse" }, 7500);
+    expect(closed.pendingTool).toBeUndefined();
+    const ended = reduce(closed, { type: "task.turn.completed", id: "t1", turnId: "x" }, 8000);
+    expect(ended.state).toBe("awaiting-input");
+    expect(ended.pendingTool).toBeUndefined();
   });
 
   it("stalled + task.progress (matching PostToolUse) recovers to working AND clears pendingTool (#354 auto-clear)", () => {

--- a/packages/core/src/state-machine.ts
+++ b/packages/core/src/state-machine.ts
@@ -119,6 +119,15 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
       // opencode SSE bridge emits task.turn.completed right after an explicit
       // `signal blocked`, and that trailing turn-end must not drop the question.
       if (rec.state === "blocked") return { ...rec, lastHeartbeat: now, lastEvent: ev.type };
+      // #492: several parallel lifecycle sources (cmux store-file watch, native
+      // claude hooks, cmux's forwarded event stream) each independently report
+      // turn-end for the same crew. A stale/heuristic report can assert
+      // task.turn.completed while a real tool call is still open (pendingTool set
+      // from its own PreToolUse) — that directly contradicts the daemon's own
+      // evidence (no matching PostToolUse yet), so it is not a genuine turn
+      // boundary. Treat it as liveness only; the real turn-end arrives once the
+      // tool actually returns and pendingTool clears.
+      if (rec.pendingTool) return stampAttempt(base, {}, now);
       return { ...stampAttempt(base, {}, now), state: "awaiting-input", pendingTool: undefined };
     case "task.delta":
       return stampAttempt(base, {}, now);  // heartbeat-only


### PR DESCRIPTION
## Summary

Fixes #492: a long tool-executing crew turn floods the captain with `CREW IDLE` (~once per watchdog tick) while the daemon's own authoritative task state stays `working`.

**Root cause (traced, matches the captain's verification comment on #492):** `squadrantd.ts` wires **three parallel lifecycle sources** for the same interactive crew — `CmuxStoreSource` (file-watch over `~/.cmuxterm/*-hook-sessions.json`), the native-claude-hooks direct path (`squadrant hooks claude <sub>` / `squadrant crew _hook <event>`), and `CmuxEventsBridge` (cmux's forwarded global hook stream). Each independently calls the daemon with `task.turn.completed` the moment it observes (or infers) a turn-end. None of them cross-check the daemon's own authoritative record before asserting it. When any one source's report races (or misreads pane silence as idle) while the crew is genuinely still inside a long, quiet tool call, the task flaps `working ↔ awaiting-input`, and `firePush`'s edge-trigger (`prev !== next.state` in `packages/core/src/daemon/reduce.ts`) fires one `CREW IDLE` per flap.

**Fix (surgical, single choke point):** the daemon already tracks `pendingTool` — opened on a real `PreToolUse`, closed on the matching `PostToolUse` (from #354's hung-tool-call work). A `task.turn.completed` arriving while `pendingTool` is still open directly contradicts that evidence (no tool has actually returned), so `packages/core/src/state-machine.ts`'s `task.turn.completed` case no longer trusts it as a genuine turn boundary in that case — it's absorbed as liveness only (state and `pendingTool` untouched). The real turn-end still delivers once the tool genuinely returns and `pendingTool` clears.

This holds regardless of *which* of the redundant lifecycle sources misfires, since the fix lives at the single shared reducer all of them funnel through.

## Test plan

- [x] RED test added first (`packages/core/src/__tests__/state-machine.test.ts`) — confirmed failing against the pre-fix code.
- [x] Unit-level fix verified: repeated `task.turn.completed` while `pendingTool` is open never re-enters `awaiting-input`; a genuine turn-end (no tool in flight) still works as before.
- [x] Integration-level regression test added (`packages/core/src/__tests__/daemon.test.ts`, `CREW IDLE debounce (#210)` block) — reproduces the flap end-to-end through `createDaemon()` and asserts **zero** `CREW IDLE` notifications fire while a tool is in flight, and exactly one fires once the tool genuinely returns.
- [x] Full clean build (`npm run build`) — passes; `node dist/index.js --help` / `node dist/squadrantd.js --help` both exit 0 (no hang).
- [x] Full test suite (`npx vitest run`, one-shot, no watch) — **150 files / 1839 tests pass**, including the 2 new + 1 modified test in this PR.
- [x] `gitnexus_impact` run on `firePush` (HIGH risk — 3 callers: `handle`/`sweep`/`reconcile`, all within `createDaemon()`; not modified here) and on `evaluateStall`/`reduce` (index couldn't resolve cross-file calls for these — confirmed manually via direct read that `reduce()` has exactly one call site, in `daemon/reduce.ts`'s `handle()`).
- [x] `gitnexus_detect_changes` — could not report on this diff; the indexed "squadrant" repo path resolves to the main checkout, not this git worktree, so its git-diff sees no changes here. Noted for the captain to re-run from the main checkout if desired.