### PR TITLE
Release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-07-08
+
+### Added
+
+- **Captain liveness redesign — hybrid ground-truth (retires the streak sweep):** captain open/close/crash detection is now driven by a persisted `LivenessRegistry` (`<stateRoot>/liveness.json`, survives daemon restart) reconciled from the cmux session store via a new `DaemonSurfaceDriver.liveness()` seam and arbitrated by a per-tick pid floor. It distinguishes a clean close (`stopped`) from a crash (`gone` — store record lingers with a dead pid) from `alive`, with provenance precedence `runtime ≥ agent > scan`. Replaces the K=3 title-sweep streak model that produced both false-positives and false-negatives and lost all state on daemon restart. Dashboards, the health IPC, and the Telegram boot-if-down probe now read one ground-truth source.
+- **Per-project effort override:** `resolveEffort` now honors a per-project `effort` in the project override config; `squadrant effort --project <name>` shows the resolved value. The global dial is unchanged, and a project with no override falls back to it.
+- **Web dashboard LIVE "mission control" tab (now the default tab):** a compact one-line-per-project view with a state-count header, attention-first ordering (blocked/errored float up, offline sinks), last-seen-age and task-count columns, a search box, sortable column headers, a status filter, and expandable per-crew detail rows. (Per-crew pid/uptime/agent/model are placeholders pending #524.)
+- **Web dashboard: status filter + per-captain badge** on the projects view.
+- **opencode init setup guidance + default global config provisioning (#511).**
+- **Daemon broadcasts a restart notice to captains on build change (#510).**
+
+### Fixed
+
+- **Captain misclassified as alive when stopped, blocking Telegram auto-launch (#517):** the alive check now reads fresh pid-verified health, so a stopped or crashed captain no longer reads `alive` and correctly triggers boot-if-down.
+- **`squadrant launch` boot-if-down was a silent no-op outside cmux (#520):** added an explicit `--headless` launch path.
+- **CLI and web dashboards showed non-running captains as `idle`:** a captain with no registry entry (`unknown`) now correctly renders `offline`.
+- **A locked or partial cmux store read no longer false-closes captains:** `liveness()` now throws on an unreadable snapshot (leaving the registry intact) instead of returning an empty set that would mark every captain stopped.
+- **CREW IDLE flood during long tool-executing turns (#492):** verified fixed (the `pendingTool` veto holds) and closed.
+
+### Changed
+
+- **Retired the title-sweep / K=3 streak captain-liveness model** in favor of the registry + pid floor.
+
 ## [0.14.3] - 2026-07-02
 
 ### Added

--- a/docs/specs/2026-07-07-captain-liveness-redesign-plan.md
+++ b/docs/specs/2026-07-07-captain-liveness-redesign-plan.md
@@ -1,0 +1,876 @@
+# Captain Liveness Redesign — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the stale, restart-volatile, title-sweep captain liveness with a hybrid ground-truth model — cmux store (via a `liveness()` runtime seam) preferred when present, backed by a squadrant-owned persisted registry — so open/close detection, dashboards, and the Telegram probe are correct and survive daemon restarts.
+
+**Architecture:** A core-owned `LivenessRegistry` (persisted to `<stateRoot>/liveness.json`) is the single source of truth. On cmux it is reconciled from `DaemonSurfaceDriver.liveness()` (authoritative — reads the cmux store, distinguishing user-close from crash). A per-tick pid floor (`kill(pid,0)`) arbitrates liveness. Both dashboards and the Telegram boot-if-down probe read this one source. Provenance precedence `runtime ≥ agent > scan` guarantees the two signals never conflict.
+
+**Tech Stack:** TypeScript (NodeNext ESM), Node `child_process`/`fs`, vitest. Monorepo packages: `shared ◄ core ◄ workspaces ◄ cli`, plus `web`.
+
+## Global Constraints
+
+- **Spec:** `docs/specs/2026-07-07-captain-liveness-redesign.md` — every task traces to a spec section.
+- **NodeNext imports:** all relative imports use the `.js` extension (e.g. `./liveness-registry.js`). `tsc` + `vitest` miss omissions; the real gate is `node dist/index.js --help` after build.
+- **GitNexus first:** before editing ANY existing function/method/class, run `gitnexus_impact({target, direction:"upstream"})` and report blast radius; run `gitnexus_detect_changes()` before each commit (repo CLAUDE.md mandate).
+- **Karpathy discipline:** surgical changes only — every changed line traces to this plan; no drive-by refactors; no speculative abstraction.
+- **macOS-only:** guard any OS-specific test with `it.skipIf(process.platform !== "darwin")`.
+- **Pure-first:** derivation/reconciliation live in pure functions (no I/O, explicit `now`) — mirrors existing `liveness.ts` / `watchdog.ts`.
+- **Health IPC shape is FROZEN:** the `health` request still returns `ComponentHealth[]` — do not change its shape; consumers depend on it.
+- **Lifecycle testing:** any manual open/close/crash test runs on a **throwaway TEST project only** — never a real captain (a probe on real brove-mobile destroyed its session on 2026-07-07).
+- **No new `HealthState` value:** reuse `alive | stale | gone | stopped | unknown`.
+
+---
+
+## File Structure
+
+| File | Responsibility | New? |
+|---|---|---|
+| `packages/shared/src/types/liveness.ts` | `LivenessEntry`, `LivenessSource`, `RuntimeLivenessRecord`, `Role` types (leaf, zero deps) | **new** |
+| `packages/core/src/liveness.ts` | pure derivation `deriveCaptainState` + reconciliation `reconcileLiveness` (extend existing file) | modify |
+| `packages/core/src/daemon/liveness-registry.ts` | `LivenessRegistry` class: in-memory map + atomic JSON persistence + boot reconcile | **new** |
+| `packages/shared/src/types/runtime.ts` | add optional `liveness()` to the daemon seam type | modify |
+| `packages/core/src/interfaces.ts` | add `liveness()` to `DaemonSurfaceDriver` | modify |
+| `packages/workspaces/src/cmux-daemon/daemon-cmux.ts` | implement `liveness()` — read store, correlate by template fingerprint | modify |
+| `packages/workspaces/src/cmux-daemon/store-fingerprint.ts` | pure helpers: parse store record → `RuntimeLivenessRecord` (role by template, project by cwd) | **new** |
+| `packages/core/src/daemon/context.ts` | swap `captainMissingStreak`+`stoppedProjects` → `livenessRegistry` | modify |
+| `packages/core/src/daemon/delivery-loop.ts` | remove title-sweep authority; add liveness tick (runtime snapshot + pid floor) | modify |
+| `packages/core/src/daemon/start.ts` | health handler derives captain state from the registry | modify |
+| `packages/core/src/telegram/control.ts` | `createIsCaptainAlive` → fresh ground-truth at call time | modify |
+| `packages/web/src/read-status.ts` | consume `health`; captain-liveness precedence | modify |
+
+---
+
+## Task 1: Pure liveness types + derivation + reconciliation
+
+Spec: §4.2, §4.3, §7. Pure functions only — the testable foundation.
+
+**Files:**
+- Create: `packages/shared/src/types/liveness.ts`
+- Modify: `packages/core/src/liveness.ts` (append)
+- Test: `packages/core/src/__tests__/liveness-derive.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `type Role = "captain" | "crew" | "command"`
+  - `type LivenessSource = "runtime" | "agent" | "scan"`
+  - `interface LivenessEntry { project: string; role: Role; pid: number | null; sessionId: string; startedAt: number; lastState: "start" | "end"; lastSeenAt: number; pidAlive: boolean; source: LivenessSource }`
+  - `deriveCaptainState(e: LivenessEntry | undefined): HealthState`
+  - `reconcileLiveness(prev: LivenessEntry | undefined, next: LivenessEntry): LivenessEntry`
+
+- [ ] **Step 1: Write the failing test** — `packages/core/src/__tests__/liveness-derive.test.ts`
+
+```ts
+import { describe, it, expect } from "vitest";
+import { deriveCaptainState, reconcileLiveness } from "../liveness.js";
+import type { LivenessEntry } from "@squadrant/shared";
+
+const base = (o: Partial<LivenessEntry> = {}): LivenessEntry => ({
+  project: "p", role: "captain", pid: 100, sessionId: "s", startedAt: 1_000,
+  lastState: "start", lastSeenAt: 1_000, pidAlive: true, source: "runtime", ...o,
+});
+
+describe("deriveCaptainState", () => {
+  it("undefined entry → unknown", () => expect(deriveCaptainState(undefined)).toBe("unknown"));
+  it("lastState=end → stopped (before pid check)", () =>
+    expect(deriveCaptainState(base({ lastState: "end", pidAlive: false }))).toBe("stopped"));
+  it("pid dead + record present (crash) → gone", () =>
+    expect(deriveCaptainState(base({ lastState: "start", pidAlive: false }))).toBe("gone"));
+  it("pid alive → alive", () => expect(deriveCaptainState(base())).toBe("alive"));
+});
+
+describe("reconcileLiveness — runtime ≥ agent > scan", () => {
+  it("scan may set pidAlive=false but not override runtime presence", () => {
+    const prev = base({ source: "runtime", lastState: "start", pidAlive: true });
+    const scan = base({ source: "scan", pidAlive: false, lastSeenAt: 2_000 });
+    const out = reconcileLiveness(prev, scan);
+    expect(out.pidAlive).toBe(false);      // liveness axis updated
+    expect(out.lastState).toBe("start");   // presence/intent unchanged by scan
+    expect(out.source).toBe("runtime");
+  });
+  it("scan cannot resurrect a dead pid; only a newer runtime/agent open does", () => {
+    const prev = base({ pidAlive: false, startedAt: 1_000 });
+    const staleScan = base({ source: "scan", pidAlive: true, startedAt: 1_000, lastSeenAt: 900 });
+    expect(reconcileLiveness(prev, staleScan).pidAlive).toBe(false);
+    const reopen = base({ source: "runtime", pid: 200, startedAt: 3_000, pidAlive: true });
+    expect(reconcileLiveness(prev, reopen).pidAlive).toBe(true);
+  });
+  it("runtime record end → lastState=end, entry kept (not dropped)", () => {
+    const prev = base({ source: "runtime", lastState: "start" });
+    const closed = base({ source: "runtime", lastState: "end", lastSeenAt: 2_000 });
+    expect(reconcileLiveness(prev, closed).lastState).toBe("end");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/core && npx vitest run src/__tests__/liveness-derive.test.ts`
+Expected: FAIL — `deriveCaptainState`/`reconcileLiveness` not exported.
+
+- [ ] **Step 3: Create the types** — `packages/shared/src/types/liveness.ts`
+
+```ts
+export type Role = "captain" | "crew" | "command";
+export type LivenessSource = "runtime" | "agent" | "scan";
+
+/** Persisted per-component liveness fact. */
+export interface LivenessEntry {
+  project: string;
+  role: Role;
+  pid: number | null;
+  sessionId: string;
+  startedAt: number;
+  /** intent: process opened vs cleanly closed. */
+  lastState: "start" | "end";
+  lastSeenAt: number;
+  /** liveness axis — written only by the pid floor. */
+  pidAlive: boolean;
+  source: LivenessSource;
+}
+
+/** One ground-truth record from a runtime's own session store (§5.4). */
+export interface RuntimeLivenessRecord {
+  role: Role | "unknown";
+  project: string;
+  pid: number | null;
+  sessionId: string;
+  present: boolean;
+  isRestorable?: boolean;
+}
+```
+
+Then export from the shared barrel — add to `packages/shared/src/index.ts` (or the `types` re-export used by the repo; confirm the existing pattern, e.g. `export * from "./types/liveness.js";`).
+
+- [ ] **Step 4: Append pure functions** — `packages/core/src/liveness.ts`
+
+```ts
+import type { LivenessEntry } from "@squadrant/shared";
+
+/**
+ * Pure. Derive a captain HealthState from its registry entry.
+ * First match wins — order matters (a clean close reads `stopped` even though
+ * its pid also dies).
+ */
+export function deriveCaptainState(e: LivenessEntry | undefined): HealthState {
+  if (!e) return "unknown";
+  if (e.lastState === "end") return "stopped"; // clean close — magenta, not a fault (#324)
+  if (!e.pidAlive) return "gone";              // pid dead, record present → crash
+  return "alive";
+}
+
+/**
+ * Pure. Reconcile an incoming signal against the prior entry.
+ * Precedence: runtime ≥ agent (authoritative for presence/intent) > scan
+ * (liveness-only). A `scan` updates `pidAlive` but never presence/intent, and
+ * never resurrects a dead pid — only a newer runtime/agent open (greater
+ * startedAt) does.
+ */
+export function reconcileLiveness(
+  prev: LivenessEntry | undefined,
+  next: LivenessEntry,
+): LivenessEntry {
+  if (!prev) return next;
+  if (next.source === "scan") {
+    // liveness-only: adopt pidAlive (and lastSeenAt) onto prev; keep presence/intent.
+    // A stale scan (older than prev) must not flip a dead pid back to alive.
+    const pidAlive = next.startedAt >= prev.startedAt ? next.pidAlive : prev.pidAlive;
+    return { ...prev, pidAlive, lastSeenAt: Math.max(prev.lastSeenAt, next.lastSeenAt) };
+  }
+  // runtime/agent authoritative. A newer open (or any end) wins; a stale one is ignored.
+  if (next.startedAt >= prev.startedAt || next.lastState === "end") return next;
+  return prev;
+}
+```
+
+- [ ] **Step 5: Build shared + run tests**
+
+Run: `npm run build -w @squadrant/shared && cd packages/core && npx vitest run src/__tests__/liveness-derive.test.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/shared/src/types/liveness.ts packages/shared/src/index.ts \
+  packages/core/src/liveness.ts packages/core/src/__tests__/liveness-derive.test.ts
+git commit -m "feat(liveness): pure captain-state derivation + reconciliation (runtime≥agent>scan)"
+```
+
+---
+
+## Task 2: LivenessRegistry with atomic persistence
+
+Spec: §4.1 (persistence), §5.3 (restart survival).
+
+**Files:**
+- Create: `packages/core/src/daemon/liveness-registry.ts`
+- Test: `packages/core/src/daemon/__tests__/liveness-registry.test.ts`
+
+**Interfaces:**
+- Consumes: `LivenessEntry`, `reconcileLiveness` (Task 1).
+- Produces:
+  - `class LivenessRegistry` with:
+    - `constructor(opts: { path: string; readFile?: (p:string)=>string|undefined; writeFile?: (p:string,c:string)=>void })`
+    - `load(): void` — seed from disk (missing/corrupt → empty).
+    - `get(project: string): LivenessEntry | undefined`
+    - `all(): LivenessEntry[]`
+    - `apply(next: LivenessEntry): void` — reconcile + persist.
+    - `markEnded(project: string, at: number): void` — set `lastState:"end"`, keep entry, persist.
+    - `setPidAlive(project: string, alive: boolean, at: number): void` — scan update, persist.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { LivenessRegistry } from "../liveness-registry.js";
+import type { LivenessEntry } from "@squadrant/shared";
+
+function memFs() {
+  const store = new Map<string, string>();
+  return {
+    store,
+    readFile: (p: string) => store.get(p),
+    writeFile: (p: string, c: string) => void store.set(p, c),
+  };
+}
+const cap = (o: Partial<LivenessEntry> = {}): LivenessEntry => ({
+  project: "p", role: "captain", pid: 100, sessionId: "s", startedAt: 1_000,
+  lastState: "start", lastSeenAt: 1_000, pidAlive: true, source: "runtime", ...o,
+});
+
+describe("LivenessRegistry", () => {
+  it("persists and reloads across a simulated restart", () => {
+    const fs = memFs();
+    const r1 = new LivenessRegistry({ path: "/x/liveness.json", ...fs });
+    r1.apply(cap());
+    const r2 = new LivenessRegistry({ path: "/x/liveness.json", ...fs });
+    r2.load();
+    expect(r2.get("p")?.pid).toBe(100);
+  });
+  it("markEnded keeps the entry (→ stopped, not forgotten)", () => {
+    const fs = memFs();
+    const r = new LivenessRegistry({ path: "/x/liveness.json", ...fs });
+    r.apply(cap());
+    r.markEnded("p", 2_000);
+    expect(r.get("p")?.lastState).toBe("end");
+  });
+  it("setPidAlive updates liveness only", () => {
+    const fs = memFs();
+    const r = new LivenessRegistry({ path: "/x/liveness.json", ...fs });
+    r.apply(cap());
+    r.setPidAlive("p", false, 2_000);
+    expect(r.get("p")?.pidAlive).toBe(false);
+    expect(r.get("p")?.lastState).toBe("start");
+  });
+  it("corrupt file loads as empty (no throw)", () => {
+    const fs = memFs(); fs.store.set("/x/liveness.json", "{not json");
+    const r = new LivenessRegistry({ path: "/x/liveness.json", ...fs });
+    expect(() => r.load()).not.toThrow();
+    expect(r.all()).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/core && npx vitest run src/daemon/__tests__/liveness-registry.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the registry** — `packages/core/src/daemon/liveness-registry.ts`
+
+```ts
+import { writeFileSync, readFileSync, renameSync } from "node:fs";
+import type { LivenessEntry } from "@squadrant/shared";
+import { reconcileLiveness } from "../liveness.js";
+
+export interface LivenessRegistryOpts {
+  path: string;
+  readFile?: (p: string) => string | undefined;
+  writeFile?: (p: string, content: string) => void;
+}
+
+/** Core-owned, disk-persisted registry — the single liveness source of truth. */
+export class LivenessRegistry {
+  private readonly path: string;
+  private readonly readFile: (p: string) => string | undefined;
+  private readonly writeFile: (p: string, content: string) => void;
+  private map = new Map<string, LivenessEntry>();
+
+  constructor(opts: LivenessRegistryOpts) {
+    this.path = opts.path;
+    this.readFile = opts.readFile ?? ((p) => { try { return readFileSync(p, "utf-8"); } catch { return undefined; } });
+    this.writeFile = opts.writeFile ?? ((p, c) => { writeFileSync(`${p}.tmp`, c); renameSync(`${p}.tmp`, p); });
+  }
+
+  load(): void {
+    const raw = this.readFile(this.path);
+    if (!raw) return;
+    try {
+      const arr = JSON.parse(raw) as LivenessEntry[];
+      this.map = new Map(arr.map((e) => [e.project, e]));
+    } catch { this.map = new Map(); }
+  }
+
+  get(project: string): LivenessEntry | undefined { return this.map.get(project); }
+  all(): LivenessEntry[] { return [...this.map.values()]; }
+
+  apply(next: LivenessEntry): void {
+    this.map.set(next.project, reconcileLiveness(this.map.get(next.project), next));
+    this.persist();
+  }
+
+  markEnded(project: string, at: number): void {
+    const e = this.map.get(project);
+    if (!e) return;
+    this.map.set(project, { ...e, lastState: "end", lastSeenAt: at });
+    this.persist();
+  }
+
+  setPidAlive(project: string, alive: boolean, at: number): void {
+    const e = this.map.get(project);
+    if (!e) return;
+    this.map.set(project, { ...e, pidAlive: alive, lastSeenAt: at });
+    this.persist();
+  }
+
+  private persist(): void {
+    try { this.writeFile(this.path, JSON.stringify(this.all(), null, 2)); } catch { /* best-effort */ }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd packages/core && npx vitest run src/daemon/__tests__/liveness-registry.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/daemon/liveness-registry.ts packages/core/src/daemon/__tests__/liveness-registry.test.ts
+git commit -m "feat(liveness): disk-persisted LivenessRegistry (survives daemon restart)"
+```
+
+---
+
+## Task 3: `liveness()` seam + cmux implementation (template-fingerprint correlation)
+
+Spec: §5.2, §5.4, §7. This is where the cmux store becomes ground-truth.
+
+**Files:**
+- Create: `packages/workspaces/src/cmux-daemon/store-fingerprint.ts`
+- Modify: `packages/shared/src/types/runtime.ts` (or `packages/core/src/interfaces.ts` — see below)
+- Modify: `packages/core/src/interfaces.ts` — add `liveness?()` to `DaemonSurfaceDriver`
+- Modify: `packages/workspaces/src/cmux-daemon/daemon-cmux.ts` — implement it
+- Test: `packages/workspaces/src/cmux-daemon/__tests__/store-fingerprint.test.ts`
+
+**Interfaces:**
+- Consumes: `RuntimeLivenessRecord` (Task 1).
+- Produces:
+  - `parseStoreRecords(fileContent: string, projects: Record<string,{path:string}>, captainTemplate?: string): RuntimeLivenessRecord[]`
+  - `DaemonSurfaceDriver.liveness?(): Promise<RuntimeLivenessRecord[]>`
+
+**GitNexus:** run `gitnexus_impact({target:"DaemonSurfaceDriver", direction:"upstream"})` before editing `interfaces.ts`.
+
+- [ ] **Step 1: Write the failing test** — `store-fingerprint.test.ts`
+
+```ts
+import { describe, it, expect } from "vitest";
+import { parseStoreRecords } from "../store-fingerprint.js";
+
+const projects = { squadrant: { path: "/Users/me/squadrant" } };
+
+const file = JSON.stringify({
+  sessions: {
+    a: { sessionId: "a", pid: 41030, cwd: "/Users/me/squadrant", isRestorable: true,
+         launchCommand: { arguments: ["claude","--append-system-prompt-file","/x/templates/captain.claude.md"] } },
+    b: { sessionId: "b", pid: 74497, cwd: "/Users/me/squadrant", isRestorable: true,
+         launchCommand: { arguments: ["claude","--append-system-prompt-file","/x/templates/side.research.claude.md"] } },
+    c: { sessionId: "c", pid: null, cwd: "/Users/me/other",
+         launchCommand: { arguments: ["claude"] } },
+  },
+});
+
+describe("parseStoreRecords", () => {
+  it("identifies the captain by template, not cwd (captain+side share cwd)", () => {
+    const recs = parseStoreRecords(file, projects);
+    const cap = recs.find((r) => r.role === "captain");
+    expect(cap?.project).toBe("squadrant");
+    expect(cap?.pid).toBe(41030);
+    expect(cap?.present).toBe(true);
+  });
+  it("classifies a sibling side-session as role 'command'/'unknown', not captain", () => {
+    const recs = parseStoreRecords(file, projects);
+    expect(recs.filter((r) => r.role === "captain")).toHaveLength(1);
+  });
+  it("handles pid:null (hibernated) without dropping the record", () => {
+    const recs = parseStoreRecords(file, projects);
+    expect(recs.some((r) => r.pid === null)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/workspaces && npx vitest run src/cmux-daemon/__tests__/store-fingerprint.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the fingerprint parser** — `store-fingerprint.ts`
+
+```ts
+import type { RuntimeLivenessRecord, Role } from "@squadrant/shared";
+
+interface RawSession {
+  sessionId?: string; pid?: number | null; cwd?: string; isRestorable?: boolean;
+  launchCommand?: { arguments?: string[]; workingDirectory?: string };
+}
+
+/** template basename → role (captain.claude.md → captain, crew.claude.md → crew, …). */
+function roleFromTemplate(args: string[] | undefined): Role | "unknown" {
+  const i = args?.indexOf("--append-system-prompt-file") ?? -1;
+  const tmpl = i >= 0 && args ? (args[i + 1] ?? "").split("/").pop() ?? "" : "";
+  if (tmpl.startsWith("captain")) return "captain";
+  if (tmpl.startsWith("crew")) return "crew";
+  if (tmpl.startsWith("command")) return "command";
+  return "unknown"; // side.research.* etc. — not a captain
+}
+
+function projectFromCwd(cwd: string, projects: Record<string, { path: string }>): string | undefined {
+  for (const [name, p] of Object.entries(projects)) {
+    if (cwd === p.path || cwd.startsWith(`${p.path}/`)) return name;
+  }
+  return undefined;
+}
+
+export function parseStoreRecords(
+  fileContent: string,
+  projects: Record<string, { path: string }>,
+): RuntimeLivenessRecord[] {
+  let parsed: { sessions?: Record<string, RawSession> };
+  try { parsed = JSON.parse(fileContent); } catch { return []; }
+  const out: RuntimeLivenessRecord[] = [];
+  for (const s of Object.values(parsed.sessions ?? {})) {
+    const cwd = s.cwd ?? s.launchCommand?.workingDirectory ?? "";
+    const project = projectFromCwd(cwd, projects);
+    if (!project || !s.sessionId) continue;
+    out.push({
+      role: roleFromTemplate(s.launchCommand?.arguments),
+      project,
+      pid: typeof s.pid === "number" ? s.pid : null,
+      sessionId: s.sessionId,
+      present: true,
+      isRestorable: s.isRestorable,
+    });
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Add `liveness()` to the daemon seam** — `packages/core/src/interfaces.ts`
+
+Inside `interface DaemonSurfaceDriver`, add (after `readPaneScreen`):
+
+```ts
+  /** Ground-truth liveness from the runtime's own session store (§5.4).
+   *  Optional — a runtime with no such store omits it. */
+  liveness?(): Promise<RuntimeLivenessRecord[]>;
+```
+
+Add the import at the top of `interfaces.ts`: `import type { RuntimeLivenessRecord } from "@squadrant/shared";`
+
+- [ ] **Step 5: Implement it in the cmux driver** — `packages/workspaces/src/cmux-daemon/daemon-cmux.ts`
+
+Add a method that reads the store dir and delegates to `parseStoreRecords`. Reuse the store dir resolution from `CmuxStoreSource` (`process.env.CMUX_AGENT_HOOK_STATE_DIR ?? ~/.cmuxterm`), glob `*-hook-sessions.json`, and pass `loadConfig().projects`:
+
+```ts
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { loadConfig } from "@squadrant/shared";
+import { parseStoreRecords } from "./store-fingerprint.js";
+import type { RuntimeLivenessRecord } from "@squadrant/shared";
+
+// …inside the daemon-cmux driver object/class…
+async liveness(): Promise<RuntimeLivenessRecord[]> {
+  const dir = process.env.CMUX_AGENT_HOOK_STATE_DIR ?? join(homedir(), ".cmuxterm");
+  const projects = loadConfig().projects as Record<string, { path: string }>;
+  let files: string[] = [];
+  try { files = readdirSync(dir).filter((f) => f.endsWith("-hook-sessions.json") && !f.endsWith(".lock")); } catch { return []; }
+  const out: RuntimeLivenessRecord[] = [];
+  for (const f of files) {
+    try { out.push(...parseStoreRecords(readFileSync(join(dir, f), "utf-8"), projects)); } catch { /* skip */ }
+  }
+  return out;
+}
+```
+
+(If the config `path` values are `~`-relative, resolve with the repo's `resolveHome` before comparing — check how `read-status.ts` / `launch.ts` resolve `proj.path` and match that.)
+
+- [ ] **Step 6: Run tests + build**
+
+Run: `cd packages/workspaces && npx vitest run src/cmux-daemon/__tests__/store-fingerprint.test.ts && npm run build -w @squadrant/shared -w @squadrant/core -w @squadrant/workspaces`
+Expected: PASS + clean build.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/workspaces/src/cmux-daemon/store-fingerprint.ts \
+  packages/workspaces/src/cmux-daemon/__tests__/store-fingerprint.test.ts \
+  packages/core/src/interfaces.ts packages/workspaces/src/cmux-daemon/daemon-cmux.ts \
+  packages/shared/src/types/runtime.ts
+git commit -m "feat(liveness): DaemonSurfaceDriver.liveness() + cmux store fingerprint correlation"
+```
+
+---
+
+## Task 4: Wire the registry into the daemon — boot reconcile, pid floor, health
+
+Spec: §4.5, §5.3, §6 (pane path). This replaces the streak model.
+
+**Files:**
+- Modify: `packages/core/src/daemon/context.ts` (~lines 113-115, 183-184)
+- Modify: `packages/core/src/daemon/delivery-loop.ts` (add liveness tick)
+- Modify: `packages/core/src/daemon/start.ts` (~lines 100-115 health handler)
+- Test: `packages/core/src/daemon/__tests__/liveness-tick.test.ts`
+
+**Interfaces:**
+- Consumes: `LivenessRegistry` (Task 2), `DaemonSurfaceDriver.liveness()` (Task 3), `deriveCaptainState` (Task 1).
+- Produces: `runLivenessTick(deps): Promise<void>` — one reconcile+floor pass.
+
+**GitNexus:** `gitnexus_impact` on `projectHealth`, `deliveryTick`, and `createDaemonContext` before editing.
+
+- [ ] **Step 1: Write the failing test** — `liveness-tick.test.ts`
+
+```ts
+import { describe, it, expect } from "vitest";
+import { LivenessRegistry } from "../liveness-registry.js";
+import { runLivenessTick } from "../delivery-loop.js";
+import type { RuntimeLivenessRecord } from "@squadrant/shared";
+
+const memReg = () => new LivenessRegistry({ path: "/x/l.json", readFile: () => undefined, writeFile: () => {} });
+
+describe("runLivenessTick", () => {
+  it("registers a captain from the runtime snapshot and marks it alive", async () => {
+    const reg = memReg();
+    const rec: RuntimeLivenessRecord = { role: "captain", project: "p", pid: 100, sessionId: "s", present: true };
+    await runLivenessTick({ registry: reg, liveness: async () => [rec], isPidAlive: () => true, now: () => 5_000 });
+    expect(reg.get("p")?.pidAlive).toBe(true);
+    expect(reg.get("p")?.lastState).toBe("start");
+  });
+  it("captain absent from snapshot → markEnded (stopped), entry kept", async () => {
+    const reg = memReg();
+    reg.apply({ project: "p", role: "captain", pid: 100, sessionId: "s", startedAt: 1_000, lastState: "start", lastSeenAt: 1_000, pidAlive: true, source: "runtime" });
+    await runLivenessTick({ registry: reg, liveness: async () => [], isPidAlive: () => true, now: () => 5_000 });
+    expect(reg.get("p")?.lastState).toBe("end");
+  });
+  it("present record + dead pid → pidAlive false (→ gone)", async () => {
+    const reg = memReg();
+    const rec: RuntimeLivenessRecord = { role: "captain", project: "p", pid: 100, sessionId: "s", present: true, isRestorable: true };
+    await runLivenessTick({ registry: reg, liveness: async () => [rec], isPidAlive: () => false, now: () => 5_000 });
+    expect(reg.get("p")?.pidAlive).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/core && npx vitest run src/daemon/__tests__/liveness-tick.test.ts`
+Expected: FAIL — `runLivenessTick` not exported.
+
+- [ ] **Step 3: Implement `runLivenessTick`** — export from `packages/core/src/daemon/delivery-loop.ts`
+
+```ts
+import type { RuntimeLivenessRecord, LivenessEntry } from "@squadrant/shared";
+import type { LivenessRegistry } from "./liveness-registry.js";
+
+export interface LivenessTickDeps {
+  registry: LivenessRegistry;
+  liveness: () => Promise<RuntimeLivenessRecord[]>;
+  isPidAlive: (pid: number) => boolean;
+  now: () => number;
+}
+
+/** One reconcile+floor pass over captain records. Runtime snapshot is authoritative;
+ *  the pid floor arbitrates liveness; a captain absent from the snapshot is marked
+ *  cleanly-closed (stopped) but NOT dropped. */
+export async function runLivenessTick(deps: LivenessTickDeps): Promise<void> {
+  const now = deps.now();
+  let records: RuntimeLivenessRecord[] = [];
+  try { records = await deps.liveness(); } catch { return; } // runtime unreachable → leave registry as-is
+  const seen = new Set<string>();
+
+  for (const r of records) {
+    if (r.role !== "captain") continue;
+    seen.add(r.project);
+    const entry: LivenessEntry = {
+      project: r.project, role: "captain", pid: r.pid, sessionId: r.sessionId,
+      startedAt: now, lastState: "start", lastSeenAt: now,
+      pidAlive: r.pid != null ? deps.isPidAlive(r.pid) : true, // pid:null hibernated → alive-unknown
+      source: "runtime",
+    };
+    // Preserve original startedAt if we already knew this captain (avoid churn):
+    const prev = deps.registry.get(r.project);
+    if (prev && prev.lastState === "start") entry.startedAt = prev.startedAt;
+    deps.registry.apply(entry);
+    if (r.pid != null) deps.registry.setPidAlive(r.project, deps.isPidAlive(r.pid), now);
+  }
+
+  // Captains we knew but the snapshot no longer lists → clean close.
+  for (const e of deps.registry.all()) {
+    if (e.role === "captain" && e.lastState === "start" && !seen.has(e.project)) {
+      deps.registry.markEnded(e.project, now);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Swap context fields** — `packages/core/src/daemon/context.ts`
+
+Run `gitnexus_impact({target:"createDaemonContext"})`. Replace the two fields (lines ~113-115) and their init (lines ~183-184):
+
+```ts
+// remove: captainMissingStreak: Map<string, number>;  stoppedProjects: Set<string>;
+// add:
+livenessRegistry: LivenessRegistry;
+```
+```ts
+// remove: captainMissingStreak: new Map(), stoppedProjects: new Set(),
+// add (construct + load so it survives restart):
+livenessRegistry: (() => {
+  const r = new LivenessRegistry({ path: join(stateRoot, "liveness.json") });
+  r.load();
+  return r;
+})(),
+```
+Add imports: `import { LivenessRegistry } from "./liveness-registry.js";` and `join` from `node:path` if not present.
+
+- [ ] **Step 5: Rewrite the health handler** — `packages/core/src/daemon/start.ts` (~lines 100-115)
+
+Replace the streak-derivation block with registry-derived state. Since `projectHealth` currently takes `captainStopped: boolean|null`, extend it minimally to accept a precomputed captain `HealthState` OR translate: pass a mapped boolean-null is lossy (can't express `gone`). Cleanest: add an optional `captainState?: HealthState` param to `projectHealth` that, when provided, wins over `captainStopped`. Then:
+
+```ts
+import { deriveCaptainState } from "../liveness.js";
+// …
+const capEntry = ctx.livenessRegistry.get(project);
+out.push(
+  ...projectHealth({
+    project, now, captainName,
+    captainStopped: null,
+    captainState: deriveCaptainState(capEntry), // new optional param, wins when present
+    commandPresent: null,
+    crews: store.list(project),
+  }),
+);
+```
+In `liveness.ts projectHealth`, honor `captainState` when supplied (falls back to the existing `captainStopped` mapping otherwise). Update the captain-row `detail` for `gone` → `"captain process died (crash) — crews reaped"`.
+
+- [ ] **Step 6: Call the tick from the delivery loop**
+
+In `createDelivery`'s `deliveryCore` (or a sibling interval), before/after the existing per-project loop, call:
+```ts
+await runLivenessTick({
+  registry: ctx.livenessRegistry,
+  liveness: () => (cmux.liveness ? cmux.liveness() : Promise.resolve([])),
+  isPidAlive: (pid) => { try { process.kill(pid, 0); return true; } catch { return false; } },
+  now: () => Date.now(),
+});
+```
+Remove the title-sweep authority (the `captainMissingStreak`/`stoppedProjects` mutation block, lines ~129-152) — the registry now owns captain presence. Keep surface discovery ONLY for the delivery target (finding where to `cmux.send`), driven by the registry's alive captains.
+
+- [ ] **Step 7: Run tests + build + real gate**
+
+Run: `cd packages/core && npx vitest run src/daemon/__tests__/liveness-tick.test.ts && cd ../.. && npm run build && node dist/index.js --help`
+Expected: PASS + build ok + `--help` prints (NodeNext `.js` import gate).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/core/src/daemon/context.ts packages/core/src/daemon/delivery-loop.ts \
+  packages/core/src/daemon/start.ts packages/core/src/liveness.ts \
+  packages/core/src/daemon/__tests__/liveness-tick.test.ts
+git commit -m "feat(liveness): registry-driven captain health via runtime snapshot + pid floor; retire streak"
+```
+
+---
+
+## Task 5: Telegram ground-truth-on-demand (#517 fix)
+
+Spec: §4.5. Direct regression fix.
+
+**Files:**
+- Modify: `packages/core/src/telegram/control.ts` (`createIsCaptainAlive`, lines 50-65)
+- Test: `packages/core/src/telegram/__tests__/is-captain-alive.test.ts`
+
+**Interfaces:**
+- Consumes: the daemon `health` reply (`ComponentHealth[]`) which now reflects the registry (Task 4). `createIsCaptainAlive` signature is unchanged (still `(sock) => (project) => Promise<boolean>`), but "alive" now means a live pid, not a stale streak.
+
+**GitNexus:** `gitnexus_impact({target:"createIsCaptainAlive"})`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { isCaptainAliveFromHealth } from "../control.js";
+import type { ComponentHealth } from "../../liveness.js";
+
+const row = (state: string): ComponentHealth =>
+  ({ kind: "captain", project: "p", ref: "c", state: state as any, lastSeenMs: null });
+
+describe("isCaptainAliveFromHealth", () => {
+  it("alive → true", () => expect(isCaptainAliveFromHealth([row("alive")], "p")).toBe(true));
+  it("gone (crash) → false → boot", () => expect(isCaptainAliveFromHealth([row("gone")], "p")).toBe(false));
+  it("stopped (closed) → false → boot", () => expect(isCaptainAliveFromHealth([row("stopped")], "p")).toBe(false));
+  it("unknown/missing → false", () => expect(isCaptainAliveFromHealth([], "p")).toBe(false));
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/core && npx vitest run src/telegram/__tests__/is-captain-alive.test.ts`
+Expected: FAIL — `isCaptainAliveFromHealth` not exported.
+
+- [ ] **Step 3: Extract the pure predicate + keep the request wrapper** — `control.ts`
+
+```ts
+import type { ComponentHealth } from "../liveness.js";
+
+/** Pure: a captain counts alive ONLY in state "alive". gone/stopped/unknown → boot. */
+export function isCaptainAliveFromHealth(rows: ComponentHealth[], project: string): boolean {
+  return rows.some((h) => h.kind === "captain" && h.project === project && h.state === "alive");
+}
+
+export function createIsCaptainAlive(sock: string): (project: string) => Promise<boolean> {
+  return async (project: string) => {
+    try {
+      const health = (await sendRequest(sock, { kind: "health", project }, 5000)) as ComponentHealth[];
+      return isCaptainAliveFromHealth(health ?? [], project);
+    } catch { return false; }
+  };
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd packages/core && npx vitest run src/telegram/__tests__/is-captain-alive.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/telegram/control.ts packages/core/src/telegram/__tests__/is-captain-alive.test.ts
+git commit -m "fix(telegram): captain alive check reads fresh pid-verified health (#517)"
+```
+
+---
+
+## Task 6: Web dashboard consumes the health source
+
+Spec: §6.
+
+**Files:**
+- Modify: `packages/web/src/read-status.ts`
+- Test: `packages/web/src/__tests__/read-status.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: the `health` IPC (`ComponentHealth[]`) alongside `list`.
+- Produces: `deriveState(tasks, captainState)` — captain liveness dominates.
+
+**GitNexus:** `gitnexus_impact({target:"readAllStatuses"})`.
+
+- [ ] **Step 1: Write the failing test** (extend existing)
+
+```ts
+import { deriveRowState } from "../read-status.js";
+
+it("captain gone → offline regardless of working tasks", () => {
+  expect(deriveRowState([{ state: "working" } as any], "gone")).toBe("offline");
+});
+it("captain stopped → offline", () => {
+  expect(deriveRowState([], "stopped")).toBe("offline");
+});
+it("captain alive → task-derived", () => {
+  expect(deriveRowState([{ state: "working" } as any], "alive")).toBe("busy");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/web && npx vitest run src/__tests__/read-status.test.ts`
+Expected: FAIL — `deriveRowState` not exported.
+
+- [ ] **Step 3: Implement precedence** — `read-status.ts`
+
+```ts
+import type { HealthState } from "@squadrant/core";
+
+/** Captain liveness dominates task activity (§6). */
+export function deriveRowState(tasks: TaskRecord[], captainState: HealthState): DashboardState {
+  if (captainState === "gone" || captainState === "stopped") return "offline";
+  return deriveState(tasks); // existing task-derived busy/blocked/errored/idle
+}
+```
+In `readAllStatuses`, fetch health once (`await deps.call({ kind: "health" })`), index captain state by project, and use `deriveRowState(tasks, capState)`. Keep the `catch → offline` fallback.
+
+- [ ] **Step 4: Run tests + build web**
+
+Run: `cd packages/web && npx vitest run src/__tests__/read-status.test.ts && npm run build -w @squadrant/web`
+Expected: PASS + build ok.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/src/read-status.ts packages/web/src/__tests__/read-status.test.ts
+git commit -m "feat(web): dashboard reflects captain liveness (one health source, captain dominates)"
+```
+
+---
+
+## Task 7: Retire the old sweep + component logs + full verification
+
+Spec: §4.4 (logs), §10 (sequencing step 6).
+
+**Files:**
+- Modify: `packages/core/src/daemon/delivery-loop.ts` (remove dead `discoverCaptainSurface` authority usage, `CAPTAIN_GONE_STREAK_K`)
+- Modify: `packages/core/src/daemon/context.ts` (remove any lingering streak refs)
+- Grep-sweep: `captainMissingStreak`, `stoppedProjects`, `CAPTAIN_GONE_STREAK_K`
+
+- [ ] **Step 1: Find every remaining reference**
+
+Run: `grep -rn "captainMissingStreak\|stoppedProjects\|CAPTAIN_GONE_STREAK_K" packages --include="*.ts" | grep -v __tests__`
+Expected: only definitions left to delete (delivery targets keep using surface discovery, but not for liveness authority).
+
+- [ ] **Step 2: Delete the dead code**
+
+Remove the streak constant, the missing-streak increment block, and `reapOrphanedCrews` invocation tied to the streak — reaping now triggers on captain→`stopped`/`gone` transition in `runLivenessTick` (fold the existing `reapOrphanedCrews(store, project)` call into the `markEnded` branch and the pid-dead branch of Task 4's tick). Keep `reapOrphanedCrews` itself.
+
+- [ ] **Step 3: Add role/source to liveness log lines**
+
+Where the tick applies a record, log: `log(`[${e.role}/${e.source}] ${project} pid=${e.pid} → ${deriveCaptainState(e)}`)`. Keep it one line, grep-able (matches §4.4 examples).
+
+- [ ] **Step 4: Full clean-room build + test + real gate**
+
+Run:
+```bash
+npm run build && npm test && node dist/index.js --help && node dist/squadrantd.js --help
+```
+Expected: build clean, all tests pass, both bins print help (NodeNext `.js` import invariant holds for BOTH entry points).
+
+- [ ] **Step 5: `gitnexus_detect_changes` + manual smoke on a THROWAWAY project**
+
+Register a throwaway test project, `squadrant launch <test>`, confirm `squadrant status --detailed` shows the captain `alive`; press workspace-X, confirm it flips to `stopped` within ~1 tick; `kill -9` a fresh captain's pid, confirm `gone`. **Never** run this on a real captain.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(liveness): retire streak-based sweep; role/source logs; final verification"
+```
+
+---
+
+## Self-Review (completed)
+
+- **Spec coverage:** §4.1→T2/T4, §4.2/4.3→T1, §4.4→T7, §4.5→T5, §5.1/§7→T1+T3+T4(+T7 smoke), §5.2→T3, §5.3→T2+T4, §5.4→T3, §6→T4(pane)+T6(web). ✅ all sections mapped.
+- **Placeholder scan:** no TBD/TODO; every code step carries real code.
+- **Type consistency:** `LivenessEntry`, `RuntimeLivenessRecord`, `deriveCaptainState`, `reconcileLiveness`, `runLivenessTick`, `parseStoreRecords`, `isCaptainAliveFromHealth`, `deriveRowState` used consistently across tasks.
+- **Open detail for the implementer:** confirm `proj.path` home-resolution in Task 3 Step 5 (match `read-status.ts`); confirm the shared barrel export path in Task 1 Step 3; extend `projectHealth` with the optional `captainState` param in Task 4 Step 5 (verify its current signature with `gitnexus_context({name:"projectHealth"})` first).

--- a/docs/specs/2026-07-07-captain-liveness-redesign.md
+++ b/docs/specs/2026-07-07-captain-liveness-redesign.md
@@ -1,0 +1,315 @@
+# Captain Liveness Redesign — hybrid ground-truth (runtime-preferred + squadrant-owned persistence)
+
+**Status:** Design (approved in brainstorm 2026-07-07/08; all §11 facts verified)
+**Owner:** research side-session → primary captain for implementation
+**Related:** #333 (LifecycleSource port), #517 (stopped captain misclassified as alive), #520 (daemon launch no-op), #519 (dashboard live logs)
+
+---
+
+## 1. Problem
+
+Captain liveness is **sweep-based, stale, and volatile**, and it is the *only* component not on the
+event-driven lifecycle path crews already use. Verified in source:
+
+- `delivery-loop.ts` sweeps `cmux.findWorkspaceId(captainTitle)` → `listSurfaces` →
+  `discoverCaptainSurface` with an **exact pane-title match** (`s.title === captainTitle`), debounced
+  by `captainMissingStreak` (K=3) before adding to `stoppedProjects`.
+- `start.ts:106` collapses that into `captainStopped = stopped ? true : streak===0 ? false : null`;
+  `liveness.ts projectHealth` maps it to `alive | stopped | unknown` (captains never report `gone`).
+- `telegram/control.ts createIsCaptainAlive` reads this **cached** health via the daemon `health`
+  IPC — so the boot-if-down probe inherits the staleness.
+
+Three defects, all the same root cause:
+
+1. **False negative** — pane `title` drifts from `captainName`, or a transient sweep miss →
+   spurious "❌ couldn't reach".
+2. **False positive (#517, worse)** — user closes the captain, then Telegram-messages within the K=3
+   window → `isAlive` still returns `alive` → daemon replies "📨 delivered" and **never launches** →
+   the message drops into a mailbox no live captain reads. Proven in daemon logs.
+3. **Restart wipes everything** — `captainMissingStreak` + `stoppedProjects` are `new Map()`/`new
+   Set()` on boot (`context.ts:183-184`). Any daemon restart (reboot, upgrade, rebuild) resets every
+   captain to `unknown`/streak-lost until the next sweep re-learns it. Very likely the deepest cause
+   of the always-wrong dashboards.
+
+**Dashboard divergence** (verified): the **web** dashboard (`read-status.ts`) doesn't consume the
+health source at all — it derives state from the task `list` IPC and only shows `offline` when that
+call *throws*. The **pane/CLI** health (`health-view.ts`) reads `health` → `projectHealth` and shows
+the stale streak. Two code paths → they disagree.
+
+## 2. Goals
+
+1. **Close detection works for every method** and flips status to offline/dead: (a) `squadrant …
+   close` CLI, (b) cmux workspace **X**, (c) cmux **app** quit, (d) captain **tab** X.
+2. **Open/registration works for every method**: `launch`, dispatch, Telegram auto-launch, manual
+   workspace open.
+3. **Both dashboards** show correct real-time status from **one** health source.
+4. **Survive daemon restarts** — status correct *immediately* after any restart.
+
+## 3. Non-goals
+
+- No captain **heartbeat** protocol (YAGNI — pid liveness already answers "is it breathing").
+- No change to the **crew** lifecycle path beyond additive field extension (§4.4).
+- Not implementing `runtime.liveness()` for non-cmux runtimes in this pass — the seam is defined so
+  they can, but cmux is the only implementation now (§5.4).
+
+## 4. Design
+
+### 4.1 Hybrid source model — runtime-preferred, squadrant-owned persistence
+
+The verified insight (probe on the real brove-mobile captain): **the runtime's own session store is
+authoritative ground-truth** and, being a *file*, it already survives daemon restarts and cleanly
+distinguishes user-close from crash (§7). So we prefer it when present — but we do **not** couple the
+core to cmux, and we do **not** lose liveness for future runtimes. Two layers:
+
+```
+        ┌─────────────────────────────────────────────────────────────┐
+        │  Squadrant Liveness Registry   (core-owned, persisted)        │
+        │  <stateRoot>/liveness.json  —  survives daemon restart        │
+        │  entry: { project, role, pid, sessionId, startedAt,           │
+        │           lastState, lastSeenAt, source }                     │
+        └───────────▲───────────────────────────▲─────────────────────┘
+                    │ authoritative (when present)│ populated directly
+        ┌───────────┴──────────────┐   ┌──────────┴──────────────────────┐
+        │ RuntimeDriver.liveness() │   │ lifecycle reports + pid floor    │
+        │  cmux impl: read/watch   │   │  claude hook (ppid), codex        │
+        │  ~/.cmuxterm/*.json      │   │  app-server, opencode SSE,        │
+        │  → §7 stopped/gone free  │   │  headless child.pid, kill(pid,0)  │
+        └──────────────────────────┘   └───────────────────────────────────┘
+             preferred on cmux              fallback / other runtimes
+```
+
+- **`RuntimeDriver.liveness()` — new optional seam.** Each runtime driver may expose ground-truth
+  liveness. The **cmux** driver implements it by reading/watching the store file. The core depends
+  only on this **interface**, never on cmux directly — the cmux-coupling lives in the cmux driver,
+  which is its entire purpose. Other runtimes return `undefined` for now.
+- **Squadrant Liveness Registry — always-on, core-owned, persisted.** The single unifying source of
+  truth the daemon reads. On cmux it is kept in sync **from** `runtime.liveness()` (cmux is
+  authoritative). Where a runtime has no liveness view, the registry is populated directly by
+  lifecycle reports + the pid floor. Persisted to `<stateRoot>/liveness.json` (atomic write) so it
+  **outlives the daemon** — solving goal 4 for every runtime, not just cmux.
+
+This is exactly the user's decision: *use cmux's ground-truth when on cmux; otherwise squadrant owns
+liveness itself — achieving cmux's "beauty" while staying ready for new runtimes.*
+
+### 4.2 The registry entry — disjoint field ownership, one derivation
+
+Two signals own **different fields** on one entry, so they can never write conflicting values.
+
+```
+LivenessEntry {              // persisted; reconstructed/reconciled on boot (§5.3)
+  project:   string
+  role:      "captain" | "crew" | "command"
+  pid:       number | null   // from runtime.liveness() (cmux store) OR hook ppid OR child.pid
+  sessionId: string
+  startedAt: number
+  lastState: "start" | "end" // intent: open vs clean-close
+  lastSeenAt:number
+  pidAlive:  boolean         // written ONLY by the pid floor (kill(pid,0))
+  source:    "runtime" | "agent" | "scan"   // provenance (see 4.3)
+}
+```
+
+| Axis | Owner | Fields |
+|---|---|---|
+| **Presence / intent** — opened? cleanly closed? | `runtime.liveness()` (authoritative) or hooks | `pid`, `startedAt`, `lastState`, `sessionId` |
+| **Liveness** — process breathing? | **pid floor** (`kill(pid,0)`, per tick) | `pidAlive` only |
+
+State is a **read-only derivation** (first match wins — order matters):
+
+```
+no entry (never registered this session) ...... unknown
+entry & lastState = "end" ..................... stopped   // clean close; magenta, not a fault
+entry & pidAlive = false ...................... gone      // pid dead, record lingered → crash; red
+entry & pidAlive = true ....................... alive
+```
+
+**Absent runtime record ≠ deleted entry.** When `runtime.liveness()` stops returning a captain that
+was registered (user closed workspace/tab → cmux removed the store record), the reconcile step sets
+that entry's `lastState = "end"` (→ `stopped`) — it does **not** drop the entry. This is exactly why
+squadrant owns persistence: it remembers "this captain was here and cleanly closed" (`stopped`, calm)
+rather than forgetting it (`unknown`). An entry is only truly absent → `unknown` when the captain was
+never registered this session, or was long-since reaped.
+
+### 4.3 Reconciliation — the non-conflict rule (extends `reduceLifecycle`)
+
+Provenance precedence, mirroring the existing `origin` tie-break in `lifecycle-source.ts`:
+
+**`runtime` (ground-truth) ≥ `agent` (hook) > `scan` (pid floor).**
+
+- `runtime.liveness()` on cmux is authoritative for presence + intent: **record absent → `stopped`**,
+  **record present + pid dead → `gone`** (probe-proven, §7). No hook needed on cmux.
+- The pid floor (`scan`) is **liveness-only** — it may set `pidAlive=false` (→ `gone`/down) but may
+  never assert presence or intent over a `runtime`/`agent` signal.
+- **Monotonic tie-break:** `pidAlive=false` overrides a stale `alive`; a dead pid is only revived by
+  a **newer** open signal (new pid, newer `startedAt`). No oscillation. **← #517 impossible.**
+- **cmux vs squadrant registry never disagree destructively:** the registry *mirrors*
+  `runtime.liveness()` on cmux (cmux wins by precedence); off cmux it is fed by hooks + floor. The
+  two are reconciled by the same last-writer-by-provenance rule — one source is authoritative per
+  axis at any time.
+
+### 4.4 New `component`/`role` field (debuggability; do NOT overload `origin`)
+
+`role` (component) and `source`/`origin` are **orthogonal axes**. Keep `origin: "agent" | "scan"`
+in the shared crew `reduceLifecycle` **unchanged** (add `"runtime"` as a new authoritative peer of
+`agent`), and carry `role: captain|crew|command` additively. Logs get the full cross-product:
+
+```
+[captain/runtime] cmux record present pid=41030 → alive
+[captain/scan   ] pid 41030 dead, record lingers → gone      // crash
+[captain/runtime] cmux record absent → stopped               // user closed workspace/tab
+[crew/agent     ] notification → needsInput
+```
+
+### 4.5 Ground-truth-on-demand for the Telegram probe
+
+`createIsCaptainAlive` (`telegram/control.ts`) must resolve **fresh at call time** — never the cached
+streak: consult `runtime.liveness()` (or the registry + a live `kill(pid,0)`).
+
+- captain present & pid alive → `alive`
+- absent, or pid dead → **not alive** → boot-if-down launches (idempotent).
+
+Direct #517 fix: the daemon can never claim "delivered" to a dead captain.
+
+## 5. Coverage — proving the goals
+
+### 5.1 Close (goal 1) — §7 resolved by probe (real brove-mobile captain)
+
+| Method | Runtime record | pid | Result |
+|---|---|---|---|
+| (a) `squadrant … close` CLI | removed (also `lastState=end`) | dead | `stopped` |
+| (b) cmux workspace **X** | **removed** | dead | `stopped` |
+| (c) captain **tab** X (workspace kept by a sibling crew) | **removed** | dead | `stopped` |
+| (d) crash (`kill -9`) | **lingers** (`isRestorable=true`) | dead | `gone` |
+| (e) cmux **app** quit | removed with the app | dead | `stopped` |
+
+The pid floor is the universal liveness-catcher; **runtime-record presence is the intent
+discriminator** — no SessionEnd hook required on cmux. (App-quit (e) inferred from (b)/store
+teardown; not re-tested to avoid killing the operator's own session.)
+
+### 5.2 Open (goal 2)
+
+Every open path starts a claude session inside a cmux workspace → cmux writes the store record →
+`runtime.liveness()` surfaces it → the registry registers the captain. **Correlation key = the
+launch-template fingerprint** (`--append-system-prompt-file` basename): `captain.claude.md` ⇒
+captain, `crew.claude.md` ⇒ crew, `side.research.claude.md` ⇒ side. `cwd` alone is ambiguous
+(captain + side-session share `cwd` *and* `workspaceId` — observed live); project is derived from
+`cwd`/`workingDirectory`. Covers `launch`, dispatch, Telegram auto-launch, and manual open uniformly.
+Edge: a hibernated session can have `pid: null` (observed) → "record present ⇒ alive-unknown" until a
+real pid appears.
+
+Off cmux (future runtimes): the open signal arrives via that runtime's lifecycle source (hook /
+app-server / SSE), populating the registry directly.
+
+### 5.3 Restart survival (goal 4)
+
+`liveness.json` is persisted on every registry mutation (atomic write). On **daemon boot**:
+1. Load `liveness.json` → seed the in-memory registry.
+2. Reconcile against `runtime.liveness()` for each cmux project (authoritative — corrects anything
+   that changed while the daemon was down: captain closed → record absent → mark `lastState="end"`
+   (`stopped`), keep the entry; still running → refresh pid).
+3. pid floor confirms liveness on the first tick.
+
+Correct within one tick of any restart, for cmux *and* future runtimes (the file outlives the daemon
+regardless of whether the runtime's own store does).
+
+### 5.4 `RuntimeDriver.liveness()` seam
+
+```ts
+interface RuntimeDriver {
+  // …existing…
+  liveness?(): Promise<RuntimeLivenessRecord[]>;   // optional; cmux implements, others return undefined
+}
+interface RuntimeLivenessRecord {
+  role: "captain" | "crew" | "command" | "unknown";  // from launch-template fingerprint
+  project: string;                                    // from cwd / workingDirectory
+  pid: number | null;
+  sessionId: string;
+  present: boolean;          // record exists in the store
+  isRestorable?: boolean;    // lingering-after-crash hint
+}
+```
+
+cmux impl: read/watch `~/.cmuxterm/*-hook-sessions.json`; the record is rich (`pid`, `isRestorable`,
+`workspaceId`, `surfaceId`, `launchCommand.arguments` incl. cwd) — everything needed. Watch via
+`fs.watch` (reuse `CmuxStoreSource`; extend its `StoreSession` schema to read `launchCommand` +
+`workspaceId`).
+
+## 6. Dashboards (goal 3) — one source
+
+Registry → `projectHealth` → **one `health` IPC** → both consumers.
+
+- **Pane/CLI** (`health-view.ts`): already reads `health`. Fix is **upstream only** — `start.ts`
+  derives captain `HealthState` from the registry instead of the streak. Zero renderer changes.
+- **Web** (`read-status.ts`): must **also** read `health`. **Precedence:** captain liveness dominates
+  task activity — `gone`/`stopped` → row offline regardless of leftover tasks; `alive` → fall back to
+  task-derived `busy`/`blocked`/`idle`.
+
+## 7. State vocabulary (D1) — resolved
+
+**Reuse existing `HealthState` values — no new enum member.** The `stopped`↔`gone` discriminator is
+**runtime-record presence + a `kill(pid,0)` check** (probe-proven, §5.1), not SessionEnd:
+
+- runtime record **absent** (or `squadrant close` / `lastState=end`) → **`stopped`** (magenta, calm;
+  honors #324 "never red-alarm an expected shutdown")
+- runtime record **present but pid dead** → **`gone`** (red fault — a crash)
+- pid alive → `alive`; never registered → `unknown`
+
+Off cmux, where there is no runtime record: intent comes from SessionEnd/close-CLI (`lastState`), else
+abrupt-death defaults to `gone`.
+
+## 8. Affected code (run `gitnexus_impact` before editing each)
+
+| Area | File | Change |
+|---|---|---|
+| **Registry + persistence** | new `packages/core/src/daemon/liveness-registry.ts` | core-owned registry; load/save `<stateRoot>/liveness.json` (atomic); boot reconcile (§5.3) |
+| Daemon context | `packages/core/src/daemon/context.ts` | replace `captainMissingStreak` + `stoppedProjects` with the registry |
+| Health projection | `packages/core/src/daemon/start.ts` | derive captain `HealthState` from the registry; drop streak logic |
+| Liveness types/derivation | `packages/core/src/liveness.ts` | pure derivation (4.2) + reconciliation (4.3); testable |
+| Runtime seam | `packages/workspaces/src/runtimes/types.ts` (+ `cmux.ts`) | add `liveness()` to the driver interface; **cmux** impl reads/watches the store, keyed by template fingerprint |
+| cmux store reader | `packages/workspaces/src/cmux-daemon/cmux-store-source.ts` | extend `StoreSession` to read `launchCommand`/`workspaceId`/`surfaceId`; expose captain/crew/side by fingerprint |
+| Delivery loop | `packages/core/src/daemon/delivery-loop.ts` | remove title-sweep authority; add pid floor per tick |
+| Component field | `packages/core/src/lifecycle-source.ts` | add `role` + `source:"runtime"` (additive; `agent`/`scan` unchanged) |
+| Telegram probe | `packages/core/src/telegram/control.ts` | `createIsCaptainAlive` → fresh ground-truth at call time (#517 fix) |
+| Web dashboard | `packages/web/src/read-status.ts` | consume `health`; captain-liveness precedence |
+
+## 9. Testing
+
+- **Pure derivation/reconciliation** (`liveness.ts`): the 4 states + `runtime≥agent>scan` precedence
+  + pid-dead-beats-stale-alive + monotonic revive. No I/O.
+- **Persistence**: registry survives a simulated restart (save → new instance → load → reconcile).
+- **Ground-truth-on-demand**: `isCaptainAlive` false for dead pid / absent record; boot-if-down
+  launches. Regression for #517.
+- **Close matrix**: the 5 rows of §5.1 → correct `stopped` vs `gone`.
+- **cmux liveness()**: template-fingerprint correlation distinguishes captain/crew/side sharing
+  cwd+workspace; `pid:null` hibernation edge.
+- **Dashboard parity**: web + pane derive the same captain state from one `health` reply.
+- **All lifecycle/close/crash tests run on a throwaway TEST project** — never a real captain (a probe
+  on the real brove-mobile captain destroyed its in-flight session on 2026-07-07).
+- Agent-parity: verify cmux path now; codex/opencode `liveness()` are follow-ups.
+
+## 10. Rollout / risk
+
+- **Blast radius:** the `health` IPC shape is unchanged (`ComponentHealth[]`) — consumers keep
+  working. Run `gitnexus_impact` on `projectHealth`, `createIsCaptainAlive`, `discoverCaptainSurface`,
+  `deliveryTick` before editing. No new `HealthState` value → no renderer churn.
+- **Sequencing:** (1) registry + persistence + pure derivation + tests; (2) `runtime.liveness()`
+  seam + cmux impl (open + §7 + restart reconcile); (3) pid floor per tick (crash→gone); (4) Telegram
+  ground-truth-on-demand (#517); (5) web dashboard; (6) retire `captainMissingStreak`/`stoppedProjects`.
+  Each independently testable.
+
+## 11. Verification status — all §11 facts resolved
+
+- **FACT 1 (§7 X-button) — RESOLVED** on the real captain: workspace-X and tab-X → record **removed**
+  + pid dead (`stopped`); `kill -9` crash → record **lingers** `isRestorable=true` + pid dead
+  (`gone`). Color rule derives from store-presence + `kill(pid,0)` alone — **no SessionEnd hook
+  needed** on cmux.
+- **FACT 2 (hooks)** — captain hooks are crew-only today (net-new). Not on the cmux critical path;
+  hooks are the *off-cmux / future-runtime* population path (§4.1) and an optional fast-open
+  corroborator.
+- **FACT 3 (pid)** — cmux **CLI** exposes no pid, so the surface-query fallback is **dropped**; but
+  the cmux **store record is rich** (pid, isRestorable, workspaceId, surfaceId, launchCommand incl.
+  cwd) — the authoritative source. Same pid source interactive crews already rely on.
+- **FACT 4 (`SQUADRANT_CAPTAIN_PROJECT`)** — not needed for cmux discovery (template fingerprint +
+  cwd suffice). Only relevant if/when the off-cmux hook path is wired.
+- **Dropped:** the "daemon restart cadence" investigation — the restarts were the user's manual
+  rebuilds, not a crash-loop. The restart-*survival* requirement (§2.4 / §5.3) stays.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "squadrant",
   "packageManager": "pnpm@10.30.3",
-  "version": "0.14.3",
+  "version": "0.15.0",
   "description": "Multi-project orchestration for your coding agents (Claude, Codex, opencode, Gemini)",
   "type": "module",
   "bin": {

--- a/packages/cli/src/__tests__/squadrantd-daemon-direct.test.ts
+++ b/packages/cli/src/__tests__/squadrantd-daemon-direct.test.ts
@@ -283,40 +283,38 @@ describe("squadrantd daemon-direct (#332)", () => {
 
     const captainTitle = "p-captain";
     const crewPane = crewPaneTitle("p", "orphan");
-    let surfCall = 0;
-    // Index 0 is consumed by boot d.reconcile() (probes the crew's own pane —
-    // keep BOTH panes present so the crew survives reconcile and is reaped only
-    // by the captain-stopped path). Then tick N uses index N.
-    const surfResults: PaneRef[][] = [
-      [{ workspaceId: "ws:1", surfaceId: "s0", title: captainTitle }, { workspaceId: "ws:1", surfaceId: "sc", title: crewPane }], // reconcile: captain+crew present
-      [{ workspaceId: "ws:1", surfaceId: "s1", title: captainTitle }, { workspaceId: "ws:1", surfaceId: "sc", title: crewPane }], // tick 1: found → deliver
-      [{ workspaceId: "ws:1", surfaceId: "s2", title: "other" }], // tick 2: gone, streak=1
-      [{ workspaceId: "ws:1", surfaceId: "s2", title: "other" }], // tick 3: gone, streak=2
-      [{ workspaceId: "ws:1", surfaceId: "s2", title: "other" }], // tick 4: gone, streak=3 → reap crews + stop
-    ];
+    // Ground-truth liveness (Task 4): the registry — not the surface sweep —
+    // now decides captain presence. Surfaces stay present throughout so this
+    // test isolates the registry-driven reap from delivery-target discovery.
+    let captainPresent = true;
     const cmux = {
       sent: [] as Array<{ text: string }>,
       send: async (_surface: PaneRef, text: string) => { (cmux as any).sent.push({ text }); },
-      listSurfaces: async () => surfResults[Math.min(surfCall++, surfResults.length - 1)],
+      listSurfaces: async () => [
+        { workspaceId: "ws:1", surfaceId: "s1", title: captainTitle },
+        { workspaceId: "ws:1", surfaceId: "sc", title: crewPane },
+      ],
       readScreen: async () => null,
       isAvailable: async () => true,
       findWorkspaceId: async (name: string) => name === captainTitle ? "ws:1" : null,
+      liveness: async () => captainPresent
+        ? [{ role: "captain" as const, project: "p", pid: 424242, sessionId: "s", present: true }]
+        : [],
     } as unknown as DaemonCmux & { sent: Array<{ text: string }> };
 
-    const handle = startSquadrantd({ stateRoot, sockPath: sock, sweepMs: 0, daemonCmux: cmux });
+    const handle = startSquadrantd({ stateRoot, sockPath: sock, sweepMs: 0, daemonCmux: cmux, isPidAlive: () => true });
     stop = handle.stop;
 
-    // Let boot reconcile settle (consumes index 0) before the manual ticks.
+    // Let boot reconcile settle before the manual ticks.
     await new Promise((r) => setTimeout(r, 20));
 
     // Crew is still live (working) before the captain goes away.
     const before = await sendRequest(sock, { kind: "status", project: "p", id: "orphan-1" }) as TaskRecord;
     expect(before.state).toBe("working");
 
-    if (handle.tickDelivery) await handle.tickDelivery(); // tick 1: captain found → deliver
-    if (handle.tickDelivery) await handle.tickDelivery(); // tick 2: streak=1
-    if (handle.tickDelivery) await handle.tickDelivery(); // tick 3: streak=2
-    if (handle.tickDelivery) await handle.tickDelivery(); // tick 4: streak=3 → reap
+    if (handle.tickDelivery) await handle.tickDelivery(); // captain present → deliver, crew untouched
+    captainPresent = false; // captain workspace closed
+    if (handle.tickDelivery) await handle.tickDelivery(); // registry sees captain absent → stopped → reap
 
     // The orphaned crew is reaped to a terminal state with the captain-stopped marker.
     const after = await sendRequest(sock, { kind: "status", project: "p", id: "orphan-1" }) as TaskRecord;

--- a/packages/cli/src/commands/__tests__/init.test.ts
+++ b/packages/cli/src/commands/__tests__/init.test.ts
@@ -17,6 +17,15 @@ const emitMock = vi.hoisted(() => vi.fn(async (_src: unknown, dest: { path: stri
   bytesWritten: 42,
 })));
 
+const ensureGlobalOpencodeConfigMock = vi.hoisted(() =>
+  vi.fn((): string | null => "/tmp/mock-opencode/opencode.json"),
+);
+
+vi.mock("../../lib/per-crew-settings.js", () => ({
+  ensureGlobalOpencodeConfig: ensureGlobalOpencodeConfigMock,
+  DEFAULT_GLOBAL_OPENCODE_CONFIG_PATH: "/tmp/mock-opencode/opencode.json",
+}));
+
 vi.mock("@squadrant/shared", async () => {
   const actual = await vi.importActual<typeof import("@squadrant/shared")>("@squadrant/shared");
   return {
@@ -107,10 +116,20 @@ describe("init — non-TTY path", () => {
     expect(text).toContain("squadrant launch");
   });
 
-  it("does NOT call saveConfig in non-TTY mode (no side effects)", async () => {
+  it("prints opencode CLI install + global config guidance (#140)", async () => {
+    await runInit({ isTTY: false });
+
+    const text = output.join("\n");
+    expect(text).toContain("opencode");
+    expect(text).toContain("npm install -g opencode-ai");
+    expect(text).toContain("/tmp/mock-opencode/opencode.json");
+  });
+
+  it("does NOT call saveConfig or provision opencode config in non-TTY mode (no side effects)", async () => {
     await runInit({ isTTY: false });
     expect(saveConfigMock).not.toHaveBeenCalled();
     expect(ensureRuntimeSyncedMock).not.toHaveBeenCalled();
+    expect(ensureGlobalOpencodeConfigMock).not.toHaveBeenCalled();
   });
 
   it("does not hang when stdin is /dev/null equivalent (isTTY=false)", async () => {
@@ -216,6 +235,38 @@ describe("init — re-run-safe (TTY mode)", () => {
     expect(emitMock).toHaveBeenCalledTimes(3);
     const text = output.join("\n");
     expect(text).toMatch(/codex.*proj-codex|proj-codex.*codex/i);
+  });
+
+  it("provisions a default global opencode config when absent (#141)", async () => {
+    vi.spyOn(fs, "existsSync").mockImplementation(() => false);
+    vi.spyOn(fs, "mkdirSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "writeFileSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "readFileSync").mockImplementation(() => "{}");
+    vi.spyOn(fs, "copyFileSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "readdirSync").mockImplementation(() => []);
+    ensureGlobalOpencodeConfigMock.mockReturnValueOnce("/tmp/mock-opencode/opencode.json");
+
+    await runInit({ isTTY: true, hub: tmpDir });
+
+    expect(ensureGlobalOpencodeConfigMock).toHaveBeenCalledOnce();
+    const text = output.join("\n");
+    expect(text).toContain("Default model config created at /tmp/mock-opencode/opencode.json");
+  });
+
+  it("does NOT overwrite an existing global opencode config", async () => {
+    vi.spyOn(fs, "existsSync").mockImplementation(() => false);
+    vi.spyOn(fs, "mkdirSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "writeFileSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "readFileSync").mockImplementation(() => "{}");
+    vi.spyOn(fs, "copyFileSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "readdirSync").mockImplementation(() => []);
+    ensureGlobalOpencodeConfigMock.mockReturnValueOnce(null);
+
+    await runInit({ isTTY: true, hub: tmpDir });
+
+    expect(ensureGlobalOpencodeConfigMock).toHaveBeenCalledOnce();
+    const text = output.join("\n");
+    expect(text).toContain("/tmp/mock-opencode/opencode.json already exists (unchanged)");
   });
 
   it("skips agent-teams write when already enabled", async () => {

--- a/packages/cli/src/commands/__tests__/launch.test.ts
+++ b/packages/cli/src/commands/__tests__/launch.test.ts
@@ -7,13 +7,14 @@
 // the parent terminal. The fix routes them through cmuxLocal, which pipes
 // (captures) fd 2 instead of inheriting it. These tests pin that contract.
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const execFileMock = vi.hoisted(() => vi.fn());
+const execSyncMock = vi.hoisted(() => vi.fn());
 vi.mock("node:child_process", () => ({
   // launch.ts imports both; only execFileSync is exercised by cmuxLocal.
   execFileSync: execFileMock,
-  execSync: vi.fn(),
+  execSync: execSyncMock,
   execFile: vi.fn(),
 }));
 
@@ -23,7 +24,7 @@ vi.mock("@squadrant/shared", async () => {
 });
 
 import { cmuxLocal, classifyStartupSurface } from "@squadrant/workspaces";
-import { deliverStartupPrompt } from "../launch.js";
+import { deliverStartupPrompt, ensureCmuxReady } from "../launch.js";
 
 describe("cmuxLocal (@squadrant/workspaces direct-cmux helper)", () => {
   beforeEach(() => {
@@ -54,6 +55,48 @@ describe("cmuxLocal (@squadrant/workspaces direct-cmux helper)", () => {
   it("returns trimmed stdout for callers that need the output", () => {
     execFileMock.mockReturnValue("  workspace:7 squadrant-captain  \n");
     expect(cmuxLocal(["current-workspace"])).toBe("workspace:7 squadrant-captain");
+  });
+});
+
+// #520: `squadrant launch` run from the daemon (no CMUX_WORKSPACE_ID, no TTY)
+// silently no-op'd — ensureCmuxReady() opened the cmux GUI app and called
+// process.exit(0) before any workspace was ever created, so Telegram
+// auto-launch's ensureCaptainAlive polled isAlive() for the full warmup
+// window and always timed out. --headless lets a non-interactive caller
+// (the daemon) bypass the isInsideCmux() gate and drive launchOneWorkspace
+// directly, the same way crew-spawn already does from the daemon.
+describe("ensureCmuxReady (#520 daemon headless launch)", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let exitSpy: any;
+
+  beforeEach(() => {
+    execSyncMock.mockReset();
+    delete process.env.CMUX_WORKSPACE_ID;
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((): never => {
+      throw new Error("process.exit called");
+    }) as never);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+  });
+
+  it("does not open the cmux app or exit when headless=true, even outside cmux", () => {
+    expect(() => ensureCmuxReady(true)).not.toThrow();
+    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("still opens the cmux app and exits when headless=false and not inside cmux (pins existing interactive behavior)", () => {
+    expect(() => ensureCmuxReady(false)).toThrow("process.exit called");
+    expect(execSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not open the cmux app when already inside cmux, regardless of headless", () => {
+    process.env.CMUX_WORKSPACE_ID = "workspace:1";
+    expect(() => ensureCmuxReady(false)).not.toThrow();
+    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/cli/src/commands/effort.ts
+++ b/packages/cli/src/commands/effort.ts
@@ -18,9 +18,9 @@ export interface EffortGetResult {
   description: string;
 }
 
-export function runEffortGet(configPath = DEFAULT_CONFIG_PATH): EffortGetResult {
+export function runEffortGet(configPath = DEFAULT_CONFIG_PATH, projectName?: string): EffortGetResult {
   const config = loadConfig(configPath);
-  const effort = resolveEffort(config);
+  const effort = resolveEffort(config, projectName);
   const description = `${effort}: ${EFFORT_MEANING[effort]}`;
   return { effort, description };
 }
@@ -83,10 +83,12 @@ export async function notifyCaptainsOfEffort(
 export const effortCommand = new Command("effort")
   .description("Get or set the global crew tokenomics dial (max | balance | low)")
   .argument("[value]", "effort level to set: max | balance | low")
-  .action(async (value: string | undefined) => {
+  .option("--project <name>", "show resolved effort for a specific project")
+  .action(async (value: string | undefined, options: { project?: string }) => {
     if (value === undefined) {
-      const { effort, description } = runEffortGet();
-      console.log(chalk.bold("Current effort:"), chalk.cyan(effort));
+      const { effort, description } = runEffortGet(undefined, options.project);
+      const label = options.project ? `${options.project} project` : "global";
+      console.log(chalk.bold(`Current effort (${label}):`), chalk.cyan(effort));
       console.log(chalk.dim(EFFORT_MEANING[effort]));
       return;
     }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -15,6 +15,7 @@ import {
 } from "@squadrant/shared";
 import { createObsidianDriver, WorkspaceRegistry } from "@squadrant/workspaces";
 import { ensureRuntimeSynced } from "@squadrant/shared";
+import { ensureGlobalOpencodeConfig, DEFAULT_GLOBAL_OPENCODE_CONFIG_PATH } from "../lib/per-crew-settings.js";
 import {
   createCursorEmitter,
   createCodexEmitter,
@@ -81,6 +82,9 @@ export const initCommand = new Command("init")
       console.log(chalk.cyan("       /plugin marketplace add superpowers"));
       console.log(chalk.cyan("       /plugin marketplace add thedotmack/claude-mem"));
       console.log(chalk.cyan("       /plugin marketplace add context7"));
+      console.log(chalk.dim("\n       Using opencode crews? Install the CLI:"));
+      console.log(chalk.cyan("       npm install -g opencode-ai"));
+      console.log(chalk.dim(`       (squadrant provisions a default model in ${DEFAULT_GLOBAL_OPENCODE_CONFIG_PATH} if it's missing)`));
       console.log(chalk.bold("\n  4/5  Register first project"));
       console.log(chalk.cyan("       squadrant projects add <name> <path>"));
       console.log(chalk.bold("\n  5/5  Telegram (optional)"));
@@ -193,6 +197,16 @@ export const initCommand = new Command("init")
     console.log(chalk.cyan("      /plugin marketplace add thedotmack/claude-mem"));
     console.log(chalk.cyan("      /plugin marketplace add context7\n"));
     console.log(chalk.dim("    Squadrant never auto-installs plugins — open Claude Code and run the commands above."));
+
+    console.log(chalk.bold("\n    Using opencode crews?"));
+    console.log(chalk.cyan("      npm install -g opencode-ai"));
+    const opencodeConfigWritten = ensureGlobalOpencodeConfig();
+    if (opencodeConfigWritten) {
+      console.log(chalk.green(`    ✔ Default model config created at ${opencodeConfigWritten}`));
+    } else {
+      console.log(chalk.dim(`    - ${DEFAULT_GLOBAL_OPENCODE_CONFIG_PATH} already exists (unchanged)`));
+    }
+    console.log(chalk.dim("    Per-crew config deep-merges with this file — edit it to change opencode's default model/plugins/mcp."));
 
     // ── 4/5  Register first project ─────────────────────────────────────────
     stepHeader(4, 5, "Register first project");

--- a/packages/cli/src/commands/launch.ts
+++ b/packages/cli/src/commands/launch.ts
@@ -31,8 +31,12 @@ const CMUX_APP = "/Applications/cmux.app";
 const TEMPLATES_DIR = path.join(os.homedir(), ".config", "squadrant", "templates");
 const SESSIONS_PATH = path.join(os.homedir(), ".config", "squadrant", "sessions.json");
 
-function ensureCmuxReady(): void {
-  if (isInsideCmux()) return;
+// #520: a non-interactive caller (the daemon's Telegram boot-if-down path)
+// has no CMUX_WORKSPACE_ID and no terminal to run `open` from — headless=true
+// bypasses the isInsideCmux() gate entirely so launchOneWorkspace can drive
+// runtime.spawn directly, the same way crew-spawn already does from the daemon.
+export function ensureCmuxReady(headless: boolean): void {
+  if (headless || isInsideCmux()) return;
 
   console.log(chalk.yellow("\n  Not running inside cmux. Opening cmux app...\n"));
   execSync(`open "${CMUX_APP}"`, { stdio: "inherit" });
@@ -47,8 +51,10 @@ export const launchCommand = new Command("launch")
   .argument("[project]", "Project name to launch captain for")
   .option("--fresh", "Start a new session instead of resuming the last one")
   .option("--all", "Launch all captain workspaces")
-  .action(async (project: string | undefined, opts: { fresh?: boolean; all?: boolean }) => {
+  .option("--headless", "Skip the interactive cmux-app requirement (used by the daemon to boot captains without a terminal)")
+  .action(async (project: string | undefined, opts: { fresh?: boolean; all?: boolean; headless?: boolean }) => {
     const config = loadConfig();
+    let hadFailure = false;
 
     // Build agent driver registry
     const drivers = {
@@ -71,7 +77,7 @@ export const launchCommand = new Command("launch")
       pinToTop = false,
       projectName?: string,
     ): Promise<void> {
-      ensureCmuxReady();
+      ensureCmuxReady(!!opts.headless);
 
       const roleConfig = config.defaults.roles?.[role as keyof NonNullable<typeof config.defaults.roles>];
       const agentName = roleConfig?.agent || "claude";
@@ -116,6 +122,7 @@ export const launchCommand = new Command("launch")
         });
       } catch (err) {
         console.error(chalk.red(`  ✘ Failed: ${(err as Error).message}`));
+        hadFailure = true;
       }
     }
 
@@ -151,7 +158,7 @@ export const launchCommand = new Command("launch")
       }
 
       // Interactive: pick captains, then launch in parallel.
-      ensureCmuxReady();
+      ensureCmuxReady(!!opts.headless);
 
       const sessions = loadSessions(SESSIONS_PATH);
       const entries: CaptainEntry[] = Object.entries(config.projects).map(([name, proj]) => ({
@@ -215,4 +222,9 @@ export const launchCommand = new Command("launch")
       );
       await launchOne(proj.captainName, "captain", projPath, config.defaults.permissions?.captain || "auto", false, true, project);
     }
+
+    // #520: surface a real launch failure (e.g. cmux spawn error) as a non-zero
+    // exit so the daemon's execFile-based caller can tell launch didn't work,
+    // instead of silently exiting 0 while ensureCaptainAlive polls to a timeout.
+    if (hadFailure) process.exitCode = 1;
   });

--- a/packages/cli/src/lib/__tests__/daemon-restart-broadcast.test.ts
+++ b/packages/cli/src/lib/__tests__/daemon-restart-broadcast.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { getDefaultConfig } from "@squadrant/shared";
+import type { SquadrantConfig, ProjectConfig } from "@squadrant/shared";
+import {
+  computeRestartSignature,
+  readPersistedRestartSignature,
+  writePersistedRestartSignature,
+  notifyCaptainsOfDaemonRestart,
+  maybeBroadcastDaemonRestart,
+} from "../daemon-restart-broadcast.js";
+
+let dir: string;
+let stateRoot: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "squadrant-restart-broadcast-"));
+  stateRoot = path.join(dir, "state");
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+function project(p: string, captainName: string): ProjectConfig {
+  return { path: p, captainName, spokeVault: "", host: "" };
+}
+
+function configWithProjects(projects: Record<string, ProjectConfig>): SquadrantConfig {
+  const config = getDefaultConfig();
+  config.projects = projects;
+  return config;
+}
+
+function makeDriver(sent: Array<{ captain: string; message: string }>, failing = new Set<string>()) {
+  return {
+    async status(name: string) {
+      if (failing.has(name)) throw new Error(`unreachable: ${name}`);
+      return { id: name };
+    },
+    async send(ref: string, message: string) {
+      sent.push({ captain: ref, message });
+    },
+  };
+}
+
+describe("computeRestartSignature", () => {
+  it("combines version and build mtime into a stable string", () => {
+    expect(computeRestartSignature("0.14.3", 1000)).toBe(computeRestartSignature("0.14.3", 1000));
+  });
+
+  it("differs when version differs", () => {
+    expect(computeRestartSignature("0.14.3", 1000)).not.toBe(computeRestartSignature("0.14.4", 1000));
+  });
+
+  it("differs when build mtime differs", () => {
+    expect(computeRestartSignature("0.14.3", 1000)).not.toBe(computeRestartSignature("0.14.3", 2000));
+  });
+});
+
+describe("persisted restart signature", () => {
+  it("returns null when nothing is persisted yet", () => {
+    expect(readPersistedRestartSignature(stateRoot)).toBeNull();
+  });
+
+  it("round-trips a written signature", () => {
+    writePersistedRestartSignature(stateRoot, "0.14.3::1000");
+    expect(readPersistedRestartSignature(stateRoot)).toBe("0.14.3::1000");
+  });
+
+  it("overwrites a previously persisted signature", () => {
+    writePersistedRestartSignature(stateRoot, "0.14.3::1000");
+    writePersistedRestartSignature(stateRoot, "0.14.4::2000");
+    expect(readPersistedRestartSignature(stateRoot)).toBe("0.14.4::2000");
+  });
+});
+
+describe("notifyCaptainsOfDaemonRestart", () => {
+  it("notifies every running captain, with no self-exclusion", async () => {
+    const projA = fs.mkdtempSync(path.join(dir, "projA-"));
+    const projB = fs.mkdtempSync(path.join(dir, "projB-"));
+    const config = configWithProjects({
+      a: project(projA, "captain-a"),
+      b: project(projB, "captain-b"),
+    });
+    const sent: Array<{ captain: string; message: string }> = [];
+
+    await notifyCaptainsOfDaemonRestart("0.14.3", config, makeDriver(sent));
+
+    expect(sent.map((s) => s.captain).sort()).toEqual(["captain-a", "captain-b"]);
+  });
+
+  it("includes the version in the notice", async () => {
+    const projA = fs.mkdtempSync(path.join(dir, "projA-"));
+    const config = configWithProjects({ a: project(projA, "captain-a") });
+    const sent: Array<{ captain: string; message: string }> = [];
+
+    await notifyCaptainsOfDaemonRestart("0.14.3", config, makeDriver(sent));
+
+    expect(sent[0].message).toContain("0.14.3");
+  });
+
+  it("notes a dev build when isDevRebuild is true", async () => {
+    const projA = fs.mkdtempSync(path.join(dir, "projA-"));
+    const config = configWithProjects({ a: project(projA, "captain-a") });
+    const sent: Array<{ captain: string; message: string }> = [];
+
+    await notifyCaptainsOfDaemonRestart("0.14.3", config, makeDriver(sent), true);
+
+    expect(sent[0].message).toContain("dev build");
+  });
+
+  it("skips an unreachable captain without throwing and still notifies the rest", async () => {
+    const projA = fs.mkdtempSync(path.join(dir, "projA-"));
+    const projB = fs.mkdtempSync(path.join(dir, "projB-"));
+    const config = configWithProjects({
+      a: project(projA, "captain-a"),
+      b: project(projB, "captain-b"),
+    });
+    const sent: Array<{ captain: string; message: string }> = [];
+
+    await expect(
+      notifyCaptainsOfDaemonRestart("0.14.3", config, makeDriver(sent, new Set(["captain-a"]))),
+    ).resolves.not.toThrow();
+
+    expect(sent.map((s) => s.captain)).toEqual(["captain-b"]);
+  });
+
+  it("no-ops silently when no projects are registered", async () => {
+    const config = configWithProjects({});
+    const sent: Array<{ captain: string; message: string }> = [];
+
+    await notifyCaptainsOfDaemonRestart("0.14.3", config, makeDriver(sent));
+
+    expect(sent).toHaveLength(0);
+  });
+});
+
+describe("maybeBroadcastDaemonRestart", () => {
+  it("broadcasts and persists on first-ever boot (no persisted signature)", async () => {
+    const projA = fs.mkdtempSync(path.join(dir, "projA-"));
+    const config = configWithProjects({ a: project(projA, "captain-a") });
+    const sent: Array<{ captain: string; message: string }> = [];
+
+    await maybeBroadcastDaemonRestart({
+      version: "0.14.3",
+      buildMtimeMs: 1000,
+      stateRoot,
+      config,
+      driver: makeDriver(sent),
+    });
+
+    expect(sent).toHaveLength(1);
+    expect(readPersistedRestartSignature(stateRoot)).toBe(computeRestartSignature("0.14.3", 1000));
+  });
+
+  it("broadcasts when the signature changed since last boot", async () => {
+    const projA = fs.mkdtempSync(path.join(dir, "projA-"));
+    const config = configWithProjects({ a: project(projA, "captain-a") });
+    writePersistedRestartSignature(stateRoot, computeRestartSignature("0.14.2", 500));
+    const sent: Array<{ captain: string; message: string }> = [];
+
+    await maybeBroadcastDaemonRestart({
+      version: "0.14.3",
+      buildMtimeMs: 1000,
+      stateRoot,
+      config,
+      driver: makeDriver(sent),
+    });
+
+    expect(sent).toHaveLength(1);
+    expect(readPersistedRestartSignature(stateRoot)).toBe(computeRestartSignature("0.14.3", 1000));
+  });
+
+  it("stays silent when the signature is unchanged (same-version crash-restart)", async () => {
+    const projA = fs.mkdtempSync(path.join(dir, "projA-"));
+    const config = configWithProjects({ a: project(projA, "captain-a") });
+    writePersistedRestartSignature(stateRoot, computeRestartSignature("0.14.3", 1000));
+    const sent: Array<{ captain: string; message: string }> = [];
+
+    await maybeBroadcastDaemonRestart({
+      version: "0.14.3",
+      buildMtimeMs: 1000,
+      stateRoot,
+      config,
+      driver: makeDriver(sent),
+    });
+
+    expect(sent).toHaveLength(0);
+  });
+
+  it("never throws even when the driver fails entirely", async () => {
+    const projA = fs.mkdtempSync(path.join(dir, "projA-"));
+    const config = configWithProjects({ a: project(projA, "captain-a") });
+    const throwingDriver = {
+      async status(): Promise<{ id: string } | null> {
+        throw new Error("boom");
+      },
+      async send(): Promise<void> {
+        throw new Error("boom");
+      },
+    };
+
+    await expect(
+      maybeBroadcastDaemonRestart({
+        version: "0.14.3",
+        buildMtimeMs: 1000,
+        stateRoot,
+        config,
+        driver: throwingDriver,
+      }),
+    ).resolves.not.toThrow();
+  });
+});

--- a/packages/cli/src/lib/__tests__/per-crew-settings.test.ts
+++ b/packages/cli/src/lib/__tests__/per-crew-settings.test.ts
@@ -9,6 +9,8 @@ import {
   healStaleCockpitRefs,
   CREW_PERMISSION_ALLOWLIST,
   mergeCrewPermissions,
+  ensureGlobalOpencodeConfig,
+  DEFAULT_GLOBAL_OPENCODE_CONFIG_PATH,
 } from "../per-crew-settings.js";
 
 describe("writePerCrewSettings", () => {
@@ -372,5 +374,66 @@ describe("writePerCrewOpencodeConfig", () => {
     expect(json.permission.edit).toBe("allow");
     expect(json.permission.read).toBe("allow");
     expect(json.permission.external_directory).toEqual({ "**": "allow" });
+  });
+});
+
+describe("ensureGlobalOpencodeConfig — #141 provision-if-absent", () => {
+  let tmp: string;
+  const configPath = () => path.join(tmp, "opencode", "opencode.json");
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "squadrant-global-opencode-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("writes a minimal default config (schema + model) when none exists", () => {
+    const out = ensureGlobalOpencodeConfig(configPath());
+    expect(out).toBe(configPath());
+    expect(fs.existsSync(configPath())).toBe(true);
+    const json = JSON.parse(fs.readFileSync(configPath(), "utf-8"));
+    expect(json).toEqual({
+      $schema: "https://opencode.ai/config.json",
+      model: "anthropic/claude-sonnet-4-5",
+    });
+  });
+
+  it("creates intermediate directories", () => {
+    ensureGlobalOpencodeConfig(configPath());
+    expect(fs.statSync(path.dirname(configPath())).isDirectory()).toBe(true);
+  });
+
+  it("returns null and never overwrites an existing config", () => {
+    fs.mkdirSync(path.dirname(configPath()), { recursive: true });
+    const existing = JSON.stringify({ model: "user-chosen/model", plugin: ["some-plugin"] }, null, 2);
+    fs.writeFileSync(configPath(), existing);
+
+    const out = ensureGlobalOpencodeConfig(configPath());
+
+    expect(out).toBeNull();
+    expect(fs.readFileSync(configPath(), "utf-8")).toBe(existing);
+  });
+
+  it("does not clobber a config written concurrently between the two racing calls (TOCTOU)", () => {
+    // Simulates two callers racing to provision the same absent path: the
+    // exclusive-create ('wx') write means only the first writer's content
+    // survives — no existsSync-then-writeFileSync gap for a second caller to
+    // land in between.
+    const first = ensureGlobalOpencodeConfig(configPath());
+    const contentAfterFirst = fs.readFileSync(configPath(), "utf-8");
+
+    const second = ensureGlobalOpencodeConfig(configPath());
+
+    expect(first).toBe(configPath());
+    expect(second).toBeNull();
+    expect(fs.readFileSync(configPath(), "utf-8")).toBe(contentAfterFirst);
+  });
+
+  it("default path constant points at ~/.config/opencode/opencode.json", () => {
+    expect(DEFAULT_GLOBAL_OPENCODE_CONFIG_PATH).toBe(
+      path.join(os.homedir(), ".config", "opencode", "opencode.json"),
+    );
   });
 });

--- a/packages/cli/src/lib/daemon-restart-broadcast.ts
+++ b/packages/cli/src/lib/daemon-restart-broadcast.ts
@@ -1,0 +1,96 @@
+// Best-effort "daemon restarted" broadcast to all running captains, fired on
+// daemon boot — but only when the running build actually changed (version or
+// local rebuild), not on a same-build launchd crash-restart. Modeled exactly
+// on notifyCaptainsOfEffort (commands/effort.ts): same driver seam, same
+// best-effort/never-throw contract.
+import fs from "node:fs";
+import path from "node:path";
+import type { SquadrantConfig } from "@squadrant/shared";
+
+/** Minimal slice of RuntimeDriver used to notify a captain. */
+export interface DaemonRestartNotifyDriver {
+  status(nameOrId: string): Promise<{ id: string } | null>;
+  send(ref: string, message: string): Promise<void>;
+}
+
+function statePath(stateRoot: string): string {
+  return path.join(stateRoot, "daemon-restart-state.json");
+}
+
+/** version + build-file mtime — differs on a version bump AND on a local
+ *  rebuild of the same version (mtime moves), but not on a plain restart. */
+export function computeRestartSignature(version: string, buildMtimeMs: number): string {
+  return `${version}::${buildMtimeMs}`;
+}
+
+export function readPersistedRestartSignature(stateRoot: string): string | null {
+  try {
+    const raw = fs.readFileSync(statePath(stateRoot), "utf-8");
+    const data = JSON.parse(raw) as { signature?: string };
+    return typeof data.signature === "string" ? data.signature : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writePersistedRestartSignature(stateRoot: string, signature: string): void {
+  fs.mkdirSync(stateRoot, { recursive: true });
+  fs.writeFileSync(statePath(stateRoot), JSON.stringify({ signature }, null, 2) + "\n");
+}
+
+function restartNotice(version: string, isDevRebuild: boolean): string {
+  const suffix = isDevRebuild ? " (dev build)" : "";
+  return `⚠️ Daemon restarted → v${version}${suffix} (control-plane bounced). Re-verify in-flight crews — a crew mid-first-turn may need a crew send.`;
+}
+
+/**
+ * Send the daemon-restart notice to every running captain. Unlike
+ * notifyCaptainsOfEffort there is no initiating cwd captain to exclude — the
+ * daemon boots independently of any captain — so this reaches ALL of them.
+ */
+export async function notifyCaptainsOfDaemonRestart(
+  version: string,
+  config: SquadrantConfig,
+  driver: DaemonRestartNotifyDriver,
+  isDevRebuild = false,
+): Promise<void> {
+  const notice = restartNotice(version, isDevRebuild);
+  for (const [, proj] of Object.entries(config.projects)) {
+    try {
+      const ref = await driver.status(proj.captainName);
+      if (ref) {
+        await driver.send(ref.id, notice);
+      }
+    } catch {
+      // individual project captain unreachable — skip
+    }
+  }
+}
+
+export interface MaybeBroadcastDaemonRestartOpts {
+  version: string;
+  buildMtimeMs: number;
+  stateRoot: string;
+  config: SquadrantConfig;
+  driver: DaemonRestartNotifyDriver;
+}
+
+/**
+ * Boot-time entry point: compare this boot's (version, buildMtime) signature
+ * against the last persisted one. Differs → broadcast + persist. Same → stay
+ * silent (e.g. launchd crash-restart of an identical build). Fully
+ * best-effort — never throws, so it can never block or crash daemon boot.
+ */
+export async function maybeBroadcastDaemonRestart(opts: MaybeBroadcastDaemonRestartOpts): Promise<void> {
+  try {
+    const { version, buildMtimeMs, stateRoot, config, driver } = opts;
+    const signature = computeRestartSignature(version, buildMtimeMs);
+    const previous = readPersistedRestartSignature(stateRoot);
+    if (previous === signature) return;
+    const isDevRebuild = previous !== null && previous.split("::")[0] === version;
+    await notifyCaptainsOfDaemonRestart(version, config, driver, isDevRebuild);
+    writePersistedRestartSignature(stateRoot, signature);
+  } catch {
+    // best-effort — never let a broadcast failure block or crash daemon boot
+  }
+}

--- a/packages/cli/src/lib/per-crew-settings.ts
+++ b/packages/cli/src/lib/per-crew-settings.ts
@@ -1,5 +1,6 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
 import { mergeClaudeHooks } from "@squadrant/agents";
 
 /**
@@ -205,6 +206,33 @@ export function writePerCrewSettingsLocal(o: {
  * BLOCKED → captain's decision is POSTed back). Default (no flag) keeps bash
  * "allow" — opencode crews stay fully autonomous unless `--approval` is passed.
  */
+export const DEFAULT_GLOBAL_OPENCODE_CONFIG_PATH = join(homedir(), ".config", "opencode", "opencode.json");
+
+/**
+ * #141: provision a minimal global opencode.json (model default) the first time
+ * squadrant runs `init`, so a fresh user's opencode crews don't silently fall
+ * back to opencode's own defaults (see writePerCrewOpencodeConfig doc above —
+ * the per-crew config deep-merges with this file for model/plugin/mcp). Never
+ * overwrites an existing file — uses an exclusive-create write ('wx') so a
+ * concurrent writer wins the race instead of one clobbering the other (no
+ * separate existsSync check, which would TOCTOU-race a concurrent create).
+ * Returns the path if it wrote one, or null if a config was already present.
+ */
+export function ensureGlobalOpencodeConfig(configPath: string = DEFAULT_GLOBAL_OPENCODE_CONFIG_PATH): string | null {
+  mkdirSync(dirname(configPath), { recursive: true });
+  const defaultConfig = {
+    $schema: "https://opencode.ai/config.json",
+    model: "anthropic/claude-sonnet-4-5",
+  };
+  try {
+    writeFileSync(configPath, JSON.stringify(defaultConfig, null, 2) + "\n", { flag: "wx" });
+    return configPath;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "EEXIST") return null;
+    throw err;
+  }
+}
+
 export function writePerCrewOpencodeConfig(o: {
   stateRoot: string;
   project: string;

--- a/packages/cli/src/squadrantd.ts
+++ b/packages/cli/src/squadrantd.ts
@@ -4,7 +4,7 @@
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
-import { readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { buildContext } from "@squadrant/core";
 import { createAttach } from "@squadrant/core";
 import { startDaemon } from "@squadrant/core";
@@ -22,9 +22,10 @@ export { discoverCaptainSurface } from "@squadrant/core";
 import type { AttachFrame } from "@squadrant/core";
 import type { PaneRef } from "@squadrant/shared";
 import { runHeadless, CodexInteractiveDriver, OpencodeSseBridge, CodexAppServerSource } from "@squadrant/agents";
-import { CmuxEventsBridge, DaemonCmux, CmuxStoreSource, NativeHookSource, resendCrewFirstTurn } from "@squadrant/workspaces";
+import { CmuxEventsBridge, DaemonCmux, CmuxStoreSource, NativeHookSource, resendCrewFirstTurn, RuntimeRegistry } from "@squadrant/workspaces";
 import { loadConfig, TERMINAL_STATES } from "@squadrant/shared";
 import { createCmuxDriver } from "@squadrant/workspaces";
+import { maybeBroadcastDaemonRestart } from "./lib/daemon-restart-broadcast.js";
 
 const SELF_PATH = fileURLToPath(import.meta.url);
 // Bundled CLI bin sits next to this daemon entry (dist/index.js · dist/squadrantd.js).
@@ -304,6 +305,28 @@ export function startSquadrantd(opts: import("@squadrant/core").SquadrantdOpts =
     };
     try { codexAppServerSource.start(codexSourceDeps); }
     catch (e) { log(`codex app-server source start failed: ${(e as Error).message}`); }
+  }
+
+  // Daemon-restart broadcast: notify every running captain that the daemon
+  // bounced, but only when the running build actually changed (version bump
+  // or local rebuild) — a same-build launchd crash-restart stays silent.
+  // Skipped under vitest (touches the real config + cmux driver, mirrors the
+  // other real-I/O boot actions guarded the same way above).
+  if (!process.env.VITEST) {
+    try {
+      const buildMtimeMs = statSync(SELF_PATH).mtimeMs;
+      const restartConfig = loadConfig();
+      const registry = new RuntimeRegistry({ cmux: createCmuxDriver() });
+      void maybeBroadcastDaemonRestart({
+        version: PKG_VERSION,
+        buildMtimeMs,
+        stateRoot,
+        config: restartConfig,
+        driver: registry.global(restartConfig),
+      });
+    } catch (e) {
+      log(`daemon-restart broadcast setup failed: ${(e as Error).message}`);
+    }
   }
 
   const origStop = h.stop.bind(h);

--- a/packages/cli/src/squadrantd.ts
+++ b/packages/cli/src/squadrantd.ts
@@ -60,7 +60,7 @@ function buildTelegramBridge(
   // sender is allowlisted (gated inside the bridge); passing them is always safe.
   const ensureCaptainAlive = createEnsureCaptainAlive({
     isAlive: createIsCaptainAlive(DAEMON_SOCK),
-    launch: createLaunch(CLI_BIN),
+    launch: createLaunch(CLI_BIN, log),
   });
   const runCommand = createRunCommand(CLI_BIN);
   const sendReply = (threadId: number | undefined, text: string, replyMarkup?: unknown) =>

--- a/packages/core/src/__tests__/group-dispatch.test.ts
+++ b/packages/core/src/__tests__/group-dispatch.test.ts
@@ -12,7 +12,7 @@ vi.mock("@squadrant/shared", () => ({
   resolveHome: (p: string) => p,
 }));
 
-import { dispatchToSibling } from "../group-dispatch.js";
+import { dispatchToSibling, isCaptainAlive } from "../group-dispatch.js";
 
 const makeConfig = (overrides: Record<string, any> = {}) => {
   const projects: Record<string, any> = {
@@ -205,5 +205,38 @@ describe("dispatchToSibling", () => {
     expect((result as any).project).toBe("projB");
     expect((result as any).state).toBe("submitted");
     expect((result as any).task).toBe("update the docs");
+  });
+});
+
+// ── isCaptainAlive (#517: "stopped" was mistakenly treated as alive) ─────────
+describe("isCaptainAlive", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns true only when the captain row reports state 'alive'", async () => {
+    sendRequestMock.mockResolvedValue([
+      { kind: "captain", project: "projA", state: "alive", lastSeenMs: Date.now() },
+    ]);
+    expect(await isCaptainAlive("projA")).toBe(true);
+  });
+
+  it("returns false when the captain workspace was closed (state 'stopped' = down)", async () => {
+    sendRequestMock.mockResolvedValue([
+      { kind: "captain", project: "projA", state: "stopped", lastSeenMs: Date.now() },
+    ]);
+    expect(await isCaptainAlive("projA")).toBe(false);
+  });
+
+  it("returns false when the captain state is unknown", async () => {
+    sendRequestMock.mockResolvedValue([
+      { kind: "captain", project: "projA", state: "unknown", lastSeenMs: null },
+    ]);
+    expect(await isCaptainAlive("projA")).toBe(false);
+  });
+
+  it("returns false when there is no captain row at all", async () => {
+    sendRequestMock.mockResolvedValue([]);
+    expect(await isCaptainAlive("projA")).toBe(false);
   });
 });

--- a/packages/core/src/__tests__/liveness-derive.test.ts
+++ b/packages/core/src/__tests__/liveness-derive.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { deriveCaptainState, reconcileLiveness } from "../liveness.js";
+import type { LivenessEntry } from "@squadrant/shared";
+
+const base = (o: Partial<LivenessEntry> = {}): LivenessEntry => ({
+  project: "p", role: "captain", pid: 100, sessionId: "s", startedAt: 1_000,
+  lastState: "start", lastSeenAt: 1_000, pidAlive: true, source: "runtime", ...o,
+});
+
+describe("deriveCaptainState", () => {
+  it("undefined entry → unknown", () => expect(deriveCaptainState(undefined)).toBe("unknown"));
+  it("lastState=end → stopped (before pid check)", () =>
+    expect(deriveCaptainState(base({ lastState: "end", pidAlive: false }))).toBe("stopped"));
+  it("pid dead + record present (crash) → gone", () =>
+    expect(deriveCaptainState(base({ lastState: "start", pidAlive: false }))).toBe("gone"));
+  it("pid alive → alive", () => expect(deriveCaptainState(base())).toBe("alive"));
+});
+
+describe("reconcileLiveness — runtime ≥ agent > scan", () => {
+  it("scan may set pidAlive=false but not override runtime presence", () => {
+    const prev = base({ source: "runtime", lastState: "start", pidAlive: true });
+    const scan = base({ source: "scan", pidAlive: false, lastSeenAt: 2_000 });
+    const out = reconcileLiveness(prev, scan);
+    expect(out.pidAlive).toBe(false);      // liveness axis updated
+    expect(out.lastState).toBe("start");   // presence/intent unchanged by scan
+    expect(out.source).toBe("runtime");
+  });
+  it("scan cannot resurrect a dead pid; only a newer runtime/agent open does", () => {
+    const prev = base({ pidAlive: false, startedAt: 1_000 });
+    const staleScan = base({ source: "scan", pidAlive: true, startedAt: 1_000, lastSeenAt: 900 });
+    expect(reconcileLiveness(prev, staleScan).pidAlive).toBe(false);
+    const reopen = base({ source: "runtime", pid: 200, startedAt: 3_000, pidAlive: true });
+    expect(reconcileLiveness(prev, reopen).pidAlive).toBe(true);
+  });
+  it("runtime record end → lastState=end, entry kept (not dropped)", () => {
+    const prev = base({ source: "runtime", lastState: "start" });
+    const closed = base({ source: "runtime", lastState: "end", lastSeenAt: 2_000 });
+    expect(reconcileLiveness(prev, closed).lastState).toBe("end");
+  });
+});

--- a/packages/core/src/__tests__/telegram-control.test.ts
+++ b/packages/core/src/__tests__/telegram-control.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const sendRequestMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../protocol.js", () => ({
+  sendRequest: sendRequestMock,
+}));
+
+import { createIsCaptainAlive } from "../telegram/control.js";
+
+// #517: Telegram auto-launch never fires because isAlive() misreports a down
+// captain as alive. Captain rows only ever report "alive" | "stopped" | "unknown"
+// (see liveness.ts projectHealth) — "stopped" means the workspace was closed.
+describe("createIsCaptainAlive", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const isAlive = createIsCaptainAlive("/tmp/fake.sock");
+
+  it("returns true when the captain row reports state 'alive'", async () => {
+    sendRequestMock.mockResolvedValue([
+      { kind: "captain", project: "squadrant", state: "alive" },
+    ]);
+    expect(await isAlive("squadrant")).toBe(true);
+  });
+
+  it("returns false when the captain workspace was closed (state 'stopped' = down)", async () => {
+    sendRequestMock.mockResolvedValue([
+      { kind: "captain", project: "squadrant", state: "stopped" },
+    ]);
+    expect(await isAlive("squadrant")).toBe(false);
+  });
+
+  it("returns false when the captain state is unknown", async () => {
+    sendRequestMock.mockResolvedValue([
+      { kind: "captain", project: "squadrant", state: "unknown" },
+    ]);
+    expect(await isAlive("squadrant")).toBe(false);
+  });
+
+  it("returns false when there is no captain row at all", async () => {
+    sendRequestMock.mockResolvedValue([]);
+    expect(await isAlive("squadrant")).toBe(false);
+  });
+
+  it("returns false when the health request throws", async () => {
+    sendRequestMock.mockRejectedValue(new Error("socket unreachable"));
+    expect(await isAlive("squadrant")).toBe(false);
+  });
+});

--- a/packages/core/src/__tests__/telegram-control.test.ts
+++ b/packages/core/src/__tests__/telegram-control.test.ts
@@ -1,12 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const sendRequestMock = vi.hoisted(() => vi.fn());
+const execFileMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../protocol.js", () => ({
   sendRequest: sendRequestMock,
 }));
 
-import { createIsCaptainAlive } from "../telegram/control.js";
+vi.mock("node:child_process", () => ({
+  execFile: execFileMock,
+}));
+
+import { createIsCaptainAlive, createLaunch } from "../telegram/control.js";
 
 // #517: Telegram auto-launch never fires because isAlive() misreports a down
 // captain as alive. Captain rows only ever report "alive" | "stopped" | "unknown"
@@ -47,5 +52,51 @@ describe("createIsCaptainAlive", () => {
   it("returns false when the health request throws", async () => {
     sendRequestMock.mockRejectedValue(new Error("socket unreachable"));
     expect(await isAlive("squadrant")).toBe(false);
+  });
+});
+
+// #520: the daemon's boot-if-down path shells out to `squadrant launch <project>`
+// via createLaunch, but its stdout/stderr were discarded and a real failure
+// (non-zero exit) was swallowed silently — ensureCaptainAlive just polled
+// isAlive() for the full warmup window with zero diagnostic trail. createLaunch
+// must now (1) pass --headless so the daemon's non-interactive launch actually
+// boots instead of opening the cmux GUI app and exiting, (2) capture + log
+// subprocess output for diagnostics, and (3) reject on failure so the daemon
+// can tell launch didn't work.
+describe("createLaunch (#520 daemon headless launch)", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  it("invokes `launch <project> --headless` so the daemon's non-interactive call actually boots the captain", async () => {
+    execFileMock.mockImplementation((_file, _args, _opts, callback) => {
+      callback(null, "", "");
+    });
+    const launch = createLaunch("/bin/squadrant-cli.js");
+    await launch("squadrant");
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    const [file, args] = execFileMock.mock.calls[0];
+    expect(file).toBe(process.execPath);
+    expect(args).toEqual(["/bin/squadrant-cli.js", "launch", "squadrant", "--headless"]);
+  });
+
+  it("logs captured subprocess output on success", async () => {
+    execFileMock.mockImplementation((_file, _args, _opts, callback) => {
+      callback(null, "  ✔ Workspace created\n", "");
+    });
+    const log = vi.fn();
+    const launch = createLaunch("/bin/squadrant-cli.js", log);
+    await launch("squadrant");
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("Workspace created"));
+  });
+
+  it("logs the captured output and rejects when the subprocess fails", async () => {
+    execFileMock.mockImplementation((_file, _args, _opts, callback) => {
+      callback(new Error("Command failed"), "", "cmux spawn did not return a workspace id");
+    });
+    const log = vi.fn();
+    const launch = createLaunch("/bin/squadrant-cli.js", log);
+    await expect(launch("squadrant")).rejects.toThrow();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("cmux spawn did not return a workspace id"));
   });
 });

--- a/packages/core/src/daemon/__tests__/liveness-registry.test.ts
+++ b/packages/core/src/daemon/__tests__/liveness-registry.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { LivenessRegistry } from "../liveness-registry.js";
+import type { LivenessEntry } from "@squadrant/shared";
+
+function memFs() {
+  const store = new Map<string, string>();
+  return {
+    store,
+    readFile: (p: string) => store.get(p),
+    writeFile: (p: string, c: string) => void store.set(p, c),
+  };
+}
+const cap = (o: Partial<LivenessEntry> = {}): LivenessEntry => ({
+  project: "p", role: "captain", pid: 100, sessionId: "s", startedAt: 1_000,
+  lastState: "start", lastSeenAt: 1_000, pidAlive: true, source: "runtime", ...o,
+});
+
+describe("LivenessRegistry", () => {
+  it("persists and reloads across a simulated restart", () => {
+    const fs = memFs();
+    const r1 = new LivenessRegistry({ path: "/x/liveness.json", ...fs });
+    r1.apply(cap());
+    const r2 = new LivenessRegistry({ path: "/x/liveness.json", ...fs });
+    r2.load();
+    expect(r2.get("p")?.pid).toBe(100);
+  });
+  it("markEnded keeps the entry (→ stopped, not forgotten)", () => {
+    const fs = memFs();
+    const r = new LivenessRegistry({ path: "/x/liveness.json", ...fs });
+    r.apply(cap());
+    r.markEnded("p", 2_000);
+    expect(r.get("p")?.lastState).toBe("end");
+  });
+  it("setPidAlive updates liveness only", () => {
+    const fs = memFs();
+    const r = new LivenessRegistry({ path: "/x/liveness.json", ...fs });
+    r.apply(cap());
+    r.setPidAlive("p", false, 2_000);
+    expect(r.get("p")?.pidAlive).toBe(false);
+    expect(r.get("p")?.lastState).toBe("start");
+  });
+  it("corrupt file loads as empty (no throw)", () => {
+    const fs = memFs(); fs.store.set("/x/liveness.json", "{not json");
+    const r = new LivenessRegistry({ path: "/x/liveness.json", ...fs });
+    expect(() => r.load()).not.toThrow();
+    expect(r.all()).toEqual([]);
+  });
+});

--- a/packages/core/src/daemon/__tests__/liveness-tick.test.ts
+++ b/packages/core/src/daemon/__tests__/liveness-tick.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { LivenessRegistry } from "../liveness-registry.js";
+import { runLivenessTick } from "../delivery-loop.js";
+import type { RuntimeLivenessRecord } from "@squadrant/shared";
+
+const memReg = () => new LivenessRegistry({ path: "/x/l.json", readFile: () => undefined, writeFile: () => {} });
+
+describe("runLivenessTick", () => {
+  it("registers a captain from the runtime snapshot and marks it alive", async () => {
+    const reg = memReg();
+    const rec: RuntimeLivenessRecord = { role: "captain", project: "p", pid: 100, sessionId: "s", present: true };
+    await runLivenessTick({ registry: reg, liveness: async () => [rec], isPidAlive: () => true, now: () => 5_000 });
+    expect(reg.get("p")?.pidAlive).toBe(true);
+    expect(reg.get("p")?.lastState).toBe("start");
+  });
+  it("captain absent from snapshot → markEnded (stopped), entry kept", async () => {
+    const reg = memReg();
+    reg.apply({ project: "p", role: "captain", pid: 100, sessionId: "s", startedAt: 1_000, lastState: "start", lastSeenAt: 1_000, pidAlive: true, source: "runtime" });
+    await runLivenessTick({ registry: reg, liveness: async () => [], isPidAlive: () => true, now: () => 5_000 });
+    expect(reg.get("p")?.lastState).toBe("end");
+  });
+  it("present record + dead pid → pidAlive false (→ gone)", async () => {
+    const reg = memReg();
+    const rec: RuntimeLivenessRecord = { role: "captain", project: "p", pid: 100, sessionId: "s", present: true, isRestorable: true };
+    await runLivenessTick({ registry: reg, liveness: async () => [rec], isPidAlive: () => false, now: () => 5_000 });
+    expect(reg.get("p")?.pidAlive).toBe(false);
+  });
+
+  it("captain absent from snapshot (→ stopped) triggers reap", async () => {
+    const reg = memReg();
+    reg.apply({ project: "p", role: "captain", pid: 100, sessionId: "s", startedAt: 1_000, lastState: "start", lastSeenAt: 1_000, pidAlive: true, source: "runtime" });
+    const reaped: string[] = [];
+    await runLivenessTick({ registry: reg, liveness: async () => [], isPidAlive: () => true, now: () => 5_000, reap: (p) => { reaped.push(p); return 0; } });
+    expect(reaped).toEqual(["p"]);
+  });
+  it("present record + dead pid (→ gone) triggers reap", async () => {
+    const reg = memReg();
+    const rec: RuntimeLivenessRecord = { role: "captain", project: "p", pid: 100, sessionId: "s", present: true, isRestorable: true };
+    const reaped: string[] = [];
+    await runLivenessTick({ registry: reg, liveness: async () => [rec], isPidAlive: () => false, now: () => 5_000, reap: (p) => { reaped.push(p); return 0; } });
+    expect(reaped).toEqual(["p"]);
+  });
+  it("alive captain does not trigger reap", async () => {
+    const reg = memReg();
+    const rec: RuntimeLivenessRecord = { role: "captain", project: "p", pid: 100, sessionId: "s", present: true };
+    const reaped: string[] = [];
+    await runLivenessTick({ registry: reg, liveness: async () => [rec], isPidAlive: () => true, now: () => 5_000, reap: (p) => { reaped.push(p); return 0; } });
+    expect(reaped).toEqual([]);
+  });
+  it("no reap dep supplied → tick still completes (optional)", async () => {
+    const reg = memReg();
+    reg.apply({ project: "p", role: "captain", pid: 100, sessionId: "s", startedAt: 1_000, lastState: "start", lastSeenAt: 1_000, pidAlive: true, source: "runtime" });
+    await expect(
+      runLivenessTick({ registry: reg, liveness: async () => [], isPidAlive: () => true, now: () => 5_000 }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/daemon/__tests__/liveness-tick.test.ts
+++ b/packages/core/src/daemon/__tests__/liveness-tick.test.ts
@@ -54,4 +54,20 @@ describe("runLivenessTick", () => {
       runLivenessTick({ registry: reg, liveness: async () => [], isPidAlive: () => true, now: () => 5_000 }),
     ).resolves.toBeUndefined();
   });
+
+  it("liveness() throwing (bad read, e.g. locked/corrupt store) leaves the registry untouched — NOT markEnded", async () => {
+    const reg = memReg();
+    reg.apply({ project: "p", role: "captain", pid: 100, sessionId: "s", startedAt: 1_000, lastState: "start", lastSeenAt: 1_000, pidAlive: true, source: "runtime" });
+    const reaped: string[] = [];
+    await runLivenessTick({
+      registry: reg,
+      liveness: async () => { throw new Error("all store files unreadable this tick"); },
+      isPidAlive: () => true,
+      now: () => 5_000,
+      reap: (p) => { reaped.push(p); return 0; },
+    });
+    expect(reg.get("p")?.lastState).toBe("start"); // NOT "end" — no false close
+    expect(reg.get("p")?.pidAlive).toBe(true);
+    expect(reaped).toEqual([]); // no reap on a failed read
+  });
 });

--- a/packages/core/src/daemon/__tests__/liveness-tick.test.ts
+++ b/packages/core/src/daemon/__tests__/liveness-tick.test.ts
@@ -70,4 +70,26 @@ describe("runLivenessTick", () => {
     expect(reg.get("p")?.pidAlive).toBe(true);
     expect(reaped).toEqual([]); // no reap on a failed read
   });
+
+  it("logs [role/source] project pid=… → state when applying a present record", async () => {
+    const reg = memReg();
+    const rec: RuntimeLivenessRecord = { role: "captain", project: "p", pid: 100, sessionId: "s", present: true };
+    const lines: string[] = [];
+    await runLivenessTick({ registry: reg, liveness: async () => [rec], isPidAlive: () => true, now: () => 5_000, log: (m) => lines.push(m) });
+    expect(lines).toContainEqual(expect.stringContaining("[captain/runtime] p pid=100 → alive"));
+  });
+  it("logs the state transition when a captain goes absent (→ stopped)", async () => {
+    const reg = memReg();
+    reg.apply({ project: "p", role: "captain", pid: 100, sessionId: "s", startedAt: 1_000, lastState: "start", lastSeenAt: 1_000, pidAlive: true, source: "runtime" });
+    const lines: string[] = [];
+    await runLivenessTick({ registry: reg, liveness: async () => [], isPidAlive: () => true, now: () => 5_000, log: (m) => lines.push(m) });
+    expect(lines).toContainEqual(expect.stringContaining("[captain/runtime] p pid=100 → stopped"));
+  });
+  it("no log dep supplied → tick still completes (optional)", async () => {
+    const reg = memReg();
+    const rec: RuntimeLivenessRecord = { role: "captain", project: "p", pid: 100, sessionId: "s", present: true };
+    await expect(
+      runLivenessTick({ registry: reg, liveness: async () => [rec], isPidAlive: () => true, now: () => 5_000 }),
+    ).resolves.toBeUndefined();
+  });
 });

--- a/packages/core/src/daemon/context.ts
+++ b/packages/core/src/daemon/context.ts
@@ -17,6 +17,7 @@ import type { AgentDriver, OpencodeBridge, CmuxEventsBridge, DaemonSurfaceDriver
 import type { TelegramBridge } from "../telegram/bridge.js";
 import type { AttachFrame } from "../protocol.js";
 import type { LifecycleSource } from "../lifecycle-source.js";
+import { LivenessRegistry } from "./liveness-registry.js";
 
 // ── Public injectable options (equivalent of old squadrantd.ts SquadrantdOpts) ───
 
@@ -109,10 +110,8 @@ export interface DaemonContext {
   inFlightHeadlessIds: Set<string>;
   /** Cancel handles for in-flight headless runs. */
   activeHeadlessKills: Set<() => void>;
-  /** #332 delivery streak counter per project for captain-absent reaping. */
-  captainMissingStreak: Map<string, number>;
-  /** #332 projects whose captain surface is confirmed gone. */
-  stoppedProjects: Set<string>;
+  /** Ground-truth captain liveness — persisted, survives daemon restart (§4.1/§5.3). */
+  livenessRegistry: LivenessRegistry;
 
   // ── Late-bound: assigned by start.ts before any timer/server fires ──────────
 
@@ -180,8 +179,11 @@ export function buildContext(opts: SquadrantdOpts): DaemonContext {
     attachConns: new Map(),
     inFlightHeadlessIds: new Set(),
     activeHeadlessKills: new Set(),
-    captainMissingStreak: new Map(),
-    stoppedProjects: new Set(),
+    livenessRegistry: (() => {
+      const r = new LivenessRegistry({ path: join(stateRoot, "liveness.json") });
+      r.load();
+      return r;
+    })(),
     resendFirstTurn: opts.resendFirstTurn,
     // Late-bound — start.ts fills these before first use:
     d: null as unknown as ReturnType<typeof createDaemon>,

--- a/packages/core/src/daemon/delivery-loop.ts
+++ b/packages/core/src/daemon/delivery-loop.ts
@@ -55,6 +55,14 @@ export interface LivenessTickDeps {
    *  liveness-only callers can omit it. Idempotent (already-terminal crews are
    *  skipped), so calling it every tick for a non-alive captain is safe. */
   reap?: (project: string) => number;
+  /** One grep-able line per applied/transitioned record (§4.4): `[role/source]
+   *  project pid=… → state`. Optional so pure liveness-only callers can omit it. */
+  log?: (msg: string) => void;
+}
+
+function logEntry(log: ((msg: string) => void) | undefined, project: string, e: LivenessEntry | undefined): void {
+  if (!log || !e) return;
+  log(`[${e.role}/${e.source}] ${project} pid=${e.pid} → ${deriveCaptainState(e)}`);
 }
 
 /** One reconcile+floor pass over captain records. Runtime snapshot is authoritative;
@@ -80,12 +88,14 @@ export async function runLivenessTick(deps: LivenessTickDeps): Promise<void> {
     if (prev && prev.lastState === "start") entry.startedAt = prev.startedAt;
     deps.registry.apply(entry);
     if (r.pid != null) deps.registry.setPidAlive(r.project, deps.isPidAlive(r.pid), now);
+    logEntry(deps.log, r.project, deps.registry.get(r.project));
   }
 
   // Captains we knew but the snapshot no longer lists → clean close.
   for (const e of deps.registry.all()) {
     if (e.role === "captain" && e.lastState === "start" && !seen.has(e.project)) {
       deps.registry.markEnded(e.project, now);
+      logEntry(deps.log, e.project, deps.registry.get(e.project));
     }
   }
 
@@ -164,6 +174,7 @@ export function createDelivery(
       liveness: () => (cmux.liveness ? cmux.liveness() : Promise.resolve([])),
       isPidAlive,
       now: () => Date.now(),
+      log,
       reap: (project) => {
         const reaped = reapOrphanedCrews(store, project);
         if (reaped > 0) {

--- a/packages/core/src/daemon/delivery-loop.ts
+++ b/packages/core/src/daemon/delivery-loop.ts
@@ -4,14 +4,15 @@ import { appendToMailbox, readCursor, writeCursor, readFromCursor } from "../mai
 import { CaptainDelivery, type CaptainDeliveryStats } from "../delivery/captain-delivery.js";
 import { loadConfig, TERMINAL_STATES } from "@squadrant/shared";
 import { STALE_THRESHOLD_MS } from "./interactive-probe.js";
-import type { TaskRecord, ControlEvent } from "@squadrant/shared";
+import { deriveCaptainState } from "../liveness.js";
+import type { TaskRecord, ControlEvent, RuntimeLivenessRecord, LivenessEntry } from "@squadrant/shared";
 import type { PaneRef } from "@squadrant/shared";
 import type { Store } from "../store.js";
 import type { DaemonSurfaceDriver } from "../interfaces.js";
 import type { DaemonContext } from "./context.js";
+import type { LivenessRegistry } from "./liveness-registry.js";
 
 const CURSOR_SUBSCRIBER = "captain";
-const CAPTAIN_GONE_STREAK_K = 3;
 
 // Must-deliver event kinds that bypass the stale-skip path (#474 D1).
 // Includes terminal transitions (done/failed/cancelled) AND task.blocked:
@@ -44,6 +45,61 @@ export function reapOrphanedCrews(store: Pick<Store, "list" | "put">, project: s
   return reaped;
 }
 
+export interface LivenessTickDeps {
+  registry: LivenessRegistry;
+  liveness: () => Promise<RuntimeLivenessRecord[]>;
+  isPidAlive: (pid: number) => boolean;
+  now: () => number;
+  /** Reap a stopped/gone captain's orphaned crews (#324 — fold-in of the old
+   *  streak-triggered reap, now driven by the registry). Optional so pure
+   *  liveness-only callers can omit it. Idempotent (already-terminal crews are
+   *  skipped), so calling it every tick for a non-alive captain is safe. */
+  reap?: (project: string) => number;
+}
+
+/** One reconcile+floor pass over captain records. Runtime snapshot is authoritative;
+ *  the pid floor arbitrates liveness; a captain absent from the snapshot is marked
+ *  cleanly-closed (stopped) but NOT dropped. */
+export async function runLivenessTick(deps: LivenessTickDeps): Promise<void> {
+  const now = deps.now();
+  let records: RuntimeLivenessRecord[] = [];
+  try { records = await deps.liveness(); } catch { return; } // runtime unreachable → leave registry as-is
+  const seen = new Set<string>();
+
+  for (const r of records) {
+    if (r.role !== "captain") continue;
+    seen.add(r.project);
+    const entry: LivenessEntry = {
+      project: r.project, role: "captain", pid: r.pid, sessionId: r.sessionId,
+      startedAt: now, lastState: "start", lastSeenAt: now,
+      pidAlive: r.pid != null ? deps.isPidAlive(r.pid) : true, // pid:null hibernated → alive-unknown
+      source: "runtime",
+    };
+    // Preserve original startedAt if we already knew this captain (avoid churn):
+    const prev = deps.registry.get(r.project);
+    if (prev && prev.lastState === "start") entry.startedAt = prev.startedAt;
+    deps.registry.apply(entry);
+    if (r.pid != null) deps.registry.setPidAlive(r.project, deps.isPidAlive(r.pid), now);
+  }
+
+  // Captains we knew but the snapshot no longer lists → clean close.
+  for (const e of deps.registry.all()) {
+    if (e.role === "captain" && e.lastState === "start" && !seen.has(e.project)) {
+      deps.registry.markEnded(e.project, now);
+    }
+  }
+
+  // Reap orphaned crews for any captain the registry now considers stopped
+  // (clean close) or gone (crash).
+  if (deps.reap) {
+    for (const e of deps.registry.all()) {
+      if (e.role !== "captain") continue;
+      const state = deriveCaptainState(e);
+      if (state === "stopped" || state === "gone") deps.reap(e.project);
+    }
+  }
+}
+
 export interface DeliveryResult {
   defaultNotify: (args: { project: string; message: string; record: TaskRecord; event: ControlEvent }) => Promise<void>;
   /** Guarded delivery tick — undefined when daemon-direct mode is OFF. */
@@ -57,7 +113,7 @@ export function createDelivery(
   ctx: DaemonContext,
   daemonCmux: DaemonSurfaceDriver | undefined,
 ): DeliveryResult {
-  const { stateRoot, store, log, captainMissingStreak, stoppedProjects, opts } = ctx;
+  const { stateRoot, store, log, livenessRegistry, isPidAlive, opts } = ctx;
 
   // ── Default push-notification wiring (mailbox-injector spec) ─────────────
   const defaultNotify = async (args: {
@@ -101,6 +157,23 @@ export function createDelivery(
   let delivering = false;
 
   const deliveryCore = async () => {
+    // Registry is the liveness authority (Task 4) — reconcile it from the
+    // runtime snapshot + pid floor before this tick's per-project pass.
+    await runLivenessTick({
+      registry: livenessRegistry,
+      liveness: () => (cmux.liveness ? cmux.liveness() : Promise.resolve([])),
+      isPidAlive,
+      now: () => Date.now(),
+      reap: (project) => {
+        const reaped = reapOrphanedCrews(store, project);
+        if (reaped > 0) {
+          const title = cfg.projects?.[project]?.captainName ?? `${project}-captain`;
+          log(`captain ${title}: reaped ${reaped} orphaned crew(s)`);
+        }
+        return reaped;
+      },
+    });
+
     const injectedSurfaces = opts.captainSurfaces ?? {};
     const allProjects = [...new Set([
       ...Object.keys(cfg.projects ?? {}),
@@ -112,44 +185,20 @@ export function createDelivery(
       const projCfg = cfg.projects?.[project];
       const captainTitle = projCfg?.captainName ?? `${project}-captain`;
 
-      // Try real discovery from cmux.
+      // Surface discovery is ONLY for the delivery target (where to cmux.send);
+      // captain presence/liveness authority now lives in livenessRegistry.
       const wsId = cmux.findWorkspaceId ? await cmux.findWorkspaceId(captainTitle) : null;
       let surface: PaneRef | null = null;
-      let surfacesLength = 0;
 
       if (wsId) {
         const surfaces = await cmux.listSurfaces(wsId);
-        surfacesLength = surfaces.length;
         surface = discoverCaptainSurface(surfaces, captainTitle);
       }
 
       // Fall back to injected surface (tests / config-less projects).
       if (!surface) surface = injectedSurfaces[project] ?? null;
 
-      if (surface) {
-        // Captain found — if previously reaped, un-reap and reset streak.
-        if (stoppedProjects.has(project)) {
-          stoppedProjects.delete(project);
-          captainMissingStreak.set(project, 0);
-        }
-        captainMissingStreak.set(project, 0);
-      } else {
-        // Streak tracking: surfaces.length > 0 means cmux is reachable but the
-        // captain's pane is provably absent. surfaces.length === 0 means cmux
-        // was unreachable (fail-soft → []), treat as "unknown" — never increment.
-        if (surfacesLength > 0) {
-          const streak = (captainMissingStreak.get(project) ?? 0) + 1;
-          captainMissingStreak.set(project, streak);
-          if (streak >= CAPTAIN_GONE_STREAK_K) {
-            if (!stoppedProjects.has(project)) {
-              stoppedProjects.add(project);
-              const reaped = reapOrphanedCrews(store, project);
-              log(`captain ${captainTitle}: surface gone for ${CAPTAIN_GONE_STREAK_K} sweeps — stopping delivery${reaped > 0 ? `, reaped ${reaped} orphaned crew(s)` : ""}`);
-            }
-          }
-        }
-        continue;
-      }
+      if (!surface) continue;
 
       const cursor = await readCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER });
       const lastAcked = cursor?.lastAckedSeq ?? 0;

--- a/packages/core/src/daemon/liveness-registry.ts
+++ b/packages/core/src/daemon/liveness-registry.ts
@@ -1,0 +1,58 @@
+import { writeFileSync, readFileSync, renameSync } from "node:fs";
+import type { LivenessEntry } from "@squadrant/shared";
+import { reconcileLiveness } from "../liveness.js";
+
+export interface LivenessRegistryOpts {
+  path: string;
+  readFile?: (p: string) => string | undefined;
+  writeFile?: (p: string, content: string) => void;
+}
+
+/** Core-owned, disk-persisted registry — the single liveness source of truth. */
+export class LivenessRegistry {
+  private readonly path: string;
+  private readonly readFile: (p: string) => string | undefined;
+  private readonly writeFile: (p: string, content: string) => void;
+  private map = new Map<string, LivenessEntry>();
+
+  constructor(opts: LivenessRegistryOpts) {
+    this.path = opts.path;
+    this.readFile = opts.readFile ?? ((p) => { try { return readFileSync(p, "utf-8"); } catch { return undefined; } });
+    this.writeFile = opts.writeFile ?? ((p, c) => { writeFileSync(`${p}.tmp`, c); renameSync(`${p}.tmp`, p); });
+  }
+
+  load(): void {
+    const raw = this.readFile(this.path);
+    if (!raw) return;
+    try {
+      const arr = JSON.parse(raw) as LivenessEntry[];
+      this.map = new Map(arr.map((e) => [e.project, e]));
+    } catch { this.map = new Map(); }
+  }
+
+  get(project: string): LivenessEntry | undefined { return this.map.get(project); }
+  all(): LivenessEntry[] { return [...this.map.values()]; }
+
+  apply(next: LivenessEntry): void {
+    this.map.set(next.project, reconcileLiveness(this.map.get(next.project), next));
+    this.persist();
+  }
+
+  markEnded(project: string, at: number): void {
+    const e = this.map.get(project);
+    if (!e) return;
+    this.map.set(project, { ...e, lastState: "end", lastSeenAt: at });
+    this.persist();
+  }
+
+  setPidAlive(project: string, alive: boolean, at: number): void {
+    const e = this.map.get(project);
+    if (!e) return;
+    this.map.set(project, { ...e, pidAlive: alive, lastSeenAt: at });
+    this.persist();
+  }
+
+  private persist(): void {
+    try { this.writeFile(this.path, JSON.stringify(this.all(), null, 2)); } catch { /* best-effort */ }
+  }
+}

--- a/packages/core/src/daemon/start.ts
+++ b/packages/core/src/daemon/start.ts
@@ -11,7 +11,7 @@ import { createDelivery } from "./delivery-loop.js";
 import { createGateResolver } from "./gates.js";
 import { createServer } from "./server.js";
 import { rotateIfNeeded, mailboxStats, readCursor } from "../mailbox.js";
-import { projectHealth, type ComponentHealth } from "../liveness.js";
+import { projectHealth, deriveCaptainState, type ComponentHealth } from "../liveness.js";
 import type { DaemonSnapshotInputs } from "../snapshot.js";
 import { loadConfig, TERMINAL_STATES, ensureCmuxAutoConfig } from "@squadrant/shared";
 import { distBuiltAt, gatherLogStats, gatherStoreStats, gatherResults } from "./snapshot-gather.js";
@@ -99,15 +99,14 @@ export function startDaemon(ctx: DaemonContext, opts: SquadrantdOpts, pkgVersion
     for (const project of names) {
       const proj = config.projects[project];
       const captainName = proj?.captainName ?? `${project}-captain`;
-      // Captain liveness from the delivery loop: stopped=true → gone,
-      // streak===0 → alive (last tick found the surface), else unknown.
-      const stopped = ctx.stoppedProjects.has(project);
-      const streak = ctx.captainMissingStreak.get(project);
-      const captainStopped: boolean | null = stopped ? true : streak === 0 ? false : null;
+      // Captain liveness from the ground-truth registry (Task 4) — runtime
+      // snapshot + pid floor, survives daemon restart (§4.1/§4.5).
+      const capEntry = ctx.livenessRegistry.get(project);
       out.push(
         ...projectHealth({
           project, now, captainName,
-          captainStopped,
+          captainStopped: null,
+          captainState: deriveCaptainState(capEntry),
           commandPresent: null,
           crews: store.list(project),
         }),

--- a/packages/core/src/group-dispatch.ts
+++ b/packages/core/src/group-dispatch.ts
@@ -36,7 +36,10 @@ export async function isCaptainAlive(
       kind: string; project: string; state: string;
     }>;
     const captain = health?.find((h) => h.kind === "captain" && h.project === project);
-    return captain != null && captain.state !== "gone" && captain.state !== "unknown";
+    // Captain rows only ever report "alive" | "stopped" | "unknown" (see
+    // liveness.ts projectHealth) — "stopped" means the workspace was closed
+    // (down), so it must NOT count as alive.
+    return captain?.state === "alive";
   } catch {
     return false;
   }

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -2,7 +2,7 @@
 // Driver-seam interfaces: the contracts that squadrantd's driver-agnostic core depends on.
 // Concrete implementations (CodexInteractiveDriver, OpencodeSseBridge, CmuxEventsBridge,
 // DaemonCmux) live in the root package host and implement these structurally.
-import type { PaneRef } from "@squadrant/shared";
+import type { PaneRef, RuntimeLivenessRecord } from "@squadrant/shared";
 
 /** Interactive agent runtime driver (codex/claude/opencode thread ops). */
 export interface AgentDriver {
@@ -44,4 +44,7 @@ export interface DaemonSurfaceDriver extends DirectCmuxReader {
   listSurfaces(wsId: string): Promise<PaneRef[]>;
   send: (surface: PaneRef, text: string, opts?: { probe?: boolean }) => Promise<void>;
   readPaneScreen(pane: PaneRef): Promise<string | null>;
+  /** Ground-truth liveness from the runtime's own session store (§5.4).
+   *  Optional — a runtime with no such store omits it. */
+  liveness?(): Promise<RuntimeLivenessRecord[]>;
 }

--- a/packages/core/src/liveness.ts
+++ b/packages/core/src/liveness.ts
@@ -80,7 +80,9 @@ export interface CrewLiveness {
  * Emits: a captain row, a command row (only when applicable), and one row per
  * non-terminal crew.
  *
- * Captain liveness (#332): driven by the daemon-direct delivery loop.
+ * Captain liveness: prefers the registry-derived `captainState` (§4.1/§4.5 —
+ * ground-truth from the LivenessRegistry) when supplied; falls back to the
+ * legacy `captainStopped` tri-state for callers that haven't migrated:
  *   captainStopped === false  → captain surface was found on last delivery tick → ALIVE
  *   captainStopped === true   → surface gone for 3+ consecutive ticks → STOPPED
  *                               (intentional close — its crews are reaped and
@@ -91,8 +93,10 @@ export function projectHealth(input: {
   project: string;
   now: number;
   captainName: string;
-  /** Delivery-loop captain surface state. See docs above. */
+  /** Delivery-loop captain surface state. See docs above. Ignored when `captainState` is supplied. */
   captainStopped: boolean | null;
+  /** Registry-derived captain state (Task 4+). Wins over `captainStopped` when present. */
+  captainState?: HealthState;
   /** true/false when a command workspace is expected; null = not applicable. */
   commandPresent: boolean | null;
   crews: CrewLiveness[];
@@ -101,17 +105,21 @@ export function projectHealth(input: {
   const out: ComponentHealth[] = [];
 
   // ── captain ────────────────────────────────────────────────────────────
-  const captainState: HealthState =
+  const captainState: HealthState = input.captainState ?? (
     captainStopped === true ? "stopped" :
     captainStopped === false ? "alive" :
-    "unknown";
+    "unknown"
+  );
   out.push({
     kind: "captain",
     project,
     ref: captainName,
     state: captainState,
     lastSeenMs: null,
-    detail: captainState === "stopped" ? "captain workspace closed — crews reaped; delivery paused" : undefined,
+    detail:
+      captainState === "stopped" ? "captain workspace closed — crews reaped; delivery paused" :
+      captainState === "gone" ? "captain process died (crash) — crews reaped" :
+      undefined,
   });
 
   // ── command (on-demand; only surfaced when applicable) ───────────────────

--- a/packages/core/src/liveness.ts
+++ b/packages/core/src/liveness.ts
@@ -5,7 +5,7 @@
 // so it is fully unit-testable. All runtime probing (cmux reads for captain
 // presence) is gathered by the caller (squadrantd) and passed in already-resolved;
 // this module never touches cmux.
-import type { TaskState, Mode } from "@squadrant/shared";
+import type { TaskState, Mode, LivenessEntry } from "@squadrant/shared";
 
 export type ComponentKind = "captain" | "crew" | "command";
 
@@ -175,3 +175,40 @@ export function healCmdFor(c: ComponentHealth): string | null {
 
 /** Per-project relay health — REMOVED (#332). No longer tracked by daemon. */
 export type RelayHealth = never;
+
+/**
+ * Pure. Derive a captain HealthState from its registry entry.
+ * First match wins — order matters (a clean close reads `stopped` even though
+ * its pid also dies).
+ */
+export function deriveCaptainState(e: LivenessEntry | undefined): HealthState {
+  if (!e) return "unknown";
+  if (e.lastState === "end") return "stopped"; // clean close — magenta, not a fault (#324)
+  if (!e.pidAlive) return "gone";              // pid dead, record present → crash
+  return "alive";
+}
+
+/**
+ * Pure. Reconcile an incoming signal against the prior entry.
+ * Precedence: runtime ≥ agent (authoritative for presence/intent) > scan
+ * (liveness-only). A `scan` updates `pidAlive` but never presence/intent, and
+ * never resurrects a dead pid — only a newer runtime/agent open (greater
+ * startedAt) does.
+ */
+export function reconcileLiveness(
+  prev: LivenessEntry | undefined,
+  next: LivenessEntry,
+): LivenessEntry {
+  if (!prev) return next;
+  if (next.source === "scan") {
+    // liveness-only: adopt pidAlive (and lastSeenAt) onto prev; keep presence/intent.
+    // A stale scan (older than prev, by lastSeenAt — scans of the same session
+    // share startedAt, so recency must be judged by lastSeenAt) must not flip a
+    // dead pid back to alive.
+    const pidAlive = next.lastSeenAt >= prev.lastSeenAt ? next.pidAlive : prev.pidAlive;
+    return { ...prev, pidAlive, lastSeenAt: Math.max(prev.lastSeenAt, next.lastSeenAt) };
+  }
+  // runtime/agent authoritative. A newer open (or any end) wins; a stale one is ignored.
+  if (next.startedAt >= prev.startedAt || next.lastState === "end") return next;
+  return prev;
+}

--- a/packages/core/src/telegram/__tests__/is-captain-alive.test.ts
+++ b/packages/core/src/telegram/__tests__/is-captain-alive.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { isCaptainAliveFromHealth } from "../control.js";
+import type { ComponentHealth } from "../../liveness.js";
+
+const row = (state: string): ComponentHealth =>
+  ({ kind: "captain", project: "p", ref: "c", state: state as any, lastSeenMs: null });
+
+describe("isCaptainAliveFromHealth", () => {
+  it("alive → true", () => expect(isCaptainAliveFromHealth([row("alive")], "p")).toBe(true));
+  it("gone (crash) → false → boot", () => expect(isCaptainAliveFromHealth([row("gone")], "p")).toBe(false));
+  it("stopped (closed) → false → boot", () => expect(isCaptainAliveFromHealth([row("stopped")], "p")).toBe(false));
+  it("unknown/missing → false", () => expect(isCaptainAliveFromHealth([], "p")).toBe(false));
+});

--- a/packages/core/src/telegram/bridge.test.ts
+++ b/packages/core/src/telegram/bridge.test.ts
@@ -110,6 +110,21 @@ describe("handleUpdate routing", () => {
     expect(d.appendCaptainMessage).toHaveBeenCalledWith(
       expect.objectContaining({ project: "brove", source: "telegram" }),
     );
+    // #517 follow-up: "launched" is a live-captain-reachable success, same as "alive".
+    expect(d.sendReply).toHaveBeenCalledWith(7, "📨 delivered to brove captain");
+    bridge.stop();
+  });
+
+  it("acks delivery when the captain was already alive (no boot needed)", async () => {
+    setTopic(stateRoot, "brove", 7);
+    const cfg = { ...baseCfg, remoteControl: true, users: [ALLOWED_USER] };
+    const d = deps({ ensureCaptainAlive: vi.fn(async () => "alive" as const) });
+    const { bridge, drained } = drive({ cfg, ...d }, [topicMsg("ship it", 7)]);
+    await drained;
+    expect(d.sendReply).toHaveBeenCalledWith(7, "📨 delivered to brove captain");
+    expect(d.appendCaptainMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ project: "brove", source: "telegram" }),
+    );
     bridge.stop();
   });
 
@@ -125,13 +140,16 @@ describe("handleUpdate routing", () => {
     bridge.stop();
   });
 
-  it("warns into the topic when warmup times out but still queues the message", async () => {
+  it("sends an explicit failure into the topic when warmup times out but still queues the message", async () => {
     setTopic(stateRoot, "brove", 7);
     const cfg = { ...baseCfg, remoteControl: true, users: [ALLOWED_USER] };
     const d = deps({ ensureCaptainAlive: vi.fn(async () => "timeout" as const) });
     const { bridge, drained } = drive({ cfg, ...d }, [topicMsg("ship it", 7)]);
     await drained;
-    expect(d.sendReply).toHaveBeenCalledWith(7, expect.stringContaining("warm up"));
+    expect(d.sendReply).toHaveBeenCalledWith(
+      7,
+      "❌ couldn't reach brove captain — saved to mailbox, will deliver when you open the workspace.",
+    );
     expect(d.appendCaptainMessage).toHaveBeenCalled();
     bridge.stop();
   });

--- a/packages/core/src/telegram/bridge.ts
+++ b/packages/core/src/telegram/bridge.ts
@@ -407,7 +407,15 @@ export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridg
     if (ensureCaptainAlive && isControlEnabled(cfg) && isAuthorized(fromId, cfg)) {
       try {
         const r = await ensureCaptainAlive(resolved.project);
-        if (r === "timeout") await reply(threadId, "⚠️ captain didn't warm up; message queued.");
+        // The ensure() result IS the delivery signal — "live captain reachable",
+        // not "message read" (no cap-side ack protocol). Surfacing it means a
+        // false-positive isAlive (#517) fails loud in Telegram instead of silently
+        // stranding the message in the mailbox.
+        if (r === "timeout") {
+          await reply(threadId, `❌ couldn't reach ${resolved.project} captain — saved to mailbox, will deliver when you open the workspace.`);
+        } else {
+          await reply(threadId, `📨 delivered to ${resolved.project} captain`);
+        }
       } catch (e) {
         log(`telegram auto-launch failed project=${resolved.project}: ${(e as Error).message}`);
       }

--- a/packages/core/src/telegram/control.ts
+++ b/packages/core/src/telegram/control.ts
@@ -54,7 +54,10 @@ export function createIsCaptainAlive(sock: string): (project: string) => Promise
         kind: string; project: string; state: string;
       }>;
       const captain = health?.find((h) => h.kind === "captain" && h.project === project);
-      return captain != null && captain.state !== "gone" && captain.state !== "unknown";
+      // Captain rows only ever report "alive" | "stopped" | "unknown" (see
+      // liveness.ts projectHealth) — "stopped" means the workspace was closed
+      // (down), so it must NOT count as alive.
+      return captain?.state === "alive";
     } catch {
       return false;
     }

--- a/packages/core/src/telegram/control.ts
+++ b/packages/core/src/telegram/control.ts
@@ -64,9 +64,30 @@ export function createIsCaptainAlive(sock: string): (project: string) => Promise
   };
 }
 
-/** Boot a captain via async execFile (NEVER execSync on the daemon hot path). */
-export function createLaunch(cliBin: string): (project: string) => Promise<void> {
-  return async (project: string) => {
-    await pExecFile(process.execPath, [cliBin, "launch", project], { timeout: 30_000 });
-  };
+/** Boot a captain via async execFile (NEVER execSync on the daemon hot path).
+ *  --headless (#520): the daemon has no CMUX_WORKSPACE_ID and no terminal, so
+ *  a plain `squadrant launch` would open the cmux GUI app and exit 0 without
+ *  ever creating a workspace. --headless makes launch drive runtime.spawn
+ *  directly instead. `log`, when given, records the subprocess's captured
+ *  output (or failure) so a broken launch leaves a diagnostic trail instead
+ *  of failing silently while ensureCaptainAlive polls to a timeout. */
+export function createLaunch(cliBin: string, log?: (m: string) => void): (project: string) => Promise<void> {
+  return (project: string) =>
+    new Promise<void>((resolve, reject) => {
+      execFile(
+        process.execPath,
+        [cliBin, "launch", project, "--headless"],
+        { timeout: 30_000 },
+        (err, stdout, stderr) => {
+          const output = capOutput(stdout ?? "", stderr ?? "");
+          if (err) {
+            log?.(`launch ${project} failed: ${output}`);
+            reject(err);
+            return;
+          }
+          if (output !== "(no output)") log?.(`launch ${project}: ${output}`);
+          resolve();
+        },
+      );
+    });
 }

--- a/packages/core/src/telegram/control.ts
+++ b/packages/core/src/telegram/control.ts
@@ -7,6 +7,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { sendRequest } from "../protocol.js";
+import type { ComponentHealth } from "../liveness.js";
 
 const pExecFile = promisify(execFile);
 
@@ -46,18 +47,18 @@ export function createRunCommand(cliBin: string): (argv: string[]) => Promise<st
   };
 }
 
+/** Pure: a captain counts alive ONLY in state "alive" — stopped (closed),
+ *  gone (crashed), and unknown/missing all mean "not alive" → boot (#517). */
+export function isCaptainAliveFromHealth(rows: ComponentHealth[], project: string): boolean {
+  return rows.some((h) => h.kind === "captain" && h.project === project && h.state === "alive");
+}
+
 /** Liveness probe via the daemon health endpoint (mirrors group.ts isCaptainAlive). */
 export function createIsCaptainAlive(sock: string): (project: string) => Promise<boolean> {
   return async (project: string) => {
     try {
-      const health = (await sendRequest(sock, { kind: "health", project }, 5000)) as Array<{
-        kind: string; project: string; state: string;
-      }>;
-      const captain = health?.find((h) => h.kind === "captain" && h.project === project);
-      // Captain rows only ever report "alive" | "stopped" | "unknown" (see
-      // liveness.ts projectHealth) — "stopped" means the workspace was closed
-      // (down), so it must NOT count as alive.
-      return captain?.state === "alive";
+      const health = (await sendRequest(sock, { kind: "health", project }, 5000)) as ComponentHealth[];
+      return isCaptainAliveFromHealth(health ?? [], project);
     } catch {
       return false;
     }

--- a/packages/shared/src/effort.ts
+++ b/packages/shared/src/effort.ts
@@ -1,7 +1,16 @@
 import type { SquadrantConfig } from "./config.js";
+import { loadProjectOverride } from "./project-config.js";
 
 export type Effort = "max" | "balance" | "low";
 
-export function resolveEffort(config: SquadrantConfig): Effort {
+export function resolveEffort(
+  config: SquadrantConfig,
+  projectName?: string,
+  projectConfigRoot?: string,
+): Effort {
+  if (projectName) {
+    const override = loadProjectOverride(projectName, projectConfigRoot);
+    return override.effort ?? config.defaults.effort ?? "balance";
+  }
   return config.defaults.effort ?? "balance";
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@ export * from "./config.js";
 export * from "./project-config.js";
 export * from "./effort.js";
 export * from "./types/runtime.js";
+export * from "./types/liveness.js";
 export * from "./types/control.js";
 export * from "./types/projection.js";
 export * from "./types/workspaces.js";

--- a/packages/shared/src/lib/__tests__/effort.test.ts
+++ b/packages/shared/src/lib/__tests__/effort.test.ts
@@ -1,7 +1,16 @@
-import { describe, it, expect } from "vitest";
-import { resolveEffort, getDefaultConfig } from "@squadrant/shared";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { resolveEffort, getDefaultConfig, saveProjectOverride } from "@squadrant/shared";
 
-describe("resolveEffort", () => {
+let root: string;
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "sq-effort-"));
+});
+afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+describe("resolveEffort — global only", () => {
   it("returns 'balance' when effort is absent", () => {
     const config = getDefaultConfig();
     delete (config.defaults as any).effort;
@@ -24,5 +33,40 @@ describe("resolveEffort", () => {
     const config = getDefaultConfig();
     (config.defaults as any).effort = "low";
     expect(resolveEffort(config)).toBe("low");
+  });
+});
+
+describe("resolveEffort — per-project override", () => {
+  it("per-project override wins over global", () => {
+    saveProjectOverride("my-proj", { effort: "low" }, root);
+    const config = getDefaultConfig();
+    (config.defaults as any).effort = "max";
+    expect(resolveEffort(config, "my-proj", root)).toBe("low");
+  });
+
+  it("no per-project override falls back to global", () => {
+    saveProjectOverride("my-proj", {}, root);
+    const config = getDefaultConfig();
+    (config.defaults as any).effort = "max";
+    expect(resolveEffort(config, "my-proj", root)).toBe("max");
+  });
+
+  it("absent per-project file falls back to global", () => {
+    const config = getDefaultConfig();
+    (config.defaults as any).effort = "low";
+    expect(resolveEffort(config, "nonexistent", root)).toBe("low");
+  });
+
+  it("per-project override with no global effort uses override directly", () => {
+    saveProjectOverride("my-proj", { effort: "low" }, root);
+    const config = getDefaultConfig();
+    delete (config.defaults as any).effort;
+    expect(resolveEffort(config, "my-proj", root)).toBe("low");
+  });
+
+  it("no override and no global falls back to 'balance'", () => {
+    const config = getDefaultConfig();
+    delete (config.defaults as any).effort;
+    expect(resolveEffort(config, "my-proj", root)).toBe("balance");
   });
 });

--- a/packages/shared/src/types/liveness.ts
+++ b/packages/shared/src/types/liveness.ts
@@ -1,0 +1,27 @@
+export type Role = "captain" | "crew" | "command";
+export type LivenessSource = "runtime" | "agent" | "scan";
+
+/** Persisted per-component liveness fact. */
+export interface LivenessEntry {
+  project: string;
+  role: Role;
+  pid: number | null;
+  sessionId: string;
+  startedAt: number;
+  /** intent: process opened vs cleanly closed. */
+  lastState: "start" | "end";
+  lastSeenAt: number;
+  /** liveness axis — written only by the pid floor. */
+  pidAlive: boolean;
+  source: LivenessSource;
+}
+
+/** One ground-truth record from a runtime's own session store (§5.4). */
+export interface RuntimeLivenessRecord {
+  role: Role | "unknown";
+  project: string;
+  pid: number | null;
+  sessionId: string;
+  present: boolean;
+  isRestorable?: boolean;
+}

--- a/packages/web/src/__tests__/read-status.test.ts
+++ b/packages/web/src/__tests__/read-status.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import type { SquadrantConfig } from "@squadrant/shared";
 import type { TaskRecord } from "@squadrant/shared";
 import type { ComponentHealth } from "@squadrant/core";
+import type { ReadStatusDeps } from "../read-status.js";
 import { readAllStatuses, deriveRowState } from "../read-status.js";
 
 function makeConfig(): SquadrantConfig {
@@ -34,6 +35,20 @@ function mkTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
   };
 }
 
+function makeAliveCall(extra: Record<string, ComponentHealth["state"]> = {}): ReadStatusDeps["call"] {
+  return async (req: unknown) => {
+    const r = req as { kind: string; project?: string };
+    if (r.kind === "health") {
+      return [
+        { kind: "captain", project: "brove", ref: "brove-captain", state: extra.brove ?? "alive", lastSeenMs: null },
+        { kind: "captain", project: "solder", ref: "solder-captain", state: extra.solder ?? "alive", lastSeenMs: null },
+      ] as ComponentHealth[];
+    }
+    if (r.kind === "list") return [];
+    throw new Error(`unexpected request kind: ${r.kind}`);
+  };
+}
+
 describe("readAllStatuses", () => {
   it("returns one row per registered project", async () => {
     const rows = await readAllStatuses({
@@ -49,6 +64,7 @@ describe("readAllStatuses", () => {
   it("maps state to idle when no tasks or all done", async () => {
     const rows = await readAllStatuses({
       config: makeConfig(),
+      call: makeAliveCall(),
       listTasks: async () => [mkTask({ state: "done" }), mkTask({ state: "submitted" })],
     });
 
@@ -58,6 +74,7 @@ describe("readAllStatuses", () => {
   it("maps state to busy when any task is working", async () => {
     const rows = await readAllStatuses({
       config: makeConfig(),
+      call: makeAliveCall(),
       listTasks: async () => [mkTask({ state: "working" })],
     });
 
@@ -67,6 +84,7 @@ describe("readAllStatuses", () => {
   it("maps state to blocked when any task is blocked", async () => {
     const rows = await readAllStatuses({
       config: makeConfig(),
+      call: makeAliveCall(),
       listTasks: async () => [mkTask({ state: "blocked" })],
     });
 
@@ -76,6 +94,7 @@ describe("readAllStatuses", () => {
   it("maps state to blocked when any task is awaiting-input", async () => {
     const rows = await readAllStatuses({
       config: makeConfig(),
+      call: makeAliveCall(),
       listTasks: async () => [mkTask({ state: "awaiting-input" })],
     });
 
@@ -85,6 +104,7 @@ describe("readAllStatuses", () => {
   it("maps state to errored when any task has failed", async () => {
     const rows = await readAllStatuses({
       config: makeConfig(),
+      call: makeAliveCall(),
       listTasks: async () => [mkTask({ state: "failed" })],
     });
 
@@ -94,6 +114,7 @@ describe("readAllStatuses", () => {
   it("maps state to errored when any task is stalled", async () => {
     const rows = await readAllStatuses({
       config: makeConfig(),
+      call: makeAliveCall(),
       listTasks: async () => [mkTask({ state: "stalled" })],
     });
 
@@ -103,6 +124,7 @@ describe("readAllStatuses", () => {
   it("state precedence: blocked beats errored", async () => {
     const rows = await readAllStatuses({
       config: makeConfig(),
+      call: makeAliveCall(),
       listTasks: async () => [
         mkTask({ state: "blocked" }),
         mkTask({ state: "failed" }),
@@ -116,6 +138,7 @@ describe("readAllStatuses", () => {
   it("state precedence: errored beats busy", async () => {
     const rows = await readAllStatuses({
       config: makeConfig(),
+      call: makeAliveCall(),
       listTasks: async () => [
         mkTask({ state: "failed" }),
         mkTask({ state: "working" }),
@@ -140,6 +163,7 @@ describe("readAllStatuses", () => {
   it("preserves project name from config", async () => {
     const rows = await readAllStatuses({
       config: makeConfig(),
+      call: makeAliveCall({ brove: "alive", solder: "alive" }),
       listTasks: async (project) => {
         if (project === "brove") return [mkTask({ state: "working", task: "brove task" })];
         return [mkTask({ state: "done", task: "solder task" })];
@@ -153,6 +177,7 @@ describe("readAllStatuses", () => {
   it("builds excerpt with active task titles", async () => {
     const rows = await readAllStatuses({
       config: makeConfig(),
+      call: makeAliveCall(),
       listTasks: async () => [
         mkTask({ state: "working", name: "feat-x", task: "build feature x" }),
         mkTask({ state: "blocked", name: "fix-y", task: "fix bug y" }),
@@ -168,6 +193,7 @@ describe("readAllStatuses", () => {
   it("builds summary-only excerpt when no active tasks", async () => {
     const rows = await readAllStatuses({
       config: makeConfig(),
+      call: makeAliveCall(),
       listTasks: async () => [mkTask({ state: "done" })],
     });
 
@@ -178,6 +204,7 @@ describe("readAllStatuses", () => {
     const before = Date.now();
     const rows = await readAllStatuses({
       config: makeConfig(),
+      call: makeAliveCall(),
       listTasks: async () => [],
     });
     const after = Date.now();
@@ -192,6 +219,7 @@ describe("readAllStatuses", () => {
     let callCount = 0;
     const rows = await readAllStatuses({
       config: makeConfig(),
+      call: makeAliveCall({ solder: "alive" }),
       listTasks: async (project) => {
         callCount++;
         if (project === "brove") throw new Error("down");
@@ -202,6 +230,22 @@ describe("readAllStatuses", () => {
     expect(rows[0].state).toBe("offline");
     expect(rows[1].state).toBe("busy");
     expect(callCount).toBe(2);
+  });
+
+  it("captain unknown → offline when health endpoint omitted a project", async () => {
+    const rows = await readAllStatuses({
+      config: makeConfig(),
+      call: async (req: unknown) => {
+        const r = req as { kind: string; project?: string };
+        if (r.kind === "health") return [] as ComponentHealth[]; // no captain entries at all
+        if (r.kind === "list") return [mkTask({ state: "working" })];
+        throw new Error(`unexpected request kind: ${r.kind}`);
+      },
+    });
+
+    // Both projects have working tasks but both captains are unknown (not in health)
+    expect(rows[0].state).toBe("offline");
+    expect(rows[1].state).toBe("offline");
   });
 
   it("captain state from health dominates task-derived state, fetched once and indexed per project", async () => {
@@ -238,7 +282,10 @@ describe("deriveRowState", () => {
   it("captain alive → task-derived", () => {
     expect(deriveRowState([mkTask({ state: "working" })], "alive")).toBe("busy");
   });
-  it("captain unknown → task-derived (no health source / not applicable)", () => {
-    expect(deriveRowState([], "unknown")).toBe("idle");
+  it("captain unknown → offline (no registry entry = not running)", () => {
+    expect(deriveRowState([], "unknown")).toBe("offline");
+  });
+  it("captain unknown → offline regardless of working tasks", () => {
+    expect(deriveRowState([mkTask({ state: "working" })], "unknown")).toBe("offline");
   });
 });

--- a/packages/web/src/__tests__/read-status.test.ts
+++ b/packages/web/src/__tests__/read-status.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
 import type { SquadrantConfig } from "@squadrant/shared";
 import type { TaskRecord } from "@squadrant/shared";
-import { readAllStatuses } from "../read-status.js";
+import type { ComponentHealth } from "@squadrant/core";
+import { readAllStatuses, deriveRowState } from "../read-status.js";
 
 function makeConfig(): SquadrantConfig {
   return {
@@ -201,5 +202,43 @@ describe("readAllStatuses", () => {
     expect(rows[0].state).toBe("offline");
     expect(rows[1].state).toBe("busy");
     expect(callCount).toBe(2);
+  });
+
+  it("captain state from health dominates task-derived state, fetched once and indexed per project", async () => {
+    let healthCalls = 0;
+    const rows = await readAllStatuses({
+      config: makeConfig(),
+      call: async (req: unknown) => {
+        const r = req as { kind: string; project?: string };
+        if (r.kind === "health") {
+          healthCalls++;
+          return [
+            { kind: "captain", project: "brove", ref: "brove-captain", state: "gone", lastSeenMs: null },
+            { kind: "captain", project: "solder", ref: "solder-captain", state: "alive", lastSeenMs: null },
+          ] as ComponentHealth[];
+        }
+        if (r.kind === "list") return [mkTask({ state: "working" })];
+        throw new Error(`unexpected request kind: ${r.kind}`);
+      },
+    });
+
+    expect(rows[0].state).toBe("offline"); // brove: gone dominates despite a working task
+    expect(rows[1].state).toBe("busy");    // solder: alive → task-derived
+    expect(healthCalls).toBe(1);           // fetched once, not per project
+  });
+});
+
+describe("deriveRowState", () => {
+  it("captain gone → offline regardless of working tasks", () => {
+    expect(deriveRowState([mkTask({ state: "working" })], "gone")).toBe("offline");
+  });
+  it("captain stopped → offline", () => {
+    expect(deriveRowState([], "stopped")).toBe("offline");
+  });
+  it("captain alive → task-derived", () => {
+    expect(deriveRowState([mkTask({ state: "working" })], "alive")).toBe("busy");
+  });
+  it("captain unknown → task-derived (no health source / not applicable)", () => {
+    expect(deriveRowState([], "unknown")).toBe("idle");
   });
 });

--- a/packages/web/src/__tests__/web-render.test.ts
+++ b/packages/web/src/__tests__/web-render.test.ts
@@ -104,14 +104,14 @@ describe("explanatory titles + captions", () => {
 });
 
 describe("tabbed navigation", () => {
-  it("renders all four tabs as a tablist", () => {
+  it("renders all five tabs as a tablist, live first", () => {
     const out = renderContent(full(daemon()));
     expect(out).toContain('role="tablist"');
-    for (const tab of ["overview", "projects", "daemon", "environment"]) {
+    for (const tab of ["live", "overview", "projects", "daemon", "environment"]) {
       expect(out).toContain(`data-tab="${tab}"`);
       expect(out).toContain(`data-panel="${tab}"`);
     }
-    expect(out).toContain("Overview");
+    expect(out).toContain("Live");
     expect(out).toContain("Environment");
   });
 });

--- a/packages/web/src/read-status.ts
+++ b/packages/web/src/read-status.ts
@@ -30,7 +30,7 @@ function deriveState(tasks: TaskRecord[]): DashboardState {
 /** Captain liveness dominates task activity (§6): a gone/stopped captain means
  *  the project is offline regardless of what its (about-to-be-reaped) tasks say. */
 export function deriveRowState(tasks: TaskRecord[], captainState: HealthState): DashboardState {
-  if (captainState === "gone" || captainState === "stopped") return "offline";
+  if (captainState === "gone" || captainState === "stopped" || captainState === "unknown") return "offline";
   return deriveState(tasks);
 }
 

--- a/packages/web/src/read-status.ts
+++ b/packages/web/src/read-status.ts
@@ -1,5 +1,6 @@
 import type { SquadrantConfig } from "@squadrant/shared";
 import type { TaskRecord } from "@squadrant/shared";
+import type { ComponentHealth, HealthState } from "@squadrant/core";
 
 export type SquadrantdCall = (req: unknown) => Promise<unknown>;
 
@@ -24,6 +25,13 @@ function deriveState(tasks: TaskRecord[]): DashboardState {
   if (tasks.some(t => t.state === "failed" || t.state === "stalled")) return "errored";
   if (tasks.some(t => t.state === "working")) return "busy";
   return "idle";
+}
+
+/** Captain liveness dominates task activity (§6): a gone/stopped captain means
+ *  the project is offline regardless of what its (about-to-be-reaped) tasks say. */
+export function deriveRowState(tasks: TaskRecord[], captainState: HealthState): DashboardState {
+  if (captainState === "gone" || captainState === "stopped") return "offline";
+  return deriveState(tasks);
 }
 
 function buildExcerpt(tasks: TaskRecord[]): string {
@@ -52,13 +60,26 @@ export async function readAllStatuses(deps: ReadStatusDeps): Promise<ProjectStat
     return result as TaskRecord[];
   });
 
+  // Fetch health ONCE (not per project) and index captain state by project —
+  // captain liveness dominates task-derived state (§6).
+  const captainStateByProject = new Map<string, HealthState>();
+  if (deps.call) {
+    try {
+      const health = (await deps.call({ kind: "health" })) as ComponentHealth[];
+      for (const h of health ?? []) {
+        if (h.kind === "captain") captainStateByProject.set(h.project, h.state);
+      }
+    } catch { /* health unavailable — fall back to task-derived state only */ }
+  }
+
   const rows: ProjectStatus[] = [];
   for (const [name, project] of Object.entries(deps.config.projects)) {
     try {
       const tasks = await listTasks(name);
+      const captainState = captainStateByProject.get(name) ?? "unknown";
       rows.push({
         project: name,
-        state: deriveState(tasks),
+        state: deriveRowState(tasks, captainState),
         lastChecked: new Date().toISOString(),
         captainWorkspace: project.captainName,
         excerpt: buildExcerpt(tasks),

--- a/packages/web/src/web-render.ts
+++ b/packages/web/src/web-render.ts
@@ -510,8 +510,63 @@ function renderEnv(ext: ExternalProbes): string {
   return out.join("");
 }
 
+// ── Tab: LIVE (compact grid) ────────────────────────────────────────────────────
+function renderLiveGrid(snap: FullSnapshot, now: number): string {
+  const out: string[] = [`<section class="panel" data-panel="live" role="tabpanel" aria-label="Live">`];
+  if (snap.daemon === "unreachable") {
+    out.push(`<div class="empty">Telemetry link lost — per-project data is served by the daemon. Start it to restore: <code>squadrant heal daemon</code></div></section>`);
+    return out.join("");
+  }
+  const d = snap.daemon;
+  const projects = new Set<string>([...d.tier1.map((c) => c.project), ...d.tier2.projects.map((p) => p.project)]);
+  if (projects.size === 0) {
+    out.push(`<div class="empty">No projects registered yet.</div>`);
+  } else {
+    out.push(`<table class="live-grid"><tbody>`);
+    for (const project of projects) {
+      const comps = d.tier1.filter((c) => c.project === project);
+      const dp = d.tier2.projects.find((p) => p.project === project);
+      const captainStopped = comps.some((c) => c.kind === "captain" && c.state === "stopped");
+      const deferralState: AnyState =
+        !captainStopped && dp && dp.deferral.stuck ? "gone" :
+        !captainStopped && dp && dp.deferral.maxDeferCount > 0 ? "stale" : "alive";
+      const rollupStates: AnyState[] = [
+        ...comps.map((c) => c.state),
+        !captainStopped && dp && dp.delivery.behind > 0 ? "stale" : "alive",
+        dp && dp.store.corruptCount > 0 ? "gone" : "alive",
+        deferralState,
+      ];
+      const rollup = worst(rollupStates);
+      const captainComp = comps.find((c) => c.kind === "captain");
+      const captainState = captainComp?.state ?? "unknown";
+      const crews = comps.filter((c) => c.kind === "crew");
+      let detail = "";
+      if (crews.length > 0) {
+        const alive = crews.filter((c) => c.state === "alive");
+        const other = crews.filter((c) => c.state !== "alive");
+        const parts: string[] = [];
+        if (alive.length > 0) parts.push(`${alive.length} working — ${alive.map((c) => c.ref).join("; ")}`);
+        for (const c of other) parts.push(`${c.state} — ${c.ref}`);
+        detail = parts.join(", ");
+      } else if (captainState === "alive") {
+        detail = "captain idle";
+      }
+      out.push(`<tr class="live-row" data-rollup="${rollup}">`);
+      out.push(`<td class="live-dot"><span class="pdot s-${rollup}"></span></td>`);
+      out.push(`<td class="live-name">${esc(project)}</td>`);
+      out.push(`<td class="live-state">${statePill(captainState)}</td>`);
+      out.push(`<td class="live-detail dim">${esc(detail)}</td>`);
+      out.push(`</tr>`);
+    }
+    out.push(`</tbody></table>`);
+  }
+  out.push(`</section>`);
+  return out.join("");
+}
+
 // ── Tab nav + content assembly ──────────────────────────────────────────────────
 const TABS: Array<[string, string]> = [
+  ["live", "Live"],
   ["overview", "Overview"],
   ["projects", "Projects"],
   ["daemon", "Daemon"],
@@ -573,6 +628,7 @@ export function renderContent(snap: FullSnapshot): string {
 
   out.push(tabNav());
   out.push(`<div class="panels">`);
+  out.push(renderLiveGrid(snap, col.now));
   out.push(renderOverview(snap, col));
   out.push(renderProjects(snap, col.now));
   out.push(renderDaemon(snap));
@@ -701,6 +757,23 @@ body{margin:0;min-height:100vh;background:radial-gradient(1200px 760px at 50% -2
 .spark-area{fill:var(--hud);opacity:.1}
 .spark-dot{fill:var(--hud)}
 
+/* Live grid (compact per-project rows) */
+.live-grid{width:100%;border-collapse:collapse;font-size:12px;table-layout:fixed}
+.live-row td{padding:5px 6px;vertical-align:middle;border-bottom:1px solid var(--track);white-space:nowrap}
+.live-row:last-child td{border-bottom:0}
+.live-dot{width:20px;text-align:center;padding-right:0!important}
+.live-dot .pdot{display:inline-block;vertical-align:middle}
+.live-name{font-weight:600;width:20%}
+.live-state{width:auto;text-align:right;padding-right:12px!important}
+.live-state .pill{font-size:10px;padding:1px 7px}
+.live-detail{overflow:hidden;text-overflow:ellipsis;width:auto;color:var(--ink-dim)}
+.live-row[data-rollup="gone"] td.live-dot .pdot{background:var(--crit);box-shadow:0 0 6px var(--crit)}
+.live-row[data-rollup="stale"] td.live-dot .pdot{background:var(--warn);box-shadow:0 0 6px var(--warn)}
+.live-row[data-rollup="stopped"] td.live-dot .pdot{background:var(--stopped)}
+.live-row[data-rollup="alive"] td.live-dot .pdot{background:var(--ok);box-shadow:0 0 6px var(--ok)}
+.live-row[data-rollup="unknown"] td.live-dot .pdot{background:var(--unk)}
+.live-row:hover{background:var(--panel-2)}
+
 /* Filter bar */
 .filter-bar{display:flex;gap:6px;margin:0 0 14px;flex-wrap:wrap}
 .filter-btn{appearance:none;background:var(--panel-2);border:1px solid var(--bezel);border-radius:999px;
@@ -779,7 +852,7 @@ body{margin:0;min-height:100vh;background:radial-gradient(1200px 760px at 50% -2
 // charts after each frame.
 const CLIENT_JS = `
 (function(){
-  var activeTab='overview';var hist={};var prev={};var currentFilter='all';
+  var activeTab='live';var hist={};var prev={};var currentFilter='all';
   function pushHist(k,v,t){var a=hist[k]||(hist[k]=[]);if(a.length&&a[a.length-1].t===t)return;a.push({t:t,v:v});if(a.length>48)a.shift();}
   function ingest(){var el=document.getElementById('squadrant-metrics');if(!el)return;var m;try{m=JSON.parse(el.textContent);}catch(e){return;}pushHist('errors',m.errors,m.t);pushHist('behind',m.behind,m.t);pushHist('crewAge',Math.round(m.crewAgeMs/1000),m.t);pushHist('defers',m.maxDeferCount,m.t);}
   function sparkSVG(a){var W=100,H=28,p=2;if(!a.length)return'';var vs=a.map(function(x){return x.v;});var mx=Math.max.apply(null,vs),mn=Math.min.apply(null,vs);if(mx===mn)mx=mn+1;var n=a.length;var pts=a.map(function(x,i){var px=n>1?p+i/(n-1)*(W-2*p):W/2;var py=H-p-(x.v-mn)/(mx-mn)*(H-2*p);return[px,py];});var d=pts.map(function(pt,i){return(i?'L':'M')+pt[0].toFixed(1)+' '+pt[1].toFixed(1);}).join(' ');var last=pts[pts.length-1];var area=d+' L'+last[0].toFixed(1)+' '+H+' L'+pts[0][0].toFixed(1)+' '+H+' Z';return'<path class="spark-area" d="'+area+'"/><path class="spark-line" d="'+d+'"/><circle class="spark-dot" cx="'+last[0].toFixed(1)+'" cy="'+last[1].toFixed(1)+'" r="2"/>';}
@@ -790,7 +863,7 @@ const CLIENT_JS = `
   function applyFilter(){document.querySelectorAll('[data-panel="projects"] .card').forEach(function(c){var r=c.getAttribute('data-rollup');if(currentFilter==='all'){c.hidden=false;}else if(currentFilter==='alive'){c.hidden=r!=='alive';}else if(currentFilter==='caution'){c.hidden=r!=='stale';}else if(currentFilter==='offline'){c.hidden=r!=='gone'&&r!=='stopped'&&r!=='unknown';}});document.querySelectorAll('.filter-btn').forEach(function(x){var on=x.getAttribute('data-filter')===currentFilter;x.classList.toggle('on',on);x.setAttribute('aria-pressed',on?'true':'false');});}
   function refresh(){ingest();applyTab();drawSparks();countUps();applyFilter();}
   document.addEventListener('click',function(e){var t=e.target&&e.target.closest?e.target.closest('[data-tab]'):null;if(t){activeTab=t.getAttribute('data-tab');applyTab();var c=document.getElementById('content');if(c){c.classList.remove('swap');void c.offsetWidth;c.classList.add('swap');}}var fb=e.target&&e.target.closest?e.target.closest('[data-filter]'):null;if(fb){currentFilter=fb.getAttribute('data-filter');applyFilter();}});
-  document.addEventListener('keydown',function(e){var ae=document.activeElement;if((e.key==='ArrowRight'||e.key==='ArrowLeft')&&ae&&ae.getAttribute&&ae.getAttribute('data-tab')){var o=['overview','projects','daemon','environment'];var i=o.indexOf(activeTab);i=(i+(e.key==='ArrowRight'?1:o.length-1))%o.length;activeTab=o[i];applyTab();var nt=document.querySelector('[data-tab="'+activeTab+'"]');if(nt)nt.focus();e.preventDefault();}});
+  document.addEventListener('keydown',function(e){var ae=document.activeElement;if((e.key==='ArrowRight'||e.key==='ArrowLeft')&&ae&&ae.getAttribute&&ae.getAttribute('data-tab')){var o=['live','overview','projects','daemon','environment'];var i=o.indexOf(activeTab);i=(i+(e.key==='ArrowRight'?1:o.length-1))%o.length;activeTab=o[i];applyTab();var nt=document.querySelector('[data-tab="'+activeTab+'"]');if(nt)nt.focus();e.preventDefault();}});
   var led=document.getElementById('led');var conn=document.getElementById('conn');var updated=document.getElementById('updated');
   function tickAge(){if(!generatedAt)return;var s=Math.max(0,Math.round((Date.now()-generatedAt)/1000));updated.textContent='updated '+s+'s ago';}
   setInterval(tickAge,1000);

--- a/packages/web/src/web-render.ts
+++ b/packages/web/src/web-render.ts
@@ -14,7 +14,7 @@
 // only when applicable; remediation is COPY-ABLE TEXT (never buttons — read-only
 // beta). Zero new deps: vanilla JS + modern CSS + inline SVG.
 import type { HealthState, ComponentHealth, DaemonSnapshot } from "@squadrant/core";
-import { healCmdFor, ageText } from "@squadrant/core";
+import { healCmdFor, ageText, CREW_STALE_MS } from "@squadrant/core";
 import type { FullSnapshot } from "./snapshot-merge.js";
 import type { ExternalProbes, Probe, ProbeState } from "./probes.js";
 
@@ -510,7 +510,13 @@ function renderEnv(ext: ExternalProbes): string {
   return out.join("");
 }
 
-// ── Tab: LIVE (compact grid) ────────────────────────────────────────────────────
+// ── Tab: LIVE (mission control) ─────────────────────────────────────────────────
+const ATTN_ORDER: Record<AnyState, number> = { stale: 0, gone: 1, alive: 2, unknown: 3, stopped: 4 };
+const STATE_LABEL: Record<string, string> = { alive: "running", stale: "blocked", gone: "errored", unknown: "idle", stopped: "offline" };
+const STATE_CLS: Record<string, string> = { alive: "s-alive", stale: "s-stale", gone: "s-gone", unknown: "s-unknown", stopped: "s-stopped" };
+const STATE_ORDER = ["alive", "stale", "gone", "unknown", "stopped"];
+const TASK_ICON: Record<string, string> = { done: "✓", working: "▶", blocked: "●", failed: "✕", cancelled: "⊙" };
+
 function renderLiveGrid(snap: FullSnapshot, now: number): string {
   const out: string[] = [`<section class="panel" data-panel="live" role="tabpanel" aria-label="Live">`];
   if (snap.daemon === "unreachable") {
@@ -522,7 +528,12 @@ function renderLiveGrid(snap: FullSnapshot, now: number): string {
   if (projects.size === 0) {
     out.push(`<div class="empty">No projects registered yet.</div>`);
   } else {
-    out.push(`<table class="live-grid"><tbody>`);
+    // Gather per-project data
+    interface RowData { name: string; rollup: AnyState; captainState: HealthState; detail: string; crews: ComponentHealth[]; tasks: Record<string, number>; }
+    const rows: RowData[] = [];
+    const stateCounts: Record<string, number> = {};
+    for (const s of STATE_ORDER) stateCounts[s] = 0;
+
     for (const project of projects) {
       const comps = d.tier1.filter((c) => c.project === project);
       const dp = d.tier2.projects.find((p) => p.project === project);
@@ -551,11 +562,55 @@ function renderLiveGrid(snap: FullSnapshot, now: number): string {
       } else if (captainState === "alive") {
         detail = "captain idle";
       }
-      out.push(`<tr class="live-row" data-rollup="${rollup}">`);
-      out.push(`<td class="live-dot"><span class="pdot s-${rollup}"></span></td>`);
-      out.push(`<td class="live-name">${esc(project)}</td>`);
-      out.push(`<td class="live-state">${statePill(captainState)}</td>`);
-      out.push(`<td class="live-detail dim">${esc(detail)}</td>`);
+      rows.push({ name: project, rollup, captainState, detail, crews, tasks: dp?.store.byState ?? {} });
+      stateCounts[rollup]++;
+    }
+
+    // State-count header
+    const headerLabels = STATE_ORDER.map((s) => `${STATE_LABEL[s]}`);
+    out.push(`<div class="live-header" data-live-header="">`);
+    out.push(headerLabels.map((l) => {
+      const raw = Object.entries(STATE_LABEL).find(([, v]) => v === l)![0];
+      const c = stateCounts[raw];
+      const cls = c === 0 ? "zero" : "";
+      return `<span class="live-stat ${cls}"><span class="pdot ${STATE_CLS[raw]}"></span>${c} ${l}</span>`;
+    }).join(` <span class="live-sep">·</span> `));
+    out.push(`</div>`);
+
+    // Attention-first sort, secondary alpha
+    rows.sort((a, b) => {
+      const d = (ATTN_ORDER[a.rollup] ?? 99) - (ATTN_ORDER[b.rollup] ?? 99);
+      return d !== 0 ? d : a.name.localeCompare(b.name);
+    });
+
+    out.push(`<table class="live-grid" data-live-table=""><thead><tr class="lh-row">`);
+    out.push(`<th class="lh-dot"></th><th class="lh-name">Project</th><th class="lh-state">Status</th><th class="lh-detail">Activity</th><th class="lh-lastseen">Last Seen</th><th class="lh-tasks">Tasks</th>`);
+    out.push(`</tr></thead><tbody>`);
+    for (const row of rows) {
+      // Crew last-seen: max age (quietest crew)
+      let maxAge = -1;
+      let maxSeenMs: number | null = null;
+      for (const c of row.crews) {
+        if (c.lastSeenMs != null) {
+          const age = now - c.lastSeenMs;
+          if (age > maxAge) { maxAge = age; maxSeenMs = c.lastSeenMs; }
+        }
+      }
+      const crewAgeStr = maxSeenMs == null ? "—" : ageText(maxSeenMs, now);
+      const crewAgeQuiet = maxSeenMs != null && maxAge > CREW_STALE_MS;
+      // Task counts
+      const tParts: string[] = [];
+      for (const [st, n] of Object.entries(row.tasks)) {
+        const icon = TASK_ICON[st] ?? st[0];
+        tParts.push(`<span class="tk">${n}${esc(icon)}</span>`);
+      }
+      out.push(`<tr class="live-row" data-rollup="${row.rollup}" data-project="${esc(row.name)}">`);
+      out.push(`<td class="live-dot"><span class="pdot s-${row.rollup}"></span></td>`);
+      out.push(`<td class="live-name">${esc(row.name)}</td>`);
+      out.push(`<td class="live-state">${statePill(row.captainState)}</td>`);
+      out.push(`<td class="live-detail dim">${esc(row.detail)}</td>`);
+      out.push(`<td class="live-lastseen${crewAgeQuiet ? " quiet" : ""}">${crewAgeStr}</td>`);
+      out.push(`<td class="live-tasks">${tParts.join("") || "<span class=\"dim\">—</span>"}</td>`);
       out.push(`</tr>`);
     }
     out.push(`</tbody></table>`);
@@ -757,22 +812,41 @@ body{margin:0;min-height:100vh;background:radial-gradient(1200px 760px at 50% -2
 .spark-area{fill:var(--hud);opacity:.1}
 .spark-dot{fill:var(--hud)}
 
-/* Live grid (compact per-project rows) */
+/* Live grid (mission control) */
 .live-grid{width:100%;border-collapse:collapse;font-size:12px;table-layout:fixed}
-.live-row td{padding:5px 6px;vertical-align:middle;border-bottom:1px solid var(--track);white-space:nowrap}
+.live-grid td,.live-grid th{padding:5px 6px;vertical-align:middle;white-space:nowrap}
+.live-grid th{padding:6px 6px 8px;text-align:left;font-family:system-ui,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-size:9px;color:var(--ink-dim);border-bottom:1px solid var(--bezel);font-weight:600;cursor:default}
+.live-grid th:hover{color:var(--ink)}
+.live-row td{border-bottom:1px solid var(--track)}
 .live-row:last-child td{border-bottom:0}
-.live-dot{width:20px;text-align:center;padding-right:0!important}
+.lh-dot{width:22px;text-align:center}
+.lh-name{width:auto;min-width:14%}
+.lh-state{width:88px;text-align:right;padding-right:12px!important}
+.lh-detail{width:auto}
+.lh-lastseen{width:105px}
+.lh-tasks{width:90px;text-align:right}
+.live-dot{width:22px;text-align:center;padding-right:0!important}
 .live-dot .pdot{display:inline-block;vertical-align:middle}
-.live-name{font-weight:600;width:20%}
-.live-state{width:auto;text-align:right;padding-right:12px!important}
+.live-name{font-weight:600}
+.live-state{width:88px;text-align:right;padding-right:12px!important}
 .live-state .pill{font-size:10px;padding:1px 7px}
-.live-detail{overflow:hidden;text-overflow:ellipsis;width:auto;color:var(--ink-dim)}
+.live-detail{overflow:hidden;text-overflow:ellipsis;color:var(--ink-dim)}
+.live-lastseen{width:105px;font-size:11px;color:var(--ink-dim)}
+.live-lastseen.quiet{color:var(--warn);font-weight:600}
+.live-tasks{width:90px;text-align:right;font-size:11px}
+.live-tasks .tk{padding:0 3px}
+.live-tasks .tk:first-child{padding-left:0}
 .live-row[data-rollup="gone"] td.live-dot .pdot{background:var(--crit);box-shadow:0 0 6px var(--crit)}
 .live-row[data-rollup="stale"] td.live-dot .pdot{background:var(--warn);box-shadow:0 0 6px var(--warn)}
 .live-row[data-rollup="stopped"] td.live-dot .pdot{background:var(--stopped)}
 .live-row[data-rollup="alive"] td.live-dot .pdot{background:var(--ok);box-shadow:0 0 6px var(--ok)}
 .live-row[data-rollup="unknown"] td.live-dot .pdot{background:var(--unk)}
 .live-row:hover{background:var(--panel-2)}
+.live-header{display:flex;gap:8px 16px;flex-wrap:wrap;padding:6px 0 10px;font-size:12px;cursor:default;user-select:none}
+.live-stat{display:flex;align-items:center;gap:5px;font-weight:600}
+.live-stat .pdot{width:6px;height:6px}
+.live-stat.zero{opacity:.35}
+.live-sep{color:var(--ink-dim);opacity:.4}
 
 /* Filter bar */
 .filter-bar{display:flex;gap:6px;margin:0 0 14px;flex-wrap:wrap}

--- a/packages/web/src/web-render.ts
+++ b/packages/web/src/web-render.ts
@@ -583,8 +583,15 @@ function renderLiveGrid(snap: FullSnapshot, now: number): string {
       return d !== 0 ? d : a.name.localeCompare(b.name);
     });
 
+    out.push(`<div class="live-controls">`);
+    out.push(`<input type="text" class="live-search" placeholder="Search projects or crews…" data-live-search="">`);
+    out.push(`<div class="filter-bar" role="group" aria-label="Filter live rows by status">`);
+    for (const fb of [["all","All"],["alive","Nominal"],["caution","Caution"],["offline","Offline"]]) {
+      out.push(`<button class="filter-btn${fb[0]==="all"?" on":""}" data-filter="${fb[0]}" data-live-filter="" aria-pressed="${fb[0]==="all"?"true":"false"}">${fb[1]}</button>`);
+    }
+    out.push(`</div></div>`);
     out.push(`<table class="live-grid" data-live-table=""><thead><tr class="lh-row">`);
-    out.push(`<th class="lh-dot"></th><th class="lh-name">Project</th><th class="lh-state">Status</th><th class="lh-detail">Activity</th><th class="lh-lastseen">Last Seen</th><th class="lh-tasks">Tasks</th>`);
+    out.push(`<th class="lh-dot"></th><th class="lh-name" data-sort="name">Project</th><th class="lh-state" data-sort="attention">Status</th><th class="lh-detail">Activity</th><th class="lh-lastseen" data-sort="activity">Last Seen</th><th class="lh-tasks">Tasks</th>`);
     out.push(`</tr></thead><tbody>`);
     for (const row of rows) {
       // Crew last-seen: max age (quietest crew)
@@ -604,7 +611,7 @@ function renderLiveGrid(snap: FullSnapshot, now: number): string {
         const icon = TASK_ICON[st] ?? st[0];
         tParts.push(`<span class="tk">${n}${esc(icon)}</span>`);
       }
-      out.push(`<tr class="live-row" data-rollup="${row.rollup}" data-project="${esc(row.name)}">`);
+      out.push(`<tr class="live-row" data-rollup="${row.rollup}" data-project="${esc(row.name)}" data-max-age="${maxAge}">`);
       out.push(`<td class="live-dot"><span class="pdot s-${row.rollup}"></span></td>`);
       out.push(`<td class="live-name">${esc(row.name)}</td>`);
       out.push(`<td class="live-state">${statePill(row.captainState)}</td>`);
@@ -812,6 +819,12 @@ body{margin:0;min-height:100vh;background:radial-gradient(1200px 760px at 50% -2
 .spark-area{fill:var(--hud);opacity:.1}
 .spark-dot{fill:var(--hud)}
 
+/* Live controls (search + filter bar) */
+.live-controls{display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin:4px 0 10px}
+.live-search{flex:1;min-width:140px;max-width:300px;padding:5px 10px;border:1px solid var(--bezel);border-radius:8px;background:var(--panel);color:var(--ink);font:12px/1.4 ui-monospace,monospace;outline:none;transition:border-color .15s ease}
+.live-search:focus{border-color:var(--hud);box-shadow:0 0 0 2px rgba(11,111,194,.15)}
+.live-search::placeholder{color:var(--ink-dim);opacity:.7}
+
 /* Live grid (mission control) */
 .live-grid{width:100%;border-collapse:collapse;font-size:12px;table-layout:fixed}
 .live-grid td,.live-grid th{padding:5px 6px;vertical-align:middle;white-space:nowrap}
@@ -926,7 +939,7 @@ body{margin:0;min-height:100vh;background:radial-gradient(1200px 760px at 50% -2
 // charts after each frame.
 const CLIENT_JS = `
 (function(){
-  var activeTab='live';var hist={};var prev={};var currentFilter='all';
+  var activeTab='live';var hist={};var prev={};var currentFilter='all';var currentSort='attention';var sortAsc=true;var currentSearch='';
   function pushHist(k,v,t){var a=hist[k]||(hist[k]=[]);if(a.length&&a[a.length-1].t===t)return;a.push({t:t,v:v});if(a.length>48)a.shift();}
   function ingest(){var el=document.getElementById('squadrant-metrics');if(!el)return;var m;try{m=JSON.parse(el.textContent);}catch(e){return;}pushHist('errors',m.errors,m.t);pushHist('behind',m.behind,m.t);pushHist('crewAge',Math.round(m.crewAgeMs/1000),m.t);pushHist('defers',m.maxDeferCount,m.t);}
   function sparkSVG(a){var W=100,H=28,p=2;if(!a.length)return'';var vs=a.map(function(x){return x.v;});var mx=Math.max.apply(null,vs),mn=Math.min.apply(null,vs);if(mx===mn)mx=mn+1;var n=a.length;var pts=a.map(function(x,i){var px=n>1?p+i/(n-1)*(W-2*p):W/2;var py=H-p-(x.v-mn)/(mx-mn)*(H-2*p);return[px,py];});var d=pts.map(function(pt,i){return(i?'L':'M')+pt[0].toFixed(1)+' '+pt[1].toFixed(1);}).join(' ');var last=pts[pts.length-1];var area=d+' L'+last[0].toFixed(1)+' '+H+' L'+pts[0][0].toFixed(1)+' '+H+' Z';return'<path class="spark-area" d="'+area+'"/><path class="spark-line" d="'+d+'"/><circle class="spark-dot" cx="'+last[0].toFixed(1)+'" cy="'+last[1].toFixed(1)+'" r="2"/>';}
@@ -934,10 +947,14 @@ const CLIENT_JS = `
   function applyTab(){var ts=document.querySelectorAll('[data-tab]');for(var i=0;i<ts.length;i++){var on=ts[i].getAttribute('data-tab')===activeTab;ts[i].setAttribute('aria-selected',on?'true':'false');ts[i].classList.toggle('on',on);}var ps=document.querySelectorAll('[data-panel]');for(var j=0;j<ps.length;j++){var on2=ps[j].getAttribute('data-panel')===activeTab;ps[j].hidden=!on2;}}
   function ease(k){return k<.5?2*k*k:1-Math.pow(-2*k+2,2)/2;}
   function countUps(){var ns=document.querySelectorAll('[data-countup]');for(var i=0;i<ns.length;i++){(function(el){var key=el.getAttribute('data-countup');var to=parseFloat(el.getAttribute('data-value'))||0;var from=prev[key]!=null?prev[key]:0;prev[key]=to;if(from===to){el.textContent=to;return;}var s=null;function step(ts){if(s===null)s=ts;var k=Math.min(1,(ts-s)/600);el.textContent=Math.round(from+(to-from)*ease(k));if(k<1)requestAnimationFrame(step);}requestAnimationFrame(step);})(ns[i]);}}
-  function applyFilter(){document.querySelectorAll('[data-panel="projects"] .card').forEach(function(c){var r=c.getAttribute('data-rollup');if(currentFilter==='all'){c.hidden=false;}else if(currentFilter==='alive'){c.hidden=r!=='alive';}else if(currentFilter==='caution'){c.hidden=r!=='stale';}else if(currentFilter==='offline'){c.hidden=r!=='gone'&&r!=='stopped'&&r!=='unknown';}});document.querySelectorAll('.filter-btn').forEach(function(x){var on=x.getAttribute('data-filter')===currentFilter;x.classList.toggle('on',on);x.setAttribute('aria-pressed',on?'true':'false');});}
-  function refresh(){ingest();applyTab();drawSparks();countUps();applyFilter();}
-  document.addEventListener('click',function(e){var t=e.target&&e.target.closest?e.target.closest('[data-tab]'):null;if(t){activeTab=t.getAttribute('data-tab');applyTab();var c=document.getElementById('content');if(c){c.classList.remove('swap');void c.offsetWidth;c.classList.add('swap');}}var fb=e.target&&e.target.closest?e.target.closest('[data-filter]'):null;if(fb){currentFilter=fb.getAttribute('data-filter');applyFilter();}});
+  function hideByFilter(r,filter){if(filter==='all')return false;if(filter==='alive')return r!=='alive';if(filter==='caution')return r!=='stale';if(filter==='offline')return r!=='gone'&&r!=='stopped'&&r!=='unknown';return false;}
+  function applyFilter(){document.querySelectorAll('[data-panel="projects"] .card').forEach(function(c){c.hidden=hideByFilter(c.getAttribute('data-rollup'),currentFilter);});document.querySelectorAll('[data-panel="live"] .live-row').forEach(function(c){c.hidden=hideByFilter(c.getAttribute('data-rollup'),currentFilter);});document.querySelectorAll('.filter-btn').forEach(function(x){var on=x.getAttribute('data-filter')===currentFilter;x.classList.toggle('on',on);x.setAttribute('aria-pressed',on?'true':'false');});}
+  function applySearch(){var q=currentSearch.toLowerCase();document.querySelectorAll('[data-panel="live"] .live-row').forEach(function(r){if(!q){if(!hideByFilter(r.getAttribute('data-rollup'),currentFilter))r.hidden=false;return;}var pn=(r.getAttribute('data-project')||'').toLowerCase();var dd=((r.querySelector('.live-detail')||{}).textContent||'').toLowerCase();var rl=r.getAttribute('data-rollup');if(hideByFilter(rl,currentFilter)){r.hidden=true;return;}r.hidden=pn.indexOf(q)===-1&&dd.indexOf(q)===-1;});}
+  function applySort(){var table=document.querySelector('[data-panel="live"] [data-live-table]');if(!table)return;var tbody=table.querySelector('tbody');if(!tbody)return;var rows=Array.prototype.slice.call(tbody.querySelectorAll('.live-row'));var dir=sortAsc?1:-1;rows.sort(function(a,b){var va,vb;if(currentSort==='name'){va=(a.getAttribute('data-project')||'').toLowerCase();vb=(b.getAttribute('data-project')||'').toLowerCase();}else if(currentSort==='attention'){var order={gone:0,stale:1,alive:2,unknown:3,stopped:4};va=order[a.getAttribute('data-rollup')]??99;vb=order[b.getAttribute('data-rollup')]??99;if(va===vb){va=(a.getAttribute('data-project')||'').toLowerCase();vb=(b.getAttribute('data-project')||'').toLowerCase();return va<vb?-1:va>vb?1:0;}}else if(currentSort==='activity'){va=parseInt(a.getAttribute('data-max-age'))||0;vb=parseInt(b.getAttribute('data-max-age'))||0;}return va<vb?-dir:va>vb?dir:0;});rows.forEach(function(r){tbody.appendChild(r);});}
+  function refresh(){ingest();applyTab();drawSparks();countUps();applyFilter();applySearch();applySort();}
+  document.addEventListener('click',function(e){var t=e.target&&e.target.closest?e.target.closest('[data-tab]'):null;if(t){activeTab=t.getAttribute('data-tab');applyTab();var c=document.getElementById('content');if(c){c.classList.remove('swap');void c.offsetWidth;c.classList.add('swap');}}var fb=e.target&&e.target.closest?e.target.closest('[data-filter]'):null;if(fb){currentFilter=fb.getAttribute('data-filter');applyFilter();applySearch();}var sh=e.target&&e.target.closest?e.target.closest('[data-sort]'):null;if(sh){var key=sh.getAttribute('data-sort');if(key===currentSort)sortAsc=!sortAsc;else{currentSort=key;sortAsc=true;}applySort();}});
   document.addEventListener('keydown',function(e){var ae=document.activeElement;if((e.key==='ArrowRight'||e.key==='ArrowLeft')&&ae&&ae.getAttribute&&ae.getAttribute('data-tab')){var o=['live','overview','projects','daemon','environment'];var i=o.indexOf(activeTab);i=(i+(e.key==='ArrowRight'?1:o.length-1))%o.length;activeTab=o[i];applyTab();var nt=document.querySelector('[data-tab="'+activeTab+'"]');if(nt)nt.focus();e.preventDefault();}});
+  document.addEventListener('input',function(e){var sb=e.target&&e.target.closest?e.target.closest('[data-live-search]'):null;if(sb){currentSearch=sb.value;applySearch();}});
   var led=document.getElementById('led');var conn=document.getElementById('conn');var updated=document.getElementById('updated');
   function tickAge(){if(!generatedAt)return;var s=Math.max(0,Math.round((Date.now()-generatedAt)/1000));updated.textContent='updated '+s+'s ago';}
   setInterval(tickAge,1000);

--- a/packages/web/src/web-render.ts
+++ b/packages/web/src/web-render.ts
@@ -619,6 +619,23 @@ function renderLiveGrid(snap: FullSnapshot, now: number): string {
       out.push(`<td class="live-lastseen${crewAgeQuiet ? " quiet" : ""}">${crewAgeStr}</td>`);
       out.push(`<td class="live-tasks">${tParts.join("") || "<span class=\"dim\">—</span>"}</td>`);
       out.push(`</tr>`);
+      // Expandable per-crew detail row (hidden by default)
+      out.push(`<tr class="live-expand" data-project="${esc(row.name)}" hidden>`);
+      out.push(`<td colspan="6"><div class="live-crew-list">`);
+      out.push(`<div class="live-crew-head"><span class="lc-name">Crew</span><span class="lc-state">Status</span><span class="lc-lastseen">Last Seen</span><span class="lc-detail">Detail</span></div>`);
+      for (const c of row.crews) {
+        const cs = ageText(c.lastSeenMs, now);
+        out.push(`<div class="live-crew-row"><span class="lc-name">${esc(c.ref)}</span><span class="lc-state">${statePill(c.state)}</span><span class="lc-lastseen">${cs}</span><span class="lc-detail dim">${c.detail ? esc(c.detail) : ""}</span></div>`);
+      }
+      if (row.crews.length === 0) {
+        out.push(`<div class="live-crew-row dim"><span class="lc-name" colspan="4">no live crews</span></div>`);
+      }
+      out.push(`</div><div class="live-crew-meta">`);
+      out.push(`<span class="lc-meta-item">pid: — (incoming)</span>`);
+      out.push(`<span class="lc-meta-item">uptime: — (incoming)</span>`);
+      out.push(`<span class="lc-meta-item">agent: — (incoming)</span>`);
+      out.push(`<span class="lc-meta-item">model: — (incoming)</span>`);
+      out.push(`</div></td></tr>`);
     }
     out.push(`</tbody></table>`);
   }
@@ -849,6 +866,24 @@ body{margin:0;min-height:100vh;background:radial-gradient(1200px 760px at 50% -2
 .live-tasks{width:90px;text-align:right;font-size:11px}
 .live-tasks .tk{padding:0 3px}
 .live-tasks .tk:first-child{padding-left:0}
+.live-row.expanded td{border-bottom-color:transparent}
+.live-expand td{padding:0 6px 10px;background:var(--panel-2);border-bottom:1px solid var(--track)}
+.live-expand td:first-child{border-radius:0 0 0 8px}
+.live-expand td:last-child{border-radius:0 0 8px 0}
+.live-crew-list{display:table;width:100%;border-collapse:collapse;font-size:12px}
+.live-crew-head,.live-crew-row{display:table-row}
+.live-crew-head>span,.live-crew-row>span{display:table-cell;padding:4px 8px;white-space:nowrap;vertical-align:middle}
+.live-crew-head>span{font-family:system-ui,sans-serif;text-transform:uppercase;letter-spacing:.1em;font-size:9px;color:var(--ink-dim);font-weight:600;border-bottom:1px solid var(--bezel)}
+.live-crew-row>span{border-bottom:1px solid var(--track)}
+.live-crew-row:last-child>span{border-bottom:0}
+.lc-name{font-weight:600}
+.lc-state{width:80px}
+.lc-state .pill{font-size:10px;padding:1px 7px}
+.lc-lastseen{width:90px;color:var(--ink-dim);font-size:11px}
+.lc-detail{color:var(--ink-dim);font-size:11px}
+.live-crew-meta{display:flex;gap:14px;padding:6px 8px 0;font-size:11px;color:var(--ink-dim);border-top:1px solid var(--track);margin-top:4px;padding-top:6px}
+.lc-meta-item{white-space:nowrap}
+.live-row.expanded+.live-expand td{background:var(--panel-2)}
 .live-row[data-rollup="gone"] td.live-dot .pdot{background:var(--crit);box-shadow:0 0 6px var(--crit)}
 .live-row[data-rollup="stale"] td.live-dot .pdot{background:var(--warn);box-shadow:0 0 6px var(--warn)}
 .live-row[data-rollup="stopped"] td.live-dot .pdot{background:var(--stopped)}
@@ -939,7 +974,7 @@ body{margin:0;min-height:100vh;background:radial-gradient(1200px 760px at 50% -2
 // charts after each frame.
 const CLIENT_JS = `
 (function(){
-  var activeTab='live';var hist={};var prev={};var currentFilter='all';var currentSort='attention';var sortAsc=true;var currentSearch='';
+  var activeTab='live';var hist={};var prev={};var currentFilter='all';var currentSort='attention';var sortAsc=true;var currentSearch='';var expandedProjects={};
   function pushHist(k,v,t){var a=hist[k]||(hist[k]=[]);if(a.length&&a[a.length-1].t===t)return;a.push({t:t,v:v});if(a.length>48)a.shift();}
   function ingest(){var el=document.getElementById('squadrant-metrics');if(!el)return;var m;try{m=JSON.parse(el.textContent);}catch(e){return;}pushHist('errors',m.errors,m.t);pushHist('behind',m.behind,m.t);pushHist('crewAge',Math.round(m.crewAgeMs/1000),m.t);pushHist('defers',m.maxDeferCount,m.t);}
   function sparkSVG(a){var W=100,H=28,p=2;if(!a.length)return'';var vs=a.map(function(x){return x.v;});var mx=Math.max.apply(null,vs),mn=Math.min.apply(null,vs);if(mx===mn)mx=mn+1;var n=a.length;var pts=a.map(function(x,i){var px=n>1?p+i/(n-1)*(W-2*p):W/2;var py=H-p-(x.v-mn)/(mx-mn)*(H-2*p);return[px,py];});var d=pts.map(function(pt,i){return(i?'L':'M')+pt[0].toFixed(1)+' '+pt[1].toFixed(1);}).join(' ');var last=pts[pts.length-1];var area=d+' L'+last[0].toFixed(1)+' '+H+' L'+pts[0][0].toFixed(1)+' '+H+' Z';return'<path class="spark-area" d="'+area+'"/><path class="spark-line" d="'+d+'"/><circle class="spark-dot" cx="'+last[0].toFixed(1)+'" cy="'+last[1].toFixed(1)+'" r="2"/>';}
@@ -951,8 +986,9 @@ const CLIENT_JS = `
   function applyFilter(){document.querySelectorAll('[data-panel="projects"] .card').forEach(function(c){c.hidden=hideByFilter(c.getAttribute('data-rollup'),currentFilter);});document.querySelectorAll('[data-panel="live"] .live-row').forEach(function(c){c.hidden=hideByFilter(c.getAttribute('data-rollup'),currentFilter);});document.querySelectorAll('.filter-btn').forEach(function(x){var on=x.getAttribute('data-filter')===currentFilter;x.classList.toggle('on',on);x.setAttribute('aria-pressed',on?'true':'false');});}
   function applySearch(){var q=currentSearch.toLowerCase();document.querySelectorAll('[data-panel="live"] .live-row').forEach(function(r){if(!q){if(!hideByFilter(r.getAttribute('data-rollup'),currentFilter))r.hidden=false;return;}var pn=(r.getAttribute('data-project')||'').toLowerCase();var dd=((r.querySelector('.live-detail')||{}).textContent||'').toLowerCase();var rl=r.getAttribute('data-rollup');if(hideByFilter(rl,currentFilter)){r.hidden=true;return;}r.hidden=pn.indexOf(q)===-1&&dd.indexOf(q)===-1;});}
   function applySort(){var table=document.querySelector('[data-panel="live"] [data-live-table]');if(!table)return;var tbody=table.querySelector('tbody');if(!tbody)return;var rows=Array.prototype.slice.call(tbody.querySelectorAll('.live-row'));var dir=sortAsc?1:-1;rows.sort(function(a,b){var va,vb;if(currentSort==='name'){va=(a.getAttribute('data-project')||'').toLowerCase();vb=(b.getAttribute('data-project')||'').toLowerCase();}else if(currentSort==='attention'){var order={gone:0,stale:1,alive:2,unknown:3,stopped:4};va=order[a.getAttribute('data-rollup')]??99;vb=order[b.getAttribute('data-rollup')]??99;if(va===vb){va=(a.getAttribute('data-project')||'').toLowerCase();vb=(b.getAttribute('data-project')||'').toLowerCase();return va<vb?-1:va>vb?1:0;}}else if(currentSort==='activity'){va=parseInt(a.getAttribute('data-max-age'))||0;vb=parseInt(b.getAttribute('data-max-age'))||0;}return va<vb?-dir:va>vb?dir:0;});rows.forEach(function(r){tbody.appendChild(r);});}
-  function refresh(){ingest();applyTab();drawSparks();countUps();applyFilter();applySearch();applySort();}
-  document.addEventListener('click',function(e){var t=e.target&&e.target.closest?e.target.closest('[data-tab]'):null;if(t){activeTab=t.getAttribute('data-tab');applyTab();var c=document.getElementById('content');if(c){c.classList.remove('swap');void c.offsetWidth;c.classList.add('swap');}}var fb=e.target&&e.target.closest?e.target.closest('[data-filter]'):null;if(fb){currentFilter=fb.getAttribute('data-filter');applyFilter();applySearch();}var sh=e.target&&e.target.closest?e.target.closest('[data-sort]'):null;if(sh){var key=sh.getAttribute('data-sort');if(key===currentSort)sortAsc=!sortAsc;else{currentSort=key;sortAsc=true;}applySort();}});
+  function applyExpand(){document.querySelectorAll('[data-panel="live"] .live-row').forEach(function(r){var pn=r.getAttribute('data-project');var er=document.querySelector('[data-panel="live"] .live-expand[data-project="'+pn+'"]');if(er){var show=!!expandedProjects[pn];er.hidden=!show;r.classList.toggle('expanded',show);}});}
+  function refresh(){ingest();applyTab();drawSparks();countUps();applyFilter();applySearch();applySort();applyExpand();}
+  document.addEventListener('click',function(e){var t=e.target&&e.target.closest?e.target.closest('[data-tab]'):null;if(t){activeTab=t.getAttribute('data-tab');applyTab();var c=document.getElementById('content');if(c){c.classList.remove('swap');void c.offsetWidth;c.classList.add('swap');}}var fb=e.target&&e.target.closest?e.target.closest('[data-filter]'):null;if(fb){currentFilter=fb.getAttribute('data-filter');applyFilter();applySearch();}var sh=e.target&&e.target.closest?e.target.closest('[data-sort]'):null;if(sh){var key=sh.getAttribute('data-sort');if(key===currentSort)sortAsc=!sortAsc;else{currentSort=key;sortAsc=true;}applySort();}var lr=e.target&&e.target.closest?e.target.closest('[data-panel="live"] .live-row'):null;if(lr&&!e.target.closest('[data-sort]')){var pn=lr.getAttribute('data-project');var er=document.querySelector('[data-panel="live"] .live-expand[data-project="'+pn+'"]');if(er){var show=er.hidden;er.hidden=!show;lr.classList.toggle('expanded',!!show);expandedProjects[pn]=!!show;}}});
   document.addEventListener('keydown',function(e){var ae=document.activeElement;if((e.key==='ArrowRight'||e.key==='ArrowLeft')&&ae&&ae.getAttribute&&ae.getAttribute('data-tab')){var o=['live','overview','projects','daemon','environment'];var i=o.indexOf(activeTab);i=(i+(e.key==='ArrowRight'?1:o.length-1))%o.length;activeTab=o[i];applyTab();var nt=document.querySelector('[data-tab="'+activeTab+'"]');if(nt)nt.focus();e.preventDefault();}});
   document.addEventListener('input',function(e){var sb=e.target&&e.target.closest?e.target.closest('[data-live-search]'):null;if(sb){currentSearch=sb.value;applySearch();}});
   var led=document.getElementById('led');var conn=document.getElementById('conn');var updated=document.getElementById('updated');

--- a/packages/web/src/web-render.ts
+++ b/packages/web/src/web-render.ts
@@ -297,6 +297,17 @@ function renderOverview(snap: FullSnapshot, col: Collected): string {
 }
 
 // ── Tab: PROJECTS ───────────────────────────────────────────────────────────────
+function filterBar(): string {
+  return [
+    `<div class="filter-bar" role="group" aria-label="Filter projects by status">`,
+    `<button class="filter-btn on" data-filter="all" aria-pressed="true">All</button>`,
+    `<button class="filter-btn" data-filter="alive" aria-pressed="false">Nominal</button>`,
+    `<button class="filter-btn" data-filter="caution" aria-pressed="false">Caution</button>`,
+    `<button class="filter-btn" data-filter="offline" aria-pressed="false">Offline</button>`,
+    `</div>`,
+  ].join("");
+}
+
 function componentRow(c: ComponentHealth, now: number): string {
   const detail = c.detail ? esc(c.detail) : "";
   const row =
@@ -330,6 +341,7 @@ function renderProjects(snap: FullSnapshot, now: number): string {
     out.push(`<div class="empty">Telemetry link lost — per-project data is served by the daemon. Start it to restore: <code>squadrant heal daemon</code></div></section>`);
     return out.join("");
   }
+  out.push(filterBar());
   const d = snap.daemon;
   const projects = new Set<string>([...d.tier1.map((c) => c.project), ...d.tier2.projects.map((p) => p.project)]);
   if (projects.size === 0) out.push(`<div class="empty">No projects registered yet.</div>`);
@@ -355,8 +367,10 @@ function renderProjects(snap: FullSnapshot, now: number): string {
       deferralState,
     ];
     const rollup = worst(rollupStates);
+    const captainComp = comps.find(c => c.kind === "captain");
+    const captainState = captainComp?.state ?? "unknown";
     out.push(`<article class="card" data-rollup="${rollup}">`);
-    out.push(`<header class="card-head"><span class="card-title">${esc(project)}</span>${statePill(rollup)}</header>`);
+    out.push(`<header class="card-head"><span class="card-title">${esc(project)}</span><div class="card-badges"><span class="captain-badge">captain ${statePill(captainState)}</span>${statePill(rollup)}</div></header>`);
     if (comps.length) {
       out.push(
         `<table class="grid"><thead><tr><th>status</th><th>kind</th><th>ref</th><th>last seen</th><th>detail</th></tr></thead><tbody>`,
@@ -687,6 +701,17 @@ body{margin:0;min-height:100vh;background:radial-gradient(1200px 760px at 50% -2
 .spark-area{fill:var(--hud);opacity:.1}
 .spark-dot{fill:var(--hud)}
 
+/* Filter bar */
+.filter-bar{display:flex;gap:6px;margin:0 0 14px;flex-wrap:wrap}
+.filter-btn{appearance:none;background:var(--panel-2);border:1px solid var(--bezel);border-radius:999px;
+  padding:4px 13px;cursor:pointer;font-family:system-ui,sans-serif;text-transform:uppercase;letter-spacing:.1em;
+  font-size:10px;font-weight:600;color:var(--ink-dim);transition:all .15s ease}
+.filter-btn:hover{background:var(--panel);border-color:var(--ink-dim);color:var(--ink)}
+.filter-btn.on{background:var(--hud);border-color:var(--hud);color:#fff;box-shadow:0 1px 3px rgba(11,111,194,.3)}
+.card-badges{display:flex;align-items:center;gap:8px;flex:none}
+.captain-badge{display:flex;align-items:center;gap:4px;font-size:10px;color:var(--ink-dim);letter-spacing:.04em}
+.captain-badge .pill{font-size:10px;padding:1px 7px}
+
 /* Cards / tables */
 .card{border:1px solid var(--bezel);border-radius:12px;background:var(--panel);box-shadow:var(--shadow);padding:14px 16px;margin-bottom:14px;border-left:3px solid var(--bezel)}
 .card[data-rollup="gone"]{border-left-color:var(--crit)}
@@ -754,7 +779,7 @@ body{margin:0;min-height:100vh;background:radial-gradient(1200px 760px at 50% -2
 // charts after each frame.
 const CLIENT_JS = `
 (function(){
-  var activeTab='overview';var hist={};var prev={};
+  var activeTab='overview';var hist={};var prev={};var currentFilter='all';
   function pushHist(k,v,t){var a=hist[k]||(hist[k]=[]);if(a.length&&a[a.length-1].t===t)return;a.push({t:t,v:v});if(a.length>48)a.shift();}
   function ingest(){var el=document.getElementById('squadrant-metrics');if(!el)return;var m;try{m=JSON.parse(el.textContent);}catch(e){return;}pushHist('errors',m.errors,m.t);pushHist('behind',m.behind,m.t);pushHist('crewAge',Math.round(m.crewAgeMs/1000),m.t);pushHist('defers',m.maxDeferCount,m.t);}
   function sparkSVG(a){var W=100,H=28,p=2;if(!a.length)return'';var vs=a.map(function(x){return x.v;});var mx=Math.max.apply(null,vs),mn=Math.min.apply(null,vs);if(mx===mn)mx=mn+1;var n=a.length;var pts=a.map(function(x,i){var px=n>1?p+i/(n-1)*(W-2*p):W/2;var py=H-p-(x.v-mn)/(mx-mn)*(H-2*p);return[px,py];});var d=pts.map(function(pt,i){return(i?'L':'M')+pt[0].toFixed(1)+' '+pt[1].toFixed(1);}).join(' ');var last=pts[pts.length-1];var area=d+' L'+last[0].toFixed(1)+' '+H+' L'+pts[0][0].toFixed(1)+' '+H+' Z';return'<path class="spark-area" d="'+area+'"/><path class="spark-line" d="'+d+'"/><circle class="spark-dot" cx="'+last[0].toFixed(1)+'" cy="'+last[1].toFixed(1)+'" r="2"/>';}
@@ -762,8 +787,9 @@ const CLIENT_JS = `
   function applyTab(){var ts=document.querySelectorAll('[data-tab]');for(var i=0;i<ts.length;i++){var on=ts[i].getAttribute('data-tab')===activeTab;ts[i].setAttribute('aria-selected',on?'true':'false');ts[i].classList.toggle('on',on);}var ps=document.querySelectorAll('[data-panel]');for(var j=0;j<ps.length;j++){var on2=ps[j].getAttribute('data-panel')===activeTab;ps[j].hidden=!on2;}}
   function ease(k){return k<.5?2*k*k:1-Math.pow(-2*k+2,2)/2;}
   function countUps(){var ns=document.querySelectorAll('[data-countup]');for(var i=0;i<ns.length;i++){(function(el){var key=el.getAttribute('data-countup');var to=parseFloat(el.getAttribute('data-value'))||0;var from=prev[key]!=null?prev[key]:0;prev[key]=to;if(from===to){el.textContent=to;return;}var s=null;function step(ts){if(s===null)s=ts;var k=Math.min(1,(ts-s)/600);el.textContent=Math.round(from+(to-from)*ease(k));if(k<1)requestAnimationFrame(step);}requestAnimationFrame(step);})(ns[i]);}}
-  function refresh(){ingest();applyTab();drawSparks();countUps();}
-  document.addEventListener('click',function(e){var t=e.target&&e.target.closest?e.target.closest('[data-tab]'):null;if(t){activeTab=t.getAttribute('data-tab');applyTab();var c=document.getElementById('content');if(c){c.classList.remove('swap');void c.offsetWidth;c.classList.add('swap');}}});
+  function applyFilter(){document.querySelectorAll('[data-panel="projects"] .card').forEach(function(c){var r=c.getAttribute('data-rollup');if(currentFilter==='all'){c.hidden=false;}else if(currentFilter==='alive'){c.hidden=r!=='alive';}else if(currentFilter==='caution'){c.hidden=r!=='stale';}else if(currentFilter==='offline'){c.hidden=r!=='gone'&&r!=='stopped'&&r!=='unknown';}});document.querySelectorAll('.filter-btn').forEach(function(x){var on=x.getAttribute('data-filter')===currentFilter;x.classList.toggle('on',on);x.setAttribute('aria-pressed',on?'true':'false');});}
+  function refresh(){ingest();applyTab();drawSparks();countUps();applyFilter();}
+  document.addEventListener('click',function(e){var t=e.target&&e.target.closest?e.target.closest('[data-tab]'):null;if(t){activeTab=t.getAttribute('data-tab');applyTab();var c=document.getElementById('content');if(c){c.classList.remove('swap');void c.offsetWidth;c.classList.add('swap');}}var fb=e.target&&e.target.closest?e.target.closest('[data-filter]'):null;if(fb){currentFilter=fb.getAttribute('data-filter');applyFilter();}});
   document.addEventListener('keydown',function(e){var ae=document.activeElement;if((e.key==='ArrowRight'||e.key==='ArrowLeft')&&ae&&ae.getAttribute&&ae.getAttribute('data-tab')){var o=['overview','projects','daemon','environment'];var i=o.indexOf(activeTab);i=(i+(e.key==='ArrowRight'?1:o.length-1))%o.length;activeTab=o[i];applyTab();var nt=document.querySelector('[data-tab="'+activeTab+'"]');if(nt)nt.focus();e.preventDefault();}});
   var led=document.getElementById('led');var conn=document.getElementById('conn');var updated=document.getElementById('updated');
   function tickAge(){if(!generatedAt)return;var s=Math.max(0,Math.round((Date.now()-generatedAt)/1000));updated.textContent='updated '+s+'s ago';}

--- a/packages/workspaces/src/cmux-daemon/__tests__/store-fingerprint.test.ts
+++ b/packages/workspaces/src/cmux-daemon/__tests__/store-fingerprint.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { parseStoreRecords } from "../store-fingerprint.js";
+
+const projects = { squadrant: { path: "/Users/me/squadrant" } };
+
+const file = JSON.stringify({
+  sessions: {
+    a: { sessionId: "a", pid: 41030, cwd: "/Users/me/squadrant", isRestorable: true,
+         launchCommand: { arguments: ["claude","--append-system-prompt-file","/x/templates/captain.claude.md"] } },
+    b: { sessionId: "b", pid: 74497, cwd: "/Users/me/squadrant", isRestorable: true,
+         launchCommand: { arguments: ["claude","--append-system-prompt-file","/x/templates/side.research.claude.md"] } },
+    // cwd matches the known project so this record isn't dropped by the
+    // project filter — pid:null (hibernated) is the thing under test here.
+    c: { sessionId: "c", pid: null, cwd: "/Users/me/squadrant",
+         launchCommand: { arguments: ["claude"] } },
+  },
+});
+
+describe("parseStoreRecords", () => {
+  it("identifies the captain by template, not cwd (captain+side share cwd)", () => {
+    const recs = parseStoreRecords(file, projects);
+    const cap = recs.find((r) => r.role === "captain");
+    expect(cap?.project).toBe("squadrant");
+    expect(cap?.pid).toBe(41030);
+    expect(cap?.present).toBe(true);
+  });
+  it("classifies a sibling side-session as role 'command'/'unknown', not captain", () => {
+    const recs = parseStoreRecords(file, projects);
+    expect(recs.filter((r) => r.role === "captain")).toHaveLength(1);
+  });
+  it("handles pid:null (hibernated) without dropping the record", () => {
+    const recs = parseStoreRecords(file, projects);
+    expect(recs.some((r) => r.pid === null)).toBe(true);
+  });
+});

--- a/packages/workspaces/src/cmux-daemon/__tests__/store-fingerprint.test.ts
+++ b/packages/workspaces/src/cmux-daemon/__tests__/store-fingerprint.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseStoreRecords } from "../store-fingerprint.js";
+import { parseStoreRecords, readLivenessSnapshot } from "../store-fingerprint.js";
 
 const projects = { squadrant: { path: "/Users/me/squadrant" } };
 
@@ -31,5 +31,28 @@ describe("parseStoreRecords", () => {
   it("handles pid:null (hibernated) without dropping the record", () => {
     const recs = parseStoreRecords(file, projects);
     expect(recs.some((r) => r.pid === null)).toBe(true);
+  });
+  it("throws on invalid JSON (distinguishes 'unreadable' from 'valid + empty')", () => {
+    expect(() => parseStoreRecords("{not json", projects)).toThrow();
+  });
+});
+
+describe("readLivenessSnapshot — distinguishes a bad read from a genuinely-empty one", () => {
+  it("all files corrupt/unreadable → throws (must NOT be treated as zero captains)", () => {
+    const readFile = () => { throw new Error("mid-write / locked"); };
+    expect(() => readLivenessSnapshot(["a-hook-sessions.json", "b-hook-sessions.json"], readFile, projects))
+      .toThrow();
+  });
+  it("one good file among corrupt ones → returns records from the good file", () => {
+    const readFile = (f: string) => {
+      if (f === "good-hook-sessions.json") return file;
+      throw new Error("corrupt");
+    };
+    const recs = readLivenessSnapshot(["bad-hook-sessions.json", "good-hook-sessions.json"], readFile, projects);
+    expect(recs.some((r) => r.role === "captain")).toBe(true);
+  });
+  it("genuinely zero files (readdir ok, none present) → returns [] (not a throw)", () => {
+    const readFile = () => { throw new Error("should never be called"); };
+    expect(readLivenessSnapshot([], readFile, projects)).toEqual([]);
   });
 });

--- a/packages/workspaces/src/cmux-daemon/daemon-cmux.ts
+++ b/packages/workspaces/src/cmux-daemon/daemon-cmux.ts
@@ -5,7 +5,7 @@ import type { RuntimeDriver, PaneRef } from "../runtimes/types.js";
 import { DeferDelivery } from "@squadrant/core";
 import { loadConfig } from "@squadrant/shared";
 import type { RuntimeLivenessRecord } from "@squadrant/shared";
-import { parseStoreRecords } from "./store-fingerprint.js";
+import { readLivenessSnapshot } from "./store-fingerprint.js";
 
 /**
  * #332: daemon-side cmux access. The daemon (a launchd process, NOT a cmux
@@ -14,8 +14,13 @@ import { parseStoreRecords } from "./store-fingerprint.js";
  *
  * Every method is FAIL-SOFT: a cmux/socket error degrades to a safe sentinel
  * ([] / null / no-op) so a transient failure NEVER false-reaps a live crew.
- * The ONE exception is DeferDelivery, which `send` re-throws so the delivery
- * loop can defer-while-typing (#258/#302).
+ * Exceptions: DeferDelivery, which `send` re-throws so the delivery loop can
+ * defer-while-typing (#258/#302); and `liveness()`, which THROWS when it
+ * cannot get a good read of the store (readdir failure, or every store file
+ * unreadable/corrupt) instead of returning [] — a locked/mid-write store must
+ * never look like "read succeeded, zero captains" (that would false-close
+ * every known captain via runLivenessTick's markEnded path). runLivenessTick
+ * already treats a thrown liveness() as "leave the registry untouched".
  *
  * This is the seam #333's LifecycleSource port sits beside.
  */
@@ -59,18 +64,17 @@ export class DaemonCmux {
     catch { return false; }
   }
 
-  /** Ground-truth liveness from cmux's own hook-sessions store (§5.4). */
+  /**
+   * Ground-truth liveness from cmux's own hook-sessions store (§5.4).
+   * THROWS (does not return []) when the dir can't be listed, or every store
+   * file failed to read/parse — see the class doc above.
+   */
   async liveness(): Promise<RuntimeLivenessRecord[]> {
     const dir = process.env.CMUX_AGENT_HOOK_STATE_DIR ?? join(homedir(), ".cmuxterm");
     const projects = loadConfig().projects as Record<string, { path: string }>;
-    let files: string[] = [];
+    let files: string[];
     try { files = readdirSync(dir).filter((f) => f.endsWith("-hook-sessions.json") && !f.endsWith(".lock")); }
-    catch { return []; }
-    const out: RuntimeLivenessRecord[] = [];
-    for (const f of files) {
-      try { out.push(...parseStoreRecords(readFileSync(join(dir, f), "utf-8"), projects)); }
-      catch { /* skip unreadable/corrupt file */ }
-    }
-    return out;
+    catch (e) { throw new Error(`liveness: could not read cmux state dir ${dir}: ${(e as Error).message}`); }
+    return readLivenessSnapshot(files, (f) => readFileSync(join(dir, f), "utf-8"), projects);
   }
 }

--- a/packages/workspaces/src/cmux-daemon/daemon-cmux.ts
+++ b/packages/workspaces/src/cmux-daemon/daemon-cmux.ts
@@ -1,5 +1,11 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
 import type { RuntimeDriver, PaneRef } from "../runtimes/types.js";
 import { DeferDelivery } from "@squadrant/core";
+import { loadConfig } from "@squadrant/shared";
+import type { RuntimeLivenessRecord } from "@squadrant/shared";
+import { parseStoreRecords } from "./store-fingerprint.js";
 
 /**
  * #332: daemon-side cmux access. The daemon (a launchd process, NOT a cmux
@@ -51,5 +57,20 @@ export class DaemonCmux {
   async isAvailable(): Promise<boolean> {
     try { await this.driver.listSurfaces(""); return true; }
     catch { return false; }
+  }
+
+  /** Ground-truth liveness from cmux's own hook-sessions store (§5.4). */
+  async liveness(): Promise<RuntimeLivenessRecord[]> {
+    const dir = process.env.CMUX_AGENT_HOOK_STATE_DIR ?? join(homedir(), ".cmuxterm");
+    const projects = loadConfig().projects as Record<string, { path: string }>;
+    let files: string[] = [];
+    try { files = readdirSync(dir).filter((f) => f.endsWith("-hook-sessions.json") && !f.endsWith(".lock")); }
+    catch { return []; }
+    const out: RuntimeLivenessRecord[] = [];
+    for (const f of files) {
+      try { out.push(...parseStoreRecords(readFileSync(join(dir, f), "utf-8"), projects)); }
+      catch { /* skip unreadable/corrupt file */ }
+    }
+    return out;
   }
 }

--- a/packages/workspaces/src/cmux-daemon/store-fingerprint.ts
+++ b/packages/workspaces/src/cmux-daemon/store-fingerprint.ts
@@ -1,0 +1,48 @@
+import { resolveHome } from "@squadrant/shared";
+import type { RuntimeLivenessRecord, Role } from "@squadrant/shared";
+
+interface RawSession {
+  sessionId?: string; pid?: number | null; cwd?: string; isRestorable?: boolean;
+  launchCommand?: { arguments?: string[]; workingDirectory?: string };
+}
+
+/** template basename → role (captain.claude.md → captain, crew.claude.md → crew, …). */
+function roleFromTemplate(args: string[] | undefined): Role | "unknown" {
+  const i = args?.indexOf("--append-system-prompt-file") ?? -1;
+  const tmpl = i >= 0 && args ? (args[i + 1] ?? "").split("/").pop() ?? "" : "";
+  if (tmpl.startsWith("captain")) return "captain";
+  if (tmpl.startsWith("crew")) return "crew";
+  if (tmpl.startsWith("command")) return "command";
+  return "unknown"; // side.research.* etc. — not a captain
+}
+
+function projectFromCwd(cwd: string, projects: Record<string, { path: string }>): string | undefined {
+  for (const [name, p] of Object.entries(projects)) {
+    const projPath = resolveHome(p.path);
+    if (cwd === projPath || cwd.startsWith(`${projPath}/`)) return name;
+  }
+  return undefined;
+}
+
+export function parseStoreRecords(
+  fileContent: string,
+  projects: Record<string, { path: string }>,
+): RuntimeLivenessRecord[] {
+  let parsed: { sessions?: Record<string, RawSession> };
+  try { parsed = JSON.parse(fileContent); } catch { return []; }
+  const out: RuntimeLivenessRecord[] = [];
+  for (const s of Object.values(parsed.sessions ?? {})) {
+    const cwd = s.cwd ?? s.launchCommand?.workingDirectory ?? "";
+    const project = projectFromCwd(cwd, projects);
+    if (!project || !s.sessionId) continue;
+    out.push({
+      role: roleFromTemplate(s.launchCommand?.arguments),
+      project,
+      pid: typeof s.pid === "number" ? s.pid : null,
+      sessionId: s.sessionId,
+      present: true,
+      isRestorable: s.isRestorable,
+    });
+  }
+  return out;
+}

--- a/packages/workspaces/src/cmux-daemon/store-fingerprint.ts
+++ b/packages/workspaces/src/cmux-daemon/store-fingerprint.ts
@@ -24,12 +24,19 @@ function projectFromCwd(cwd: string, projects: Record<string, { path: string }>)
   return undefined;
 }
 
+/**
+ * Parse one store file's content. Throws on invalid JSON — a corrupt/mid-write
+ * file is a failed read, NOT a valid file with zero sessions; callers (see
+ * `readLivenessSnapshot`) must be able to tell the two apart so a locked file
+ * never false-reads as "no captains".
+ */
 export function parseStoreRecords(
   fileContent: string,
   projects: Record<string, { path: string }>,
 ): RuntimeLivenessRecord[] {
   let parsed: { sessions?: Record<string, RawSession> };
-  try { parsed = JSON.parse(fileContent); } catch { return []; }
+  try { parsed = JSON.parse(fileContent); }
+  catch (e) { throw new Error(`parseStoreRecords: invalid JSON: ${(e as Error).message}`); }
   const out: RuntimeLivenessRecord[] = [];
   for (const s of Object.values(parsed.sessions ?? {})) {
     const cwd = s.cwd ?? s.launchCommand?.workingDirectory ?? "";
@@ -43,6 +50,32 @@ export function parseStoreRecords(
       present: true,
       isRestorable: s.isRestorable,
     });
+  }
+  return out;
+}
+
+/**
+ * Read+parse every given store file, tolerating individual bad files (locked
+ * mid-write, corrupt) as long as at least one yields a good read. Only throws
+ * when EVERY file failed — a locked/corrupt store must never look like "read
+ * succeeded, zero captains present" (that would false-close every known
+ * captain this tick). Genuinely zero files (none present) is a valid empty read.
+ */
+export function readLivenessSnapshot(
+  files: string[],
+  readFile: (filename: string) => string,
+  projects: Record<string, { path: string }>,
+): RuntimeLivenessRecord[] {
+  const out: RuntimeLivenessRecord[] = [];
+  let successes = 0;
+  for (const f of files) {
+    try {
+      out.push(...parseStoreRecords(readFile(f), projects));
+      successes++;
+    } catch { /* this file unreadable/corrupt — other files may still be good */ }
+  }
+  if (files.length > 0 && successes === 0) {
+    throw new Error(`readLivenessSnapshot: all ${files.length} store file(s) unreadable/corrupt this tick`);
   }
   return out;
 }


### PR DESCRIPTION
Cuts **squadrant v0.15.0** off develop (21 commits since v0.14.3).

## Headline
- **Captain liveness redesign** — hybrid ground-truth (persisted `LivenessRegistry` + cmux store `liveness()` seam + per-tick pid floor), retires the K=3 title-sweep streak model. Correct alive/gone/stopped detection that survives daemon restart. Smoke-verified live (alive→gone→stopped each within one tick).

## Also in this release
- **Per-project effort** override (`squadrant effort --project`)
- **CLI + web dashboards**: non-running captains now `offline` (not `idle`); web status filter + per-captain badge; new **LIVE mission-control tab** (count header, attention-first ordering, search/sort, expandable crew rows)
- Fixes: #517 (stale-alive blocking Telegram auto-launch), #520 (boot-if-down silent no-op → `--headless`), store-lock false-close hardening
- Also bundles previously-merged #510 (restart broadcast), #511 (opencode init)

## Verification
- 1955 tests green (159 files), both bins gate-clean
- Liveness smoke-tested on a throwaway project; dashboards + per-project effort verified live via hotpatch

Follow-ups tracked: #522 (idle phrasing), #523 (errored rollup), #524 (LIVE per-crew plumbing).

On merge, release.yml tags `v0.15.0`, creates the GitHub release from the CHANGELOG, and publishes to npm.