### PR TITLE
fix(daemon): boot-if-down launch was a silent no-op outside cmux (#520)

### DIFF
--- a/packages/cli/src/commands/__tests__/launch.test.ts
+++ b/packages/cli/src/commands/__tests__/launch.test.ts
@@ -7,13 +7,14 @@
 // the parent terminal. The fix routes them through cmuxLocal, which pipes
 // (captures) fd 2 instead of inheriting it. These tests pin that contract.
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const execFileMock = vi.hoisted(() => vi.fn());
+const execSyncMock = vi.hoisted(() => vi.fn());
 vi.mock("node:child_process", () => ({
   // launch.ts imports both; only execFileSync is exercised by cmuxLocal.
   execFileSync: execFileMock,
-  execSync: vi.fn(),
+  execSync: execSyncMock,
   execFile: vi.fn(),
 }));
 
@@ -23,7 +24,7 @@ vi.mock("@squadrant/shared", async () => {
 });
 
 import { cmuxLocal, classifyStartupSurface } from "@squadrant/workspaces";
-import { deliverStartupPrompt } from "../launch.js";
+import { deliverStartupPrompt, ensureCmuxReady } from "../launch.js";
 
 describe("cmuxLocal (@squadrant/workspaces direct-cmux helper)", () => {
   beforeEach(() => {
@@ -54,6 +55,48 @@ describe("cmuxLocal (@squadrant/workspaces direct-cmux helper)", () => {
   it("returns trimmed stdout for callers that need the output", () => {
     execFileMock.mockReturnValue("  workspace:7 squadrant-captain  \n");
     expect(cmuxLocal(["current-workspace"])).toBe("workspace:7 squadrant-captain");
+  });
+});
+
+// #520: `squadrant launch` run from the daemon (no CMUX_WORKSPACE_ID, no TTY)
+// silently no-op'd — ensureCmuxReady() opened the cmux GUI app and called
+// process.exit(0) before any workspace was ever created, so Telegram
+// auto-launch's ensureCaptainAlive polled isAlive() for the full warmup
+// window and always timed out. --headless lets a non-interactive caller
+// (the daemon) bypass the isInsideCmux() gate and drive launchOneWorkspace
+// directly, the same way crew-spawn already does from the daemon.
+describe("ensureCmuxReady (#520 daemon headless launch)", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let exitSpy: any;
+
+  beforeEach(() => {
+    execSyncMock.mockReset();
+    delete process.env.CMUX_WORKSPACE_ID;
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((): never => {
+      throw new Error("process.exit called");
+    }) as never);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+  });
+
+  it("does not open the cmux app or exit when headless=true, even outside cmux", () => {
+    expect(() => ensureCmuxReady(true)).not.toThrow();
+    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("still opens the cmux app and exits when headless=false and not inside cmux (pins existing interactive behavior)", () => {
+    expect(() => ensureCmuxReady(false)).toThrow("process.exit called");
+    expect(execSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not open the cmux app when already inside cmux, regardless of headless", () => {
+    process.env.CMUX_WORKSPACE_ID = "workspace:1";
+    expect(() => ensureCmuxReady(false)).not.toThrow();
+    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/cli/src/commands/launch.ts
+++ b/packages/cli/src/commands/launch.ts
@@ -31,8 +31,12 @@ const CMUX_APP = "/Applications/cmux.app";
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "squadrant", "templates");
 const SESSIONS_PATH = path.join(os.homedir(), ".config", "squadrant", "sessions.json");
 
-function ensureCmuxReady(): void {
-  if (isInsideCmux()) return;
+// #520: a non-interactive caller (the daemon's Telegram boot-if-down path)
+// has no CMUX_WORKSPACE_ID and no terminal to run `open` from — headless=true
+// bypasses the isInsideCmux() gate entirely so launchOneWorkspace can drive
+// runtime.spawn directly, the same way crew-spawn already does from the daemon.
+export function ensureCmuxReady(headless: boolean): void {
+  if (headless || isInsideCmux()) return;
 
   console.log(chalk.yellow("\n  Not running inside cmux. Opening cmux app...\n"));
   execSync(`open "${CMUX_APP}"`, { stdio: "inherit" });
@@ -47,8 +51,10 @@ export const launchCommand = new Command("launch")
   .argument("[project]", "Project name to launch captain for")
   .option("--fresh", "Start a new session instead of resuming the last one")
   .option("--all", "Launch all captain workspaces")
-  .action(async (project: string | undefined, opts: { fresh?: boolean; all?: boolean }) => {
+  .option("--headless", "Skip the interactive cmux-app requirement (used by the daemon to boot captains without a terminal)")
+  .action(async (project: string | undefined, opts: { fresh?: boolean; all?: boolean; headless?: boolean }) => {
     const config = loadConfig();
+    let hadFailure = false;
 
     // Build agent driver registry
     const drivers = {
@@ -71,7 +77,7 @@ export const launchCommand = new Command("launch")
       pinToTop = false,
       projectName?: string,
     ): Promise<void> {
-      ensureCmuxReady();
+      ensureCmuxReady(!!opts.headless);
 
       const roleConfig = config.defaults.roles?.[role as keyof NonNullable<typeof config.defaults.roles>];
       const agentName = roleConfig?.agent || "claude";
@@ -116,6 +122,7 @@ export const launchCommand = new Command("launch")
         });
       } catch (err) {
         console.error(chalk.red(`  ✘ Failed: ${(err as Error).message}`));
+        hadFailure = true;
       }
     }
 
@@ -151,7 +158,7 @@ export const launchCommand = new Command("launch")
       }
 
       // Interactive: pick captains, then launch in parallel.
-      ensureCmuxReady();
+      ensureCmuxReady(!!opts.headless);
 
       const sessions = loadSessions(SESSIONS_PATH);
       const entries: CaptainEntry[] = Object.entries(config.projects).map(([name, proj]) => ({
@@ -215,4 +222,9 @@ export const launchCommand = new Command("launch")
       );
       await launchOne(proj.captainName, "captain", projPath, config.defaults.permissions?.captain || "auto", false, true, project);
     }
+
+    // #520: surface a real launch failure (e.g. cmux spawn error) as a non-zero
+    // exit so the daemon's execFile-based caller can tell launch didn't work,
+    // instead of silently exiting 0 while ensureCaptainAlive polls to a timeout.
+    if (hadFailure) process.exitCode = 1;
   });

--- a/packages/cli/src/squadrantd.ts
+++ b/packages/cli/src/squadrantd.ts
@@ -60,7 +60,7 @@ function buildTelegramBridge(
   // sender is allowlisted (gated inside the bridge); passing them is always safe.
   const ensureCaptainAlive = createEnsureCaptainAlive({
     isAlive: createIsCaptainAlive(DAEMON_SOCK),
-    launch: createLaunch(CLI_BIN),
+    launch: createLaunch(CLI_BIN, log),
   });
   const runCommand = createRunCommand(CLI_BIN);
   const sendReply = (threadId: number | undefined, text: string, replyMarkup?: unknown) =>

--- a/packages/core/src/__tests__/telegram-control.test.ts
+++ b/packages/core/src/__tests__/telegram-control.test.ts
@@ -1,12 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const sendRequestMock = vi.hoisted(() => vi.fn());
+const execFileMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../protocol.js", () => ({
   sendRequest: sendRequestMock,
 }));
 
-import { createIsCaptainAlive } from "../telegram/control.js";
+vi.mock("node:child_process", () => ({
+  execFile: execFileMock,
+}));
+
+import { createIsCaptainAlive, createLaunch } from "../telegram/control.js";
 
 // #517: Telegram auto-launch never fires because isAlive() misreports a down
 // captain as alive. Captain rows only ever report "alive" | "stopped" | "unknown"
@@ -47,5 +52,51 @@ describe("createIsCaptainAlive", () => {
   it("returns false when the health request throws", async () => {
     sendRequestMock.mockRejectedValue(new Error("socket unreachable"));
     expect(await isAlive("squadrant")).toBe(false);
+  });
+});
+
+// #520: the daemon's boot-if-down path shells out to `squadrant launch <project>`
+// via createLaunch, but its stdout/stderr were discarded and a real failure
+// (non-zero exit) was swallowed silently — ensureCaptainAlive just polled
+// isAlive() for the full warmup window with zero diagnostic trail. createLaunch
+// must now (1) pass --headless so the daemon's non-interactive launch actually
+// boots instead of opening the cmux GUI app and exiting, (2) capture + log
+// subprocess output for diagnostics, and (3) reject on failure so the daemon
+// can tell launch didn't work.
+describe("createLaunch (#520 daemon headless launch)", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  it("invokes `launch <project> --headless` so the daemon's non-interactive call actually boots the captain", async () => {
+    execFileMock.mockImplementation((_file, _args, _opts, callback) => {
+      callback(null, "", "");
+    });
+    const launch = createLaunch("/bin/squadrant-cli.js");
+    await launch("squadrant");
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    const [file, args] = execFileMock.mock.calls[0];
+    expect(file).toBe(process.execPath);
+    expect(args).toEqual(["/bin/squadrant-cli.js", "launch", "squadrant", "--headless"]);
+  });
+
+  it("logs captured subprocess output on success", async () => {
+    execFileMock.mockImplementation((_file, _args, _opts, callback) => {
+      callback(null, "  ✔ Workspace created\n", "");
+    });
+    const log = vi.fn();
+    const launch = createLaunch("/bin/squadrant-cli.js", log);
+    await launch("squadrant");
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("Workspace created"));
+  });
+
+  it("logs the captured output and rejects when the subprocess fails", async () => {
+    execFileMock.mockImplementation((_file, _args, _opts, callback) => {
+      callback(new Error("Command failed"), "", "cmux spawn did not return a workspace id");
+    });
+    const log = vi.fn();
+    const launch = createLaunch("/bin/squadrant-cli.js", log);
+    await expect(launch("squadrant")).rejects.toThrow();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("cmux spawn did not return a workspace id"));
   });
 });

--- a/packages/core/src/telegram/control.ts
+++ b/packages/core/src/telegram/control.ts
@@ -64,9 +64,30 @@ export function createIsCaptainAlive(sock: string): (project: string) => Promise
   };
 }
 
-/** Boot a captain via async execFile (NEVER execSync on the daemon hot path). */
-export function createLaunch(cliBin: string): (project: string) => Promise<void> {
-  return async (project: string) => {
-    await pExecFile(process.execPath, [cliBin, "launch", project], { timeout: 30_000 });
-  };
+/** Boot a captain via async execFile (NEVER execSync on the daemon hot path).
+ *  --headless (#520): the daemon has no CMUX_WORKSPACE_ID and no terminal, so
+ *  a plain `squadrant launch` would open the cmux GUI app and exit 0 without
+ *  ever creating a workspace. --headless makes launch drive runtime.spawn
+ *  directly instead. `log`, when given, records the subprocess's captured
+ *  output (or failure) so a broken launch leaves a diagnostic trail instead
+ *  of failing silently while ensureCaptainAlive polls to a timeout. */
+export function createLaunch(cliBin: string, log?: (m: string) => void): (project: string) => Promise<void> {
+  return (project: string) =>
+    new Promise<void>((resolve, reject) => {
+      execFile(
+        process.execPath,
+        [cliBin, "launch", project, "--headless"],
+        { timeout: 30_000 },
+        (err, stdout, stderr) => {
+          const output = capOutput(stdout ?? "", stderr ?? "");
+          if (err) {
+            log?.(`launch ${project} failed: ${output}`);
+            reject(err);
+            return;
+          }
+          if (output !== "(no output)") log?.(`launch ${project}: ${output}`);
+          resolve();
+        },
+      );
+    });
 }


### PR DESCRIPTION
## Summary

Fixes #520 — Telegram's boot-if-down auto-launch silently no-op'd whenever the daemon tried to boot a down captain.

**Root cause:** `squadrant launch <project>` calls `ensureCmuxReady()` first, which opens the cmux GUI app and `process.exit(0)`s whenever `CMUX_WORKSPACE_ID` isn't set in the environment — true for every process the daemon spawns via `execFile` (the launchd plist only sets `PATH`). Telegram's auto-launch path (`bridge.ts` → `ensureCaptainAlive` → `createLaunch` in `core/telegram/control.ts`) shells out to exactly that command, so the daemon's launch call always exited 0 having created nothing, and `ensureCaptainAlive` polled `isAlive()` for the full 120s warmup window before reporting "❌ couldn't reach captain" to the user.

**Fix:**
- Add a `--headless` flag to `squadrant launch` that bypasses the `isInsideCmux()` gate, letting a non-interactive caller drive `launchOneWorkspace` directly — the same `runtime.spawn` path `crew-spawn.ts` already uses from the daemon.
- The daemon's `createLaunch` now passes `--headless`, captures + logs the subprocess's stdout/stderr (previously discarded), and rejects on a real failure instead of silently swallowing it.
- `squadrant launch` now sets a non-zero exit code on a genuine launch failure so the daemon can tell.

**Verified against ground truth** (not just that the CLI printed success):
1. Reproduced the exact bug: `env -u CMUX_WORKSPACE_ID node dist/index.js launch claude-skills` (no `--headless`) → exit 0, no workspace created, cmux app opened.
2. Confirmed the fix: same command **with** `--headless` → a real cmux workspace was created (`squadrant runtime list` showed it), and `squadrant runtime read-screen claude-skills` showed an actual live Claude Code captain session running its startup checklist.
3. Cleaned up the verification-only workspace afterward. The live `brove-mobile` captain (mid-work) was never touched.

Out of scope (deferred, separate issue per the task brief): the captain-health surface-title probe false-negative that misclassifies a stopped captain as alive — that's #517's follow-on, not part of this fix.

## Test plan
- [x] New unit tests for `ensureCmuxReady(headless)` bypass (`packages/cli/src/commands/__tests__/launch.test.ts`) — written first, watched RED, then GREEN.
- [x] New unit tests for `createLaunch` (`--headless` arg, output capture/logging, reject-on-failure) (`packages/core/src/__tests__/telegram-control.test.ts`) — written first, watched RED, then GREEN.
- [x] Full monorepo build (`npm run build`) — clean.
- [x] Full test suite (`npm test`) — 154 files / 1910 tests passing.
- [x] Manual ground-truth verification against a live cmux instance (see above).