### PR TITLE
fix(#516): make captain crew-send modal-aware — fail loudly instead of silently confirming the default

### DIFF
--- a/packages/cli/src/commands/__tests__/crew.test.ts
+++ b/packages/cli/src/commands/__tests__/crew.test.ts
@@ -59,6 +59,7 @@ vi.mock("@squadrant/workspaces", () => ({
     await sendToPane(pane, msg);
     return { delivered: true };
   },
+  paneHasOpenModal: async () => false,
   getFreePort: vi.fn().mockResolvedValue(12345),
 }));
 

--- a/packages/cli/src/commands/crew.ts
+++ b/packages/cli/src/commands/crew.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { loadConfig, resolveTextInput } from "@squadrant/shared";
 import type { PanePlacement } from "@squadrant/shared";
-import { createCmuxDriver, RuntimeRegistry, resolveCaptainWorkspace, sendFirstTurnWhenReady, confirmedSendToPane, getFreePort } from "@squadrant/workspaces";
+import { createCmuxDriver, RuntimeRegistry, resolveCaptainWorkspace, sendFirstTurnWhenReady, confirmedSendToPane, paneHasOpenModal, getFreePort } from "@squadrant/workspaces";
 import { CapabilityRegistry, createClaudeDriver, createCodexDriver, createGeminiDriver, createOpencodeDriver } from "@squadrant/agents";
 import {
   runCrewSpawn as coreRunCrewSpawn,
@@ -67,6 +67,8 @@ export async function runCrewSend(project: string, name: string, message: string
     // #448: use paste-settle-Enter confirmation for follow-up sends (same guard
     // as first-turn #447) so large messages don't strand in paste mode.
     sendToPane: (pane, msg) => confirmedSendToPane(runtime, pane, msg),
+    // #516: side-effect-free modal precheck, run before any daemon-state emit.
+    isBlockedByModal: (pane) => paneHasOpenModal(runtime, pane),
   });
 }
 

--- a/packages/core/src/__tests__/crew-spawn.test.ts
+++ b/packages/core/src/__tests__/crew-spawn.test.ts
@@ -671,6 +671,23 @@ describe("runCrewSend", () => {
     expect(injectedSend).toHaveBeenCalledWith(expect.anything(), "big message");
     expect(runtime.sendToPane).not.toHaveBeenCalled();
   });
+
+  // #516: when the injected sendToPane reports blockedByModal (an open
+  // AskUserQuestion/permission modal), the send must fail LOUDLY — a thrown
+  // error, not a silent 'success' — so the captain knows the message never
+  // reached the crew instead of the crew silently acting on its default option.
+  it("throws loudly when send is blocked by an open modal (#516)", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:crew-1" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    const injectedSend = vi.fn().mockResolvedValue({ delivered: false, blockedByModal: true });
+    await expect(
+      runCrewSend(PROJECT, "crew-1", "pick option 2", runtime, "workspace:1", {
+        listTasks: vi.fn().mockResolvedValue([]),
+        emitEvent: vi.fn(),
+        sendToPane: injectedSend,
+      }),
+    ).rejects.toThrow(/interactive prompt/i);
+  });
 });
 
 // ─── runCrewRead ─────────────────────────────────────────────────────────────

--- a/packages/core/src/__tests__/crew-spawn.test.ts
+++ b/packages/core/src/__tests__/crew-spawn.test.ts
@@ -688,6 +688,33 @@ describe("runCrewSend", () => {
       }),
     ).rejects.toThrow(/interactive prompt/i);
   });
