### PR TITLE
fix(#570): eliminate vitest watch-mode footgun + machine-wide test-run semaphore

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "build": "tsc -b --force packages/shared packages/core packages/agents packages/workspaces packages/web packages/cli && tsup",
     "dev": "tsup --watch",
-    "test": "vitest",
+    "test": "node scripts/heavy-lock.mjs -- vitest run",
+    "test:watch": "vitest",
     "lint": "tsc --noEmit",
     "codex:gen-types": "bash scripts/gen-codex-types.sh"
   },

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -235,7 +235,7 @@ After a crew task completes:
 1. Review the work — read the diff, check the branch.
 2. Merge their branch if appropriate.
 3. Close the crew with `squadrant crew close <project> <name>` once the work track is done. (Or let the crew exit itself — the tab closes when the CLI ends.)
-4. After closing a crew, VERIFY no orphaned processes remain — e.g. `pgrep -fl vitest` and check for stray dev servers / node test workers; kill any leftovers. Do NOT run the full test suite repeatedly or concurrently across worktrees (a single `vitest run` spawns a ~per-CPU worker pool that uses gigabytes; several at once exhaust RAM). Prefer one verification on the authoritative checkout.
+4. After closing a crew, VERIFY no orphaned processes remain — e.g. `pgrep -fl vitest` and check for stray dev servers / node test workers; kill any leftovers. `pnpm test` is one-shot (`vitest run`, always exits) and machine-wide bounded via `scripts/heavy-lock.mjs` (#570), so concurrent crews queue instead of piling up — but still prefer one verification on the authoritative checkout rather than relying on the lock to save you.
 5. Record learnings if any (see "Recording Learnings" below).
 6. Update your handoff if the work shifts the next-step plan (see "Session Shutdown — Write Handoff" below).
 

--- a/scripts/heavy-lock.mjs
+++ b/scripts/heavy-lock.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+// Machine-wide semaphore for heavy commands (test runs, builds) so concurrent
+// crews WAIT for a slot instead of piling up and saturating the machine (#570).
+//
+// macOS has no flock(1), so the lock is mkdir-based: mkdir is atomic on POSIX,
+// so "did I create this directory" is a race-free ownership check. Each slot
+// directory holds the holder's pid; a slot whose pid is no longer alive is
+// stale (its holder crashed or was SIGKILLed) and gets reclaimed rather than
+// deadlocking the repo forever.
+//
+// Usage: node scripts/heavy-lock.mjs -- <command> [args...]
+// Env:   SQUADRANT_HEAVY_MAX (default 2) — max concurrent holders machine-wide.
+import { spawn } from "node:child_process";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const MAX = Math.max(1, Number.parseInt(process.env.SQUADRANT_HEAVY_MAX, 10) || 2);
+const LOCK_ROOT = join(tmpdir(), "squadrant-heavy-lock");
+const POLL_MS = 1000;
+const LOG_EVERY_MS = 10_000;
+
+const sep = process.argv.indexOf("--");
+if (sep === -1 || sep === process.argv.length - 1) {
+  console.error("usage: node scripts/heavy-lock.mjs -- <command> [args...]");
+  process.exit(1);
+}
+const command = process.argv[sep + 1];
+const commandArgs = process.argv.slice(sep + 2);
+
+mkdirSync(LOCK_ROOT, { recursive: true });
+
+const slotDir = (n) => join(LOCK_ROOT, `slot-${n}`);
+
+function isAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Returns true if we now own slot n. Reclaims the slot if its holder is dead.
+function tryAcquire(n) {
+  const dir = slotDir(n);
+  try {
+    mkdirSync(dir);
+    writeFileSync(join(dir, "pid"), String(process.pid));
+    return true;
+  } catch (err) {
+    if (err.code !== "EEXIST") throw err;
+  }
+  let holderPid;
+  try {
+    holderPid = Number.parseInt(readFileSync(join(dir, "pid"), "utf8"), 10);
+  } catch {
+    return false; // slot mid-creation by another process; contended, not stale
+  }
+  if (holderPid && isAlive(holderPid)) return false;
+  // Stale slot (holder pid is dead) — reclaim. rmSync+mkdirSync isn't a single
+  // atomic op, but the final mkdirSync is: if another process reclaims first,
+  // ours throws EEXIST and we just loop around and try again.
+  rmSync(dir, { recursive: true, force: true });
+  try {
+    mkdirSync(dir);
+  } catch (err) {
+    if (err.code === "EEXIST") return false;
+    throw err;
+  }
+  writeFileSync(join(dir, "pid"), String(process.pid));
+  return true;
+}
+
+function countBusy() {
+  let busy = 0;
+  for (let n = 0; n < MAX; n++) {
+    try {
+      readFileSync(join(slotDir(n), "pid"));
+      busy++;
+    } catch {
+      // slot not held
+    }
+  }
+  return busy;
+}
+
+async function acquireSlot() {
+  let lastLog = 0;
+  for (;;) {
+    for (let n = 0; n < MAX; n++) {
+      if (tryAcquire(n)) return n;
+    }
+    const now = Date.now();
+    if (now - lastLog >= LOG_EVERY_MS) {
+      console.error(`[heavy-lock] waiting for test slot (${countBusy()} ahead, max ${MAX} concurrent)...`);
+      lastLog = now;
+    }
+    await new Promise((r) => setTimeout(r, POLL_MS));
+  }
+}
+
+let heldSlot = null;
+function release() {
+  if (heldSlot === null) return;
+  const n = heldSlot;
+  heldSlot = null;
+  rmSync(slotDir(n), { recursive: true, force: true });
+}
+process.on("exit", release);
+
+const slot = await acquireSlot();
+heldSlot = slot;
+console.error(`[heavy-lock] slot ${slot}/${MAX - 1} acquired — running: ${command} ${commandArgs.join(" ")}`);
+
+const child = spawn(command, commandArgs, { stdio: "inherit" });
+process.on("SIGINT", () => child.kill("SIGINT"));
+process.on("SIGTERM", () => child.kill("SIGTERM"));
+
+let exitCode;
+try {
+  exitCode = await new Promise((resolve, reject) => {
+    child.on("exit", (code, signal) => resolve(signal ? 1 : (code ?? 1)));
+    child.on("error", reject);
+  });
+} finally {
+  release();
+}
+process.exit(exitCode);


### PR DESCRIPTION
## Summary
- `package.json` `"test"` was bare `vitest`, which enters **watch mode** (never exits, holds a filesystem watcher on the whole monorepo, re-runs the full suite on every file change) whenever it runs in a TTY — exactly what a crew's cmux pane is. Fixed to `"vitest run"` (one-shot, always exits); watch mode moved to opt-in `"test:watch"` for humans.
- Even one-shot concurrent runs saturate the machine and produce contention-flakes (measured in #570: 4x `vitest run` peaked at 11.77 load / 98% CPU on 12 cores, 1/4 runs failed purely from contention). Added `scripts/heavy-lock.mjs`, an mkdir-based machine-wide semaphore (macOS has no `flock(1)`) bounding concurrent heavy commands via `SQUADRANT_HEAVY_MAX` (default 2). A slot held by a dead pid is reclaimed, so a killed crew can never deadlock the repo.
- `"test"` is wired through the lock so it is **structurally** impossible for N crews to each launch a full test run simultaneously — not just guidance in `plugin/skills/captain-ops/SKILL.md` (updated to reflect this and drop the retracted "per-CPU worker pool" theory).

Corrects the record on #570: the issue's original body wrongly claimed vitest spawns an uncapped per-CPU worker pool. `vitest.config.ts` has capped `maxForks: 2` since 2026-06-18, before the incident (see the issue author's own correction comment). The real mechanism is watch-mode-never-exits + unbounded concurrent runs, per the issue's own measured data.

## Verification (behavioral, not just exit codes — per issue's own instructions)
a) `perl -e 'alarm shift; exec @ARGV' 90 script -q /dev/null npm test` (simulates a crew's real TTY) — **exits** with code 0/1 after ~15s. No "Waiting for file changes." No leftover `vitest`/`heavy-lock` processes (`pgrep -fl` confirmed clean).
b) 4x `SQUADRANT_HEAVY_MAX=2 npm test` launched concurrently: logs show 2 runs acquire slots immediately (`slot 0/1 acquired`, `slot 1/1 acquired`), the other 2 log `waiting for test slot (2 ahead, max 2 concurrent)...` and queue until a slot frees. Sampled `busy_slots` never exceeded 2 across the whole run (vs. 4 processes actually launched). Peak 1-min load observed: 12.11 (this machine had other ambient processes running; the structural guarantee — max 2 concurrent — held throughout).
c) SIGKILL'd the `heavy-lock.mjs` process while it held the only slot (`SQUADRANT_HEAVY_MAX=1`) — the slot directory persisted with the dead pid (uncatchable signal, no cleanup possible). A second run detected the dead pid and reclaimed the slot immediately (no wait, no deadlock), completed normally, and released the slot cleanly on exit.

All spawned test/lock processes were cleaned up after each experiment; `pgrep -fl vitest`/`heavy-lock` confirmed no orphans.

## Note (pre-existing, out of scope)
Verification (b) surfaced a pre-existing test isolation bug: `packages/shared/src/lib/__tests__/config.test.ts` derives its tmp dir from `Date.now()`, so two concurrent runs can collide and both fail. Unrelated to this fix (the lock bounds CPU/RAM contention, not shared-tmp-path collisions) — flagging for a follow-up, not fixing here.

## Test plan
- [x] `pnpm build` clean
- [x] `pnpm test` (via lock) — 167/167 test files pass in isolation
- [x] Watch-mode-in-TTY behavior verified (a)
- [x] Concurrency bound verified (b)
- [x] Stale-lock reclaim verified (c)
- [ ] CI green (`gh pr checks`)