### PR TITLE
chore: back-merge v0.14.2 into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.2] - 2026-07-02
+
+### Fixed
+
+- **fix(crew): opencode first-turn drop from splash-marker drift (#499):** the hardcoded splash marker `Ask anything…` (U+2026 ellipsis) never matched opencode's real render, `Ask anything...` (ASCII dots), so first-turn delivery confirmation could false-positive with no retry safety net. Fixed with drift-tolerant matching, a `sawSplash` fail-closed latch, and a positive readiness gate.
+
 ## [0.14.1] - 2026-07-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **fix(crew): opencode first-turn drop from splash-marker drift (#499):** the hardcoded splash marker `Ask anything…` (U+2026 ellipsis) never matched opencode's real render, `Ask anything...` (ASCII dots), so first-turn delivery confirmation could false-positive with no retry safety net. Fixed with drift-tolerant matching, a `sawSplash` fail-closed latch, and a positive readiness gate.
+- **fix(web): idle/never-launched projects health-neutral in the dashboard rollup (#498):** projects registered but idle/never-launched (captain not alive) no longer trip the master annunciator to DEGRADED, and template-hash drift is demoted out of the rollup — only a genuinely alive captain's delivery backlog or real faults read DEGRADED now.
 
 ## [0.14.1] - 2026-07-01
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "squadrant",
   "packageManager": "pnpm@10.30.3",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Multi-project orchestration for your coding agents (Claude, Codex, opencode, Gemini)",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Syncs the v0.14.2 release (main) back into develop: version bump to 0.14.2 + CHANGELOG entries for #499 and #498.
- develop already has the #500 (#499 fix) and #498 code merged, so this is expected to be a clean, code-free merge (version/CHANGELOG only).

## Test plan
- [x] Confirmed origin/main HEAD is the merged v0.14.2 release PR (#502)
- [x] npm 0.14.2 + tag + GitHub release already verified live