+
+  // #516 review follow-up: the daemon-state emit block (task.reopened/task.started)
+  // ran BEFORE the blockedByModal check, so a modal-blocked send still flipped a
+  // blocked task to working — clearing BLOCKED before the crew ever saw the new
+  // message. That is the exact lost-signal class #183 protects against. The
+  // isBlockedByModal precheck must run first and make the whole send a TRUE no-op
+  // on daemon state — not just a no-op on the pane — when a modal is open.
+  it("emits NO daemon event and never attempts delivery when isBlockedByModal reports an open modal (#516)", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:crew-1" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    const emitEvent = vi.fn().mockResolvedValue(undefined);
+    const listTasks = vi.fn().mockResolvedValue([
+      { id: "t1", name: "crew-1", state: "blocked" } as Partial<TaskRecord>,
+    ]);
+    const isBlockedByModal = vi.fn().mockResolvedValue(true);
+    const injectedSend = vi.fn();
+    await expect(
+      runCrewSend(PROJECT, "crew-1", "pick option 2", runtime, "workspace:1", {
+        listTasks,
+        emitEvent,
+        sendToPane: injectedSend,
+        isBlockedByModal,
+      }),
+    ).rejects.toThrow(/interactive prompt/i);
+    expect(emitEvent).not.toHaveBeenCalled();
+    expect(injectedSend).not.toHaveBeenCalled();
+  });
 });
 
 // ─── runCrewRead ─────────────────────────────────────────────────────────────

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -471,7 +471,7 @@ export async function runCrewSend(
     // runtime.sendToPane so the caller can inject paste-settle-Enter hardening.
     // Falls back to runtime.sendToPane when absent (preserves existing behaviour
     // for callers that don't inject it, e.g. unit tests).
-    sendToPane?: (pane: PaneRef, message: string) => Promise<{ delivered: boolean }>;
+    sendToPane?: (pane: PaneRef, message: string) => Promise<{ delivered: boolean; blockedByModal?: boolean }>;
   },
 ): Promise<void> {
   const crew = await findCrewPane(runtime, workspaceId, project, name);
@@ -496,8 +496,18 @@ export async function runCrewSend(
     // Swallow daemon errors so crews without a daemon or offline daemon
     // still receive the sent message.
   }
-  const deliver = deps.sendToPane ?? ((pane, msg) => runtime.sendToPane(pane, msg).then(() => ({ delivered: true })));
-  const { delivered } = await deliver(crew, message);
+  const deliver: (pane: PaneRef, msg: string) => Promise<{ delivered: boolean; blockedByModal?: boolean }> =
+    deps.sendToPane ?? ((pane, msg) => runtime.sendToPane(pane, msg).then(() => ({ delivered: true })));
+  const { delivered, blockedByModal } = await deliver(crew, message);
+  // #516: an open AskUserQuestion/permission modal must fail LOUDLY — throwing
+  // (rather than the generic delivered:false warning below) stops the CLI's
+  // "✔ Sent" success line from printing, so the captain can't mistake this for
+  // a delivered message and unknowingly let the crew act on the modal's default.
+  if (blockedByModal) {
+    throw new Error(
+      `Crew '${name}' has an interactive prompt open (AskUserQuestion/permission) — message NOT delivered, to avoid confirming its default option. Wait for the prompt to close, then re-send with 'squadrant crew send ${project} ${name}'.`,
+    );
+  }
   if (!delivered) {
     process.stderr.write(`⚠️  Message not delivered to crew '${name}' — use 'squadrant crew send ${project} ${name}' to re-send.\n`);
   }

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -472,11 +472,23 @@ export async function runCrewSend(
     // Falls back to runtime.sendToPane when absent (preserves existing behaviour
     // for callers that don't inject it, e.g. unit tests).
     sendToPane?: (pane: PaneRef, message: string) => Promise<{ delivered: boolean; blockedByModal?: boolean }>;
+    // #516: optional side-effect-free precheck for an open AskUserQuestion/
+    // permission modal. Checked BEFORE the daemon-state emit block below so a
+    // modal-blocked send is a true no-op on daemon state, not just on the pane.
+    // Deliberately separate from sendToPane: that closure only reports
+    // blockedByModal AFTER attempting delivery, which is too late here — the
+    // emit block must never run for a message that never reached the crew.
+    isBlockedByModal?: (pane: PaneRef) => Promise<boolean>;
   },
 ): Promise<void> {
   const crew = await findCrewPane(runtime, workspaceId, project, name);
   if (!crew) {
     throw new Error(`Crew '${name}' not found for ${project}. Run 'squadrant crew list ${project}'.`);
+  }
+  const blockedByModalMessage = () =>
+    `Crew '${name}' has an interactive prompt open (AskUserQuestion/permission) — message NOT delivered, to avoid confirming its default option. Wait for the prompt to close, then re-send with 'squadrant crew send ${project} ${name}'.`;
+  if (deps.isBlockedByModal && (await deps.isBlockedByModal(crew))) {
+    throw new Error(blockedByModalMessage());
   }
   // Best-effort attention-state handling before delivering the captain's answer.
   // Terminal task (done/failed): reopen so the next signal done fires CREW DONE (#148).
@@ -499,14 +511,12 @@ export async function runCrewSend(
   const deliver: (pane: PaneRef, msg: string) => Promise<{ delivered: boolean; blockedByModal?: boolean }> =
     deps.sendToPane ?? ((pane, msg) => runtime.sendToPane(pane, msg).then(() => ({ delivered: true })));
   const { delivered, blockedByModal } = await deliver(crew, message);
-  // #516: an open AskUserQuestion/permission modal must fail LOUDLY — throwing
-  // (rather than the generic delivered:false warning below) stops the CLI's
-  // "✔ Sent" success line from printing, so the captain can't mistake this for
-  // a delivered message and unknowingly let the crew act on the modal's default.
+  // #516 backstop: covers the TOCTOU window between the precheck above and this
+  // delivery attempt, and callers that don't inject isBlockedByModal at all. By
+  // this point the emit block (if any) has already run — unavoidable without the
+  // precheck — but the send still fails loudly instead of reporting success.
   if (blockedByModal) {
-    throw new Error(
-      `Crew '${name}' has an interactive prompt open (AskUserQuestion/permission) — message NOT delivered, to avoid confirming its default option. Wait for the prompt to close, then re-send with 'squadrant crew send ${project} ${name}'.`,
-    );
+    throw new Error(blockedByModalMessage());
   }
   if (!delivered) {
     process.stderr.write(`⚠️  Message not delivered to crew '${name}' — use 'squadrant crew send ${project} ${name}' to re-send.\n`);

--- a/packages/workspaces/src/__tests__/crew-pane.test.ts
+++ b/packages/workspaces/src/__tests__/crew-pane.test.ts
@@ -380,6 +380,68 @@ describe("confirmedSendToPane — follow-up crew send (#448)", () => {
   });
 });
 
+// ─── #516: modal-aware crew send ──────────────────────────────────────────────
+// The delivery-path guard (sendToSurface, #484) already refuses to keystroke
+// into an open AskUserQuestion/permission SELECTION MODAL. confirmedSendToPane
+// — the primitive behind captain `crew send` — has no equivalent guard: it
+// pastes the captain's message and unconditionally fires Enter, which the
+// modal reads as "confirm the highlighted (Recommended) option". The captain's
+// message is dropped with no error, and the crew commits to the wrong choice
+// (#516 production incidents on friendslop-factory).
+const MODAL_SCREEN = `…transcript…
+${HR}
+ ☐ Color
+
+Which color do you prefer?
+
+❯ 1. Red
+     Red
+  2. Blue
+     Blue
+  3. Green
+     Green
+  4. Type something.
+${HR}
+  5. Chat about this
+
+Enter to select · ↑/↓ to navigate · Esc to cancel`;
+
+describe("confirmedSendToPane — modal-aware crew send (#516)", () => {
+  let readPaneScreen: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
+  const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, pasteToPane, sendKeyToPane });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    readPaneScreen = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("never keystrokes into an open AskUserQuestion modal — fails loudly instead of confirming the default", async () => {
+    readPaneScreen.mockResolvedValue(MODAL_SCREEN);
+
+    const promise = confirmedSendToPane(rt(), pane, "pick option 2");
+    await vi.advanceTimersByTimeAsync(5000);
+    const result = await promise;
+
+    // The modal's highlighted default must never be auto-confirmed by our Enter.
+    expect(sendKeyToPane).not.toHaveBeenCalled();
+    // The message must never be typed into the picker either.
+    expect(pasteToPane).not.toHaveBeenCalled();
+    // Non-delivery must be distinguishable from an ordinary retry-exhausted
+    // failure so the caller can warn the captain LOUDLY (not the generic
+    // "use crew send to re-send" message).
+    expect(result).toEqual({ delivered: false, blockedByModal: true });
+  });
+});
+
 // ─── #455: large-paste race — empty box before paste renders ─────────────────
 
 describe("sendFirstTurnWhenReady — large paste race (#455)", () => {

--- a/packages/workspaces/src/__tests__/crew-pane.test.ts
+++ b/packages/workspaces/src/__tests__/crew-pane.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { sendFirstTurnWhenReady, confirmedSendToPane, resendCrewFirstTurn } from "../crew-pane.js";
+import { sendFirstTurnWhenReady, confirmedSendToPane, resendCrewFirstTurn, paneHasOpenModal } from "../crew-pane.js";
 import type { PaneRef, WorkspaceRef } from "@squadrant/shared";
 
 // Realistic Claude-Code-style screen: the live input box is the region between the
@@ -439,6 +439,24 @@ describe("confirmedSendToPane — modal-aware crew send (#516)", () => {
     // failure so the caller can warn the captain LOUDLY (not the generic
     // "use crew send to re-send" message).
     expect(result).toEqual({ delivered: false, blockedByModal: true });
+  });
+});
+
+// #516 review follow-up: runCrewSend needs a side-effect-free precheck it can
+// run BEFORE its daemon-state emit block, so a modal-blocked send never flips
+// task state either. paneHasOpenModal is that precheck — a single read, no
+// pane touch — reusing the same hasModalOptionList detection as the guard above.
+describe("paneHasOpenModal (#516)", () => {
+  it("returns true when the pane shows an open selection modal", async () => {
+    const readPaneScreen = vi.fn().mockResolvedValue(MODAL_SCREEN);
+    const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+    await expect(paneHasOpenModal({ readPaneScreen }, pane)).resolves.toBe(true);
+  });
+
+  it("returns false for an ordinary idle pane", async () => {
+    const readPaneScreen = vi.fn().mockResolvedValue(EMPTY_BOX);
+    const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+    await expect(paneHasOpenModal({ readPaneScreen }, pane)).resolves.toBe(false);
   });
 });
 

