### PR TITLE
fix(#574,#557): shared task-record selection + fail loudly on terminal signal

### DIFF
--- a/packages/cli/src/__tests__/crew-control.test.ts
+++ b/packages/cli/src/__tests__/crew-control.test.ts
@@ -76,4 +76,19 @@ describe("runCrewSignal (#557)", () => {
     await runCrewSignal("done", { taskId: "t1", project: "p", message: "finished", writeResult: () => "ref" }, { call });
     expect(call).toHaveBeenCalledWith(expect.objectContaining({ kind: "event", event: expect.objectContaining({ type: "task.done", id: "t1" }) }));
   });
+
+  // Pre-merge review: the status call can resolve with no record at all — a
+  // dropped/pruned task id (#554: terminal records are pruned past a 20-record
+  // cap; the record can also simply not exist yet on a fresh/racy daemon). A
+  // missing record is NOT evidence of "already terminal" — treating it as such
+  // (or worse, dereferencing .state on it) must never crash `crew signal done`.
+  // A crash here drops CREW DONE exactly like #574 did, just via a new door.
+  it("does not throw a TypeError and still sends the event when status resolves with no record (dropped/pruned task, #554)", async () => {
+    const call = vi.fn().mockImplementation(async (req: any) => {
+      if (req.kind === "status") return undefined;
+      return { ok: true };
+    });
+    await runCrewSignal("done", { taskId: "gone-id", project: "p", message: "finished", writeResult: () => "ref" }, { call });
+    expect(call).toHaveBeenCalledWith(expect.objectContaining({ kind: "event", event: expect.objectContaining({ type: "task.done", id: "gone-id" }) }));
+  });
 });

--- a/packages/cli/src/__tests__/crew-control.test.ts
+++ b/packages/cli/src/__tests__/crew-control.test.ts
@@ -1,6 +1,7 @@
 // src/control/__tests__/crew-control.test.ts
 import { describe, it, expect, vi } from "vitest";
