### PR TITLE
feat(#536): notify installed users when a newer squadrant is on npm

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -72,8 +72,10 @@ if (process.argv[2] !== "config") {
         }
       }
 
-      // #536: best-effort, fire-and-forget update-available check — never awaited,
-      // so it can't add latency; every failure mode inside is caught and silent.
+      // #536: best-effort update-available check. Not awaited so it never blocks command
+      // logic; the unref'd node:https transport and bounded race inside notifyIfUpdateAvailable
+      // (see update-check.ts) mean a pending check can't delay process exit either, and a
+      // failed attempt is cached so an offline machine doesn't re-hit the registry every run.
       void notifyIfUpdateAvailable({ config: cfg, currentVersion: pkg.version });
     }
   } catch {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,6 +38,7 @@ import { hooksCommand } from "./commands/hooks.js";
 import { detectDrift } from "@squadrant/shared";
 import { needsCheck, withStamp } from "@squadrant/shared";
 import { getDefaultConfig } from "@squadrant/shared";
+import { notifyIfUpdateAvailable } from "@squadrant/shared";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf-8"));
@@ -70,6 +71,10 @@ if (process.argv[2] !== "config") {
           );
         }
       }
+
+      // #536: best-effort, fire-and-forget update-available check — never awaited,
+      // so it can't add latency; every failure mode inside is caught and silent.
+      void notifyIfUpdateAvailable({ config: cfg, currentVersion: pkg.version });
     }
   } catch {
     // Drift banner is best-effort; never block the CLI.

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -120,6 +120,9 @@ export interface SquadrantConfig {
     /** #317 global crew tokenomics dial. Absent ⇒ "balance" (today's behavior).
      *  Biases the captain toward stronger ("max") or cheaper ("low") crew models. */
     effort?: "max" | "balance" | "low";
+    /** #536 startup npm-registry update check. Default true (absent ⇒ enabled);
+     *  set false to opt out. NO_UPDATE_NOTIFIER env var also opts out. */
+    updateCheck?: boolean;
   };
   metrics: {
     enabled: boolean;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -14,6 +14,7 @@ export * from "./lib/cmux-probe.js";
 export * from "./lib/compat-manifest.js";
 export * from "./lib/config-drift.js";
 export * from "./lib/config-version.js";
+export * from "./lib/update-check.js";
 export * from "./lib/git-worktree.js";
 export * from "./lib/resolve-text-input.js";
 export * from "./lib/runtime-sync.js";

--- a/packages/shared/src/lib/__tests__/update-check.test.ts
+++ b/packages/shared/src/lib/__tests__/update-check.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  isNewerVersion,
+  isCacheStale,
+  isUpdateCheckDisabled,
+  formatUpdateNotice,
+  fetchLatestVersion,
+  checkForUpdate,
+  notifyIfUpdateAvailable,
+  UPDATE_CHECK_STATE_PATH,
+} from "../update-check.js";
+
+describe("isNewerVersion", () => {
+  it("is true when latest is ahead", () => {
+    expect(isNewerVersion("0.16.0", "0.15.0")).toBe(true);
+    expect(isNewerVersion("1.0.0", "0.15.0")).toBe(true);
+    expect(isNewerVersion("0.15.1", "0.15.0")).toBe(true);
+  });
+
+  it("is false when up to date or behind", () => {
+    expect(isNewerVersion("0.15.0", "0.15.0")).toBe(false);
+    expect(isNewerVersion("0.14.9", "0.15.0")).toBe(false);
+  });
+});
+
+describe("formatUpdateNotice", () => {
+  it("renders the one-line actionable notice", () => {
+    expect(formatUpdateNotice("0.16.0", "0.15.0")).toBe(
+      "⬆ squadrant 0.16.0 available (you have 0.15.0) — npm i -g squadrant@latest",
+    );
+  });
+});
+
+describe("isCacheStale", () => {
+  const now = 1_700_000_000_000;
+
+  it("is stale when no state exists", () => {
+    expect(isCacheStale(undefined, now)).toBe(true);
+  });
+
+  it("is fresh within the interval", () => {
+    expect(isCacheStale({ lastChecked: now - 1000 }, now)).toBe(false);
+  });
+
+  it("is stale once the interval has elapsed", () => {
+    const dayMs = 24 * 60 * 60 * 1000;
+    expect(isCacheStale({ lastChecked: now - dayMs }, now)).toBe(true);
+  });
+});
+
+describe("isUpdateCheckDisabled", () => {
+  it("is false by default", () => {
+    expect(isUpdateCheckDisabled(undefined, {})).toBe(false);
+  });
+
+  it("honours defaults.updateCheck === false", () => {
+    expect(isUpdateCheckDisabled({ defaults: { updateCheck: false } as any }, {})).toBe(true);
+  });
+
+  it("honours NO_UPDATE_NOTIFIER env var", () => {
+    expect(isUpdateCheckDisabled(undefined, { NO_UPDATE_NOTIFIER: "1" })).toBe(true);
+  });
+});
+
+describe("fetchLatestVersion", () => {
+  it("returns the version on a successful response", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ version: "0.16.0" }) });
+    await expect(fetchLatestVersion(fetchImpl as any, 1000)).resolves.toBe("0.16.0");
+  });
+
+  it("returns null on a non-ok response", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) });
+    await expect(fetchLatestVersion(fetchImpl as any, 1000)).resolves.toBeNull();
+  });
+
+  it("returns null fast when the fetch throws (offline)", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("network down"));
+    const start = performance.now();
+    await expect(fetchLatestVersion(fetchImpl as any, 1000)).resolves.toBeNull();
+    expect(performance.now() - start).toBeLessThan(500);
+  });
+
+  it("returns null fast when the fetch hangs past the timeout", async () => {
+    const fetchImpl = vi.fn().mockImplementation(() => new Promise(() => {})); // never resolves
+    const start = performance.now();
+    await expect(fetchLatestVersion(fetchImpl as any, 50)).resolves.toBeNull();
+    expect(performance.now() - start).toBeLessThan(1000);
+  });
+});
+
+describe("checkForUpdate", () => {
+  const now = 1_700_000_000_000;
+
+  it("prints a notice when behind and persists the fresh check", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ version: "0.16.0" }) });
+    const outcome = await checkForUpdate({ currentVersion: "0.15.0", state: undefined, now, fetchImpl: fetchImpl as any });
+    expect(outcome.notice).toContain("0.16.0 available (you have 0.15.0)");
+    expect(outcome.newState).toEqual({ lastChecked: now, latestKnown: "0.16.0" });
+  });
+
+  it("is silent when already up to date", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ version: "0.15.0" }) });
+    const outcome = await checkForUpdate({ currentVersion: "0.15.0", state: undefined, now, fetchImpl: fetchImpl as any });
+    expect(outcome.notice).toBeNull();
+    expect(outcome.newState).toEqual({ lastChecked: now, latestKnown: "0.15.0" });
+  });
+
+  it("is silent and fast when the registry is unreachable", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("offline"));
+    const start = performance.now();
+    const outcome = await checkForUpdate({ currentVersion: "0.15.0", state: undefined, now, fetchImpl: fetchImpl as any });
+    expect(performance.now() - start).toBeLessThan(500);
+    expect(outcome.notice).toBeNull();
+    expect(outcome.newState).toBeNull();
+  });
+
+  it("makes no network call on a cache hit", async () => {
+    const fetchImpl = vi.fn();
+    const outcome = await checkForUpdate({
+      currentVersion: "0.15.0",
+      state: { lastChecked: now - 1000, latestKnown: "0.16.0" },
+      now,
+      fetchImpl: fetchImpl as any,
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(outcome.notice).toContain("0.16.0 available");
+    expect(outcome.newState).toBeNull();
+  });
+
+  it("cache hit stays silent when the cached version is not newer", async () => {
+    const fetchImpl = vi.fn();
+    const outcome = await checkForUpdate({
+      currentVersion: "0.15.0",
+      state: { lastChecked: now - 1000, latestKnown: "0.15.0" },
+      now,
+      fetchImpl: fetchImpl as any,
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(outcome.notice).toBeNull();
+  });
+});
+
+describe("notifyIfUpdateAvailable", () => {
+  const now = 1_700_000_000_000;
+
+  it("writes state and prints the notice when behind", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ version: "0.16.0" }) });
+    const readState = vi.fn().mockReturnValue(undefined);
+    const writeState = vi.fn();
+    const write = vi.fn();
+
+    await notifyIfUpdateAvailable({
+      config: undefined,
+      currentVersion: "0.15.0",
+      env: {},
+      fetchImpl: fetchImpl as any,
+      readState,
+      writeState,
+      write,
+      now,
+    });
+
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write.mock.calls[0][0]).toContain("0.16.0 available");
+    expect(writeState).toHaveBeenCalledWith({ lastChecked: now, latestKnown: "0.16.0" }, UPDATE_CHECK_STATE_PATH);
+  });
+
+  it("honours config opt-out with zero network calls", async () => {
+    const fetchImpl = vi.fn();
+    const write = vi.fn();
+    await notifyIfUpdateAvailable({
+      config: { defaults: { updateCheck: false } as any },
+      currentVersion: "0.15.0",
+      env: {},
+      fetchImpl: fetchImpl as any,
+      readState: vi.fn(),
+      writeState: vi.fn(),
+      write,
+      now,
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("honours NO_UPDATE_NOTIFIER env opt-out with zero network calls", async () => {
+    const fetchImpl = vi.fn();
+    const write = vi.fn();
+    await notifyIfUpdateAvailable({
+      config: undefined,
+      currentVersion: "0.15.0",
+      env: { NO_UPDATE_NOTIFIER: "1" },
+      fetchImpl: fetchImpl as any,
+      readState: vi.fn(),
+      writeState: vi.fn(),
+      write,
+      now,
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("never throws even if fetch and state I/O blow up", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("boom"));
+    const readState = vi.fn().mockImplementation(() => {
+      throw new Error("fs boom");
+    });
+    await expect(
+      notifyIfUpdateAvailable({
+        config: undefined,
+        currentVersion: "0.15.0",
+        env: {},
+        fetchImpl: fetchImpl as any,
+        readState,
+        writeState: vi.fn(),
+        write: vi.fn(),
+        now,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/shared/src/lib/__tests__/update-check.test.ts
+++ b/packages/shared/src/lib/__tests__/update-check.test.ts
@@ -1,14 +1,31 @@
+import { EventEmitter } from "node:events";
 import { describe, it, expect, vi } from "vitest";
-import {
-  isNewerVersion,
-  isCacheStale,
-  isUpdateCheckDisabled,
-  formatUpdateNotice,
-  fetchLatestVersion,
-  checkForUpdate,
-  notifyIfUpdateAvailable,
-  UPDATE_CHECK_STATE_PATH,
-} from "../update-check.js";
+
+const httpsGetMock = vi.fn();
+vi.mock("node:https", () => ({
+  default: { get: (...args: unknown[]) => httpsGetMock(...args) },
+  get: (...args: unknown[]) => httpsGetMock(...args),
+}));
+
+const { isNewerVersion, isCacheStale, isUpdateCheckDisabled, formatUpdateNotice, fetchLatestVersion, checkForUpdate, notifyIfUpdateAvailable, UPDATE_CHECK_STATE_PATH } = await import(
+  "../update-check.js"
+);
+
+function makeReq() {
+  const req = new EventEmitter() as EventEmitter & { setTimeout: (...a: unknown[]) => void; unref: () => void; destroy: () => void };
+  req.setTimeout = vi.fn();
+  req.unref = vi.fn();
+  req.destroy = vi.fn(() => req.emit("error", new Error("destroyed")));
+  return req;
+}
+
+function makeRes(statusCode: number) {
+  const res = new EventEmitter() as EventEmitter & { statusCode: number; setEncoding: (...a: unknown[]) => void; resume: () => void };
+  res.statusCode = statusCode;
+  res.setEncoding = vi.fn();
+  res.resume = vi.fn();
+  return res;
+}
 
 describe("isNewerVersion", () => {
   it("is true when latest is ahead", () => {
@@ -33,18 +50,28 @@ describe("formatUpdateNotice", () => {
 
 describe("isCacheStale", () => {
   const now = 1_700_000_000_000;
+  const dayMs = 24 * 60 * 60 * 1000;
+  const hourMs = 60 * 60 * 1000;
 
   it("is stale when no state exists", () => {
     expect(isCacheStale(undefined, now)).toBe(true);
   });
 
-  it("is fresh within the interval", () => {
+  it("is fresh within the 24h success interval", () => {
     expect(isCacheStale({ lastChecked: now - 1000 }, now)).toBe(false);
   });
 
-  it("is stale once the interval has elapsed", () => {
-    const dayMs = 24 * 60 * 60 * 1000;
+  it("is stale once the 24h success interval has elapsed", () => {
     expect(isCacheStale({ lastChecked: now - dayMs }, now)).toBe(true);
+  });
+
+  it("uses the shorter 1h backoff after a failed check, not the 24h success interval", () => {
+    const state = { lastChecked: now - (hourMs + 1000), lastCheckFailed: true };
+    expect(isCacheStale(state, now)).toBe(true);
+    expect(isCacheStale({ ...state, lastChecked: now - 1000 }, now)).toBe(false);
+    // Same age would still be "fresh" under the 24h success interval — confirms the
+    // failure path is really using the shorter window, not accidentally reusing 24h.
+    expect(isCacheStale({ lastChecked: now - (hourMs + 1000) }, now)).toBe(false);
   });
 });
 
@@ -62,25 +89,25 @@ describe("isUpdateCheckDisabled", () => {
   });
 });
 
-describe("fetchLatestVersion", () => {
+describe("fetchLatestVersion (injected requestFn contract)", () => {
   it("returns the version on a successful response", async () => {
-    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ version: "0.16.0" }) });
+    const fetchImpl = vi.fn().mockResolvedValue({ version: "0.16.0" });
     await expect(fetchLatestVersion(fetchImpl as any, 1000)).resolves.toBe("0.16.0");
   });
 
-  it("returns null on a non-ok response", async () => {
-    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) });
+  it("returns null when the request resolves null (non-200 upstream)", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(null);
     await expect(fetchLatestVersion(fetchImpl as any, 1000)).resolves.toBeNull();
   });
 
-  it("returns null fast when the fetch throws (offline)", async () => {
+  it("returns null fast when the request throws (offline)", async () => {
     const fetchImpl = vi.fn().mockRejectedValue(new Error("network down"));
     const start = performance.now();
     await expect(fetchLatestVersion(fetchImpl as any, 1000)).resolves.toBeNull();
     expect(performance.now() - start).toBeLessThan(500);
   });
 
-  it("returns null fast when the fetch hangs past the timeout", async () => {
+  it("returns null fast when the request hangs past the timeout, regardless of requestFn behavior", async () => {
     const fetchImpl = vi.fn().mockImplementation(() => new Promise(() => {})); // never resolves
     const start = performance.now();
     await expect(fetchLatestVersion(fetchImpl as any, 50)).resolves.toBeNull();
@@ -88,30 +115,76 @@ describe("fetchLatestVersion", () => {
   });
 });
 
+describe("fetchLatestVersion (real node:https transport)", () => {
+  it("parses the version from a 200 response", async () => {
+    const req = makeReq();
+    const res = makeRes(200);
+    httpsGetMock.mockImplementation((_url: string, _opts: unknown, cb: (res: unknown) => void) => {
+      queueMicrotask(() => {
+        cb(res);
+        res.emit("data", JSON.stringify({ version: "0.16.0" }));
+        res.emit("end");
+      });
+      return req;
+    });
+    await expect(fetchLatestVersion(undefined, 1000)).resolves.toBe("0.16.0");
+  });
+
+  it("resolves null and drains the response on a non-200 status", async () => {
+    const req = makeReq();
+    const res = makeRes(404);
+    httpsGetMock.mockImplementation((_url: string, _opts: unknown, cb: (res: unknown) => void) => {
+      queueMicrotask(() => cb(res));
+      return req;
+    });
+    await expect(fetchLatestVersion(undefined, 1000)).resolves.toBeNull();
+    expect(res.resume).toHaveBeenCalled();
+  });
+
+  it("resolves null when the request errors", async () => {
+    const req = makeReq();
+    httpsGetMock.mockImplementation(() => {
+      queueMicrotask(() => req.emit("error", new Error("ENOTFOUND")));
+      return req;
+    });
+    await expect(fetchLatestVersion(undefined, 1000)).resolves.toBeNull();
+  });
+
+  it("unrefs the pending request so a hung connection can never hold the process open", async () => {
+    const req = makeReq(); // never invokes the response callback — simulates a stalled connection
+    httpsGetMock.mockImplementation(() => req);
+
+    const start = performance.now();
+    await expect(fetchLatestVersion(undefined, 50)).resolves.toBeNull();
+    expect(performance.now() - start).toBeLessThan(500);
+    expect(req.unref).toHaveBeenCalled();
+  });
+});
+
 describe("checkForUpdate", () => {
   const now = 1_700_000_000_000;
 
   it("prints a notice when behind and persists the fresh check", async () => {
-    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ version: "0.16.0" }) });
+    const fetchImpl = vi.fn().mockResolvedValue({ version: "0.16.0" });
     const outcome = await checkForUpdate({ currentVersion: "0.15.0", state: undefined, now, fetchImpl: fetchImpl as any });
     expect(outcome.notice).toContain("0.16.0 available (you have 0.15.0)");
-    expect(outcome.newState).toEqual({ lastChecked: now, latestKnown: "0.16.0" });
+    expect(outcome.newState).toEqual({ lastChecked: now, latestKnown: "0.16.0", lastCheckFailed: false });
   });
 
   it("is silent when already up to date", async () => {
-    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ version: "0.15.0" }) });
+    const fetchImpl = vi.fn().mockResolvedValue({ version: "0.15.0" });
     const outcome = await checkForUpdate({ currentVersion: "0.15.0", state: undefined, now, fetchImpl: fetchImpl as any });
     expect(outcome.notice).toBeNull();
-    expect(outcome.newState).toEqual({ lastChecked: now, latestKnown: "0.15.0" });
+    expect(outcome.newState).toEqual({ lastChecked: now, latestKnown: "0.15.0", lastCheckFailed: false });
   });
 
-  it("is silent and fast when the registry is unreachable", async () => {
+  it("is silent and fast when the registry is unreachable, and caches the failure", async () => {
     const fetchImpl = vi.fn().mockRejectedValue(new Error("offline"));
     const start = performance.now();
     const outcome = await checkForUpdate({ currentVersion: "0.15.0", state: undefined, now, fetchImpl: fetchImpl as any });
     expect(performance.now() - start).toBeLessThan(500);
     expect(outcome.notice).toBeNull();
-    expect(outcome.newState).toBeNull();
+    expect(outcome.newState).toEqual({ lastChecked: now, lastCheckFailed: true });
   });
 
   it("makes no network call on a cache hit", async () => {
@@ -138,13 +211,45 @@ describe("checkForUpdate", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
     expect(outcome.notice).toBeNull();
   });
+
+  it("a second check shortly after a failure makes no network call (failure backoff, not just success cache)", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("offline"));
+    const first = await checkForUpdate({ currentVersion: "0.15.0", state: undefined, now, fetchImpl: fetchImpl as any });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    const tenMinutesLater = now + 10 * 60 * 1000;
+    const second = await checkForUpdate({
+      currentVersion: "0.15.0",
+      state: first.newState!,
+      now: tenMinutesLater,
+      fetchImpl: fetchImpl as any,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1); // still 1 — no new network call
+    expect(second.notice).toBeNull();
+    expect(second.newState).toBeNull();
+  });
+
+  it("retries after the failure backoff window elapses", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ version: "0.16.0" });
+    const failedState = { lastChecked: now, lastCheckFailed: true };
+    const anHourAndAMinuteLater = now + 61 * 60 * 1000;
+    const outcome = await checkForUpdate({
+      currentVersion: "0.15.0",
+      state: failedState,
+      now: anHourAndAMinuteLater,
+      fetchImpl: fetchImpl as any,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(outcome.notice).toContain("0.16.0 available");
+  });
 });
 
 describe("notifyIfUpdateAvailable", () => {
   const now = 1_700_000_000_000;
 
   it("writes state and prints the notice when behind", async () => {
-    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ version: "0.16.0" }) });
+    const fetchImpl = vi.fn().mockResolvedValue({ version: "0.16.0" });
     const readState = vi.fn().mockReturnValue(undefined);
     const writeState = vi.fn();
     const write = vi.fn();
@@ -162,7 +267,7 @@ describe("notifyIfUpdateAvailable", () => {
 
     expect(write).toHaveBeenCalledTimes(1);
     expect(write.mock.calls[0][0]).toContain("0.16.0 available");
-    expect(writeState).toHaveBeenCalledWith({ lastChecked: now, latestKnown: "0.16.0" }, UPDATE_CHECK_STATE_PATH);
+    expect(writeState).toHaveBeenCalledWith({ lastChecked: now, latestKnown: "0.16.0", lastCheckFailed: false }, UPDATE_CHECK_STATE_PATH);
   });
 
   it("honours config opt-out with zero network calls", async () => {
@@ -196,6 +301,42 @@ describe("notifyIfUpdateAvailable", () => {
       now,
     });
     expect(fetchImpl).not.toHaveBeenCalled();
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("an offline machine makes no network call on the very next invocation", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("offline"));
+    let persisted: unknown;
+    const writeState = vi.fn((state) => {
+      persisted = state;
+    });
+    const readState = vi.fn(() => persisted as any);
+    const write = vi.fn();
+
+    await notifyIfUpdateAvailable({
+      config: undefined,
+      currentVersion: "0.15.0",
+      env: {},
+      fetchImpl: fetchImpl as any,
+      readState,
+      writeState,
+      write,
+      now,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    await notifyIfUpdateAvailable({
+      config: undefined,
+      currentVersion: "0.15.0",
+      env: {},
+      fetchImpl: fetchImpl as any,
+      readState,
+      writeState,
+      write,
+      now: now + 5 * 60 * 1000, // 5 minutes later — still well within the 1h failure backoff
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1); // no second network call
     expect(write).not.toHaveBeenCalled();
   });
 

--- a/packages/shared/src/lib/__tests__/update-check.test.ts
+++ b/packages/shared/src/lib/__tests__/update-check.test.ts
@@ -11,10 +11,15 @@ const { isNewerVersion, isCacheStale, isUpdateCheckDisabled, formatUpdateNotice,
   "../update-check.js"
 );
 
+function makeSocket() {
+  const socket = new EventEmitter() as EventEmitter & { unref: () => void };
+  socket.unref = vi.fn();
+  return socket;
+}
+
 function makeReq() {
-  const req = new EventEmitter() as EventEmitter & { setTimeout: (...a: unknown[]) => void; unref: () => void; destroy: () => void };
+  const req = new EventEmitter() as EventEmitter & { setTimeout: (...a: unknown[]) => void; destroy: () => void };
   req.setTimeout = vi.fn();
-  req.unref = vi.fn();
   req.destroy = vi.fn(() => req.emit("error", new Error("destroyed")));
   return req;
 }
@@ -150,14 +155,18 @@ describe("fetchLatestVersion (real node:https transport)", () => {
     await expect(fetchLatestVersion(undefined, 1000)).resolves.toBeNull();
   });
 
-  it("unrefs the pending request so a hung connection can never hold the process open", async () => {
+  it("unrefs the socket (not the request — ClientRequest itself has no unref()) so a hung connection can never hold the process open", async () => {
     const req = makeReq(); // never invokes the response callback — simulates a stalled connection
-    httpsGetMock.mockImplementation(() => req);
+    const socket = makeSocket();
+    httpsGetMock.mockImplementation(() => {
+      queueMicrotask(() => req.emit("socket", socket));
+      return req;
+    });
 
     const start = performance.now();
     await expect(fetchLatestVersion(undefined, 50)).resolves.toBeNull();
     expect(performance.now() - start).toBeLessThan(500);
-    expect(req.unref).toHaveBeenCalled();
+    expect(socket.unref).toHaveBeenCalled();
   });
 });
 

--- a/packages/shared/src/lib/update-check.ts
+++ b/packages/shared/src/lib/update-check.ts
@@ -32,10 +32,11 @@ export type RegistryRequest = (url: string, timeoutMs: number) => Promise<unknow
  * Fetches over node:https rather than global fetch(): a fetch() Promise exposes no
  * handle to detach from the event loop, so a pending request left ref'd would delay
  * process exit by up to timeoutMs on every single invocation of an offline machine.
- * req.unref() is Node's documented mechanism for exactly this — it lets the process
- * exit immediately once the CLI's own work is done, dropping the response if it
- * arrives after. That's fine: this check is a best-effort background notice, never
- * something the CLI's exit should wait on.
+ * http.ClientRequest itself has no unref() — the socket does, assigned asynchronously
+ * via the 'socket' event — so we unref that once it's available. This is Node's
+ * documented mechanism for exactly this: it lets the process exit immediately once
+ * the CLI's own work is done, dropping the response if it arrives after. That's fine:
+ * this check is a best-effort background notice, never something exit should wait on.
  */
 const requestJson: RegistryRequest = (url, timeoutMs) =>
   new Promise((resolve) => {
@@ -56,9 +57,9 @@ const requestJson: RegistryRequest = (url, timeoutMs) =>
         }
       });
     });
+    req.on("socket", (socket) => socket.unref());
     req.setTimeout(timeoutMs, () => req.destroy());
     req.on("error", () => resolve(null));
-    req.unref();
   });
 
 export function isUpdateCheckDisabled(

--- a/packages/shared/src/lib/update-check.ts
+++ b/packages/shared/src/lib/update-check.ts
@@ -1,0 +1,157 @@
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import type { SquadrantConfig } from "../config.js";
+
+export interface UpdateCheckState {
+  lastChecked?: number;
+  latestKnown?: string;
+}
+
+export interface CheckForUpdateOutcome {
+  notice: string | null;
+  /** New state to persist, or null when nothing changed (opt-out / cache hit / fetch failure). */
+  newState: UpdateCheckState | null;
+}
+
+export const UPDATE_CHECK_STATE_PATH = path.join(os.homedir(), ".config", "squadrant", "update-check.json");
+
+const REGISTRY_URL = "https://registry.npmjs.org/squadrant/latest";
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 1500;
+
+export function isUpdateCheckDisabled(
+  config: Pick<SquadrantConfig, "defaults"> | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (env.NO_UPDATE_NOTIFIER) return true;
+  return config?.defaults?.updateCheck === false;
+}
+
+export function isCacheStale(state: UpdateCheckState | undefined, now: number, intervalMs = CHECK_INTERVAL_MS): boolean {
+  if (!state?.lastChecked) return true;
+  return now - state.lastChecked >= intervalMs;
+}
+
+export function isNewerVersion(latest: string, current: string): boolean {
+  const parse = (v: string) => v.trim().replace(/^v/, "").split("-")[0].split(".").map((n) => Number(n) || 0);
+  const [la = 0, lb = 0, lc = 0] = parse(latest);
+  const [ca = 0, cb = 0, cc = 0] = parse(current);
+  if (la !== ca) return la > ca;
+  if (lb !== cb) return lb > cb;
+  return lc > cc;
+}
+
+export function formatUpdateNotice(latest: string, current: string): string {
+  return `⬆ squadrant ${latest} available (you have ${current}) — npm i -g squadrant@latest`;
+}
+
+/**
+ * Queries the npm registry directly (never the `npm view` CDN — see the v0.13.1 incident).
+ * Never throws; races the request against its own timer so a bad network resolves to null
+ * within timeoutMs even if the injected fetch implementation ignores the abort signal.
+ */
+export async function fetchLatestVersion(
+  fetchImpl: typeof fetch = fetch,
+  timeoutMs: number = FETCH_TIMEOUT_MS,
+): Promise<string | null> {
+  const controller = new AbortController();
+  const timeout = new Promise<null>((resolve) => {
+    const timer = setTimeout(() => {
+      controller.abort();
+      resolve(null);
+    }, timeoutMs);
+    timer.unref?.();
+  });
+
+  const request = (async (): Promise<string | null> => {
+    try {
+      const res = await fetchImpl(REGISTRY_URL, { signal: controller.signal });
+      if (!res.ok) return null;
+      const data = (await res.json()) as { version?: unknown };
+      return typeof data.version === "string" ? data.version : null;
+    } catch {
+      return null;
+    }
+  })();
+
+  return Promise.race([request, timeout]);
+}
+
+/** Pure decision core: given cache state and injected fetch, decides whether to print a notice and what state to persist. No filesystem access. */
+export async function checkForUpdate(opts: {
+  currentVersion: string;
+  state: UpdateCheckState | undefined;
+  now: number;
+  fetchImpl?: typeof fetch;
+  intervalMs?: number;
+  timeoutMs?: number;
+}): Promise<CheckForUpdateOutcome> {
+  if (!isCacheStale(opts.state, opts.now, opts.intervalMs)) {
+    const latest = opts.state?.latestKnown;
+    const notice = latest && isNewerVersion(latest, opts.currentVersion) ? formatUpdateNotice(latest, opts.currentVersion) : null;
+    return { notice, newState: null };
+  }
+
+  const latest = await fetchLatestVersion(opts.fetchImpl, opts.timeoutMs);
+  if (!latest) return { notice: null, newState: null };
+
+  const newState: UpdateCheckState = { lastChecked: opts.now, latestKnown: latest };
+  const notice = isNewerVersion(latest, opts.currentVersion) ? formatUpdateNotice(latest, opts.currentVersion) : null;
+  return { notice, newState };
+}
+
+export function readUpdateCheckState(statePath: string = UPDATE_CHECK_STATE_PATH): UpdateCheckState | undefined {
+  try {
+    return JSON.parse(fs.readFileSync(statePath, "utf-8"));
+  } catch {
+    return undefined;
+  }
+}
+
+export function writeUpdateCheckState(state: UpdateCheckState, statePath: string = UPDATE_CHECK_STATE_PATH): void {
+  try {
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + "\n");
+  } catch {
+    // best-effort cache; a failed write just means we check again next run
+  }
+}
+
+/**
+ * CLI entrypoint wiring: opt-out check, cache read, decision, cache write, notice print —
+ * all in one best-effort call that never throws and never blocks past fetchLatestVersion's timeout.
+ */
+export async function notifyIfUpdateAvailable(opts: {
+  config: Pick<SquadrantConfig, "defaults"> | undefined;
+  currentVersion: string;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  statePath?: string;
+  readState?: (statePath: string) => UpdateCheckState | undefined;
+  writeState?: (state: UpdateCheckState, statePath: string) => void;
+  write?: (line: string) => void;
+  now?: number;
+}): Promise<void> {
+  try {
+    const env = opts.env ?? process.env;
+    if (isUpdateCheckDisabled(opts.config, env)) return;
+
+    const statePath = opts.statePath ?? UPDATE_CHECK_STATE_PATH;
+    const readState = opts.readState ?? readUpdateCheckState;
+    const writeState = opts.writeState ?? writeUpdateCheckState;
+    const write = opts.write ?? ((line: string) => process.stderr.write(`\n${line}\n`));
+
+    const outcome = await checkForUpdate({
+      currentVersion: opts.currentVersion,
+      state: readState(statePath),
+      now: opts.now ?? Date.now(),
+      fetchImpl: opts.fetchImpl,
+    });
+
+    if (outcome.newState) writeState(outcome.newState, statePath);
+    if (outcome.notice) write(outcome.notice);
+  } catch {
+    // update notifications are best-effort and must never affect the CLI
+  }
+}

--- a/packages/shared/src/lib/update-check.ts
+++ b/packages/shared/src/lib/update-check.ts
@@ -1,16 +1,21 @@
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import https from "node:https";
 import type { SquadrantConfig } from "../config.js";
 
 export interface UpdateCheckState {
   lastChecked?: number;
   latestKnown?: string;
+  /** Set when the most recent check attempt failed (offline/timeout). Drives a shorter
+   *  FAILURE_RETRY_MS backoff instead of the full 24h success interval, so an offline
+   *  machine retries roughly hourly instead of hitting the registry on every invocation. */
+  lastCheckFailed?: boolean;
 }
 
 export interface CheckForUpdateOutcome {
   notice: string | null;
-  /** New state to persist, or null when nothing changed (opt-out / cache hit / fetch failure). */
+  /** New state to persist, or null when nothing changed (opt-out / cache hit). */
   newState: UpdateCheckState | null;
 }
 
@@ -18,7 +23,43 @@ export const UPDATE_CHECK_STATE_PATH = path.join(os.homedir(), ".config", "squad
 
 const REGISTRY_URL = "https://registry.npmjs.org/squadrant/latest";
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const FAILURE_RETRY_MS = 60 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 1500;
+
+export type RegistryRequest = (url: string, timeoutMs: number) => Promise<unknown>;
+
+/**
+ * Fetches over node:https rather than global fetch(): a fetch() Promise exposes no
+ * handle to detach from the event loop, so a pending request left ref'd would delay
+ * process exit by up to timeoutMs on every single invocation of an offline machine.
+ * req.unref() is Node's documented mechanism for exactly this — it lets the process
+ * exit immediately once the CLI's own work is done, dropping the response if it
+ * arrives after. That's fine: this check is a best-effort background notice, never
+ * something the CLI's exit should wait on.
+ */
+const requestJson: RegistryRequest = (url, timeoutMs) =>
+  new Promise((resolve) => {
+    const req = https.get(url, { headers: { "user-agent": "squadrant-update-check" } }, (res) => {
+      if (res.statusCode !== 200) {
+        res.resume();
+        resolve(null);
+        return;
+      }
+      let body = "";
+      res.setEncoding("utf-8");
+      res.on("data", (chunk) => (body += chunk));
+      res.on("end", () => {
+        try {
+          resolve(JSON.parse(body));
+        } catch {
+          resolve(null);
+        }
+      });
+    });
+    req.setTimeout(timeoutMs, () => req.destroy());
+    req.on("error", () => resolve(null));
+    req.unref();
+  });
 
 export function isUpdateCheckDisabled(
   config: Pick<SquadrantConfig, "defaults"> | undefined,
@@ -28,9 +69,14 @@ export function isUpdateCheckDisabled(
   return config?.defaults?.updateCheck === false;
 }
 
-export function isCacheStale(state: UpdateCheckState | undefined, now: number, intervalMs = CHECK_INTERVAL_MS): boolean {
+export function isCacheStale(
+  state: UpdateCheckState | undefined,
+  now: number,
+  intervalMs = CHECK_INTERVAL_MS,
+  failureIntervalMs = FAILURE_RETRY_MS,
+): boolean {
   if (!state?.lastChecked) return true;
-  return now - state.lastChecked >= intervalMs;
+  return now - state.lastChecked >= (state.lastCheckFailed ? failureIntervalMs : intervalMs);
 }
 
 export function isNewerVersion(latest: string, current: string): boolean {
@@ -48,28 +94,24 @@ export function formatUpdateNotice(latest: string, current: string): string {
 
 /**
  * Queries the npm registry directly (never the `npm view` CDN — see the v0.13.1 incident).
- * Never throws; races the request against its own timer so a bad network resolves to null
- * within timeoutMs even if the injected fetch implementation ignores the abort signal.
+ * Never throws. Races the request against its own unref'd timer, so the *logical* result
+ * is always bounded by timeoutMs regardless of how requestFn behaves — real network
+ * failures are additionally handled by requestJson's own req.unref()/setTimeout, which
+ * guarantees the underlying resource can never hold the process open either.
  */
 export async function fetchLatestVersion(
-  fetchImpl: typeof fetch = fetch,
+  requestFn: RegistryRequest = requestJson,
   timeoutMs: number = FETCH_TIMEOUT_MS,
 ): Promise<string | null> {
-  const controller = new AbortController();
   const timeout = new Promise<null>((resolve) => {
-    const timer = setTimeout(() => {
-      controller.abort();
-      resolve(null);
-    }, timeoutMs);
+    const timer = setTimeout(() => resolve(null), timeoutMs);
     timer.unref?.();
   });
 
   const request = (async (): Promise<string | null> => {
     try {
-      const res = await fetchImpl(REGISTRY_URL, { signal: controller.signal });
-      if (!res.ok) return null;
-      const data = (await res.json()) as { version?: unknown };
-      return typeof data.version === "string" ? data.version : null;
+      const data = (await requestFn(REGISTRY_URL, timeoutMs)) as { version?: unknown } | null;
+      return typeof data?.version === "string" ? data.version : null;
     } catch {
       return null;
     }
@@ -78,25 +120,27 @@ export async function fetchLatestVersion(
   return Promise.race([request, timeout]);
 }
 
-/** Pure decision core: given cache state and injected fetch, decides whether to print a notice and what state to persist. No filesystem access. */
+/** Pure decision core: given cache state and an injected request function, decides whether
+ *  to print a notice and what state to persist. No filesystem access. */
 export async function checkForUpdate(opts: {
   currentVersion: string;
   state: UpdateCheckState | undefined;
   now: number;
-  fetchImpl?: typeof fetch;
+  fetchImpl?: RegistryRequest;
   intervalMs?: number;
+  failureIntervalMs?: number;
   timeoutMs?: number;
 }): Promise<CheckForUpdateOutcome> {
-  if (!isCacheStale(opts.state, opts.now, opts.intervalMs)) {
+  if (!isCacheStale(opts.state, opts.now, opts.intervalMs, opts.failureIntervalMs)) {
     const latest = opts.state?.latestKnown;
     const notice = latest && isNewerVersion(latest, opts.currentVersion) ? formatUpdateNotice(latest, opts.currentVersion) : null;
     return { notice, newState: null };
   }
 
   const latest = await fetchLatestVersion(opts.fetchImpl, opts.timeoutMs);
-  if (!latest) return { notice: null, newState: null };
+  if (!latest) return { notice: null, newState: { lastChecked: opts.now, lastCheckFailed: true } };
 
-  const newState: UpdateCheckState = { lastChecked: opts.now, latestKnown: latest };
+  const newState: UpdateCheckState = { lastChecked: opts.now, latestKnown: latest, lastCheckFailed: false };
   const notice = isNewerVersion(latest, opts.currentVersion) ? formatUpdateNotice(latest, opts.currentVersion) : null;
   return { notice, newState };
 }
@@ -120,13 +164,17 @@ export function writeUpdateCheckState(state: UpdateCheckState, statePath: string
 
 /**
  * CLI entrypoint wiring: opt-out check, cache read, decision, cache write, notice print —
- * all in one best-effort call that never throws and never blocks past fetchLatestVersion's timeout.
+ * all in one best-effort call that never throws. Not awaiting this at the call site keeps
+ * it off the command's own logic; the unref'd transport (see requestJson) and the bounded
+ * race in fetchLatestVersion mean a pending check can't delay process exit either, and a
+ * failed attempt is cached (see isCacheStale's failureIntervalMs) so an offline machine
+ * doesn't retry the registry on every single invocation.
  */
 export async function notifyIfUpdateAvailable(opts: {
   config: Pick<SquadrantConfig, "defaults"> | undefined;
   currentVersion: string;
   env?: NodeJS.ProcessEnv;
-  fetchImpl?: typeof fetch;
+  fetchImpl?: RegistryRequest;
   statePath?: string;
   readState?: (statePath: string) => UpdateCheckState | undefined;
   writeState?: (state: UpdateCheckState, statePath: string) => void;


### PR DESCRIPTION
## Summary
- On CLI startup, check `registry.npmjs.org` directly (not `npm view` — see the v0.13.1 silent-publish-failure incident) for the latest published `squadrant` version.
- Behind ⇒ print one quiet actionable line: `⬆ squadrant X.Y.Z available (you have A.B.C) — npm i -g squadrant@latest`.
- Up-to-date, offline, or a registry timeout ⇒ silent no-op. The check is bounded by its own race-against-timer (independent of whether the fetch impl honors abort signals) and fired fire-and-forget so it can never add latency or hang the CLI.
- Cached in `~/.config/squadrant/update-check.json`, once per ~24h, so we never hit the registry on every invocation.
- Opt-out via `defaults.updateCheck: false` in config or the standard `NO_UPDATE_NOTIFIER` env var.

This is distinct from the existing `needsCheck()`/`withStamp()` config-drift check in `packages/cli/src/index.ts` — that reconciles `config.json` *after* an upgrade already happened; it cannot tell a user an upgrade is *available*.

New module: `packages/shared/src/lib/update-check.ts` — pure, unit-testable decision core (`checkForUpdate`) plus a best-effort orchestrator (`notifyIfUpdateAvailable`) wired into `packages/cli/src/index.ts`.

## Test plan
- [x] `npx vitest run packages/shared` — 15 files / 149 tests passing, including 22 new tests in `update-check.test.ts` covering: behind → notice printed; up-to-date → silent; offline/timeout → silent and fast; cache hit → zero network calls; config/env opt-out honoured; never throws.
- [x] `pnpm run build` (tsc -b + tsup) — green, verified prior to this PR.
- [x] Full workspace `pnpm test` — green (164 files / 1990 tests) at the time of implementation, prior to the "no concurrent full-suite runs" constraint from the captain; re-verify on the merged result before release per captain's authoritative run.