### PR TITLE
fix(#565): captain re-adoption after cmux restart — role restoration + no-death-by-absence fail-safe

### DIFF
--- a/packages/cli/src/__tests__/squadrantd-daemon-direct.test.ts
+++ b/packages/cli/src/__tests__/squadrantd-daemon-direct.test.ts
@@ -262,7 +262,16 @@ describe("squadrantd daemon-direct (#332)", () => {
     // If tick 9 had captain found, delivery would resume to 3.
   });
 
-  it("reaps the stopped project's orphaned interactive crews to 'cancelled' (captain-stopped)", async () => {
+  // #565: reaping is destructive (it terminalizes live crew tasks), so the
+  // contract changed on purpose — "absent from the runtime snapshot" is no
+  // longer sufficient to reap on its own. The daemon now requires POSITIVE
+  // evidence the captain's pid is actually dead. A genuine close (user closes
+  // the workspace) kills the pid too, so this fixture simulates both: the
+  // snapshot going empty AND the tracked pid dying. Absence alone (the old
+  // contract, asserted by this test pre-#565) would silently reap crews that
+  // are still working the moment cmux's snapshot merely glitches — that's
+  // exactly what cost the user 3 live crews the morning of the incident.
+  it("reaps the stopped project's orphaned interactive crews to 'cancelled' (captain-stopped) — genuine close: snapshot empty AND pid confirmed dead", async () => {
     dir = mkdtempSync(join(tmpdir(), "cp-dd-orphan-"));
     const sock = join(dir, "c.sock");
     const stateRoot = join(dir, "state");
@@ -287,6 +296,7 @@ describe("squadrantd daemon-direct (#332)", () => {
     // now decides captain presence. Surfaces stay present throughout so this
     // test isolates the registry-driven reap from delivery-target discovery.
     let captainPresent = true;
+    let captainPidAlive = true; // genuine close kills the pid too, not just the snapshot entry
     const cmux = {
       sent: [] as Array<{ text: string }>,
       send: async (_surface: PaneRef, text: string) => { (cmux as any).sent.push({ text }); },
@@ -302,7 +312,7 @@ describe("squadrantd daemon-direct (#332)", () => {
         : [],
     } as unknown as DaemonCmux & { sent: Array<{ text: string }> };
 
-    const handle = startSquadrantd({ stateRoot, sockPath: sock, sweepMs: 0, daemonCmux: cmux, isPidAlive: () => true });
+    const handle = startSquadrantd({ stateRoot, sockPath: sock, sweepMs: 0, daemonCmux: cmux, isPidAlive: () => captainPidAlive });
     stop = handle.stop;
 
     // Let boot reconcile settle before the manual ticks.
@@ -314,12 +324,71 @@ describe("squadrantd daemon-direct (#332)", () => {
 
     if (handle.tickDelivery) await handle.tickDelivery(); // captain present → deliver, crew untouched
     captainPresent = false; // captain workspace closed
-    if (handle.tickDelivery) await handle.tickDelivery(); // registry sees captain absent → stopped → reap
+    captainPidAlive = false; // ...and the process is confirmed dead (genuine close)
+    if (handle.tickDelivery) await handle.tickDelivery(); // registry sees captain gone + pid dead → stopped → reap
 
     // The orphaned crew is reaped to a terminal state with the captain-stopped marker.
     const after = await sendRequest(sock, { kind: "status", project: "p", id: "orphan-1" }) as TaskRecord;
     expect(after.state).toBe("cancelled");
     expect(after.lastEvent).toBe("captain-stopped");
+  });
+
+  // #565 — the actual incident: the captain vanishes from the runtime
+  // snapshot (a cmux store glitch, e.g. a degraded launchCommand losing its
+  // role marker) but its pid is still very much alive. The crew must NOT be
+  // reaped — absence-from-snapshot alone is no longer positive evidence of
+  // death.
+  it("captain absent from snapshot but pid still alive → crew is NOT reaped, task stays 'working' (#565)", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-dd-orphan-alive-"));
+    const sock = join(dir, "c.sock");
+    const stateRoot = join(dir, "state");
+    mkdirSync(join(stateRoot, "inbox"), { recursive: true });
+
+    const crew: TaskRecord = {
+      id: "orphan-1", project: "p", provider: "claude", mode: "interactive",
+      state: "working", task: "build", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "task.started", heartbeatBudgetMs: 1000,
+      name: "orphan",
+      attempts: [{ attemptId: "a0", startedAt: 1, lastHeartbeatAt: 1 }],
+    };
+    await appendToMailbox({ stateRoot, project: "p", taskRecord: crew, event: EVENT, message: "CREW DONE #1" });
+    await writeCursor({ stateRoot, project: "p", subscriber: "captain", lastAckedSeq: 0 });
+    mkdirSync(join(stateRoot, "p"), { recursive: true });
+    writeFileSync(join(stateRoot, "p", `${crew.id}.json`), JSON.stringify(crew));
+
+    const captainTitle = "p-captain";
+    const crewPane = crewPaneTitle("p", "orphan");
+    let captainPresent = true;
+    const cmux = {
+      sent: [] as Array<{ text: string }>,
+      send: async (_surface: PaneRef, text: string) => { (cmux as any).sent.push({ text }); },
+      listSurfaces: async () => [
+        { workspaceId: "ws:1", surfaceId: "s1", title: captainTitle },
+        { workspaceId: "ws:1", surfaceId: "sc", title: crewPane },
+      ],
+      readScreen: async () => null,
+      isAvailable: async () => true,
+      findWorkspaceId: async (name: string) => name === captainTitle ? "ws:1" : null,
+      // Only the runtime snapshot glitches (goes empty) — the pid never dies.
+      liveness: async () => captainPresent
+        ? [{ role: "captain" as const, project: "p", pid: 424242, sessionId: "s", present: true }]
+        : [],
+    } as unknown as DaemonCmux & { sent: Array<{ text: string }> };
+
+    const handle = startSquadrantd({ stateRoot, sockPath: sock, sweepMs: 0, daemonCmux: cmux, isPidAlive: () => true });
+    stop = handle.stop;
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    const before = await sendRequest(sock, { kind: "status", project: "p", id: "orphan-1" }) as TaskRecord;
+    expect(before.state).toBe("working");
+
+    if (handle.tickDelivery) await handle.tickDelivery(); // captain present → deliver, crew untouched
+    captainPresent = false; // snapshot glitch: captain vanishes from the runtime read
+    if (handle.tickDelivery) await handle.tickDelivery(); // pid still alive → must NOT infer death
+
+    const after = await sendRequest(sock, { kind: "status", project: "p", id: "orphan-1" }) as TaskRecord;
+    expect(after.state).toBe("working");
   });
 
   it("does NOT reap on a single transient empty sweep (K>1)", async () => {

--- a/packages/core/src/__tests__/liveness-derive.test.ts
+++ b/packages/core/src/__tests__/liveness-derive.test.ts
@@ -37,4 +37,30 @@ describe("reconcileLiveness — runtime ≥ agent > scan", () => {
     const closed = base({ source: "runtime", lastState: "end", lastSeenAt: 2_000 });
     expect(reconcileLiveness(prev, closed).lastState).toBe("end");
   });
+
+  // #565: a captain that comes back after being marked stopped/gone must be
+  // re-adopted even when the fresh runtime snapshot's startedAt is OLDER than
+  // the stale record's — a live pid outranks a startedAt comparison once prev
+  // is already dead. Reproduces the live incident: same session, prev pid dead
+  // + lastState="end" with a startedAt 6.6s NEWER than the live reopen signal.
+  it("re-adopts a live pid even when its startedAt is older than a dead prev (#565)", () => {
+    const prev = base({
+      pid: 10194, lastState: "end", pidAlive: false,
+      startedAt: 1_675_625, lastSeenAt: 1_675_625,
+    });
+    const reopen = base({
+      pid: 61850, lastState: "start", pidAlive: true,
+      startedAt: 1_669_016, lastSeenAt: 2_000_000,
+    });
+    const out = reconcileLiveness(prev, reopen);
+    expect(out.pidAlive).toBe(true);
+    expect(out.lastState).toBe("start");
+    expect(out.pid).toBe(61850);
+  });
+
+  it("does NOT let a stale-but-alive duplicate override an already-alive prev (#527 guard)", () => {
+    const prev = base({ pid: 100, lastState: "start", pidAlive: true, startedAt: 5_000 });
+    const staleDuplicate = base({ pid: 200, lastState: "start", pidAlive: true, startedAt: 1_000 });
+    expect(reconcileLiveness(prev, staleDuplicate)).toBe(prev);
+  });
 });

--- a/packages/core/src/daemon/__tests__/liveness-tick.test.ts
+++ b/packages/core/src/daemon/__tests__/liveness-tick.test.ts
@@ -14,11 +14,45 @@ describe("runLivenessTick", () => {
     expect(reg.get("p")?.pidAlive).toBe(true);
     expect(reg.get("p")?.lastState).toBe("start");
   });
-  it("captain absent from snapshot → markEnded (stopped), entry kept", async () => {
+  it("captain absent from snapshot + pid confirmed dead → markEnded (stopped), entry kept", async () => {
     const reg = memReg();
     reg.apply({ project: "p", role: "captain", pid: 100, sessionId: "s", startedAt: 1_000, lastState: "start", lastSeenAt: 1_000, pidAlive: true, source: "runtime" });
-    await runLivenessTick({ registry: reg, liveness: async () => [], isPidAlive: () => true, now: () => 5_000 });
+    await runLivenessTick({ registry: reg, liveness: async () => [], isPidAlive: () => false, now: () => 5_000 });
     expect(reg.get("p")?.lastState).toBe("end");
+  });
+
+  // #565: absence from a single snapshot is not proof of death. Reproduces the
+  // live incident — bet2fun-app's captain vanished from the runtime snapshot
+  // (its cmux record degraded to role:"unknown") while its pid was still very
+  // much alive; the old code inferred "ended" from absence alone and silently
+  // paused delivery + reaped its live crews forever.
+  it("captain absent from snapshot but pid still alive → NOT marked ended (#565 fail-safe)", async () => {
+    const reg = memReg();
+    reg.apply({ project: "p", role: "captain", pid: 100, sessionId: "s", startedAt: 1_000, lastState: "start", lastSeenAt: 1_000, pidAlive: true, source: "runtime" });
+    const lines: string[] = [];
+    await runLivenessTick({ registry: reg, liveness: async () => [], isPidAlive: () => true, now: () => 5_000, log: (m) => lines.push(m) });
+    expect(reg.get("p")?.lastState).toBe("start");
+    expect(deriveCaptainState(reg.get("p"))).toBe("alive");
+    expect(lines).toContainEqual(expect.stringContaining("missing from snapshot but not confirmed dead"));
+  });
+
+  it("captain absent from snapshot with an unknown (null) pid → left alone, not marked ended (#565 fail-safe)", async () => {
+    const reg = memReg();
+    reg.apply({ project: "p", role: "captain", pid: null, sessionId: "s", startedAt: 1_000, lastState: "start", lastSeenAt: 1_000, pidAlive: true, source: "runtime" });
+    await runLivenessTick({ registry: reg, liveness: async () => [], isPidAlive: () => { throw new Error("must not be called with a null pid"); }, now: () => 5_000 });
+    expect(reg.get("p")?.lastState).toBe("start");
+  });
+
+  // #565 root cause: cmux degraded the live captain's launchCommand so
+  // roleFromTemplate can no longer classify it — the record shows up with
+  // role:"unknown" even though its sessionId is the one we already confirmed
+  // is this project's captain.
+  it("record with role:unknown but a known-captain sessionId is still treated as the captain (#565)", async () => {
+    const reg = memReg();
+    reg.apply({ project: "p", role: "captain", pid: 100, sessionId: "s", startedAt: 1_000, lastState: "end", lastSeenAt: 1_000, pidAlive: false, source: "runtime" });
+    const degraded: RuntimeLivenessRecord = { role: "unknown", project: "p", pid: 100, sessionId: "s", present: true };
+    await runLivenessTick({ registry: reg, liveness: async () => [degraded], isPidAlive: () => true, now: () => 5_000 });
+    expect(deriveCaptainState(reg.get("p"))).toBe("alive");
   });
   it("present record + dead pid → pidAlive false (→ gone)", async () => {
     const reg = memReg();
@@ -27,12 +61,20 @@ describe("runLivenessTick", () => {
     expect(reg.get("p")?.pidAlive).toBe(false);
   });
 
-  it("captain absent from snapshot (→ stopped) triggers reap", async () => {
+  it("captain absent from snapshot + pid confirmed dead (→ stopped) triggers reap", async () => {
+    const reg = memReg();
+    reg.apply({ project: "p", role: "captain", pid: 100, sessionId: "s", startedAt: 1_000, lastState: "start", lastSeenAt: 1_000, pidAlive: true, source: "runtime" });
+    const reaped: string[] = [];
+    await runLivenessTick({ registry: reg, liveness: async () => [], isPidAlive: () => false, now: () => 5_000, reap: (p) => { reaped.push(p); return 0; } });
+    expect(reaped).toEqual(["p"]);
+  });
+
+  it("captain absent from snapshot but pid still alive → NOT reaped (#565 fail-safe)", async () => {
     const reg = memReg();
     reg.apply({ project: "p", role: "captain", pid: 100, sessionId: "s", startedAt: 1_000, lastState: "start", lastSeenAt: 1_000, pidAlive: true, source: "runtime" });
     const reaped: string[] = [];
     await runLivenessTick({ registry: reg, liveness: async () => [], isPidAlive: () => true, now: () => 5_000, reap: (p) => { reaped.push(p); return 0; } });
-    expect(reaped).toEqual(["p"]);
+    expect(reaped).toEqual([]);
   });
   it("present record + dead pid (→ gone) triggers reap", async () => {
     const reg = memReg();
@@ -79,11 +121,11 @@ describe("runLivenessTick", () => {
     await runLivenessTick({ registry: reg, liveness: async () => [rec], isPidAlive: () => true, now: () => 5_000, log: (m) => lines.push(m) });
     expect(lines).toContainEqual(expect.stringContaining("[captain/runtime] p pid=100 → alive"));
   });
-  it("logs the state transition when a captain goes absent (→ stopped)", async () => {
+  it("logs the state transition when a captain goes absent + pid confirmed dead (→ stopped)", async () => {
     const reg = memReg();
     reg.apply({ project: "p", role: "captain", pid: 100, sessionId: "s", startedAt: 1_000, lastState: "start", lastSeenAt: 1_000, pidAlive: true, source: "runtime" });
     const lines: string[] = [];
-    await runLivenessTick({ registry: reg, liveness: async () => [], isPidAlive: () => true, now: () => 5_000, log: (m) => lines.push(m) });
+    await runLivenessTick({ registry: reg, liveness: async () => [], isPidAlive: () => false, now: () => 5_000, log: (m) => lines.push(m) });
     expect(lines).toContainEqual(expect.stringContaining("[captain/runtime] p pid=100 → stopped"));
   });
   it("no log dep supplied → tick still completes (optional)", async () => {

--- a/packages/core/src/daemon/delivery-loop.ts
+++ b/packages/core/src/daemon/delivery-loop.ts
@@ -74,12 +74,25 @@ export async function runLivenessTick(deps: LivenessTickDeps): Promise<void> {
   try { records = await deps.liveness(); } catch { return; } // runtime unreachable → leave registry as-is
   const seen = new Set<string>();
 
+  // #565: cmux's own store can degrade a session's launchCommand (observed live:
+  // a crash/reattach left it as bare `["claude"]`, no --append-system-prompt-file)
+  // so the record reads role:"unknown" even though it's the exact same session
+  // already confirmed as this project's captain. SessionId identity outranks a
+  // degraded launchCommand classification — restore "captain" for any record
+  // whose sessionId matches an already-known captain for that project.
+  const knownCaptainSessions = new Map<string, string>(); // sessionId → project
+  for (const e of deps.registry.all()) {
+    if (e.role === "captain") knownCaptainSessions.set(e.sessionId, e.project);
+  }
+
   // #527: multiple cmux sessions can share a cwd, producing duplicate project
   // entries. Group by project and pick one winner to avoid last-write-wins
   // collision (dead pid overwriting live).
   const byProject = new Map<string, RuntimeLivenessRecord[]>();
   for (const r of records) {
-    if (r.role !== "captain") continue;
+    const role = r.role === "captain" || knownCaptainSessions.get(r.sessionId) === r.project
+      ? "captain" : r.role;
+    if (role !== "captain") continue;
     let arr = byProject.get(r.project);
     if (!arr) { arr = []; byProject.set(r.project, arr); }
     arr.push(r);
@@ -103,12 +116,21 @@ export async function runLivenessTick(deps: LivenessTickDeps): Promise<void> {
     logEntry(deps.log, project, deps.registry.get(project));
   }
 
-  // Captains we knew but the snapshot no longer lists → clean close.
+  // Captains we knew but the snapshot no longer lists → clean close — but ONLY
+  // with positive evidence the pid is actually dead (#565). Absence from a
+  // single snapshot read is not proof of death (a store-file parsing glitch,
+  // a degraded record, a transient cmux hiccup); inferring "ended" from
+  // absence alone silently and permanently pauses delivery for a captain that
+  // is still running. When the tracked pid can't be confirmed dead (still
+  // alive, or unknown/null), leave the entry alone.
   for (const e of deps.registry.all()) {
-    if (e.role === "captain" && e.lastState === "start" && !seen.has(e.project)) {
-      deps.registry.markEnded(e.project, now);
-      logEntry(deps.log, e.project, deps.registry.get(e.project));
+    if (e.role !== "captain" || e.lastState !== "start" || seen.has(e.project)) continue;
+    if (e.pid == null || deps.isPidAlive(e.pid)) {
+      deps.log?.(`[${e.role}/runtime] ${e.project} pid=${e.pid} missing from snapshot but not confirmed dead — leaving alive`);
+      continue;
     }
+    deps.registry.markEnded(e.project, now);
+    logEntry(deps.log, e.project, deps.registry.get(e.project));
   }
 
   // Reap orphaned crews for any captain the registry now considers stopped

--- a/packages/core/src/liveness.ts
+++ b/packages/core/src/liveness.ts
@@ -218,5 +218,12 @@ export function reconcileLiveness(
   }
   // runtime/agent authoritative. A newer open (or any end) wins; a stale one is ignored.
   if (next.startedAt >= prev.startedAt || next.lastState === "end") return next;
+  // #565: prev is already dead (stopped/gone) and next reports a live pid — a
+  // live process outranks a startedAt comparison, otherwise a captain that
+  // comes back can never be re-adopted once wrongly marked dead. Does not
+  // apply when prev is still alive: an older-but-live duplicate must not
+  // override the currently-tracked live session (#527).
+  const prevAlive = prev.lastState === "start" && prev.pidAlive;
+  if (!prevAlive && next.lastState === "start" && next.pidAlive) return next;
   return prev;
 }


### PR DESCRIPTION
## Summary

**Correction:** this PR originally claimed the fix was a `reconcileLiveness` startedAt-ordering change. That theory was wrong (confirmed by the reporter against live daemon/cmux data) and does **not** explain the incident. It's kept as a defensive hardening only — see "Kept as hardening" below — but it is not what fixes #565.

**The actual root cause and fix**, verified against the live incident data pulled from the running daemon and the real `~/.cmuxterm/claude-hook-sessions.json`:

cmux's own hook-sessions record for the still-alive `bet2fun-app` captain (pid alive 7h49m+) degraded to a bare `launchCommand` (`["claude"]`, missing `--append-system-prompt-file`) after a crash/reattach. `runLivenessTick`'s `roleFromTemplate` classification depends entirely on that flag, so the record read `role:"unknown"`, was filtered out of the captain group, and the project fell out of `seen` on the very next tick — triggering `markEnded()` → `"stopped"` forever, crews reaped, delivery permanently paused. The pid was alive the entire time; nothing ever re-checked that before inferring death.

Two changes, both in `packages/core/src/daemon/delivery-loop.ts` (`runLivenessTick`):

1. **Root cause fix** — sessionId identity now outranks a degraded/unclassifiable `launchCommand`. A record whose `sessionId` matches an already-known captain for its project is treated as that captain regardless of what `roleFromTemplate` currently reads.
2. **Fail-safe / intentional contract change** — a captain missing from the runtime snapshot is no longer marked ended on absence alone. `markEnded` now requires positive evidence: the tracked pid must be confirmed dead via `isPidAlive`. If the pid is still alive, or unknown/null, the entry is left alone (a log line is emitted instead). This also gates the #324 reaper, which fires off the same derived state — so live crews can no longer be reaped from an inferred signal.

### This is a deliberate breaking change to the reap contract, not a side effect

Reaping is destructive — it terminalizes live, working crew tasks. The old contract ("absent from one runtime snapshot read → captain is stopped → reap its crews") is exactly what turned a cosmetic cmux store glitch into 3 cancelled crews that were actively committing code the morning of this incident. `packages/cli/src/__tests__/squadrantd-daemon-direct.test.ts` had a test that encoded the old contract directly (`isPidAlive: () => true` yet still asserting the crew got reaped on snapshot absence). Rather than loosen the fix to keep that test green, the test was updated to reflect the new, intentional contract:
- The genuine-close case now simulates what actually happens on a real close — the snapshot goes empty **and** the pid dies — and still asserts the crew gets reaped. The real reap path is preserved and covered.
- A new test reproduces the actual incident: captain absent from the snapshot but pid still alive → crew is **not** reaped, task stays `"working"`.

### Kept as hardening (not the fix)
`packages/core/src/liveness.ts`'s `reconcileLiveness`: a live pid now outranks a startedAt-ordering comparison once `prev` is already dead, so a captain can't get stuck if `reconcileLiveness` ever sees a live reopen with an older `startedAt` for some other reason. Doesn't apply when `prev` is still alive (preserves the existing #527 stale-duplicate guard). Independently reasonable, doesn't fix #565 on its own.

## Test plan
- [x] Added regression tests reproducing the exact incident: (a) a record with `role:"unknown"` but a known-captain `sessionId` is still treated as the captain, (b) a captain absent from the snapshot with a still-alive pid is NOT marked ended and NOT reaped (core-level + CLI integration-level), (c) same with an unknown/null pid
- [x] Updated the pre-existing tests that encoded the old (buggy) absence-implies-death contract — both in `packages/core` (unit) and `packages/cli` (integration) — to require genuine death instead, and added the inverse case alongside each
- [x] `npx tsc -b` on `packages/shared`/`packages/core`/`packages/agents`/`packages/workspaces` (leaf deps, needed to unblock local test resolution in this fresh worktree) + `npx vitest run` in `packages/core` (42 files/656 tests) and `packages/cli` (58/59 files, 479/480 tests — the one failing file is an unrelated pre-existing `@squadrant/web` unbuilt-dist issue in this worktree) — all green
- [x] `npx tsc --noEmit` clean in both `packages/core` and `packages/cli`