--- a/packages/workspaces/src/crew-pane.ts
+++ b/packages/workspaces/src/crew-pane.ts
@@ -120,6 +120,23 @@ export async function resolveCaptainWorkspace(project: string): Promise<{
 }
 
 /**
+ * #516: cheap, side-effect-free check for an open AskUserQuestion/permission
+ * SELECTION MODAL — a single screen read, no paste, no keystroke. Lets
+ * runCrewSend skip its daemon-state emit (task.reopened/task.started) AND the
+ * pane touch entirely when the crew can't actually receive the message right
+ * now, so a modal-blocked send is a true no-op rather than just skipping the
+ * pane write. confirmedSendToPane keeps its own copy of this check as the
+ * pane-touch backstop for the TOCTOU window between this precheck and delivery.
+ */
+export async function paneHasOpenModal(
+  runtime: Pick<RuntimeDriver, "readPaneScreen">,
+  pane: PaneRef,
+): Promise<boolean> {
+  const screen = (await runtime.readPaneScreen(pane)) ?? "";
+  return hasModalOptionList(screen);
+}
+
+/**
  * Deliver a message to a crew pane with the paste-settle-Enter confirmation
  * sequence from #447. Shared by the follow-up `crew send` path (#448) and
  * available for first-turn use — both call the same submit hardening:

--- a/packages/workspaces/src/crew-pane.ts
+++ b/packages/workspaces/src/crew-pane.ts
@@ -6,7 +6,7 @@ import net from "node:net";
 import { loadConfig } from "@squadrant/shared";
 import type { PaneRef, RuntimeDriver } from "@squadrant/shared";
 import { RuntimeRegistry } from "./runtimes/registry.js";
-import { createCmuxDriver, parseDraftFromScreen, hasCCInputBox, classifyStartupSurface } from "./runtimes/cmux.js";
+import { createCmuxDriver, parseDraftFromScreen, hasCCInputBox, hasModalOptionList, classifyStartupSurface } from "./runtimes/cmux.js";
 import { titleFor, isCrewTitle, screenHasSplashMarker } from "@squadrant/core";
 import type { TurnAcceptanceConfig } from "@squadrant/core";
 
@@ -131,13 +131,24 @@ export async function resolveCaptainWorkspace(project: string): Promise<{
  * Returns `{ delivered: true }` when the box empties after the draft was seen
  * (positive submit confirmation), or `{ delivered: false }` if the retry loop
  * exhausts without confirmation (#466: callers surface non-delivery explicitly).
+ * Returns `{ delivered: false, blockedByModal: true }` without touching the
+ * pane at all when an AskUserQuestion/permission SELECTION MODAL is open (#516).
  */
 export async function confirmedSendToPane(
   runtime: Pick<RuntimeDriver, "readPaneScreen" | "pasteToPane" | "sendKeyToPane">,
   pane: PaneRef,
   message: string,
-): Promise<{ delivered: boolean }> {
+): Promise<{ delivered: boolean; blockedByModal?: boolean }> {
   const preSendScreen = (await runtime.readPaneScreen(pane)) ?? "";
+  // #516: a selection modal renders its highlighted default option ("❯ 1. Red")
+  // in the same HR-bounded region a real draft would occupy, so the settle
+  // loop below can't tell "modal open" apart from "draft present" — sending
+  // Enter here would CONFIRM the modal's default instead of delivering the
+  // captain's message (mirrors the #484 guard on the sendToSurface delivery
+  // path, which has no equivalent here). Never keystroke into it.
+  if (hasModalOptionList(preSendScreen)) {
+    return { delivered: false, blockedByModal: true };
+  }
   await runtime.pasteToPane(pane, message);
   // #455: track whether the paste ever rendered so we don't treat an empty box
   // that was NEVER populated as a successful submit (race: paste still in flight

--- a/packages/workspaces/src/index.ts
+++ b/packages/workspaces/src/index.ts
@@ -9,4 +9,4 @@ export { CmuxStoreSource } from "./cmux-daemon/cmux-store-source.js";
 export type { CmuxStoreSourceOpts } from "./cmux-daemon/cmux-store-source.js";
 export { NativeHookSource, installClaudeHooks, mapSubToLifecycle } from "./native-hooks/native-hook-source.js";
 export type { NativeHookSourceOpts, ClaudeHooksInstallOpts } from "./native-hooks/native-hook-source.js";
-export { getFreePort, listProjectCrews, findCrew, resolveCaptainWorkspace, sendFirstTurnWhenReady, confirmedSendToPane, resendCrewFirstTurn } from "./crew-pane.js";
+export { getFreePort, listProjectCrews, findCrew, resolveCaptainWorkspace, sendFirstTurnWhenReady, confirmedSendToPane, resendCrewFirstTurn, paneHasOpenModal } from "./crew-pane.js";


### PR DESCRIPTION
## Summary

Fixes #516: captain `crew send` was silently dropped when the crew had an interactive AskUserQuestion/permission modal open, and the crew proceeded on its own 'Recommended' default — this caused two wrong commits in production on friendslop-factory.

## Root cause

The delivery path (`sendToSurface`, `packages/workspaces/src/runtimes/cmux.ts:643`) already guards against this — `hasModalOptionList(screen) → throw new DeferDelivery(null)` (the #484 fix). But the captain→crew send path, `confirmedSendToPane`, had **no equivalent guard**.

An open selection modal (AskUserQuestion or a permission-approval picker) renders its highlighted default option (`❯ 1. Red`) inside the same HR-bounded region a real draft would occupy. `confirmedSendToPane`'s `settleInputBox` reads that rendered option and treats it as "draft already present" (`sawDraft = true`) from the very first read — before any paste happens. It then unconditionally sends `Enter`, which the modal reads as **confirm the highlighted default** instead of "submit the captain's message". The message is lost, the crew commits to the default, and the caller sees `{ delivered: true }` (a false positive) because the screen changed after the modal closed.

## Fix

Chose **(b) fail loudly** per the issue's steer — smaller, safer change that directly kills the silent-default failure mode:

1. `confirmedSendToPane` (`packages/workspaces/src/crew-pane.ts`) now checks `hasModalOptionList(preSendScreen)` *before* touching the pane at all. If a modal is open, it returns `{ delivered: false, blockedByModal: true }` without pasting or sending any keystroke — mirrors the `sendToSurface` guard, on the one path that lacked it.
2. `runCrewSend` (`packages/core/src/crew-spawn.ts`) now **throws** when `blockedByModal` is set, instead of the generic stderr warning used for ordinary non-delivery. This matters because the CLI's `crew send` command (`packages/cli/src/commands/crew.ts`) only prints the success `✔ Sent` line if `runCrewSend` doesn't throw — the previous stderr-warning path let that green checkmark print regardless, which is exactly how the send silently "reported success" per the issue repro. Throwing makes the CLI print a red error and exit 1, and the message is unambiguous about *why*: the crew has an interactive prompt open and the message needs to be re-sent once it closes.

Because both `sendFirstTurnWhenReady` and `resendCrewFirstTurn` share `confirmedSendToPane` under the hood, they get the same protection for free — no separate changes needed there.

## Verification

- New failing test written first (`packages/workspaces/src/__tests__/crew-pane.test.ts`) using a realistic AskUserQuestion screen fixture (mirrors `docs/reports/484-askuserquestion-fixture.txt`) — confirmed RED: pre-fix, `sendKeyToPane` fired `Enter` 5 times into the modal.
- New failing test for the loud-failure contract (`packages/core/src/__tests__/crew-spawn.test.ts`) — confirmed RED before the throw was added.
- Both now pass; a normal idle-pane send and a real in-progress draft still behave exactly as before (existing #448/#455/#466 tests unchanged and green).
- `npm run build && npm test`: full monorepo build clean, **163 test files / 1970 tests passing**.
- GitNexus impact analysis on both changed symbols (`confirmedSendToPane`, `runCrewSend`) returned risk **LOW** (single direct caller each, no cascading breakage).

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 1970/1970 passing
- [x] New #516 regression tests fail on the pre-fix code, pass after
- [x] Existing modal-adjacent tests (#448, #455, #466) unaffected