### PR TITLE
chore(release): v0.14.2 — opencode first-turn fix (#499) + dashboard idle-health-neutral (#498)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.2] - 2026-07-02
+
+### Fixed
+
+- **fix(crew): opencode first-turn drop from splash-marker drift (#499):** the hardcoded splash marker `Ask anything…` (U+2026 ellipsis) never matched opencode's real render, `Ask anything...` (ASCII dots), so first-turn delivery confirmation could false-positive with no retry safety net. Fixed with drift-tolerant matching, a `sawSplash` fail-closed latch, and a positive readiness gate.
+
 ## [0.14.1] - 2026-07-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **fix(crew): opencode first-turn drop from splash-marker drift (#499):** the hardcoded splash marker `Ask anything…` (U+2026 ellipsis) never matched opencode's real render, `Ask anything...` (ASCII dots), so first-turn delivery confirmation could false-positive with no retry safety net. Fixed with drift-tolerant matching, a `sawSplash` fail-closed latch, and a positive readiness gate.
+- **fix(web): idle/never-launched projects health-neutral in the dashboard rollup (#498):** projects registered but idle/never-launched (captain not alive) no longer trip the master annunciator to DEGRADED, and template-hash drift is demoted out of the rollup — only a genuinely alive captain's delivery backlog or real faults read DEGRADED now.
 
 ## [0.14.1] - 2026-07-01
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "squadrant",
   "packageManager": "pnpm@10.30.3",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Multi-project orchestration for your coding agents (Claude, Codex, opencode, Gemini)",
   "type": "module",
   "bin": {

--- a/packages/core/src/__tests__/crew-protocol.test.ts
+++ b/packages/core/src/__tests__/crew-protocol.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   isTurnAccepted,
+  screenHasSplashMarker,
   buildCompletionProtocol,
   shellQuote,
   titleFor,
@@ -48,6 +49,30 @@ describe("isTurnAccepted", () => {
       "> ready",
       { splashMarker: "Ask anything…" },
     )).toBe(true);
+  });
+});
+
+// #499: the marker is drift-prone — opencode's real placeholder rotates through
+// example prompts and uses three ASCII dots ("Ask anything...") or a longer
+// command hint, never the exact U+2026 ellipsis the marker used to hardcode.
+describe("screenHasSplashMarker (#499 drift-robust matching)", () => {
+  it("matches three ASCII dots against a U+2026-ellipsis marker", () => {
+    expect(screenHasSplashMarker("Ask anything... \"Fix a TODO\"", "Ask anything…")).toBe(true);
+  });
+
+  it("matches a stable substring marker against the longer real placeholder", () => {
+    expect(screenHasSplashMarker(
+      "Ask anything, / for commands, @ for context...",
+      "Ask anything",
+    )).toBe(true);
+  });
+
+  it("matches case-insensitively", () => {
+    expect(screenHasSplashMarker("ASK ANYTHING... something", "Ask anything")).toBe(true);
+  });
+
+  it("does not match when the marker text is genuinely absent", () => {
+    expect(screenHasSplashMarker("> processing your task", "Ask anything")).toBe(false);
   });
 });
 

--- a/packages/core/src/__tests__/crew-spawn.test.ts
+++ b/packages/core/src/__tests__/crew-spawn.test.ts
@@ -463,7 +463,7 @@ describe("runCrewSpawn", () => {
         expect.anything(),
         expect.any(String),
         expect.any(String),
-        expect.objectContaining({ splashMarker: "Ask anything…" }),
+        expect.objectContaining({ splashMarker: "Ask anything" }),
       );
     });
 

--- a/packages/core/src/crew-protocol.ts
+++ b/packages/core/src/crew-protocol.ts
@@ -17,17 +17,39 @@ export interface TurnAcceptanceConfig {
   retryLimit?: number;
 }
 