-import { buildDispatchRequest, buildStatusRequest, buildGateResolveRequest } from "../commands/crew-control.js";
+import { buildDispatchRequest, buildStatusRequest, buildGateResolveRequest, runCrewSignal } from "../commands/crew-control.js";
+import type { TaskRecord } from "@squadrant/shared";
 
 describe("crew-control request builders", () => {
   it("dispatch request carries project/provider/mode/task and a generated id", () => {
@@ -47,5 +48,32 @@ describe("crew-control request builders", () => {
     expect(r.kind).toBe("gate-resolve");
     expect(r.gateId).toBe("g1");
     expect(r.payload).toEqual({ text: "approve", decision: "approve" });
+  });
+});
+
+// #557: `crew signal done` returned exit 0 for a task that was already terminal
+// (e.g. a duplicate/stale record picked by #574's divergent selection) — the
+// daemon's reduce() silently absorbs any event on a terminal record, and the
+// CLI never inspected the resulting state, so a signal that changed nothing
+// still reported success. runCrewSignal must check current state FIRST and
+// fail loudly instead of emitting an event that will be silently ignored.
+describe("runCrewSignal (#557)", () => {
+  it("fails loudly instead of silently succeeding when the target task is already terminal", async () => {
+    const call = vi.fn().mockResolvedValue({ id: "t1", state: "done" } as Partial<TaskRecord>);
+    await expect(
+      runCrewSignal("done", { taskId: "t1", project: "p", message: "finished" }, { call }),
+    ).rejects.toThrow(/already terminal/i);
+    // Only the status check ran — no task.done event was sent for the no-op.
+    expect(call).toHaveBeenCalledTimes(1);
+    expect(call).toHaveBeenCalledWith(buildStatusRequest("p", "t1"));
+  });
+
+  it("sends the event normally when the target task is not yet terminal", async () => {
+    const call = vi.fn().mockImplementation(async (req: any) => {
+      if (req.kind === "status") return { id: "t1", state: "working" };
+      return { ok: true };
+    });
+    await runCrewSignal("done", { taskId: "t1", project: "p", message: "finished", writeResult: () => "ref" }, { call });
+    expect(call).toHaveBeenCalledWith(expect.objectContaining({ kind: "event", event: expect.objectContaining({ type: "task.done", id: "t1" }) }));
   });
 });

--- a/packages/cli/src/commands/crew-control.ts
+++ b/packages/cli/src/commands/crew-control.ts
@@ -173,6 +173,46 @@ function defaultWriteResult(id: string, payload: string): string {
 }
 
 /**
+ * #557: `squadrant crew signal <state>` used to emit its event and exit 0
+ * unconditionally — but the daemon's reduce() treats terminal states as
+ * absorbing (any event on an already-terminal task record is a silent no-op,
+ * see state-machine.ts). A signal that lands on a task record which is
+ * already done/failed/cancelled therefore changed nothing while still
+ * reporting success, exactly the class of bug #566 fixed for `crew send`:
+ * a call site must confirm its effect landed or fail loudly, never
+ * silent-succeed. This wraps buildSignalRequest with an upfront status check
+ * so the CLI throws instead of emitting an event doomed to be ignored.
+ */
+export async function runCrewSignal(
+  signal: "done" | "blocked" | "failed",
+  o: {
+    message?: string;
+    question?: string;
+    error?: string;
+    taskId?: string;
+    project?: string;
+    writeResult?: (id: string, payload: string) => string;
+  },
+  deps: { call: (req: unknown) => Promise<unknown> },
+): Promise<void> {
+  const taskId = o.taskId ?? process.env.SQUADRANT_CREW_TASK_ID;
+  const project = o.project ?? process.env.SQUADRANT_CREW_PROJECT;
+  if (!taskId)
+    throw new Error("not running under a crew (SQUADRANT_CREW_TASK_ID unset)");
+  if (!project)
+    throw new Error("not running under a crew (SQUADRANT_CREW_PROJECT unset)");
+  const current = (await deps.call(buildStatusRequest(project, taskId))) as TaskRecord;
+  if (TERMINAL_STATES.has(current.state)) {
+    throw new Error(
+      `Task ${taskId} is already terminal (state=${current.state}) — signal '${signal}' would be silently ignored. ` +
+        `If this crew started a new turn, its task record was never reopened — re-send via 'squadrant crew send' first.`,
+    );
+  }
+  const req = buildSignalRequest(signal, { ...o, writeResult: o.writeResult ?? defaultWriteResult });
+  await deps.call(req);
+}
+
+/**
  * Attach the control-plane verbs onto an existing `squadrant crew` command so
  * they coexist with the legacy cmux-scrape verbs (spawn/send/read/close/list).
  * The control-plane task listing is `tasks` (not `list`) to avoid colliding
@@ -307,15 +347,14 @@ export function addControlPlaneCrewCommands(crew: Command): void {
         process.exit(2);
       }
       try {
-        const req = buildSignalRequest(state as "done" | "blocked" | "failed", {
+        await runCrewSignal(state as "done" | "blocked" | "failed", {
           ...(opts.message !== undefined ? { message: opts.message } : {}),
           ...(opts.question !== undefined ? { question: opts.question } : {}),
           ...(opts.error !== undefined ? { error: opts.error } : {}),
           ...(opts.taskId !== undefined ? { taskId: opts.taskId } : {}),
           ...(opts.project !== undefined ? { project: opts.project } : {}),
           writeResult: defaultWriteResult,
-        });
-        await squadrantdCall(req);
+        }, { call: squadrantdCall });
         process.exit(0);
       } catch (e) {
         process.stderr.write(`${(e as Error).message}\n`);

--- a/packages/cli/src/commands/crew-control.ts
+++ b/packages/cli/src/commands/crew-control.ts
@@ -201,11 +201,18 @@ export async function runCrewSignal(
     throw new Error("not running under a crew (SQUADRANT_CREW_TASK_ID unset)");
   if (!project)
     throw new Error("not running under a crew (SQUADRANT_CREW_PROJECT unset)");
-  const current = (await deps.call(buildStatusRequest(project, taskId))) as TaskRecord;
-  if (TERMINAL_STATES.has(current.state)) {
+  // The record can legitimately be missing (a dropped/pruned task id, #554 —
+  // terminal records are pruned past a per-project cap, or a fresh daemon
+  // hasn't registered it yet). That is NOT evidence the task is terminal, so
+  // it must never be treated as such — and never dereferenced blindly, or a
+  // crash here drops CREW DONE exactly like #574 did, just via a new door.
+  // Fall through to the normal emit, which surfaces its own clear error if the
+  // id truly doesn't exist.
+  const current = (await deps.call(buildStatusRequest(project, taskId))) as TaskRecord | null | undefined;
+  if (current && TERMINAL_STATES.has(current.state)) {
     throw new Error(
-      `Task ${taskId} is already terminal (state=${current.state}) — signal '${signal}' would be silently ignored. ` +
-        `If this crew started a new turn, its task record was never reopened — re-send via 'squadrant crew send' first.`,
+      `Task ${taskId} is already terminal (state=${current.state}) — signal '${signal}' would be silently ignored by the daemon. ` +
+        `Stop here: your task record was never reopened for this turn. Ask the captain to run 'squadrant crew send' to reopen it before signaling again.`,
     );
   }
   const req = buildSignalRequest(signal, { ...o, writeResult: o.writeResult ?? defaultWriteResult });

--- a/packages/core/src/__tests__/crew-spawn.test.ts
+++ b/packages/core/src/__tests__/crew-spawn.test.ts
@@ -657,6 +657,29 @@ describe("runCrewSend", () => {
     expect(runtime.sendToPane).toHaveBeenCalledWith(expect.anything(), "msg");
   });
 
+  // #574: runCrewSend picked tasks.find() = FIRST same-name match, while
+  // runCrewClose (#513) picks the MOST RECENT same-name match. With duplicate
+  // records (e.g. an orphaned record from a prior close/respawn race), the two
+  // call sites disagreed on which record is "the" live one — send would reopen
+  // a stale record instead of the one the live crew actually reports against,
+  // so a later `crew signal done` targeting the live (already-terminal) record
+  // never observably reopened, silently dropping CREW DONE. Send must pick the
+  // same most-recent-by-createdAt record as close.
+  it("reopens the MOST RECENT same-name record, not the first match (duplicate same-name records, #574)", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:cv-qa" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    const emitEvent = vi.fn().mockResolvedValue(undefined);
+    // Stale orphaned record (non-terminal, earlier) listed BEFORE the live
+    // crew's own record (terminal, later) — array order must not matter.
+    const stale = { id: "old-id", name: "cv-qa", state: "working", createdAt: 1000 } as Partial<TaskRecord>;
+    const live = { id: "new-id", name: "cv-qa", state: "done", createdAt: 2000 } as Partial<TaskRecord>;
+    await runCrewSend(PROJECT, "cv-qa", "msg", runtime, "workspace:1", {
+      listTasks: vi.fn().mockResolvedValue([stale, live]),
+      emitEvent,
+    });
+    expect(emitEvent).toHaveBeenCalledWith(PROJECT, { type: "task.reopened", id: "new-id" });
+  });
+
   // #448: when deps.sendToPane is injected, it is used instead of runtime.sendToPane
   // so the CLI can supply the paste-settle-Enter confirmed-submit helper.
   it("uses deps.sendToPane when provided, bypassing runtime.sendToPane", async () => {

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -459,6 +459,17 @@ export async function runCrewSpawn(
 
 // ─── crew session operations ──────────────────────────────────────────────────
 
+// #574: the single record-selection rule for "which task record is THE record
+// for this crew name" when duplicates exist (e.g. an orphaned record left by a
+// close/respawn race, #513). Every call site that resolves a crew name to a
+// task record MUST go through this helper — runCrewSend and runCrewClose used
+// to each inline their own pick (first-match vs most-recent), and disagreed on
+// live vs. stale duplicates, causing the two sides of a crew's lifecycle to
+// silently track different ids.
+function pickMostRecentTask(tasks: TaskRecord[]): TaskRecord {
+  return tasks.reduce((a, b) => ((b.createdAt ?? 0) > (a.createdAt ?? 0) ? b : a));
+}
+
 export async function runCrewSend(
   project: string,
   name: string,
@@ -496,8 +507,8 @@ export async function runCrewSend(
   // Blocked task: emit task.started to clear blocked→working so a subsequent real
   // permission prompt re-fires CREW BLOCKED (#182).
   try {
-    const tasks = await deps.listTasks(project);
-    const task = tasks.find((t) => t.name === name);
+    const matches = (await deps.listTasks(project)).filter((t) => t.name === name);
+    const task = matches.length > 0 ? pickMostRecentTask(matches) : undefined;
     if (task) {
       if (TERMINAL_STATES.has(task.state)) {
         await deps.emitEvent(project, { type: "task.reopened", id: task.id });
@@ -591,7 +602,7 @@ export async function runCrewClose(
       // respawn). Terminalize every non-terminal match so none linger to fire
       // a phantom CREW STALLED/IDLE later. Reap/worktree cleanup below anchors
       // on the most-recently-dispatched match — the one the live pane belongs to.
-      const primary = matches.reduce((a, b) => ((b.createdAt ?? 0) > (a.createdAt ?? 0) ? b : a));
+      const primary = pickMostRecentTask(matches);
       taskId = primary.id;
       if (primary.cwd && projRoot && primary.cwd !== projRoot) {
         worktreeCwd = primary.cwd;


### PR DESCRIPTION
## Summary
- #574: `runCrewSend` picked `tasks.find()` (first same-name match) while `runCrewClose` (#513) picks the most-recent same-name match — with duplicate records (e.g. an orphaned record from a close/respawn race) the two call sites could disagree on which record is "the" live one, so a crew's own signal never observably reopened/terminalized the record the captain was tracking, silently dropping CREW DONE. Extracted a single `pickMostRecentTask()` helper and pointed both call sites at it so they cannot diverge again.
- #557: `squadrant crew signal done|blocked|failed` emitted its event and exited 0 unconditionally, even when the target task record was already terminal. The daemon's `reduce()` absorbs any event on a terminal record as a silent no-op, so the signal changed nothing while still reporting success. `runCrewSignal` now checks current task state via a status round-trip first and throws (nonzero exit, clear message) instead of silently succeeding — mirrors the #566 "confirm delivery or fail loudly" principle.

## Root-cause verification
Before writing any code, verified both halves against the actual source (not the filed-issue hypothesis) per the task's requirement:
- `packages/core/src/crew-spawn.ts`: confirmed `runCrewSend`'s `tasks.find()` (first match) vs `runCrewClose`'s `matches.reduce(...)` (most-recent) divergence exists exactly as hypothesized.
- `packages/core/src/state-machine.ts:53`: confirmed `reduce()` returns the record unchanged when `TERMINAL_STATES.has(rec.state)`, and `applyEvent`/the daemon's `event` handler in `packages/core/src/daemon/reduce.ts` return that unchanged record with no error — so a signal on an already-terminal task really is a silent no-op that the old CLI code could not observe.

## Test plan
- [x] Added a failing-first test in `crew-spawn.test.ts` reproducing #574 (duplicate same-name records, stale-vs-live), confirmed it failed against the old code, then passed after the fix.
- [x] Added failing-first tests in `crew-control.test.ts` for `runCrewSignal` reproducing #557 (already-terminal task → throws; non-terminal task → event still sent normally).
- [x] `pnpm test` (bounded by `scripts/heavy-lock.mjs`) green: 167 files / 2046 passed, 1 pre-existing skip.
- [x] No stray vitest/dev-server processes left running.