### PR TITLE
fix(#527): deduplicate runtime records per project in runLivenessTick

### DIFF
--- a/packages/core/src/daemon/__tests__/liveness-tick.test.ts
+++ b/packages/core/src/daemon/__tests__/liveness-tick.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { LivenessRegistry } from "../liveness-registry.js";
 import { runLivenessTick } from "../delivery-loop.js";
+import { deriveCaptainState } from "../../liveness.js";
 import type { RuntimeLivenessRecord } from "@squadrant/shared";
 
 const memReg = () => new LivenessRegistry({ path: "/x/l.json", readFile: () => undefined, writeFile: () => {} });
@@ -91,5 +92,35 @@ describe("runLivenessTick", () => {
     await expect(
       runLivenessTick({ registry: reg, liveness: async () => [rec], isPidAlive: () => true, now: () => 5_000 }),
     ).resolves.toBeUndefined();
+  });
+
+  // ── #527: multiple cmux sessions sharing a project cwd ─────────────────
+
+  it("two records same project, DEAD pid iterated LAST → picks alive (regression for #527)", async () => {
+    const reg = memReg();
+    const live: RuntimeLivenessRecord = { role: "captain", project: "p", pid: 100, sessionId: "s1", present: true };
+    const dead: RuntimeLivenessRecord = { role: "captain", project: "p", pid: 200, sessionId: "s2", present: true, isRestorable: true };
+    await runLivenessTick({
+      registry: reg,
+      liveness: async () => [live, dead],
+      isPidAlive: (pid) => pid === 100,
+      now: () => 5_000,
+    });
+    expect(reg.get("p")?.pidAlive).toBe(true);
+    expect(deriveCaptainState(reg.get("p"))).toBe("alive");
+  });
+
+  it("two records same project, both pids dead → captain gone", async () => {
+    const reg = memReg();
+    const dead1: RuntimeLivenessRecord = { role: "captain", project: "p", pid: 100, sessionId: "s1", present: true, isRestorable: true };
+    const dead2: RuntimeLivenessRecord = { role: "captain", project: "p", pid: 200, sessionId: "s2", present: true, isRestorable: true };
+    await runLivenessTick({
+      registry: reg,
+      liveness: async () => [dead1, dead2],
+      isPidAlive: () => false,
+      now: () => 5_000,
+    });
+    expect(reg.get("p")?.pidAlive).toBe(false);
+    expect(deriveCaptainState(reg.get("p"))).toBe("gone");
   });
 });

--- a/packages/core/src/daemon/delivery-loop.ts
+++ b/packages/core/src/daemon/delivery-loop.ts
@@ -74,21 +74,33 @@ export async function runLivenessTick(deps: LivenessTickDeps): Promise<void> {
   try { records = await deps.liveness(); } catch { return; } // runtime unreachable → leave registry as-is
   const seen = new Set<string>();
 
+  // #527: multiple cmux sessions can share a cwd, producing duplicate project
+  // entries. Group by project and pick one winner to avoid last-write-wins
+  // collision (dead pid overwriting live).
+  const byProject = new Map<string, RuntimeLivenessRecord[]>();
   for (const r of records) {
     if (r.role !== "captain") continue;
-    seen.add(r.project);
+    let arr = byProject.get(r.project);
+    if (!arr) { arr = []; byProject.set(r.project, arr); }
+    arr.push(r);
+  }
+
+  for (const [project, recs] of byProject) {
+    seen.add(project);
+    // Prefer pidAlive===true (or pid:null hibernated), then first in order.
+    const winner = recs.find(r => r.pid == null || deps.isPidAlive(r.pid)) ?? recs[0];
     const entry: LivenessEntry = {
-      project: r.project, role: "captain", pid: r.pid, sessionId: r.sessionId,
+      project, role: "captain", pid: winner.pid, sessionId: winner.sessionId,
       startedAt: now, lastState: "start", lastSeenAt: now,
-      pidAlive: r.pid != null ? deps.isPidAlive(r.pid) : true, // pid:null hibernated → alive-unknown
+      pidAlive: winner.pid != null ? deps.isPidAlive(winner.pid) : true,
       source: "runtime",
     };
     // Preserve original startedAt if we already knew this captain (avoid churn):
-    const prev = deps.registry.get(r.project);
+    const prev = deps.registry.get(project);
     if (prev && prev.lastState === "start") entry.startedAt = prev.startedAt;
     deps.registry.apply(entry);
-    if (r.pid != null) deps.registry.setPidAlive(r.project, deps.isPidAlive(r.pid), now);
-    logEntry(deps.log, r.project, deps.registry.get(r.project));
+    if (winner.pid != null) deps.registry.setPidAlive(project, deps.isPidAlive(winner.pid), now);
+    logEntry(deps.log, project, deps.registry.get(project));
   }
 
   // Captains we knew but the snapshot no longer lists → clean close.


### PR DESCRIPTION
Fix last-write-wins collision in runLivenessTick when two cmux sessions share a cwd. Group by project, pick winner (prefer pidAlive===true), apply only the winner. Closes #527.