### PR TITLE
Release v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-07-01
+
+### Fixed
+
+- **CREW IDLE no longer floods the captain during long tool-executing crew turns (#492):** `task.turn.completed` is treated as liveness-only while a tool call is still in flight, vetoing spurious awaiting-input flaps from racing lifecycle sources.
+
 ## [0.14.0] - 2026-07-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "squadrant",
   "packageManager": "pnpm@10.30.3",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Multi-project orchestration for your coding agents (Claude, Codex, opencode, Gemini)",
   "type": "module",
   "bin": {

--- a/packages/core/src/__tests__/daemon.test.ts
+++ b/packages/core/src/__tests__/daemon.test.ts
@@ -699,6 +699,40 @@ describe("daemon – blocked crew resume path (#183)", () => {
       await d.handle({ kind: "event", project: "p", event: { type: "task.blocked", id: "t-blk", reason: "r", question: "q" } });
       expect(calls.filter((c) => c.message.includes("CREW BLOCKED"))).toHaveLength(1);
     });
+
+    // #492: a long tool-executing turn floods the captain with CREW IDLE ~once
+    // per watchdog tick while the daemon's own task state stays 'working'. Root
+    // cause: squadrant's daemon wires THREE parallel lifecycle sources for the
+    // same interactive crew (cmux-store file-watch, native claude hooks, cmux's
+    // forwarded event stream) — any one of them can independently (and
+    // erroneously) report task.turn.completed while a real tool call is still
+    // open. Reproduced here at the daemon/notify level (not just state-machine)
+    // to prove the flood is silenced end-to-end.
+    it("a genuinely in-flight tool call absorbs repeated turn.completed flaps with ZERO CREW IDLE fires (#492)", async () => {
+      const store = createStore(dir);
+      store.put(rec("t-flood", { state: "working" }));
+      const calls: any[] = [];
+      let nowMs = 100_000; // long past any captain-turn debounce window
+      const d = createDaemon({ store, now: () => nowMs, notify: async (a) => { calls.push(a); } });
+      // The real tool call starts (PreToolUse) — pendingTool opens.
+      await d.handle({ kind: "event", project: "p", event: { type: "task.progress", id: "t-flood", note: "agent.hook.PreToolUse", tool: "Bash" } });
+      // Three independent lifecycle sources each flap turn.completed on their
+      // own watchdog tick while the SAME tool call is still outstanding.
+      for (const t of [110_000, 130_000, 150_000, 170_000]) {
+        nowMs = t;
+        await d.handle({ kind: "event", project: "p", event: { type: "task.turn.completed", id: "t-flood", turnId: "racy-source" } });
+      }
+      expect(store.get("p", "t-flood")?.state).toBe("working");
+      expect(calls.filter((c) => c.message.includes("CREW IDLE"))).toHaveLength(0);
+
+      // Once the tool genuinely returns, the NEXT turn-end is real and delivers.
+      nowMs = 180_000;
+      await d.handle({ kind: "event", project: "p", event: { type: "task.progress", id: "t-flood", note: "posttooluse" } });
+      nowMs = 190_000;
+      await d.handle({ kind: "event", project: "p", event: { type: "task.turn.completed", id: "t-flood", turnId: "racy-source" } });
+      expect(store.get("p", "t-flood")?.state).toBe("awaiting-input");
+      expect(calls.filter((c) => c.message.includes("CREW IDLE"))).toHaveLength(1);
+    });
   });
 
   it("awaiting-input + task.started → working + subsequent task.blocked fires CREW BLOCKED (#183)", async () => {

--- a/packages/core/src/__tests__/state-machine.test.ts
+++ b/packages/core/src/__tests__/state-machine.test.ts
@@ -202,13 +202,45 @@ describe("state-machine reduce", () => {
     expect(still.pendingTool).toEqual({ name: "Bash", since: 7000 });
   });
 
-  it("turn boundaries clear pendingTool (turn.completed / task.started)", () => {
-    const open = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Bash" }, 7000);
-    const ended = reduce(open, { type: "task.turn.completed", id: "t1", turnId: "x" }, 8000);
-    expect(ended.pendingTool).toBeUndefined();
-    const started = reduce(reduce(open, { type: "task.blocked", id: "t1", reason: "r", question: "q?" }, 8000),
+  it("a genuine turn boundary (no tool in flight) clears pendingTool on turn.completed / task.started", () => {
+    const started = reduce(reduce(rec({ state: "working" }), { type: "task.blocked", id: "t1", reason: "r", question: "q?" }, 8000),
       { type: "task.started", id: "t1" }, 9000);
     expect(started.pendingTool).toBeUndefined();
+  });
+
+  // ── #492: CREW IDLE flood — turn.completed contradicted by an in-flight tool ──
+  // Multiple parallel lifecycle sources (cmux-store file-watch, native claude
+  // hooks, cmux's forwarded event stream) independently report turn-end for the
+  // same crew. A stale/heuristic report can assert task.turn.completed while a
+  // real tool call is still open (pendingTool set from its own PreToolUse) — that
+  // is self-contradictory (the daemon's own evidence says a tool never returned),
+  // so it must not be trusted as a genuine turn boundary.
+  it("task.turn.completed while a tool is genuinely in flight is NOT trusted as a turn boundary (#492)", () => {
+    const open = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Bash" }, 7000);
+    const stillOpen = reduce(open, { type: "task.turn.completed", id: "t1", turnId: "x" }, 8000);
+    expect(stillOpen.state).toBe("working"); // never flips to awaiting-input
+    expect(stillOpen.pendingTool).toEqual({ name: "Bash", since: 7000 }); // tool window untouched
+    expect(stillOpen.lastHeartbeat).toBe(8000); // still counts as liveness
+  });
+
+  it("repeated contradicted task.turn.completed reports never re-enter awaiting-input (flood guard)", () => {
+    const open = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Bash" }, 7000);
+    // Simulate several racing lifecycle sources each independently re-asserting
+    // turn-end on every watchdog tick while the same tool call is still open.
+    let cur = open;
+    for (const t of [8000, 9000, 10000, 11000]) {
+      cur = reduce(cur, { type: "task.turn.completed", id: "t1", turnId: "x" }, t);
+      expect(cur.state).toBe("working");
+    }
+  });
+
+  it("once the tool genuinely returns (PostToolUse), a subsequent task.turn.completed IS a real boundary", () => {
+    const open = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Bash" }, 7000);
+    const closed = reduce(open, { type: "task.progress", id: "t1", note: "posttooluse" }, 7500);
+    expect(closed.pendingTool).toBeUndefined();
+    const ended = reduce(closed, { type: "task.turn.completed", id: "t1", turnId: "x" }, 8000);
+    expect(ended.state).toBe("awaiting-input");
+    expect(ended.pendingTool).toBeUndefined();
   });
 
   it("stalled + task.progress (matching PostToolUse) recovers to working AND clears pendingTool (#354 auto-clear)", () => {

--- a/packages/core/src/state-machine.ts
+++ b/packages/core/src/state-machine.ts
@@ -119,6 +119,15 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
       // opencode SSE bridge emits task.turn.completed right after an explicit
       // `signal blocked`, and that trailing turn-end must not drop the question.
       if (rec.state === "blocked") return { ...rec, lastHeartbeat: now, lastEvent: ev.type };
+      // #492: several parallel lifecycle sources (cmux store-file watch, native
+      // claude hooks, cmux's forwarded event stream) each independently report
+      // turn-end for the same crew. A stale/heuristic report can assert
+      // task.turn.completed while a real tool call is still open (pendingTool set
+      // from its own PreToolUse) — that directly contradicts the daemon's own
+      // evidence (no matching PostToolUse yet), so it is not a genuine turn
+      // boundary. Treat it as liveness only; the real turn-end arrives once the
+      // tool actually returns and pendingTool clears.
+      if (rec.pendingTool) return stampAttempt(base, {}, now);
       return { ...stampAttempt(base, {}, now), state: "awaiting-input", pendingTool: undefined };
     case "task.delta":
       return stampAttempt(base, {}, now);  // heartbeat-only


### PR DESCRIPTION
## Summary

Patch release containing a single fix already merged to `develop`:

- **#492 — CREW IDLE no longer floods the captain during long tool-executing crew turns.** `task.turn.completed` is treated as liveness-only while a tool call is still in flight, vetoing spurious awaiting-input flaps from racing lifecycle sources. (PR #495)

## Changes in this PR

- `package.json`: version 0.14.0 → 0.14.1
- `CHANGELOG.md`: new `[0.14.1]` entry

No source changes — the fix itself is already on `develop` (commit acd398a, merged via PR #495).

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run build` — clean build, no errors
- [x] `pnpm test` — 150/150 test files, 1839/1839 tests passing (one intermittent timing-based flake in `squadrantd-daemon-direct.test.ts` re-entrancy guard test observed once under parallel load, confirmed pre-existing/unrelated — reproduces identically on base `develop` and passes reliably in isolation and on repeat full-suite runs)