### PR TITLE
fix(#538): squadrant status shows real captain liveness — stop reading a frontmatter field nothing writes

### DIFF
--- a/packages/cli/src/commands/__tests__/status.test.ts
+++ b/packages/cli/src/commands/__tests__/status.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { captainIndicator } from "../status.js";
+
+// #538: default `squadrant status` used to derive the ●/○ indicator from
+// status.md's `captain_session` frontmatter, which nothing in the codebase
+// writes — so it always rendered offline regardless of true liveness. The
+// indicator must come from the daemon's registry-derived HealthState instead.
+describe("captainIndicator (#538)", () => {
+  it("alive → green filled circle", () => {
+    expect(captainIndicator("alive")).toContain("●");
+  });
+
+  it("stale → still green filled circle (degrading but not dead)", () => {
+    expect(captainIndicator("stale")).toContain("●");
+  });
+
+  it("gone → dim empty circle", () => {
+    expect(captainIndicator("gone")).toContain("○");
+  });
+
+  it("stopped → dim empty circle", () => {
+    expect(captainIndicator("stopped")).toContain("○");
+  });
+
+  it("unknown state → dim '?' (never asserts offline on missing data)", () => {
+    expect(captainIndicator("unknown")).toContain("?");
+  });
+
+  it("no entry at all (daemon unreachable) → dim '?', not offline", () => {
+    expect(captainIndicator(undefined)).toContain("?");
+  });
+});

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -4,10 +4,10 @@ import matter from "gray-matter";
 import { loadConfig } from "@squadrant/shared";
 import { createObsidianDriver, WorkspaceRegistry } from "@squadrant/workspaces";
 import { queryHealth, printServiceHealth } from "./health-view.js";
+import type { ComponentHealth } from "@squadrant/core";
 
 interface StatusFrontmatter {
   project?: string;
-  captain_session?: string;
   last_updated?: string;
   active_crew?: number;
   tasks_total?: number;
@@ -40,6 +40,20 @@ function progressBar(completed: number, total: number): string {
   return `${bar} ${pct}%`;
 }
 
+/**
+ * Pure. Render the captain liveness indicator from the daemon's registry-derived
+ * state (#538) — never from status.md, which nothing writes to.
+ * `undefined` means the daemon returned no entry for this project (never
+ * registered / not yet probed); together with "unknown" it renders "?" rather
+ * than the offline glyph, since asserting offline on missing data is a false
+ * negative (#538's core ask).
+ */
+export function captainIndicator(state: ComponentHealth["state"] | undefined): string {
+  if (state === "alive" || state === "stale") return chalk.green("●");
+  if (state === undefined || state === "unknown") return chalk.dim("?");
+  return chalk.dim("○");
+}
+
 export const statusCommand = new Command("status")
   .description("Show status of all projects from spoke vault status files")
   .option("--detailed", "also show live per-component service health from the daemon (#77)")
@@ -51,6 +65,19 @@ export const statusCommand = new Command("status")
     if (projects.length === 0) {
       console.log(chalk.yellow("\nNo projects registered. Use: squadrant projects add <name> <path>\n"));
       return;
+    }
+
+    // Ground-truth captain liveness comes from the daemon's LivenessRegistry
+    // (#538) — status.md's `captain_session` frontmatter is written by nothing
+    // and was always stale/absent, producing false "offline" reads for captains
+    // that were demonstrably alive. `null` means the daemon is unreachable —
+    // liveness is genuinely unknown, not offline (#538's core ask).
+    const health = await queryHealth();
+    const captainStateByProject = new Map<string, ComponentHealth["state"]>();
+    if (health) {
+      for (const c of health) {
+        if (c.kind === "captain") captainStateByProject.set(c.project, c.state);
+      }
     }
 
     console.log(chalk.bold("\nProject Status\n"));
@@ -78,10 +105,7 @@ export const statusCommand = new Command("status")
         continue;
       }
 
-      const sessionIndicator =
-        fm.captain_session === "active"
-          ? chalk.green("●")
-          : chalk.dim("○");
+      const sessionIndicator = captainIndicator(captainStateByProject.get(name));
       const captainDisplay = `${project.captainName.padEnd(11)} ${sessionIndicator}`;
       const crew = String(fm.active_crew ?? 0).padEnd(6);
       const progress = progressBar(
@@ -100,6 +124,6 @@ export const statusCommand = new Command("status")
     // #77: --detailed adds the live service-health view (relay/captain/crew/
     // command per-component last-seen + state) queried from the daemon.
     if (opts.detailed) {
-      printServiceHealth(await queryHealth());
+      printServiceHealth(health);
     }
   });


### PR DESCRIPTION
Closes #538.

## Root cause — not what the issue guessed

The issue (and the captain) assumed the `LivenessRegistry` was going stale across a daemon restart, or that reassigned cmux surface ids were breaking record matching. **Both were wrong. The registry was fine — fresh and correctly reconciled.**

The real bug: `squadrant status`s default view **never queried the daemon at all**. It derived the captain indicator from `status.md` frontmatter:

```js
const sessionIndicator = fm.captain_session === "active" ? green("●") : dim("○");
```

`captain_session` is written by **nothing** in the codebase. So the ternary always fell through to `○` — every project rendered offline unconditionally, regardless of actual liveness. It was not going stale after a restart; it was never live in the first place. (The single `●` seen on `scaffold-stark-rn` was a stale hand-written frontmatter value.)

The daemon-backed liveness view existed but was gated behind `--detailed`, so the *default* view — the one a worried user actually runs — was the only one disconnected from ground truth.

## Fix

- Query the daemon health once (`queryHealth()`) and derive the captain indicator from the registry-backed `ComponentHealth.state`, not from `status.md`.
- **Never assert offline on missing data** (the issue’s core ask): `alive`/`stale` → `●`; `unknown` *or no entry at all* → `?`; only a genuine offline state → `○`. A daemon that is unreachable yields `null` health → everything renders `?`, because liveness is then genuinely *unknown*, not *offline*.
- Drop the dead `captain_session` field from the frontmatter interface.
- Reuse the single `queryHealth()` result for `--detailed` instead of querying twice.

## Why this mattered

This is the command a user reaches for to answer *“is my work still attached to the daemon?”* It answered “everything is dead” while every workspace was alive, resumed and correctly attached — a false negative at exactly the moment the user is already worried. That is strictly worse than printing nothing.

## Tests

`packages/cli/src/commands/__tests__/status.test.ts` — `captainIndicator` is pure and directly covered: alive/stale → `●`, unknown → `?`, **missing entry → `?` (not `○`)**, offline → `○`.

Scoped `vitest run` on `packages/cli` only, per the captain’s machine-load constraint; CI runs the authoritative clean build.