### PR TITLE
feat(daemon): broadcast restart notice to captains on build change

### DIFF
--- a/packages/cli/src/lib/__tests__/daemon-restart-broadcast.test.ts
+++ b/packages/cli/src/lib/__tests__/daemon-restart-broadcast.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { getDefaultConfig } from "@squadrant/shared";
+import type { SquadrantConfig, ProjectConfig } from "@squadrant/shared";
+import {
+  computeRestartSignature,
+  readPersistedRestartSignature,
+  writePersistedRestartSignature,
+  notifyCaptainsOfDaemonRestart,
+  maybeBroadcastDaemonRestart,
+} from "../daemon-restart-broadcast.js";
+
+let dir: string;
+let stateRoot: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "squadrant-restart-broadcast-"));
+  stateRoot = path.join(dir, "state");
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+function project(p: string, captainName: string): ProjectConfig {
+  return { path: p, captainName, spokeVault: "", host: "" };
+}
+
+function configWithProjects(projects: Record<string, ProjectConfig>): SquadrantConfig {
+  const config = getDefaultConfig();
+  config.projects = projects;
+  return config;
+}
+
+function makeDriver(sent: Array<{ captain: string; message: string }>, failing = new Set<string>()) {
+  return {
+    async status(name: string) {
+      if (failing.has(name)) throw new Error(`unreachable: ${name}`);
+      return { id: name };
+    },
+    async send(ref: string, message: string) {
+      sent.push({ captain: ref, message });
+    },
+  };
+}
+
+describe("computeRestartSignature", () => {
+  it("combines version and build mtime into a stable string", () => {
+    expect(computeRestartSignature("0.14.3", 1000)).toBe(computeRestartSignature("0.14.3", 1000));
+  });
+
+  it("differs when version differs", () => {
+    expect(computeRestartSignature("0.14.3", 1000)).not.toBe(computeRestartSignature("0.14.4", 1000));
+  });
+
+  it("differs when build mtime differs", () => {
+    expect(computeRestartSignature("0.14.3", 1000)).not.toBe(computeRestartSignature("0.14.3", 2000));
+  });
+});
+
+describe("persisted restart signature", () => {
+  it("returns null when nothing is persisted yet", () => {
+    expect(readPersistedRestartSignature(stateRoot)).toBeNull();
+  });
+
+  it("round-trips a written signature", () => {
+    writePersistedRestartSignature(stateRoot, "0.14.3::1000");
+    expect(readPersistedRestartSignature(stateRoot)).toBe("0.14.3::1000");
+  });
+
+  it("overwrites a previously persisted signature", () => {
+    writePersistedRestartSignature(stateRoot, "0.14.3::1000");
+    writePersistedRestartSignature(stateRoot, "0.14.4::2000");
+    expect(readPersistedRestartSignature(stateRoot)).toBe("0.14.4::2000");
+  });
+});
+
+describe("notifyCaptainsOfDaemonRestart", () => {
+  it("notifies every running captain, with no self-exclusion", async () => {
+    const projA = fs.mkdtempSync(path.join(dir, "projA-"));
+    const projB = fs.mkdtempSync(path.join(dir, "projB-"));
+    const config = configWithProjects({
+      a: project(projA, "captain-a"),
+      b: project(projB, "captain-b"),
+    });
+    const sent: Array<{ captain: string; message: string }> = [];
+
+    await notifyCaptainsOfDaemonRestart("0.14.3", config, makeDriver(sent));
+
+    expect(sent.map((s) => s.captain).sort()).toEqual(["captain-a", "captain-b"]);
+  });
+
+  it("includes the version in the notice", async () => {
+    const projA = fs.mkdtempSync(path.join(dir, "projA-"));
+    const config = configWithProjects({ a: project(projA, "captain-a") });
+    const sent: Array<{ captain: string; message: string }> = [];
+
+    await notifyCaptainsOfDaemonRestart("0.14.3", config, makeDriver(sent));
+
+    expect(sent[0].message).toContain("0.14.3");
+  });
+
+  it("notes a dev build when isDevRebuild is true", async () => {
+    const projA = fs.mkdtempSync(path.join(dir, "projA-"));
+    const config = configWithProjects({ a: project(projA, "captain-a") });
+    const sent: Array<{ captain: string; message: string }> = [];
+
+    await notifyCaptainsOfDaemonRestart("0.14.3", config, makeDriver(sent), true);
+
+    expect(sent[0].message).toContain("dev build");
+  });
+
+  it("skips an unreachable captain without throwing and still notifies the rest", async () => {
+    const projA = fs.mkdtempSync(path.join(dir, "projA-"));
+    const projB = fs.mkdtempSync(path.join(dir, "projB-"));
+    const config = configWithProjects({
+      a: project(projA, "captain-a"),
+      b: project(projB, "captain-b"),
+    });
+    const sent: Array<{ captain: string; message: string }> = [];
+
+    await expect(
+      notifyCaptainsOfDaemonRestart("0.14.3", config, makeDriver(sent, new Set(["captain-a"]))),
+    ).resolves.not.toThrow();
+
+    expect(sent.map((s) => s.captain)).toEqual(["captain-b"]);
+  });
+
+  it("no-ops silently when no projects are registered", async () => {
+    const config = configWithProjects({});
+    const sent: Array<{ captain: string; message: string }> = [];
+
+    await notifyCaptainsOfDaemonRestart("0.14.3", config, makeDriver(sent));
+
+    expect(sent).toHaveLength(0);
+  });
+});
+
+describe("maybeBroadcastDaemonRestart", () => {
+  it("broadcasts and persists on first-ever boot (no persisted signature)", async () => {
+    const projA = fs.mkdtempSync(path.join(dir, "projA-"));
+    const config = configWithProjects({ a: project(projA, "captain-a") });
+    const sent: Array<{ captain: string; message: string }> = [];
+
+    await maybeBroadcastDaemonRestart({
+      version: "0.14.3",
+      buildMtimeMs: 1000,
+      stateRoot,
+      config,
+      driver: makeDriver(sent),
+    });
+
+    expect(sent).toHaveLength(1);
+    expect(readPersistedRestartSignature(stateRoot)).toBe(computeRestartSignature("0.14.3", 1000));
+  });
+
+  it("broadcasts when the signature changed since last boot", async () => {
+    const projA = fs.mkdtempSync(path.join(dir, "projA-"));
+    const config = configWithProjects({ a: project(projA, "captain-a") });
+    writePersistedRestartSignature(stateRoot, computeRestartSignature("0.14.2", 500));
+    const sent: Array<{ captain: string; message: string }> = [];
+
+    await maybeBroadcastDaemonRestart({
+      version: "0.14.3",
+      buildMtimeMs: 1000,
+      stateRoot,
+      config,
+      driver: makeDriver(sent),
+    });
+
+    expect(sent).toHaveLength(1);
+    expect(readPersistedRestartSignature(stateRoot)).toBe(computeRestartSignature("0.14.3", 1000));
+  });
+
+  it("stays silent when the signature is unchanged (same-version crash-restart)", async () => {
+    const projA = fs.mkdtempSync(path.join(dir, "projA-"));
+    const config = configWithProjects({ a: project(projA, "captain-a") });
+    writePersistedRestartSignature(stateRoot, computeRestartSignature("0.14.3", 1000));
+    const sent: Array<{ captain: string; message: string }> = [];
+
+    await maybeBroadcastDaemonRestart({
+      version: "0.14.3",
+      buildMtimeMs: 1000,
+      stateRoot,
+      config,
+      driver: makeDriver(sent),
+    });
+
+    expect(sent).toHaveLength(0);
+  });
+
+  it("never throws even when the driver fails entirely", async () => {
+    const projA = fs.mkdtempSync(path.join(dir, "projA-"));
+    const config = configWithProjects({ a: project(projA, "captain-a") });
+    const throwingDriver = {
+      async status(): Promise<{ id: string } | null> {
+        throw new Error("boom");
+      },
+      async send(): Promise<void> {
+        throw new Error("boom");
+      },
+    };
+
+    await expect(
+      maybeBroadcastDaemonRestart({
+        version: "0.14.3",
+        buildMtimeMs: 1000,
+        stateRoot,
+        config,
+        driver: throwingDriver,
+      }),
+    ).resolves.not.toThrow();
+  });
+});

