### PR TITLE
fix(web): idle/never-launched projects health-neutral in dashboard rollup

### DIFF
--- a/packages/web/src/__tests__/web-render.test.ts
+++ b/packages/web/src/__tests__/web-render.test.ts
@@ -459,6 +459,58 @@ describe("global delivery-lag excludes offline-captain projects", () => {
   });
 });
 
+describe("idle/never-launched projects are health-neutral for the master annunciator", () => {
+  it("an idle project (captain unknown) with delivery backlog does NOT trip DEGRADED", () => {
+    const d = daemon();
+    d.tier1 = [
+      { kind: "captain", project: "squadrant", ref: "captain", state: "unknown", lastSeenMs: null },
+    ];
+    d.tier2.projects[0].delivery = { maxSeq: 10, lastAckedSeq: 2, behind: 8 };
+    const out = renderContent(full(d));
+    expect(out).toContain('class="annunciator a-ok');
+    expect(out).toContain("NOMINAL");
+    expect(out).not.toContain('class="annunciator a-warn');
+  });
+
+  it("template-hash drift alone does NOT trip DEGRADED (demoted to soft/info)", () => {
+    const drifted: ExternalProbes = {
+      ...externalHealthy,
+      config: { ...externalHealthy.config, sessions: { state: "stale", detail: "template drift: 12 distinct hashes" } },
+    };
+    const out = renderContent(full(daemon(), drifted));
+    expect(out).toContain('class="annunciator a-ok');
+    expect(out).toContain("NOMINAL");
+    // the drift signal still surfaces in the Environment tab, just doesn't roll up
+    expect(out).toContain("template drift: 12 distinct hashes");
+  });
+
+  it("a fleet of idle/unknown projects plus template drift together still reads NOMINAL", () => {
+    const d = daemon();
+    d.tier1 = [
+      { kind: "captain", project: "squadrant", ref: "captain", state: "unknown", lastSeenMs: null },
+    ];
+    d.tier2.projects[0].delivery = { maxSeq: 10, lastAckedSeq: 2, behind: 8 };
+    const drifted: ExternalProbes = {
+      ...externalHealthy,
+      config: { ...externalHealthy.config, sessions: { state: "stale", detail: "template drift: 12 distinct hashes" } },
+    };
+    const out = renderContent(full(d, drifted));
+    expect(out).toContain('class="annunciator a-ok');
+    expect(out).toContain("NOMINAL");
+  });
+
+  it("delivery backlog for a genuinely ALIVE captain still trips DEGRADED (regression guard)", () => {
+    const d = daemon();
+    d.tier1 = [
+      { kind: "captain", project: "squadrant", ref: "captain", state: "alive", lastSeenMs: 999_000 },
+    ];
+    d.tier2.projects[0].delivery = { maxSeq: 10, lastAckedSeq: 2, behind: 8 };
+    const out = renderContent(full(d));
+    expect(out).toContain('class="annunciator a-warn');
+    expect(out).toContain("DEGRADED");
+  });
+});
+
 describe("global results location", () => {
   it("global results line appears only in the daemon tab, not the projects tab", () => {
     const out = renderContent(full(daemon()));

--- a/packages/web/src/web-render.ts
+++ b/packages/web/src/web-render.ts
@@ -169,7 +169,11 @@ function collect(snap: FullSnapshot): Collected {
     env.vaults.hub.state,
     ...env.vaults.spokes.map((s) => s.state),
     env.config.parseable.state,
-    env.config.sessions.state,
+    // Template-hash drift (env.config.sessions.state) is demoted to soft/info:
+    // projects registered but idle/never-launched legitimately sit on older
+    // template versions, so drift alone is not actionable trouble. Its own
+    // status still renders in the Environment tab; it just no longer rolls up
+    // into envT/overall/masterClass.
     ...env.config.projectPaths.map((p) => p.state),
   ];
   const daemonStates: AnyState[] = [];
@@ -188,7 +192,11 @@ function collect(snap: FullSnapshot): Collected {
       if (c.kind === "crew" && c.detail?.startsWith("undelivered")) undelivered++;
     }
     for (const p of snap.daemon.tier2.projects) {
-      if (p.delivery.behind > 0) projStates.push("stale");
+      // Idle/never-launched projects (captain not alive — stopped or unknown)
+      // are health-neutral: unread backlog for an offline captain is expected,
+      // not a live caution. Mirrors liveDeliveryBehind's alive-only gate below.
+      const captain = snap.daemon.tier1.find((c) => c.kind === "captain" && c.project === p.project);
+      if (captain?.state === "alive" && p.delivery.behind > 0) projStates.push("stale");
       if (p.store.corruptCount > 0) projStates.push("gone");
       maxDeferCount = Math.max(maxDeferCount, p.deferral.maxDeferCount);
     }


### PR DESCRIPTION
## Summary
- Registered-but-idle/never-launched projects (captain `state: "unknown"`) were producing a permanent false **DEGRADED** annunciator: `collect()` in `web-render.ts` pushed a `"stale"` tally entry for *any* project's delivery backlog, with no gate on captain aliveness — unlike the existing `liveDeliveryBehind()` helper, which already excludes non-alive (stopped/unknown) captains from the same backlog metric. This fix applies the same gate: only count delivery backlog as a caution when the captain is `"alive"`.
- Template-hash drift (`env.config.sessions.state`) is demoted out of the `envT`/`overall` tallies that feed the master annunciator — projects registered but idle legitimately sit on older template versions across the fleet, so drift alone isn't actionable trouble. The probe's own status still renders in the Environment tab; it just no longer trips DEGRADED by itself.
- A genuinely alive-but-behind captain, and real faults (corrupt store, `gone` components), are untouched and still escalate the annunciator (verified by regression tests).

## Root cause
Not the raw `'unknown'` captain state itself — `masterClass()` never reads `t.unknown` at all, so it can't trip DEGRADED directly. The actual trigger was the *unguarded* delivery-backlog push in `collect()`'s tier2 loop, plus template-hash drift being tallied as a plain `"stale"` like any other caution.

## Impact analysis (GitNexus, run before editing per repo policy)
- `collect()` — **LOW** risk: 3 impacted symbols (`renderContent` d=1; `renderHtml`, `renderTickJson` d=2), 1 module, both `renderHtml`/`renderTickJson` render paths (HTML page + SSE tick).
- `masterClass()` — **HIGH** risk as a symbol (2 direct callers, 3 processes), but **its function body is unmodified** — only the `Tally` data fed into it (via `collect()`) changes. Flagging per CLAUDE.md's HIGH/CRITICAL warning requirement; the annunciator's behavior for this specific scenario changes intentionally (that's the fix goal), no other path through `masterClass` is touched.
- `gitnexus_detect_changes()` could not be run meaningfully pre-commit: the indexed "squadrant" repo path (`/Users/q3labsadmin/me/squadrant`) is the main checkout, not this crew's git worktree, so it reports "no changes detected" regardless of the real diff. Verified scope manually instead: diff is confined to `collect()`'s body in `web-render.ts` (2 statements) plus its test file — matches exactly what `gitnexus_impact` was run against.

## Test plan
- [x] Added 4 tests: idle/unknown captain + backlog → NOMINAL; template drift alone → NOMINAL; both combined → NOMINAL; alive captain + backlog → still DEGRADED (regression guard).
- [x] Existing per-project-card "stopped distinguished from fault (#324/#323)" and "global delivery-lag excludes offline-captain projects" suites untouched and passing (different code path — per-card rollup, not the master tally).
- [x] Full clean build (`npm run build`) — tsc + tsup, no errors.
- [x] Full test suite: `npx vitest run` — 150 files / 1843 tests passed.