### PR TITLE
fix(daemon): self-heal undelivered first turns instead of only alerting (#466)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (4506 symbols, 6820 relationships, 166 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (4511 symbols, 6828 relationships, 166 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (4506 symbols, 6820 relationships, 166 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (4511 symbols, 6828 relationships, 166 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/packages/cli/src/squadrantd.ts
+++ b/packages/cli/src/squadrantd.ts
@@ -15,13 +15,14 @@ import type { TelegramBridge } from "@squadrant/core";
 import type { LifecycleSnapshot, LifecycleSourceDeps } from "@squadrant/core";
 import type { TelegramConfig } from "@squadrant/shared";
 import { createRunCommand, createIsCaptainAlive, createLaunch } from "@squadrant/core";
+import { buildCompletionProtocol } from "@squadrant/core";
 export type { SquadrantdOpts } from "@squadrant/core";
 export { defaultIsPidAlive } from "@squadrant/core";
 export { discoverCaptainSurface } from "@squadrant/core";
 import type { AttachFrame } from "@squadrant/core";
 import type { PaneRef } from "@squadrant/shared";
 import { runHeadless, CodexInteractiveDriver, OpencodeSseBridge, CodexAppServerSource } from "@squadrant/agents";
-import { CmuxEventsBridge, DaemonCmux, CmuxStoreSource, NativeHookSource } from "@squadrant/workspaces";
+import { CmuxEventsBridge, DaemonCmux, CmuxStoreSource, NativeHookSource, resendCrewFirstTurn } from "@squadrant/workspaces";
 import { loadConfig, TERMINAL_STATES } from "@squadrant/shared";
 import { createCmuxDriver } from "@squadrant/workspaces";
 
@@ -159,6 +160,22 @@ export function startSquadrantd(opts: import("@squadrant/core").SquadrantdOpts =
   // ── daemonCmux resolution ─────────────────────────────────────────────────
   ctx.daemonCmux = opts.daemonCmux
     ?? (opts.makeDaemonCmux ?? (() => new DaemonCmux(createCmuxDriver())))();
+
+  // ── #466 self-heal: first-turn resend wiring ──────────────────────────────
+  // Uses a fresh cmux RuntimeDriver (independent of daemonCmux's narrower
+  // DaemonSurfaceDriver seam, which lacks the paste/sendKey primitives) to
+  // drive the same paste-settle-Enter delivery path a manual `crew send` uses.
+  // Scoped to claude crews — the facet #466's frozen frame confirmed; other
+  // providers safely report non-delivery (the daemon's sweep loop still alerts
+  // via CREW UNDELIVERED rather than silently retrying forever).
+  const resendRuntime = createCmuxDriver();
+  ctx.resendFirstTurn = opts.resendFirstTurn ?? (async (rec) => {
+    if (rec.provider !== "claude" || !rec.name) return { delivered: false };
+    const proj = loadConfig().projects[rec.project];
+    const captainName = proj?.captainName ?? `${rec.project}-captain`;
+    const message = `${rec.task}\n\n${buildCompletionProtocol(rec.id, rec.project)}`;
+    return resendCrewFirstTurn(resendRuntime, captainName, rec.project, rec.name, message);
+  });
 
   // ── launchHeadless default ────────────────────────────────────────────────
   // Kept here so this file is the sole importer of headless-launcher (daemon/* can't).

--- a/packages/core/src/__tests__/daemon.test.ts
+++ b/packages/core/src/__tests__/daemon.test.ts
@@ -135,17 +135,17 @@ describe("daemon handler", () => {
     expect(calls[0].event.type).toBe("task.quiet");
   });
 
-  // #466: an interactive crew that is quiet past its budget but has NEVER had
-  // firstTurnConfirmedAt set must emit CREW UNDELIVERED — not "deep thinking".
-  // This catches the race where spawn sends the first turn into a not-yet-ready
-  // box and the crew sits idle at an empty prompt (0% ctx, $0.00).
-  it("sweep: interactive quiet task with NO firstTurnConfirmedAt → CREW UNDELIVERED (#466)", async () => {
+  // #466: an interactive crew whose first turn is undelivered past the dedicated
+  // (createdAt-based) budget must emit CREW UNDELIVERED — not "deep thinking" —
+  // even when no resendFirstTurn capability is wired (pure unit test / non-cmux
+  // deployment), which preserves the prior alert-only behavior as a fallback.
+  it("sweep: interactive task with NO firstTurnConfirmedAt past the undelivered budget → CREW UNDELIVERED (#466)", async () => {
     const store = createStore(dir);
     const calls: any[] = [];
     // firstTurnConfirmedAt intentionally absent — first turn may not have landed
-    store.put(rec("u1", { mode: "interactive", state: "working", lastHeartbeat: 0,
+    store.put(rec("u1", { mode: "interactive", state: "working", createdAt: 0, lastHeartbeat: 0,
       heartbeatBudgetMs: 100, attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 0 }] }));
-    const d = createDaemon({ store, now: () => 1000, notify: async (a) => { calls.push(a); } });
+    const d = createDaemon({ store, now: () => 1000, firstTurnUndeliveredBudgetMs: 100, notify: async (a) => { calls.push(a); } });
     await d.sweep();
     expect(store.get("p", "u1")?.state).toBe("working"); // state unchanged
     expect(calls.length).toBe(1);
@@ -169,13 +169,14 @@ describe("daemon handler", () => {
     expect(calls[0].message).not.toMatch(/UNDELIVERED/);
   });
 
-  // #466: task within heartbeat budget — no UNDELIVERED (not yet timed out).
-  it("sweep: interactive task within budget with NO firstTurnConfirmedAt → no notification (#466)", async () => {
+  // #466: task within the undelivered budget (measured from createdAt) — no
+  // UNDELIVERED (not yet timed out).
+  it("sweep: interactive task within the undelivered budget with NO firstTurnConfirmedAt → no notification (#466)", async () => {
     const store = createStore(dir);
     const calls: any[] = [];
-    store.put(rec("u3", { mode: "interactive", state: "working", lastHeartbeat: 950,
+    store.put(rec("u3", { mode: "interactive", state: "working", createdAt: 950, lastHeartbeat: 950,
       heartbeatBudgetMs: 100, attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 950 }] }));
-    const d = createDaemon({ store, now: () => 1000, notify: async (a) => { calls.push(a); } });
+    const d = createDaemon({ store, now: () => 1000, firstTurnUndeliveredBudgetMs: 100, notify: async (a) => { calls.push(a); } });
     await d.sweep();
     expect(calls.length).toBe(0); // within budget → silent
   });
@@ -184,12 +185,12 @@ describe("daemon handler", () => {
   // crew still in `submitted` (never received task.started — the first turn was
   // dropped before CC could process it). The prior fix only wired UNDELIVERED under
   // `working`, so a silently-dropped crew was never flagged.
-  it("sweep: interactive `submitted` task past budget with no firstTurnConfirmedAt → CREW UNDELIVERED (#466-single)", async () => {
+  it("sweep: interactive `submitted` task past the undelivered budget with no firstTurnConfirmedAt → CREW UNDELIVERED (#466-single)", async () => {
     const store = createStore(dir);
     const calls: any[] = [];
-    store.put(rec("s-undelivered", { mode: "interactive", state: "submitted", lastHeartbeat: 0,
+    store.put(rec("s-undelivered", { mode: "interactive", state: "submitted", createdAt: 0, lastHeartbeat: 0,
       heartbeatBudgetMs: 100, attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 0 }] }));
-    const d = createDaemon({ store, now: () => 1000, notify: async (a) => { calls.push(a); } });
+    const d = createDaemon({ store, now: () => 1000, firstTurnUndeliveredBudgetMs: 100, notify: async (a) => { calls.push(a); } });
     await d.sweep();
     expect(store.get("p", "s-undelivered")?.state).toBe("submitted"); // state unchanged
     expect(calls.length).toBe(1);
@@ -198,15 +199,114 @@ describe("daemon handler", () => {
     expect(calls[0].event.type).toBe("task.quiet");
   });
 
-  // A `submitted` crew within the heartbeat budget must NOT fire (no false alarm).
-  it("sweep: interactive `submitted` task WITHIN budget → no notification (#466-single)", async () => {
+  // A `submitted` crew within the undelivered budget must NOT fire (no false alarm).
+  it("sweep: interactive `submitted` task WITHIN the undelivered budget → no notification (#466-single)", async () => {
     const store = createStore(dir);
     const calls: any[] = [];
-    store.put(rec("s-ok", { mode: "interactive", state: "submitted", lastHeartbeat: 950,
+    store.put(rec("s-ok", { mode: "interactive", state: "submitted", createdAt: 950, lastHeartbeat: 950,
       heartbeatBudgetMs: 100, attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 950 }] }));
-    const d = createDaemon({ store, now: () => 1000, notify: async (a) => { calls.push(a); } });
+    const d = createDaemon({ store, now: () => 1000, firstTurnUndeliveredBudgetMs: 100, notify: async (a) => { calls.push(a); } });
     await d.sweep();
     expect(calls.length).toBe(0);
+  });
+
+  // ─── #466 self-heal: auto-resend the first turn instead of only alerting ────
+
+  // The core self-heal contract: once the undelivered budget elapses, the daemon
+  // calls the injected resendFirstTurn hook and — on a positively-confirmed
+  // delivery — stamps firstTurnConfirmedAt itself, with NO manual `crew send`.
+  // heartbeatBudgetMs is deliberately huge and lastHeartbeat is fresh (990, 10ms
+  // before `now`) to prove the undelivered check is decoupled from heartbeat
+  // liveness — a heartbeat that keeps resetting must NOT mask a genuinely
+  // undelivered first turn (the root-cause finding from #466's frozen frame).
+  it("sweep: past-budget working task auto-resends and self-confirms without a manual crew send (#466 self-heal)", async () => {
+    const store = createStore(dir);
+    const notifyCalls: any[] = [];
+    const resendCalls: TaskRecord[] = [];
+    store.put(rec("heal1", { mode: "interactive", state: "working", createdAt: 0, lastHeartbeat: 990,
+      heartbeatBudgetMs: 86_400_000, // huge — the old quiet-based check would never fire on this
+      attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 990 }] }));
+    const d = createDaemon({
+      store, now: () => 1000,
+      firstTurnUndeliveredBudgetMs: 100,
+      notify: async (a) => { notifyCalls.push(a); },
+      resendFirstTurn: async (r) => { resendCalls.push(r); return { delivered: true }; },
+    });
+    await d.sweep();
+    expect(resendCalls.length).toBe(1);
+    expect(resendCalls[0].id).toBe("heal1");
+    expect(store.get("p", "heal1")?.state).toBe("working"); // no forced state transition
+    expect(store.get("p", "heal1")?.firstTurnConfirmedAt).toBe(1000); // self-stamped
+    expect(notifyCalls.some((c) => /AUTO-RESENT/.test(c.message))).toBe(true);
+  });
+
+  // The `submitted` path (crew never even reached task.started) gets the same
+  // self-heal treatment.
+  it("sweep: past-budget `submitted` task also auto-resends and self-confirms (#466 self-heal)", async () => {
+    const store = createStore(dir);
+    const resendCalls: TaskRecord[] = [];
+    store.put(rec("heal5", { mode: "interactive", state: "submitted", createdAt: 0, lastHeartbeat: 0,
+      heartbeatBudgetMs: 86_400_000 }));
+    const d = createDaemon({
+      store, now: () => 1000,
+      firstTurnUndeliveredBudgetMs: 100,
+      resendFirstTurn: async (r) => { resendCalls.push(r); return { delivered: true }; },
+    });
+    await d.sweep();
+    expect(resendCalls.length).toBe(1);
+    expect(store.get("p", "heal5")?.firstTurnConfirmedAt).toBe(1000);
+  });
+
+  // CRITICAL SAFETY: never double-deliver. Once firstTurnConfirmedAt is already
+  // set, resendFirstTurn must never be invoked, regardless of how far past the
+  // budget the record is.
+  it("sweep: never calls resendFirstTurn once firstTurnConfirmedAt is already confirmed (#466 no double-delivery)", async () => {
+    const store = createStore(dir);
+    const resendCalls: TaskRecord[] = [];
+    store.put(rec("heal2", { mode: "interactive", state: "working", createdAt: 0, lastHeartbeat: 0,
+      firstTurnConfirmedAt: 5, heartbeatBudgetMs: 86_400_000,
+      attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 0 }] }));
+    const d = createDaemon({
+      store, now: () => 1000,
+      firstTurnUndeliveredBudgetMs: 100,
+      resendFirstTurn: async (r) => { resendCalls.push(r); return { delivered: true }; },
+    });
+    await d.sweep();
+    expect(resendCalls.length).toBe(0);
+  });
+
+  // CRITICAL SAFETY: the resend must RE-CHECK readiness on its own (never a
+  // blind paste) — modeled here by a resendFirstTurn that reports delivered:false
+  // when it decides the pane isn't ready. A failed attempt must not corrupt
+  // state and must be retried later (debounce test below), not treated as fatal.
+  // Also verifies the debounce: a second sweep tick within the cooldown window
+  // must NOT re-invoke resendFirstTurn, and a tick after the cooldown elapses
+  // DOES retry.
+  it("sweep: debounces resend attempts and retries after the cooldown elapses (#466 debounce)", async () => {
+    const store = createStore(dir);
+    const notifyCalls: any[] = [];
+    const resendCalls: TaskRecord[] = [];
+    store.put(rec("heal4", { mode: "interactive", state: "working", createdAt: 0, lastHeartbeat: 0,
+      heartbeatBudgetMs: 86_400_000,
+      attempts: [{ attemptId: "a0", startedAt: 0, lastHeartbeatAt: 0 }] }));
+    let tick = 1000;
+    const d = createDaemon({
+      store, now: () => tick,
+      firstTurnUndeliveredBudgetMs: 100,
+      firstTurnResendCooldownMs: 500,
+      notify: async (a) => { notifyCalls.push(a); },
+      resendFirstTurn: async (r) => { resendCalls.push(r); return { delivered: false }; }, // pane still not ready
+    });
+    await d.sweep(); // t=1000: first attempt
+    expect(resendCalls.length).toBe(1);
+    expect(notifyCalls.some((c) => /will retry/i.test(c.message))).toBe(true);
+    tick = 1200; // 200ms later — inside the 500ms cooldown
+    await d.sweep();
+    expect(resendCalls.length).toBe(1); // debounced
+    tick = 1600; // 600ms after the first attempt — cooldown elapsed
+    await d.sweep();
+    expect(resendCalls.length).toBe(2); // retried
+    expect(store.get("p", "heal4")?.firstTurnConfirmedAt).toBeUndefined(); // never fabricated
   });
 
   // #466: task.first-turn.confirmed event stamps firstTurnConfirmedAt on the record.

--- a/packages/core/src/daemon/context.ts
+++ b/packages/core/src/daemon/context.ts
@@ -72,6 +72,11 @@ export interface SquadrantdOpts {
   captainSurfaces?: Record<string, PaneRef>;
   /** #348: override the cmux socket auto-config re-check. */
   runCmuxAutoConfig?: () => Promise<AutoConfigResult>;
+  /** #466 self-heal: re-deliver a crew's first turn when the daemon detects it
+   *  never landed. Production wiring lives in squadrantd.ts (host); inject a
+   *  fake for tests. See DaemonDeps.resendFirstTurn (daemon/reduce.ts) for the
+   *  full contract. */
+  resendFirstTurn?: (rec: TaskRecord) => Promise<{ delivered: boolean }>;
 }
 
 export function defaultIsPidAlive(pid: number): boolean {
@@ -117,6 +122,9 @@ export interface DaemonContext {
   notify: (args: { project: string; message: string; record: TaskRecord; event: ControlEvent }) => Promise<void> | void;
   /** Resolved surface driver for daemon-direct delivery. */
   daemonCmux: DaemonSurfaceDriver | undefined;
+  /** #466 self-heal: resolved first-turn resend function (undefined when
+   *  opts.resendFirstTurn was not provided, e.g. non-cmux deployments). */
+  resendFirstTurn: ((rec: TaskRecord) => Promise<{ delivered: boolean }>) | undefined;
   /** Resolved agent driver. */
   codexDriver: AgentDriver;
   /** Resolved opencode SSE bridge. */
@@ -174,6 +182,7 @@ export function buildContext(opts: SquadrantdOpts): DaemonContext {
     activeHeadlessKills: new Set(),
     captainMissingStreak: new Map(),
     stoppedProjects: new Set(),
+    resendFirstTurn: opts.resendFirstTurn,
     // Late-bound — start.ts fills these before first use:
     d: null as unknown as ReturnType<typeof createDaemon>,
     notify: null as unknown as DaemonContext["notify"],

--- a/packages/core/src/daemon/reduce.ts
+++ b/packages/core/src/daemon/reduce.ts
@@ -62,7 +62,34 @@ export interface DaemonDeps {
    * Distinct from the per-task heartbeat budget (stall detection).
    */
   taskTimeoutMs?: number;
+  /**
+   * #466 self-heal: re-deliver a crew's first turn when the daemon detects it
+   * never landed (firstTurnConfirmedAt still absent past firstTurnUndeliveredBudgetMs).
+   * MUST re-check TUI/pane readiness itself before sending — never blind-send
+   * into a still-booting pane — and return { delivered: true } ONLY on a
+   * positively-confirmed submit (mirrors sendFirstTurnWhenReady/confirmedSendToPane).
+   * When absent, sweep falls back to the prior alert-only behavior (pure unit
+   * tests, non-cmux deployments).
+   */
+  resendFirstTurn?: (rec: TaskRecord) => Promise<{ delivered: boolean }>;
+  /** Override for testing; production default is DEFAULT_FIRST_TURN_UNDELIVERED_BUDGET_MS. */
+  firstTurnUndeliveredBudgetMs?: number;
+  /** Override for testing; production default is DEFAULT_FIRST_TURN_RESEND_COOLDOWN_MS. */
+  firstTurnResendCooldownMs?: number;
 }
+
+// #466: dedicated, tight budget for detecting an undelivered first turn —
+// measured from createdAt (monotonic; never reset by heartbeat activity), NOT
+// from lastHeartbeat/heartbeatBudgetMs. The frozen-frame root cause showed
+// heartbeats can keep flowing on a crew whose first turn never landed, which
+// would mask the drop indefinitely under a heartbeat-based gate. The default
+// sits comfortably above crew-pane's own SEND_FIRST_TURN_TIMEOUT_MS (90s) plus
+// its confirmedSendToPane fallback retries (worst case ~100s), so the daemon's
+// resend never races the crew's own in-flight first-turn delivery attempt.
+export const DEFAULT_FIRST_TURN_UNDELIVERED_BUDGET_MS = 120_000;
+// Minimum gap between resend attempts for the same task — avoids hammering a
+// still-not-ready pane with pastes every sweep tick.
+export const DEFAULT_FIRST_TURN_RESEND_COOLDOWN_MS = 60_000;
 
 // #225 hard crew task-timeout: default wall-clock ceiling (8h). A crew can
 // heartbeat continuously yet be stuck on one task — the stall watchdog won't
@@ -254,6 +281,79 @@ export function createDaemon(deps: DaemonDeps) {
   // the quiet episode so exactly one QUIET fires per episode; when the crew shows
   // activity again, liveness advances and a later quiet episode re-notifies.
   const quietNotifiedAt = new Map<string, number>();
+  // #466: per-task debounce for first-turn resend attempts — avoids hammering
+  // a still-not-ready pane with pastes every sweep tick.
+  const resendAttemptedAt = new Map<string, number>();
+  const firstTurnUndeliveredBudgetMs = deps.firstTurnUndeliveredBudgetMs ?? DEFAULT_FIRST_TURN_UNDELIVERED_BUDGET_MS;
+  const firstTurnResendCooldownMs = deps.firstTurnResendCooldownMs ?? DEFAULT_FIRST_TURN_RESEND_COOLDOWN_MS;
+
+  // Shared event-application core (extracted from handle()'s "event" case) so
+  // the #466 self-heal path below can stamp task.first-turn.confirmed through
+  // the same reduce → store.put → firePush pipeline as a normal socket event.
+  async function applyEvent(project: string, event: ControlEvent): Promise<TaskRecord> {
+    if (!KNOWN_EVENT_TYPES.has((event as any).type)) {
+      throw new Error(`unknown event type '${(event as any).type}' — not a valid ControlEvent`);
+    }
+    const cur = store.get(project, event.id);
+    if (!cur) throw new Error(`unknown task ${event.id}`);
+    if (event.type === "task.started") lastCaptainTurnAt.set(event.id, now());
+    if (event.type === "task.session.ended" && !TERMINAL_STATES.has(cur.state)) {
+      const liveness = deps.isSurfaceAlive ? await deps.isSurfaceAlive(cur) : "unknown";
+      if (liveness !== "gone") return cur; // alive/unknown: no-op, keep current state
+    }
+    const next = reduce(cur, event, now());
+    if (next !== cur) {
+      store.put(next); // skip redundant write on terminal no-ops
+      firePush(deps, project, cur.state, next, event, lastCaptainTurnAt.get(next.id));
+    }
+    return next;
+  }
+
+  // #466 self-heal: attempt to recover a task whose first turn never landed.
+  // Called from sweep() once undeliveredMs exceeds firstTurnUndeliveredBudgetMs.
+  // Debounced per-task via resendAttemptedAt. Re-fetches the record from the
+  // store right before acting so a confirmation that lands concurrently (e.g.
+  // the UserPromptSubmit hook) is never double-delivered — CRITICAL SAFETY.
+  async function attemptFirstTurnRecovery(r: TaskRecord, undeliveredMs: number): Promise<void> {
+    const lastAttempt = resendAttemptedAt.get(r.id);
+    if (lastAttempt != null && now() - lastAttempt < firstTurnResendCooldownMs) return;
+    resendAttemptedAt.set(r.id, now());
+
+    const fresh = store.get(r.project, r.id);
+    if (!fresh || fresh.firstTurnConfirmedAt) return; // already landed — idempotent no-op
+
+    const tag = crewTag(fresh);
+    const fireNotify = (message: string) => {
+      if (!deps.notify) return;
+      const synthEvent: ControlEvent = { type: "task.quiet", id: fresh.id, quietMs: undeliveredMs };
+      try {
+        const p = deps.notify({ project: fresh.project, message, record: store.get(fresh.project, fresh.id) ?? fresh, event: synthEvent });
+        if (p && typeof (p as Promise<void>).catch === "function") (p as Promise<void>).catch(() => {});
+      } catch { /* swallowed — a flaky notifier must never trip the sweep */ }
+    };
+
+    if (!deps.resendFirstTurn) {
+      // No resend capability wired (pure unit tests / non-cmux deployment) —
+      // preserve the prior alert-only behavior.
+      fireNotify(`⚠️ CREW UNDELIVERED ${tag}: first turn may not have landed (0 activity) — re-send the task or check the spawn.`);
+      return;
+    }
+
+    let result: { delivered: boolean };
+    try { result = await deps.resendFirstTurn(fresh); }
+    catch { result = { delivered: false }; }
+
+    if (result.delivered) {
+      // The reducer's task.first-turn.confirmed path is itself idempotent
+      // (first occurrence only — #470), so calling it here is safe even if the
+      // resend's own hook confirmation raced ahead of us.
+      try { await applyEvent(fresh.project, { type: "task.first-turn.confirmed", id: fresh.id }); } catch { /* best-effort */ }
+      fireNotify(`🔁 CREW FIRST-TURN AUTO-RESENT ${tag}: first turn had not landed after ${Math.round(undeliveredMs / 1000)}s — re-sent automatically.`);
+    } else {
+      fireNotify(`⚠️ CREW UNDELIVERED ${tag}: first turn may not have landed — auto-resend attempted but the pane wasn't ready; will retry.`);
+    }
+  }
+
   return {
     async handle(req: Req): Promise<TaskRecord | TaskRecord[]> {
       switch (req.kind) {
@@ -307,26 +407,7 @@ export function createDaemon(deps: DaemonDeps) {
           if (!KNOWN_EVENT_TYPES.has((req.event as any).type)) {
             throw new Error(`unknown event type '${(req.event as any).type}' — not a valid ControlEvent`);
           }
-          const cur = store.get(req.project, req.event.id);
-          if (!cur) throw new Error(`unknown task ${req.event.id}`);
-          // A captain turn (crew send/reply) arrives as task.started → record it
-          // so a quick trailing turn-end is debounced (#210).
-          if (req.event.type === "task.started") lastCaptainTurnAt.set(req.event.id, now());
-          // #227: gate SessionEnd behind surface-liveness — only terminalize
-          // when the surface is provably GONE. Prevents a nested/spurious
-          // SessionEnd from false-cancelling a live crew while preserving the
-          // #139 dead-crew behavior. "unknown" never cancels (transient cmux
-          // outage), identical to the sweep reaper's semantics.
-          if (req.event.type === "task.session.ended" && !TERMINAL_STATES.has(cur.state)) {
-            const liveness = deps.isSurfaceAlive ? await deps.isSurfaceAlive(cur) : "unknown";
-            if (liveness !== "gone") return cur; // alive/unknown: no-op, keep current state
-          }
-          const next = reduce(cur, req.event, now());
-          if (next !== cur) {
-            store.put(next); // skip redundant write on terminal no-ops
-            firePush(deps, req.project, cur.state, next, req.event, lastCaptainTurnAt.get(next.id));
-          }
-          return next;
+          return applyEvent(req.project, req.event);
         }
         case "status": {
           const r = store.get(req.project, req.id);
@@ -389,6 +470,10 @@ export function createDaemon(deps: DaemonDeps) {
         }
       }
 
+      // #466: first-turn recovery attempts fired this tick — awaited together at
+      // the end so the loop below never blocks on a slow pane round-trip.
+      const recoveryPromises: Promise<void>[] = [];
+
       for (const r of store.listAll()) {
         // #378: GC terminal records whose last heartbeat is older than the TTL.
         if (TERMINAL_STATES.has(r.state) && t - r.lastHeartbeat > TERMINAL_RECORD_TTL_MS) {
@@ -448,23 +533,14 @@ export function createDaemon(deps: DaemonDeps) {
           }
         }
         // #466-single: An interactive crew spawned but never started stays in
-        // `submitted` — no task.started hook ever fires, so the CREW QUIET/
-        // UNDELIVERED block below (which requires `working`) is unreachable.
-        // Surface CREW UNDELIVERED here for the quiet-past-budget submitted case
-        // so a silently-dropped first turn is caught regardless of state.
+        // `submitted` — no task.started hook ever fires, so the working-state
+        // undelivered check below is unreachable. Recover it here too, keyed
+        // off createdAt (not lastHeartbeat/heartbeatBudgetMs — see #466 self-heal
+        // below) so a silently-dropped first turn is caught regardless of state.
         if (r.mode === "interactive" && r.state === "submitted" && !r.firstTurnConfirmedAt) {
-          const elapsed = t - r.lastHeartbeat;
-          if (elapsed > r.heartbeatBudgetMs) {
-            if (deps.notify && quietNotifiedAt.get(r.id) !== r.lastHeartbeat) {
-              quietNotifiedAt.set(r.id, r.lastHeartbeat);
-              const tag = crewTag(r);
-              const synthEvent: ControlEvent = { type: "task.quiet", id: r.id, quietMs: elapsed };
-              const message = `⚠️ CREW UNDELIVERED ${tag}: first turn may not have landed (crew never started) — re-send the task or check the spawn.`;
-              try {
-                const p = deps.notify({ project: r.project, message, record: r, event: synthEvent });
-                if (p && typeof (p as Promise<void>).catch === "function") (p as Promise<void>).catch(() => {});
-              } catch { /* swallowed */ }
-            }
+          const undeliveredMs = t - r.createdAt;
+          if (undeliveredMs > firstTurnUndeliveredBudgetMs) {
+            recoveryPromises.push(attemptFirstTurnRecovery(r, undeliveredMs));
             continue;
           }
         }
@@ -484,14 +560,28 @@ export function createDaemon(deps: DaemonDeps) {
           firePush(deps, r.project, r.state, idle, synthEvent, lastCaptainTurnAt.get(r.id));
           continue;
         }
+        // #466 self-heal: an interactive `working` crew that has NEVER had
+        // firstTurnConfirmedAt set may be sitting at an empty prompt (the crew
+        // pane never actually ingested the first turn). Checked BEFORE the
+        // heartbeat-driven CREW QUIET branch below and gated on createdAt, NOT
+        // on heartbeat liveness — the frozen-frame root cause showed heartbeats
+        // can keep flowing on a crew whose first turn never landed, which would
+        // otherwise mask the drop indefinitely.
+        if (r.mode === "interactive" && r.state === "working" && !r.pendingTool && !r.firstTurnConfirmedAt) {
+          const undeliveredMs = t - r.createdAt;
+          if (undeliveredMs > firstTurnUndeliveredBudgetMs) {
+            recoveryPromises.push(attemptFirstTurnRecovery(r, undeliveredMs));
+            continue;
+          }
+        }
         // #354 CREW QUIET: a `working` interactive crew quiet past its heartbeat
         // budget with NO tool in flight is alive but deep-thinking (no hook fires
         // during pure model thinking). Surface a distinct, non-alarming nudge —
         // NOT 'awaiting-input' (the turn never ended; real CREW IDLE comes only
         // from the Stop hook). State stays `working`; notify once per episode.
-        // #466: if firstTurnConfirmedAt is unset the crew may never have received
-        // its first task — emit CREW UNDELIVERED instead of "deep thinking".
-        if (r.mode === "interactive" && r.state === "working" && !r.pendingTool) {
+        // Only reachable once firstTurnConfirmedAt is set — the undelivered
+        // check above owns the !firstTurnConfirmedAt case.
+        if (r.mode === "interactive" && r.state === "working" && !r.pendingTool && r.firstTurnConfirmedAt) {
           const liveness = r.attempts.at(-1)?.lastHeartbeatAt ?? r.lastHeartbeat;
           const quiet = t - liveness;
           if (quiet > r.heartbeatBudgetMs) {
@@ -499,15 +589,8 @@ export function createDaemon(deps: DaemonDeps) {
               quietNotifiedAt.set(r.id, liveness);
               const tag = crewTag(r);
               const synthEvent: ControlEvent = { type: "task.quiet", id: r.id, quietMs: quiet };
-              let message: string;
-              if (!r.firstTurnConfirmedAt) {
-                // #466: no confirmed delivery → crew may be sitting at an empty
-                // prompt. Alert distinctly so the captain can re-send the task.
-                message = `⚠️ CREW UNDELIVERED ${tag}: first turn may not have landed (0 activity) — re-send the task or check the spawn.`;
-              } else {
-                const mins = Math.max(1, Math.round(quiet / 60000));
-                message = `CREW QUIET ${tag}: working ~${mins}min with no tool activity — likely deep thinking (no reply expected yet).`;
-              }
+              const mins = Math.max(1, Math.round(quiet / 60000));
+              const message = `CREW QUIET ${tag}: working ~${mins}min with no tool activity — likely deep thinking (no reply expected yet).`;
               try {
                 const p = deps.notify({ project: r.project, message, record: r, event: synthEvent });
                 if (p && typeof (p as Promise<void>).catch === "function") (p as Promise<void>).catch(() => {});
@@ -523,6 +606,10 @@ export function createDaemon(deps: DaemonDeps) {
         // recoverStall does NOT check heartbeat freshness — guard per its contract
         if (recovered && t - r.lastHeartbeat <= r.heartbeatBudgetMs) store.put(recovered);
       }
+      // #466: wait for this tick's first-turn recovery attempts. They ran
+      // independently (not serialized in the loop above), so this only adds
+      // the latency of the slowest single attempt, not their sum.
+      await Promise.all(recoveryPromises);
     },
     async reconcile(): Promise<void> {
       const alive = deps.isPidAlive ?? (() => true);

--- a/packages/core/src/daemon/start.ts
+++ b/packages/core/src/daemon/start.ts
@@ -59,6 +59,7 @@ export function startDaemon(ctx: DaemonContext, opts: SquadrantdOpts, pkgVersion
   const d = createDaemon({
     store, now: () => Date.now(), isPidAlive, notify, taskTimeoutMs,
     isSurfaceAlive: surfaceProbe,
+    resendFirstTurn: ctx.resendFirstTurn,
     launchHeadless: opts.launchHeadless!,
     isHeadlessInFlight: (id) => inFlightHeadlessIds.has(id),
     launchInteractive: async (rec) => {

--- a/packages/workspaces/src/__tests__/crew-pane.test.ts
+++ b/packages/workspaces/src/__tests__/crew-pane.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { sendFirstTurnWhenReady, confirmedSendToPane } from "../crew-pane.js";
-import type { PaneRef } from "@squadrant/shared";
+import { sendFirstTurnWhenReady, confirmedSendToPane, resendCrewFirstTurn } from "../crew-pane.js";
+import type { PaneRef, WorkspaceRef } from "@squadrant/shared";
 
 // Realistic Claude-Code-style screen: the live input box is the region between the
 // last two horizontal rules. parseDraftFromScreen reads exactly that region, so the
@@ -982,5 +982,97 @@ describe("confirmedSendToPane — screen change without sawDraft is NOT delivery
     const result = await promise;
 
     expect(result).toEqual({ delivered: false });
+  });
+});
+
+// #466 daemon self-heal: resendCrewFirstTurn is the pane-touching primitive the
+// daemon's sweep-loop resend hook calls. It must find the crew's own pane (not
+// blind-send anywhere), RE-CHECK TUI readiness itself (never blind-paste into a
+// still-booting box), and only then submit via the same paste-settle-Enter path
+// as a manual `crew send`.
+describe("resendCrewFirstTurn — #466 daemon self-heal", () => {
+  const HR = "─".repeat(60);
+  const box = (content: string) =>
+    `…transcript…\n${HR}\n❯ ${content}\n${HR}\n   Model: Sonnet 4.6  Ctx Used: 0.0%`;
+  const READY_EMPTY_BOX = box(""); // hasCCInputBox ✓ + classifyStartupSurface === "idle"
+  const BOOTING_SCREEN = "claude-mem: loading MCP server…\n(no input box yet)";
+
+  const captainPane: WorkspaceRef = { id: "w:captain", name: "p-captain", status: "running" };
+  const crewPane: PaneRef = { workspaceId: "w:captain", surfaceId: "s:crew1" };
+  const crewTitle = "🔧 p:crew1";
+
+  let status: ReturnType<typeof vi.fn>;
+  let listSurfaces: ReturnType<typeof vi.fn>;
+  let readPaneScreen: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
+  const rt = () => ({ status, listSurfaces, readPaneScreen, pasteToPane, sendKeyToPane });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    status = vi.fn();
+    listSurfaces = vi.fn();
+    readPaneScreen = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
+  });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it("delivers when the crew pane is found and its box is CC-initialized-ready", async () => {
+    status.mockResolvedValue(captainPane);
+    listSurfaces.mockResolvedValue([{ ...crewPane, title: crewTitle }]);
+    // confirmedSendToPane needs to observe the draft rendered before it can
+    // confirm submission — simulate paste rendering then the box clearing.
+    let readCount = 0;
+    readPaneScreen.mockImplementation(async () => {
+      readCount++;
+      if (readCount === 1) return READY_EMPTY_BOX;              // resendCrewFirstTurn's own readiness check
+      if (readCount === 2) return READY_EMPTY_BOX;              // confirmedSendToPane preSendScreen
+      if (readCount <= 4) return box("[Pasted text #1]");       // settle: draft rendered
+      return READY_EMPTY_BOX;                                    // post-Enter: box empty → submitted
+    });
+
+    const promise = resendCrewFirstTurn(rt(), "p-captain", "p", "crew1", "the task");
+    await vi.advanceTimersByTimeAsync(8000);
+    const result = await promise;
+
+    expect(result).toEqual({ delivered: true });
+    expect(pasteToPane).toHaveBeenCalledWith({ ...crewPane, title: crewTitle }, "the task");
+  });
+
+  it("returns delivered:false without touching the pane when the captain workspace can't be found", async () => {
+    status.mockResolvedValue(null);
+
+    const result = await resendCrewFirstTurn(rt(), "p-captain", "p", "crew1", "the task");
+
+    expect(result).toEqual({ delivered: false });
+    expect(pasteToPane).not.toHaveBeenCalled();
+    expect(sendKeyToPane).not.toHaveBeenCalled();
+  });
+
+  it("returns delivered:false without touching the pane when no surface matches the crew's title", async () => {
+    status.mockResolvedValue(captainPane);
+    listSurfaces.mockResolvedValue([{ workspaceId: "w:captain", surfaceId: "s:other", title: "🔧 p:someone-else" }]);
+
+    const result = await resendCrewFirstTurn(rt(), "p-captain", "p", "crew1", "the task");
+
+    expect(result).toEqual({ delivered: false });
+    expect(pasteToPane).not.toHaveBeenCalled();
+  });
+
+  // CRITICAL SAFETY (#466): never blind-send into a still-booting pane. If the
+  // re-check finds the box not yet CC-initialized-ready, resendCrewFirstTurn
+  // must return delivered:false WITHOUT pasting anything — the daemon retries
+  // on a later sweep tick instead.
+  it("returns delivered:false without pasting when the pane is still not ready (never blind-sends)", async () => {
+    status.mockResolvedValue(captainPane);
+    listSurfaces.mockResolvedValue([{ ...crewPane, title: crewTitle }]);
+    readPaneScreen.mockResolvedValue(BOOTING_SCREEN);
+
+    const result = await resendCrewFirstTurn(rt(), "p-captain", "p", "crew1", "the task");
+
+    expect(result).toEqual({ delivered: false });
+    expect(pasteToPane).not.toHaveBeenCalled();
+    expect(sendKeyToPane).not.toHaveBeenCalled();
   });
 });

--- a/packages/workspaces/src/crew-pane.ts
+++ b/packages/workspaces/src/crew-pane.ts
@@ -166,6 +166,35 @@ export async function confirmedSendToPane(
   return { delivered: false };
 }
 
+/**
+ * #466 daemon self-heal: the pane-touching primitive behind the daemon's
+ * sweep-loop first-turn resend hook. Finds the crew's own pane by title (never
+ * blind-sends anywhere), RE-CHECKS TUI readiness itself (never blind-pastes into
+ * a still-booting box — CRITICAL SAFETY), and only then submits via the same
+ * paste-settle-Enter path a manual `crew send` uses. Returns { delivered: false }
+ * without touching the pane when the crew can't be found or isn't ready yet —
+ * the caller (the daemon sweep loop) retries on a later tick.
+ */
+export async function resendCrewFirstTurn(
+  runtime: Pick<RuntimeDriver, "status" | "listSurfaces" | "readPaneScreen" | "pasteToPane" | "sendKeyToPane">,
+  captainName: string,
+  project: string,
+  name: string,
+  message: string,
+): Promise<{ delivered: boolean }> {
+  const captain = await runtime.status(captainName);
+  if (!captain) return { delivered: false };
+  const surfaces = await runtime.listSurfaces(captain.id);
+  const want = titleFor(project, name);
+  const pane = surfaces.find((s) => s.title === want);
+  if (!pane) return { delivered: false };
+  const screen = (await runtime.readPaneScreen(pane)) ?? "";
+  if (!hasCCInputBox(screen) || classifyStartupSurface(screen) !== "idle") {
+    return { delivered: false }; // still not ready — caller retries on a later tick
+  }
+  return confirmedSendToPane(runtime, pane, message);
+}
+
 export async function sendFirstTurnWhenReady(
   runtime: Pick<RuntimeDriver, "readPaneScreen" | "sendToPane" | "pasteToPane" | "sendKeyToPane">,
   pane: PaneRef,

--- a/packages/workspaces/src/index.ts
+++ b/packages/workspaces/src/index.ts
@@ -9,4 +9,4 @@ export { CmuxStoreSource } from "./cmux-daemon/cmux-store-source.js";
 export type { CmuxStoreSourceOpts } from "./cmux-daemon/cmux-store-source.js";
 export { NativeHookSource, installClaudeHooks, mapSubToLifecycle } from "./native-hooks/native-hook-source.js";
 export type { NativeHookSourceOpts, ClaudeHooksInstallOpts } from "./native-hooks/native-hook-source.js";
-export { getFreePort, listProjectCrews, findCrew, resolveCaptainWorkspace, sendFirstTurnWhenReady, confirmedSendToPane } from "./crew-pane.js";
+export { getFreePort, listProjectCrews, findCrew, resolveCaptainWorkspace, sendFirstTurnWhenReady, confirmedSendToPane, resendCrewFirstTurn } from "./crew-pane.js";


### PR DESCRIPTION
## Summary

Fixes #466 — a slow-boot claude crew's first turn gets pasted before the TUI is input-ready and silently drops. Two daemon subsystems then disagreed: the CREW UNDELIVERED watchdog correctly detected `firstTurnConfirmedAt` absent but only *alerted* ~5min later, while heartbeats kept the task-tracker reporting `working` the whole time.

**Root cause of the watchdog's own weakness**: it measured "undelivered" as `now - lastHeartbeat > heartbeatBudgetMs` — but heartbeats reset that clock. A crew whose first turn never landed can still emit unrelated heartbeats, masking the drop indefinitely (confirmed in the frozen frame: heartbeats flowed the entire 128s window while `firstTurnConfirmedAt` stayed absent).

## Fix — two layers

**Primary (daemon self-heal, `packages/core/src/daemon/reduce.ts`)**
- `sweep()` now measures the undelivered window from `createdAt` (monotonic, never reset by heartbeat activity) via a dedicated `DEFAULT_FIRST_TURN_UNDELIVERED_BUDGET_MS` (120s) — decoupled entirely from `heartbeatBudgetMs`. Applies uniformly to both the `submitted` and `working` undelivered cases (previously two separate, heartbeat-driven branches).
- Once past budget, the daemon calls the new `resendFirstTurn` hook to auto-resend the first turn — mirroring what a manual `crew send` does. Debounced per-task via `firstTurnResendCooldownMs` (60s) so a still-not-ready pane isn't hammered every sweep tick; retries on subsequent ticks if the pane still isn't ready.
- On a confirmed resend, the daemon self-stamps `task.first-turn.confirmed` through the same `reduce → store.put → firePush` pipeline a real hook event uses (extracted into a shared `applyEvent` helper) — no manual intervention needed.
- **Idempotent / no double-delivery**: re-checks `firstTurnConfirmedAt` on the live store immediately before resending (guards the race where a hook confirmation lands concurrently with the daemon's own recovery attempt). The reducer's `task.first-turn.confirmed` handling was already idempotent (#470), so even a redundant stamp is a safe no-op.
- Recovery attempts run independently per sweep tick and are `Promise.all`'d at the end, so one slow/undelivered crew never blocks the rest of the sweep loop from processing other tasks.

**Secondary (delivery primitive, `packages/workspaces/src/crew-pane.ts`)**
- New `resendCrewFirstTurn`: finds the crew's own pane by title (never blind-sends anywhere), **re-checks TUI readiness itself** using the same `hasCCInputBox`/`classifyStartupSurface` gate as the original delivery path (never blind-pastes into a still-booting box), then submits via the existing `confirmedSendToPane` paste-settle-Enter path.
- Wired in `squadrantd.ts` behind a fresh `RuntimeDriver`, scoped to `provider === "claude"` — the facet #466's frozen frame confirmed. Other providers (opencode, codex) safely report non-delivery from this hook, so the daemon still surfaces `CREW UNDELIVERED` for them via the alert-only fallback rather than attempting an unsupported pane interaction.

I did **not** touch `sendFirstTurnWhenReady`'s own 90s timeout/blind-send behavior (the issue's secondary "reduces frequency" suggestion) — the daemon-side self-heal is the confirmed backstop and required change; tuning the initial delivery timing further is lower-value, higher-risk without live validation, and out of scope for a surgical fix.

## Impact / blast radius

`gitnexus_impact`/`gitnexus_detect_changes` returned empty/unreliable results in this worktree for `createDaemon`, `reduce`, `sendFirstTurnWhenReady`, and `startDaemon` (0 callers reported for functions with real, verified callers) even after a fresh `npx gitnexus analyze` — likely a GitNexus git-worktree detection limitation, not a true zero-impact signal. I did the blast-radius analysis manually instead:

- `createDaemon`/`sweep()` (`packages/core/src/daemon/reduce.ts`) — the shared control-plane daemon core, called once from `daemon/start.ts`. Changes are additive (new optional `DaemonDeps` fields with safe fallbacks) plus a refactor-preserving extraction (`applyEvent`) — the `"event"` request-handling behavior is byte-for-byte identical, verified by the full existing test suite passing unchanged.
- `sendFirstTurnWhenReady` (`packages/workspaces/src/crew-pane.ts`) — **not modified**. `resendCrewFirstTurn` is a new, separate function reusing existing exported primitives (`confirmedSendToPane`, `hasCCInputBox`, `classifyStartupSurface`, `titleFor`), so the existing spawn-time delivery path (called from `crew.ts`, `side.ts`) is untouched.
- `DaemonContext`/`SquadrantdOpts` (`packages/core/src/daemon/context.ts`) — one new optional field each, defaulting to `undefined`.
- `squadrantd.ts` — new wiring block, additive only.

This is HIGH risk in the sense that it's control-plane code, but the diff is surgical and every existing test (daemon lifecycle, crew-spawn, delivery-loop, etc.) passes unchanged.

## How the tests prove self-heal + no double-delivery

`packages/core/src/__tests__/daemon.test.ts`:
- **Self-heal, no manual `crew send`**: a `working` task past the undelivered budget with a **fresh heartbeat and a huge `heartbeatBudgetMs`** (proving decoupling from heartbeat-masking) auto-calls `resendFirstTurn`, and on `delivered:true` the daemon itself stamps `firstTurnConfirmedAt` — asserted directly against the store, no hook/manual send involved.
- Same self-heal proven for the `submitted` (never-started) path.
- **No double-delivery**: `resendFirstTurn` is never called once `firstTurnConfirmedAt` is already set, regardless of how far past budget the record is.
- **Debounce + retry**: two sweep ticks inside the cooldown window fire `resendFirstTurn` once; a tick after cooldown retries. A failed resend (`delivered:false`) never fabricates `firstTurnConfirmedAt`.
- Existing CREW QUIET / CREW UNDELIVERED (alert-only fallback, no `resendFirstTurn` wired) tests updated to the new `createdAt`-based budget and still pass.

`packages/workspaces/src/__tests__/crew-pane.test.ts`:
- `resendCrewFirstTurn` delivers when the pane is found and CC-initialized-ready.
- Returns `delivered:false` **without touching the pane** when the captain workspace can't be found, when no surface matches the crew's title, or — **critical safety** — when the pane is found but not yet ready (proves it never blind-sends).

## Verification

- Full clean `pnpm install` + `npm run build` (all 6 packages, `tsc -b --force` + `tsup`) — zero type errors.
- Full monorepo test suite: **1859/1859 passing** (150 test files), including the new/updated tests above.
- `gitnexus_detect_changes` was run pre-commit per repo policy but returned "No changes detected" against a real, verified diff — flagging this as a tool limitation rather than silently trusting it.

Live end-to-end validation (daemon restart to pick up the built `squadrantd.js`) is out of scope for this PR per the task brief — that's the captain's follow-up after merge.