### PR TITLE
feat(init): opencode setup guidance + provision default global config

### DIFF
--- a/packages/cli/src/commands/__tests__/init.test.ts
+++ b/packages/cli/src/commands/__tests__/init.test.ts
@@ -17,6 +17,15 @@ const emitMock = vi.hoisted(() => vi.fn(async (_src: unknown, dest: { path: stri
   bytesWritten: 42,
 })));
 
+const ensureGlobalOpencodeConfigMock = vi.hoisted(() =>
+  vi.fn((): string | null => "/tmp/mock-opencode/opencode.json"),
+);
+
+vi.mock("../../lib/per-crew-settings.js", () => ({
+  ensureGlobalOpencodeConfig: ensureGlobalOpencodeConfigMock,
+  DEFAULT_GLOBAL_OPENCODE_CONFIG_PATH: "/tmp/mock-opencode/opencode.json",
+}));
+
 vi.mock("@squadrant/shared", async () => {
   const actual = await vi.importActual<typeof import("@squadrant/shared")>("@squadrant/shared");
   return {
@@ -107,10 +116,20 @@ describe("init — non-TTY path", () => {
     expect(text).toContain("squadrant launch");
   });
 
-  it("does NOT call saveConfig in non-TTY mode (no side effects)", async () => {
+  it("prints opencode CLI install + global config guidance (#140)", async () => {
+    await runInit({ isTTY: false });
+
+    const text = output.join("\n");
+    expect(text).toContain("opencode");
+    expect(text).toContain("npm install -g opencode-ai");
+    expect(text).toContain("/tmp/mock-opencode/opencode.json");
+  });
+
+  it("does NOT call saveConfig or provision opencode config in non-TTY mode (no side effects)", async () => {
     await runInit({ isTTY: false });
     expect(saveConfigMock).not.toHaveBeenCalled();
     expect(ensureRuntimeSyncedMock).not.toHaveBeenCalled();
+    expect(ensureGlobalOpencodeConfigMock).not.toHaveBeenCalled();
   });
 
   it("does not hang when stdin is /dev/null equivalent (isTTY=false)", async () => {
@@ -216,6 +235,38 @@ describe("init — re-run-safe (TTY mode)", () => {
     expect(emitMock).toHaveBeenCalledTimes(3);
     const text = output.join("\n");
     expect(text).toMatch(/codex.*proj-codex|proj-codex.*codex/i);
+  });
+
+  it("provisions a default global opencode config when absent (#141)", async () => {
+    vi.spyOn(fs, "existsSync").mockImplementation(() => false);
+    vi.spyOn(fs, "mkdirSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "writeFileSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "readFileSync").mockImplementation(() => "{}");
+    vi.spyOn(fs, "copyFileSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "readdirSync").mockImplementation(() => []);
+    ensureGlobalOpencodeConfigMock.mockReturnValueOnce("/tmp/mock-opencode/opencode.json");
+
+    await runInit({ isTTY: true, hub: tmpDir });
+
+    expect(ensureGlobalOpencodeConfigMock).toHaveBeenCalledOnce();
+    const text = output.join("\n");
+    expect(text).toContain("Default model config created at /tmp/mock-opencode/opencode.json");
+  });
+
+  it("does NOT overwrite an existing global opencode config", async () => {
+    vi.spyOn(fs, "existsSync").mockImplementation(() => false);
+    vi.spyOn(fs, "mkdirSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "writeFileSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "readFileSync").mockImplementation(() => "{}");
+    vi.spyOn(fs, "copyFileSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "readdirSync").mockImplementation(() => []);
+    ensureGlobalOpencodeConfigMock.mockReturnValueOnce(null);
+
+    await runInit({ isTTY: true, hub: tmpDir });
+
+    expect(ensureGlobalOpencodeConfigMock).toHaveBeenCalledOnce();
+    const text = output.join("\n");
+    expect(text).toContain("/tmp/mock-opencode/opencode.json already exists (unchanged)");
   });
 
   it("skips agent-teams write when already enabled", async () => {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -15,6 +15,7 @@ import {
 } from "@squadrant/shared";
 import { createObsidianDriver, WorkspaceRegistry } from "@squadrant/workspaces";
 import { ensureRuntimeSynced } from "@squadrant/shared";
+import { ensureGlobalOpencodeConfig, DEFAULT_GLOBAL_OPENCODE_CONFIG_PATH } from "../lib/per-crew-settings.js";
 import {
   createCursorEmitter,
   createCodexEmitter,
@@ -81,6 +82,9 @@ export const initCommand = new Command("init")
       console.log(chalk.cyan("       /plugin marketplace add superpowers"));
       console.log(chalk.cyan("       /plugin marketplace add thedotmack/claude-mem"));
       console.log(chalk.cyan("       /plugin marketplace add context7"));
+      console.log(chalk.dim("\n       Using opencode crews? Install the CLI:"));
+      console.log(chalk.cyan("       npm install -g opencode-ai"));
+      console.log(chalk.dim(`       (squadrant provisions a default model in ${DEFAULT_GLOBAL_OPENCODE_CONFIG_PATH} if it's missing)`));
       console.log(chalk.bold("\n  4/5  Register first project"));
       console.log(chalk.cyan("       squadrant projects add <name> <path>"));
       console.log(chalk.bold("\n  5/5  Telegram (optional)"));
@@ -193,6 +197,16 @@ export const initCommand = new Command("init")
     console.log(chalk.cyan("      /plugin marketplace add thedotmack/claude-mem"));
     console.log(chalk.cyan("      /plugin marketplace add context7\n"));
     console.log(chalk.dim("    Squadrant never auto-installs plugins — open Claude Code and run the commands above."));
+
+    console.log(chalk.bold("\n    Using opencode crews?"));
+    console.log(chalk.cyan("      npm install -g opencode-ai"));
+    const opencodeConfigWritten = ensureGlobalOpencodeConfig();
+    if (opencodeConfigWritten) {
+      console.log(chalk.green(`    ✔ Default model config created at ${opencodeConfigWritten}`));
+    } else {
+      console.log(chalk.dim(`    - ${DEFAULT_GLOBAL_OPENCODE_CONFIG_PATH} already exists (unchanged)`));
+    }
+    console.log(chalk.dim("    Per-crew config deep-merges with this file — edit it to change opencode's default model/plugins/mcp."));
 
     // ── 4/5  Register first project ─────────────────────────────────────────
     stepHeader(4, 5, "Register first project");

--- a/packages/cli/src/lib/__tests__/per-crew-settings.test.ts
+++ b/packages/cli/src/lib/__tests__/per-crew-settings.test.ts
@@ -416,6 +416,21 @@ describe("ensureGlobalOpencodeConfig — #141 provision-if-absent", () => {
     expect(fs.readFileSync(configPath(), "utf-8")).toBe(existing);
   });
 
+  it("does not clobber a config written concurrently between the two racing calls (TOCTOU)", () => {
+    // Simulates two callers racing to provision the same absent path: the
+    // exclusive-create ('wx') write means only the first writer's content
+    // survives — no existsSync-then-writeFileSync gap for a second caller to
+    // land in between.
+    const first = ensureGlobalOpencodeConfig(configPath());
+    const contentAfterFirst = fs.readFileSync(configPath(), "utf-8");
+
+    const second = ensureGlobalOpencodeConfig(configPath());
+
+    expect(first).toBe(configPath());
+    expect(second).toBeNull();
+    expect(fs.readFileSync(configPath(), "utf-8")).toBe(contentAfterFirst);
+  });
+
   it("default path constant points at ~/.config/opencode/opencode.json", () => {
     expect(DEFAULT_GLOBAL_OPENCODE_CONFIG_PATH).toBe(
       path.join(os.homedir(), ".config", "opencode", "opencode.json"),

--- a/packages/cli/src/lib/__tests__/per-crew-settings.test.ts
+++ b/packages/cli/src/lib/__tests__/per-crew-settings.test.ts
@@ -9,6 +9,8 @@ import {
   healStaleCockpitRefs,
   CREW_PERMISSION_ALLOWLIST,
   mergeCrewPermissions,
+  ensureGlobalOpencodeConfig,
+  DEFAULT_GLOBAL_OPENCODE_CONFIG_PATH,
 } from "../per-crew-settings.js";
 
 describe("writePerCrewSettings", () => {
@@ -372,5 +374,51 @@ describe("writePerCrewOpencodeConfig", () => {
     expect(json.permission.edit).toBe("allow");
     expect(json.permission.read).toBe("allow");
     expect(json.permission.external_directory).toEqual({ "**": "allow" });
+  });
+});
+
+describe("ensureGlobalOpencodeConfig — #141 provision-if-absent", () => {
+  let tmp: string;
+  const configPath = () => path.join(tmp, "opencode", "opencode.json");
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "squadrant-global-opencode-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("writes a minimal default config (schema + model) when none exists", () => {
+    const out = ensureGlobalOpencodeConfig(configPath());
+    expect(out).toBe(configPath());
+    expect(fs.existsSync(configPath())).toBe(true);
+    const json = JSON.parse(fs.readFileSync(configPath(), "utf-8"));
+    expect(json).toEqual({
+      $schema: "https://opencode.ai/config.json",
+      model: "anthropic/claude-sonnet-4-5",
+    });
+  });
+
+  it("creates intermediate directories", () => {
+    ensureGlobalOpencodeConfig(configPath());
+    expect(fs.statSync(path.dirname(configPath())).isDirectory()).toBe(true);
+  });
+
+  it("returns null and never overwrites an existing config", () => {
+    fs.mkdirSync(path.dirname(configPath()), { recursive: true });
+    const existing = JSON.stringify({ model: "user-chosen/model", plugin: ["some-plugin"] }, null, 2);
+    fs.writeFileSync(configPath(), existing);
+
+    const out = ensureGlobalOpencodeConfig(configPath());
+
+    expect(out).toBeNull();
+    expect(fs.readFileSync(configPath(), "utf-8")).toBe(existing);
+  });
+
+  it("default path constant points at ~/.config/opencode/opencode.json", () => {
+    expect(DEFAULT_GLOBAL_OPENCODE_CONFIG_PATH).toBe(
+      path.join(os.homedir(), ".config", "opencode", "opencode.json"),
+    );
   });
 });

--- a/packages/cli/src/lib/per-crew-settings.ts
+++ b/packages/cli/src/lib/per-crew-settings.ts
@@ -1,5 +1,6 @@
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
 import { mergeClaudeHooks } from "@squadrant/agents";
 
 /**
@@ -205,6 +206,27 @@ export function writePerCrewSettingsLocal(o: {
  * BLOCKED → captain's decision is POSTed back). Default (no flag) keeps bash
  * "allow" — opencode crews stay fully autonomous unless `--approval` is passed.
  */
+export const DEFAULT_GLOBAL_OPENCODE_CONFIG_PATH = join(homedir(), ".config", "opencode", "opencode.json");
+
+/**
+ * #141: provision a minimal global opencode.json (model default) the first time
+ * squadrant runs `init`, so a fresh user's opencode crews don't silently fall
+ * back to opencode's own defaults (see writePerCrewOpencodeConfig doc above —
+ * the per-crew config deep-merges with this file for model/plugin/mcp). Never
+ * overwrites an existing file. Returns the path if it wrote one, or null if a
+ * config was already present.
+ */
+export function ensureGlobalOpencodeConfig(configPath: string = DEFAULT_GLOBAL_OPENCODE_CONFIG_PATH): string | null {
+  if (existsSync(configPath)) return null;
+  mkdirSync(dirname(configPath), { recursive: true });
+  const defaultConfig = {
+    $schema: "https://opencode.ai/config.json",
+    model: "anthropic/claude-sonnet-4-5",
+  };
+  writeFileSync(configPath, JSON.stringify(defaultConfig, null, 2) + "\n");
+  return configPath;
+}
+
 export function writePerCrewOpencodeConfig(o: {
   stateRoot: string;
   project: string;

--- a/packages/cli/src/lib/per-crew-settings.ts
+++ b/packages/cli/src/lib/per-crew-settings.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 import { mergeClaudeHooks } from "@squadrant/agents";
@@ -213,18 +213,24 @@ export const DEFAULT_GLOBAL_OPENCODE_CONFIG_PATH = join(homedir(), ".config", "o
  * squadrant runs `init`, so a fresh user's opencode crews don't silently fall
  * back to opencode's own defaults (see writePerCrewOpencodeConfig doc above —
  * the per-crew config deep-merges with this file for model/plugin/mcp). Never
- * overwrites an existing file. Returns the path if it wrote one, or null if a
- * config was already present.
+ * overwrites an existing file — uses an exclusive-create write ('wx') so a
+ * concurrent writer wins the race instead of one clobbering the other (no
+ * separate existsSync check, which would TOCTOU-race a concurrent create).
+ * Returns the path if it wrote one, or null if a config was already present.
  */
 export function ensureGlobalOpencodeConfig(configPath: string = DEFAULT_GLOBAL_OPENCODE_CONFIG_PATH): string | null {
-  if (existsSync(configPath)) return null;
   mkdirSync(dirname(configPath), { recursive: true });
   const defaultConfig = {
     $schema: "https://opencode.ai/config.json",
     model: "anthropic/claude-sonnet-4-5",
   };
-  writeFileSync(configPath, JSON.stringify(defaultConfig, null, 2) + "\n");
-  return configPath;
+  try {
+    writeFileSync(configPath, JSON.stringify(defaultConfig, null, 2) + "\n", { flag: "wx" });
+    return configPath;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "EEXIST") return null;
+    throw err;
+  }
 }
 
 export function writePerCrewOpencodeConfig(o: {


### PR DESCRIPTION
## Summary
- `squadrant init`'s manual-steps output now covers opencode: install the CLI (`npm install -g opencode-ai`) and the global `~/.config/opencode/opencode.json` expectation, alongside the existing Claude plugin steps.
- `init` provisions a minimal global `opencode.json` (`$schema` + `model`) on first run **only if the file is absent** — never overwrites an existing config. This gives fresh installs a sane default instead of silently falling back to opencode's own defaults, since `writePerCrewOpencodeConfig` deep-merges its per-crew permissions block with this file for model/plugin/mcp.
- Non-TTY checklist output stays side-effect-free (mentions the guidance in text only; provisioning only happens in the interactive TTY flow, next to the existing step-3/5 side effects).

Closes #140
Closes #141

## Test plan
- [x] Extended `packages/cli/src/lib/__tests__/per-crew-settings.test.ts` with a dedicated `ensureGlobalOpencodeConfig` suite: writes minimal default, creates intermediate dirs, never overwrites an existing file, default path constant matches `~/.config/opencode/opencode.json`.
- [x] Extended `packages/cli/src/commands/__tests__/init.test.ts`: non-TTY output includes the opencode install/config guidance and does **not** trigger provisioning (no side effects); TTY mode provisions when absent and skips when already present.
- [x] `pnpm run build` (full monorepo tsc -b + tsup) — green.
- [x] `node dist/index.js --help`, `node dist/index.js crew --help`, `node dist/squadrantd.js --help` — smoke-tested, no ESM resolution crashes.
- [x] `npx vitest run` — full suite, 153 files / 1893 tests passed.