### PR TITLE
fix(#529, #531): route ping/runtime send through the mailbox, delete send-key, drain command workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.15.0] - 2026-07-08
+### BREAKING
+
+- **Deleted the `squadrant runtime send-key` command.** It had zero callers across all plugins and templates. Deferring an unconditional `Enter` keypress through the mailbox guard changes its semantics entirely (what it submits depends on what draft the user typed while the key was queued). If you need to simulate a raw keypress without draft protection, shell out to the underlying binary directly: `/Applications/cmux.app/Contents/Resources/bin/cmux send-key --workspace "workspace:N" Enter`.
 
 ### Added
 

--- a/packages/cli/src/commands/__tests__/effort.test.ts
+++ b/packages/cli/src/commands/__tests__/effort.test.ts
@@ -1,10 +1,15 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
+import os from "node:os";
 import { getDefaultConfig, saveConfig } from "@squadrant/shared";
 import type { SquadrantConfig, ProjectConfig } from "@squadrant/shared";
-import { runEffortGet, runEffortSet, notifyCaptainsOfEffort } from "../effort.js";
+import { runEffortGet, runEffortSet, notifyCaptainsOfEffort, effortCommand } from "../effort.js";
+
+const requireDaemon = vi.hoisted(() => vi.fn());
+vi.mock("../../lib/require-daemon.js", () => ({
+  requireDaemon,
+}));
 
 let dir: string;
 let cfgPath: string;
@@ -13,6 +18,8 @@ beforeEach(() => {
   dir = fs.mkdtempSync(path.join(os.tmpdir(), "squadrant-effort-"));
   cfgPath = path.join(dir, "config.json");
   saveConfig(getDefaultConfig(), cfgPath);
+  vi.resetAllMocks();
+  requireDaemon.mockResolvedValue(undefined);
 });
 afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
 
@@ -187,5 +194,23 @@ describe("effort notify (self-notification exclusion)", () => {
 
     expect(sent).toHaveLength(0);
     expect(spy.projects.sort()).toEqual(["a", "b"]);
+  });
+
+  it("handles driver failure gracefully without throwing (best effort)", async () => {
+    const config = configWithProjects({
+      a: project(path.join(dir, "projA"), "captain-a"),
+    });
+
+    const driver = {
+      status: vi.fn().mockRejectedValue(new Error("daemon unreachable"))
+    };
+    
+    const append = vi.fn();
+    
+    // Should NOT throw
+    await notifyCaptainsOfEffort("low", config, driver, path.join(dir, "elsewhere"), append);
+    
+    // And should not have appended
+    expect(append).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/__tests__/ping.test.ts
+++ b/packages/cli/src/commands/__tests__/ping.test.ts
@@ -27,6 +27,7 @@ vi.mock("@squadrant/workspaces", () => ({
 const loadConfig = vi.hoisted(() => vi.fn());
 vi.mock("@squadrant/shared", () => ({
   loadConfig,
+  DEFAULT_CONFIG_PATH: "/dummy/path/.config/squadrant/config.json",
 }));
 
 const appendCaptainMessage = vi.hoisted(() => vi.fn());

--- a/packages/cli/src/commands/__tests__/runtime.test.ts
+++ b/packages/cli/src/commands/__tests__/runtime.test.ts
@@ -28,6 +28,7 @@ vi.mock("@squadrant/workspaces", () => ({
 const loadConfig = vi.hoisted(() => vi.fn());
 vi.mock("@squadrant/shared", () => ({
   loadConfig,
+  DEFAULT_CONFIG_PATH: "/dummy/path/.config/squadrant/config.json",
 }));
 
 const appendCaptainMessage = vi.hoisted(() => vi.fn());

--- a/packages/cli/src/commands/__tests__/runtime.test.ts
+++ b/packages/cli/src/commands/__tests__/runtime.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Command } from "commander";
 
 const status = vi.hoisted(() => vi.fn());
 const send = vi.hoisted(() => vi.fn());
@@ -40,7 +41,11 @@ vi.mock("../../lib/require-daemon.js", () => ({
   requireDaemon,
 }));
 
-import { runPing } from "../ping.js";
+// Mock process.exit and console.error
+vi.spyOn(process, "exit").mockImplementation((() => {}) as any);
+vi.spyOn(console, "error").mockImplementation(() => {});
+
+import { runRuntimeSend } from "../runtime.js";
 
 const makeConfig = () => ({
   commandName: "command",
@@ -57,48 +62,46 @@ const makeConfig = () => ({
   metrics: { enabled: false, path: "/tmp/metrics.json" },
 });
 
-describe("runPing", () => {
+describe("runtime send", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     loadConfig.mockReturnValue(makeConfig());
     requireDaemon.mockResolvedValue(undefined);
-  });
-
-  it("rejects an unregistered project with a clear error", async () => {
-    await expect(runPing("nope", "hello")).rejects.toThrow(/not found/i);
-    expect(send).not.toHaveBeenCalled();
-    expect(sendKey).not.toHaveBeenCalled();
-    expect(appendCaptainMessage).not.toHaveBeenCalled();
+    status.mockResolvedValue({ id: "ws-1", name: "⚓ A-captain", status: "running" });
   });
 
   it("delivers the message via the mailbox (enqueue) when daemon is running", async () => {
-    status.mockResolvedValue({ id: "ws-1", name: "⚓ A-captain", status: "running" });
-
-    await runPing("projA", "hello from ping");
+    await runRuntimeSend("projA", "hello from runtime send", {});
 
     expect(send).not.toHaveBeenCalled();
     expect(sendKey).not.toHaveBeenCalled();
     expect(appendCaptainMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         project: "projA",
-        text: "hello from ping",
+        text: "hello from runtime send",
         source: "cli",
       })
     );
   });
 
-  it("errors clearly when the target captain is not running (no auto-boot)", async () => {
-    status.mockResolvedValue(null);
+  it("enqueues under cfg.commandName when using --command", async () => {
+    await runRuntimeSend("hello from command", undefined, { command: true });
 
-    await expect(runPing("projA", "hello")).rejects.toThrow(/not running/i);
     expect(send).not.toHaveBeenCalled();
-    expect(appendCaptainMessage).not.toHaveBeenCalled();
+    expect(sendKey).not.toHaveBeenCalled();
+    expect(appendCaptainMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        project: "command",
+        text: "hello from command",
+        source: "cli",
+      })
+    );
   });
 
   it("enqueues nothing if the daemon is not running", async () => {
     requireDaemon.mockRejectedValue(new Error("daemon not running"));
 
-    await expect(runPing("projA", "hello")).rejects.toThrow(/daemon not running/i);
+    await expect(runRuntimeSend("projA", "hello from runtime send", {})).rejects.toThrow(/daemon not running/i);
     
     expect(send).not.toHaveBeenCalled();
     expect(sendKey).not.toHaveBeenCalled();

--- a/packages/cli/src/commands/ping.ts
+++ b/packages/cli/src/commands/ping.ts
@@ -4,11 +4,10 @@
 // registered project's captain pane. No tracked task, no report-back.
 // Reuses the same delivery mechanism as `squadrant runtime send`.
 
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 import { Command } from "commander";
 import chalk from "chalk";
-import { loadConfig } from "@squadrant/shared";
+import { loadConfig, DEFAULT_CONFIG_PATH } from "@squadrant/shared";
 import { appendCaptainMessage } from "@squadrant/core";
 import { buildRegistry, resolveTarget, needRef } from "./runtime.js";
 import { requireDaemon } from "../lib/require-daemon.js";
@@ -21,7 +20,7 @@ export async function runPing(project: string, message: string): Promise<void> {
   await requireDaemon();
   await needRef(resolved);
   
-  const stateRoot = join(homedir(), ".config", "squadrant", "state");
+  const stateRoot = join(dirname(DEFAULT_CONFIG_PATH), "state");
   await appendCaptainMessage({
     stateRoot,
     project,

--- a/packages/cli/src/commands/ping.ts
+++ b/packages/cli/src/commands/ping.ts
@@ -4,17 +4,30 @@
 // registered project's captain pane. No tracked task, no report-back.
 // Reuses the same delivery mechanism as `squadrant runtime send`.
 
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { Command } from "commander";
 import chalk from "chalk";
 import { loadConfig } from "@squadrant/shared";
+import { appendCaptainMessage } from "@squadrant/core";
 import { buildRegistry, resolveTarget, needRef } from "./runtime.js";
+import { requireDaemon } from "../lib/require-daemon.js";
 
 export async function runPing(project: string, message: string): Promise<void> {
   const config = loadConfig();
   const registry = buildRegistry();
   const resolved = resolveTarget(registry, config, project, false);
-  const ref = await needRef(resolved);
-  await resolved.driver.send(ref, message);
+  
+  await requireDaemon();
+  await needRef(resolved);
+  
+  const stateRoot = join(homedir(), ".config", "squadrant", "state");
+  await appendCaptainMessage({
+    stateRoot,
+    project,
+    text: message,
+    source: "cli",
+  });
 }
 
 export const pingCommand = new Command("ping")

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -76,6 +76,38 @@ runtimeCommand
     }
   });
 
+export async function runRuntimeSend(arg1: string, arg2: string | undefined, opts: { command?: boolean }) {
+  const config = loadConfig();
+  const registry = buildRegistry();
+  
+  if (opts.command && arg2 !== undefined) {
+    throw new Error("With --command, pass only the message (not a project name)");
+  }
+  const target = opts.command ? undefined : arg1;
+  const message = opts.command ? arg1 : arg2;
+  if (!message) throw new Error("Message is required");
+  
+  const { requireDaemon } = await import("../lib/require-daemon.js");
+  const { appendCaptainMessage } = await import("@squadrant/core");
+  await requireDaemon();
+  
+  const resolved = resolveTarget(registry, config, target, !!opts.command);
+  await needRef(resolved);
+  
+  const finalProject = opts.command ? config.commandName : target!;
+  
+  const { join } = await import("node:path");
+  const { homedir } = await import("node:os");
+  const stateRoot = join(homedir(), ".config", "squadrant", "state");
+
+  await appendCaptainMessage({
+    stateRoot,
+    project: finalProject,
+    text: message,
+    source: "cli",
+  });
+}
+
 runtimeCommand
   .command("send")
   .description("Send a message to a target workspace AND commit with Enter. With --command, the first positional is the message.")
@@ -83,43 +115,8 @@ runtimeCommand
   .argument("[arg2]", "Message (when target is a project). Omit when using --command.")
   .option("--command", "Target the command workspace")
   .action(async (arg1: string, arg2: string | undefined, opts: { command?: boolean }) => {
-    const config = loadConfig();
-    const registry = buildRegistry();
     try {
-      if (opts.command && arg2 !== undefined) {
-        throw new Error("With --command, pass only the message (not a project name)");
-      }
-      const target = opts.command ? undefined : arg1;
-      const message = opts.command ? arg1 : arg2;
-      if (!message) throw new Error("Message is required");
-      const resolved = resolveTarget(registry, config, target, !!opts.command);
-      const ref = await needRef(resolved);
-      await resolved.driver.send(ref, message);
-    } catch (err) {
-      console.error(chalk.red((err as Error).message));
-      process.exit(1);
-    }
-  });
-
-runtimeCommand
-  .command("send-key")
-  .description("Send a literal key press (e.g. Enter, Escape) to a target workspace. With --command, the first positional is the key.")
-  .argument("<arg1>", "Project name, or the key when --command is used")
-  .argument("[arg2]", "Key name (when target is a project). Omit when using --command.")
-  .option("--command", "Target the command workspace")
-  .action(async (arg1: string, arg2: string | undefined, opts: { command?: boolean }) => {
-    const config = loadConfig();
-    const registry = buildRegistry();
-    try {
-      if (opts.command && arg2 !== undefined) {
-        throw new Error("With --command, pass only the key (not a project name)");
-      }
-      const target = opts.command ? undefined : arg1;
-      const key = opts.command ? arg1 : arg2;
-      if (!key) throw new Error("Key is required");
-      const resolved = resolveTarget(registry, config, target, !!opts.command);
-      const ref = await needRef(resolved);
-      await resolved.driver.sendKey(ref, key);
+      await runRuntimeSend(arg1, arg2, opts);
     } catch (err) {
       console.error(chalk.red((err as Error).message));
       process.exit(1);

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -94,18 +94,18 @@ export async function runRuntimeSend(arg1: string, arg2: string | undefined, opt
   const resolved = resolveTarget(registry, config, target, !!opts.command);
   await needRef(resolved);
   
-  const finalProject = opts.command ? config.commandName : target!;
-  
-  const { join } = await import("node:path");
-  const { homedir } = await import("node:os");
-  const stateRoot = join(homedir(), ".config", "squadrant", "state");
+      const finalProject = opts.command ? config.commandName : target!;
+      
+      const { join, dirname } = await import("node:path");
+      const { DEFAULT_CONFIG_PATH } = await import("@squadrant/shared");
+      const stateRoot = join(dirname(DEFAULT_CONFIG_PATH), "state");
 
-  await appendCaptainMessage({
-    stateRoot,
-    project: finalProject,
-    text: message,
-    source: "cli",
-  });
+      await appendCaptainMessage({
+        stateRoot,
+        project: finalProject,
+        text: message,
+        source: "cli",
+      });
 }
 
 runtimeCommand

--- a/packages/cli/src/lib/__tests__/require-daemon.test.ts
+++ b/packages/cli/src/lib/__tests__/require-daemon.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from "vitest";
+import { requireDaemon } from "../require-daemon.js";
+import { isDaemonSocketLive } from "@squadrant/core";
+
+vi.mock("@squadrant/core", () => ({
+  isDaemonSocketLive: vi.fn(),
+}));
+
+describe("requireDaemon", () => {
+  it("resolves successfully if socket is live", async () => {
+    vi.mocked(isDaemonSocketLive).mockResolvedValue(true);
+    await expect(requireDaemon("dummy.sock")).resolves.toBeUndefined();
+    expect(isDaemonSocketLive).toHaveBeenCalledWith("dummy.sock");
+  });
+
+  it("throws an error if socket is dead", async () => {
+    vi.mocked(isDaemonSocketLive).mockResolvedValue(false);
+    await expect(requireDaemon("dummy.sock")).rejects.toThrow(
+      "daemon not running — message NOT delivered. Start it with 'squadrant launch <project>'."
+    );
+  });
+});

--- a/packages/cli/src/lib/require-daemon.ts
+++ b/packages/cli/src/lib/require-daemon.ts
@@ -1,0 +1,22 @@
+import { sendRequest } from "@squadrant/core";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const DEFAULT_SOCK_PATH = join(homedir(), ".config", "squadrant", "squadrant.sock");
+
+export async function requireDaemon(sockPath: string = DEFAULT_SOCK_PATH): Promise<void> {
+  try {
+    // Only check if the daemon is alive. We don't care about a specific project here.
+    // The health endpoint responds even if project is omitted.
+    // We set a very short timeout, as a local socket should be instant.
+    await sendRequest(sockPath, { kind: "health" }, 2000);
+  } catch (err: any) {
+    // We only fail if it's genuinely down (e.g. ECONNREFUSED) or timed out.
+    // If it threw some other error but it *is* a squadrant error (e.g. invalid response format),
+    // the daemon might still be up, but standard ECONNREFUSED means it's down.
+    if (err.code === "ECONNREFUSED" || err.code === "ENOENT" || err.message.includes("timeout")) {
+      console.error("daemon not running — message NOT delivered. Start it with 'squadrant launch <project>'.");
+      process.exit(1);
+    }
+  }
+}

--- a/packages/cli/src/lib/require-daemon.ts
+++ b/packages/cli/src/lib/require-daemon.ts
@@ -1,22 +1,12 @@
-import { sendRequest } from "@squadrant/core";
+import { isDaemonSocketLive } from "@squadrant/core";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
 const DEFAULT_SOCK_PATH = join(homedir(), ".config", "squadrant", "squadrant.sock");
 
 export async function requireDaemon(sockPath: string = DEFAULT_SOCK_PATH): Promise<void> {
-  try {
-    // Only check if the daemon is alive. We don't care about a specific project here.
-    // The health endpoint responds even if project is omitted.
-    // We set a very short timeout, as a local socket should be instant.
-    await sendRequest(sockPath, { kind: "health" }, 2000);
-  } catch (err: any) {
-    // We only fail if it's genuinely down (e.g. ECONNREFUSED) or timed out.
-    // If it threw some other error but it *is* a squadrant error (e.g. invalid response format),
-    // the daemon might still be up, but standard ECONNREFUSED means it's down.
-    if (err.code === "ECONNREFUSED" || err.code === "ENOENT" || err.message.includes("timeout")) {
-      console.error("daemon not running — message NOT delivered. Start it with 'squadrant launch <project>'.");
-      process.exit(1);
-    }
+  const isLive = await isDaemonSocketLive(sockPath);
+  if (!isLive) {
+    throw new Error("daemon not running — message NOT delivered. Start it with 'squadrant launch <project>'.");
   }
 }

--- a/packages/core/src/__tests__/delivery-loop.test.ts
+++ b/packages/core/src/__tests__/delivery-loop.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDelivery } from "../daemon/delivery-loop.js";
+import { createStore } from "../store.js";
+import { LivenessRegistry } from "../daemon/liveness-registry.js";
+import { appendCaptainMessage } from "../mailbox.js";
+import { STALE_THRESHOLD_MS } from "../daemon/interactive-probe.js";
+
+function freshState(): string {
+  return mkdtempSync(join(tmpdir(), "deliv-"));
+}
+
+describe("delivery-loop", () => {
+  it("exempts non-daemon captain.message from stale-skip (#531)", async () => {
+    const stateRoot = freshState();
+    const store = createStore(stateRoot);
+    store.put({
+      id: "t1", project: "demo", provider: "claude", mode: "interactive",
+      state: "submitted", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000, attempts: []
+    });
+    const livenessRegistry = new LivenessRegistry({ path: join(stateRoot, "live.json") });
+    
+    // Simulate liveness
+    livenessRegistry.apply({
+      project: "demo",
+      role: "captain",
+      pid: 123,
+      sessionId: "s1",
+      startedAt: Date.now(),
+      lastState: "start",
+      lastSeenAt: Date.now(),
+      pidAlive: true,
+      source: "runtime"
+    });
+    
+    // Create an old telegram message (stale)
+    await appendCaptainMessage({
+      stateRoot, project: "demo", text: "telegram message", source: "telegram"
+    });
+    
+    // Create an old daemon message (stale)
+    await appendCaptainMessage({
+      stateRoot, project: "demo", text: "daemon message", source: "daemon"
+    });
+    
+    // Shift the clock so these messages are very old
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + STALE_THRESHOLD_MS + 1000);
+    
+    const logs: string[] = [];
+    const cmux = {
+      listSurfaces: async () => [{ id: "s1", title: "demo-captain", command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => "demo-captain> ",
+      send: async (surface: any, text: string) => {
+        logs.push(`sent: ${text}`);
+      }
+    };
+    
+    const deliv = createDelivery({
+      stateRoot, store, livenessRegistry, log: (m: string) => {}, isPidAlive: () => true, opts: {}
+    } as any, cmux as any);
+    
+    await deliv.deliveryTick!();
+    
+    // Wait for async background things if necessary
+    // Then check what was sent
+    expect(logs).toContain("sent: telegram message");
+    expect(logs).not.toContain("sent: daemon message");
+    
+    vi.useRealTimers();
+  });
+
+  it("drains and delivers entries under cfg.commandName", async () => {
+    const stateRoot = freshState();
+    const store = createStore(stateRoot);
+    const livenessRegistry = new LivenessRegistry({ path: join(stateRoot, "live.json") });
+    
+    // Command workspace has no project config, it relies on cfg.commandName
+    const { loadConfig } = await import("@squadrant/shared");
+    const cfg = loadConfig();
+    const commandName = cfg.commandName; // Usually "🏛️ command"
+    
+    livenessRegistry.apply({
+      project: commandName,
+      role: "captain",
+      pid: 123,
+      sessionId: "s1",
+      startedAt: Date.now(),
+      lastState: "start",
+      lastSeenAt: Date.now(),
+      pidAlive: true,
+      source: "runtime"
+    });
+    
+    await appendCaptainMessage({
+      stateRoot, project: commandName, text: "hello command", source: "cli"
+    });
+    
+    const logs: string[] = [];
+    const cmux = {
+      listSurfaces: async () => [{ id: "s1", title: commandName, command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => `${commandName}> `,
+      send: async (surface: any, text: string) => {
+        logs.push(`sent: ${text}`);
+      }
+    };
+    
+    const deliv = createDelivery({
+      stateRoot, store, livenessRegistry, log: () => {}, isPidAlive: () => true, opts: {}
+    } as any, cmux as any);
+    
+    await deliv.deliveryTick!();
+    
+    expect(logs).toContain("sent: hello command");
+  });
+});

--- a/packages/core/src/daemon/delivery-loop.ts
+++ b/packages/core/src/daemon/delivery-loop.ts
@@ -202,11 +202,14 @@ export function createDelivery(
       ...Object.keys(cfg.projects ?? {}),
       ...Object.keys(injectedSurfaces),
       ...store.listAll().map((t) => t.project),
+      cfg.commandName,
     ])];
 
     for (const project of allProjects) {
       const projCfg = cfg.projects?.[project];
-      const captainTitle = projCfg?.captainName ?? `${project}-captain`;
+      const captainTitle = project === cfg.commandName 
+        ? cfg.commandName 
+        : (projCfg?.captainName ?? `${project}-captain`);
 
       // Surface discovery is ONLY for the delivery target (where to cmux.send);
       // captain presence/liveness authority now lives in livenessRegistry.
@@ -241,11 +244,17 @@ export function createDelivery(
           // undelivered CREW DONE must reach the captain even after a daemon
           // restart >5min after enqueue. Non-terminal backlog suppression stays.
           if (!TERMINAL_KINDS.has(entry.kind)) {
-            log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=stale-skipped`);
-            await writeCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER, lastAckedSeq: entry.seq });
-            continue;
+            // #531: exempt non-daemon captain.message (human/cli) from stale-skip
+            const isExemptMessage = entry.kind === "captain.message" && entry.payload?.source !== "daemon";
+            if (!isExemptMessage) {
+              log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=stale-skipped`);
+              await writeCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER, lastAckedSeq: entry.seq });
+              continue;
+            }
+            log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=stale-exempt-deliver`);
+          } else {
+            log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=stale-terminal-deliver`);
           }
-          log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=stale-terminal-deliver`);
         }
         const result = await d.deliver(entry, (text, sendOpts) =>
           cmux.send(surface!, text, sendOpts),

--- a/packages/core/src/mailbox.ts
+++ b/packages/core/src/mailbox.ts
@@ -151,7 +151,7 @@ export async function appendCaptainMessage(opts: {
   stateRoot: string;
   project: string;
   text: string;
-  source: "telegram" | "daemon";
+  source: "telegram" | "daemon" | "cli";
 }): Promise<void> {
   await appendEntry(opts.stateRoot, opts.project, (seq) => ({
     seq,

--- a/packages/core/src/telegram/bridge.ts
+++ b/packages/core/src/telegram/bridge.ts
@@ -45,7 +45,7 @@ export interface TelegramBridgeOptions {
   /** Root for per-project override files. Defaults to ~/.config/squadrant. */
   configRoot?: string;
   client: TelegramClient;
-  appendCaptainMessage: (a: { stateRoot: string; project: string; text: string; source: "telegram" }) => Promise<void>;
+  appendCaptainMessage: (a: { stateRoot: string; project: string; text: string; source: "telegram" | "daemon" | "cli" }) => Promise<void>;
   log: (msg: string) => void;
   // ── Control surfaces (#402/#403/#321) — all optional. When undefined the bridge
   // keeps exact v1 behavior (queue-only project topics, General topic dropped).


### PR DESCRIPTION
Rebased continuation of #532 (auto-closed when its base `crew/draft-guard` was deleted by the #530 squash-merge). Same commits, replayed onto develop.

Implements `docs/specs/2026-07-09-draft-clobber-mailbox-routing.md`.

- **Delete `squadrant runtime send-key`** — zero callers anywhere. Deferring a keypress is semantically wrong: the guard only releases when the input box is empty, which is exactly when a queued `Enter` is meaningless. BREAKING note in CHANGELOG.
- **`ping` + `runtime send` → mailbox**, with `requireDaemon()` (fail-closed via `isDaemonSocketLive`). Never silently enqueue into a void.
- **`delivery-loop` drains the command workspace** — `cfg.commandName` is not a project, so `runtime send --command` routed through the mailbox would have lost messages permanently.
- **#531**: `captain.message` is exempt from stale-skip iff `payload.source !== "daemon"`. Confirmed in production: a real inbound Telegram message (seq=85, 2026-07-07) was silently acked and dropped when the daemon restarted 2h43m later.
- `notifiers/cmux.ts` fixed transitively. `effort` left best-effort (its job is writing config).

Verified locally: the two new `delivery-loop` tests **fail** against the pre-fix base (command drain, #531 exemption); build clean; `npm test` 1966/1966.

Closes #529. Closes #531.