### PR TITLE
chore: back-merge v0.14.1 to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-07-01
+
+### Fixed
+
+- **CREW IDLE no longer floods the captain during long tool-executing crew turns (#492):** `task.turn.completed` is treated as liveness-only while a tool call is still in flight, vetoing spurious awaiting-input flaps from racing lifecycle sources.
+
 ## [0.14.0] - 2026-07-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "squadrant",
   "packageManager": "pnpm@10.30.3",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Multi-project orchestration for your coding agents (Claude, Codex, opencode, Gemini)",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Sync the v0.14.1 release commit (version bump + CHANGELOG) from main back into develop. The #492 fix itself is already on develop; this brings the release bump.