### PR TITLE
fix(#535): daemon boot/exit markers + restart-survival proof

### DIFF
--- a/packages/cli/src/__tests__/squadrantd-boot-marker.test.ts
+++ b/packages/cli/src/__tests__/squadrantd-boot-marker.test.ts
@@ -1,0 +1,71 @@
+// #535: the daemon must write a greppable boot marker on startup and a
+// matching exit marker on stop() — a restart must never be inferred from
+// process START time alone.
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startSquadrantd } from "../squadrantd.js";
+
+describe("squadrantd boot/exit markers (#535)", () => {
+  let dir: string;
+  afterEach(() => { if (dir) rmSync(dir, { recursive: true, force: true }); });
+
+  it("logs a boot marker with pid/version/socket on startup", () => {
+    dir = mkdtempSync(join(tmpdir(), "boot-marker-"));
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    let handle: ReturnType<typeof startSquadrantd> | undefined;
+    try {
+      handle = startSquadrantd({ stateRoot: join(dir, "state"), sockPath: join(dir, "c.sock"), sweepMs: 0 });
+      const lines = writeSpy.mock.calls.map((c) => String(c[0]));
+      const bootLine = lines.find((l) => /\[squadrantd\].*\bboot pid=\d+ version=\S+ socket=\S+/.test(l));
+      expect(bootLine).toBeDefined();
+      expect(bootLine).toContain(`pid=${process.pid}`);
+    } finally {
+      writeSpy.mockRestore();
+      handle?.stop();
+    }
+  });
+
+  it("logs an exit marker carrying the shutdown reason on stop()", async () => {
+    dir = mkdtempSync(join(tmpdir(), "boot-marker-"));
+    const handle = startSquadrantd({ stateRoot: join(dir, "state"), sockPath: join(dir, "c.sock"), sweepMs: 0 });
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      await handle.stop("SIGTERM");
+      const lines = writeSpy.mock.calls.map((c) => String(c[0]));
+      const exitLine = lines.find((l) => /\bexit pid=\d+ reason=SIGTERM\b/.test(l));
+      expect(exitLine).toBeDefined();
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
+  it("writes the exit marker synchronously — before any awaited teardown resolves", () => {
+    dir = mkdtempSync(join(tmpdir(), "boot-marker-"));
+    const handle = startSquadrantd({ stateRoot: join(dir, "state"), sockPath: join(dir, "c.sock"), sweepMs: 0 });
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      // Do NOT await — simulates a caller that fires-and-forgets (the historical
+      // bug: SIGTERM handler called h.stop() then process.exit() immediately).
+      void handle.stop("SIGTERM");
+      const lines = writeSpy.mock.calls.map((c) => String(c[0]));
+      expect(lines.some((l) => /\bexit pid=\d+ reason=SIGTERM\b/.test(l))).toBe(true);
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
+  it("defaults the exit reason to 'requested' when the caller passes none", async () => {
+    dir = mkdtempSync(join(tmpdir(), "boot-marker-"));
+    const handle = startSquadrantd({ stateRoot: join(dir, "state"), sockPath: join(dir, "c.sock"), sweepMs: 0 });
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      await handle.stop();
+      const lines = writeSpy.mock.calls.map((c) => String(c[0]));
+      expect(lines.some((l) => /\bexit pid=\d+ reason=requested\b/.test(l))).toBe(true);
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+});

--- a/packages/cli/src/squadrantd.ts
+++ b/packages/cli/src/squadrantd.ts
@@ -332,18 +332,30 @@ export function startSquadrantd(opts: import("@squadrant/core").SquadrantdOpts =
   }
 
   const origStop = h.stop.bind(h);
-  h.stop = async () => {
+  h.stop = async (reason?: string) => {
     try { cmuxStoreSource.stop(); } catch { /* best-effort */ }
     try { nativeHookSource.stop(); } catch { /* best-effort */ }
     try { codexAppServerSource.stop(); } catch { /* best-effort */ }
-    return origStop();
+    return origStop(reason);
   };
 
   return h;
 }
 
+/** Greppable crash marker (#535) — matches the `[squadrantd] <iso> <msg>` shape
+ *  ctx.log uses, but writes directly since ctx.log doesn't exist until buildContext()
+ *  runs; a crash before that point must still be diagnosable. */
+function logCrashMarker(kind: "uncaughtException" | "unhandledRejection", err: unknown): void {
+  const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+  process.stderr.write(`[squadrantd] ${new Date().toISOString()} ${kind} pid=${process.pid} error=${message}\n`);
+}
+
 // Executed by launchd (ProgramArguments → this file's compiled .js).
 if (process.argv[1] && process.argv[1].endsWith("squadrantd.js")) {
+  // Registered before any boot work so a crash during startup is still logged.
+  process.on("uncaughtException", (err) => { logCrashMarker("uncaughtException", err); process.exit(1); });
+  process.on("unhandledRejection", (reason) => { logCrashMarker("unhandledRejection", reason); process.exit(1); });
+
   void (async () => {
     // #360 layer 1: this entry takes no CLI flags. A build smoke-test like
     // `node dist/squadrantd.js --help` must NOT boot a daemon — it would hang
@@ -363,6 +375,12 @@ if (process.argv[1] && process.argv[1].endsWith("squadrantd.js")) {
       process.exit(0);
     }
     const h = startSquadrantd({ sweepMs: 30000 });
-    process.on("SIGTERM", () => { h.stop(); process.exit(0); });
+    // #535: await stop() before exiting — it writes the exit marker and runs
+    // teardown (bridges, in-flight headless kills) synchronously-then-async;
+    // exiting immediately after firing it (not awaiting) raced process.exit()
+    // against that work and silently dropped it every time.
+    const shutdown = (signal: "SIGTERM" | "SIGINT") => { void h.stop(signal).finally(() => process.exit(0)); };
+    process.on("SIGTERM", () => shutdown("SIGTERM"));
+    process.on("SIGINT", () => shutdown("SIGINT"));
   })();
 }

--- a/packages/core/src/__tests__/delivery-loop.test.ts
+++ b/packages/core/src/__tests__/delivery-loop.test.ts
@@ -5,8 +5,9 @@ import { join } from "node:path";
 import { createDelivery } from "../daemon/delivery-loop.js";
 import { createStore } from "../store.js";
 import { LivenessRegistry } from "../daemon/liveness-registry.js";
-import { appendCaptainMessage } from "../mailbox.js";
+import { appendCaptainMessage, appendToMailbox, readCursor } from "../mailbox.js";
 import { STALE_THRESHOLD_MS } from "../daemon/interactive-probe.js";
+import { DeferDelivery } from "../delivery/defer-delivery.js";
 
 function freshState(): string {
   return mkdtempSync(join(tmpdir(), "deliv-"));
@@ -115,7 +116,132 @@ describe("delivery-loop", () => {
     } as any, cmux as any);
     
     await deliv.deliveryTick!();
-    
+
     expect(logs).toContain("sent: hello command");
+  });
+
+  // #535: repro sketch — a dispatch report-back lands in the mailbox, the
+  // daemon restarts before the captain pane accepts it, and a fresh daemon
+  // instance resumes over the same on-disk mailbox + cursor. It must deliver
+  // the report-back exactly once: never dropped, never duplicated.
+  it("delivers a report-back exactly once across a simulated daemon restart (#535)", async () => {
+    const stateRoot = freshState();
+    const project = "alpha";
+    const store = createStore(stateRoot);
+    store.put({
+      id: "disp1", project, provider: "claude", mode: "interactive",
+      state: "done", task: "dispatch B->A report-back", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000, attempts: [],
+    });
+    await appendToMailbox({
+      stateRoot, project,
+      taskRecord: store.list(project)[0],
+      event: { type: "task.done", id: "disp1" } as any,
+      message: "dispatch report-back",
+    });
+
+    const captainName = `${project}-captain`;
+    function newRegistry() {
+      const registry = new LivenessRegistry({ path: join(stateRoot, "live.json") });
+      registry.apply({
+        project, role: "captain", pid: 123, sessionId: "s1",
+        startedAt: Date.now(), lastState: "start", lastSeenAt: Date.now(),
+        pidAlive: true, source: "runtime",
+      });
+      return registry;
+    }
+
+    // ── "Session 1": daemon boots, attempts delivery, captain pane is busy
+    // (deferred) — restart happens before the report-back settles. ──
+    const sent: string[] = [];
+    const busyCmux = {
+      listSurfaces: async () => [{ id: "s1", title: captainName, command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => `${captainName}> `,
+      send: async () => { throw new DeferDelivery("captain is composing"); },
+    };
+    const session1 = createDelivery({
+      stateRoot, store, livenessRegistry: newRegistry(), log: () => {}, isPidAlive: () => true, opts: {},
+    } as any, busyCmux as any);
+    await session1.deliveryTick!();
+    expect(sent).toHaveLength(0);
+    const cursorAfterSession1 = await readCursor({ stateRoot, project, subscriber: "captain" });
+    expect(cursorAfterSession1?.lastAckedSeq ?? 0).toBe(0); // not acked — never sent
+
+    // ── "Session 2": fresh daemon process (new in-memory delivery state,
+    // fresh liveness registry) resumes from the same on-disk mailbox+cursor.
+    // The pane is now free — delivery succeeds. ──
+    const readyCmux = {
+      listSurfaces: async () => [{ id: "s1", title: captainName, command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => `${captainName}> `,
+      send: async (_surface: any, text: string) => { sent.push(text); },
+    };
+    const session2 = createDelivery({
+      stateRoot, store, livenessRegistry: newRegistry(), log: () => {}, isPidAlive: () => true, opts: {},
+    } as any, readyCmux as any);
+    await session2.deliveryTick!();
+    expect(sent).toEqual(["dispatch report-back"]);
+    const cursorAfterSession2 = await readCursor({ stateRoot, project, subscriber: "captain" });
+    expect(cursorAfterSession2?.lastAckedSeq).toBe(1);
+
+    // A further tick (still session 2, or a hypothetical session 3) must not
+    // redeliver — the cursor already acked seq 1.
+    await session2.deliveryTick!();
+    expect(sent).toEqual(["dispatch report-back"]);
+  });
+
+  // #535 question 2: is the #531 stale-skip exemption for human/CLI-originated
+  // captain.message data-driven (persisted per-entry), or does it depend on
+  // in-memory state that a restart would lose? Model two daemon sessions: the
+  // message ages past STALE_THRESHOLD_MS while no session is running (as if
+  // the daemon was down), then a *fresh* session (new sessionStartMs, matching
+  // a real restart) resumes and must still deliver it.
+  it("the #531 stale-skip exemption survives a restart — it is computed from the persisted entry, not session state", async () => {
+    const stateRoot = freshState();
+    const project = "beta";
+    const captainName = `${project}-captain`;
+    const store = createStore(stateRoot);
+    // The delivery loop only visits projects it knows about (config, injected
+    // surfaces, or the task store) — seed a task so "beta" is in scope.
+    store.put({
+      id: "t1", project, provider: "claude", mode: "interactive",
+      state: "submitted", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000, attempts: [],
+    });
+    const livenessRegistry = new LivenessRegistry({ path: join(stateRoot, "live.json") });
+    livenessRegistry.apply({
+      project, role: "captain", pid: 123, sessionId: "s1",
+      startedAt: Date.now(), lastState: "start", lastSeenAt: Date.now(),
+      pidAlive: true, source: "runtime",
+    });
+
+    await appendCaptainMessage({ stateRoot, project, text: "human/cli message", source: "cli" });
+    await appendCaptainMessage({ stateRoot, project, text: "daemon message", source: "daemon" });
+
+    // Simulate the daemon being down for longer than the stale threshold —
+    // the messages sat on disk, unprocessed, across the gap.
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + STALE_THRESHOLD_MS + 1000);
+
+    // "Restart": createDelivery() is called only now, so its sessionStartMs
+    // captures the post-restart clock — a fresh daemon lifetime, not the one
+    // that existed when the messages were enqueued.
+    const sent: string[] = [];
+    const cmux = {
+      listSurfaces: async () => [{ id: "s1", title: captainName, command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => `${captainName}> `,
+      send: async (_surface: any, text: string) => { sent.push(text); },
+    };
+    const postRestart = createDelivery({
+      stateRoot, store, livenessRegistry, log: () => {}, isPidAlive: () => true, opts: {},
+    } as any, cmux as any);
+    await postRestart.deliveryTick!();
+
+    expect(sent).toContain("human/cli message");
+    expect(sent).not.toContain("daemon message");
+
+    vi.useRealTimers();
   });
 });

--- a/packages/core/src/daemon/start.ts
+++ b/packages/core/src/daemon/start.ts
@@ -21,7 +21,9 @@ const CURSOR_SUBSCRIBER = "captain";
 const SNAPSHOT_LOG_WINDOW_MS = 60 * 60 * 1000;
 
 export interface DaemonHandle {
-  stop(): Promise<void>;
+  /** `reason` is folded into the exit log line (e.g. "SIGTERM", "SIGINT") so a
+   *  restart is diagnosable from the log instead of inferred (#535). */
+  stop(reason?: string): Promise<void>;
   tickDelivery: (() => Promise<void>) | undefined;
   tickProbe: (() => Promise<void>) | undefined;
 }
@@ -216,7 +218,9 @@ export function startDaemon(ctx: DaemonContext, opts: SquadrantdOpts, pkgVersion
   // ── Server + timers ───────────────────────────────────────────────────────
 
   const server = createServer(ctx, { buildHealth, gatherSnapshotInputs, cancelPromotionsFor, broadcast });
-  log(`started pid=${process.pid} sock=${ctx.sockPath} stateRoot=${stateRoot}`);
+  // #535: greppable boot marker — a restart must be diagnosable from the log,
+  // never inferred from process START time.
+  log(`boot pid=${process.pid} version=${pkgVersion} socket=${ctx.sockPath} stateRoot=${stateRoot}`);
 
   let deliveryTick: (() => Promise<void>) | undefined = initialDeliveryTick;
   let probeTick: (() => Promise<void>) | undefined;
@@ -280,7 +284,10 @@ export function startDaemon(ctx: DaemonContext, opts: SquadrantdOpts, pkgVersion
   }
 
   return {
-    stop(): Promise<void> {
+    stop(reason = "requested"): Promise<void> {
+      // #535: write the exit marker synchronously, before any async
+      // teardown, so it lands even if the caller doesn't await this promise.
+      log(`exit pid=${process.pid} reason=${reason}`);
       if (deliveryTimer) clearInterval(deliveryTimer);
       if (probeTimer) clearInterval(probeTimer);
       if (timer) clearInterval(timer);
@@ -289,7 +296,7 @@ export function startDaemon(ctx: DaemonContext, opts: SquadrantdOpts, pkgVersion
       try { ctx.telegramBridge?.stop(); } catch { /* best-effort */ }
       try { ctx.codexDriver.stop?.(); } catch { /* best-effort */ }
       for (const kill of ctx.activeHeadlessKills) kill();
-      return new Promise<void>((resolve) => server.close(() => { log("stopped"); resolve(); }));
+      return new Promise<void>((resolve) => server.close(() => { log(`exit-complete pid=${process.pid}`); resolve(); }));
     },
     tickDelivery: deliveryTick,
     tickProbe: probeTick,


### PR DESCRIPTION
## Summary

- **Boot/exit markers (the actual ask).** The daemon already logged a startup line (`started pid=…`), but it didn't match any of the greppable keywords the issue named (`boot|listening on|uncaughtException|SIGTERM`) — hence "0 hits" and the restart had to be inferred from process `STARTED` time. Renamed it to `boot pid=<pid> version=<v> socket=<path> stateRoot=<path>`.
- **Exit marker never fired — real bug, not just a naming gap.** `squadrantd.ts`'s `SIGTERM` handler called `h.stop()` without awaiting it, then called `process.exit(0)` immediately. `stop()`'s log line only fired inside `server.close()`'s async callback, so `process.exit(0)` killed the process before that callback (and the rest of teardown — bridge stops, in-flight headless kills) ever ran. 184 `started` lines / 0 `stopped` lines in the production log confirm this: every restart silently skipped teardown. Fixed by (a) writing the exit marker synchronously as the first line of `stop()`, and (b) awaiting `h.stop(signal)` before `process.exit()` in the signal handlers. Also added a `SIGINT` handler (was missing) and `uncaughtException`/`unhandledRejection` markers registered before any boot work runs.
- **Restart survival — investigated, found already correct, proved with tests.** Traced the mailbox/delivery-loop layer: both the mailbox log and the delivery cursor are durably persisted to disk (fsync'd, atomic rename) and the cursor only advances *after* a confirmed send. A fresh daemon session resumes from the same on-disk cursor, so the realistic restart case (repro sketch: restart before the report-back settles) delivers **exactly once** — proved in `delivery-loop.test.ts`. The `#531` stale-skip exemption for human/CLI-originated `captain.message` is computed purely from the persisted entry's `payload.source`, not from any in-daemon-session state, so it holds across a restart by construction — also proved with a two-session test.
- **Correction to the issue's evidence:** the `seq=31 captain.message` deferred/delivered episode (19:28–19:29 UTC) happened over an hour after the restart at 18:23:40, inside the same continuous daemon session (only one `boot` line in that window) — it's normal defer-then-deliver retry (busy pane), not restart-spanning behavior. The `seq=30/24 task.failed` episode *is* restart-adjacent (6s after boot) and is exactly the scenario the new test covers.
- **Known residual, not fixed here (out of scope):** there's a narrow window between a confirmed `cmux.send()` and the cursor-persisting `writeCursor()` call where a hard kill (e.g. `SIGKILL`, OOM) mid-tick could cause a duplicate delivery on restart — never a loss, since the cursor never advances without a confirmed send. This is a pre-existing at-least-once characteristic of the ack-after-send design, not introduced or worsened by this change. Fixing it would need a two-phase commit on the cursor, which is a bigger change than #535 asked for; flagging it here for visibility.

## Root cause (systematic-debugging)

1. `packages/core/src/daemon/start.ts:219` already had a boot log line, just under a name (`started`) that didn't match the issue's grep pattern.
2. `packages/cli/src/squadrantd.ts:366` (`process.on("SIGTERM", () => { h.stop(); process.exit(0); })`) never awaited the async `stop()`, so its log write and teardown never completed before the process died — the actual reason for "0 exit markers ever."
3. No `SIGINT`, `uncaughtException`, or `unhandledRejection` handlers existed at all.

## Changes

- `packages/core/src/daemon/start.ts` — boot line renamed/extended (adds `version`); `stop(reason?)` now logs `exit pid=… reason=…` synchronously before any teardown, and `exit-complete` after `server.close()` finishes.
- `packages/cli/src/squadrantd.ts` — `SIGTERM`/`SIGINT` handlers now await `h.stop(signal)` before exiting; added `uncaughtException`/`unhandledRejection` markers.
- `packages/core/src/__tests__/delivery-loop.test.ts` — two new tests: exactly-once delivery across a simulated restart (defer → restart → deliver, no duplicate on a further tick), and the `#531` exemption surviving a restart (fresh session, aged entry, still delivered for `source !== "daemon"`).
- `packages/cli/src/__tests__/squadrantd-boot-marker.test.ts` — new: boot marker format, exit marker + reason, exit marker written synchronously (even when the caller doesn't await), default reason.

## Manual verification (real daemon, not just tests)

```
launchctl kickstart -k gui/$(id -u)/com.squadrant.daemon
grep -E 'boot pid=|exit pid=|exit-complete pid=' ~/.config/squadrant/squadrantd.log | tail -6
```
Expect an `exit pid=… reason=SIGTERM` immediately followed by `exit-complete pid=…` for the old pid, then `boot pid=… version=… socket=…` for the new one — restart now diagnosable straight from the log instead of inferred from process START time.

## Test plan

- [x] `npx vitest run packages/core/src packages/cli/src` — 100 files / 1123 tests passed (scoped run; full monorepo `npm test` deferred per captain — concurrent crews running it were starving the machine; captain will run the authoritative full build+test on the merged result before release).
- [x] `npm run build` — clean (also needed once to fix this worktree's stale `node_modules` → `@squadrant/core` symlink, which was resolving to the main repo's checkout instead of this worktree's).
- [ ] Manual restart verification above — not yet run against the live daemon (would require a live restart during active sessions); steps documented for the captain to run.