### PR TITLE
Release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Two racing captain records for one project could flip a live captain to `gone` (#527):** when two cmux sessions share a cwd (a live captain plus a stale corpse from session restore), the runtime snapshot returned two records for the same project key and `LivenessRegistry`'s last-write-wins apply could let the dead-pid record win. Records are now grouped and deduplicated per project before applying, preferring the record with a live pid.
 - **Daemon-restart and effort broadcasts could clobber an in-progress captain draft (#529):** both broadcasts wrote directly into the captain pane via `CmuxDriver.send`, unconditionally overwriting whatever the user was typing. They now route through the same mailbox (`appendCaptainMessage`) the delivery loop already drain-protects.
 - **CLI-originated interrupts (ping, runtime send) bypassed the same draft-clobber protection (#529, #531):** routed through the mailbox; `squadrant runtime send-key` is removed (see Breaking).
-- **Crew close/respawn race could leave a zombie task record or fire a false `CREW STALLED` for an already-closed crew (#513, #522).**
+- **Crew close/respawn race could leave a zombie task record or fire a false `CREW STALLED` for an already-closed crew (#513).**
+
+### Changed
+
+- **`CREW IDLE` wording softened (#522):** `awaiting-input` is reached only via a genuine turn-boundary event (`task.turn.completed`) — never a watchdog-derived path — so it always means the crew deliberately ended its turn, including a long-lived crew pausing between sequential subtasks. The old "review and reply or close" phrasing read like a possible fault; it now reads "turn ended, awaiting your reply."
 
 ### BREAKING
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-07-11
+
+### Added
+
+- **Update notifier: warn installed users when a newer squadrant is on npm (#536):** CLI startup checks `registry.npmjs.org` directly (never the `npm view` CDN — see the v0.13.1 silent-publish-failure incident), caching the result for ~24h. Behind → a single actionable stderr line; up-to-date, offline, or timed-out → silent no-op, fired fire-and-forget via `node:https` with the request socket `unref()`'d so it never adds latency or blocks process exit. A failed check backs off for 1h instead of re-hitting the registry on every invocation. Opt-out via `defaults.updateCheck=false` or `NO_UPDATE_NOTIFIER`.
+- **`squadrant launch --keep` flag (#534):** mirrors `--fresh` — resumes the latest session even after a day rollover or template-hash change, so a captain session can survive across day/template boundaries instead of being forced fresh. Still starts fresh on a genuine first launch. `--fresh` and `--keep` are mutually exclusive.
+- **Daemon boot/exit markers (#535):** the daemon now stamps an explicit boot marker on start and an exit marker on a clean `stop()`, closing an un-awaited-shutdown gap where teardown could be skipped from the log's perspective on restart.
+
+### Fixed
+
+- **`squadrant status` default view showed a live captain as offline (#538):** the default table derived its captain indicator from `status.md`'s `captain_session` frontmatter — a Reactor-engine relic (retired #155) nothing writes anymore — while `--detailed` already read the daemon's `LivenessRegistry` correctly. The default view now shares the same `queryHealth()` call as `--detailed`; an unreachable daemon renders `?` rather than asserting offline (a false "unknown" is safe, a false "offline" is not).
+- **Captain `crew send` could silently confirm an open modal's default option, dropping the intended message (#516):** `confirmedSendToPane` had no equivalent to the delivery path's `hasModalOptionList` guard, so a paste+Enter into an open `AskUserQuestion`/permission modal would confirm the modal's highlighted default instead of delivering the message — this produced two wrong commits in production. `crew send` now precheck-fails loudly (throws, no "✔ Sent") instead of silently succeeding, without prematurely clearing a task's `BLOCKED` state ahead of the precheck.
+- **Two racing captain records for one project could flip a live captain to `gone` (#527):** when two cmux sessions share a cwd (a live captain plus a stale corpse from session restore), the runtime snapshot returned two records for the same project key and `LivenessRegistry`'s last-write-wins apply could let the dead-pid record win. Records are now grouped and deduplicated per project before applying, preferring the record with a live pid.
+- **Daemon-restart and effort broadcasts could clobber an in-progress captain draft (#529):** both broadcasts wrote directly into the captain pane via `CmuxDriver.send`, unconditionally overwriting whatever the user was typing. They now route through the same mailbox (`appendCaptainMessage`) the delivery loop already drain-protects.
+- **CLI-originated interrupts (ping, runtime send) bypassed the same draft-clobber protection (#529, #531):** routed through the mailbox; `squadrant runtime send-key` is removed (see Breaking).
+- **Crew close/respawn race could leave a zombie task record or fire a false `CREW STALLED` for an already-closed crew (#513, #522).**
+
 ### BREAKING
 
 - **Deleted the `squadrant runtime send-key` command.** It had zero callers across all plugins and templates. Deferring an unconditional `Enter` keypress through the mailbox guard changes its semantics entirely (what it submits depends on what draft the user typed while the key was queued). If you need to simulate a raw keypress without draft protection, shell out to the underlying binary directly: `/Applications/cmux.app/Contents/Resources/bin/cmux send-key --workspace "workspace:N" Enter`.
+
+## [0.15.0] - 2026-07-08
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.15.0] - 2026-07-08
+### BREAKING
+
+- **Deleted the `squadrant runtime send-key` command.** It had zero callers across all plugins and templates. Deferring an unconditional `Enter` keypress through the mailbox guard changes its semantics entirely (what it submits depends on what draft the user typed while the key was queued). If you need to simulate a raw keypress without draft protection, shell out to the underlying binary directly: `/Applications/cmux.app/Contents/Resources/bin/cmux send-key --workspace "workspace:N" Enter`.
 
 ### Added
 

--- a/docs/specs/2026-07-09-draft-clobber-mailbox-routing.md
+++ b/docs/specs/2026-07-09-draft-clobber-mailbox-routing.md
@@ -1,0 +1,269 @@
+# Draft-Clobber: Route Interrupts Through the Mailbox
+
+**Status:** Approved (design) — not implemented
+**Date:** 2026-07-09
+**Author:** captain brainstorm (owner-approved)
+**Issue:** #529
+**Scope:** control plane — `squadrant ping`, `squadrant runtime send`, `squadrant runtime send-key`, `delivery-loop.ts`
+
+## Problem
+
+squadrant talks to agent panes by **simulating a keyboard**. There is no message API:
+
+```ts
+await cmux(["send", "--workspace", ws, "--surface", sf, sanitizeForCmuxSend(message)]);
+await cmux(["send-key", "--workspace", ws, "--surface", sf, "Enter"]);
+```
+— `packages/workspaces/src/runtimes/cmux.ts:472-473`
+
+So when a notice is injected while the user is mid-typing in a captain pane, the text
+**appends to their draft** and the unconditional `Enter` **submits the whole thing**.
+
+Reported symptom: on daemon restart the broadcast
+`⚠️ Daemon restarted → v0.15.0 (control-plane bounced)…` landed in the captain's prompt and
+submitted, swallowing the user's in-progress message.
+
+## Root cause: the guard is welded to the retry loop
+
+A screen-reading guard already exists — `CmuxDriver.sendToSurface`
+(`packages/workspaces/src/runtimes/cmux.ts:593`):
+
+| Condition | Action | Issue |
+|---|---|---|
+| `draft === null` (input box not visible) | `throw DeferDelivery(null)` (`:633`) | #268 |
+| `hasModalOptionList(screen)` | `throw DeferDelivery(null)` (`:643`) | #484 |
+| `draft === ""` | `deliver()` — the only write path (`:646`) | — |
+| `draft` non-empty, no probe | `throw DeferDelivery(draft)` (`:650`) | #302 |
+| probe mode | backspace ghost-probe (`:652-702`) | #258 |
+
+The guard signals "wait" by **throwing**. Throwing only works if a caller **retries**.
+
+**Exactly one caller in the repo catches `DeferDelivery`:** `CaptainDelivery.deliver`
+(`packages/core/src/delivery/captain-delivery.ts:75`), driven by the daemon delivery-loop
+(`packages/core/src/daemon/delivery-loop.ts:250`), which does **not** advance the mailbox
+cursor — so the entry is retried on the next tick. `daemon-cmux.ts:34` merely re-throws.
+
+Therefore:
+
+- Callers **with** a retry loop (the daemon) may use the guard → safe.
+- Callers **without** one (every CLI one-shot; the boot-time broadcast) cannot use the guard —
+  catching `DeferDelivery` in a process that is about to exit accomplishes nothing. They are
+  forced onto the raw path `CmuxDriver.send` (`cmux.ts:461-480`): send + unconditional `Enter`,
+  zero screen reads.
+
+**The mailbox is the only bridge between the two worlds.** It lets a no-retry caller borrow the
+daemon's retry. This is why Telegram inbound (`telegram/bridge.ts:423` → `appendCaptainMessage`)
+is safe and `ping` is not — not because anyone protected Telegram, but because it happened to go
+through the mailbox.
+
+Protection lives at the **call site**, not at the **chokepoint**. `CmuxDriver.send` is the
+innocuous-looking default, so every new surface is unsafe by default. #258 / #302 / #484 each
+patched one call site; they are symptoms of this layer.
+
+## Three classes of traffic
+
+| Class | Producer | Path today | Verdict |
+|---|---|---|---|
+| **Lifecycle** — `CREW DONE/IDLE/BLOCKED/STALLED` | daemon, `reduce.ts:157` | socket → mailbox → guard | ✅ already safe |
+| **Inbound conversation** — Telegram, `ping`, `runtime send` | outside the daemon | Telegram: mailbox ✅ · ping / runtime send: **raw** 🔴 | fix |
+| **System directives** — restart broadcast, effort change | daemon boot / CLI | **raw** 🔴 | PR #530 |
+
+Both classes 2 and 3 are **interrupts**: they change captain behaviour and require action. An
+`interrupt` / `passive` taxonomy was considered and **rejected** — the passive bucket has zero
+members. Liveness transitions and config drift never touch the pane; they live in
+`squadrantd.log` and the dashboard. Do not introduce the split without a real member.
+
+The bug was never "too many interrupts". It is that **interrupts bypass the guard**.
+
+## Design
+
+CLI one-shots stop being typists and become **producers**. They enqueue; the daemon delivers.
+
+```
+CLI (ping / runtime send)
+  ├─ requireDaemon()          NEW — socket dead → exit 1, nothing enqueued
+  ├─ needRef()                unchanged — target workspace not running → exit 1
+  └─ appendCaptainMessage()   enqueue, then exit
+                                   ↓
+daemon delivery-loop → CaptainDelivery → sendToSurface → [guard] → write only when box empty
+                            ↑ DeferDelivery → retry next tick
+```
+
+Because enqueue happens **only when the daemon is alive**, entries drain within a tick or two.
+The stale-skip rule (below) therefore never fires for them, and needs no change.
+
+### Fail-fast vs best-effort
+
+The distinction is **what the caller is for**, not what it touches.
+
+| Command | Primary job | Notification | Daemon down |
+|---|---|---|---|
+| `ping` | *is* delivering a message | — | `exit 1`, nothing enqueued |
+| `runtime send` | *is* delivering a message | — | `exit 1`, nothing enqueued |
+| `effort` | write config | incidental | write config, `exit 0` — notice may be dropped |
+| restart broadcast | — | — | cannot happen — runs *inside* the daemon at boot |
+
+`effort` is already best-effort: `commands/effort.ts:115-117` catches and prints
+`(no running captain detected — change applies on next launch)`. Preserve that. `requireDaemon()`
+applies **only** to `ping` and `runtime send`.
+
+`appendCaptainMessage` writes a local file, so `effort` enqueues whether or not the daemon is up.
+If the daemon is down and later boots past the stale window, the effort notice is dropped. That is
+**accepted**: the config write — the command's actual job — already succeeded, and the next captain
+launch reads the new value anyway. Do **not** add `requireDaemon()` to `effort` to "fix" this; doing
+so would fail a command that did its job.
+
+There must be no path where a message is silently discarded while the caller believes it was sent.
+
+### `--command` requires a delivery-loop change
+
+`runtime send --command` targets the **command workspace**. The drain loop iterates:
+
+```ts
+const allProjects = [...new Set([
+  ...Object.keys(cfg.projects ?? {}),
+  ...Object.keys(injectedSurfaces),
+  ...store.listAll().map((t) => t.project),
+])];
+```
+— `packages/core/src/daemon/delivery-loop.ts:201-206`
+
+`cfg.commandName` (default `"🏛️ command"`) is **not a project**, so an entry enqueued under that
+name is never read. Line 209 compounds it:
+`const captainTitle = projCfg?.captainName ?? \`${project}-captain\`` — the wrong surface title
+for the command workspace.
+
+Routing the notifier through the mailbox without fixing this would **lose the message permanently**.
+`delivery-loop.ts` must therefore be **in scope**, contrary to the constraint imposed on the first
+crew attempt (see Rejected Alternatives).
+
+### `source` widening
+
+`appendCaptainMessage` takes `source: "telegram" | "daemon"` (`packages/core/src/mailbox.ts:154`).
+`ping` and `runtime send` are typed by a human or an agent, not by the daemon. Add `"cli"` —
+one line. Do **not** reuse `"daemon"`: nothing reads `payload.source` today, but a mislabelled
+record is a lie that will be believed the moment someone writes the first reader.
+
+## Per-surface change table
+
+| # | Surface | file:line | Change |
+|---|---|---|---|
+| 1 | `runtime send-key` | `packages/cli/src/commands/runtime.ts:105-122` | **Delete the command.** |
+| 2 | `ping` | `packages/cli/src/commands/ping.ts:17` | `requireDaemon()` + `appendCaptainMessage(source:"cli")` |
+| 3 | `runtime send` | `packages/cli/src/commands/runtime.ts:97` | same; `--command` → `project = cfg.commandName` |
+| 4 | drain loop | `packages/core/src/daemon/delivery-loop.ts:201-209` | include `cfg.commandName` in `allProjects`; use it verbatim as the surface title |
+| 5 | `mailbox.ts` | `packages/core/src/mailbox.ts:154` | widen `source` to `"telegram" \| "daemon" \| "cli"` |
+| 6 | `notifiers/cmux.ts` | `:32` | **no change** — shells out to `runtime send --command`, fixed transitively |
+| 7 | restart + effort broadcasts | — | **no change** — PR #530 already routes them via `appendCaptainMessage` |
+
+## Migration: deleting `runtime send-key`
+
+`squadrant runtime send-key` has **zero callers**. Verified across source, `plugin/skills/`,
+`templates/`, `~/.config/squadrant/scripts/`, and shell history. It is registered
+(`packages/cli/src/index.ts`) and defined (`runtime.ts:105`) and never invoked.
+
+The escape hatch people actually use is the cmux binary directly:
+
+```
+/Applications/cmux.app/Contents/Resources/bin/cmux send-key --workspace "workspace:N" Enter
+```
+— `plugin/skills/command-ops/SKILL.md:73`
+
+`squadrant` is published to npm, so removing a public CLI verb is a **breaking change**. The owner
+approved deletion without a deprecation cycle. Record it under **BREAKING** in `CHANGELOG.md`,
+naming the cmux-binary replacement.
+
+Delete rather than guard: a keypress cannot be queued sensibly. The guard only releases when the
+input box is **empty** — which is precisely when a deferred `Enter` is meaningless. A key's meaning
+is bound to the screen state at the instant it is pressed; deferring it changes what it does. That
+is the whole argument against the rejected alternative below.
+
+## Non-goals (explicitly out of scope)
+
+- **`sendRaw` / inverting the chokepoint default.** Making `CmuxDriver.send` draft-aware and
+  exposing a loudly-named raw variant is the right long-term shape, but it changes the semantics of
+  a function with six call sites. Deferred to its own issue.
+- **`launch-workspace.ts:74`** — raw `runtime.send` into a *booting* captain, already gated by its
+  own `idle/working` classify. Left alone.
+- **Raw-but-benign `sendToPane` callers** — `crew-spawn.ts:189,358,412,447`, `side-session.ts:158,190`,
+  `dashboard.ts:77`, `command.ts:80`. They target freshly created empty panes. Safe by construction,
+  not by guard. Unchanged, but note the assumption is unenforced.
+- **The stale-skip rule** (`delivery-loop.ts:239`). Unchanged. Fail-fast means new entries are only
+  written when the daemon is alive, so they drain long before the 5-minute window.
+- **`confirmedSendToPane`** (`crew-pane.ts:135`) — protects against paste-strand (#339); guarantees
+  the *crew's* payload is submitted. It does **not** check for a human draft, and it targets crew
+  panes. Different protection, different subject. Do not conflate. The name is a trap: `confirmed`
+  reads as "safe for the user" and is not.
+
+## Known adjacent bug (file separately)
+
+Telegram inbound is also `kind: "captain.message"`, which is **not** in `TERMINAL_KINDS`
+(`delivery-loop.ts:20`). An inbound Telegram message enqueued while the daemon is down is
+**silently acked and dropped** when the daemon next boots more than `STALE_THRESHOLD_MS` later
+(`delivery-loop.ts:239-246` advances the cursor). Pre-existing, outside #529. Owner elected to
+leave it and file separately.
+
+## Why it fired when it did
+
+The restart broadcast is gated on a signature of `version::buildMtimeMs`
+(`daemon-restart-broadcast.ts:26-39`). A local `npm run build` moves `dist`'s mtime → the signature
+changes → the next daemon boot broadcasts to every live captain, raw, with `Enter`.
+
+**Every dev rebuild followed by a daemon restart clobbers every captain's draft.** Not bad luck.
+
+## Tests
+
+Each surface, unit level, with a fake driver:
+
+- **`ping`** — asserts **zero** `driver.send` / `driver.sendKey` calls, and exactly **one**
+  mailbox entry with `source: "cli"`.
+- **`runtime send`** — same.
+- **`runtime send --command`** — enqueues under `cfg.commandName`.
+- **Daemon down** — `ping` and `runtime send` exit non-zero **and** enqueue **nothing**. Assert both;
+  the exit code alone would pass against a version that enqueued first and then threw.
+- **`effort` with daemon down** — writes config and exits **zero**. Guards the best-effort contract
+  against an over-eager `requireDaemon()`. Do not assert on enqueue here: the mailbox write is a
+  local file append and succeeds regardless of daemon state.
+- **`delivery-loop`** — an entry under `cfg.commandName` is drained and delivered. *This test must
+  fail against current `develop`* — that failure is the evidence the gap is real. A test that passes
+  before the fix proves nothing.
+- **`send-key`** — the command is no longer registered on the CLI program.
+
+Assert on **call counts**, not just mailbox contents. The point is that nothing keystrokes the pane.
+
+## Rejected alternatives
+
+**Mailbox `captain.send-key` kind** (crew attempt, preserved at `.scratch/p2-rejected-154601.patch`).
+Added a `captain.send-key` mailbox kind, `sendKeyToSurface`, and a `keyOnly` parameter threaded
+through `sendToSurface`. Rejected because:
+
+1. It built a queueing mechanism for a command with zero callers that is being deleted.
+2. Deferring a keypress is semantically wrong (see Migration, above).
+3. `sendToSurface(surface, "", { keyOnly })` — a text-send function repurposed to send keys with an
+   empty payload — muddies the contract.
+4. `sendKeyToSurface?` was declared **optional** on the driver interface: a driver that forgets to
+   implement it falls back silently.
+
+The attempt was, however, **right about `delivery-loop`**: it independently discovered that the
+command workspace is not drained and patched `cfg.commandName` in. The captain's "do not touch
+delivery-loop" constraint was wrong, and the crew was penalised for obeying the problem rather than
+the instruction. That constraint is lifted in this spec (change #4).
+
+**Two physical channels** (system log vs conversation). Rejected: the mailbox *is* the channel; what
+was missing was a classification, and the classification turned out to have an empty bucket. Two
+channels means two cursors, two drains, two failure modes, for the same result.
+
+**Routing `ping` through the daemon socket** (like `dispatch`). Considered, to make `ping` visible
+in `squadrantd.log` — it currently bypasses the daemon entirely and leaves no trace. Rejected:
+`delivery-loop` **already logs every delivered entry** (`delivery seq=… kind=… outcome=delivered`),
+so the mailbox route provides the same visibility without a new socket verb.
+
+## Open questions
+
+1. Should `requireDaemon()` live in `packages/cli/src/lib/` or reuse an existing socket helper?
+   `group-dispatch.ts:35` already probes daemon health via `sendRequest(sockPath, { kind: "health" })`.
+   Prefer reuse over a new probe.
+2. Exact wording and exit code for the daemon-down error. Suggested: `exit 1`,
+   `daemon not running — message NOT delivered. Start it with 'squadrant launch <project>'.`
+3. Does anything outside this repo depend on `squadrant runtime send-key`? Assumed no; a wider search
+   before the release would cost little.

--- a/docs/specs/2026-07-09-draft-clobber-mailbox-routing.md
+++ b/docs/specs/2026-07-09-draft-clobber-mailbox-routing.md
@@ -155,6 +155,7 @@ record is a lie that will be believed the moment someone writes the first reader
 | 5 | `mailbox.ts` | `packages/core/src/mailbox.ts:154` | widen `source` to `"telegram" \| "daemon" \| "cli"` |
 | 6 | `notifiers/cmux.ts` | `:32` | **no change** — shells out to `runtime send --command`, fixed transitively |
 | 7 | restart + effort broadcasts | — | **no change** — PR #530 already routes them via `appendCaptainMessage` |
+| 8 | stale-skip (#531) | `packages/core/src/daemon/delivery-loop.ts:239-246` | exempt `captain.message` when `payload.source !== "daemon"` |
 
 ## Migration: deleting `runtime send-key`
 
@@ -188,14 +189,60 @@ is the whole argument against the rejected alternative below.
 - **Raw-but-benign `sendToPane` callers** — `crew-spawn.ts:189,358,412,447`, `side-session.ts:158,190`,
   `dashboard.ts:77`, `command.ts:80`. They target freshly created empty panes. Safe by construction,
   not by guard. Unchanged, but note the assumption is unenforced.
-- **The stale-skip rule** (`delivery-loop.ts:239`). Unchanged. Fail-fast means new entries are only
-  written when the daemon is alive, so they drain long before the 5-minute window.
+- ~~**The stale-skip rule**~~ — now **in scope**, see "Folded in: #531" above.
 - **`confirmedSendToPane`** (`crew-pane.ts:135`) — protects against paste-strand (#339); guarantees
   the *crew's* payload is submitted. It does **not** check for a human draft, and it targets crew
   panes. Different protection, different subject. Do not conflate. The name is a trap: `confirmed`
   reads as "safe for the user" and is not.
 
-## Known adjacent bug (file separately)
+## Folded in: #531 — silent drop of human messages
+
+**Confirmed in production**, not hypothetical. `squadrantd.log`:
+
+```
+2026-07-07T16:57:15.303Z delivery seq=85 kind=captain.message outcome=stale-skipped
+```
+
+That seq is still in `state/inbox/brove-mobile.log`:
+
+```json
+{"seq":85,"ts":"2026-07-07T14:14:48.715Z","kind":"captain.message",
+ "payload":{"source":"telegram"},
+ "message":"📩 [from Telegram] Hi, this messahe to test new quadrant bug fix and state (second test)"}
+```
+
+A real inbound Telegram message from the owner, enqueued at 14:14, silently acked and discarded at
+16:57 when the daemon restarted 2h43m later. It never reached the captain, and nothing surfaced the
+loss.
+
+### Why the current rule eats it
+
+`delivery-loop.ts:239-246` skips any entry older than `sessionStartMs - STALE_THRESHOLD_MS` unless
+its kind is in `TERMINAL_KINDS`. But terminal kinds already deliver regardless of age (#474). So the
+only thing stale-skip actually suppresses is **non-terminal bot chatter** — `task.started`, turn
+events — which is exactly the storm #332 BUG-3 was written to dam. It eats human messages by
+accident, not by design.
+
+### The rule
+
+Exempting *all* `captain.message` would resurrect stale system notices: a `⚠️ Daemon restarted` from
+two days ago injected today is noise. The correct axis is `payload.source`:
+
+| `source` | Producer | Stale behaviour |
+|---|---|---|
+| `telegram` | the human | **always deliver** — someone is waiting for a reply |
+| `cli` | human/agent typing `ping` / `runtime send` | **always deliver** |
+| `daemon` | restart / effort broadcast | may be skipped — context has expired |
+
+> `captain.message` is exempt from stale-skip **iff** `payload.source !== "daemon"`.
+
+This gives `payload.source` — a field nothing has ever read — its first consumer, and retroactively
+justifies widening it to include `"cli"` (change #5).
+
+Storm risk is bounded: only human-originated messages are exempt, they are low-volume, and delivery
+is still paced one entry per tick behind the draft guard.
+
+## Known adjacent bug (superseded — now in scope)
 
 Telegram inbound is also `kind: "captain.message"`, which is **not** in `TERMINAL_KINDS`
 (`delivery-loop.ts:20`). Any `captain.message` that is enqueued but **not yet delivered** when the
@@ -240,6 +287,11 @@ Each surface, unit level, with a fake driver:
   fail against current `develop`* — that failure is the evidence the gap is real. A test that passes
   before the fix proves nothing.
 - **`send-key`** — the command is no longer registered on the CLI program.
+- **#531 stale-skip** — an entry with `kind: "captain.message"`, `payload.source: "telegram"`, and a
+  `ts` older than `sessionStartMs - STALE_THRESHOLD_MS` **is delivered**, and the cursor is not
+  advanced past it undelivered. *This test must fail against current `develop`.* Companion test: the
+  same entry with `source: "daemon"` **is** stale-skipped, proving the exemption is scoped and did
+  not simply disable the storm dam.
 
 Assert on **call counts**, not just mailbox contents. The point is that nothing keystrokes the pane.
 

--- a/docs/specs/2026-07-09-draft-clobber-mailbox-routing.md
+++ b/docs/specs/2026-07-09-draft-clobber-mailbox-routing.md
@@ -198,10 +198,22 @@ is the whole argument against the rejected alternative below.
 ## Known adjacent bug (file separately)
 
 Telegram inbound is also `kind: "captain.message"`, which is **not** in `TERMINAL_KINDS`
-(`delivery-loop.ts:20`). An inbound Telegram message enqueued while the daemon is down is
-**silently acked and dropped** when the daemon next boots more than `STALE_THRESHOLD_MS` later
-(`delivery-loop.ts:239-246` advances the cursor). Pre-existing, outside #529. Owner elected to
-leave it and file separately.
+(`delivery-loop.ts:20`). Any `captain.message` that is enqueued but **not yet delivered** when the
+daemon restarts more than `STALE_THRESHOLD_MS` (5 min, `interactive-probe.ts:7`) later is silently
+acked and dropped — `delivery-loop.ts:239-246` advances the cursor past it.
+
+Reachable two ways, both ordinary:
+
+1. The captain has a draft, so delivery defers (#302) — then the daemon restarts.
+2. The captain workspace is **closed**, so `delivery-loop.ts:224` (`if (!surface) continue;`) never
+   reads the cursor at all. Messages queue for as long as the workspace is shut. Reopen it and
+   restart the daemon, and the whole backlog is discarded.
+
+Note the bridge runs **inside** the daemon (`squadrantd.ts:68`), so a message cannot be enqueued
+while the daemon is down — there is no consumer. The trigger is an *undelivered* message surviving a
+restart, not one *sent* during an outage.
+
+Pre-existing, outside #529. Owner elected to file separately and fix later.
 
 ## Why it fired when it did
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "squadrant",
   "packageManager": "pnpm@10.30.3",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Multi-project orchestration for your coding agents (Claude, Codex, opencode, Gemini)",
   "type": "module",
   "bin": {

--- a/packages/cli/src/__tests__/squadrantd-boot-marker.test.ts
+++ b/packages/cli/src/__tests__/squadrantd-boot-marker.test.ts
@@ -1,0 +1,71 @@
+// #535: the daemon must write a greppable boot marker on startup and a
+// matching exit marker on stop() — a restart must never be inferred from
+// process START time alone.
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startSquadrantd } from "../squadrantd.js";
+
+describe("squadrantd boot/exit markers (#535)", () => {
+  let dir: string;
+  afterEach(() => { if (dir) rmSync(dir, { recursive: true, force: true }); });
+
+  it("logs a boot marker with pid/version/socket on startup", () => {
+    dir = mkdtempSync(join(tmpdir(), "boot-marker-"));
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    let handle: ReturnType<typeof startSquadrantd> | undefined;
+    try {
+      handle = startSquadrantd({ stateRoot: join(dir, "state"), sockPath: join(dir, "c.sock"), sweepMs: 0 });
+      const lines = writeSpy.mock.calls.map((c) => String(c[0]));
+      const bootLine = lines.find((l) => /\[squadrantd\].*\bboot pid=\d+ version=\S+ socket=\S+/.test(l));
+      expect(bootLine).toBeDefined();
+      expect(bootLine).toContain(`pid=${process.pid}`);
+    } finally {
+      writeSpy.mockRestore();
+      handle?.stop();
+    }
+  });
+
+  it("logs an exit marker carrying the shutdown reason on stop()", async () => {
+    dir = mkdtempSync(join(tmpdir(), "boot-marker-"));
+    const handle = startSquadrantd({ stateRoot: join(dir, "state"), sockPath: join(dir, "c.sock"), sweepMs: 0 });
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      await handle.stop("SIGTERM");
+      const lines = writeSpy.mock.calls.map((c) => String(c[0]));
+      const exitLine = lines.find((l) => /\bexit pid=\d+ reason=SIGTERM\b/.test(l));
+      expect(exitLine).toBeDefined();
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
+  it("writes the exit marker synchronously — before any awaited teardown resolves", () => {
+    dir = mkdtempSync(join(tmpdir(), "boot-marker-"));
+    const handle = startSquadrantd({ stateRoot: join(dir, "state"), sockPath: join(dir, "c.sock"), sweepMs: 0 });
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      // Do NOT await — simulates a caller that fires-and-forgets (the historical
+      // bug: SIGTERM handler called h.stop() then process.exit() immediately).
+      void handle.stop("SIGTERM");
+      const lines = writeSpy.mock.calls.map((c) => String(c[0]));
+      expect(lines.some((l) => /\bexit pid=\d+ reason=SIGTERM\b/.test(l))).toBe(true);
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
+  it("defaults the exit reason to 'requested' when the caller passes none", async () => {
+    dir = mkdtempSync(join(tmpdir(), "boot-marker-"));
+    const handle = startSquadrantd({ stateRoot: join(dir, "state"), sockPath: join(dir, "c.sock"), sweepMs: 0 });
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      await handle.stop();
+      const lines = writeSpy.mock.calls.map((c) => String(c[0]));
+      expect(lines.some((l) => /\bexit pid=\d+ reason=requested\b/.test(l))).toBe(true);
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+});

--- a/packages/cli/src/commands/__tests__/crew.test.ts
+++ b/packages/cli/src/commands/__tests__/crew.test.ts
@@ -59,6 +59,7 @@ vi.mock("@squadrant/workspaces", () => ({
     await sendToPane(pane, msg);
     return { delivered: true };
   },
+  paneHasOpenModal: async () => false,
   getFreePort: vi.fn().mockResolvedValue(12345),
 }));
 

--- a/packages/cli/src/commands/__tests__/effort.test.ts
+++ b/packages/cli/src/commands/__tests__/effort.test.ts
@@ -120,7 +120,26 @@ describe("effort notify (self-notification exclusion)", () => {
     return { path: p, captainName, spokeVault: "", host: "" };
   }
 
-  it("does NOT notify the captain whose project path is the cwd, but DOES notify the others", async () => {
+  /** Track calls to appendCaptainMessage — used to prove the broadcast routes
+   *  through the mailbox instead of driver.send. */
+  function makeAppendSpy(): {
+    fn: (project: string, text: string) => Promise<void>;
+    projects: string[];
+    texts: string[];
+  } {
+    const projects: string[] = [];
+    const texts: string[] = [];
+    return {
+      fn: async (project, text) => {
+        projects.push(project);
+        texts.push(text);
+      },
+      projects,
+      texts,
+    };
+  }
+
+  it("does NOT call driver.send — enqueues to mailbox instead", async () => {
     const projA = fs.mkdtempSync(path.join(dir, "projA-"));
     const projB = fs.mkdtempSync(path.join(dir, "projB-"));
     const config = configWithProjects({
@@ -128,13 +147,15 @@ describe("effort notify (self-notification exclusion)", () => {
       b: project(projB, "captain-b"),
     });
     const sent: Array<{ captain: string; message: string }> = [];
+    const spy = makeAppendSpy();
 
-    await notifyCaptainsOfEffort("low", config, makeDriver(sent), projA);
+    await notifyCaptainsOfEffort("low", config, makeDriver(sent), projA, spy.fn);
 
-    const captains = sent.map((s) => s.captain);
-    expect(captains).not.toContain("captain-a"); // self — already saw stdout
-    expect(captains).toContain("captain-b"); // other running captain still notified
-    expect(captains).toHaveLength(1);
+    // MUST NOT call driver.send
+    expect(sent).toHaveLength(0);
+    // MUST enqueue to mailbox instead — only project-b (cwd-projA excluded)
+    expect(spy.projects).toEqual(["b"]);
+    expect(spy.texts[0]).toContain("effort");
   });
 
   it("matches cwd through symlinks (realpath), still excluding self", async () => {
@@ -143,11 +164,13 @@ describe("effort notify (self-notification exclusion)", () => {
     fs.symlinkSync(projA, link);
     const config = configWithProjects({ a: project(projA, "captain-a") });
     const sent: Array<{ captain: string; message: string }> = [];
+    const spy = makeAppendSpy();
 
     // cwd given via the symlink should still resolve to projA and skip it.
-    await notifyCaptainsOfEffort("max", config, makeDriver(sent), link);
+    await notifyCaptainsOfEffort("max", config, makeDriver(sent), link, spy.fn);
 
     expect(sent).toHaveLength(0);
+    expect(spy.projects).toHaveLength(0);
   });
 
   it("notifies every captain when cwd matches no project path", async () => {
@@ -158,9 +181,11 @@ describe("effort notify (self-notification exclusion)", () => {
       b: project(projB, "captain-b"),
     });
     const sent: Array<{ captain: string; message: string }> = [];
+    const spy = makeAppendSpy();
 
-    await notifyCaptainsOfEffort("balance", config, makeDriver(sent), path.join(dir, "elsewhere"));
+    await notifyCaptainsOfEffort("balance", config, makeDriver(sent), path.join(dir, "elsewhere"), spy.fn);
 
-    expect(sent.map((s) => s.captain).sort()).toEqual(["captain-a", "captain-b"]);
+    expect(sent).toHaveLength(0);
+    expect(spy.projects.sort()).toEqual(["a", "b"]);
   });
 });

--- a/packages/cli/src/commands/__tests__/effort.test.ts
+++ b/packages/cli/src/commands/__tests__/effort.test.ts
@@ -1,10 +1,15 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
+import os from "node:os";
 import { getDefaultConfig, saveConfig } from "@squadrant/shared";
 import type { SquadrantConfig, ProjectConfig } from "@squadrant/shared";
-import { runEffortGet, runEffortSet, notifyCaptainsOfEffort } from "../effort.js";
+import { runEffortGet, runEffortSet, notifyCaptainsOfEffort, effortCommand } from "../effort.js";
+
+const requireDaemon = vi.hoisted(() => vi.fn());
+vi.mock("../../lib/require-daemon.js", () => ({
+  requireDaemon,
+}));
 
 let dir: string;
 let cfgPath: string;
@@ -13,6 +18,8 @@ beforeEach(() => {
   dir = fs.mkdtempSync(path.join(os.tmpdir(), "squadrant-effort-"));
   cfgPath = path.join(dir, "config.json");
   saveConfig(getDefaultConfig(), cfgPath);
+  vi.resetAllMocks();
+  requireDaemon.mockResolvedValue(undefined);
 });
 afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
 
@@ -187,5 +194,23 @@ describe("effort notify (self-notification exclusion)", () => {
 
     expect(sent).toHaveLength(0);
     expect(spy.projects.sort()).toEqual(["a", "b"]);
+  });
+
+  it("handles driver failure gracefully without throwing (best effort)", async () => {
+    const config = configWithProjects({
+      a: project(path.join(dir, "projA"), "captain-a"),
+    });
+
+    const driver = {
+      status: vi.fn().mockRejectedValue(new Error("daemon unreachable"))
+    };
+    
+    const append = vi.fn();
+    
+    // Should NOT throw
+    await notifyCaptainsOfEffort("low", config, driver, path.join(dir, "elsewhere"), append);
+    
+    // And should not have appended
+    expect(append).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/__tests__/runtime.test.ts
+++ b/packages/cli/src/commands/__tests__/runtime.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Command } from "commander";
 
 const status = vi.hoisted(() => vi.fn());
 const send = vi.hoisted(() => vi.fn());
@@ -41,7 +42,11 @@ vi.mock("../../lib/require-daemon.js", () => ({
   requireDaemon,
 }));
 
-import { runPing } from "../ping.js";
+// Mock process.exit and console.error
+vi.spyOn(process, "exit").mockImplementation((() => {}) as any);
+vi.spyOn(console, "error").mockImplementation(() => {});
+
+import { runRuntimeSend } from "../runtime.js";
 
 const makeConfig = () => ({
   commandName: "command",
@@ -58,48 +63,46 @@ const makeConfig = () => ({
   metrics: { enabled: false, path: "/tmp/metrics.json" },
 });
 
-describe("runPing", () => {
+describe("runtime send", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     loadConfig.mockReturnValue(makeConfig());
     requireDaemon.mockResolvedValue(undefined);
-  });
-
-  it("rejects an unregistered project with a clear error", async () => {
-    await expect(runPing("nope", "hello")).rejects.toThrow(/not found/i);
-    expect(send).not.toHaveBeenCalled();
-    expect(sendKey).not.toHaveBeenCalled();
-    expect(appendCaptainMessage).not.toHaveBeenCalled();
+    status.mockResolvedValue({ id: "ws-1", name: "⚓ A-captain", status: "running" });
   });
 
   it("delivers the message via the mailbox (enqueue) when daemon is running", async () => {
-    status.mockResolvedValue({ id: "ws-1", name: "⚓ A-captain", status: "running" });
-
-    await runPing("projA", "hello from ping");
+    await runRuntimeSend("projA", "hello from runtime send", {});
 
     expect(send).not.toHaveBeenCalled();
     expect(sendKey).not.toHaveBeenCalled();
     expect(appendCaptainMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         project: "projA",
-        text: "hello from ping",
+        text: "hello from runtime send",
         source: "cli",
       })
     );
   });
 
-  it("errors clearly when the target captain is not running (no auto-boot)", async () => {
-    status.mockResolvedValue(null);
+  it("enqueues under cfg.commandName when using --command", async () => {
+    await runRuntimeSend("hello from command", undefined, { command: true });
 
-    await expect(runPing("projA", "hello")).rejects.toThrow(/not running/i);
     expect(send).not.toHaveBeenCalled();
-    expect(appendCaptainMessage).not.toHaveBeenCalled();
+    expect(sendKey).not.toHaveBeenCalled();
+    expect(appendCaptainMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        project: "command",
+        text: "hello from command",
+        source: "cli",
+      })
+    );
   });
 
   it("enqueues nothing if the daemon is not running", async () => {
     requireDaemon.mockRejectedValue(new Error("daemon not running"));
 
-    await expect(runPing("projA", "hello")).rejects.toThrow(/daemon not running/i);
+    await expect(runRuntimeSend("projA", "hello from runtime send", {})).rejects.toThrow(/daemon not running/i);
     
     expect(send).not.toHaveBeenCalled();
     expect(sendKey).not.toHaveBeenCalled();

--- a/packages/cli/src/commands/__tests__/status.test.ts
+++ b/packages/cli/src/commands/__tests__/status.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { captainIndicator } from "../status.js";
+
+// #538: default `squadrant status` used to derive the ●/○ indicator from
+// status.md's `captain_session` frontmatter, which nothing in the codebase
+// writes — so it always rendered offline regardless of true liveness. The
+// indicator must come from the daemon's registry-derived HealthState instead.
+describe("captainIndicator (#538)", () => {
+  it("alive → green filled circle", () => {
+    expect(captainIndicator("alive")).toContain("●");
+  });
+
+  it("stale → still green filled circle (degrading but not dead)", () => {
+    expect(captainIndicator("stale")).toContain("●");
+  });
+
+  it("gone → dim empty circle", () => {
+    expect(captainIndicator("gone")).toContain("○");
+  });
+
+  it("stopped → dim empty circle", () => {
+    expect(captainIndicator("stopped")).toContain("○");
+  });
+
+  it("unknown state → dim '?' (never asserts offline on missing data)", () => {
+    expect(captainIndicator("unknown")).toContain("?");
+  });
+
+  it("no entry at all (daemon unreachable) → dim '?', not offline", () => {
+    expect(captainIndicator(undefined)).toContain("?");
+  });
+});

--- a/packages/cli/src/commands/crew.ts
+++ b/packages/cli/src/commands/crew.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { loadConfig, resolveTextInput } from "@squadrant/shared";
 import type { PanePlacement } from "@squadrant/shared";
-import { createCmuxDriver, RuntimeRegistry, resolveCaptainWorkspace, sendFirstTurnWhenReady, confirmedSendToPane, getFreePort } from "@squadrant/workspaces";
+import { createCmuxDriver, RuntimeRegistry, resolveCaptainWorkspace, sendFirstTurnWhenReady, confirmedSendToPane, paneHasOpenModal, getFreePort } from "@squadrant/workspaces";
 import { CapabilityRegistry, createClaudeDriver, createCodexDriver, createGeminiDriver, createOpencodeDriver } from "@squadrant/agents";
 import {
   runCrewSpawn as coreRunCrewSpawn,
@@ -67,6 +67,8 @@ export async function runCrewSend(project: string, name: string, message: string
     // #448: use paste-settle-Enter confirmation for follow-up sends (same guard
     // as first-turn #447) so large messages don't strand in paste mode.
     sendToPane: (pane, msg) => confirmedSendToPane(runtime, pane, msg),
+    // #516: side-effect-free modal precheck, run before any daemon-state emit.
+    isBlockedByModal: (pane) => paneHasOpenModal(runtime, pane),
   });
 }
 

--- a/packages/cli/src/commands/effort.ts
+++ b/packages/cli/src/commands/effort.ts
@@ -4,6 +4,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { loadConfig, saveConfig, resolveEffort, DEFAULT_CONFIG_PATH } from "@squadrant/shared";
 import type { SquadrantConfig, Effort } from "@squadrant/shared";
+import { appendCaptainMessage } from "@squadrant/core";
 
 const VALID_EFFORTS: Effort[] = ["max", "balance", "low"];
 
@@ -36,10 +37,9 @@ export function runEffortSet(value: string, configPath = DEFAULT_CONFIG_PATH): v
   saveConfig(config, configPath);
 }
 
-/** Minimal slice of RuntimeDriver used to notify a captain. */
+/** Minimal slice of RuntimeDriver used to resolve captain status. */
 interface EffortNotifyDriver {
   status(nameOrId: string): Promise<{ id: string } | null>;
-  send(ref: string, message: string): Promise<void>;
 }
 
 /** Resolve a path through symlinks; fall back to a plain resolve if it
@@ -53,26 +53,28 @@ function canonical(p: string): string {
 }
 
 /**
- * Send the effort-change notice to every running captain EXCEPT the one in the
- * current working directory. The captain that ran `squadrant effort` already saw
- * the stdout '✔ effort → ...' confirmation, so injecting the notice into its own
- * pane is a duplicate self-notification. Other running captains still get it.
+ * Send the effort-change notice to every running captain via the mailbox.
+ * The captain that ran `squadrant effort` already saw stdout, so that project
+ * is excluded. Routes through the mailbox so the daemon's delivery-loop drains
+ * it with draft protection (#529).
+ * appendCaptainMessage is a closure capturing stateRoot from the caller.
  */
 export async function notifyCaptainsOfEffort(
   effort: Effort,
   config: SquadrantConfig,
   driver: EffortNotifyDriver,
   cwd: string = process.cwd(),
+  append: (project: string, text: string) => Promise<void>,
 ): Promise<void> {
   const here = canonical(cwd);
   const notice = `🎚️ effort → ${effort}: ${EFFORT_MEANING[effort]}`;
-  for (const [, proj] of Object.entries(config.projects)) {
+  for (const [projName, proj] of Object.entries(config.projects)) {
     // Skip the captain running in this same directory — it already saw stdout.
     if (canonical(proj.path) === here) continue;
     try {
       const ref = await driver.status(proj.captainName);
       if (ref) {
-        await driver.send(ref.id, notice);
+        await append(projName, notice);
       }
     } catch {
       // individual project captain unreachable — skip
@@ -104,14 +106,18 @@ export const effortCommand = new Command("effort")
     console.log(chalk.green(`✔ effort → ${effort}`));
     console.log(chalk.dim(EFFORT_MEANING[effort]));
 
-    // Best-effort active notify: send a one-line notice to any running captain.
+    // Best-effort active notify: enqueue to the mailbox for every running captain.
     // Never hard-fails — config is already written above.
+    // Routes through the mailbox (not driver.send) to avoid clobbering user draft (#529).
     try {
       const { createCmuxDriver, RuntimeRegistry } = await import("@squadrant/workspaces");
       const config = loadConfig();
       const registry = new RuntimeRegistry({ cmux: createCmuxDriver() });
       const driver = registry.global(config);
-      await notifyCaptainsOfEffort(effort, config, driver);
+      const stateRoot = path.join(path.dirname(DEFAULT_CONFIG_PATH), "state");
+      const append = (project: string, text: string) =>
+        appendCaptainMessage({ stateRoot, project, text, source: "daemon" });
+      await notifyCaptainsOfEffort(effort, config, driver, process.cwd(), append);
     } catch {
       // runtime unavailable — config already written, change applies on next launch
       console.log(chalk.dim("(no running captain detected — change applies on next launch)"));

--- a/packages/cli/src/commands/launch.ts
+++ b/packages/cli/src/commands/launch.ts
@@ -50,9 +50,15 @@ export const launchCommand = new Command("launch")
   )
   .argument("[project]", "Project name to launch captain for")
   .option("--fresh", "Start a new session instead of resuming the last one")
+  .option("--keep", "Resume the latest session even on a new day / after a template change")
   .option("--all", "Launch all captain workspaces")
   .option("--headless", "Skip the interactive cmux-app requirement (used by the daemon to boot captains without a terminal)")
-  .action(async (project: string | undefined, opts: { fresh?: boolean; all?: boolean; headless?: boolean }) => {
+  .action(async (project: string | undefined, opts: { fresh?: boolean; keep?: boolean; all?: boolean; headless?: boolean }) => {
+    if (opts.fresh && opts.keep) {
+      console.error(chalk.red("\n  ✘ --fresh and --keep are mutually exclusive\n"));
+      process.exit(1);
+    }
+
     const config = loadConfig();
     let hadFailure = false;
 
@@ -100,6 +106,7 @@ export const launchCommand = new Command("launch")
           role,
           cwd,
           forceFreshOverride: opts.fresh,
+          keepOverride: opts.keep,
           sessionsPath: SESSIONS_PATH,
           templatesDir: TEMPLATES_DIR,
           agentCmdFactory: (forceFresh) =>

--- a/packages/cli/src/commands/ping.ts
+++ b/packages/cli/src/commands/ping.ts
@@ -4,17 +4,29 @@
 // registered project's captain pane. No tracked task, no report-back.
 // Reuses the same delivery mechanism as `squadrant runtime send`.
 
+import { join, dirname } from "node:path";
 import { Command } from "commander";
 import chalk from "chalk";
-import { loadConfig } from "@squadrant/shared";
+import { loadConfig, DEFAULT_CONFIG_PATH } from "@squadrant/shared";
+import { appendCaptainMessage } from "@squadrant/core";
 import { buildRegistry, resolveTarget, needRef } from "./runtime.js";
+import { requireDaemon } from "../lib/require-daemon.js";
 
 export async function runPing(project: string, message: string): Promise<void> {
   const config = loadConfig();
   const registry = buildRegistry();
   const resolved = resolveTarget(registry, config, project, false);
-  const ref = await needRef(resolved);
-  await resolved.driver.send(ref, message);
+  
+  await requireDaemon();
+  await needRef(resolved);
+  
+  const stateRoot = join(dirname(DEFAULT_CONFIG_PATH), "state");
+  await appendCaptainMessage({
+    stateRoot,
+    project,
+    text: message,
+    source: "cli",
+  });
 }
 
 export const pingCommand = new Command("ping")

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -76,6 +76,38 @@ runtimeCommand
     }
   });
 
+export async function runRuntimeSend(arg1: string, arg2: string | undefined, opts: { command?: boolean }) {
+  const config = loadConfig();
+  const registry = buildRegistry();
+  
+  if (opts.command && arg2 !== undefined) {
+    throw new Error("With --command, pass only the message (not a project name)");
+  }
+  const target = opts.command ? undefined : arg1;
+  const message = opts.command ? arg1 : arg2;
+  if (!message) throw new Error("Message is required");
+  
+  const { requireDaemon } = await import("../lib/require-daemon.js");
+  const { appendCaptainMessage } = await import("@squadrant/core");
+  await requireDaemon();
+  
+  const resolved = resolveTarget(registry, config, target, !!opts.command);
+  await needRef(resolved);
+  
+      const finalProject = opts.command ? config.commandName : target!;
+      
+      const { join, dirname } = await import("node:path");
+      const { DEFAULT_CONFIG_PATH } = await import("@squadrant/shared");
+      const stateRoot = join(dirname(DEFAULT_CONFIG_PATH), "state");
+
+      await appendCaptainMessage({
+        stateRoot,
+        project: finalProject,
+        text: message,
+        source: "cli",
+      });
+}
+
 runtimeCommand
   .command("send")
   .description("Send a message to a target workspace AND commit with Enter. With --command, the first positional is the message.")
@@ -83,43 +115,8 @@ runtimeCommand
   .argument("[arg2]", "Message (when target is a project). Omit when using --command.")
   .option("--command", "Target the command workspace")
   .action(async (arg1: string, arg2: string | undefined, opts: { command?: boolean }) => {
-    const config = loadConfig();
-    const registry = buildRegistry();
     try {
-      if (opts.command && arg2 !== undefined) {
-        throw new Error("With --command, pass only the message (not a project name)");
-      }
-      const target = opts.command ? undefined : arg1;
-      const message = opts.command ? arg1 : arg2;
-      if (!message) throw new Error("Message is required");
-      const resolved = resolveTarget(registry, config, target, !!opts.command);
-      const ref = await needRef(resolved);
-      await resolved.driver.send(ref, message);
-    } catch (err) {
-      console.error(chalk.red((err as Error).message));
-      process.exit(1);
-    }
-  });
-
-runtimeCommand
-  .command("send-key")
-  .description("Send a literal key press (e.g. Enter, Escape) to a target workspace. With --command, the first positional is the key.")
-  .argument("<arg1>", "Project name, or the key when --command is used")
-  .argument("[arg2]", "Key name (when target is a project). Omit when using --command.")
-  .option("--command", "Target the command workspace")
-  .action(async (arg1: string, arg2: string | undefined, opts: { command?: boolean }) => {
-    const config = loadConfig();
-    const registry = buildRegistry();
-    try {
-      if (opts.command && arg2 !== undefined) {
-        throw new Error("With --command, pass only the key (not a project name)");
-      }
-      const target = opts.command ? undefined : arg1;
-      const key = opts.command ? arg1 : arg2;
-      if (!key) throw new Error("Key is required");
-      const resolved = resolveTarget(registry, config, target, !!opts.command);
-      const ref = await needRef(resolved);
-      await resolved.driver.sendKey(ref, key);
+      await runRuntimeSend(arg1, arg2, opts);
     } catch (err) {
       console.error(chalk.red((err as Error).message));
       process.exit(1);

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -4,10 +4,10 @@ import matter from "gray-matter";
 import { loadConfig } from "@squadrant/shared";
 import { createObsidianDriver, WorkspaceRegistry } from "@squadrant/workspaces";
 import { queryHealth, printServiceHealth } from "./health-view.js";
+import type { ComponentHealth } from "@squadrant/core";
 
 interface StatusFrontmatter {
   project?: string;
-  captain_session?: string;
   last_updated?: string;
   active_crew?: number;
   tasks_total?: number;
@@ -40,6 +40,20 @@ function progressBar(completed: number, total: number): string {
   return `${bar} ${pct}%`;
 }
 
+/**
+ * Pure. Render the captain liveness indicator from the daemon's registry-derived
+ * state (#538) — never from status.md, which nothing writes to.
+ * `undefined` means the daemon returned no entry for this project (never
+ * registered / not yet probed); together with "unknown" it renders "?" rather
+ * than the offline glyph, since asserting offline on missing data is a false
+ * negative (#538's core ask).
+ */
+export function captainIndicator(state: ComponentHealth["state"] | undefined): string {
+  if (state === "alive" || state === "stale") return chalk.green("●");
+  if (state === undefined || state === "unknown") return chalk.dim("?");
+  return chalk.dim("○");
+}
+
 export const statusCommand = new Command("status")
   .description("Show status of all projects from spoke vault status files")
   .option("--detailed", "also show live per-component service health from the daemon (#77)")
@@ -51,6 +65,19 @@ export const statusCommand = new Command("status")
     if (projects.length === 0) {
       console.log(chalk.yellow("\nNo projects registered. Use: squadrant projects add <name> <path>\n"));
       return;
+    }
+
+    // Ground-truth captain liveness comes from the daemon's LivenessRegistry
+    // (#538) — status.md's `captain_session` frontmatter is written by nothing
+    // and was always stale/absent, producing false "offline" reads for captains
+    // that were demonstrably alive. `null` means the daemon is unreachable —
+    // liveness is genuinely unknown, not offline (#538's core ask).
+    const health = await queryHealth();
+    const captainStateByProject = new Map<string, ComponentHealth["state"]>();
+    if (health) {
+      for (const c of health) {
+        if (c.kind === "captain") captainStateByProject.set(c.project, c.state);
+      }
     }
 
     console.log(chalk.bold("\nProject Status\n"));
@@ -78,10 +105,7 @@ export const statusCommand = new Command("status")
         continue;
       }
 
-      const sessionIndicator =
-        fm.captain_session === "active"
-          ? chalk.green("●")
-          : chalk.dim("○");
+      const sessionIndicator = captainIndicator(captainStateByProject.get(name));
       const captainDisplay = `${project.captainName.padEnd(11)} ${sessionIndicator}`;
       const crew = String(fm.active_crew ?? 0).padEnd(6);
       const progress = progressBar(
@@ -100,6 +124,6 @@ export const statusCommand = new Command("status")
     // #77: --detailed adds the live service-health view (relay/captain/crew/
     // command per-component last-seen + state) queried from the daemon.
     if (opts.detailed) {
-      printServiceHealth(await queryHealth());
+      printServiceHealth(health);
     }
   });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,6 +38,7 @@ import { hooksCommand } from "./commands/hooks.js";
 import { detectDrift } from "@squadrant/shared";
 import { needsCheck, withStamp } from "@squadrant/shared";
 import { getDefaultConfig } from "@squadrant/shared";
+import { notifyIfUpdateAvailable } from "@squadrant/shared";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf-8"));
@@ -70,6 +71,12 @@ if (process.argv[2] !== "config") {
           );
         }
       }
+
+      // #536: best-effort update-available check. Not awaited so it never blocks command
+      // logic; the unref'd node:https transport and bounded race inside notifyIfUpdateAvailable
+      // (see update-check.ts) mean a pending check can't delay process exit either, and a
+      // failed attempt is cached so an offline machine doesn't re-hit the registry every run.
+      void notifyIfUpdateAvailable({ config: cfg, currentVersion: pkg.version });
     }
   } catch {
     // Drift banner is best-effort; never block the CLI.

--- a/packages/cli/src/lib/__tests__/daemon-restart-broadcast.test.ts
+++ b/packages/cli/src/lib/__tests__/daemon-restart-broadcast.test.ts
@@ -43,6 +43,25 @@ function makeDriver(sent: Array<{ captain: string; message: string }>, failing =
   };
 }
 
+/** Track calls to appendCaptainMessage — used to prove the broadcast routes
+ *  through the mailbox instead of driver.send. */
+function makeAppendSpy(): {
+  fn: (project: string, text: string) => Promise<void>;
+  projects: string[];
+  texts: string[];
+} {
+  const projects: string[] = [];
+  const texts: string[] = [];
+  return {
+    fn: async (project, text) => {
+      projects.push(project);
+      texts.push(text);
+    },
+    projects,
+    texts,
+  };
+}
+
 describe("computeRestartSignature", () => {
   it("combines version and build mtime into a stable string", () => {
     expect(computeRestartSignature("0.14.3", 1000)).toBe(computeRestartSignature("0.14.3", 1000));
@@ -75,7 +94,7 @@ describe("persisted restart signature", () => {
 });
 
 describe("notifyCaptainsOfDaemonRestart", () => {
-  it("notifies every running captain, with no self-exclusion", async () => {
+  it("does NOT call driver.send — enqueues to mailbox instead", async () => {
     const projA = fs.mkdtempSync(path.join(dir, "projA-"));
     const projB = fs.mkdtempSync(path.join(dir, "projB-"));
     const config = configWithProjects({
@@ -83,30 +102,37 @@ describe("notifyCaptainsOfDaemonRestart", () => {
       b: project(projB, "captain-b"),
     });
     const sent: Array<{ captain: string; message: string }> = [];
+    const spy = makeAppendSpy();
 
-    await notifyCaptainsOfDaemonRestart("0.14.3", config, makeDriver(sent));
+    await notifyCaptainsOfDaemonRestart("0.14.3", config, makeDriver(sent), false, spy.fn);
 
-    expect(sent.map((s) => s.captain).sort()).toEqual(["captain-a", "captain-b"]);
+    expect(sent).toHaveLength(0);
+    expect(spy.projects.sort()).toEqual(["a", "b"]);
+    expect(spy.texts[0]).toContain("0.14.3");
   });
 
   it("includes the version in the notice", async () => {
     const projA = fs.mkdtempSync(path.join(dir, "projA-"));
     const config = configWithProjects({ a: project(projA, "captain-a") });
     const sent: Array<{ captain: string; message: string }> = [];
+    const spy = makeAppendSpy();
 
-    await notifyCaptainsOfDaemonRestart("0.14.3", config, makeDriver(sent));
+    await notifyCaptainsOfDaemonRestart("0.14.3", config, makeDriver(sent), false, spy.fn);
 
-    expect(sent[0].message).toContain("0.14.3");
+    expect(sent).toHaveLength(0);
+    expect(spy.texts[0]).toContain("0.14.3");
   });
 
   it("notes a dev build when isDevRebuild is true", async () => {
     const projA = fs.mkdtempSync(path.join(dir, "projA-"));
     const config = configWithProjects({ a: project(projA, "captain-a") });
     const sent: Array<{ captain: string; message: string }> = [];
+    const spy = makeAppendSpy();
 
-    await notifyCaptainsOfDaemonRestart("0.14.3", config, makeDriver(sent), true);
+    await notifyCaptainsOfDaemonRestart("0.14.3", config, makeDriver(sent), true, spy.fn);
 
-    expect(sent[0].message).toContain("dev build");
+    expect(sent).toHaveLength(0);
+    expect(spy.texts[0]).toContain("dev build");
   });
 
   it("skips an unreachable captain without throwing and still notifies the rest", async () => {
@@ -117,21 +143,25 @@ describe("notifyCaptainsOfDaemonRestart", () => {
       b: project(projB, "captain-b"),
     });
     const sent: Array<{ captain: string; message: string }> = [];
+    const spy = makeAppendSpy();
 
     await expect(
-      notifyCaptainsOfDaemonRestart("0.14.3", config, makeDriver(sent, new Set(["captain-a"]))),
+      notifyCaptainsOfDaemonRestart("0.14.3", config, makeDriver(sent, new Set(["captain-a"])), false, spy.fn),
     ).resolves.not.toThrow();
 
-    expect(sent.map((s) => s.captain)).toEqual(["captain-b"]);
+    expect(sent).toHaveLength(0);
+    expect(spy.projects).toEqual(["b"]);
   });
 
   it("no-ops silently when no projects are registered", async () => {
     const config = configWithProjects({});
     const sent: Array<{ captain: string; message: string }> = [];
+    const spy = makeAppendSpy();
 
-    await notifyCaptainsOfDaemonRestart("0.14.3", config, makeDriver(sent));
+    await notifyCaptainsOfDaemonRestart("0.14.3", config, makeDriver(sent), false, spy.fn);
 
     expect(sent).toHaveLength(0);
+    expect(spy.projects).toHaveLength(0);
   });
 });
 
@@ -140,16 +170,20 @@ describe("maybeBroadcastDaemonRestart", () => {
     const projA = fs.mkdtempSync(path.join(dir, "projA-"));
     const config = configWithProjects({ a: project(projA, "captain-a") });
     const sent: Array<{ captain: string; message: string }> = [];
+    const spy = makeAppendSpy();
+    const driver = makeDriver(sent);
 
     await maybeBroadcastDaemonRestart({
       version: "0.14.3",
       buildMtimeMs: 1000,
       stateRoot,
       config,
-      driver: makeDriver(sent),
+      driver,
+      appendCaptainMessage: spy.fn,
     });
 
-    expect(sent).toHaveLength(1);
+    expect(sent).toHaveLength(0);
+    expect(spy.projects).toEqual(["a"]);
     expect(readPersistedRestartSignature(stateRoot)).toBe(computeRestartSignature("0.14.3", 1000));
   });
 
@@ -158,16 +192,20 @@ describe("maybeBroadcastDaemonRestart", () => {
     const config = configWithProjects({ a: project(projA, "captain-a") });
     writePersistedRestartSignature(stateRoot, computeRestartSignature("0.14.2", 500));
     const sent: Array<{ captain: string; message: string }> = [];
+    const spy = makeAppendSpy();
+    const driver = makeDriver(sent);
 
     await maybeBroadcastDaemonRestart({
       version: "0.14.3",
       buildMtimeMs: 1000,
       stateRoot,
       config,
-      driver: makeDriver(sent),
+      driver,
+      appendCaptainMessage: spy.fn,
     });
 
-    expect(sent).toHaveLength(1);
+    expect(sent).toHaveLength(0);
+    expect(spy.projects).toEqual(["a"]);
     expect(readPersistedRestartSignature(stateRoot)).toBe(computeRestartSignature("0.14.3", 1000));
   });
 
@@ -176,21 +214,26 @@ describe("maybeBroadcastDaemonRestart", () => {
     const config = configWithProjects({ a: project(projA, "captain-a") });
     writePersistedRestartSignature(stateRoot, computeRestartSignature("0.14.3", 1000));
     const sent: Array<{ captain: string; message: string }> = [];
+    const spy = makeAppendSpy();
+    const driver = makeDriver(sent);
 
     await maybeBroadcastDaemonRestart({
       version: "0.14.3",
       buildMtimeMs: 1000,
       stateRoot,
       config,
-      driver: makeDriver(sent),
+      driver,
+      appendCaptainMessage: spy.fn,
     });
 
     expect(sent).toHaveLength(0);
+    expect(spy.projects).toHaveLength(0);
   });
 
   it("never throws even when the driver fails entirely", async () => {
     const projA = fs.mkdtempSync(path.join(dir, "projA-"));
     const config = configWithProjects({ a: project(projA, "captain-a") });
+    const spy = makeAppendSpy();
     const throwingDriver = {
       async status(): Promise<{ id: string } | null> {
         throw new Error("boom");
@@ -207,6 +250,7 @@ describe("maybeBroadcastDaemonRestart", () => {
         stateRoot,
         config,
         driver: throwingDriver,
+        appendCaptainMessage: spy.fn,
       }),
     ).resolves.not.toThrow();
   });

--- a/packages/cli/src/lib/__tests__/require-daemon.test.ts
+++ b/packages/cli/src/lib/__tests__/require-daemon.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from "vitest";
+import { requireDaemon } from "../require-daemon.js";
+import { isDaemonSocketLive } from "@squadrant/core";
+
+vi.mock("@squadrant/core", () => ({
+  isDaemonSocketLive: vi.fn(),
+}));
+
+describe("requireDaemon", () => {
+  it("resolves successfully if socket is live", async () => {
+    vi.mocked(isDaemonSocketLive).mockResolvedValue(true);
+    await expect(requireDaemon("dummy.sock")).resolves.toBeUndefined();
+    expect(isDaemonSocketLive).toHaveBeenCalledWith("dummy.sock");
+  });
+
+  it("throws an error if socket is dead", async () => {
+    vi.mocked(isDaemonSocketLive).mockResolvedValue(false);
+    await expect(requireDaemon("dummy.sock")).rejects.toThrow(
+      "daemon not running — message NOT delivered. Start it with 'squadrant launch <project>'."
+    );
+  });
+});

--- a/packages/cli/src/lib/daemon-restart-broadcast.ts
+++ b/packages/cli/src/lib/daemon-restart-broadcast.ts
@@ -1,17 +1,21 @@
 // Best-effort "daemon restarted" broadcast to all running captains, fired on
 // daemon boot — but only when the running build actually changed (version or
-// local rebuild), not on a same-build launchd crash-restart. Modeled exactly
-// on notifyCaptainsOfEffort (commands/effort.ts): same driver seam, same
-// best-effort/never-throw contract.
+// local rebuild), not on a same-build launchd crash-restart. Routes through the
+// mailbox (appendCaptainMessage) so the daemon's delivery-loop drains it with
+// draft protection, instead of raw driver.send which clobbers the user's draft
+// (#529).
 import fs from "node:fs";
 import path from "node:path";
 import type { SquadrantConfig } from "@squadrant/shared";
 
-/** Minimal slice of RuntimeDriver used to notify a captain. */
+/** Minimal slice of RuntimeDriver used to resolve captain status. */
 export interface DaemonRestartNotifyDriver {
   status(nameOrId: string): Promise<{ id: string } | null>;
-  send(ref: string, message: string): Promise<void>;
 }
+
+/** Matches the appendCaptainMessage signature from @squadrant/core/mailbox.
+ *  The caller provides the closure with stateRoot already bound. */
+export type AppendCaptainMessageFn = (project: string, text: string) => Promise<void>;
 
 function statePath(stateRoot: string): string {
   return path.join(stateRoot, "daemon-restart-state.json");
@@ -44,22 +48,26 @@ function restartNotice(version: string, isDevRebuild: boolean): string {
 }
 
 /**
- * Send the daemon-restart notice to every running captain. Unlike
- * notifyCaptainsOfEffort there is no initiating cwd captain to exclude — the
- * daemon boots independently of any captain — so this reaches ALL of them.
+ * Send the daemon-restart notice to every running captain via the mailbox.
+ * Unlike notifyCaptainsOfEffort there is no initiating cwd captain to exclude —
+ * the daemon boots independently of any captain — so this reaches ALL of them.
+ * The appendCaptainMessage callback is a closure that captures stateRoot from
+ * the caller (squadrantd.ts), so it takes (projectName, text).
  */
 export async function notifyCaptainsOfDaemonRestart(
   version: string,
   config: SquadrantConfig,
   driver: DaemonRestartNotifyDriver,
   isDevRebuild = false,
+  appendCaptainMessage: AppendCaptainMessageFn,
 ): Promise<void> {
   const notice = restartNotice(version, isDevRebuild);
-  for (const [, proj] of Object.entries(config.projects)) {
+  for (const [projName] of Object.entries(config.projects)) {
     try {
+      const proj = config.projects[projName];
       const ref = await driver.status(proj.captainName);
       if (ref) {
-        await driver.send(ref.id, notice);
+        await appendCaptainMessage(projName, notice);
       }
     } catch {
       // individual project captain unreachable — skip
@@ -73,6 +81,7 @@ export interface MaybeBroadcastDaemonRestartOpts {
   stateRoot: string;
   config: SquadrantConfig;
   driver: DaemonRestartNotifyDriver;
+  appendCaptainMessage: AppendCaptainMessageFn;
 }
 
 /**
@@ -83,12 +92,12 @@ export interface MaybeBroadcastDaemonRestartOpts {
  */
 export async function maybeBroadcastDaemonRestart(opts: MaybeBroadcastDaemonRestartOpts): Promise<void> {
   try {
-    const { version, buildMtimeMs, stateRoot, config, driver } = opts;
+    const { version, buildMtimeMs, stateRoot, config, driver, appendCaptainMessage } = opts;
     const signature = computeRestartSignature(version, buildMtimeMs);
     const previous = readPersistedRestartSignature(stateRoot);
     if (previous === signature) return;
     const isDevRebuild = previous !== null && previous.split("::")[0] === version;
-    await notifyCaptainsOfDaemonRestart(version, config, driver, isDevRebuild);
+    await notifyCaptainsOfDaemonRestart(version, config, driver, isDevRebuild, appendCaptainMessage);
     writePersistedRestartSignature(stateRoot, signature);
   } catch {
     // best-effort — never let a broadcast failure block or crash daemon boot

--- a/packages/cli/src/lib/require-daemon.ts
+++ b/packages/cli/src/lib/require-daemon.ts
@@ -1,0 +1,12 @@
+import { isDaemonSocketLive } from "@squadrant/core";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const DEFAULT_SOCK_PATH = join(homedir(), ".config", "squadrant", "squadrant.sock");
+
+export async function requireDaemon(sockPath: string = DEFAULT_SOCK_PATH): Promise<void> {
+  const isLive = await isDaemonSocketLive(sockPath);
+  if (!isLive) {
+    throw new Error("daemon not running — message NOT delivered. Start it with 'squadrant launch <project>'.");
+  }
+}

--- a/packages/cli/src/squadrantd.ts
+++ b/packages/cli/src/squadrantd.ts
@@ -323,6 +323,8 @@ export function startSquadrantd(opts: import("@squadrant/core").SquadrantdOpts =
         stateRoot,
         config: restartConfig,
         driver: registry.global(restartConfig),
+        appendCaptainMessage: (project: string, text: string) =>
+          appendCaptainMessage({ stateRoot, project, text, source: "daemon" }),
       });
     } catch (e) {
       log(`daemon-restart broadcast setup failed: ${(e as Error).message}`);

--- a/packages/cli/src/squadrantd.ts
+++ b/packages/cli/src/squadrantd.ts
@@ -332,18 +332,30 @@ export function startSquadrantd(opts: import("@squadrant/core").SquadrantdOpts =
   }
 
   const origStop = h.stop.bind(h);
-  h.stop = async () => {
+  h.stop = async (reason?: string) => {
     try { cmuxStoreSource.stop(); } catch { /* best-effort */ }
     try { nativeHookSource.stop(); } catch { /* best-effort */ }
     try { codexAppServerSource.stop(); } catch { /* best-effort */ }
-    return origStop();
+    return origStop(reason);
   };
 
   return h;
 }
 
+/** Greppable crash marker (#535) — matches the `[squadrantd] <iso> <msg>` shape
+ *  ctx.log uses, but writes directly since ctx.log doesn't exist until buildContext()
+ *  runs; a crash before that point must still be diagnosable. */
+function logCrashMarker(kind: "uncaughtException" | "unhandledRejection", err: unknown): void {
+  const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+  process.stderr.write(`[squadrantd] ${new Date().toISOString()} ${kind} pid=${process.pid} error=${message}\n`);
+}
+
 // Executed by launchd (ProgramArguments → this file's compiled .js).
 if (process.argv[1] && process.argv[1].endsWith("squadrantd.js")) {
+  // Registered before any boot work so a crash during startup is still logged.
+  process.on("uncaughtException", (err) => { logCrashMarker("uncaughtException", err); process.exit(1); });
+  process.on("unhandledRejection", (reason) => { logCrashMarker("unhandledRejection", reason); process.exit(1); });
+
   void (async () => {
     // #360 layer 1: this entry takes no CLI flags. A build smoke-test like
     // `node dist/squadrantd.js --help` must NOT boot a daemon — it would hang
@@ -363,6 +375,12 @@ if (process.argv[1] && process.argv[1].endsWith("squadrantd.js")) {
       process.exit(0);
     }
     const h = startSquadrantd({ sweepMs: 30000 });
-    process.on("SIGTERM", () => { h.stop(); process.exit(0); });
+    // #535: await stop() before exiting — it writes the exit marker and runs
+    // teardown (bridges, in-flight headless kills) synchronously-then-async;
+    // exiting immediately after firing it (not awaiting) raced process.exit()
+    // against that work and silently dropped it every time.
+    const shutdown = (signal: "SIGTERM" | "SIGINT") => { void h.stop(signal).finally(() => process.exit(0)); };
+    process.on("SIGTERM", () => shutdown("SIGTERM"));
+    process.on("SIGINT", () => shutdown("SIGINT"));
   })();
 }

--- a/packages/core/src/__tests__/crew-spawn.test.ts
+++ b/packages/core/src/__tests__/crew-spawn.test.ts
@@ -671,6 +671,50 @@ describe("runCrewSend", () => {
     expect(injectedSend).toHaveBeenCalledWith(expect.anything(), "big message");
     expect(runtime.sendToPane).not.toHaveBeenCalled();
   });
+
+  // #516: when the injected sendToPane reports blockedByModal (an open
+  // AskUserQuestion/permission modal), the send must fail LOUDLY — a thrown
+  // error, not a silent 'success' — so the captain knows the message never
+  // reached the crew instead of the crew silently acting on its default option.
+  it("throws loudly when send is blocked by an open modal (#516)", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:crew-1" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    const injectedSend = vi.fn().mockResolvedValue({ delivered: false, blockedByModal: true });
+    await expect(
+      runCrewSend(PROJECT, "crew-1", "pick option 2", runtime, "workspace:1", {
+        listTasks: vi.fn().mockResolvedValue([]),
+        emitEvent: vi.fn(),
+        sendToPane: injectedSend,
+      }),
+    ).rejects.toThrow(/interactive prompt/i);
+  });
+
+  // #516 review follow-up: the daemon-state emit block (task.reopened/task.started)
+  // ran BEFORE the blockedByModal check, so a modal-blocked send still flipped a
+  // blocked task to working — clearing BLOCKED before the crew ever saw the new
+  // message. That is the exact lost-signal class #183 protects against. The
+  // isBlockedByModal precheck must run first and make the whole send a TRUE no-op
+  // on daemon state — not just a no-op on the pane — when a modal is open.
+  it("emits NO daemon event and never attempts delivery when isBlockedByModal reports an open modal (#516)", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:crew-1" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    const emitEvent = vi.fn().mockResolvedValue(undefined);
+    const listTasks = vi.fn().mockResolvedValue([
+      { id: "t1", name: "crew-1", state: "blocked" } as Partial<TaskRecord>,
+    ]);
+    const isBlockedByModal = vi.fn().mockResolvedValue(true);
+    const injectedSend = vi.fn();
+    await expect(
+      runCrewSend(PROJECT, "crew-1", "pick option 2", runtime, "workspace:1", {
+        listTasks,
+        emitEvent,
+        sendToPane: injectedSend,
+        isBlockedByModal,
+      }),
+    ).rejects.toThrow(/interactive prompt/i);
+    expect(emitEvent).not.toHaveBeenCalled();
+    expect(injectedSend).not.toHaveBeenCalled();
+  });
 });
 
 // ─── runCrewRead ─────────────────────────────────────────────────────────────

--- a/packages/core/src/__tests__/crew-spawn.test.ts
+++ b/packages/core/src/__tests__/crew-spawn.test.ts
@@ -811,4 +811,100 @@ describe("runCrewClose", () => {
     // pane found, pane closed; no throw despite daemon error
     expect(runtime.closePane).toHaveBeenCalledOnce();
   });
+
+  // ── #513: same-name respawn zombie regression ────────────────────────────
+  // Repro: spawn cv-qa (opencode) -> close IMMEDIATELY -> respawn cv-qa
+  // (claude). The daemon later fires a false CREW STALLED for the CLOSED
+  // opencode task because close's single listTasks() snapshot missed the
+  // record (registration race) and/or a stale same-name record survives
+  // uncancelled once a second one exists.
+
+  it("retries the name lookup when the first snapshot has no match yet, then terminalizes it (registration race)", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:cv-qa" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    const task = { id: "b3449b4a", name: "cv-qa", state: "working", provider: "opencode", cwd: PROJ_PATH } as Partial<TaskRecord>;
+    const emitEvent = vi.fn().mockResolvedValue(undefined);
+    // First snapshot: dispatch hasn't landed yet (empty). Second snapshot: it has.
+    const listTasks = vi.fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([task]);
+
+    await runCrewClose(PROJECT, "cv-qa", runtime, "workspace:1", {
+      listTasks,
+      emitEvent,
+      closeCodexThread: vi.fn(),
+      sleep: vi.fn().mockResolvedValue(undefined), // no real delay in tests
+    });
+
+    expect(listTasks.mock.calls.length).toBeGreaterThan(1);
+    expect(emitEvent).toHaveBeenCalledWith(
+      PROJECT,
+      expect.objectContaining({ type: "task.cancelled", id: "b3449b4a" }),
+    );
+  });
+
+  it("gives up after bounded retries and still closes the pane when no daemon record ever appears", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:cv-qa" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    const emitEvent = vi.fn().mockResolvedValue(undefined);
+    const listTasks = vi.fn().mockResolvedValue([]);
+
+    await runCrewClose(PROJECT, "cv-qa", runtime, "workspace:1", {
+      listTasks,
+      emitEvent,
+      closeCodexThread: vi.fn(),
+      sleep: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(emitEvent).not.toHaveBeenCalledWith(
+      PROJECT,
+      expect.objectContaining({ type: "task.cancelled" }),
+    );
+    expect(runtime.closePane).toHaveBeenCalledOnce();
+  });
+
+  it("terminalizes EVERY non-terminal record matching the name, not just the first match (duplicate same-name records)", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:cv-qa" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    const emitEvent = vi.fn().mockResolvedValue(undefined);
+    // A prior close-race left an orphaned opencode record uncancelled; the
+    // live claude crew (respawned under the same name) is the one being closed now.
+    const zombie = { id: "b3449b4a", name: "cv-qa", state: "working", provider: "opencode", cwd: PROJ_PATH, createdAt: 1000 } as Partial<TaskRecord>;
+    const live = { id: "f6f5200d", name: "cv-qa", state: "working", provider: "claude", cwd: PROJ_PATH, createdAt: 2000 } as Partial<TaskRecord>;
+
+    await runCrewClose(PROJECT, "cv-qa", runtime, "workspace:1", {
+      listTasks: vi.fn().mockResolvedValue([zombie, live]),
+      emitEvent,
+      closeCodexThread: vi.fn(),
+      sleep: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(emitEvent).toHaveBeenCalledWith(
+      PROJECT,
+      expect.objectContaining({ type: "task.cancelled", id: "b3449b4a" }),
+    );
+    expect(emitEvent).toHaveBeenCalledWith(
+      PROJECT,
+      expect.objectContaining({ type: "task.cancelled", id: "f6f5200d" }),
+    );
+  });
+
+  it("anchors reap/worktree cleanup on the most-recently-dispatched match when duplicates exist", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:cv-qa" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    const oldWorktree = `${PROJ_PATH}/.worktrees/myproj-cv-qa-old`;
+    const newWorktree = `${PROJ_PATH}/.worktrees/myproj-cv-qa-new`;
+    const zombie = { id: "old-id", name: "cv-qa", state: "working", provider: "opencode", cwd: oldWorktree, createdAt: 1000 } as Partial<TaskRecord>;
+    const live = { id: "new-id", name: "cv-qa", state: "working", provider: "claude", cwd: newWorktree, createdAt: 2000 } as Partial<TaskRecord>;
+
+    await runCrewClose(PROJECT, "cv-qa", runtime, "workspace:1", {
+      listTasks: vi.fn().mockResolvedValue([zombie, live]),
+      emitEvent: vi.fn().mockResolvedValue(undefined),
+      closeCodexThread: vi.fn(),
+      sleep: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(removeWorktreeMock).toHaveBeenCalledWith(PROJ_PATH, newWorktree);
+    expect(removeWorktreeMock).not.toHaveBeenCalledWith(PROJ_PATH, oldWorktree);
+  });
 });

--- a/packages/core/src/__tests__/daemon.test.ts
+++ b/packages/core/src/__tests__/daemon.test.ts
@@ -790,6 +790,22 @@ describe("daemon – blocked crew resume path (#183)", () => {
       expect(calls.filter((c) => c.message.includes("CREW IDLE"))).toHaveLength(1);
     });
 
+    // #522: awaiting-input is reached ONLY via a genuine turn-boundary event
+    // (never a watchdog guess — see reduce.ts formatMessage). A deliberate
+    // turn-end mid-plan (e.g. a long-lived crew pausing between sequential
+    // subtasks) is mechanically identical to any other turn-end, so the
+    // message must read calm rather than like a possible stall.
+    it("uses calm 'awaiting your reply' phrasing, not the old alarming 'review and reply or close' wording (#522)", async () => {
+      const store = createStore(dir);
+      store.put(rec("t-calm", { state: "working" }));
+      const calls: any[] = [];
+      const d = createDaemon({ store, now: () => 50_000, notify: async (a) => { calls.push(a); } });
+      await d.handle({ kind: "event", project: "p", event: { type: "task.turn.completed", id: "t-calm", turnId: "turn-1" } });
+      expect(calls).toHaveLength(1);
+      expect(calls[0].message).toBe(`CREW IDLE ${crewTag(store.get("p", "t-calm")!)}: turn ended, awaiting your reply.`);
+      expect(calls[0].message).not.toContain("review and reply or close");
+    });
+
     it("does NOT debounce CREW BLOCKED even right after a captain turn", async () => {
       const store = createStore(dir);
       store.put(rec("t-blk", { state: "working" }));

--- a/packages/core/src/__tests__/delivery-loop.test.ts
+++ b/packages/core/src/__tests__/delivery-loop.test.ts
@@ -5,8 +5,9 @@ import { join } from "node:path";
 import { createDelivery } from "../daemon/delivery-loop.js";
 import { createStore } from "../store.js";
 import { LivenessRegistry } from "../daemon/liveness-registry.js";
-import { appendCaptainMessage } from "../mailbox.js";
+import { appendCaptainMessage, appendToMailbox, readCursor } from "../mailbox.js";
 import { STALE_THRESHOLD_MS } from "../daemon/interactive-probe.js";
+import { DeferDelivery } from "../delivery/defer-delivery.js";
 
 function freshState(): string {
   return mkdtempSync(join(tmpdir(), "deliv-"));
@@ -115,7 +116,132 @@ describe("delivery-loop", () => {
     } as any, cmux as any);
     
     await deliv.deliveryTick!();
-    
+
     expect(logs).toContain("sent: hello command");
+  });
+
+  // #535: repro sketch — a dispatch report-back lands in the mailbox, the
+  // daemon restarts before the captain pane accepts it, and a fresh daemon
+  // instance resumes over the same on-disk mailbox + cursor. It must deliver
+  // the report-back exactly once: never dropped, never duplicated.
+  it("delivers a report-back exactly once across a simulated daemon restart (#535)", async () => {
+    const stateRoot = freshState();
+    const project = "alpha";
+    const store = createStore(stateRoot);
+    store.put({
+      id: "disp1", project, provider: "claude", mode: "interactive",
+      state: "done", task: "dispatch B->A report-back", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000, attempts: [],
+    });
+    await appendToMailbox({
+      stateRoot, project,
+      taskRecord: store.list(project)[0],
+      event: { type: "task.done", id: "disp1" } as any,
+      message: "dispatch report-back",
+    });
+
+    const captainName = `${project}-captain`;
+    function newRegistry() {
+      const registry = new LivenessRegistry({ path: join(stateRoot, "live.json") });
+      registry.apply({
+        project, role: "captain", pid: 123, sessionId: "s1",
+        startedAt: Date.now(), lastState: "start", lastSeenAt: Date.now(),
+        pidAlive: true, source: "runtime",
+      });
+      return registry;
+    }
+
+    // ── "Session 1": daemon boots, attempts delivery, captain pane is busy
+    // (deferred) — restart happens before the report-back settles. ──
+    const sent: string[] = [];
+    const busyCmux = {
+      listSurfaces: async () => [{ id: "s1", title: captainName, command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => `${captainName}> `,
+      send: async () => { throw new DeferDelivery("captain is composing"); },
+    };
+    const session1 = createDelivery({
+      stateRoot, store, livenessRegistry: newRegistry(), log: () => {}, isPidAlive: () => true, opts: {},
+    } as any, busyCmux as any);
+    await session1.deliveryTick!();
+    expect(sent).toHaveLength(0);
+    const cursorAfterSession1 = await readCursor({ stateRoot, project, subscriber: "captain" });
+    expect(cursorAfterSession1?.lastAckedSeq ?? 0).toBe(0); // not acked — never sent
+
+    // ── "Session 2": fresh daemon process (new in-memory delivery state,
+    // fresh liveness registry) resumes from the same on-disk mailbox+cursor.
+    // The pane is now free — delivery succeeds. ──
+    const readyCmux = {
+      listSurfaces: async () => [{ id: "s1", title: captainName, command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => `${captainName}> `,
+      send: async (_surface: any, text: string) => { sent.push(text); },
+    };
+    const session2 = createDelivery({
+      stateRoot, store, livenessRegistry: newRegistry(), log: () => {}, isPidAlive: () => true, opts: {},
+    } as any, readyCmux as any);
+    await session2.deliveryTick!();
+    expect(sent).toEqual(["dispatch report-back"]);
+    const cursorAfterSession2 = await readCursor({ stateRoot, project, subscriber: "captain" });
+    expect(cursorAfterSession2?.lastAckedSeq).toBe(1);
+
+    // A further tick (still session 2, or a hypothetical session 3) must not
+    // redeliver — the cursor already acked seq 1.
+    await session2.deliveryTick!();
+    expect(sent).toEqual(["dispatch report-back"]);
+  });
+
+  // #535 question 2: is the #531 stale-skip exemption for human/CLI-originated
+  // captain.message data-driven (persisted per-entry), or does it depend on
+  // in-memory state that a restart would lose? Model two daemon sessions: the
+  // message ages past STALE_THRESHOLD_MS while no session is running (as if
+  // the daemon was down), then a *fresh* session (new sessionStartMs, matching
+  // a real restart) resumes and must still deliver it.
+  it("the #531 stale-skip exemption survives a restart — it is computed from the persisted entry, not session state", async () => {
+    const stateRoot = freshState();
+    const project = "beta";
+    const captainName = `${project}-captain`;
+    const store = createStore(stateRoot);
+    // The delivery loop only visits projects it knows about (config, injected
+    // surfaces, or the task store) — seed a task so "beta" is in scope.
+    store.put({
+      id: "t1", project, provider: "claude", mode: "interactive",
+      state: "submitted", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000, attempts: [],
+    });
+    const livenessRegistry = new LivenessRegistry({ path: join(stateRoot, "live.json") });
+    livenessRegistry.apply({
+      project, role: "captain", pid: 123, sessionId: "s1",
+      startedAt: Date.now(), lastState: "start", lastSeenAt: Date.now(),
+      pidAlive: true, source: "runtime",
+    });
+
+    await appendCaptainMessage({ stateRoot, project, text: "human/cli message", source: "cli" });
+    await appendCaptainMessage({ stateRoot, project, text: "daemon message", source: "daemon" });
+
+    // Simulate the daemon being down for longer than the stale threshold —
+    // the messages sat on disk, unprocessed, across the gap.
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + STALE_THRESHOLD_MS + 1000);
+
+    // "Restart": createDelivery() is called only now, so its sessionStartMs
+    // captures the post-restart clock — a fresh daemon lifetime, not the one
+    // that existed when the messages were enqueued.
+    const sent: string[] = [];
+    const cmux = {
+      listSurfaces: async () => [{ id: "s1", title: captainName, command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => `${captainName}> `,
+      send: async (_surface: any, text: string) => { sent.push(text); },
+    };
+    const postRestart = createDelivery({
+      stateRoot, store, livenessRegistry, log: () => {}, isPidAlive: () => true, opts: {},
+    } as any, cmux as any);
+    await postRestart.deliveryTick!();
+
+    expect(sent).toContain("human/cli message");
+    expect(sent).not.toContain("daemon message");
+
+    vi.useRealTimers();
   });
 });

--- a/packages/core/src/__tests__/delivery-loop.test.ts
+++ b/packages/core/src/__tests__/delivery-loop.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDelivery } from "../daemon/delivery-loop.js";
+import { createStore } from "../store.js";
+import { LivenessRegistry } from "../daemon/liveness-registry.js";
+import { appendCaptainMessage } from "../mailbox.js";
+import { STALE_THRESHOLD_MS } from "../daemon/interactive-probe.js";
+
+function freshState(): string {
+  return mkdtempSync(join(tmpdir(), "deliv-"));
+}
+
+describe("delivery-loop", () => {
+  it("exempts non-daemon captain.message from stale-skip (#531)", async () => {
+    const stateRoot = freshState();
+    const store = createStore(stateRoot);
+    store.put({
+      id: "t1", project: "demo", provider: "claude", mode: "interactive",
+      state: "submitted", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000, attempts: []
+    });
+    const livenessRegistry = new LivenessRegistry({ path: join(stateRoot, "live.json") });
+    
+    // Simulate liveness
+    livenessRegistry.apply({
+      project: "demo",
+      role: "captain",
+      pid: 123,
+      sessionId: "s1",
+      startedAt: Date.now(),
+      lastState: "start",
+      lastSeenAt: Date.now(),
+      pidAlive: true,
+      source: "runtime"
+    });
+    
+    // Create an old telegram message (stale)
+    await appendCaptainMessage({
+      stateRoot, project: "demo", text: "telegram message", source: "telegram"
+    });
+    
+    // Create an old daemon message (stale)
+    await appendCaptainMessage({
+      stateRoot, project: "demo", text: "daemon message", source: "daemon"
+    });
+    
+    // Shift the clock so these messages are very old
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + STALE_THRESHOLD_MS + 1000);
+    
+    const logs: string[] = [];
+    const cmux = {
+      listSurfaces: async () => [{ id: "s1", title: "demo-captain", command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => "demo-captain> ",
+      send: async (surface: any, text: string) => {
+        logs.push(`sent: ${text}`);
+      }
+    };
+    
+    const deliv = createDelivery({
+      stateRoot, store, livenessRegistry, log: (m: string) => {}, isPidAlive: () => true, opts: {}
+    } as any, cmux as any);
+    
+    await deliv.deliveryTick!();
+    
+    // Wait for async background things if necessary
+    // Then check what was sent
+    expect(logs).toContain("sent: telegram message");
+    expect(logs).not.toContain("sent: daemon message");
+    
+    vi.useRealTimers();
+  });
+
+  it("drains and delivers entries under cfg.commandName", async () => {
+    const stateRoot = freshState();
+    const store = createStore(stateRoot);
+    const livenessRegistry = new LivenessRegistry({ path: join(stateRoot, "live.json") });
+    
+    // Command workspace has no project config, it relies on cfg.commandName
+    const { loadConfig } = await import("@squadrant/shared");
+    const cfg = loadConfig();
+    const commandName = cfg.commandName; // Usually "🏛️ command"
+    
+    livenessRegistry.apply({
+      project: commandName,
+      role: "captain",
+      pid: 123,
+      sessionId: "s1",
+      startedAt: Date.now(),
+      lastState: "start",
+      lastSeenAt: Date.now(),
+      pidAlive: true,
+      source: "runtime"
+    });
+    
+    await appendCaptainMessage({
+      stateRoot, project: commandName, text: "hello command", source: "cli"
+    });
+    
+    const logs: string[] = [];
+    const cmux = {
+      listSurfaces: async () => [{ id: "s1", title: commandName, command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => `${commandName}> `,
+      send: async (surface: any, text: string) => {
+        logs.push(`sent: ${text}`);
+      }
+    };
+    
+    const deliv = createDelivery({
+      stateRoot, store, livenessRegistry, log: () => {}, isPidAlive: () => true, opts: {}
+    } as any, cmux as any);
+    
+    await deliv.deliveryTick!();
+    
+    expect(logs).toContain("sent: hello command");
+  });
+});

--- a/packages/core/src/__tests__/launch-workspace.test.ts
+++ b/packages/core/src/__tests__/launch-workspace.test.ts
@@ -1,0 +1,95 @@
+// Unit tests for launchOneWorkspace's --keep semantics (#534).
+// Uses real fs on a temp dir (mirrors session-freshness.test.ts) plus a
+// minimal RuntimeDriver mock — no real processes or cmux.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import type { RuntimeDriver } from "@squadrant/shared";
+import { launchOneWorkspace } from "../launch-workspace.js";
+import { saveSessions, computeTemplateHash } from "../session-freshness.js";
+
+let tmpDir: string;
+let sessionsPath: string;
+let templatesDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "squadrant-lw-test-"));
+  sessionsPath = path.join(tmpDir, "sessions.json");
+  templatesDir = path.join(tmpDir, "templates");
+  fs.mkdirSync(templatesDir, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function makeRuntime(): RuntimeDriver {
+  return {
+    name: "mock",
+    probe: vi.fn(),
+    list: vi.fn(),
+    status: vi.fn().mockResolvedValue(null),
+    spawn: vi.fn().mockResolvedValue({ id: "workspace:1", name: "ws", status: "running" }),
+    send: vi.fn(),
+    sendKey: vi.fn(),
+    readScreen: vi.fn(),
+    stop: vi.fn(),
+    newPane: vi.fn(),
+    closePane: vi.fn(),
+    sendToPane: vi.fn(),
+    pasteToPane: vi.fn(),
+    sendKeyToPane: vi.fn(),
+    readPaneScreen: vi.fn(),
+    listSurfaces: vi.fn(),
+    spawnInjector: vi.fn(),
+  } as unknown as RuntimeDriver;
+}
+
+describe("launchOneWorkspace --keep (#534)", () => {
+  it("resumes (no forceFresh) when keepOverride overrides a 'new day' reason", async () => {
+    const hash = computeTemplateHash("captain", templatesDir);
+    saveSessions(sessionsPath, { workspaces: { "ws-1": { lastLaunched: "2000-01-01", templateHash: hash } } });
+
+    const agentCmdFactory = vi.fn().mockReturnValue("claude-cli");
+    const onFreshReason = vi.fn();
+
+    await launchOneWorkspace({
+      workspaceName: "ws-1",
+      role: "captain",
+      cwd: tmpDir,
+      keepOverride: true,
+      sessionsPath,
+      templatesDir,
+      agentCmdFactory,
+      runtime: makeRuntime(),
+      onFreshReason,
+    });
+
+    expect(agentCmdFactory).toHaveBeenCalledWith(false);
+    expect(onFreshReason).toHaveBeenCalledWith(
+      expect.stringContaining("keeping previous session (--keep)"),
+    );
+  });
+
+  it("still starts fresh on a genuine first launch even with keepOverride (nothing to resume)", async () => {
+    const agentCmdFactory = vi.fn().mockReturnValue("claude-cli");
+    const onFreshReason = vi.fn();
+
+    await launchOneWorkspace({
+      workspaceName: "ws-new",
+      role: "captain",
+      cwd: tmpDir,
+      keepOverride: true,
+      sessionsPath,
+      templatesDir,
+      agentCmdFactory,
+      runtime: makeRuntime(),
+      onFreshReason,
+    });
+
+    expect(agentCmdFactory).toHaveBeenCalledWith(true);
+    expect(onFreshReason).toHaveBeenCalledWith("first launch");
+  });
+});

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -471,12 +471,24 @@ export async function runCrewSend(
     // runtime.sendToPane so the caller can inject paste-settle-Enter hardening.
     // Falls back to runtime.sendToPane when absent (preserves existing behaviour
     // for callers that don't inject it, e.g. unit tests).
-    sendToPane?: (pane: PaneRef, message: string) => Promise<{ delivered: boolean }>;
+    sendToPane?: (pane: PaneRef, message: string) => Promise<{ delivered: boolean; blockedByModal?: boolean }>;
+    // #516: optional side-effect-free precheck for an open AskUserQuestion/
+    // permission modal. Checked BEFORE the daemon-state emit block below so a
+    // modal-blocked send is a true no-op on daemon state, not just on the pane.
+    // Deliberately separate from sendToPane: that closure only reports
+    // blockedByModal AFTER attempting delivery, which is too late here — the
+    // emit block must never run for a message that never reached the crew.
+    isBlockedByModal?: (pane: PaneRef) => Promise<boolean>;
   },
 ): Promise<void> {
   const crew = await findCrewPane(runtime, workspaceId, project, name);
   if (!crew) {
     throw new Error(`Crew '${name}' not found for ${project}. Run 'squadrant crew list ${project}'.`);
+  }
+  const blockedByModalMessage = () =>
+    `Crew '${name}' has an interactive prompt open (AskUserQuestion/permission) — message NOT delivered, to avoid confirming its default option. Wait for the prompt to close, then re-send with 'squadrant crew send ${project} ${name}'.`;
+  if (deps.isBlockedByModal && (await deps.isBlockedByModal(crew))) {
+    throw new Error(blockedByModalMessage());
   }
   // Best-effort attention-state handling before delivering the captain's answer.
   // Terminal task (done/failed): reopen so the next signal done fires CREW DONE (#148).
@@ -496,8 +508,16 @@ export async function runCrewSend(
     // Swallow daemon errors so crews without a daemon or offline daemon
     // still receive the sent message.
   }
-  const deliver = deps.sendToPane ?? ((pane, msg) => runtime.sendToPane(pane, msg).then(() => ({ delivered: true })));
-  const { delivered } = await deliver(crew, message);
+  const deliver: (pane: PaneRef, msg: string) => Promise<{ delivered: boolean; blockedByModal?: boolean }> =
+    deps.sendToPane ?? ((pane, msg) => runtime.sendToPane(pane, msg).then(() => ({ delivered: true })));
+  const { delivered, blockedByModal } = await deliver(crew, message);
+  // #516 backstop: covers the TOCTOU window between the precheck above and this
+  // delivery attempt, and callers that don't inject isBlockedByModal at all. By
+  // this point the emit block (if any) has already run — unavoidable without the
+  // precheck — but the send still fails loudly instead of reporting success.
+  if (blockedByModal) {
+    throw new Error(blockedByModalMessage());
+  }
   if (!delivered) {
     process.stderr.write(`⚠️  Message not delivered to crew '${name}' — use 'squadrant crew send ${project} ${name}' to re-send.\n`);
   }

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -516,6 +516,13 @@ export async function runCrewRead(
   return runtime.readPaneScreen(crew);
 }
 
+// #513: close's listTasks() lookup can race a same-name crew's own dispatch —
+// closing immediately after spawn may snapshot the daemon before the task
+// record is registered. A few short retries close that window without adding
+// meaningful latency to the common (already-registered) case.
+const CLOSE_LOOKUP_RETRIES = 3;
+const CLOSE_LOOKUP_RETRY_DELAY_MS = 150;
+
 export async function runCrewClose(
   project: string,
   name: string,
@@ -525,8 +532,11 @@ export async function runCrewClose(
     listTasks(project: string): Promise<TaskRecord[]>;
     emitEvent(project: string, event: ControlEvent): Promise<void>;
     closeCodexThread(taskId: string): Promise<void>;
+    /** Injectable for tests; defaults to a real delay. */
+    sleep?: (ms: number) => Promise<void>;
   },
 ): Promise<void> {
+  const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
   // resolveCaptainWorkspace already validated the project exists; reload for its
   // root path so we can tell a worktree crew (cwd != root) from a root crew.
   const projRoot = loadConfig().projects[project]?.path;
@@ -542,21 +552,34 @@ export async function runCrewClose(
   // its own worktree (cwd recorded by the daemon differs from the root checkout).
   let worktreeCwd: string | undefined;
   try {
-    const tasks = await deps.listTasks(project);
-    const task = tasks.find((t) => t.name === name);
-    if (task) {
-      taskId = task.id;
-      if (task.cwd && projRoot && task.cwd !== projRoot) {
-        worktreeCwd = task.cwd;
+    let matches = (await deps.listTasks(project)).filter((t) => t.name === name);
+    // #513: the record may not be registered yet (close raced spawn's own
+    // dispatch). Retry briefly before concluding this crew has no daemon task.
+    for (let attempt = 0; attempt < CLOSE_LOOKUP_RETRIES && matches.length === 0; attempt++) {
+      await sleep(CLOSE_LOOKUP_RETRY_DELAY_MS);
+      matches = (await deps.listTasks(project)).filter((t) => t.name === name);
+    }
+    if (matches.length > 0) {
+      // #513: a name can match more than one record (e.g. an orphaned record
+      // left by a prior close that raced dispatch, followed by a same-name
+      // respawn). Terminalize every non-terminal match so none linger to fire
+      // a phantom CREW STALLED/IDLE later. Reap/worktree cleanup below anchors
+      // on the most-recently-dispatched match — the one the live pane belongs to.
+      const primary = matches.reduce((a, b) => ((b.createdAt ?? 0) > (a.createdAt ?? 0) ? b : a));
+      taskId = primary.id;
+      if (primary.cwd && projRoot && primary.cwd !== projRoot) {
+        worktreeCwd = primary.cwd;
       }
-      if (!TERMINAL_STATES.has(task.state)) {
-        await deps.emitEvent(project, { type: "task.cancelled", id: task.id, reason: "closed by captain" });
-      }
-      // Codex teardown: the pane only hosts the `crew attach` renderer; the thread
-      // (and its per-thread MCP servers) live on the shared app-server, so closing
-      // the pane alone leaks them. Tell the daemon to archive the thread.
-      if (task.provider === "codex") {
-        await deps.closeCodexThread(task.id);
+      for (const task of matches) {
+        if (!TERMINAL_STATES.has(task.state)) {
+          await deps.emitEvent(project, { type: "task.cancelled", id: task.id, reason: "closed by captain" });
+        }
+        // Codex teardown: the pane only hosts the `crew attach` renderer; the thread
+        // (and its per-thread MCP servers) live on the shared app-server, so closing
+        // the pane alone leaks them. Tell the daemon to archive the thread.
+        if (task.provider === "codex") {
+          await deps.closeCodexThread(task.id);
+        }
       }
     }
   } catch {

--- a/packages/core/src/daemon/__tests__/liveness-tick.test.ts
+++ b/packages/core/src/daemon/__tests__/liveness-tick.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { LivenessRegistry } from "../liveness-registry.js";
 import { runLivenessTick } from "../delivery-loop.js";
+import { deriveCaptainState } from "../../liveness.js";
 import type { RuntimeLivenessRecord } from "@squadrant/shared";
 
 const memReg = () => new LivenessRegistry({ path: "/x/l.json", readFile: () => undefined, writeFile: () => {} });
@@ -91,5 +92,35 @@ describe("runLivenessTick", () => {
     await expect(
       runLivenessTick({ registry: reg, liveness: async () => [rec], isPidAlive: () => true, now: () => 5_000 }),
     ).resolves.toBeUndefined();
+  });
+
+  // ── #527: multiple cmux sessions sharing a project cwd ─────────────────
+
+  it("two records same project, DEAD pid iterated LAST → picks alive (regression for #527)", async () => {
+    const reg = memReg();
+    const live: RuntimeLivenessRecord = { role: "captain", project: "p", pid: 100, sessionId: "s1", present: true };
+    const dead: RuntimeLivenessRecord = { role: "captain", project: "p", pid: 200, sessionId: "s2", present: true, isRestorable: true };
+    await runLivenessTick({
+      registry: reg,
+      liveness: async () => [live, dead],
+      isPidAlive: (pid) => pid === 100,
+      now: () => 5_000,
+    });
+    expect(reg.get("p")?.pidAlive).toBe(true);
+    expect(deriveCaptainState(reg.get("p"))).toBe("alive");
+  });
+
+  it("two records same project, both pids dead → captain gone", async () => {
+    const reg = memReg();
+    const dead1: RuntimeLivenessRecord = { role: "captain", project: "p", pid: 100, sessionId: "s1", present: true, isRestorable: true };
+    const dead2: RuntimeLivenessRecord = { role: "captain", project: "p", pid: 200, sessionId: "s2", present: true, isRestorable: true };
+    await runLivenessTick({
+      registry: reg,
+      liveness: async () => [dead1, dead2],
+      isPidAlive: () => false,
+      now: () => 5_000,
+    });
+    expect(reg.get("p")?.pidAlive).toBe(false);
+    expect(deriveCaptainState(reg.get("p"))).toBe("gone");
   });
 });

--- a/packages/core/src/daemon/delivery-loop.ts
+++ b/packages/core/src/daemon/delivery-loop.ts
@@ -74,21 +74,33 @@ export async function runLivenessTick(deps: LivenessTickDeps): Promise<void> {
   try { records = await deps.liveness(); } catch { return; } // runtime unreachable → leave registry as-is
   const seen = new Set<string>();
 
+  // #527: multiple cmux sessions can share a cwd, producing duplicate project
+  // entries. Group by project and pick one winner to avoid last-write-wins
+  // collision (dead pid overwriting live).
+  const byProject = new Map<string, RuntimeLivenessRecord[]>();
   for (const r of records) {
     if (r.role !== "captain") continue;
-    seen.add(r.project);
+    let arr = byProject.get(r.project);
+    if (!arr) { arr = []; byProject.set(r.project, arr); }
+    arr.push(r);
+  }
+
+  for (const [project, recs] of byProject) {
+    seen.add(project);
+    // Prefer pidAlive===true (or pid:null hibernated), then first in order.
+    const winner = recs.find(r => r.pid == null || deps.isPidAlive(r.pid)) ?? recs[0];
     const entry: LivenessEntry = {
-      project: r.project, role: "captain", pid: r.pid, sessionId: r.sessionId,
+      project, role: "captain", pid: winner.pid, sessionId: winner.sessionId,
       startedAt: now, lastState: "start", lastSeenAt: now,
-      pidAlive: r.pid != null ? deps.isPidAlive(r.pid) : true, // pid:null hibernated → alive-unknown
+      pidAlive: winner.pid != null ? deps.isPidAlive(winner.pid) : true,
       source: "runtime",
     };
     // Preserve original startedAt if we already knew this captain (avoid churn):
-    const prev = deps.registry.get(r.project);
+    const prev = deps.registry.get(project);
     if (prev && prev.lastState === "start") entry.startedAt = prev.startedAt;
     deps.registry.apply(entry);
-    if (r.pid != null) deps.registry.setPidAlive(r.project, deps.isPidAlive(r.pid), now);
-    logEntry(deps.log, r.project, deps.registry.get(r.project));
+    if (winner.pid != null) deps.registry.setPidAlive(project, deps.isPidAlive(winner.pid), now);
+    logEntry(deps.log, project, deps.registry.get(project));
   }
 
   // Captains we knew but the snapshot no longer lists → clean close.

--- a/packages/core/src/daemon/delivery-loop.ts
+++ b/packages/core/src/daemon/delivery-loop.ts
@@ -202,11 +202,14 @@ export function createDelivery(
       ...Object.keys(cfg.projects ?? {}),
       ...Object.keys(injectedSurfaces),
       ...store.listAll().map((t) => t.project),
+      cfg.commandName,
     ])];
 
     for (const project of allProjects) {
       const projCfg = cfg.projects?.[project];
-      const captainTitle = projCfg?.captainName ?? `${project}-captain`;
+      const captainTitle = project === cfg.commandName 
+        ? cfg.commandName 
+        : (projCfg?.captainName ?? `${project}-captain`);
 
       // Surface discovery is ONLY for the delivery target (where to cmux.send);
       // captain presence/liveness authority now lives in livenessRegistry.
@@ -241,11 +244,17 @@ export function createDelivery(
           // undelivered CREW DONE must reach the captain even after a daemon
           // restart >5min after enqueue. Non-terminal backlog suppression stays.
           if (!TERMINAL_KINDS.has(entry.kind)) {
-            log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=stale-skipped`);
-            await writeCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER, lastAckedSeq: entry.seq });
-            continue;
+            // #531: exempt non-daemon captain.message (human/cli) from stale-skip
+            const isExemptMessage = entry.kind === "captain.message" && entry.payload?.source !== "daemon";
+            if (!isExemptMessage) {
+              log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=stale-skipped`);
+              await writeCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER, lastAckedSeq: entry.seq });
+              continue;
+            }
+            log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=stale-exempt-deliver`);
+          } else {
+            log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=stale-terminal-deliver`);
           }
-          log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=stale-terminal-deliver`);
         }
         const result = await d.deliver(entry, (text, sendOpts) =>
           cmux.send(surface!, text, sendOpts),

--- a/packages/core/src/daemon/reduce.ts
+++ b/packages/core/src/daemon/reduce.ts
@@ -172,7 +172,15 @@ function formatMessage(rec: TaskRecord, event?: ControlEvent): string | null {
       return `CREW STALLED ${tag}: no heartbeat in ${rec.heartbeatBudgetMs}ms`;
     }
     case "awaiting-input":
-      return `CREW IDLE ${tag}: turn ended / awaiting your input — review and reply or close.`;
+      // #522: 'awaiting-input' is reached ONLY via a genuine turn-boundary event
+      // (task.turn.completed — see state-machine.ts) — there is no separate
+      // watchdog-derived path into this state (the old wall-clock idle flip was
+      // retired by #354; evaluateStall never produces 'awaiting-input'). So this
+      // always means "the crew deliberately ended its turn", including the
+      // common case of a long-lived crew pausing between sequential subtasks.
+      // The former "review and reply or close" phrasing read like a possible
+      // fault and forced a spot-check every time; state calmly instead.
+      return `CREW IDLE ${tag}: turn ended, awaiting your reply.`;
     default:
       return null;
   }

--- a/packages/core/src/daemon/start.ts
+++ b/packages/core/src/daemon/start.ts
@@ -21,7 +21,9 @@ const CURSOR_SUBSCRIBER = "captain";
 const SNAPSHOT_LOG_WINDOW_MS = 60 * 60 * 1000;
 
 export interface DaemonHandle {
-  stop(): Promise<void>;
+  /** `reason` is folded into the exit log line (e.g. "SIGTERM", "SIGINT") so a
+   *  restart is diagnosable from the log instead of inferred (#535). */
+  stop(reason?: string): Promise<void>;
   tickDelivery: (() => Promise<void>) | undefined;
   tickProbe: (() => Promise<void>) | undefined;
 }
@@ -216,7 +218,9 @@ export function startDaemon(ctx: DaemonContext, opts: SquadrantdOpts, pkgVersion
   // ── Server + timers ───────────────────────────────────────────────────────
 
   const server = createServer(ctx, { buildHealth, gatherSnapshotInputs, cancelPromotionsFor, broadcast });
-  log(`started pid=${process.pid} sock=${ctx.sockPath} stateRoot=${stateRoot}`);
+  // #535: greppable boot marker — a restart must be diagnosable from the log,
+  // never inferred from process START time.
+  log(`boot pid=${process.pid} version=${pkgVersion} socket=${ctx.sockPath} stateRoot=${stateRoot}`);
 
   let deliveryTick: (() => Promise<void>) | undefined = initialDeliveryTick;
   let probeTick: (() => Promise<void>) | undefined;
@@ -280,7 +284,10 @@ export function startDaemon(ctx: DaemonContext, opts: SquadrantdOpts, pkgVersion
   }
 
   return {
-    stop(): Promise<void> {
+    stop(reason = "requested"): Promise<void> {
+      // #535: write the exit marker synchronously, before any async
+      // teardown, so it lands even if the caller doesn't await this promise.
+      log(`exit pid=${process.pid} reason=${reason}`);
       if (deliveryTimer) clearInterval(deliveryTimer);
       if (probeTimer) clearInterval(probeTimer);
       if (timer) clearInterval(timer);
@@ -289,7 +296,7 @@ export function startDaemon(ctx: DaemonContext, opts: SquadrantdOpts, pkgVersion
       try { ctx.telegramBridge?.stop(); } catch { /* best-effort */ }
       try { ctx.codexDriver.stop?.(); } catch { /* best-effort */ }
       for (const kill of ctx.activeHeadlessKills) kill();
-      return new Promise<void>((resolve) => server.close(() => { log("stopped"); resolve(); }));
+      return new Promise<void>((resolve) => server.close(() => { log(`exit-complete pid=${process.pid}`); resolve(); }));
     },
     tickDelivery: deliveryTick,
     tickProbe: probeTick,

--- a/packages/core/src/launch-workspace.ts
+++ b/packages/core/src/launch-workspace.ts
@@ -178,6 +178,13 @@ export interface LaunchOneOpts {
   cwd: string;
   /** Honour the --fresh CLI flag when true. */
   forceFreshOverride?: boolean;
+  /**
+   * Honour the --keep CLI flag when true: suppress the "new day" and
+   * "template instructions updated" auto-fresh reasons so the session
+   * resumes. Never suppresses "first launch" — there is no session to
+   * resume yet.
+   */
+  keepOverride?: boolean;
   sessionsPath: string;
   templatesDir: string;
   /**
@@ -212,7 +219,9 @@ export async function launchOneWorkspace(opts: LaunchOneOpts): Promise<void> {
       sessionsPath: opts.sessionsPath,
       templatesDir: opts.templatesDir,
     });
-    if (auto.fresh) {
+    if (auto.fresh && opts.keepOverride && auto.reason !== "first launch") {
+      opts.onFreshReason?.(`keeping previous session (--keep) despite: ${auto.reason}`);
+    } else if (auto.fresh) {
       opts.onFreshReason?.(auto.reason ?? "starting fresh");
       forceFresh = true;
     }

--- a/packages/core/src/mailbox.ts
+++ b/packages/core/src/mailbox.ts
@@ -151,7 +151,7 @@ export async function appendCaptainMessage(opts: {
   stateRoot: string;
   project: string;
   text: string;
-  source: "telegram" | "daemon";
+  source: "telegram" | "daemon" | "cli";
 }): Promise<void> {
   await appendEntry(opts.stateRoot, opts.project, (seq) => ({
     seq,

--- a/packages/core/src/mailbox.ts
+++ b/packages/core/src/mailbox.ts
@@ -151,7 +151,7 @@ export async function appendCaptainMessage(opts: {
   stateRoot: string;
   project: string;
   text: string;
-  source: "telegram";
+  source: "telegram" | "daemon";
 }): Promise<void> {
   await appendEntry(opts.stateRoot, opts.project, (seq) => ({
     seq,

--- a/packages/core/src/telegram/bridge.ts
+++ b/packages/core/src/telegram/bridge.ts
@@ -45,7 +45,7 @@ export interface TelegramBridgeOptions {
   /** Root for per-project override files. Defaults to ~/.config/squadrant. */
   configRoot?: string;
   client: TelegramClient;
-  appendCaptainMessage: (a: { stateRoot: string; project: string; text: string; source: "telegram" }) => Promise<void>;
+  appendCaptainMessage: (a: { stateRoot: string; project: string; text: string; source: "telegram" | "daemon" | "cli" }) => Promise<void>;
   log: (msg: string) => void;
   // ── Control surfaces (#402/#403/#321) — all optional. When undefined the bridge
   // keeps exact v1 behavior (queue-only project topics, General topic dropped).

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -120,6 +120,9 @@ export interface SquadrantConfig {
     /** #317 global crew tokenomics dial. Absent ⇒ "balance" (today's behavior).
      *  Biases the captain toward stronger ("max") or cheaper ("low") crew models. */
     effort?: "max" | "balance" | "low";
+    /** #536 startup npm-registry update check. Default true (absent ⇒ enabled);
+     *  set false to opt out. NO_UPDATE_NOTIFIER env var also opts out. */
+    updateCheck?: boolean;
   };
   metrics: {
     enabled: boolean;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -14,6 +14,7 @@ export * from "./lib/cmux-probe.js";
 export * from "./lib/compat-manifest.js";
 export * from "./lib/config-drift.js";
 export * from "./lib/config-version.js";
+export * from "./lib/update-check.js";
 export * from "./lib/git-worktree.js";
 export * from "./lib/resolve-text-input.js";
 export * from "./lib/runtime-sync.js";

--- a/packages/shared/src/lib/__tests__/update-check.test.ts
+++ b/packages/shared/src/lib/__tests__/update-check.test.ts
@@ -1,0 +1,370 @@
+import { EventEmitter } from "node:events";
+import { describe, it, expect, vi } from "vitest";
+
+const httpsGetMock = vi.fn();
+vi.mock("node:https", () => ({
+  default: { get: (...args: unknown[]) => httpsGetMock(...args) },
+  get: (...args: unknown[]) => httpsGetMock(...args),
+}));
+
+const { isNewerVersion, isCacheStale, isUpdateCheckDisabled, formatUpdateNotice, fetchLatestVersion, checkForUpdate, notifyIfUpdateAvailable, UPDATE_CHECK_STATE_PATH } = await import(
+  "../update-check.js"
+);
+
+function makeSocket() {
+  const socket = new EventEmitter() as EventEmitter & { unref: () => void };
+  socket.unref = vi.fn();
+  return socket;
+}
+
+function makeReq() {
+  const req = new EventEmitter() as EventEmitter & { setTimeout: (...a: unknown[]) => void; destroy: () => void };
+  req.setTimeout = vi.fn();
+  req.destroy = vi.fn(() => req.emit("error", new Error("destroyed")));
+  return req;
+}
+
+function makeRes(statusCode: number) {
+  const res = new EventEmitter() as EventEmitter & { statusCode: number; setEncoding: (...a: unknown[]) => void; resume: () => void };
+  res.statusCode = statusCode;
+  res.setEncoding = vi.fn();
+  res.resume = vi.fn();
+  return res;
+}
+
+describe("isNewerVersion", () => {
+  it("is true when latest is ahead", () => {
+    expect(isNewerVersion("0.16.0", "0.15.0")).toBe(true);
+    expect(isNewerVersion("1.0.0", "0.15.0")).toBe(true);
+    expect(isNewerVersion("0.15.1", "0.15.0")).toBe(true);
+  });
+
+  it("is false when up to date or behind", () => {
+    expect(isNewerVersion("0.15.0", "0.15.0")).toBe(false);
+    expect(isNewerVersion("0.14.9", "0.15.0")).toBe(false);
+  });
+});
+
+describe("formatUpdateNotice", () => {
+  it("renders the one-line actionable notice", () => {
+    expect(formatUpdateNotice("0.16.0", "0.15.0")).toBe(
+      "⬆ squadrant 0.16.0 available (you have 0.15.0) — npm i -g squadrant@latest",
+    );
+  });
+});
+
+describe("isCacheStale", () => {
+  const now = 1_700_000_000_000;
+  const dayMs = 24 * 60 * 60 * 1000;
+  const hourMs = 60 * 60 * 1000;
+
+  it("is stale when no state exists", () => {
+    expect(isCacheStale(undefined, now)).toBe(true);
+  });
+
+  it("is fresh within the 24h success interval", () => {
+    expect(isCacheStale({ lastChecked: now - 1000 }, now)).toBe(false);
+  });
+
+  it("is stale once the 24h success interval has elapsed", () => {
+    expect(isCacheStale({ lastChecked: now - dayMs }, now)).toBe(true);
+  });
+
+  it("uses the shorter 1h backoff after a failed check, not the 24h success interval", () => {
+    const state = { lastChecked: now - (hourMs + 1000), lastCheckFailed: true };
+    expect(isCacheStale(state, now)).toBe(true);
+    expect(isCacheStale({ ...state, lastChecked: now - 1000 }, now)).toBe(false);
+    // Same age would still be "fresh" under the 24h success interval — confirms the
+    // failure path is really using the shorter window, not accidentally reusing 24h.
+    expect(isCacheStale({ lastChecked: now - (hourMs + 1000) }, now)).toBe(false);
+  });
+});
+
+describe("isUpdateCheckDisabled", () => {
+  it("is false by default", () => {
+    expect(isUpdateCheckDisabled(undefined, {})).toBe(false);
+  });
+
+  it("honours defaults.updateCheck === false", () => {
+    expect(isUpdateCheckDisabled({ defaults: { updateCheck: false } as any }, {})).toBe(true);
+  });
+
+  it("honours NO_UPDATE_NOTIFIER env var", () => {
+    expect(isUpdateCheckDisabled(undefined, { NO_UPDATE_NOTIFIER: "1" })).toBe(true);
+  });
+});
+
+describe("fetchLatestVersion (injected requestFn contract)", () => {
+  it("returns the version on a successful response", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ version: "0.16.0" });
+    await expect(fetchLatestVersion(fetchImpl as any, 1000)).resolves.toBe("0.16.0");
+  });
+
+  it("returns null when the request resolves null (non-200 upstream)", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(null);
+    await expect(fetchLatestVersion(fetchImpl as any, 1000)).resolves.toBeNull();
+  });
+
+  it("returns null fast when the request throws (offline)", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("network down"));
+    const start = performance.now();
+    await expect(fetchLatestVersion(fetchImpl as any, 1000)).resolves.toBeNull();
+    expect(performance.now() - start).toBeLessThan(500);
+  });
+
+  it("returns null fast when the request hangs past the timeout, regardless of requestFn behavior", async () => {
+    const fetchImpl = vi.fn().mockImplementation(() => new Promise(() => {})); // never resolves
+    const start = performance.now();
+    await expect(fetchLatestVersion(fetchImpl as any, 50)).resolves.toBeNull();
+    expect(performance.now() - start).toBeLessThan(1000);
+  });
+});
+
+describe("fetchLatestVersion (real node:https transport)", () => {
+  it("parses the version from a 200 response", async () => {
+    const req = makeReq();
+    const res = makeRes(200);
+    httpsGetMock.mockImplementation((_url: string, _opts: unknown, cb: (res: unknown) => void) => {
+      queueMicrotask(() => {
+        cb(res);
+        res.emit("data", JSON.stringify({ version: "0.16.0" }));
+        res.emit("end");
+      });
+      return req;
+    });
+    await expect(fetchLatestVersion(undefined, 1000)).resolves.toBe("0.16.0");
+  });
+
+  it("resolves null and drains the response on a non-200 status", async () => {
+    const req = makeReq();
+    const res = makeRes(404);
+    httpsGetMock.mockImplementation((_url: string, _opts: unknown, cb: (res: unknown) => void) => {
+      queueMicrotask(() => cb(res));
+      return req;
+    });
+    await expect(fetchLatestVersion(undefined, 1000)).resolves.toBeNull();
+    expect(res.resume).toHaveBeenCalled();
+  });
+
+  it("resolves null when the request errors", async () => {
+    const req = makeReq();
+    httpsGetMock.mockImplementation(() => {
+      queueMicrotask(() => req.emit("error", new Error("ENOTFOUND")));
+      return req;
+    });
+    await expect(fetchLatestVersion(undefined, 1000)).resolves.toBeNull();
+  });
+
+  it("unrefs the socket (not the request — ClientRequest itself has no unref()) so a hung connection can never hold the process open", async () => {
+    const req = makeReq(); // never invokes the response callback — simulates a stalled connection
+    const socket = makeSocket();
+    httpsGetMock.mockImplementation(() => {
+      queueMicrotask(() => req.emit("socket", socket));
+      return req;
+    });
+
+    const start = performance.now();
+    await expect(fetchLatestVersion(undefined, 50)).resolves.toBeNull();
+    expect(performance.now() - start).toBeLessThan(500);
+    expect(socket.unref).toHaveBeenCalled();
+  });
+});
+
+describe("checkForUpdate", () => {
+  const now = 1_700_000_000_000;
+
+  it("prints a notice when behind and persists the fresh check", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ version: "0.16.0" });
+    const outcome = await checkForUpdate({ currentVersion: "0.15.0", state: undefined, now, fetchImpl: fetchImpl as any });
+    expect(outcome.notice).toContain("0.16.0 available (you have 0.15.0)");
+    expect(outcome.newState).toEqual({ lastChecked: now, latestKnown: "0.16.0", lastCheckFailed: false });
+  });
+
+  it("is silent when already up to date", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ version: "0.15.0" });
+    const outcome = await checkForUpdate({ currentVersion: "0.15.0", state: undefined, now, fetchImpl: fetchImpl as any });
+    expect(outcome.notice).toBeNull();
+    expect(outcome.newState).toEqual({ lastChecked: now, latestKnown: "0.15.0", lastCheckFailed: false });
+  });
+
+  it("is silent and fast when the registry is unreachable, and caches the failure", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("offline"));
+    const start = performance.now();
+    const outcome = await checkForUpdate({ currentVersion: "0.15.0", state: undefined, now, fetchImpl: fetchImpl as any });
+    expect(performance.now() - start).toBeLessThan(500);
+    expect(outcome.notice).toBeNull();
+    expect(outcome.newState).toEqual({ lastChecked: now, lastCheckFailed: true });
+  });
+
+  it("makes no network call on a cache hit", async () => {
+    const fetchImpl = vi.fn();
+    const outcome = await checkForUpdate({
+      currentVersion: "0.15.0",
+      state: { lastChecked: now - 1000, latestKnown: "0.16.0" },
+      now,
+      fetchImpl: fetchImpl as any,
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(outcome.notice).toContain("0.16.0 available");
+    expect(outcome.newState).toBeNull();
+  });
+
+  it("cache hit stays silent when the cached version is not newer", async () => {
+    const fetchImpl = vi.fn();
+    const outcome = await checkForUpdate({
+      currentVersion: "0.15.0",
+      state: { lastChecked: now - 1000, latestKnown: "0.15.0" },
+      now,
+      fetchImpl: fetchImpl as any,
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(outcome.notice).toBeNull();
+  });
+
+  it("a second check shortly after a failure makes no network call (failure backoff, not just success cache)", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("offline"));
+    const first = await checkForUpdate({ currentVersion: "0.15.0", state: undefined, now, fetchImpl: fetchImpl as any });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    const tenMinutesLater = now + 10 * 60 * 1000;
+    const second = await checkForUpdate({
+      currentVersion: "0.15.0",
+      state: first.newState!,
+      now: tenMinutesLater,
+      fetchImpl: fetchImpl as any,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1); // still 1 — no new network call
+    expect(second.notice).toBeNull();
+    expect(second.newState).toBeNull();
+  });
+
+  it("retries after the failure backoff window elapses", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ version: "0.16.0" });
+    const failedState = { lastChecked: now, lastCheckFailed: true };
+    const anHourAndAMinuteLater = now + 61 * 60 * 1000;
+    const outcome = await checkForUpdate({
+      currentVersion: "0.15.0",
+      state: failedState,
+      now: anHourAndAMinuteLater,
+      fetchImpl: fetchImpl as any,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(outcome.notice).toContain("0.16.0 available");
+  });
+});
+
+describe("notifyIfUpdateAvailable", () => {
+  const now = 1_700_000_000_000;
+
+  it("writes state and prints the notice when behind", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ version: "0.16.0" });
+    const readState = vi.fn().mockReturnValue(undefined);
+    const writeState = vi.fn();
+    const write = vi.fn();
+
+    await notifyIfUpdateAvailable({
+      config: undefined,
+      currentVersion: "0.15.0",
+      env: {},
+      fetchImpl: fetchImpl as any,
+      readState,
+      writeState,
+      write,
+      now,
+    });
+
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write.mock.calls[0][0]).toContain("0.16.0 available");
+    expect(writeState).toHaveBeenCalledWith({ lastChecked: now, latestKnown: "0.16.0", lastCheckFailed: false }, UPDATE_CHECK_STATE_PATH);
+  });
+
+  it("honours config opt-out with zero network calls", async () => {
+    const fetchImpl = vi.fn();
+    const write = vi.fn();
+    await notifyIfUpdateAvailable({
+      config: { defaults: { updateCheck: false } as any },
+      currentVersion: "0.15.0",
+      env: {},
+      fetchImpl: fetchImpl as any,
+      readState: vi.fn(),
+      writeState: vi.fn(),
+      write,
+      now,
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("honours NO_UPDATE_NOTIFIER env opt-out with zero network calls", async () => {
+    const fetchImpl = vi.fn();
+    const write = vi.fn();
+    await notifyIfUpdateAvailable({
+      config: undefined,
+      currentVersion: "0.15.0",
+      env: { NO_UPDATE_NOTIFIER: "1" },
+      fetchImpl: fetchImpl as any,
+      readState: vi.fn(),
+      writeState: vi.fn(),
+      write,
+      now,
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("an offline machine makes no network call on the very next invocation", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("offline"));
+    let persisted: unknown;
+    const writeState = vi.fn((state) => {
+      persisted = state;
+    });
+    const readState = vi.fn(() => persisted as any);
+    const write = vi.fn();
+
+    await notifyIfUpdateAvailable({
+      config: undefined,
+      currentVersion: "0.15.0",
+      env: {},
+      fetchImpl: fetchImpl as any,
+      readState,
+      writeState,
+      write,
+      now,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    await notifyIfUpdateAvailable({
+      config: undefined,
+      currentVersion: "0.15.0",
+      env: {},
+      fetchImpl: fetchImpl as any,
+      readState,
+      writeState,
+      write,
+      now: now + 5 * 60 * 1000, // 5 minutes later — still well within the 1h failure backoff
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1); // no second network call
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("never throws even if fetch and state I/O blow up", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("boom"));
+    const readState = vi.fn().mockImplementation(() => {
+      throw new Error("fs boom");
+    });
+    await expect(
+      notifyIfUpdateAvailable({
+        config: undefined,
+        currentVersion: "0.15.0",
+        env: {},
+        fetchImpl: fetchImpl as any,
+        readState,
+        writeState: vi.fn(),
+        write: vi.fn(),
+        now,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/shared/src/lib/update-check.ts
+++ b/packages/shared/src/lib/update-check.ts
@@ -1,0 +1,206 @@
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import https from "node:https";
+import type { SquadrantConfig } from "../config.js";
+
+export interface UpdateCheckState {
+  lastChecked?: number;
+  latestKnown?: string;
+  /** Set when the most recent check attempt failed (offline/timeout). Drives a shorter
+   *  FAILURE_RETRY_MS backoff instead of the full 24h success interval, so an offline
+   *  machine retries roughly hourly instead of hitting the registry on every invocation. */
+  lastCheckFailed?: boolean;
+}
+
+export interface CheckForUpdateOutcome {
+  notice: string | null;
+  /** New state to persist, or null when nothing changed (opt-out / cache hit). */
+  newState: UpdateCheckState | null;
+}
+
+export const UPDATE_CHECK_STATE_PATH = path.join(os.homedir(), ".config", "squadrant", "update-check.json");
+
+const REGISTRY_URL = "https://registry.npmjs.org/squadrant/latest";
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const FAILURE_RETRY_MS = 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 1500;
+
+export type RegistryRequest = (url: string, timeoutMs: number) => Promise<unknown>;
+
+/**
+ * Fetches over node:https rather than global fetch(): a fetch() Promise exposes no
+ * handle to detach from the event loop, so a pending request left ref'd would delay
+ * process exit by up to timeoutMs on every single invocation of an offline machine.
+ * http.ClientRequest itself has no unref() — the socket does, assigned asynchronously
+ * via the 'socket' event — so we unref that once it's available. This is Node's
+ * documented mechanism for exactly this: it lets the process exit immediately once
+ * the CLI's own work is done, dropping the response if it arrives after. That's fine:
+ * this check is a best-effort background notice, never something exit should wait on.
+ */
+const requestJson: RegistryRequest = (url, timeoutMs) =>
+  new Promise((resolve) => {
+    const req = https.get(url, { headers: { "user-agent": "squadrant-update-check" } }, (res) => {
+      if (res.statusCode !== 200) {
+        res.resume();
+        resolve(null);
+        return;
+      }
+      let body = "";
+      res.setEncoding("utf-8");
+      res.on("data", (chunk) => (body += chunk));
+      res.on("end", () => {
+        try {
+          resolve(JSON.parse(body));
+        } catch {
+          resolve(null);
+        }
+      });
+    });
+    req.on("socket", (socket) => socket.unref());
+    req.setTimeout(timeoutMs, () => req.destroy());
+    req.on("error", () => resolve(null));
+  });
+
+export function isUpdateCheckDisabled(
+  config: Pick<SquadrantConfig, "defaults"> | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (env.NO_UPDATE_NOTIFIER) return true;
+  return config?.defaults?.updateCheck === false;
+}
+
+export function isCacheStale(
+  state: UpdateCheckState | undefined,
+  now: number,
+  intervalMs = CHECK_INTERVAL_MS,
+  failureIntervalMs = FAILURE_RETRY_MS,
+): boolean {
+  if (!state?.lastChecked) return true;
+  return now - state.lastChecked >= (state.lastCheckFailed ? failureIntervalMs : intervalMs);
+}
+
+export function isNewerVersion(latest: string, current: string): boolean {
+  const parse = (v: string) => v.trim().replace(/^v/, "").split("-")[0].split(".").map((n) => Number(n) || 0);
+  const [la = 0, lb = 0, lc = 0] = parse(latest);
+  const [ca = 0, cb = 0, cc = 0] = parse(current);
+  if (la !== ca) return la > ca;
+  if (lb !== cb) return lb > cb;
+  return lc > cc;
+}
+
+export function formatUpdateNotice(latest: string, current: string): string {
+  return `⬆ squadrant ${latest} available (you have ${current}) — npm i -g squadrant@latest`;
+}
+
+/**
+ * Queries the npm registry directly (never the `npm view` CDN — see the v0.13.1 incident).
+ * Never throws. Races the request against its own unref'd timer, so the *logical* result
+ * is always bounded by timeoutMs regardless of how requestFn behaves — real network
+ * failures are additionally handled by requestJson's own req.unref()/setTimeout, which
+ * guarantees the underlying resource can never hold the process open either.
+ */
+export async function fetchLatestVersion(
+  requestFn: RegistryRequest = requestJson,
+  timeoutMs: number = FETCH_TIMEOUT_MS,
+): Promise<string | null> {
+  const timeout = new Promise<null>((resolve) => {
+    const timer = setTimeout(() => resolve(null), timeoutMs);
+    timer.unref?.();
+  });
+
+  const request = (async (): Promise<string | null> => {
+    try {
+      const data = (await requestFn(REGISTRY_URL, timeoutMs)) as { version?: unknown } | null;
+      return typeof data?.version === "string" ? data.version : null;
+    } catch {
+      return null;
+    }
+  })();
+
+  return Promise.race([request, timeout]);
+}
+
+/** Pure decision core: given cache state and an injected request function, decides whether
+ *  to print a notice and what state to persist. No filesystem access. */
+export async function checkForUpdate(opts: {
+  currentVersion: string;
+  state: UpdateCheckState | undefined;
+  now: number;
+  fetchImpl?: RegistryRequest;
+  intervalMs?: number;
+  failureIntervalMs?: number;
+  timeoutMs?: number;
+}): Promise<CheckForUpdateOutcome> {
+  if (!isCacheStale(opts.state, opts.now, opts.intervalMs, opts.failureIntervalMs)) {
+    const latest = opts.state?.latestKnown;
+    const notice = latest && isNewerVersion(latest, opts.currentVersion) ? formatUpdateNotice(latest, opts.currentVersion) : null;
+    return { notice, newState: null };
+  }
+
+  const latest = await fetchLatestVersion(opts.fetchImpl, opts.timeoutMs);
+  if (!latest) return { notice: null, newState: { lastChecked: opts.now, lastCheckFailed: true } };
+
+  const newState: UpdateCheckState = { lastChecked: opts.now, latestKnown: latest, lastCheckFailed: false };
+  const notice = isNewerVersion(latest, opts.currentVersion) ? formatUpdateNotice(latest, opts.currentVersion) : null;
+  return { notice, newState };
+}
+
+export function readUpdateCheckState(statePath: string = UPDATE_CHECK_STATE_PATH): UpdateCheckState | undefined {
+  try {
+    return JSON.parse(fs.readFileSync(statePath, "utf-8"));
+  } catch {
+    return undefined;
+  }
+}
+
+export function writeUpdateCheckState(state: UpdateCheckState, statePath: string = UPDATE_CHECK_STATE_PATH): void {
+  try {
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + "\n");
+  } catch {
+    // best-effort cache; a failed write just means we check again next run
+  }
+}
+
+/**
+ * CLI entrypoint wiring: opt-out check, cache read, decision, cache write, notice print —
+ * all in one best-effort call that never throws. Not awaiting this at the call site keeps
+ * it off the command's own logic; the unref'd transport (see requestJson) and the bounded
+ * race in fetchLatestVersion mean a pending check can't delay process exit either, and a
+ * failed attempt is cached (see isCacheStale's failureIntervalMs) so an offline machine
+ * doesn't retry the registry on every single invocation.
+ */
+export async function notifyIfUpdateAvailable(opts: {
+  config: Pick<SquadrantConfig, "defaults"> | undefined;
+  currentVersion: string;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: RegistryRequest;
+  statePath?: string;
+  readState?: (statePath: string) => UpdateCheckState | undefined;
+  writeState?: (state: UpdateCheckState, statePath: string) => void;
+  write?: (line: string) => void;
+  now?: number;
+}): Promise<void> {
+  try {
+    const env = opts.env ?? process.env;
+    if (isUpdateCheckDisabled(opts.config, env)) return;
+
+    const statePath = opts.statePath ?? UPDATE_CHECK_STATE_PATH;
+    const readState = opts.readState ?? readUpdateCheckState;
+    const writeState = opts.writeState ?? writeUpdateCheckState;
+    const write = opts.write ?? ((line: string) => process.stderr.write(`\n${line}\n`));
+
+    const outcome = await checkForUpdate({
+      currentVersion: opts.currentVersion,
+      state: readState(statePath),
+      now: opts.now ?? Date.now(),
+      fetchImpl: opts.fetchImpl,
+    });
+
+    if (outcome.newState) writeState(outcome.newState, statePath);
+    if (outcome.notice) write(outcome.notice);
+  } catch {
+    // update notifications are best-effort and must never affect the CLI
+  }
+}

--- a/packages/workspaces/src/__tests__/crew-pane.test.ts
+++ b/packages/workspaces/src/__tests__/crew-pane.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { sendFirstTurnWhenReady, confirmedSendToPane, resendCrewFirstTurn } from "../crew-pane.js";
+import { sendFirstTurnWhenReady, confirmedSendToPane, resendCrewFirstTurn, paneHasOpenModal } from "../crew-pane.js";
 import type { PaneRef, WorkspaceRef } from "@squadrant/shared";
 
 // Realistic Claude-Code-style screen: the live input box is the region between the
@@ -377,6 +377,86 @@ describe("confirmedSendToPane — follow-up crew send (#448)", () => {
 
     expect(pasteToPane).toHaveBeenCalledTimes(1);
     expect(sendKeyToPane).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── #516: modal-aware crew send ──────────────────────────────────────────────
+// The delivery-path guard (sendToSurface, #484) already refuses to keystroke
+// into an open AskUserQuestion/permission SELECTION MODAL. confirmedSendToPane
+// — the primitive behind captain `crew send` — has no equivalent guard: it
+// pastes the captain's message and unconditionally fires Enter, which the
+// modal reads as "confirm the highlighted (Recommended) option". The captain's
+// message is dropped with no error, and the crew commits to the wrong choice
+// (#516 production incidents on friendslop-factory).
+const MODAL_SCREEN = `…transcript…
+${HR}
+ ☐ Color
+
+Which color do you prefer?
+
+❯ 1. Red
+     Red
+  2. Blue
+     Blue
+  3. Green
+     Green
+  4. Type something.
+${HR}
+  5. Chat about this
+
+Enter to select · ↑/↓ to navigate · Esc to cancel`;
+
+describe("confirmedSendToPane — modal-aware crew send (#516)", () => {
+  let readPaneScreen: ReturnType<typeof vi.fn>;
+  let pasteToPane: ReturnType<typeof vi.fn>;
+  let sendKeyToPane: ReturnType<typeof vi.fn>;
+  const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+  const rt = () => ({ readPaneScreen, pasteToPane, sendKeyToPane });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    readPaneScreen = vi.fn();
+    pasteToPane = vi.fn();
+    sendKeyToPane = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("never keystrokes into an open AskUserQuestion modal — fails loudly instead of confirming the default", async () => {
+    readPaneScreen.mockResolvedValue(MODAL_SCREEN);
+
+    const promise = confirmedSendToPane(rt(), pane, "pick option 2");
+    await vi.advanceTimersByTimeAsync(5000);
+    const result = await promise;
+
+    // The modal's highlighted default must never be auto-confirmed by our Enter.
+    expect(sendKeyToPane).not.toHaveBeenCalled();
+    // The message must never be typed into the picker either.
+    expect(pasteToPane).not.toHaveBeenCalled();
+    // Non-delivery must be distinguishable from an ordinary retry-exhausted
+    // failure so the caller can warn the captain LOUDLY (not the generic
+    // "use crew send to re-send" message).
+    expect(result).toEqual({ delivered: false, blockedByModal: true });
+  });
+});
+
+// #516 review follow-up: runCrewSend needs a side-effect-free precheck it can
+// run BEFORE its daemon-state emit block, so a modal-blocked send never flips
+// task state either. paneHasOpenModal is that precheck — a single read, no
+// pane touch — reusing the same hasModalOptionList detection as the guard above.
+describe("paneHasOpenModal (#516)", () => {
+  it("returns true when the pane shows an open selection modal", async () => {
+    const readPaneScreen = vi.fn().mockResolvedValue(MODAL_SCREEN);
+    const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+    await expect(paneHasOpenModal({ readPaneScreen }, pane)).resolves.toBe(true);
+  });
+
+  it("returns false for an ordinary idle pane", async () => {
+    const readPaneScreen = vi.fn().mockResolvedValue(EMPTY_BOX);
+    const pane: PaneRef = { workspaceId: "w:1", surfaceId: "s:1" };
+    await expect(paneHasOpenModal({ readPaneScreen }, pane)).resolves.toBe(false);
   });
 });
 

--- a/packages/workspaces/src/crew-pane.ts
+++ b/packages/workspaces/src/crew-pane.ts
@@ -6,7 +6,7 @@ import net from "node:net";
 import { loadConfig } from "@squadrant/shared";
 import type { PaneRef, RuntimeDriver } from "@squadrant/shared";
 import { RuntimeRegistry } from "./runtimes/registry.js";
-import { createCmuxDriver, parseDraftFromScreen, hasCCInputBox, classifyStartupSurface } from "./runtimes/cmux.js";
+import { createCmuxDriver, parseDraftFromScreen, hasCCInputBox, hasModalOptionList, classifyStartupSurface } from "./runtimes/cmux.js";
 import { titleFor, isCrewTitle, screenHasSplashMarker } from "@squadrant/core";
 import type { TurnAcceptanceConfig } from "@squadrant/core";
 
@@ -120,6 +120,23 @@ export async function resolveCaptainWorkspace(project: string): Promise<{
 }
 
 /**
+ * #516: cheap, side-effect-free check for an open AskUserQuestion/permission
+ * SELECTION MODAL — a single screen read, no paste, no keystroke. Lets
+ * runCrewSend skip its daemon-state emit (task.reopened/task.started) AND the
+ * pane touch entirely when the crew can't actually receive the message right
+ * now, so a modal-blocked send is a true no-op rather than just skipping the
+ * pane write. confirmedSendToPane keeps its own copy of this check as the
+ * pane-touch backstop for the TOCTOU window between this precheck and delivery.
+ */
+export async function paneHasOpenModal(
+  runtime: Pick<RuntimeDriver, "readPaneScreen">,
+  pane: PaneRef,
+): Promise<boolean> {
+  const screen = (await runtime.readPaneScreen(pane)) ?? "";
+  return hasModalOptionList(screen);
+}
+
+/**
  * Deliver a message to a crew pane with the paste-settle-Enter confirmation
  * sequence from #447. Shared by the follow-up `crew send` path (#448) and
  * available for first-turn use — both call the same submit hardening:
@@ -131,13 +148,24 @@ export async function resolveCaptainWorkspace(project: string): Promise<{
  * Returns `{ delivered: true }` when the box empties after the draft was seen
  * (positive submit confirmation), or `{ delivered: false }` if the retry loop
  * exhausts without confirmation (#466: callers surface non-delivery explicitly).
+ * Returns `{ delivered: false, blockedByModal: true }` without touching the
+ * pane at all when an AskUserQuestion/permission SELECTION MODAL is open (#516).
  */
 export async function confirmedSendToPane(
   runtime: Pick<RuntimeDriver, "readPaneScreen" | "pasteToPane" | "sendKeyToPane">,
   pane: PaneRef,
   message: string,
-): Promise<{ delivered: boolean }> {
+): Promise<{ delivered: boolean; blockedByModal?: boolean }> {
   const preSendScreen = (await runtime.readPaneScreen(pane)) ?? "";
+  // #516: a selection modal renders its highlighted default option ("❯ 1. Red")
+  // in the same HR-bounded region a real draft would occupy, so the settle
+  // loop below can't tell "modal open" apart from "draft present" — sending
+  // Enter here would CONFIRM the modal's default instead of delivering the
+  // captain's message (mirrors the #484 guard on the sendToSurface delivery
+  // path, which has no equivalent here). Never keystroke into it.
+  if (hasModalOptionList(preSendScreen)) {
+    return { delivered: false, blockedByModal: true };
+  }
   await runtime.pasteToPane(pane, message);
   // #455: track whether the paste ever rendered so we don't treat an empty box
   // that was NEVER populated as a successful submit (race: paste still in flight

--- a/packages/workspaces/src/index.ts
+++ b/packages/workspaces/src/index.ts
@@ -9,4 +9,4 @@ export { CmuxStoreSource } from "./cmux-daemon/cmux-store-source.js";
 export type { CmuxStoreSourceOpts } from "./cmux-daemon/cmux-store-source.js";
 export { NativeHookSource, installClaudeHooks, mapSubToLifecycle } from "./native-hooks/native-hook-source.js";
 export type { NativeHookSourceOpts, ClaudeHooksInstallOpts } from "./native-hooks/native-hook-source.js";
-export { getFreePort, listProjectCrews, findCrew, resolveCaptainWorkspace, sendFirstTurnWhenReady, confirmedSendToPane, resendCrewFirstTurn } from "./crew-pane.js";
+export { getFreePort, listProjectCrews, findCrew, resolveCaptainWorkspace, sendFirstTurnWhenReady, confirmedSendToPane, resendCrewFirstTurn, paneHasOpenModal } from "./crew-pane.js";


### PR DESCRIPTION
Cuts **squadrant v0.16.0** off develop (13 commits since v0.15.0).

## Headline
- **`squadrant launch --keep` flag (#534):** mirrors `--fresh` — resume a captain session across day/template boundaries instead of forcing a fresh one.
- **Update notifier (#536):** CLI startup checks npm for a newer squadrant (fire-and-forget, `node:https` + socket `unref()`, 24h cache / 1h failure backoff) and prints one actionable line when behind.

## Also in this release
- Fixes: #538 (`squadrant status` default view showed a live captain as offline), #516 (captain `crew send` could silently confirm an open modal instead of delivering), #527 (racing captain records could flip a live captain to `gone`), #529/#531 (daemon-restart/effort broadcasts and CLI interrupts could clobber an in-progress captain draft — now routed through the mailbox), #513/#522 (crew close/respawn race — zombie task record / false `CREW STALLED`)
- Daemon boot/exit markers (#535)
- Breaking: `squadrant runtime send-key` removed (zero callers; see CHANGELOG for the raw-keypress escape hatch)
- Also restores the `## [0.15.0]` CHANGELOG heading, which a later commit had accidentally dropped, silently folding its entries back into Unreleased

## Verification
- develop is green: 166 files / 2020 tests, clean build (verified prior to this branch; not re-run here — CI will run the full suite on this PR)

On merge, release.yml tags `v0.16.0`, creates the GitHub release from the CHANGELOG, and publishes to npm.