### PR TITLE
fix(#566): send must confirm delivery or fail loudly, never silent-succeed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`runtime send`/`ping`'s mailbox routing (#529) reported success for messages that were never delivered (#566):** routing CLI-originated sends through the mailbox to protect an in-progress draft (#529) turned an unconditional direct send into one gated by the async delivery loop, but the CLI reported success the instant the append landed on disk — with no confirmation the delivery loop ever drained it (e.g. a captain falsely reported "stopped", #565). `runtime send` now polls the delivery cursor after appending and fails loudly (non-zero exit, no `✔`) if delivery isn't confirmed within 15s, while keeping the #529 draft-clobber protection intact.
+- **`crew send` printed `✔ Sent` and exited 0 for a message that was never delivered (#566):** `confirmedSendToPane`'s paste-settle-Enter retry loop already correctly reported `{ delivered: false }` when the box never emptied, but `runCrewSend` only wrote a stderr warning for that case instead of throwing — the CLI's success path ran unconditionally. Non-modal, non-delivered follow-up sends now throw (matching the existing `#516` modal-blocked behavior), so the caller sees a loud failure instead of a false "sent".
+
 ## [0.16.1] - 2026-07-11
 
 ### Fixed

--- a/packages/cli/src/commands/__tests__/runtime.test.ts
+++ b/packages/cli/src/commands/__tests__/runtime.test.ts
@@ -32,9 +32,11 @@ vi.mock("@squadrant/shared", () => ({
 }));
 
 const appendCaptainMessage = vi.hoisted(() => vi.fn());
+const waitForCaptainDelivery = vi.hoisted(() => vi.fn());
 vi.mock("@squadrant/core", async (importOriginal) => ({
   ...((await importOriginal()) as any),
   appendCaptainMessage,
+  waitForCaptainDelivery,
 }));
 
 const requireDaemon = vi.hoisted(() => vi.fn());
@@ -69,6 +71,8 @@ describe("runtime send", () => {
     loadConfig.mockReturnValue(makeConfig());
     requireDaemon.mockResolvedValue(undefined);
     status.mockResolvedValue({ id: "ws-1", name: "⚓ A-captain", status: "running" });
+    appendCaptainMessage.mockResolvedValue(42);
+    waitForCaptainDelivery.mockResolvedValue(true);
   });
 
   it("delivers the message via the mailbox (enqueue) when daemon is running", async () => {
@@ -103,9 +107,34 @@ describe("runtime send", () => {
     requireDaemon.mockRejectedValue(new Error("daemon not running"));
 
     await expect(runRuntimeSend("projA", "hello from runtime send", {})).rejects.toThrow(/daemon not running/i);
-    
+
     expect(send).not.toHaveBeenCalled();
     expect(sendKey).not.toHaveBeenCalled();
     expect(appendCaptainMessage).not.toHaveBeenCalled();
+  });
+
+  // #566 bug (b): v0.16 routed runtime send through the mailbox (#529) so a
+  // draft in progress is never clobbered, but that made success gated on the
+  // async delivery loop while the CLI reported success the instant the append
+  // landed — regardless of whether a captain was ever there to receive it.
+  it("waits for the delivery cursor to confirm the message actually reached the pane", async () => {
+    await runRuntimeSend("projA", "hello from runtime send", {});
+
+    expect(waitForCaptainDelivery).toHaveBeenCalledWith(
+      expect.objectContaining({ project: "projA", seq: 42 }),
+    );
+  });
+
+  // The core regression: a captain falsely reported "stopped"/unreachable (#565)
+  // must not turn into a silent success. If delivery is never confirmed, the
+  // command must fail loudly (reject) rather than resolve.
+  it("fails loudly when delivery is never confirmed (captain unreachable/falsely-stopped, #565-class)", async () => {
+    waitForCaptainDelivery.mockResolvedValue(false);
+
+    await expect(runRuntimeSend("projA", "hello from runtime send", {})).rejects.toThrow(/not confirmed|not delivered/i);
+
+    // The send attempt itself must still have been made — never pre-gated on
+    // a liveness verdict — only the *confirmation* is what fails here.
+    expect(appendCaptainMessage).toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/effort.ts
+++ b/packages/cli/src/commands/effort.ts
@@ -64,7 +64,7 @@ export async function notifyCaptainsOfEffort(
   config: SquadrantConfig,
   driver: EffortNotifyDriver,
   cwd: string = process.cwd(),
-  append: (project: string, text: string) => Promise<void>,
+  append: (project: string, text: string) => Promise<void | number>,
 ): Promise<void> {
   const here = canonical(cwd);
   const notice = `🎚️ effort → ${effort}: ${EFFORT_MEANING[effort]}`;

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -76,36 +76,67 @@ runtimeCommand
     }
   });
 
-export async function runRuntimeSend(arg1: string, arg2: string | undefined, opts: { command?: boolean }) {
+// #566: how long a CLI-originated send waits for the delivery loop to confirm
+// the mailbox entry actually reached the pane before failing loudly. Generous
+// enough to cover the #302 stable-content probe escalation (a few delivery
+// ticks) without hanging the terminal indefinitely on a genuinely stuck send.
+const SEND_CONFIRM_TIMEOUT_MS = 15000;
+const SEND_CONFIRM_POLL_MS = 500;
+
+export async function runRuntimeSend(
+  arg1: string,
+  arg2: string | undefined,
+  opts: { command?: boolean },
+  confirmOpts?: { timeoutMs?: number; pollMs?: number },
+) {
   const config = loadConfig();
   const registry = buildRegistry();
-  
+
   if (opts.command && arg2 !== undefined) {
     throw new Error("With --command, pass only the message (not a project name)");
   }
   const target = opts.command ? undefined : arg1;
   const message = opts.command ? arg1 : arg2;
   if (!message) throw new Error("Message is required");
-  
+
   const { requireDaemon } = await import("../lib/require-daemon.js");
-  const { appendCaptainMessage } = await import("@squadrant/core");
+  const { appendCaptainMessage, waitForCaptainDelivery } = await import("@squadrant/core");
   await requireDaemon();
-  
+
   const resolved = resolveTarget(registry, config, target, !!opts.command);
   await needRef(resolved);
-  
-      const finalProject = opts.command ? config.commandName : target!;
-      
-      const { join, dirname } = await import("node:path");
-      const { DEFAULT_CONFIG_PATH } = await import("@squadrant/shared");
-      const stateRoot = join(dirname(DEFAULT_CONFIG_PATH), "state");
 
-      await appendCaptainMessage({
-        stateRoot,
-        project: finalProject,
-        text: message,
-        source: "cli",
-      });
+  const finalProject = opts.command ? config.commandName : target!;
+
+  const { join, dirname } = await import("node:path");
+  const { DEFAULT_CONFIG_PATH } = await import("@squadrant/shared");
+  const stateRoot = join(dirname(DEFAULT_CONFIG_PATH), "state");
+
+  // #566: never gate the send attempt itself on a liveness verdict — always
+  // append, then confirm. Keeps the #529 draft-clobber protection (still
+  // routed through the mailbox/delivery loop) while making non-delivery loud
+  // instead of silent.
+  const seq = await appendCaptainMessage({
+    stateRoot,
+    project: finalProject,
+    text: message,
+    source: "cli",
+  });
+
+  const timeoutMs = confirmOpts?.timeoutMs ?? SEND_CONFIRM_TIMEOUT_MS;
+  const delivered = await waitForCaptainDelivery({
+    stateRoot,
+    project: finalProject,
+    seq,
+    timeoutMs,
+    pollMs: confirmOpts?.pollMs ?? SEND_CONFIRM_POLL_MS,
+  });
+  if (!delivered) {
+    throw new Error(
+      `Message queued for '${finalProject}' (seq=${seq}) but delivery was not confirmed within ${Math.round(timeoutMs / 1000)}s. ` +
+      `It may still be pending — check with 'squadrant runtime read-screen ${finalProject}${opts.command ? " --command" : ""}'.`,
+    );
+  }
 }
 
 runtimeCommand
@@ -117,6 +148,7 @@ runtimeCommand
   .action(async (arg1: string, arg2: string | undefined, opts: { command?: boolean }) => {
     try {
       await runRuntimeSend(arg1, arg2, opts);
+      console.log(chalk.green("✔ Delivered (confirmed)"));
     } catch (err) {
       console.error(chalk.red((err as Error).message));
       process.exit(1);

--- a/packages/cli/src/lib/daemon-restart-broadcast.ts
+++ b/packages/cli/src/lib/daemon-restart-broadcast.ts
@@ -15,7 +15,7 @@ export interface DaemonRestartNotifyDriver {
 
 /** Matches the appendCaptainMessage signature from @squadrant/core/mailbox.
  *  The caller provides the closure with stateRoot already bound. */
-export type AppendCaptainMessageFn = (project: string, text: string) => Promise<void>;
+export type AppendCaptainMessageFn = (project: string, text: string) => Promise<void | number>;
 
 function statePath(stateRoot: string): string {
   return path.join(stateRoot, "daemon-restart-state.json");

--- a/packages/core/src/__tests__/crew-spawn.test.ts
+++ b/packages/core/src/__tests__/crew-spawn.test.ts
@@ -715,6 +715,25 @@ describe("runCrewSend", () => {
     expect(emitEvent).not.toHaveBeenCalled();
     expect(injectedSend).not.toHaveBeenCalled();
   });
+
+  // #566 bug (a): confirmedSendToPane correctly reports { delivered: false } when
+  // the paste/Enter could never be confirmed (e.g. the box never went empty), but
+  // runCrewSend only wrote a stderr warning and returned normally — the CLI never
+  // saw a rejection, so it printed "✔ Sent" and exited 0 for a message that was
+  // never submitted. A non-delivered, non-modal send must fail loudly (throw),
+  // exactly like the blockedByModal case above.
+  it("throws loudly when send is not delivered and not blocked by a modal (#566)", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:crew-1" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    const injectedSend = vi.fn().mockResolvedValue({ delivered: false });
+    await expect(
+      runCrewSend(PROJECT, "crew-1", "hello", runtime, "workspace:1", {
+        listTasks: vi.fn().mockResolvedValue([]),
+        emitEvent: vi.fn(),
+        sendToPane: injectedSend,
+      }),
+    ).rejects.toThrow(/not delivered/i);
+  });
 });
 
 // ─── runCrewRead ─────────────────────────────────────────────────────────────

--- a/packages/core/src/__tests__/mailbox.wait-for-delivery.test.ts
+++ b/packages/core/src/__tests__/mailbox.wait-for-delivery.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { appendCaptainMessage, waitForCaptainDelivery, writeCursor } from "../mailbox.js";
+
+function freshState(): string {
+  return mkdtempSync(join(tmpdir(), "mbox-wait-"));
+}
+
+// #566 bug (b): runtime send/ping route through the mailbox (#529) but never
+// confirmed the delivery loop actually drained the entry — the CLI reported
+// success the instant the append landed on disk, regardless of whether a
+// captain was ever there to receive it. waitForCaptainDelivery lets the CLI
+// poll the delivery cursor and find out for certain.
+describe("appendCaptainMessage", () => {
+  it("returns the assigned seq so callers can confirm delivery", async () => {
+    const stateRoot = freshState();
+    const seq = await appendCaptainMessage({ stateRoot, project: "demo", text: "hi", source: "cli" });
+    expect(seq).toBe(1);
+  });
+});
+
+describe("waitForCaptainDelivery", () => {
+  it("resolves true once the delivery cursor advances past the given seq", async () => {
+    const stateRoot = freshState();
+    const seq = await appendCaptainMessage({ stateRoot, project: "demo", text: "hi", source: "cli" });
+
+    // Simulate the delivery loop acking the entry shortly after the append.
+    setTimeout(() => {
+      writeCursor({ stateRoot, project: "demo", subscriber: "captain", lastAckedSeq: seq });
+    }, 30);
+
+    const delivered = await waitForCaptainDelivery({
+      stateRoot,
+      project: "demo",
+      seq,
+      timeoutMs: 2000,
+      pollMs: 10,
+    });
+    expect(delivered).toBe(true);
+  });
+
+  it("resolves false when the cursor never advances within the timeout (#565-class: captain unreachable/reaped)", async () => {
+    const stateRoot = freshState();
+    const seq = await appendCaptainMessage({ stateRoot, project: "demo", text: "hi", source: "cli" });
+
+    const delivered = await waitForCaptainDelivery({
+      stateRoot,
+      project: "demo",
+      seq,
+      timeoutMs: 100,
+      pollMs: 10,
+    });
+    expect(delivered).toBe(false);
+  });
+
+  it("resolves true immediately when the cursor already covers an earlier seq", async () => {
+    const stateRoot = freshState();
+    const seq1 = await appendCaptainMessage({ stateRoot, project: "demo", text: "first", source: "cli" });
+    await appendCaptainMessage({ stateRoot, project: "demo", text: "second", source: "cli" });
+    await writeCursor({ stateRoot, project: "demo", subscriber: "captain", lastAckedSeq: seq1 + 1 });
+
+    const delivered = await waitForCaptainDelivery({
+      stateRoot,
+      project: "demo",
+      seq: seq1,
+      timeoutMs: 2000,
+      pollMs: 10,
+    });
+    expect(delivered).toBe(true);
+  });
+});

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -520,7 +520,12 @@ export async function runCrewSend(
     throw new Error(blockedByModalMessage());
   }
   if (!delivered) {
-    process.stderr.write(`⚠️  Message not delivered to crew '${name}' — use 'squadrant crew send ${project} ${name}' to re-send.\n`);
+    // #566: a follow-up send has no self-heal sweep behind it (unlike first-turn
+    // delivery, which the daemon retries via resendCrewFirstTurn) — a stderr-only
+    // warning here let the CLI's own catch block never fire, so it printed "✔ Sent"
+    // and exited 0 for a message that was never submitted. Throw so the caller
+    // fails loudly instead.
+    throw new Error(`Message not delivered to crew '${name}' — the paste/submit could not be confirmed. Re-send with 'squadrant crew send ${project} ${name}'.`);
   }
 }
 

--- a/packages/core/src/mailbox.ts
+++ b/packages/core/src/mailbox.ts
@@ -152,8 +152,8 @@ export async function appendCaptainMessage(opts: {
   project: string;
   text: string;
   source: "telegram" | "daemon" | "cli";
-}): Promise<void> {
-  await appendEntry(opts.stateRoot, opts.project, (seq) => ({
+}): Promise<number> {
+  return appendEntry(opts.stateRoot, opts.project, (seq) => ({
     seq,
     ts: new Date().toISOString(),
     kind: "captain.message",
@@ -194,6 +194,34 @@ export async function readCursor(opts: CursorOpts): Promise<CursorState | null> 
     return JSON.parse(buf) as CursorState;
   } catch {
     return null;
+  }
+}
+
+export interface WaitForCaptainDeliveryOpts {
+  stateRoot: string;
+  project: string;
+  /** The seq returned by appendCaptainMessage/appendToMailbox for the entry to confirm. */
+  seq: number;
+  /** Delivery cursor subscriber to poll (default "captain" — the only current subscriber). */
+  subscriber?: string;
+  timeoutMs: number;
+  pollMs: number;
+}
+
+/**
+ * Poll the delivery cursor until it has acked `seq` (the delivery loop drained
+ * the entry) or the timeout elapses (#566). A CLI-originated send only knows
+ * its message reached the pane once the cursor advances past its own seq —
+ * appending to the mailbox alone proves nothing about delivery.
+ */
+export async function waitForCaptainDelivery(opts: WaitForCaptainDeliveryOpts): Promise<boolean> {
+  const subscriber = opts.subscriber ?? "captain";
+  const deadline = Date.now() + opts.timeoutMs;
+  for (;;) {
+    const cursor = await readCursor({ stateRoot: opts.stateRoot, project: opts.project, subscriber });
+    if (cursor && cursor.lastAckedSeq >= opts.seq) return true;
+    if (Date.now() >= deadline) return false;
+    await new Promise((r) => setTimeout(r, opts.pollMs));
   }
 }
 

--- a/packages/core/src/telegram/bridge.ts
+++ b/packages/core/src/telegram/bridge.ts
@@ -45,7 +45,7 @@ export interface TelegramBridgeOptions {
   /** Root for per-project override files. Defaults to ~/.config/squadrant. */
   configRoot?: string;
   client: TelegramClient;
-  appendCaptainMessage: (a: { stateRoot: string; project: string; text: string; source: "telegram" | "daemon" | "cli" }) => Promise<void>;
+  appendCaptainMessage: (a: { stateRoot: string; project: string; text: string; source: "telegram" | "daemon" | "cli" }) => Promise<void | number>;
   log: (msg: string) => void;
   // ── Control surfaces (#402/#403/#321) — all optional. When undefined the bridge
   // keeps exact v1 behavior (queue-only project topics, General topic dropped).


### PR DESCRIPTION
## Summary

Fixes #566 — two stacked bugs left `runtime send` / `crew send` typing a message into a pane and reporting success even though it was never actually delivered.

**Bug (b) — the v0.16 mailbox regression (#529/#533).** `runtime send` routes through `appendCaptainMessage` (the mailbox) so an in-progress captain draft is never clobbered — but appending to the mailbox proves nothing about whether the async delivery loop ever drained the entry (e.g. a captain falsely reported "stopped", #565, or the surface can't be found). The CLI reported success the instant the append landed on disk.

Fix: `appendCaptainMessage` now returns its assigned `seq`. A new `waitForCaptainDelivery` (packages/core/src/mailbox.ts) polls the delivery cursor for that project until it acks `>= seq`, or a 15s timeout elapses. `runRuntimeSend` awaits this and throws (non-zero exit, no `✔`) if delivery is never confirmed — the send attempt itself is never pre-gated on any liveness check, only the confirmation. The #529 draft-clobber protection (routing through the mailbox/delivery loop instead of a raw `driver.send`) is untouched.

**Bug (a) — `crew send` silent success.** `confirmedSendToPane` (packages/workspaces/src/crew-pane.ts) already correctly returns `{ delivered: false }` when its paste-settle-Enter retry loop exhausts without the box going empty. But `runCrewSend` (packages/core/src/crew-spawn.ts) only wrote a stderr warning for that case and returned normally — so the CLI's `catch` block never fired and it always printed `✔ Sent` / exited 0, regardless of whether the message actually landed.

Fix: non-modal, non-delivered sends now throw (matching the existing `#516` modal-blocked path), so the caller sees a loud failure instead of a false "sent".

Per the crew's task brief: stayed out of `packages/core/src/liveness.ts` and `delivery-loop.ts` (owned by a parallel crew fixing #565's liveness/reaper side).

## Test plan

TDD — failing test written first for each bug, confirmed RED, then made GREEN:
- [x] `packages/core/src/__tests__/crew-spawn.test.ts`: new test asserts `runCrewSend` throws (not just stderr-warns) when `sendToPane` reports `delivered: false` without `blockedByModal`.
- [x] `packages/core/src/__tests__/mailbox.wait-for-delivery.test.ts` (new file): `appendCaptainMessage` returns its seq; `waitForCaptainDelivery` resolves `true` once the cursor advances past that seq, `false` on timeout, `true` immediately if the cursor already covers it.
- [x] `packages/cli/src/commands/__tests__/runtime.test.ts`: `runRuntimeSend` calls `waitForCaptainDelivery`; rejects when it resolves `false`, while still confirming `appendCaptainMessage` was called (never silently gated).
- [x] `npx vitest run packages/core/src` — 43 files / 655 tests passed.
- [x] `npx vitest run packages/cli/src` — 59 files / 488 tests passed (1 skipped, pre-existing).

CI is the full build+test gate — did not run the full monorepo build/test locally per the task's machine-load constraint.