--- a/packages/cli/src/lib/daemon-restart-broadcast.ts
+++ b/packages/cli/src/lib/daemon-restart-broadcast.ts
@@ -1,0 +1,96 @@
+// Best-effort "daemon restarted" broadcast to all running captains, fired on
+// daemon boot — but only when the running build actually changed (version or
+// local rebuild), not on a same-build launchd crash-restart. Modeled exactly
+// on notifyCaptainsOfEffort (commands/effort.ts): same driver seam, same
+// best-effort/never-throw contract.
+import fs from "node:fs";
+import path from "node:path";
+import type { SquadrantConfig } from "@squadrant/shared";
+
+/** Minimal slice of RuntimeDriver used to notify a captain. */
+export interface DaemonRestartNotifyDriver {
+  status(nameOrId: string): Promise<{ id: string } | null>;
+  send(ref: string, message: string): Promise<void>;
+}
+
+function statePath(stateRoot: string): string {
+  return path.join(stateRoot, "daemon-restart-state.json");
+}
+
+/** version + build-file mtime — differs on a version bump AND on a local
+ *  rebuild of the same version (mtime moves), but not on a plain restart. */
+export function computeRestartSignature(version: string, buildMtimeMs: number): string {
+  return `${version}::${buildMtimeMs}`;
+}
+
+export function readPersistedRestartSignature(stateRoot: string): string | null {
+  try {
+    const raw = fs.readFileSync(statePath(stateRoot), "utf-8");
+    const data = JSON.parse(raw) as { signature?: string };
+    return typeof data.signature === "string" ? data.signature : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writePersistedRestartSignature(stateRoot: string, signature: string): void {
+  fs.mkdirSync(stateRoot, { recursive: true });
+  fs.writeFileSync(statePath(stateRoot), JSON.stringify({ signature }, null, 2) + "\n");
+}
+
+function restartNotice(version: string, isDevRebuild: boolean): string {
+  const suffix = isDevRebuild ? " (dev build)" : "";
+  return `⚠️ Daemon restarted → v${version}${suffix} (control-plane bounced). Re-verify in-flight crews — a crew mid-first-turn may need a crew send.`;
+}
+
+/**
+ * Send the daemon-restart notice to every running captain. Unlike
+ * notifyCaptainsOfEffort there is no initiating cwd captain to exclude — the
+ * daemon boots independently of any captain — so this reaches ALL of them.
+ */
+export async function notifyCaptainsOfDaemonRestart(
+  version: string,
+  config: SquadrantConfig,
+  driver: DaemonRestartNotifyDriver,
+  isDevRebuild = false,
+): Promise<void> {
+  const notice = restartNotice(version, isDevRebuild);
+  for (const [, proj] of Object.entries(config.projects)) {
+    try {
+      const ref = await driver.status(proj.captainName);
+      if (ref) {
+        await driver.send(ref.id, notice);
+      }
+    } catch {
+      // individual project captain unreachable — skip
+    }
+  }
+}
+
+export interface MaybeBroadcastDaemonRestartOpts {
+  version: string;
+  buildMtimeMs: number;
+  stateRoot: string;
+  config: SquadrantConfig;
+  driver: DaemonRestartNotifyDriver;
+}
+
+/**
+ * Boot-time entry point: compare this boot's (version, buildMtime) signature
+ * against the last persisted one. Differs → broadcast + persist. Same → stay
+ * silent (e.g. launchd crash-restart of an identical build). Fully
+ * best-effort — never throws, so it can never block or crash daemon boot.
+ */
+export async function maybeBroadcastDaemonRestart(opts: MaybeBroadcastDaemonRestartOpts): Promise<void> {
+  try {
+    const { version, buildMtimeMs, stateRoot, config, driver } = opts;
+    const signature = computeRestartSignature(version, buildMtimeMs);
+    const previous = readPersistedRestartSignature(stateRoot);
+    if (previous === signature) return;
+    const isDevRebuild = previous !== null && previous.split("::")[0] === version;
+    await notifyCaptainsOfDaemonRestart(version, config, driver, isDevRebuild);
+    writePersistedRestartSignature(stateRoot, signature);
+  } catch {
+    // best-effort — never let a broadcast failure block or crash daemon boot
+  }
+}

--- a/packages/cli/src/squadrantd.ts
+++ b/packages/cli/src/squadrantd.ts
@@ -4,7 +4,7 @@
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
-import { readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { buildContext } from "@squadrant/core";
 import { createAttach } from "@squadrant/core";
 import { startDaemon } from "@squadrant/core";
@@ -22,9 +22,10 @@ export { discoverCaptainSurface } from "@squadrant/core";
 import type { AttachFrame } from "@squadrant/core";
 import type { PaneRef } from "@squadrant/shared";
 import { runHeadless, CodexInteractiveDriver, OpencodeSseBridge, CodexAppServerSource } from "@squadrant/agents";
-import { CmuxEventsBridge, DaemonCmux, CmuxStoreSource, NativeHookSource, resendCrewFirstTurn } from "@squadrant/workspaces";
+import { CmuxEventsBridge, DaemonCmux, CmuxStoreSource, NativeHookSource, resendCrewFirstTurn, RuntimeRegistry } from "@squadrant/workspaces";
 import { loadConfig, TERMINAL_STATES } from "@squadrant/shared";
 import { createCmuxDriver } from "@squadrant/workspaces";
+import { maybeBroadcastDaemonRestart } from "./lib/daemon-restart-broadcast.js";
 
 const SELF_PATH = fileURLToPath(import.meta.url);
 // Bundled CLI bin sits next to this daemon entry (dist/index.js · dist/squadrantd.js).
@@ -304,6 +305,28 @@ export function startSquadrantd(opts: import("@squadrant/core").SquadrantdOpts =
     };
     try { codexAppServerSource.start(codexSourceDeps); }
     catch (e) { log(`codex app-server source start failed: ${(e as Error).message}`); }
+  }
+
+  // Daemon-restart broadcast: notify every running captain that the daemon
+  // bounced, but only when the running build actually changed (version bump
+  // or local rebuild) — a same-build launchd crash-restart stays silent.
+  // Skipped under vitest (touches the real config + cmux driver, mirrors the
+  // other real-I/O boot actions guarded the same way above).
+  if (!process.env.VITEST) {
+    try {
+      const buildMtimeMs = statSync(SELF_PATH).mtimeMs;
+      const restartConfig = loadConfig();
+      const registry = new RuntimeRegistry({ cmux: createCmuxDriver() });
+      void maybeBroadcastDaemonRestart({
+        version: PKG_VERSION,
+        buildMtimeMs,
+        stateRoot,
+        config: restartConfig,
+        driver: registry.global(restartConfig),
+      });
+    } catch (e) {
+      log(`daemon-restart broadcast setup failed: ${(e as Error).message}`);
+    }
   }
 
   const origStop = h.stop.bind(h);


### PR DESCRIPTION
## Summary
- Add `notifyCaptainsOfDaemonRestart` in `packages/cli/src/lib/daemon-restart-broadcast.ts`, modeled exactly on `notifyCaptainsOfEffort` (packages/cli/src/commands/effort.ts:56-112) — same `{status, send}` driver seam, same best-effort/never-throw contract. Unlike effort's notify, there's no initiating captain to exclude, so this reaches ALL running captains.
- Add `computeRestartSignature`/`readPersistedRestartSignature`/`writePersistedRestartSignature`, persisting `{version}::{buildMtimeMs}` under `<stateRoot>/daemon-restart-state.json` (mirrors `packages/core/src/telegram/state.ts`'s small-JSON-under-stateRoot pattern).
- Add `maybeBroadcastDaemonRestart`: the boot orchestrator. Compares this boot's signature against the persisted one — differs → broadcast + persist; same → stays silent (same-build launchd crash-restart). Wrapped in try/catch so a broadcast failure can never block or crash daemon boot.
- Wire it into `startSquadrantd()` in `packages/cli/src/squadrantd.ts`, guarded by `!process.env.VITEST` (mirrors the existing autoconfig/cmux-events-bridge boot guards — this touches the real config + cmux driver). `buildMtimeMs` is the running daemon's own compiled file (`statSync(SELF_PATH).mtimeMs`, where `SELF_PATH` already resolves to the compiled `dist/squadrantd.js` at runtime) — the simplest reliable signal for both version bumps and local rebuilds of the same version.

Message: `⚠️ Daemon restarted → v<version>[ (dev build)] (control-plane bounced). Re-verify in-flight crews — a crew mid-first-turn may need a crew send.` The "(dev build)" suffix appears only when the version is unchanged but the build hash moved (a local rebuild).

## Impact analysis (GitNexus, per CLAUDE.md)
- `gitnexus_impact(notifyCaptainsOfEffort, upstream)` → LOW risk, 1 direct caller (`effortCommand`). Not modified — only used as a reference pattern.
- `gitnexus_impact(startDaemon, upstream)` → LOW risk, 0 callers outside its own entry.
- `gitnexus_impact(startSquadrantd, upstream)` → LOW risk, 4 direct callers (smoke scripts + itself), no execution-flow breakage.
- All edits are additive (one new file) or append-only wiring inside `startSquadrantd` (no existing function signatures changed), so blast radius stayed LOW throughout.
- `gitnexus_detect_changes` reports "no changes" because the indexed `squadrant` repo is anchored at the main worktree checkout, not this git-worktree branch — a known path limitation, not a signal the diff is empty (confirmed via `git diff --stat`: 1 file changed, 2 new files added).

## Test plan
- [x] TDD: wrote 15 tests first in `packages/cli/src/lib/__tests__/daemon-restart-broadcast.test.ts`, watched them fail (module not found), then implemented `daemon-restart-broadcast.ts` to make them pass.
- [x] **signature-changed → broadcast fires**: `"broadcasts when the signature changed since last boot"` — persists an old signature, calls with a new version/mtime, asserts the driver's `send` was called and the new signature persisted.
- [x] **signature-same → silent**: `"stays silent when the signature is unchanged (same-version crash-restart)"` — persists the exact signature, asserts `send` was never called.
- [x] **first-ever boot → broadcast**: `"broadcasts and persists on first-ever boot (no persisted signature)"` — no prior state file, asserts it broadcasts (treats absent state as changed).
- [x] **broadcast failure never throws**: `"never throws even when the driver fails entirely"` — a driver whose every method rejects; asserts `maybeBroadcastDaemonRestart` still resolves.
- [x] All-captains reach + no self-exclusion, dev-build note, per-project unreachable-captain skip, no-projects no-op — see remaining 11 tests in the same file.
- [x] `npm run build` — clean full build (tsc -b --force across all 6 packages + tsup), no errors.
- [x] `npx vitest run` — full workspace suite: **153 test files / 1886 tests, all passing**.