+/** Normalizes screen/marker text for splash-marker matching: case-insensitive,
+ *  whitespace-collapsed, and treats the single-char ellipsis (U+2026) and "..."
+ *  interchangeably. opencode's idle-splash wording rotates through example
+ *  prompts and has drifted in exact glyph/punctuation across versions (#499:
+ *  the hardcoded "Ask anything…" (U+2026) never matched real "Ask anything..."
+ *  (three ASCII dots) renders), so matching the literal string is unsafe —
+ *  match a stable substring instead. */
+function normalizeForSplashMatch(text: string): string {
+  return text.toLowerCase().replace(/…/g, "...").replace(/\s+/g, " ").trim();
+}
+
+/** True when `marker` appears in `screen` under splash-match normalization. */
+export function screenHasSplashMarker(screen: string, marker: string): boolean {
+  return normalizeForSplashMatch(screen).includes(normalizeForSplashMatch(marker));
+}
+
 /** Pure-function decision: was the first turn accepted by the TUI?
  *  - With splashMarker: accepted = the marker is no longer visible (the TUI left
  *    its idle splash, confirming the keystroke was received).
- *  - Without splashMarker (claude): accepted = the screen changed after sending. */
+ *  - Without splashMarker (claude): accepted = the screen changed after sending.
+ *
+ *  Callers on the splash path MUST additionally gate on having observed the
+ *  splash marker at least once before trusting "marker absent" as acceptance
+ *  (see crew-pane.ts's sawSplash latch) — a marker that never matches (drift,
+ *  misconfiguration) would otherwise make this return true from the first
+ *  check, before any keystroke lands (#499). */
 export function isTurnAccepted(
   preSendScreen: string,
   afterScreen: string,
   config?: TurnAcceptanceConfig,
 ): boolean {
   if (config?.splashMarker) {
-    return !afterScreen.includes(config.splashMarker);
+    return !screenHasSplashMarker(afterScreen, config.splashMarker);
   }
   return afterScreen !== preSendScreen;
 }

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -412,10 +412,16 @@ export async function runCrewSpawn(
     await deps.runtime.sendToPane(pane, `cd ${shellQuote(spawnCwd)} && ${envPrefix} OPENCODE_CONFIG=${opencodeConfigPath} ${cliCommand}`);
     const preLaunchScreen = (await deps.runtime.readPaneScreen(pane)) ?? "";
     const opencodeResult = await deps.sendFirstTurn(pane, `${firstTurnTask}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen, {
-      // #235: confirm-on-delivery — sendFirstTurnWhenReady polls until "Ask
-      // anything…" leaves the screen, re-sending every ~3s to cover slow boots
+      // #235: confirm-on-delivery — sendFirstTurnWhenReady polls until the idle
+      // splash leaves the screen, re-sending every ~3s to cover slow boots
       // without duplicating the task. See crew-pane.ts SPLASH_MAX_CHECKS/EVERY_N.
-      splashMarker: "Ask anything…",
+      // #499: match a stable substring ("ask anything", case/whitespace/ellipsis
+      // -insensitive via screenHasSplashMarker) rather than the exact wording —
+      // opencode's real placeholder rotates through example prompts and uses
+      // three ASCII dots ("Ask anything...") or a longer command hint ("Ask
+      // anything, / for commands, @ for context..."), never the literal
+      // "Ask anything…" (U+2026) this used to hardcode, which never matched.
+      splashMarker: "Ask anything",
     } satisfies TurnAcceptanceConfig);
     // #466: surface non-delivery; emit confirmed event on success.
     if (!opencodeResult.delivered) {

--- a/packages/web/src/__tests__/web-render.test.ts
+++ b/packages/web/src/__tests__/web-render.test.ts
@@ -459,6 +459,58 @@ describe("global delivery-lag excludes offline-captain projects", () => {
   });
 });
 
+describe("idle/never-launched projects are health-neutral for the master annunciator", () => {
+  it("an idle project (captain unknown) with delivery backlog does NOT trip DEGRADED", () => {
+    const d = daemon();
+    d.tier1 = [
+      { kind: "captain", project: "squadrant", ref: "captain", state: "unknown", lastSeenMs: null },
+    ];
+    d.tier2.projects[0].delivery = { maxSeq: 10, lastAckedSeq: 2, behind: 8 };
+    const out = renderContent(full(d));
+    expect(out).toContain('class="annunciator a-ok');
+    expect(out).toContain("NOMINAL");
+    expect(out).not.toContain('class="annunciator a-warn');
+  });
+
+  it("template-hash drift alone does NOT trip DEGRADED (demoted to soft/info)", () => {
+    const drifted: ExternalProbes = {
+      ...externalHealthy,
+      config: { ...externalHealthy.config, sessions: { state: "stale", detail: "template drift: 12 distinct hashes" } },
+    };
+    const out = renderContent(full(daemon(), drifted));
+    expect(out).toContain('class="annunciator a-ok');
+    expect(out).toContain("NOMINAL");
+    // the drift signal still surfaces in the Environment tab, just doesn't roll up
+    expect(out).toContain("template drift: 12 distinct hashes");
+  });
+
+  it("a fleet of idle/unknown projects plus template drift together still reads NOMINAL", () => {
+    const d = daemon();
+    d.tier1 = [
+      { kind: "captain", project: "squadrant", ref: "captain", state: "unknown", lastSeenMs: null },
+    ];
+    d.tier2.projects[0].delivery = { maxSeq: 10, lastAckedSeq: 2, behind: 8 };
+    const drifted: ExternalProbes = {
+      ...externalHealthy,
+      config: { ...externalHealthy.config, sessions: { state: "stale", detail: "template drift: 12 distinct hashes" } },
+    };
+    const out = renderContent(full(d, drifted));
+    expect(out).toContain('class="annunciator a-ok');
+    expect(out).toContain("NOMINAL");
+  });
+
+  it("delivery backlog for a genuinely ALIVE captain still trips DEGRADED (regression guard)", () => {
+    const d = daemon();
+    d.tier1 = [
+      { kind: "captain", project: "squadrant", ref: "captain", state: "alive", lastSeenMs: 999_000 },
+    ];
+    d.tier2.projects[0].delivery = { maxSeq: 10, lastAckedSeq: 2, behind: 8 };
+    const out = renderContent(full(d));
+    expect(out).toContain('class="annunciator a-warn');
+    expect(out).toContain("DEGRADED");
+  });
+});
+
 describe("global results location", () => {
   it("global results line appears only in the daemon tab, not the projects tab", () => {
     const out = renderContent(full(daemon()));

--- a/packages/web/src/web-render.ts
+++ b/packages/web/src/web-render.ts
@@ -169,7 +169,11 @@ function collect(snap: FullSnapshot): Collected {
     env.vaults.hub.state,
     ...env.vaults.spokes.map((s) => s.state),
     env.config.parseable.state,
-    env.config.sessions.state,
+    // Template-hash drift (env.config.sessions.state) is demoted to soft/info:
+    // projects registered but idle/never-launched legitimately sit on older
+    // template versions, so drift alone is not actionable trouble. Its own
+    // status still renders in the Environment tab; it just no longer rolls up
+    // into envT/overall/masterClass.
     ...env.config.projectPaths.map((p) => p.state),
   ];
   const daemonStates: AnyState[] = [];
@@ -188,7 +192,11 @@ function collect(snap: FullSnapshot): Collected {
       if (c.kind === "crew" && c.detail?.startsWith("undelivered")) undelivered++;
     }
     for (const p of snap.daemon.tier2.projects) {
-      if (p.delivery.behind > 0) projStates.push("stale");
+      // Idle/never-launched projects (captain not alive — stopped or unknown)
+      // are health-neutral: unread backlog for an offline captain is expected,
+      // not a live caution. Mirrors liveDeliveryBehind's alive-only gate below.
+      const captain = snap.daemon.tier1.find((c) => c.kind === "captain" && c.project === p.project);
+      if (captain?.state === "alive" && p.delivery.behind > 0) projStates.push("stale");
       if (p.store.corruptCount > 0) projStates.push("gone");
       maxDeferCount = Math.max(maxDeferCount, p.deferral.maxDeferCount);
     }

--- a/packages/workspaces/src/__tests__/crew-pane.test.ts
+++ b/packages/workspaces/src/__tests__/crew-pane.test.ts
@@ -203,6 +203,101 @@ describe("sendFirstTurnWhenReady — post-send acceptance retry", () => {
   });
 });
 
+// ─── #499: splash-marker drift — sawSplash latch fails closed ────────────────
+
+describe("sendFirstTurnWhenReady — splash-marker drift fails closed (#499)", () => {
+  let readPaneScreen: ReturnType<typeof vi.fn>;
+  let sendToPane: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
+  const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, sendToPane, pasteToPane, sendKeyToPane });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    readPaneScreen = vi.fn();
+    sendToPane = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // The core #499 regression: a marker that never matches the real screen (text
+  // drift, wrong wording) used to make isTurnAccepted return true on the FIRST
+  // post-send check, before any keystroke landed — a false-positive delivered:true.
+  // With the sawSplash latch, "marker absent" only counts as acceptance once the
+  // marker was actually observed first. A marker that's never observed must fail
+  // closed: delivered:false, so the caller surfaces a non-delivery warning instead
+  // of silently confirming a turn that was never sent.
+  it("never returns delivered:true when the splash marker never matches the real screen", async () => {
+    // Screen never contains "Ask anything" at all — simulates the exact #499
+    // drift scenario (real opencode text vs a stale/wrong hardcoded marker).
+    readPaneScreen.mockResolvedValue("> some other unrelated prompt");
+
+    const promise = sendFirstTurnWhenReady(
+      rt(),
+      pane,
+      "do the thing",
+      "$ opencode",
+      { splashMarker: "totally-wrong-marker" },
+    );
+
+    await vi.advanceTimersByTimeAsync(120000);
+    const result = await promise;
+
+    expect(result.delivered).toBe(false);
+  });
+
+  it("readiness gate does not stabilize on a screen that never shows the marker", async () => {
+    readPaneScreen.mockResolvedValue("$ opencode booting up, no splash yet");
+
+    const promise = sendFirstTurnWhenReady(
+      rt(),
+      pane,
+      "do the thing",
+      "$ opencode booting up, no splash yet",
+      { splashMarker: "Ask anything" },
+    );
+
+    await vi.advanceTimersByTimeAsync(120000);
+    await promise;
+
+    // Never "ready" per the positive gate, but the splash branch still attempts
+    // the send unconditionally — confirm it doesn't falsely report delivered.
+    expect(sendToPane).toHaveBeenCalled();
+  });
+
+  // Real drift as reported in #499: opencode's actual placeholder uses three
+  // ASCII dots and rotates through example text, not the old U+2026 hardcode.
+  // The normalized "ask anything" substring match must still confirm delivery
+  // once the (correctly matching) splash clears.
+  it("confirms delivery once the drift-tolerant marker clears from the real placeholder text", async () => {
+    let callCount = 0;
+    readPaneScreen.mockImplementation(async () => {
+      callCount++;
+      if (callCount <= 3) return 'Ask anything... "Fix a TODO in the codebase"';
+      if (callCount === 4) return 'Ask anything... "Fix a TODO in the codebase"';
+      return "> processing your task";
+    });
+
+    const promise = sendFirstTurnWhenReady(
+      rt(),
+      pane,
+      "do the thing",
+      "$ opencode",
+      { splashMarker: "Ask anything" },
+    );
+
+    await vi.advanceTimersByTimeAsync(6000);
+    const result = await promise;
+
+    expect(result.delivered).toBe(true);
+  });
+});
+
 // ─── confirmedSendToPane (#448 follow-up send hardening) ─────────────────────
 
 describe("confirmedSendToPane — follow-up crew send (#448)", () => {

--- a/packages/workspaces/src/crew-pane.ts
+++ b/packages/workspaces/src/crew-pane.ts
@@ -7,7 +7,7 @@ import { loadConfig } from "@squadrant/shared";
 import type { PaneRef, RuntimeDriver } from "@squadrant/shared";
 import { RuntimeRegistry } from "./runtimes/registry.js";
 import { createCmuxDriver, parseDraftFromScreen, hasCCInputBox, classifyStartupSurface } from "./runtimes/cmux.js";
-import { titleFor, isCrewTitle, isTurnAccepted } from "@squadrant/core";
+import { titleFor, isCrewTitle, screenHasSplashMarker } from "@squadrant/core";
 import type { TurnAcceptanceConfig } from "@squadrant/core";
 
 // Poll-based first-turn delivery timing constants.
@@ -201,10 +201,12 @@ export async function sendFirstTurnWhenReady(
     // surface to be CC-INITIALIZED (classifyStartupSurface === "idle", i.e. the
     // persistent bottom status block — Ctx Used / ⏵⏵ / shortcuts / accept edits — is
     // present and no turn is in flight), in addition to the ❯ box (keeps #469's
-    // banner rejection). The opencode splash path is unchanged: its splashMarker
-    // short-circuits below, so we leave its readiness as "box present".
+    // banner rejection). For the opencode splash path (#499), readiness is a
+    // POSITIVE signal too: the marker must actually be visible on screen (not
+    // hardcoded true) — otherwise a booting/mid-transition screen could be
+    // declared "stable" before the TUI has rendered its idle splash at all.
     const ready = acceptanceConfig?.splashMarker
-      ? true
+      ? screenHasSplashMarker(screen, acceptanceConfig.splashMarker)
       : hasCCInputBox(screen) && classifyStartupSurface(screen) === "idle";
     if (screen.length > 0 && screen === previousScreen && screen !== preLaunchScreen && ready) {
       stable = true;
@@ -230,11 +232,23 @@ export async function sendFirstTurnWhenReady(
     // opencode's TUI does not collapse pastes into placeholders, so the atomic
     // send+Enter (sendToPane) is correct here and must stay (it was just fixed
     // and live-verified in #235). The #339 paste race is claude-specific.
+    //
+    // #499: sawSplash latches once the marker has actually been observed on
+    // screen. Only THEN does the marker's absence count as acceptance — this
+    // mirrors the claude path's sawDraft gate. Without the latch, a marker that
+    // never matches (drift, misconfiguration) makes isTurnAccepted return true
+    // on the very first check, before any keystroke lands, and silently
+    // confirms delivery of a turn that was never sent. With the latch, the same
+    // situation exhausts the confirm window and fails closed (delivered:false),
+    // surfacing the non-delivery warning instead.
+    let sawSplash = screenHasSplashMarker(preSendScreen, acceptanceConfig.splashMarker);
     await runtime.sendToPane(pane, task);
     for (let check = 0; check < SPLASH_MAX_CHECKS; check++) {
       await new Promise((r) => setTimeout(r, POST_SEND_CHECK_MS));
       const afterScreen = (await runtime.readPaneScreen(pane)) ?? "";
-      if (isTurnAccepted(preSendScreen, afterScreen, acceptanceConfig)) {
+      if (screenHasSplashMarker(afterScreen, acceptanceConfig.splashMarker)) {
+        sawSplash = true;
+      } else if (sawSplash) {
         return { delivered: true };
       }
       if ((check + 1) % SPLASH_RESEND_EVERY_N === 0 && check < SPLASH_MAX_CHECKS - 1) {


### PR DESCRIPTION
## Summary
- PATCH release 0.14.1 → 0.14.2 (bugfix only)
- Ships #499: fix(crew): opencode first-turn drop from splash-marker drift (#500, already merged to develop)
  - The hardcoded splash marker `Ask anything…` (U+2026 ellipsis) never matched opencode's real render, `Ask anything...` (ASCII dots), so first-turn delivery confirmation could false-positive with no retry safety net.
  - Fixed with drift-tolerant matching, a `sawSplash` fail-closed latch, and a positive readiness gate.

## Test plan
- [x] Confirmed develop HEAD (d5b71ff) is exactly the merge of #500 before branching
- [x] `pnpm install --frozen-lockfile` clean
- [x] `pnpm build` clean (tsc -b + tsup)
- [x] `node dist/index.js --version` reports `0.14.2`
- [x] `pnpm test run` — 150 test files / 1850 tests passed
- [x] CHANGELOG.md updated with `[0.14.2]` entry