### PR TITLE
fix(telegram): stopped captain misclassified as alive, blocking auto-launch (#517)

### DIFF
--- a/packages/core/src/__tests__/group-dispatch.test.ts
+++ b/packages/core/src/__tests__/group-dispatch.test.ts
@@ -12,7 +12,7 @@ vi.mock("@squadrant/shared", () => ({
   resolveHome: (p: string) => p,
 }));
 
-import { dispatchToSibling } from "../group-dispatch.js";
+import { dispatchToSibling, isCaptainAlive } from "../group-dispatch.js";
 
 const makeConfig = (overrides: Record<string, any> = {}) => {
   const projects: Record<string, any> = {
@@ -205,5 +205,38 @@ describe("dispatchToSibling", () => {
     expect((result as any).project).toBe("projB");
     expect((result as any).state).toBe("submitted");
     expect((result as any).task).toBe("update the docs");
+  });
+});
+
+// ── isCaptainAlive (#517: "stopped" was mistakenly treated as alive) ─────────
+describe("isCaptainAlive", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns true only when the captain row reports state 'alive'", async () => {
+    sendRequestMock.mockResolvedValue([
+      { kind: "captain", project: "projA", state: "alive", lastSeenMs: Date.now() },
+    ]);
+    expect(await isCaptainAlive("projA")).toBe(true);
+  });
+
+  it("returns false when the captain workspace was closed (state 'stopped' = down)", async () => {
+    sendRequestMock.mockResolvedValue([
+      { kind: "captain", project: "projA", state: "stopped", lastSeenMs: Date.now() },
+    ]);
+    expect(await isCaptainAlive("projA")).toBe(false);
+  });
+
+  it("returns false when the captain state is unknown", async () => {
+    sendRequestMock.mockResolvedValue([
+      { kind: "captain", project: "projA", state: "unknown", lastSeenMs: null },
+    ]);
+    expect(await isCaptainAlive("projA")).toBe(false);
+  });
+
+  it("returns false when there is no captain row at all", async () => {
+    sendRequestMock.mockResolvedValue([]);
+    expect(await isCaptainAlive("projA")).toBe(false);
   });
 });

--- a/packages/core/src/__tests__/telegram-control.test.ts
+++ b/packages/core/src/__tests__/telegram-control.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const sendRequestMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../protocol.js", () => ({
+  sendRequest: sendRequestMock,
+}));
+
+import { createIsCaptainAlive } from "../telegram/control.js";
+
+// #517: Telegram auto-launch never fires because isAlive() misreports a down
+// captain as alive. Captain rows only ever report "alive" | "stopped" | "unknown"
+// (see liveness.ts projectHealth) — "stopped" means the workspace was closed.
+describe("createIsCaptainAlive", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const isAlive = createIsCaptainAlive("/tmp/fake.sock");
+
+  it("returns true when the captain row reports state 'alive'", async () => {
+    sendRequestMock.mockResolvedValue([
+      { kind: "captain", project: "squadrant", state: "alive" },
+    ]);
+    expect(await isAlive("squadrant")).toBe(true);
+  });
+
+  it("returns false when the captain workspace was closed (state 'stopped' = down)", async () => {
+    sendRequestMock.mockResolvedValue([
+      { kind: "captain", project: "squadrant", state: "stopped" },
+    ]);
+    expect(await isAlive("squadrant")).toBe(false);
+  });
+
+  it("returns false when the captain state is unknown", async () => {
+    sendRequestMock.mockResolvedValue([
+      { kind: "captain", project: "squadrant", state: "unknown" },
+    ]);
+    expect(await isAlive("squadrant")).toBe(false);
+  });
+
+  it("returns false when there is no captain row at all", async () => {
+    sendRequestMock.mockResolvedValue([]);
+    expect(await isAlive("squadrant")).toBe(false);
+  });
+
+  it("returns false when the health request throws", async () => {
+    sendRequestMock.mockRejectedValue(new Error("socket unreachable"));
+    expect(await isAlive("squadrant")).toBe(false);
+  });
+});

--- a/packages/core/src/group-dispatch.ts
+++ b/packages/core/src/group-dispatch.ts
@@ -36,7 +36,10 @@ export async function isCaptainAlive(
       kind: string; project: string; state: string;
     }>;
     const captain = health?.find((h) => h.kind === "captain" && h.project === project);
-    return captain != null && captain.state !== "gone" && captain.state !== "unknown";
+    // Captain rows only ever report "alive" | "stopped" | "unknown" (see
+    // liveness.ts projectHealth) — "stopped" means the workspace was closed
+    // (down), so it must NOT count as alive.
+    return captain?.state === "alive";
   } catch {
     return false;
   }

--- a/packages/core/src/telegram/bridge.test.ts
+++ b/packages/core/src/telegram/bridge.test.ts
@@ -110,6 +110,21 @@ describe("handleUpdate routing", () => {
     expect(d.appendCaptainMessage).toHaveBeenCalledWith(
       expect.objectContaining({ project: "brove", source: "telegram" }),
     );
+    // #517 follow-up: "launched" is a live-captain-reachable success, same as "alive".
+    expect(d.sendReply).toHaveBeenCalledWith(7, "📨 delivered to brove captain");
+    bridge.stop();
+  });
+
+  it("acks delivery when the captain was already alive (no boot needed)", async () => {
+    setTopic(stateRoot, "brove", 7);
+    const cfg = { ...baseCfg, remoteControl: true, users: [ALLOWED_USER] };
+    const d = deps({ ensureCaptainAlive: vi.fn(async () => "alive" as const) });
+    const { bridge, drained } = drive({ cfg, ...d }, [topicMsg("ship it", 7)]);
+    await drained;
+    expect(d.sendReply).toHaveBeenCalledWith(7, "📨 delivered to brove captain");
+    expect(d.appendCaptainMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ project: "brove", source: "telegram" }),
+    );
     bridge.stop();
   });
 
