### PR TITLE
Release v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-07-11
+
+### Fixed
+
+- **Crew worktrees silently type-checked and tested against the MAIN checkout instead of their own code (#387):** `git worktree add` never populates `node_modules`, and crew worktrees live nested under `<repoRoot>/.worktrees/`. A worktree with no local `node_modules` does not fail — Node's module resolution silently walks UP past it into the main checkout's `node_modules`. So a crew's `tsc`/`vitest` could resolve workspace packages to the main repo's stale code rather than the crew's own uncommitted changes, and pass. This made crew self-verification unreliable: a TS2339 slipped past every local check and was caught only by CI. `addWorktree()` now installs the worktree's own dependencies immediately on creation, detecting the package manager from the lockfile present (pnpm / yarn / npm / bun), no-opping for non-JS projects, and warning loudly (rather than silently skipping) when a package.json has no lockfile. pnpm was NOT at fault — each worktree correctly carries its own workspace root.
+- **N concurrent crews could starve the machine and take down the cmux control plane (#387):** crews run build/test commands at their own discretion, so there is no central point to queue them. The crew's top-level process is now launched under `nice -n 10`, which every child it forks (tsc, vitest workers) inherits — so a burst of concurrent crew builds degrades gracefully instead of starving cmux and the daemon.
+- **Spotlight indexing exclusion for crew worktrees is now automatic (#387):** the `.metadata_never_index` marker is written to the worktree root on creation (macOS only, best-effort). Previously this was a manual, uncommitted, single-machine mitigation.
+
 ## [0.16.0] - 2026-07-11
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "squadrant",
   "packageManager": "pnpm@10.30.3",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Multi-project orchestration for your coding agents (Claude, Codex, opencode, Gemini)",
   "type": "module",
   "bin": {

--- a/packages/core/src/crew-protocol.ts
+++ b/packages/core/src/crew-protocol.ts
@@ -82,6 +82,23 @@ export function titleFor(project: string, name: string): string {
   return `🔧 ${project}:${name}`;
 }
 
+// #387: crews run arbitrary CPU-heavy commands (npm run build && npm test) at
+// their own discretion — squadrant never sees or controls those invocations,
+// so there's no central point to queue or cap them. `nice` sidesteps that:
+// applied to the crew's top-level CLI process at launch, every child it later
+// forks (tsc, vitest workers, pnpm) inherits the lowered scheduling priority.
+// Under N concurrent crews this keeps the OS scheduler favoring cmux/the
+// daemon's control-plane process over crew compute, so a burst of crew builds
+// slows down instead of starving the process that both crews depend on to stay
+// reachable. NICE_LEVEL 10 is a moderate deprioritization (range -20..19,
+// default 0) — enough to yield under contention without idling crew work when
+// the machine is otherwise quiet.
+const CREW_NICE_LEVEL = 10;
+
+export function niceCrewCommand(cmd: string): string {
+  return `nice -n ${CREW_NICE_LEVEL} ${cmd}`;
+}
+
 export function isCrewTitle(project: string, title: string): boolean {
   return title.startsWith(`🔧 ${project}:`);
 }

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -25,6 +25,7 @@ import { resolveCrewRoute, type CrewRouteResult } from "./crew-routing.js";
 import {
   buildCompletionProtocol,
   shellQuote,
+  niceCrewCommand,
   titleFor,
   isCrewTitle,
   nameFromTitle,
@@ -355,7 +356,7 @@ export async function runCrewSpawn(
     // Prefix the CLI command with env so the hook bridge + signal verb running
     // inside the crew's cmux tab can identify their task.
     const envPrefix = `SQUADRANT_CREW_TASK_ID=${rec.id} SQUADRANT_CREW_PROJECT=${input.project}`;
-    await deps.runtime.sendToPane(pane, `cd ${shellQuote(spawnCwd)} && ${envPrefix} ${cliCommand}`);
+    await deps.runtime.sendToPane(pane, `cd ${shellQuote(spawnCwd)} && ${envPrefix} ${niceCrewCommand(cliCommand)}`);
     const preLaunchScreen = (await deps.runtime.readPaneScreen(pane)) ?? "";
     const claudeResult = await deps.sendFirstTurn(pane, `${firstTurnTask}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen);
     // #466: surface non-delivery explicitly instead of silently returning success.
@@ -409,7 +410,7 @@ export async function runCrewSpawn(
     const title = titleFor(input.project, name);
     const pane = await deps.runtime.newPane({ workspaceId: captain.id, direction, title });
     const envPrefix = `SQUADRANT_CREW_TASK_ID=${rec.id} SQUADRANT_CREW_PROJECT=${input.project}`;
-    await deps.runtime.sendToPane(pane, `cd ${shellQuote(spawnCwd)} && ${envPrefix} OPENCODE_CONFIG=${opencodeConfigPath} ${cliCommand}`);
+    await deps.runtime.sendToPane(pane, `cd ${shellQuote(spawnCwd)} && ${envPrefix} OPENCODE_CONFIG=${opencodeConfigPath} ${niceCrewCommand(cliCommand)}`);
     const preLaunchScreen = (await deps.runtime.readPaneScreen(pane)) ?? "";
     const opencodeResult = await deps.sendFirstTurn(pane, `${firstTurnTask}\n\n${buildCompletionProtocol(rec.id, input.project)}`, preLaunchScreen, {
       // #235: confirm-on-delivery — sendFirstTurnWhenReady polls until the idle
@@ -444,7 +445,7 @@ export async function runCrewSpawn(
   const direction: PanePlacement = input.direction ?? "tab";
   const title = titleFor(input.project, name);
   const pane = await deps.runtime.newPane({ workspaceId: captain.id, direction, title });
-  await deps.runtime.sendToPane(pane, cliCommand);
+  await deps.runtime.sendToPane(pane, niceCrewCommand(cliCommand));
   if (interactive) {
     const preLaunchScreen = (await deps.runtime.readPaneScreen(pane)) ?? "";
     const genericResult = await deps.sendFirstTurn(pane, firstTurnTask, preLaunchScreen);

--- a/packages/shared/src/lib/__tests__/git-worktree.test.ts
+++ b/packages/shared/src/lib/__tests__/git-worktree.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import path from "node:path";
 
 const execFileSyncMock = vi.hoisted(() => vi.fn());
@@ -8,7 +8,43 @@ vi.mock("node:child_process", async (importOriginal) => {
   return { ...merged, default: merged };
 });
 
+// #387: ensureSpotlightExcluded touches the real filesystem (mkdir + marker
+// file) — mock it so addWorktree tests stay hermetic instead of writing into
+// /tmp on a real macOS dev machine.
+const mkdirSyncMock = vi.hoisted(() => vi.fn());
+const existsSyncMock = vi.hoisted(() => vi.fn((_p?: unknown) => false));
+const writeFileSyncMock = vi.hoisted(() => vi.fn());
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  const merged = {
+    ...actual,
+    mkdirSync: mkdirSyncMock,
+    existsSync: existsSyncMock,
+    writeFileSync: writeFileSyncMock,
+  };
+  return { ...merged, default: merged };
+});
+
 import { worktreePath, crewBranch, addWorktree, removeWorktree, resolveWorktreeBase } from "../git-worktree.js";
+
+// #387: addWorktree() runs for every registered project, not just pnpm ones —
+// stub existsSync per project "kind" so installWorktreeDependencies sees the
+// lockfile (or absence of package.json/lockfile) a real project would have.
+function mockProjectFiles(kind: "pnpm" | "yarn" | "npm" | "bun" | "no-lockfile" | "non-js"): void {
+  existsSyncMock.mockReset();
+  existsSyncMock.mockImplementation((p: unknown) => {
+    const s = String(p);
+    if (kind === "non-js") return false;
+    if (s.endsWith("package.json")) return true;
+    switch (kind) {
+      case "pnpm": return s.endsWith("pnpm-lock.yaml");
+      case "yarn": return s.endsWith("yarn.lock");
+      case "npm": return s.endsWith("package-lock.json");
+      case "bun": return s.endsWith("bun.lockb");
+      case "no-lockfile": return false;
+    }
+  });
+}
 
 describe("worktreePath", () => {
   it("resolves <repoRoot>/<worktreeDir>/<project>-<name>", () => {
@@ -31,7 +67,12 @@ describe("crewBranch", () => {
 });
 
 describe("addWorktree", () => {
-  beforeEach(() => execFileSyncMock.mockReset());
+  beforeEach(() => {
+    execFileSyncMock.mockReset();
+    mkdirSyncMock.mockReset();
+    writeFileSyncMock.mockReset();
+    mockProjectFiles("pnpm"); // default: squadrant itself is a pnpm project
+  });
 
   it("runs `git -C <repo> worktree add <path> -b crew/<name> <base>` and returns the path", () => {
     // No existing branch: show-ref throws (not found), worktree add succeeds.
@@ -53,6 +94,44 @@ describe("addWorktree", () => {
       ["-C", "/tmp/brove", "worktree", "add", expectedPath, "-b", "crew/crew-1", "develop"],
       expect.objectContaining({ stdio: "pipe" }),
     );
+  });
+
+  // ── #387: install a real, isolated dependency tree so a crew's own worktree
+  // never silently falls through to the main checkout's node_modules ────────
+
+  it("installs dependencies in the new worktree via `pnpm -C <wt> install --frozen-lockfile`", () => {
+    execFileSyncMock.mockImplementationOnce(() => { throw new Error("not found"); }); // show-ref
+    execFileSyncMock.mockReturnValue(Buffer.from("")); // worktree add, then pnpm install
+
+    const wt = addWorktree({
+      repoRoot: "/tmp/brove",
+      worktreeDir: ".worktrees",
+      project: "brove",
+      name: "crew-1",
+      base: "develop",
+    });
+
+    expect(execFileSyncMock).toHaveBeenLastCalledWith(
+      "pnpm",
+      ["-C", wt, "install", "--frozen-lockfile"],
+      expect.objectContaining({ stdio: "pipe" }),
+    );
+  });
+
+  it("propagates a failed install instead of handing the crew a broken worktree", () => {
+    execFileSyncMock.mockImplementationOnce(() => { throw new Error("not found"); }); // show-ref
+    execFileSyncMock.mockReturnValueOnce(Buffer.from("")); // worktree add
+    execFileSyncMock.mockImplementationOnce(() => { throw new Error("ERR_PNPM_FROZEN_LOCKFILE"); }); // pnpm install
+
+    expect(() =>
+      addWorktree({
+        repoRoot: "/tmp/brove",
+        worktreeDir: ".worktrees",
+        project: "brove",
+        name: "crew-1",
+        base: "develop",
+      }),
+    ).toThrow("ERR_PNPM_FROZEN_LOCKFILE");
   });
 
   // ── #460: stale branch collision handling ──────────────────────────────────
@@ -110,6 +189,129 @@ describe("addWorktree", () => {
       ["-C", "/tmp/brove", "worktree", "add", expectedPath, "-b", "crew/fix-1-2", "develop"],
       expect.objectContaining({ stdio: "pipe" }),
     );
+  });
+});
+
+// ── #387: addWorktree() serves every registered project, not just pnpm ones ─
+
+describe("addWorktree — package manager detection (#387)", () => {
+  beforeEach(() => {
+    execFileSyncMock.mockReset();
+    execFileSyncMock.mockImplementationOnce(() => { throw new Error("not found"); }); // show-ref
+    execFileSyncMock.mockReturnValue(Buffer.from("")); // worktree add, then install
+    mkdirSyncMock.mockReset();
+    writeFileSyncMock.mockReset();
+  });
+
+  it("installs a yarn project via `yarn install --frozen-lockfile`", () => {
+    mockProjectFiles("yarn");
+
+    const wt = addWorktree({ repoRoot: "/tmp/brove", worktreeDir: ".worktrees", project: "brove", name: "crew-1", base: "develop" });
+
+    expect(execFileSyncMock).toHaveBeenLastCalledWith(
+      "yarn",
+      ["install", "--frozen-lockfile"],
+      expect.objectContaining({ cwd: wt, stdio: "pipe" }),
+    );
+  });
+
+  it("installs an npm project via `npm ci`", () => {
+    mockProjectFiles("npm");
+
+    const wt = addWorktree({ repoRoot: "/tmp/brove", worktreeDir: ".worktrees", project: "brove", name: "crew-1", base: "develop" });
+
+    expect(execFileSyncMock).toHaveBeenLastCalledWith(
+      "npm",
+      ["ci"],
+      expect.objectContaining({ cwd: wt, stdio: "pipe" }),
+    );
+  });
+
+  it("installs a bun project via `bun install --frozen-lockfile`", () => {
+    mockProjectFiles("bun");
+
+    const wt = addWorktree({ repoRoot: "/tmp/brove", worktreeDir: ".worktrees", project: "brove", name: "crew-1", base: "develop" });
+
+    expect(execFileSyncMock).toHaveBeenLastCalledWith(
+      "bun",
+      ["install", "--frozen-lockfile"],
+      expect.objectContaining({ cwd: wt, stdio: "pipe" }),
+    );
+  });
+
+  it("skips install for a non-JS project (no package.json) without throwing", () => {
+    mockProjectFiles("non-js");
+
+    expect(() =>
+      addWorktree({ repoRoot: "/tmp/brove", worktreeDir: ".worktrees", project: "brove", name: "crew-1", base: "develop" }),
+    ).not.toThrow();
+
+    const nonGitCalls = execFileSyncMock.mock.calls.filter((c) => c[0] !== "git");
+    expect(nonGitCalls).toHaveLength(0);
+  });
+
+  it("skips install when package.json has no recognized lockfile, without guessing a package manager, but warns on stderr", () => {
+    mockProjectFiles("no-lockfile");
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    let wt = "";
+    expect(() => {
+      wt = addWorktree({ repoRoot: "/tmp/brove", worktreeDir: ".worktrees", project: "brove", name: "crew-1", base: "develop" });
+    }).not.toThrow();
+
+    const nonGitCalls = execFileSyncMock.mock.calls.filter((c) => c[0] !== "git");
+    expect(nonGitCalls).toHaveLength(0);
+    expect(stderrWrite).toHaveBeenCalledWith(expect.stringContaining(wt));
+    expect(stderrWrite).toHaveBeenCalledWith(expect.stringContaining("no lockfile"));
+
+    stderrWrite.mockRestore();
+  });
+});
+
+// ── #387: Spotlight (mds) exclusion marker on the worktree root ─────────────
+
+describe("addWorktree — Spotlight exclusion (#387)", () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    execFileSyncMock.mockReset();
+    execFileSyncMock.mockImplementationOnce(() => { throw new Error("not found"); }); // show-ref
+    execFileSyncMock.mockReturnValue(Buffer.from("")); // worktree add, pnpm install
+    mkdirSyncMock.mockReset();
+    existsSyncMock.mockReset().mockReturnValue(false);
+    writeFileSyncMock.mockReset();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  it("drops a .metadata_never_index marker in the worktree root on darwin", () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+
+    addWorktree({ repoRoot: "/tmp/brove", worktreeDir: ".worktrees", project: "brove", name: "crew-1", base: "develop" });
+
+    const worktreeDirAbs = path.resolve("/tmp/brove", ".worktrees");
+    expect(mkdirSyncMock).toHaveBeenCalledWith(worktreeDirAbs, { recursive: true });
+    expect(writeFileSyncMock).toHaveBeenCalledWith(path.join(worktreeDirAbs, ".metadata_never_index"), "");
+  });
+
+  it("skips the marker on non-darwin platforms", () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+
+    addWorktree({ repoRoot: "/tmp/brove", worktreeDir: ".worktrees", project: "brove", name: "crew-1", base: "develop" });
+
+    expect(mkdirSyncMock).not.toHaveBeenCalled();
+    expect(writeFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("does not rewrite the marker when it already exists (one marker covers every worktree under it)", () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    existsSyncMock.mockReturnValue(true);
+
+    addWorktree({ repoRoot: "/tmp/brove", worktreeDir: ".worktrees", project: "brove", name: "crew-1", base: "develop" });
+
+    expect(writeFileSyncMock).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/shared/src/lib/git-worktree.ts
+++ b/packages/shared/src/lib/git-worktree.ts
@@ -10,6 +10,7 @@
 // Builds and the daemon still run from the MAIN checkout's `dist`; worktrees
 // edit source only (issue #216 caveat).
 import { execFileSync } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 
 export interface WorktreeSpec {
@@ -32,6 +33,27 @@ export function worktreePath(repoRoot: string, worktreeDir: string, project: str
 /** Crew branch name for a worktree crew. */
 export function crewBranch(name: string): string {
   return `crew/${name}`;
+}
+
+/**
+ * #387: macOS Spotlight (mds/mdworker) indexing every crew worktree's
+ * node_modules can itself starve CPU. A `.metadata_never_index` marker file
+ * excludes its directory (recursively, including subdirectories created
+ * later) from indexing. Dropping ONE marker in the worktree ROOT (once, the
+ * first time a project spawns a worktree crew) covers every crew worktree
+ * ever created under it after — no per-worktree marker needed. Best-effort
+ * and macOS-only: never blocks worktree creation over an indexing nicety.
+ */
+function ensureSpotlightExcluded(repoRoot: string, worktreeDir: string): void {
+  if (process.platform !== "darwin") return;
+  try {
+    const dir = path.resolve(repoRoot, worktreeDir);
+    fs.mkdirSync(dir, { recursive: true });
+    const marker = path.join(dir, ".metadata_never_index");
+    if (!fs.existsSync(marker)) fs.writeFileSync(marker, "");
+  } catch {
+    // Best-effort — Spotlight exclusion is a nicety, not a correctness requirement.
+  }
 }
 
 // #359: derive the branch a new worktree should be based on. Reads origin/HEAD
@@ -62,6 +84,8 @@ export function resolveWorktreeBase(repoRoot: string, fallback = "develop"): str
  *   uniquified name.
  */
 export function addWorktree(spec: WorktreeSpec): string {
+  ensureSpotlightExcluded(spec.repoRoot, spec.worktreeDir);
+
   const originalBranch = crewBranch(spec.name);
 
   let targetName = spec.name;
@@ -127,7 +151,51 @@ export function addWorktree(spec: WorktreeSpec): string {
     ["-C", spec.repoRoot, "worktree", "add", wt, "-b", targetBranch, spec.base],
     { stdio: "pipe" },
   );
+  installWorktreeDependencies(wt);
   return wt;
+}
+
+/**
+ * #387: `git worktree add` never populates node_modules — a fresh worktree
+ * has none. Node's module resolution walks up parent directories looking for
+ * node_modules, and since worktrees live nested under <repoRoot>/<worktreeDir>/,
+ * a worktree with no local node_modules silently falls through to the main
+ * checkout's node_modules instead of failing — so a crew's tsc/vitest run can
+ * type-check or test against the main repo's stale code without any error.
+ * Installing here, synchronously, before the worktree is handed to a crew
+ * closes that gap: the worktree always has its own complete dependency tree,
+ * or worktree creation fails loudly instead of leaving a crew to discover the
+ * gap mid-task.
+ *
+ * addWorktree() is called for every registered project, not just squadrant's
+ * own repo — projects use pnpm, yarn, or npm, and some aren't JS projects at
+ * all. Detect the package manager from its lockfile rather than assuming
+ * pnpm; each is invoked with its own frozen/reproducible-install flag so this
+ * never silently drifts the project's lockfile. No package.json → nothing to
+ * install, not an error. package.json with no recognized lockfile → skip
+ * rather than guess: without a lockfile there's no deterministic manifest to
+ * freeze against, and guessing a package manager risks generating a stray
+ * lockfile the crew never asked for — but that skip still leaves the worktree
+ * without its own node_modules, i.e. still exposed to the exact silent
+ * cross-checkout resolution this function exists to close. Warn on stderr so
+ * that exposure is visible instead of silent.
+ */
+function installWorktreeDependencies(wt: string): void {
+  if (!fs.existsSync(path.join(wt, "package.json"))) return;
+
+  if (fs.existsSync(path.join(wt, "pnpm-lock.yaml"))) {
+    execFileSync("pnpm", ["-C", wt, "install", "--frozen-lockfile"], { stdio: "pipe" });
+  } else if (fs.existsSync(path.join(wt, "yarn.lock"))) {
+    execFileSync("yarn", ["install", "--frozen-lockfile"], { cwd: wt, stdio: "pipe" });
+  } else if (fs.existsSync(path.join(wt, "package-lock.json"))) {
+    execFileSync("npm", ["ci"], { cwd: wt, stdio: "pipe" });
+  } else if (fs.existsSync(path.join(wt, "bun.lockb"))) {
+    execFileSync("bun", ["install", "--frozen-lockfile"], { cwd: wt, stdio: "pipe" });
+  } else {
+    process.stderr.write(
+      `worktree ${wt}: package.json present but no lockfile — dependencies not installed; local typechecks/tests may resolve against the main checkout instead of this worktree.\n`,
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
Cuts **squadrant v0.16.1** off develop (1 commit since v0.16.0) — patch release, one fix (#387).

## Fixed
- **Crew worktrees silently type-checked and tested against the MAIN checkout instead of their own code (#387):** `git worktree add` never populates `node_modules`; Node's module resolution silently walked up past a worktree with no local `node_modules` into the main checkout's, so a crew's `tsc`/`vitest` could pass against stale main-checkout code instead of the crew's own uncommitted changes. `addWorktree()` now installs the worktree's own dependencies on creation (pnpm/yarn/npm/bun, detected from lockfile), no-ops for non-JS projects, and warns loudly when a package.json has no lockfile.
- **N concurrent crews could starve the machine and take down the cmux control plane (#387):** crew top-level process now launched under `nice -n 10`, inherited by all child processes (tsc, vitest workers).
- **Spotlight indexing exclusion for crew worktrees is now automatic (#387):** `.metadata_never_index` marker written on worktree creation (macOS, best-effort).

## Verification
- develop is green: 166 files / 2030 tests, clean build (verified on develop prior to this branch; not re-run here — CI runs the full suite on this PR).

On merge, release.yml tags `v0.16.1`, creates the GitHub release from the CHANGELOG, and publishes to npm.