### PR TITLE
docs: log 2026-07-02 lifecycle run + correct codex interactivity claim

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -93,7 +93,7 @@ See the [architecture diagram](diagrams/2026-06-18-squadrant-monorepo-architectu
 
 - **Command** (Opus) — *on-demand* cross-project session. Spawned by `squadrant command --task <briefing|learnings-review|wiki-aggregate>` in a split pane; exits when the task completes. No persistent Command process.
 - **Captain** (Opus) — project leader, uses Agent Teams + git worktrees
-- **Crew** (Sonnet by default) — interactive sub-session running as a new tab in the captain's workspace (or a split pane via `--direction`). Each crew is named (`crew-1`, `crew-2`, …) and stays idle between turns waiting for the captain's next message — same model as a Claude Agent Team subagent. Spawn with `squadrant crew spawn`, send follow-ups with `squadrant crew send`, close when done. Works with any agent CLI (claude and opencode are fully interactive; codex/gemini currently print-mode). Uses GSD for complex tasks.
+- **Crew** (Sonnet by default) — interactive sub-session running as a new tab in the captain's workspace (or a split pane via `--direction`). Each crew is named (`crew-1`, `crew-2`, …) and stays idle between turns waiting for the captain's next message — same model as a Claude Agent Team subagent. Spawn with `squadrant crew spawn`, send follow-ups with `squadrant crew send`, close when done. Works with any agent CLI (claude, opencode, and codex are fully interactive; gemini currently print-mode). Uses GSD for complex tasks.
 
 ### Model Routing
 
@@ -118,7 +118,7 @@ User-facing notifications run behind a pluggable **notifier driver** (currently 
 
 Crew is the captain's equivalent of an Agent Team subagent — but runtime-agnostic. The captain spawns a crew via `squadrant crew spawn <project> "<task>" [--name <n>]`, which opens a new tab in the captain's cmux workspace, boots an interactive Claude session (no `-p`), and sends the task as the first turn. The crew works on it and **stays idle** waiting for follow-ups. The captain drives the session with `squadrant crew send/read/close/list`, addressing each crew by its tab title (`🔧 <project>:<name>`).
 
-Pass `--direction right|left|up|down` to use a split pane instead of a tab. State lives in the surface buffer + git; tabs die with the captain workspace on `squadrant shutdown`. Non-Claude agents (codex/gemini) currently still launch in print-mode; full interactive support is a follow-up. See [`docs/specs/archive/2026-05-05-squadrant-thin-redirect-design.md`](specs/archive/2026-05-05-squadrant-thin-redirect-design.md).
+Pass `--direction right|left|up|down` to use a split pane instead of a tab. State lives in the surface buffer + git; tabs die with the captain workspace on `squadrant shutdown`. codex now launches interactively (parity with claude/opencode); gemini currently still launches in print-mode, full interactive support is a follow-up. See [`docs/specs/archive/2026-05-05-squadrant-thin-redirect-design.md`](specs/archive/2026-05-05-squadrant-thin-redirect-design.md).
 
 ### Effort Dial (Tokenomics)
 

--- a/docs/testing/crew-lifecycle-checklist.md
+++ b/docs/testing/crew-lifecycle-checklist.md
@@ -160,6 +160,7 @@ notification reaching the captain session, not just the crew screen.
 | 2026-06-03 | codex | ffc97f6 | PASS | PASS | DEFERRED (--approval) | GAP (#210) | PASS | PASS | Signals via `--task-id` (PR #173) self-injected in `developerInstructions`; verified live. Earlier 'fail' was a test error (bare signal w/o `--task-id`). |
 | 2026-06-03 | opencode | ffc97f6 | PASS | PASS | DEFERRED (config) | GAP (#210) | PASS | PASS | All explicit signals + SSE turn-end work; CP4 ping blocked by #210. |
 | 2026-06-19 | (all agents) | e06bc3a | PENDING | PENDING | PENDING | PENDING | PENDING | PENDING | PENDING — captain live run in progress; validates #354 three-state CP4 (QUIET/STALLED/IDLE) + #332 daemon-direct delivery (relay deleted) |
+| 2026-07-02 | (all agents) | d5b71ff | PASS | PASS | DEFERRED (auto mode) | PENDING | PASS | PASS | Core smoke on installed 0.14.1 + cmux 0.64.17: CP1 first-turn delivery + CP2 blocked→answer + CP5 done + CP6 reopen all PASS ×3 (claude/opencode/codex). CP3 deferred-by-design (auto mode). CP4 not run this pass. Finding: codex now INTERACTIVE (crew send reaches it, verified live). confirmedSendToPane follow-up-send false-warns "not delivered" on opencode+codex then auto-retries+lands (cosmetic, same screen-scrape-drift class as #499). |
 
 ---
 

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -191,7 +191,7 @@ To change the effort dial: `squadrant effort <max|balance|low>` or use the `squa
 - **For complex multi-step tasks** (3+ steps, multiple files), tell the crew to use GSD inside the task prompt: *"This is a complex task. Use `/gsd:plan-phase` and `/gsd:execute-phase` for wave-based execution with fresh context per step."*
 - **For simple tasks**, don't mention GSD — the crew will handle it directly.
 
-> Non-Claude agents (codex / gemini) currently still launch in print-mode (one-shot) rather than as interactive sessions; `send` won't reach them yet. Prefer Claude crews when you want multi-turn dialogue.
+> codex crews are fully interactive (parity with claude/opencode) — `send` reaches them for follow-up turns (verified live 2026-07-02). gemini currently still launches in print-mode (one-shot) rather than as an interactive session; `send` won't reach it yet.
 
 ## Task Coordination
 


### PR DESCRIPTION
## Summary
- Append a 2026-07-02 result-log row to `docs/testing/crew-lifecycle-checklist.md` — core smoke pass on installed 0.14.1 + cmux 0.64.17: CP1/CP2/CP5/CP6 PASS ×3 (claude/opencode/codex), CP3 deferred-by-design (auto mode), CP4 not run this pass. Notes codex is now interactive and a cosmetic `confirmedSendToPane` false-warn on opencode/codex follow-up sends.
- Correct the outdated "codex only launches in print-mode / `send` won't reach it" claim in `docs/reference.md` (2 spots) and `plugin/skills/captain-ops/SKILL.md` — codex crews are now fully interactive (danger-full-access sandbox), verified live 2026-07-02. gemini's print-mode caveat is left intact (unverified this pass).

## Test plan
- [x] Doc-only diff — no source code touched
- [x] Grepped repo for other stale "print-mode"/"won't reach" codex claims (CHANGELOG.md entries are historical/dated, left untouched)