### PR TITLE
fix: implement mailbox routing for CLI interrupts (#529, #531)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.15.0] - 2026-07-08
+### BREAKING
+
+- **Deleted the `squadrant runtime send-key` command.** It had zero callers across all plugins and templates. Deferring an unconditional `Enter` keypress through the mailbox guard changes its semantics entirely (what it submits depends on what draft the user typed while the key was queued). If you need to simulate a raw keypress without draft protection, shell out to the underlying binary directly: `/Applications/cmux.app/Contents/Resources/bin/cmux send-key --workspace "workspace:N" Enter`.
 
 ### Added
 

--- a/docs/specs/2026-07-09-draft-clobber-mailbox-routing.md
+++ b/docs/specs/2026-07-09-draft-clobber-mailbox-routing.md
@@ -1,0 +1,333 @@
+# Draft-Clobber: Route Interrupts Through the Mailbox
+
+**Status:** Approved (design) — not implemented
+**Date:** 2026-07-09
+**Author:** captain brainstorm (owner-approved)
+**Issue:** #529
+**Scope:** control plane — `squadrant ping`, `squadrant runtime send`, `squadrant runtime send-key`, `delivery-loop.ts`
+
+## Problem
+
+squadrant talks to agent panes by **simulating a keyboard**. There is no message API:
+
+```ts
+await cmux(["send", "--workspace", ws, "--surface", sf, sanitizeForCmuxSend(message)]);
+await cmux(["send-key", "--workspace", ws, "--surface", sf, "Enter"]);
+```
+— `packages/workspaces/src/runtimes/cmux.ts:472-473`
+
+So when a notice is injected while the user is mid-typing in a captain pane, the text
+**appends to their draft** and the unconditional `Enter` **submits the whole thing**.
+
+Reported symptom: on daemon restart the broadcast
+`⚠️ Daemon restarted → v0.15.0 (control-plane bounced)…` landed in the captain's prompt and
+submitted, swallowing the user's in-progress message.
+
+## Root cause: the guard is welded to the retry loop
+
+A screen-reading guard already exists — `CmuxDriver.sendToSurface`
+(`packages/workspaces/src/runtimes/cmux.ts:593`):
+
+| Condition | Action | Issue |
+|---|---|---|
+| `draft === null` (input box not visible) | `throw DeferDelivery(null)` (`:633`) | #268 |
+| `hasModalOptionList(screen)` | `throw DeferDelivery(null)` (`:643`) | #484 |
+| `draft === ""` | `deliver()` — the only write path (`:646`) | — |
+| `draft` non-empty, no probe | `throw DeferDelivery(draft)` (`:650`) | #302 |
+| probe mode | backspace ghost-probe (`:652-702`) | #258 |
+
+The guard signals "wait" by **throwing**. Throwing only works if a caller **retries**.
+
+**Exactly one caller in the repo catches `DeferDelivery`:** `CaptainDelivery.deliver`
+(`packages/core/src/delivery/captain-delivery.ts:75`), driven by the daemon delivery-loop
+(`packages/core/src/daemon/delivery-loop.ts:250`), which does **not** advance the mailbox
+cursor — so the entry is retried on the next tick. `daemon-cmux.ts:34` merely re-throws.
+
+Therefore:
+
+- Callers **with** a retry loop (the daemon) may use the guard → safe.
+- Callers **without** one (every CLI one-shot; the boot-time broadcast) cannot use the guard —
+  catching `DeferDelivery` in a process that is about to exit accomplishes nothing. They are
+  forced onto the raw path `CmuxDriver.send` (`cmux.ts:461-480`): send + unconditional `Enter`,
+  zero screen reads.
+
+**The mailbox is the only bridge between the two worlds.** It lets a no-retry caller borrow the
+daemon's retry. This is why Telegram inbound (`telegram/bridge.ts:423` → `appendCaptainMessage`)
+is safe and `ping` is not — not because anyone protected Telegram, but because it happened to go
+through the mailbox.
+
+Protection lives at the **call site**, not at the **chokepoint**. `CmuxDriver.send` is the
+innocuous-looking default, so every new surface is unsafe by default. #258 / #302 / #484 each
+patched one call site; they are symptoms of this layer.
+
+## Three classes of traffic
+
+| Class | Producer | Path today | Verdict |
+|---|---|---|---|
+| **Lifecycle** — `CREW DONE/IDLE/BLOCKED/STALLED` | daemon, `reduce.ts:157` | socket → mailbox → guard | ✅ already safe |
+| **Inbound conversation** — Telegram, `ping`, `runtime send` | outside the daemon | Telegram: mailbox ✅ · ping / runtime send: **raw** 🔴 | fix |
+| **System directives** — restart broadcast, effort change | daemon boot / CLI | **raw** 🔴 | PR #530 |
+
+Both classes 2 and 3 are **interrupts**: they change captain behaviour and require action. An
+`interrupt` / `passive` taxonomy was considered and **rejected** — the passive bucket has zero
+members. Liveness transitions and config drift never touch the pane; they live in
+`squadrantd.log` and the dashboard. Do not introduce the split without a real member.
+
+The bug was never "too many interrupts". It is that **interrupts bypass the guard**.
+
+## Design
+
+CLI one-shots stop being typists and become **producers**. They enqueue; the daemon delivers.
+
+```
+CLI (ping / runtime send)
+  ├─ requireDaemon()          NEW — socket dead → exit 1, nothing enqueued
+  ├─ needRef()                unchanged — target workspace not running → exit 1
+  └─ appendCaptainMessage()   enqueue, then exit
+                                   ↓
+daemon delivery-loop → CaptainDelivery → sendToSurface → [guard] → write only when box empty
+                            ↑ DeferDelivery → retry next tick
+```
+
+Because enqueue happens **only when the daemon is alive**, entries drain within a tick or two.
+The stale-skip rule (below) therefore never fires for them, and needs no change.
+
+### Fail-fast vs best-effort
+
+The distinction is **what the caller is for**, not what it touches.
+
+| Command | Primary job | Notification | Daemon down |
+|---|---|---|---|
+| `ping` | *is* delivering a message | — | `exit 1`, nothing enqueued |
+| `runtime send` | *is* delivering a message | — | `exit 1`, nothing enqueued |
+| `effort` | write config | incidental | write config, `exit 0` — notice may be dropped |
+| restart broadcast | — | — | cannot happen — runs *inside* the daemon at boot |
+
+`effort` is already best-effort: `commands/effort.ts:115-117` catches and prints
+`(no running captain detected — change applies on next launch)`. Preserve that. `requireDaemon()`
+applies **only** to `ping` and `runtime send`.
+
+`appendCaptainMessage` writes a local file, so `effort` enqueues whether or not the daemon is up.
+If the daemon is down and later boots past the stale window, the effort notice is dropped. That is
+**accepted**: the config write — the command's actual job — already succeeded, and the next captain
+launch reads the new value anyway. Do **not** add `requireDaemon()` to `effort` to "fix" this; doing
+so would fail a command that did its job.
+
+There must be no path where a message is silently discarded while the caller believes it was sent.
+
+### `--command` requires a delivery-loop change
+
+`runtime send --command` targets the **command workspace**. The drain loop iterates:
+
+```ts
+const allProjects = [...new Set([
+  ...Object.keys(cfg.projects ?? {}),
+  ...Object.keys(injectedSurfaces),
+  ...store.listAll().map((t) => t.project),
+])];
+```
+— `packages/core/src/daemon/delivery-loop.ts:201-206`
+
+`cfg.commandName` (default `"🏛️ command"`) is **not a project**, so an entry enqueued under that
+name is never read. Line 209 compounds it:
+`const captainTitle = projCfg?.captainName ?? \`${project}-captain\`` — the wrong surface title
+for the command workspace.
+
+Routing the notifier through the mailbox without fixing this would **lose the message permanently**.
+`delivery-loop.ts` must therefore be **in scope**, contrary to the constraint imposed on the first
+crew attempt (see Rejected Alternatives).
+
+### `source` widening
+
+`appendCaptainMessage` takes `source: "telegram" | "daemon"` (`packages/core/src/mailbox.ts:154`).
+`ping` and `runtime send` are typed by a human or an agent, not by the daemon. Add `"cli"` —
+one line. Do **not** reuse `"daemon"`: nothing reads `payload.source` today, but a mislabelled
+record is a lie that will be believed the moment someone writes the first reader.
+
+## Per-surface change table
+
+| # | Surface | file:line | Change |
+|---|---|---|---|
+| 1 | `runtime send-key` | `packages/cli/src/commands/runtime.ts:105-122` | **Delete the command.** |
+| 2 | `ping` | `packages/cli/src/commands/ping.ts:17` | `requireDaemon()` + `appendCaptainMessage(source:"cli")` |
+| 3 | `runtime send` | `packages/cli/src/commands/runtime.ts:97` | same; `--command` → `project = cfg.commandName` |
+| 4 | drain loop | `packages/core/src/daemon/delivery-loop.ts:201-209` | include `cfg.commandName` in `allProjects`; use it verbatim as the surface title |
+| 5 | `mailbox.ts` | `packages/core/src/mailbox.ts:154` | widen `source` to `"telegram" \| "daemon" \| "cli"` |
+| 6 | `notifiers/cmux.ts` | `:32` | **no change** — shells out to `runtime send --command`, fixed transitively |
+| 7 | restart + effort broadcasts | — | **no change** — PR #530 already routes them via `appendCaptainMessage` |
+| 8 | stale-skip (#531) | `packages/core/src/daemon/delivery-loop.ts:239-246` | exempt `captain.message` when `payload.source !== "daemon"` |
+
+## Migration: deleting `runtime send-key`
+
+`squadrant runtime send-key` has **zero callers**. Verified across source, `plugin/skills/`,
+`templates/`, `~/.config/squadrant/scripts/`, and shell history. It is registered
+(`packages/cli/src/index.ts`) and defined (`runtime.ts:105`) and never invoked.
+
+The escape hatch people actually use is the cmux binary directly:
+
+```
+/Applications/cmux.app/Contents/Resources/bin/cmux send-key --workspace "workspace:N" Enter
+```
+— `plugin/skills/command-ops/SKILL.md:73`
+
+`squadrant` is published to npm, so removing a public CLI verb is a **breaking change**. The owner
+approved deletion without a deprecation cycle. Record it under **BREAKING** in `CHANGELOG.md`,
+naming the cmux-binary replacement.
+
+Delete rather than guard: a keypress cannot be queued sensibly. The guard only releases when the
+input box is **empty** — which is precisely when a deferred `Enter` is meaningless. A key's meaning
+is bound to the screen state at the instant it is pressed; deferring it changes what it does. That
+is the whole argument against the rejected alternative below.
+
+## Non-goals (explicitly out of scope)
+
+- **`sendRaw` / inverting the chokepoint default.** Making `CmuxDriver.send` draft-aware and
+  exposing a loudly-named raw variant is the right long-term shape, but it changes the semantics of
+  a function with six call sites. Deferred to its own issue.
+- **`launch-workspace.ts:74`** — raw `runtime.send` into a *booting* captain, already gated by its
+  own `idle/working` classify. Left alone.
+- **Raw-but-benign `sendToPane` callers** — `crew-spawn.ts:189,358,412,447`, `side-session.ts:158,190`,
+  `dashboard.ts:77`, `command.ts:80`. They target freshly created empty panes. Safe by construction,
+  not by guard. Unchanged, but note the assumption is unenforced.
+- ~~**The stale-skip rule**~~ — now **in scope**, see "Folded in: #531" above.
+- **`confirmedSendToPane`** (`crew-pane.ts:135`) — protects against paste-strand (#339); guarantees
+  the *crew's* payload is submitted. It does **not** check for a human draft, and it targets crew
+  panes. Different protection, different subject. Do not conflate. The name is a trap: `confirmed`
+  reads as "safe for the user" and is not.
+
+## Folded in: #531 — silent drop of human messages
+
+**Confirmed in production**, not hypothetical. `squadrantd.log`:
+
+```
+2026-07-07T16:57:15.303Z delivery seq=85 kind=captain.message outcome=stale-skipped
+```
+
+That seq is still in `state/inbox/brove-mobile.log`:
+
+```json
+{"seq":85,"ts":"2026-07-07T14:14:48.715Z","kind":"captain.message",
+ "payload":{"source":"telegram"},
+ "message":"📩 [from Telegram] Hi, this messahe to test new quadrant bug fix and state (second test)"}
+```
+
+A real inbound Telegram message from the owner, enqueued at 14:14, silently acked and discarded at
+16:57 when the daemon restarted 2h43m later. It never reached the captain, and nothing surfaced the
+loss.
+
+### Why the current rule eats it
+
+`delivery-loop.ts:239-246` skips any entry older than `sessionStartMs - STALE_THRESHOLD_MS` unless
+its kind is in `TERMINAL_KINDS`. But terminal kinds already deliver regardless of age (#474). So the
+only thing stale-skip actually suppresses is **non-terminal bot chatter** — `task.started`, turn
+events — which is exactly the storm #332 BUG-3 was written to dam. It eats human messages by
+accident, not by design.
+
+### The rule
+
+Exempting *all* `captain.message` would resurrect stale system notices: a `⚠️ Daemon restarted` from
+two days ago injected today is noise. The correct axis is `payload.source`:
+
+| `source` | Producer | Stale behaviour |
+|---|---|---|
+| `telegram` | the human | **always deliver** — someone is waiting for a reply |
+| `cli` | human/agent typing `ping` / `runtime send` | **always deliver** |
+| `daemon` | restart / effort broadcast | may be skipped — context has expired |
+
+> `captain.message` is exempt from stale-skip **iff** `payload.source !== "daemon"`.
+
+This gives `payload.source` — a field nothing has ever read — its first consumer, and retroactively
+justifies widening it to include `"cli"` (change #5).
+
+Storm risk is bounded: only human-originated messages are exempt, they are low-volume, and delivery
+is still paced one entry per tick behind the draft guard.
+
+## Known adjacent bug (superseded — now in scope)
+
+Telegram inbound is also `kind: "captain.message"`, which is **not** in `TERMINAL_KINDS`
+(`delivery-loop.ts:20`). Any `captain.message` that is enqueued but **not yet delivered** when the
+daemon restarts more than `STALE_THRESHOLD_MS` (5 min, `interactive-probe.ts:7`) later is silently
+acked and dropped — `delivery-loop.ts:239-246` advances the cursor past it.
+
+Reachable two ways, both ordinary:
+
+1. The captain has a draft, so delivery defers (#302) — then the daemon restarts.
+2. The captain workspace is **closed**, so `delivery-loop.ts:224` (`if (!surface) continue;`) never
+   reads the cursor at all. Messages queue for as long as the workspace is shut. Reopen it and
+   restart the daemon, and the whole backlog is discarded.
+
+Note the bridge runs **inside** the daemon (`squadrantd.ts:68`), so a message cannot be enqueued
+while the daemon is down — there is no consumer. The trigger is an *undelivered* message surviving a
+restart, not one *sent* during an outage.
+
+Pre-existing, outside #529. Owner elected to file separately and fix later.
+
+## Why it fired when it did
+
+The restart broadcast is gated on a signature of `version::buildMtimeMs`
+(`daemon-restart-broadcast.ts:26-39`). A local `npm run build` moves `dist`'s mtime → the signature
+changes → the next daemon boot broadcasts to every live captain, raw, with `Enter`.
+
+**Every dev rebuild followed by a daemon restart clobbers every captain's draft.** Not bad luck.
+
+## Tests
+
+Each surface, unit level, with a fake driver:
+
+- **`ping`** — asserts **zero** `driver.send` / `driver.sendKey` calls, and exactly **one**
+  mailbox entry with `source: "cli"`.
+- **`runtime send`** — same.
+- **`runtime send --command`** — enqueues under `cfg.commandName`.
+- **Daemon down** — `ping` and `runtime send` exit non-zero **and** enqueue **nothing**. Assert both;
+  the exit code alone would pass against a version that enqueued first and then threw.
+- **`effort` with daemon down** — writes config and exits **zero**. Guards the best-effort contract
+  against an over-eager `requireDaemon()`. Do not assert on enqueue here: the mailbox write is a
+  local file append and succeeds regardless of daemon state.
+- **`delivery-loop`** — an entry under `cfg.commandName` is drained and delivered. *This test must
+  fail against current `develop`* — that failure is the evidence the gap is real. A test that passes
+  before the fix proves nothing.
+- **`send-key`** — the command is no longer registered on the CLI program.
+- **#531 stale-skip** — an entry with `kind: "captain.message"`, `payload.source: "telegram"`, and a
+  `ts` older than `sessionStartMs - STALE_THRESHOLD_MS` **is delivered**, and the cursor is not
+  advanced past it undelivered. *This test must fail against current `develop`.* Companion test: the
+  same entry with `source: "daemon"` **is** stale-skipped, proving the exemption is scoped and did
+  not simply disable the storm dam.
+
+Assert on **call counts**, not just mailbox contents. The point is that nothing keystrokes the pane.
+
+## Rejected alternatives
+
+**Mailbox `captain.send-key` kind** (crew attempt, preserved at `.scratch/p2-rejected-154601.patch`).
+Added a `captain.send-key` mailbox kind, `sendKeyToSurface`, and a `keyOnly` parameter threaded
+through `sendToSurface`. Rejected because:
+
+1. It built a queueing mechanism for a command with zero callers that is being deleted.
+2. Deferring a keypress is semantically wrong (see Migration, above).
+3. `sendToSurface(surface, "", { keyOnly })` — a text-send function repurposed to send keys with an
+   empty payload — muddies the contract.
+4. `sendKeyToSurface?` was declared **optional** on the driver interface: a driver that forgets to
+   implement it falls back silently.
+
+The attempt was, however, **right about `delivery-loop`**: it independently discovered that the
+command workspace is not drained and patched `cfg.commandName` in. The captain's "do not touch
+delivery-loop" constraint was wrong, and the crew was penalised for obeying the problem rather than
+the instruction. That constraint is lifted in this spec (change #4).
+
+**Two physical channels** (system log vs conversation). Rejected: the mailbox *is* the channel; what
+was missing was a classification, and the classification turned out to have an empty bucket. Two
+channels means two cursors, two drains, two failure modes, for the same result.
+
+**Routing `ping` through the daemon socket** (like `dispatch`). Considered, to make `ping` visible
+in `squadrantd.log` — it currently bypasses the daemon entirely and leaves no trace. Rejected:
+`delivery-loop` **already logs every delivered entry** (`delivery seq=… kind=… outcome=delivered`),
+so the mailbox route provides the same visibility without a new socket verb.
+
+## Open questions
+
+1. Should `requireDaemon()` live in `packages/cli/src/lib/` or reuse an existing socket helper?
+   `group-dispatch.ts:35` already probes daemon health via `sendRequest(sockPath, { kind: "health" })`.
+   Prefer reuse over a new probe.
+2. Exact wording and exit code for the daemon-down error. Suggested: `exit 1`,
+   `daemon not running — message NOT delivered. Start it with 'squadrant launch <project>'.`
+3. Does anything outside this repo depend on `squadrant runtime send-key`? Assumed no; a wider search
+   before the release would cost little.

--- a/packages/cli/src/commands/__tests__/effort.test.ts
+++ b/packages/cli/src/commands/__tests__/effort.test.ts
@@ -1,10 +1,15 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
+import os from "node:os";
 import { getDefaultConfig, saveConfig } from "@squadrant/shared";
 import type { SquadrantConfig, ProjectConfig } from "@squadrant/shared";
-import { runEffortGet, runEffortSet, notifyCaptainsOfEffort } from "../effort.js";
+import { runEffortGet, runEffortSet, notifyCaptainsOfEffort, effortCommand } from "../effort.js";
+
+const requireDaemon = vi.hoisted(() => vi.fn());
+vi.mock("../../lib/require-daemon.js", () => ({
+  requireDaemon,
+}));
 
 let dir: string;
 let cfgPath: string;
@@ -13,6 +18,8 @@ beforeEach(() => {
   dir = fs.mkdtempSync(path.join(os.tmpdir(), "squadrant-effort-"));
   cfgPath = path.join(dir, "config.json");
   saveConfig(getDefaultConfig(), cfgPath);
+  vi.resetAllMocks();
+  requireDaemon.mockResolvedValue(undefined);
 });
 afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
 
@@ -187,5 +194,23 @@ describe("effort notify (self-notification exclusion)", () => {
 
     expect(sent).toHaveLength(0);
     expect(spy.projects.sort()).toEqual(["a", "b"]);
+  });
+
+  it("handles driver failure gracefully without throwing (best effort)", async () => {
+    const config = configWithProjects({
+      a: project(path.join(dir, "projA"), "captain-a"),
+    });
+
+    const driver = {
+      status: vi.fn().mockRejectedValue(new Error("daemon unreachable"))
+    };
+    
+    const append = vi.fn();
+    
+    // Should NOT throw
+    await notifyCaptainsOfEffort("low", config, driver, path.join(dir, "elsewhere"), append);
+    
+    // And should not have appended
+    expect(append).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/__tests__/ping.test.ts
+++ b/packages/cli/src/commands/__tests__/ping.test.ts
@@ -27,6 +27,7 @@ vi.mock("@squadrant/workspaces", () => ({
 const loadConfig = vi.hoisted(() => vi.fn());
 vi.mock("@squadrant/shared", () => ({
   loadConfig,
+  DEFAULT_CONFIG_PATH: "/dummy/path/.config/squadrant/config.json",
 }));
 
 const appendCaptainMessage = vi.hoisted(() => vi.fn());

--- a/packages/cli/src/commands/__tests__/runtime.test.ts
+++ b/packages/cli/src/commands/__tests__/runtime.test.ts
@@ -28,6 +28,7 @@ vi.mock("@squadrant/workspaces", () => ({
 const loadConfig = vi.hoisted(() => vi.fn());
 vi.mock("@squadrant/shared", () => ({
   loadConfig,
+  DEFAULT_CONFIG_PATH: "/dummy/path/.config/squadrant/config.json",
 }));
 
 const appendCaptainMessage = vi.hoisted(() => vi.fn());

--- a/packages/cli/src/commands/__tests__/runtime.test.ts
+++ b/packages/cli/src/commands/__tests__/runtime.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Command } from "commander";
 
 const status = vi.hoisted(() => vi.fn());
 const send = vi.hoisted(() => vi.fn());
@@ -40,7 +41,11 @@ vi.mock("../../lib/require-daemon.js", () => ({
   requireDaemon,
 }));
 
-import { runPing } from "../ping.js";
+// Mock process.exit and console.error
+vi.spyOn(process, "exit").mockImplementation((() => {}) as any);
+vi.spyOn(console, "error").mockImplementation(() => {});
+
+import { runRuntimeSend } from "../runtime.js";
 
 const makeConfig = () => ({
   commandName: "command",
@@ -57,48 +62,46 @@ const makeConfig = () => ({
   metrics: { enabled: false, path: "/tmp/metrics.json" },
 });
 
-describe("runPing", () => {
+describe("runtime send", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     loadConfig.mockReturnValue(makeConfig());
     requireDaemon.mockResolvedValue(undefined);
-  });
-
-  it("rejects an unregistered project with a clear error", async () => {
-    await expect(runPing("nope", "hello")).rejects.toThrow(/not found/i);
-    expect(send).not.toHaveBeenCalled();
-    expect(sendKey).not.toHaveBeenCalled();
-    expect(appendCaptainMessage).not.toHaveBeenCalled();
+    status.mockResolvedValue({ id: "ws-1", name: "⚓ A-captain", status: "running" });
   });
 
   it("delivers the message via the mailbox (enqueue) when daemon is running", async () => {
-    status.mockResolvedValue({ id: "ws-1", name: "⚓ A-captain", status: "running" });
-
-    await runPing("projA", "hello from ping");
+    await runRuntimeSend("projA", "hello from runtime send", {});
 
     expect(send).not.toHaveBeenCalled();
     expect(sendKey).not.toHaveBeenCalled();
     expect(appendCaptainMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         project: "projA",
-        text: "hello from ping",
+        text: "hello from runtime send",
         source: "cli",
       })
     );
   });
 
-  it("errors clearly when the target captain is not running (no auto-boot)", async () => {
-    status.mockResolvedValue(null);
+  it("enqueues under cfg.commandName when using --command", async () => {
+    await runRuntimeSend("hello from command", undefined, { command: true });
 
-    await expect(runPing("projA", "hello")).rejects.toThrow(/not running/i);
     expect(send).not.toHaveBeenCalled();
-    expect(appendCaptainMessage).not.toHaveBeenCalled();
+    expect(sendKey).not.toHaveBeenCalled();
+    expect(appendCaptainMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        project: "command",
+        text: "hello from command",
+        source: "cli",
+      })
+    );
   });
 
   it("enqueues nothing if the daemon is not running", async () => {
     requireDaemon.mockRejectedValue(new Error("daemon not running"));
 
-    await expect(runPing("projA", "hello")).rejects.toThrow(/daemon not running/i);
+    await expect(runRuntimeSend("projA", "hello from runtime send", {})).rejects.toThrow(/daemon not running/i);
     
     expect(send).not.toHaveBeenCalled();
     expect(sendKey).not.toHaveBeenCalled();

--- a/packages/cli/src/commands/ping.ts
+++ b/packages/cli/src/commands/ping.ts
@@ -4,11 +4,10 @@
 // registered project's captain pane. No tracked task, no report-back.
 // Reuses the same delivery mechanism as `squadrant runtime send`.
 
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 import { Command } from "commander";
 import chalk from "chalk";
-import { loadConfig } from "@squadrant/shared";
+import { loadConfig, DEFAULT_CONFIG_PATH } from "@squadrant/shared";
 import { appendCaptainMessage } from "@squadrant/core";
 import { buildRegistry, resolveTarget, needRef } from "./runtime.js";
 import { requireDaemon } from "../lib/require-daemon.js";
@@ -21,7 +20,7 @@ export async function runPing(project: string, message: string): Promise<void> {
   await requireDaemon();
   await needRef(resolved);
   
-  const stateRoot = join(homedir(), ".config", "squadrant", "state");
+  const stateRoot = join(dirname(DEFAULT_CONFIG_PATH), "state");
   await appendCaptainMessage({
     stateRoot,
     project,

--- a/packages/cli/src/commands/ping.ts
+++ b/packages/cli/src/commands/ping.ts
@@ -4,17 +4,30 @@
 // registered project's captain pane. No tracked task, no report-back.
 // Reuses the same delivery mechanism as `squadrant runtime send`.
 
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { Command } from "commander";
 import chalk from "chalk";
 import { loadConfig } from "@squadrant/shared";
+import { appendCaptainMessage } from "@squadrant/core";
 import { buildRegistry, resolveTarget, needRef } from "./runtime.js";
+import { requireDaemon } from "../lib/require-daemon.js";
 
 export async function runPing(project: string, message: string): Promise<void> {
   const config = loadConfig();
   const registry = buildRegistry();
   const resolved = resolveTarget(registry, config, project, false);
-  const ref = await needRef(resolved);
-  await resolved.driver.send(ref, message);
+  
+  await requireDaemon();
+  await needRef(resolved);
+  
+  const stateRoot = join(homedir(), ".config", "squadrant", "state");
+  await appendCaptainMessage({
+    stateRoot,
+    project,
+    text: message,
+    source: "cli",
+  });
 }
 
 export const pingCommand = new Command("ping")

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -76,6 +76,38 @@ runtimeCommand
     }
   });
 
+export async function runRuntimeSend(arg1: string, arg2: string | undefined, opts: { command?: boolean }) {
+  const config = loadConfig();
+  const registry = buildRegistry();
+  
+  if (opts.command && arg2 !== undefined) {
+    throw new Error("With --command, pass only the message (not a project name)");
+  }
+  const target = opts.command ? undefined : arg1;
+  const message = opts.command ? arg1 : arg2;
+  if (!message) throw new Error("Message is required");
+  
+  const { requireDaemon } = await import("../lib/require-daemon.js");
+  const { appendCaptainMessage } = await import("@squadrant/core");
+  await requireDaemon();
+  
+  const resolved = resolveTarget(registry, config, target, !!opts.command);
+  await needRef(resolved);
+  
+  const finalProject = opts.command ? config.commandName : target!;
+  
+  const { join } = await import("node:path");
+  const { homedir } = await import("node:os");
+  const stateRoot = join(homedir(), ".config", "squadrant", "state");
+
+  await appendCaptainMessage({
+    stateRoot,
+    project: finalProject,
+    text: message,
+    source: "cli",
+  });
+}
+
 runtimeCommand
   .command("send")
   .description("Send a message to a target workspace AND commit with Enter. With --command, the first positional is the message.")
@@ -83,43 +115,8 @@ runtimeCommand
   .argument("[arg2]", "Message (when target is a project). Omit when using --command.")
   .option("--command", "Target the command workspace")
   .action(async (arg1: string, arg2: string | undefined, opts: { command?: boolean }) => {
-    const config = loadConfig();
-    const registry = buildRegistry();
     try {
-      if (opts.command && arg2 !== undefined) {
-        throw new Error("With --command, pass only the message (not a project name)");
-      }
-      const target = opts.command ? undefined : arg1;
-      const message = opts.command ? arg1 : arg2;
-      if (!message) throw new Error("Message is required");
-      const resolved = resolveTarget(registry, config, target, !!opts.command);
-      const ref = await needRef(resolved);
-      await resolved.driver.send(ref, message);
-    } catch (err) {
-      console.error(chalk.red((err as Error).message));
-      process.exit(1);
-    }
-  });
-
-runtimeCommand
-  .command("send-key")
-  .description("Send a literal key press (e.g. Enter, Escape) to a target workspace. With --command, the first positional is the key.")
-  .argument("<arg1>", "Project name, or the key when --command is used")
-  .argument("[arg2]", "Key name (when target is a project). Omit when using --command.")
-  .option("--command", "Target the command workspace")
-  .action(async (arg1: string, arg2: string | undefined, opts: { command?: boolean }) => {
-    const config = loadConfig();
-    const registry = buildRegistry();
-    try {
-      if (opts.command && arg2 !== undefined) {
-        throw new Error("With --command, pass only the key (not a project name)");
-      }
-      const target = opts.command ? undefined : arg1;
-      const key = opts.command ? arg1 : arg2;
-      if (!key) throw new Error("Key is required");
-      const resolved = resolveTarget(registry, config, target, !!opts.command);
-      const ref = await needRef(resolved);
-      await resolved.driver.sendKey(ref, key);
+      await runRuntimeSend(arg1, arg2, opts);
     } catch (err) {
       console.error(chalk.red((err as Error).message));
       process.exit(1);

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -94,18 +94,18 @@ export async function runRuntimeSend(arg1: string, arg2: string | undefined, opt
   const resolved = resolveTarget(registry, config, target, !!opts.command);
   await needRef(resolved);
   
-  const finalProject = opts.command ? config.commandName : target!;
-  
-  const { join } = await import("node:path");
-  const { homedir } = await import("node:os");
-  const stateRoot = join(homedir(), ".config", "squadrant", "state");
+      const finalProject = opts.command ? config.commandName : target!;
+      
+      const { join, dirname } = await import("node:path");
+      const { DEFAULT_CONFIG_PATH } = await import("@squadrant/shared");
+      const stateRoot = join(dirname(DEFAULT_CONFIG_PATH), "state");
 
-  await appendCaptainMessage({
-    stateRoot,
-    project: finalProject,
-    text: message,
-    source: "cli",
-  });
+      await appendCaptainMessage({
+        stateRoot,
+        project: finalProject,
+        text: message,
+        source: "cli",
+      });
 }
 
 runtimeCommand

--- a/packages/cli/src/lib/__tests__/require-daemon.test.ts
+++ b/packages/cli/src/lib/__tests__/require-daemon.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from "vitest";
+import { requireDaemon } from "../require-daemon.js";
+import { isDaemonSocketLive } from "@squadrant/core";
+
+vi.mock("@squadrant/core", () => ({
+  isDaemonSocketLive: vi.fn(),
+}));
+
+describe("requireDaemon", () => {
+  it("resolves successfully if socket is live", async () => {
+    vi.mocked(isDaemonSocketLive).mockResolvedValue(true);
+    await expect(requireDaemon("dummy.sock")).resolves.toBeUndefined();
+    expect(isDaemonSocketLive).toHaveBeenCalledWith("dummy.sock");
+  });
+
+  it("throws an error if socket is dead", async () => {
+    vi.mocked(isDaemonSocketLive).mockResolvedValue(false);
+    await expect(requireDaemon("dummy.sock")).rejects.toThrow(
+      "daemon not running — message NOT delivered. Start it with 'squadrant launch <project>'."
+    );
+  });
+});

--- a/packages/cli/src/lib/require-daemon.ts
+++ b/packages/cli/src/lib/require-daemon.ts
@@ -1,0 +1,22 @@
+import { sendRequest } from "@squadrant/core";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const DEFAULT_SOCK_PATH = join(homedir(), ".config", "squadrant", "squadrant.sock");
+
+export async function requireDaemon(sockPath: string = DEFAULT_SOCK_PATH): Promise<void> {
+  try {
+    // Only check if the daemon is alive. We don't care about a specific project here.
+    // The health endpoint responds even if project is omitted.
+    // We set a very short timeout, as a local socket should be instant.
+    await sendRequest(sockPath, { kind: "health" }, 2000);
+  } catch (err: any) {
+    // We only fail if it's genuinely down (e.g. ECONNREFUSED) or timed out.
+    // If it threw some other error but it *is* a squadrant error (e.g. invalid response format),
+    // the daemon might still be up, but standard ECONNREFUSED means it's down.
+    if (err.code === "ECONNREFUSED" || err.code === "ENOENT" || err.message.includes("timeout")) {
+      console.error("daemon not running — message NOT delivered. Start it with 'squadrant launch <project>'.");
+      process.exit(1);
+    }
+  }
+}

--- a/packages/cli/src/lib/require-daemon.ts
+++ b/packages/cli/src/lib/require-daemon.ts
@@ -1,22 +1,12 @@
-import { sendRequest } from "@squadrant/core";
+import { isDaemonSocketLive } from "@squadrant/core";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
 const DEFAULT_SOCK_PATH = join(homedir(), ".config", "squadrant", "squadrant.sock");
 
 export async function requireDaemon(sockPath: string = DEFAULT_SOCK_PATH): Promise<void> {
-  try {
-    // Only check if the daemon is alive. We don't care about a specific project here.
-    // The health endpoint responds even if project is omitted.
-    // We set a very short timeout, as a local socket should be instant.
-    await sendRequest(sockPath, { kind: "health" }, 2000);
-  } catch (err: any) {
-    // We only fail if it's genuinely down (e.g. ECONNREFUSED) or timed out.
-    // If it threw some other error but it *is* a squadrant error (e.g. invalid response format),
-    // the daemon might still be up, but standard ECONNREFUSED means it's down.
-    if (err.code === "ECONNREFUSED" || err.code === "ENOENT" || err.message.includes("timeout")) {
-      console.error("daemon not running — message NOT delivered. Start it with 'squadrant launch <project>'.");
-      process.exit(1);
-    }
+  const isLive = await isDaemonSocketLive(sockPath);
+  if (!isLive) {
+    throw new Error("daemon not running — message NOT delivered. Start it with 'squadrant launch <project>'.");
   }
 }

--- a/packages/core/src/__tests__/delivery-loop.test.ts
+++ b/packages/core/src/__tests__/delivery-loop.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDelivery } from "../daemon/delivery-loop.js";
+import { createStore } from "../store.js";
+import { LivenessRegistry } from "../daemon/liveness-registry.js";
+import { appendCaptainMessage } from "../mailbox.js";
+import { STALE_THRESHOLD_MS } from "../daemon/interactive-probe.js";
+
+function freshState(): string {
+  return mkdtempSync(join(tmpdir(), "deliv-"));
+}
+
+describe("delivery-loop", () => {
+  it("exempts non-daemon captain.message from stale-skip (#531)", async () => {
+    const stateRoot = freshState();
+    const store = createStore(stateRoot);
+    store.put({
+      id: "t1", project: "demo", provider: "claude", mode: "interactive",
+      state: "submitted", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000, attempts: []
+    });
+    const livenessRegistry = new LivenessRegistry({ path: join(stateRoot, "live.json") });
+    
+    // Simulate liveness
+    livenessRegistry.apply({
+      project: "demo",
+      role: "captain",
+      pid: 123,
+      sessionId: "s1",
+      startedAt: Date.now(),
+      lastState: "start",
+      lastSeenAt: Date.now(),
+      pidAlive: true,
+      source: "runtime"
+    });
+    
+    // Create an old telegram message (stale)
+    await appendCaptainMessage({
+      stateRoot, project: "demo", text: "telegram message", source: "telegram"
+    });
+    
+    // Create an old daemon message (stale)
+    await appendCaptainMessage({
+      stateRoot, project: "demo", text: "daemon message", source: "daemon"
+    });
+    
+    // Shift the clock so these messages are very old
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + STALE_THRESHOLD_MS + 1000);
+    
+    const logs: string[] = [];
+    const cmux = {
+      listSurfaces: async () => [{ id: "s1", title: "demo-captain", command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => "demo-captain> ",
+      send: async (surface: any, text: string) => {
+        logs.push(`sent: ${text}`);
+      }
+    };
+    
+    const deliv = createDelivery({
+      stateRoot, store, livenessRegistry, log: (m: string) => {}, isPidAlive: () => true, opts: {}
+    } as any, cmux as any);
+    
+    await deliv.deliveryTick!();
+    
+    // Wait for async background things if necessary
+    // Then check what was sent
+    expect(logs).toContain("sent: telegram message");
+    expect(logs).not.toContain("sent: daemon message");
+    
+    vi.useRealTimers();
+  });
+
+  it("drains and delivers entries under cfg.commandName", async () => {
+    const stateRoot = freshState();
+    const store = createStore(stateRoot);
+    const livenessRegistry = new LivenessRegistry({ path: join(stateRoot, "live.json") });
+    
+    // Command workspace has no project config, it relies on cfg.commandName
+    const { loadConfig } = await import("@squadrant/shared");
+    const cfg = loadConfig();
+    const commandName = cfg.commandName; // Usually "🏛️ command"
+    
+    livenessRegistry.apply({
+      project: commandName,
+      role: "captain",
+      pid: 123,
+      sessionId: "s1",
+      startedAt: Date.now(),
+      lastState: "start",
+      lastSeenAt: Date.now(),
+      pidAlive: true,
+      source: "runtime"
+    });
+    
+    await appendCaptainMessage({
+      stateRoot, project: commandName, text: "hello command", source: "cli"
+    });
+    
+    const logs: string[] = [];
+    const cmux = {
+      listSurfaces: async () => [{ id: "s1", title: commandName, command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => `${commandName}> `,
+      send: async (surface: any, text: string) => {
+        logs.push(`sent: ${text}`);
+      }
+    };
+    
+    const deliv = createDelivery({
+      stateRoot, store, livenessRegistry, log: () => {}, isPidAlive: () => true, opts: {}
+    } as any, cmux as any);
+    
+    await deliv.deliveryTick!();
+    
+    expect(logs).toContain("sent: hello command");
+  });
+});

--- a/packages/core/src/daemon/delivery-loop.ts
+++ b/packages/core/src/daemon/delivery-loop.ts
@@ -202,11 +202,14 @@ export function createDelivery(
       ...Object.keys(cfg.projects ?? {}),
       ...Object.keys(injectedSurfaces),
       ...store.listAll().map((t) => t.project),
+      cfg.commandName,
     ])];
 
     for (const project of allProjects) {
       const projCfg = cfg.projects?.[project];
-      const captainTitle = projCfg?.captainName ?? `${project}-captain`;
+      const captainTitle = project === cfg.commandName 
+        ? cfg.commandName 
+        : (projCfg?.captainName ?? `${project}-captain`);
 
       // Surface discovery is ONLY for the delivery target (where to cmux.send);
       // captain presence/liveness authority now lives in livenessRegistry.
@@ -241,11 +244,17 @@ export function createDelivery(
           // undelivered CREW DONE must reach the captain even after a daemon
           // restart >5min after enqueue. Non-terminal backlog suppression stays.
           if (!TERMINAL_KINDS.has(entry.kind)) {
-            log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=stale-skipped`);
-            await writeCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER, lastAckedSeq: entry.seq });
-            continue;
+            // #531: exempt non-daemon captain.message (human/cli) from stale-skip
+            const isExemptMessage = entry.kind === "captain.message" && entry.payload?.source !== "daemon";
+            if (!isExemptMessage) {
+              log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=stale-skipped`);
+              await writeCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER, lastAckedSeq: entry.seq });
+              continue;
+            }
+            log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=stale-exempt-deliver`);
+          } else {
+            log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=stale-terminal-deliver`);
           }
-          log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=stale-terminal-deliver`);
         }
         const result = await d.deliver(entry, (text, sendOpts) =>
           cmux.send(surface!, text, sendOpts),

--- a/packages/core/src/mailbox.ts
+++ b/packages/core/src/mailbox.ts
@@ -151,7 +151,7 @@ export async function appendCaptainMessage(opts: {
   stateRoot: string;
   project: string;
   text: string;
-  source: "telegram" | "daemon";
+  source: "telegram" | "daemon" | "cli";
 }): Promise<void> {
   await appendEntry(opts.stateRoot, opts.project, (seq) => ({
     seq,

--- a/packages/core/src/telegram/bridge.ts
+++ b/packages/core/src/telegram/bridge.ts
@@ -45,7 +45,7 @@ export interface TelegramBridgeOptions {
   /** Root for per-project override files. Defaults to ~/.config/squadrant. */
   configRoot?: string;
   client: TelegramClient;
-  appendCaptainMessage: (a: { stateRoot: string; project: string; text: string; source: "telegram" }) => Promise<void>;
+  appendCaptainMessage: (a: { stateRoot: string; project: string; text: string; source: "telegram" | "daemon" | "cli" }) => Promise<void>;
   log: (msg: string) => void;
   // ── Control surfaces (#402/#403/#321) — all optional. When undefined the bridge
   // keeps exact v1 behavior (queue-only project topics, General topic dropped).


### PR DESCRIPTION
Implements the remaining phases of #529 and #531 per the design spec docs/specs/2026-07-09-draft-clobber-mailbox-routing.md.

- Deletes the unused `squadrant runtime send-key` command (breaking).
- Re-routes `squadrant ping` and `squadrant runtime send` through the mailbox using `appendCaptainMessage` to get draft-guard protection.
- Adds `requireDaemon()` fail-fast gating for `ping` and `runtime send` to prevent silent queuing when the daemon is offline.
- Enhances `delivery-loop.ts` to drain entries destined for the command workspace.
- Exempts human-originated `captain.message` entries (`source: "telegram" | "cli"`) from stale-skip, fixing silent drops (#531).
- Adds tests verifying that `ping` and `runtime send` enqueue without bypassing the draft-guard, and that non-daemon messages are not stale-skipped.