### PR TITLE
fix(#513, #522): terminalize same-name crew records reliably; calm CREW IDLE wording

### DIFF
--- a/packages/core/src/__tests__/crew-spawn.test.ts
+++ b/packages/core/src/__tests__/crew-spawn.test.ts
@@ -811,4 +811,100 @@ describe("runCrewClose", () => {
     // pane found, pane closed; no throw despite daemon error
     expect(runtime.closePane).toHaveBeenCalledOnce();
   });
+
+  // ── #513: same-name respawn zombie regression ────────────────────────────
+  // Repro: spawn cv-qa (opencode) -> close IMMEDIATELY -> respawn cv-qa
+  // (claude). The daemon later fires a false CREW STALLED for the CLOSED
+  // opencode task because close's single listTasks() snapshot missed the
+  // record (registration race) and/or a stale same-name record survives
+  // uncancelled once a second one exists.
+
+  it("retries the name lookup when the first snapshot has no match yet, then terminalizes it (registration race)", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:cv-qa" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    const task = { id: "b3449b4a", name: "cv-qa", state: "working", provider: "opencode", cwd: PROJ_PATH } as Partial<TaskRecord>;
+    const emitEvent = vi.fn().mockResolvedValue(undefined);
+    // First snapshot: dispatch hasn't landed yet (empty). Second snapshot: it has.
+    const listTasks = vi.fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([task]);
+
+    await runCrewClose(PROJECT, "cv-qa", runtime, "workspace:1", {
+      listTasks,
+      emitEvent,
+      closeCodexThread: vi.fn(),
+      sleep: vi.fn().mockResolvedValue(undefined), // no real delay in tests
+    });
+
+    expect(listTasks.mock.calls.length).toBeGreaterThan(1);
+    expect(emitEvent).toHaveBeenCalledWith(
+      PROJECT,
+      expect.objectContaining({ type: "task.cancelled", id: "b3449b4a" }),
+    );
+  });
+
+  it("gives up after bounded retries and still closes the pane when no daemon record ever appears", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:cv-qa" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    const emitEvent = vi.fn().mockResolvedValue(undefined);
+    const listTasks = vi.fn().mockResolvedValue([]);
+
+    await runCrewClose(PROJECT, "cv-qa", runtime, "workspace:1", {
+      listTasks,
+      emitEvent,
+      closeCodexThread: vi.fn(),
+      sleep: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(emitEvent).not.toHaveBeenCalledWith(
+      PROJECT,
+      expect.objectContaining({ type: "task.cancelled" }),
+    );
+    expect(runtime.closePane).toHaveBeenCalledOnce();
+  });
+
+  it("terminalizes EVERY non-terminal record matching the name, not just the first match (duplicate same-name records)", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:cv-qa" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    const emitEvent = vi.fn().mockResolvedValue(undefined);
+    // A prior close-race left an orphaned opencode record uncancelled; the
+    // live claude crew (respawned under the same name) is the one being closed now.
+    const zombie = { id: "b3449b4a", name: "cv-qa", state: "working", provider: "opencode", cwd: PROJ_PATH, createdAt: 1000 } as Partial<TaskRecord>;
+    const live = { id: "f6f5200d", name: "cv-qa", state: "working", provider: "claude", cwd: PROJ_PATH, createdAt: 2000 } as Partial<TaskRecord>;
+
+    await runCrewClose(PROJECT, "cv-qa", runtime, "workspace:1", {
+      listTasks: vi.fn().mockResolvedValue([zombie, live]),
+      emitEvent,
+      closeCodexThread: vi.fn(),
+      sleep: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(emitEvent).toHaveBeenCalledWith(
+      PROJECT,
+      expect.objectContaining({ type: "task.cancelled", id: "b3449b4a" }),
+    );
+    expect(emitEvent).toHaveBeenCalledWith(
+      PROJECT,
+      expect.objectContaining({ type: "task.cancelled", id: "f6f5200d" }),
+    );
+  });
+
+  it("anchors reap/worktree cleanup on the most-recently-dispatched match when duplicates exist", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:cv-qa" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    const oldWorktree = `${PROJ_PATH}/.worktrees/myproj-cv-qa-old`;
+    const newWorktree = `${PROJ_PATH}/.worktrees/myproj-cv-qa-new`;
+    const zombie = { id: "old-id", name: "cv-qa", state: "working", provider: "opencode", cwd: oldWorktree, createdAt: 1000 } as Partial<TaskRecord>;
+    const live = { id: "new-id", name: "cv-qa", state: "working", provider: "claude", cwd: newWorktree, createdAt: 2000 } as Partial<TaskRecord>;
+
+    await runCrewClose(PROJECT, "cv-qa", runtime, "workspace:1", {
+      listTasks: vi.fn().mockResolvedValue([zombie, live]),
+      emitEvent: vi.fn().mockResolvedValue(undefined),
+      closeCodexThread: vi.fn(),
+      sleep: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(removeWorktreeMock).toHaveBeenCalledWith(PROJ_PATH, newWorktree);
+    expect(removeWorktreeMock).not.toHaveBeenCalledWith(PROJ_PATH, oldWorktree);
+  });
 });

--- a/packages/core/src/__tests__/daemon.test.ts
+++ b/packages/core/src/__tests__/daemon.test.ts
@@ -790,6 +790,22 @@ describe("daemon – blocked crew resume path (#183)", () => {
       expect(calls.filter((c) => c.message.includes("CREW IDLE"))).toHaveLength(1);
     });
 
+    // #522: awaiting-input is reached ONLY via a genuine turn-boundary event
+    // (never a watchdog guess — see reduce.ts formatMessage). A deliberate
+    // turn-end mid-plan (e.g. a long-lived crew pausing between sequential
+    // subtasks) is mechanically identical to any other turn-end, so the
+    // message must read calm rather than like a possible stall.
+    it("uses calm 'awaiting your reply' phrasing, not the old alarming 'review and reply or close' wording (#522)", async () => {
+      const store = createStore(dir);
+      store.put(rec("t-calm", { state: "working" }));
+      const calls: any[] = [];
+      const d = createDaemon({ store, now: () => 50_000, notify: async (a) => { calls.push(a); } });
+      await d.handle({ kind: "event", project: "p", event: { type: "task.turn.completed", id: "t-calm", turnId: "turn-1" } });
+      expect(calls).toHaveLength(1);
+      expect(calls[0].message).toBe(`CREW IDLE ${crewTag(store.get("p", "t-calm")!)}: turn ended, awaiting your reply.`);
+      expect(calls[0].message).not.toContain("review and reply or close");
+    });
+
     it("does NOT debounce CREW BLOCKED even right after a captain turn", async () => {
       const store = createStore(dir);
       store.put(rec("t-blk", { state: "working" }));

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -516,6 +516,13 @@ export async function runCrewRead(
   return runtime.readPaneScreen(crew);
 }
 
+// #513: close's listTasks() lookup can race a same-name crew's own dispatch —
+// closing immediately after spawn may snapshot the daemon before the task
+// record is registered. A few short retries close that window without adding
+// meaningful latency to the common (already-registered) case.
+const CLOSE_LOOKUP_RETRIES = 3;
+const CLOSE_LOOKUP_RETRY_DELAY_MS = 150;
+
 export async function runCrewClose(
   project: string,
   name: string,
@@ -525,8 +532,11 @@ export async function runCrewClose(
     listTasks(project: string): Promise<TaskRecord[]>;
     emitEvent(project: string, event: ControlEvent): Promise<void>;
     closeCodexThread(taskId: string): Promise<void>;
+    /** Injectable for tests; defaults to a real delay. */
+    sleep?: (ms: number) => Promise<void>;
   },
 ): Promise<void> {
+  const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
   // resolveCaptainWorkspace already validated the project exists; reload for its
   // root path so we can tell a worktree crew (cwd != root) from a root crew.
   const projRoot = loadConfig().projects[project]?.path;
@@ -542,21 +552,34 @@ export async function runCrewClose(
   // its own worktree (cwd recorded by the daemon differs from the root checkout).
   let worktreeCwd: string | undefined;
   try {
-    const tasks = await deps.listTasks(project);
-    const task = tasks.find((t) => t.name === name);
-    if (task) {
-      taskId = task.id;
-      if (task.cwd && projRoot && task.cwd !== projRoot) {
-        worktreeCwd = task.cwd;
+    let matches = (await deps.listTasks(project)).filter((t) => t.name === name);
+    // #513: the record may not be registered yet (close raced spawn's own
+    // dispatch). Retry briefly before concluding this crew has no daemon task.
+    for (let attempt = 0; attempt < CLOSE_LOOKUP_RETRIES && matches.length === 0; attempt++) {
+      await sleep(CLOSE_LOOKUP_RETRY_DELAY_MS);
+      matches = (await deps.listTasks(project)).filter((t) => t.name === name);
+    }
+    if (matches.length > 0) {
+      // #513: a name can match more than one record (e.g. an orphaned record
+      // left by a prior close that raced dispatch, followed by a same-name
+      // respawn). Terminalize every non-terminal match so none linger to fire
+      // a phantom CREW STALLED/IDLE later. Reap/worktree cleanup below anchors
+      // on the most-recently-dispatched match — the one the live pane belongs to.
+      const primary = matches.reduce((a, b) => ((b.createdAt ?? 0) > (a.createdAt ?? 0) ? b : a));
+      taskId = primary.id;
+      if (primary.cwd && projRoot && primary.cwd !== projRoot) {
+        worktreeCwd = primary.cwd;
       }
-      if (!TERMINAL_STATES.has(task.state)) {
-        await deps.emitEvent(project, { type: "task.cancelled", id: task.id, reason: "closed by captain" });
-      }
-      // Codex teardown: the pane only hosts the `crew attach` renderer; the thread
-      // (and its per-thread MCP servers) live on the shared app-server, so closing
-      // the pane alone leaks them. Tell the daemon to archive the thread.
-      if (task.provider === "codex") {
-        await deps.closeCodexThread(task.id);
+      for (const task of matches) {
+        if (!TERMINAL_STATES.has(task.state)) {
+          await deps.emitEvent(project, { type: "task.cancelled", id: task.id, reason: "closed by captain" });
+        }
+        // Codex teardown: the pane only hosts the `crew attach` renderer; the thread
+        // (and its per-thread MCP servers) live on the shared app-server, so closing
+        // the pane alone leaks them. Tell the daemon to archive the thread.
+        if (task.provider === "codex") {
+          await deps.closeCodexThread(task.id);
+        }
       }
     }
   } catch {

--- a/packages/core/src/daemon/reduce.ts
+++ b/packages/core/src/daemon/reduce.ts
@@ -172,7 +172,15 @@ function formatMessage(rec: TaskRecord, event?: ControlEvent): string | null {
       return `CREW STALLED ${tag}: no heartbeat in ${rec.heartbeatBudgetMs}ms`;
     }
     case "awaiting-input":
-      return `CREW IDLE ${tag}: turn ended / awaiting your input — review and reply or close.`;
+      // #522: 'awaiting-input' is reached ONLY via a genuine turn-boundary event
+      // (task.turn.completed — see state-machine.ts) — there is no separate
+      // watchdog-derived path into this state (the old wall-clock idle flip was
+      // retired by #354; evaluateStall never produces 'awaiting-input'). So this
+      // always means "the crew deliberately ended its turn", including the
+      // common case of a long-lived crew pausing between sequential subtasks.
+      // The former "review and reply or close" phrasing read like a possible
+      // fault and forced a spot-check every time; state calmly instead.
+      return `CREW IDLE ${tag}: turn ended, awaiting your reply.`;
     default:
       return null;
   }


### PR DESCRIPTION
## Summary

Both issues verified against current `develop` before any fix (per systematic-debugging: reproduce first, don't patch a symptom that no longer exists).

### #513 — false CREW STALLED for a closed crew after same-name respawn

**Verified real**, but the captain's own stated root cause ("close does not deregister") was already fixed by #184/#139 — `runCrewClose` does terminalize the task record it finds. The actual gap, confirmed by a reproducing test against the *current* implementation:

- `runCrewClose` took a **single** `deps.listTasks()` snapshot and did a plain `.find(t => t.name === name)`. If the crew was closed immediately after spawn, that snapshot can race the spawn's own dispatch RPC and return zero matches — close then silently no-ops on the daemon side (still closes the pane), leaving the just-created task record permanently non-terminal. It sits at `working` and the stall watchdog fires on it ~15min later, forever, referencing the closed crew's old id/agent — exactly the reported symptom. The escalation comment on #513 (a genuine `CREW DONE` for the *live* respawned crew going unnoticed) is consistent with a second, uncancelled same-name record piling up in the mailbox alongside the real one.
- Secondary risk also confirmed: once two same-name records exist (one zombie, one live), `.find()` picks whichever comes first — not necessarily the live one.

**Fix** (`packages/core/src/crew-spawn.ts`):
1. Filter-then-retry: if the name has zero matches on the first snapshot, retry up to 3× (150ms apart) before concluding there's no daemon task — closes the registration-race window.
2. Terminalize **every** non-terminal record matching the name, not just the first `.find()` hit — orphaned zombies get cleaned up the moment anyone closes that name again. Reap/worktree cleanup still anchors on the most-recently-dispatched match (the one actually backing the live pane).

Tests added in `crew-spawn.test.ts` reproduce the race (fail on old code, pass on new) and cover the duplicate-record and worktree-anchoring cases.

### #522 — CREW IDLE phrasing is ambiguous

**Verified, but the issue's stated mechanism is stale.** The "watchdog-derived idle" path it describes (a wall-clock flip straight to `awaiting-input`) was already retired by #354 — `evaluateStall` never produces `awaiting-input` anymore (only `stalled`, which has its own distinct `CREW STALLED` message). Grepping the reducer confirms `task.turn.completed` is the *only* code path that ever sets `awaiting-input` today (`state-machine.ts:131`), so `CREW IDLE` already always means a genuine turn boundary — the docs (`docs/testing/crew-lifecycle-checklist.md:94`) say the same.

So no branching logic was needed (there's no second path to disambiguate). Fixed by softening the wording unconditionally, since it's accurate 100% of the time:

- Before: `CREW IDLE [...]: turn ended / awaiting your input — review and reply or close.`
- After: `CREW IDLE [...]: turn ended, awaiting your reply.`

Kept the `CREW IDLE` prefix (rather than introducing a new `CREW AWAITING` prefix as the issue sketched) since it's the documented, tested, greppable identifier for this exact signal across docs/tests/telegram formatting, and a rename would be a much larger, purely cosmetic blast radius for a wording-only fix.

## Test plan
- [x] `npx vitest run` in `packages/core` — 646/646 passed (single run, per current machine-load constraint)
- [x] `npx tsc --noEmit` in `packages/core` — clean
- [x] New tests added specifically reproduce both bugs against the pre-fix code