### PR TITLE
fix(agents): opencode SSE bridge boot-grace outlasts first-turn delivery budget (#504)

### DIFF
--- a/packages/agents/src/opencode/__tests__/sse-bridge.test.ts
+++ b/packages/agents/src/opencode/__tests__/sse-bridge.test.ts
@@ -97,6 +97,36 @@ describe("OpencodeSseBridge", () => {
     expect(log).toHaveBeenCalled();
   });
 
+  // #504: the bridge's boot-grace window must outlast the crew's own
+  // first-turn delivery budget (SEND_FIRST_TURN_TIMEOUT_MS = 90s in
+  // crew-pane.ts, i.e. 180 attempts at the 500ms default reconnect
+  // interval) — otherwise the daemon can permanently stop watching a crew
+  // (missing both turn-end AND permission-gate events) while the CLI's own
+  // pane-polling delivery is still succeeding. Live-reproduced 2026-07-02:
+  // squadrantd.log recorded the bridge giving up after 60 attempts (30s)
+  // during a real CP3 permission-gate run.
+  it("default boot-grace window outlasts the 90s first-turn delivery budget (#504)", async () => {
+    const events: ControlEvent[] = [];
+    const ATTEMPTS_PAST_OLD_30S_BUDGET = 180; // 90s / 500ms — old default (60) gave up here
+    const fetchImpl = vi.fn();
+    for (let i = 0; i < ATTEMPTS_PAST_OLD_30S_BUDGET; i++) {
+      fetchImpl.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    }
+    fetchImpl.mockResolvedValue(
+      sseResponse(['data: {"type":"session.idle","properties":{"sessionID":"s"}}\n']),
+    );
+    const bridge = new OpencodeSseBridge({
+      emit: (e) => events.push(e),
+      fetchImpl,
+      sleep: () => Promise.resolve(),
+      // No maxBootAttempts override — exercises the real default.
+    });
+    bridge.start({ taskId: "t7", port: 8000 });
+    for (let i = 0; i < ATTEMPTS_PAST_OLD_30S_BUDGET + 10; i++) await flush();
+    expect(fetchImpl.mock.calls.length).toBeGreaterThan(ATTEMPTS_PAST_OLD_30S_BUDGET);
+    expect(events).toEqual([{ type: "task.turn.completed", id: "t7", turnId: "s" }]);
+  });
+
   it("stop() aborts the subscription and ignores later data", async () => {
     const events: ControlEvent[] = [];
     let pulled = 0;

--- a/packages/agents/src/opencode/sse-bridge.ts
+++ b/packages/agents/src/opencode/sse-bridge.ts
@@ -23,7 +23,17 @@ export interface OpencodeSseBridgeDeps {
   sleep?: (ms: number) => Promise<void>;
   /** Backoff between reconnect attempts (ms, default 500). */
   reconnectMs?: number;
-  /** Attempts to reach the server before giving up the boot wait (default 60 ≈ 30s). */
+  /** Attempts to reach the server before giving up the boot wait (default 240
+   *  ≈ 120s). Must comfortably outlast the crew's own first-turn delivery
+   *  budget (SEND_FIRST_TURN_TIMEOUT_MS = 90s in crew-pane.ts) — #504:
+   *  otherwise the bridge can give up and permanently stop watching a crew
+   *  (both turn-end AND permission-gate detection) while the CLI's own
+   *  pane-polling delivery mechanism is still patiently retrying and
+   *  eventually succeeds, leaving the daemon silently, irrecoverably blind
+   *  for the rest of that crew's life. Live-reproduced 2026-07-02: opencode's
+   *  embedded HTTP server took >30s to bind under concurrent crew-spawn load,
+   *  the bridge gave up at 60 attempts, and the crew's later permission gate
+   *  (which fires correctly once subscribed — verified live) was never seen. */
   maxBootAttempts?: number;
   log?: (msg: string) => void;
 }
@@ -102,7 +112,7 @@ export class OpencodeSseBridge {
     const fetchImpl = this.deps.fetchImpl ?? fetch;
     const sleep = this.deps.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
     const reconnectMs = this.deps.reconnectMs ?? 500;
-    const maxBoot = this.deps.maxBootAttempts ?? 60;
+    const maxBoot = this.deps.maxBootAttempts ?? 240;
     const url = `http://127.0.0.1:${port}/event`;
     let booted = false;
     let bootAttempts = 0;


### PR DESCRIPTION
## Summary

Fixes #504 — but the issue's stated root cause was incorrect. `OpencodeSseBridge` already correctly subscribes to `permission.asked` (added 2026-06-04, well before the issue was filed); live-testing against a real running `opencode` 1.17.13 server (both `serve` and the actual `opencode --port N` TUI-mode invocation squadrant uses) confirms the event fires with exactly the schema the bridge expects.

The real bug is a timeout-budget mismatch:
- `OpencodeSseBridge`'s boot-grace window (`maxBootAttempts`) defaulted to 60 attempts × 500ms ≈ **30s**.
- The crew's own first-turn delivery mechanism (`sendFirstTurnWhenReady` in `crew-pane.ts`) patiently retries for up to `SEND_FIRST_TURN_TIMEOUT_MS` = **90s**.

Under concurrent crew-spawn load, opencode's embedded HTTP server can take longer than 30s to bind. `squadrantd.log` confirms the bridge gave up (`opencode SSE bridge: gave up connecting to ... after 60 attempts`) at exactly the timestamp of the 2026-07-02 CP3 permission-gate test run. The CLI's own delivery mechanism has a longer budget and succeeds afterward, so the crew reaches its permission gate normally and shows the modal on-screen — but the bridge already permanently stopped watching by then, so **both turn-end and permission-gate detection go dark** for that crew's remaining life, with only a log line (no captain-visible signal). This exactly matches the observed symptom: `state=working, lastEvent=task.first-turn.confirmed` forever.

## Fix

Raise the default `maxBootAttempts` from 60 (~30s) to 240 (~120s) so the bridge's boot-grace window comfortably outlasts the 90s first-turn delivery budget with margin.

## Test plan
- [x] `npx vitest run packages/agents/src/opencode/__tests__/sse-bridge.test.ts` — 12/12 pass, including a new regression test asserting the default budget survives 180 failed connection attempts (the old 30s default's exact failure point) before succeeding
- [x] `npx vitest run packages/agents` — 313/313 pass
- [x] `npx tsc --noEmit -p packages/agents/tsconfig.json` — clean
- [x] Live-reproduced against real opencode 1.17.13 (`opencode serve` and `opencode --port N` TUI mode) to confirm `permission.asked` schema/behavior matches the bridge's expectations
- [x] Confirmed via `squadrantd.log` that the bridge's 30s give-up coincides exactly with the 2026-07-02 CP3 test window

Recommend correcting #504's root-cause description before closing — the "bridge never subscribes to permission.asked" claim does not match the code (verified via `git blame`, unit tests, and live testing).