@@ -125,13 +140,16 @@ describe("handleUpdate routing", () => {
     bridge.stop();
   });
 
-  it("warns into the topic when warmup times out but still queues the message", async () => {
+  it("sends an explicit failure into the topic when warmup times out but still queues the message", async () => {
     setTopic(stateRoot, "brove", 7);
     const cfg = { ...baseCfg, remoteControl: true, users: [ALLOWED_USER] };
     const d = deps({ ensureCaptainAlive: vi.fn(async () => "timeout" as const) });
     const { bridge, drained } = drive({ cfg, ...d }, [topicMsg("ship it", 7)]);
     await drained;
-    expect(d.sendReply).toHaveBeenCalledWith(7, expect.stringContaining("warm up"));
+    expect(d.sendReply).toHaveBeenCalledWith(
+      7,
+      "❌ couldn't reach brove captain — saved to mailbox, will deliver when you open the workspace.",
+    );
     expect(d.appendCaptainMessage).toHaveBeenCalled();
     bridge.stop();
   });

--- a/packages/core/src/telegram/bridge.ts
+++ b/packages/core/src/telegram/bridge.ts
@@ -407,7 +407,15 @@ export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridg
     if (ensureCaptainAlive && isControlEnabled(cfg) && isAuthorized(fromId, cfg)) {
       try {
         const r = await ensureCaptainAlive(resolved.project);
-        if (r === "timeout") await reply(threadId, "⚠️ captain didn't warm up; message queued.");
+        // The ensure() result IS the delivery signal — "live captain reachable",
+        // not "message read" (no cap-side ack protocol). Surfacing it means a
+        // false-positive isAlive (#517) fails loud in Telegram instead of silently
+        // stranding the message in the mailbox.
+        if (r === "timeout") {
+          await reply(threadId, `❌ couldn't reach ${resolved.project} captain — saved to mailbox, will deliver when you open the workspace.`);
+        } else {
+          await reply(threadId, `📨 delivered to ${resolved.project} captain`);
+        }
       } catch (e) {
         log(`telegram auto-launch failed project=${resolved.project}: ${(e as Error).message}`);
       }

--- a/packages/core/src/telegram/control.ts
+++ b/packages/core/src/telegram/control.ts
@@ -54,7 +54,10 @@ export function createIsCaptainAlive(sock: string): (project: string) => Promise
         kind: string; project: string; state: string;
       }>;
       const captain = health?.find((h) => h.kind === "captain" && h.project === project);
-      return captain != null && captain.state !== "gone" && captain.state !== "unknown";
+      // Captain rows only ever report "alive" | "stopped" | "unknown" (see
+      // liveness.ts projectHealth) — "stopped" means the workspace was closed
+      // (down), so it must NOT count as alive.
+      return captain?.state === "alive";
     } catch {
       return false;
     }


### PR DESCRIPTION
## Summary
- Root cause of #517: `projectHealth()` (liveness.ts) only ever emits `"alive" | "stopped" | "unknown"` for a captain row — it never emits `"gone"`. But `isCaptainAlive` / `createIsCaptainAlive` (in `group-dispatch.ts` and `telegram/control.ts`) both checked `state !== "gone" && state !== "unknown"`, so a captain with a closed workspace (state `"stopped"`, i.e. actually down) was misread as alive.
- `ensureCaptainAlive` short-circuits on that false positive (`if (await deps.isAlive(project)) return "alive"`) and never calls `launch()`. An inbound Telegram message to a down captain is appended to the mailbox but the workspace never boots — it just sits there until the user manually opens it.
- Fixed both identical occurrences of the predicate to require `state === "alive"` explicitly. Neither function had any test coverage before this change, which is how the bug shipped unnoticed.

**Follow-up (same PR, user-approved scope extension):** surface `ensureCaptainAlive`'s result back to Telegram instead of swallowing it — the fix above only makes that return value honest; this makes it visible.
- `"alive"` / `"launched"` → `📨 delivered to <project> captain`
- `"timeout"` → `❌ couldn't reach <project> captain — saved to mailbox, will deliver when you open the workspace.`
- Replaces the previous weak `⚠️ captain didn't warm up; message queued.` line.
- No cap-side ack protocol added — the `ensureCaptainAlive` return value IS the signal ("live captain reachable", not "message read"). If a false-positive `isAlive` ever slips through again, the user now gets an explicit failure in Telegram instead of silence.

## Test plan
- [x] New regression tests pinning the `"stopped"` case in `packages/core/src/__tests__/group-dispatch.test.ts` (`isCaptainAlive` describe block) and a new `packages/core/src/__tests__/telegram-control.test.ts` for `createIsCaptainAlive`
- [x] New/updated tests in `packages/core/src/telegram/bridge.test.ts` covering the `alive`/`launched` → ✅ reply and `timeout` → ❌ reply paths
- [x] `npm run build` — passes
- [x] `npm test` (full suite) — 154 files / 1896 tests passing
- [x] `tsc --noEmit` on core — clean
- [x] No live daemon touched; all reproduction via stubbed unit tests

Fixes #517