### PR TITLE
fix(#575,#576): effort dial write scope and notify must match reality

### DIFF
--- a/packages/cli/src/commands/__tests__/effort.test.ts
+++ b/packages/cli/src/commands/__tests__/effort.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { getDefaultConfig, saveConfig } from "@squadrant/shared";
+import { getDefaultConfig, saveConfig, loadConfig, resolveEffort, saveProjectOverride } from "@squadrant/shared";
 import type { SquadrantConfig, ProjectConfig } from "@squadrant/shared";
-import { runEffortGet, runEffortSet, notifyCaptainsOfEffort, effortCommand } from "../effort.js";
+import { runEffortGet, runEffortSet, notifyCaptainsOfEffort, effortScopeLabel, effortCommand } from "../effort.js";
 
 const requireDaemon = vi.hoisted(() => vi.fn());
 vi.mock("../../lib/require-daemon.js", () => ({
@@ -104,6 +104,55 @@ describe("effort set", () => {
   });
 });
 
+describe("effort set — per-project scope (#575)", () => {
+  it("writes the override into projects/<name>.json, not defaults.effort", () => {
+    const config = getDefaultConfig();
+    (config.defaults as any).effort = "low";
+    saveConfig(config, cfgPath);
+
+    runEffortSet("balance", cfgPath, "oneplan", dir);
+
+    const reloaded = loadConfig(cfgPath);
+    expect(resolveEffort(reloaded, "oneplan", dir)).toBe("balance");
+    // global dial must be untouched
+    expect(resolveEffort(reloaded)).toBe("low");
+  });
+
+  it("does not affect a different project's resolved effort", () => {
+    const config = getDefaultConfig();
+    (config.defaults as any).effort = "low";
+    saveConfig(config, cfgPath);
+
+    runEffortSet("max", cfgPath, "oneplan", dir);
+
+    const reloaded = loadConfig(cfgPath);
+    expect(resolveEffort(reloaded, "other-project", dir)).toBe("low");
+  });
+
+  it("round-trips: project-scoped set then resolveEffort for that project returns the new value", () => {
+    runEffortSet("max", cfgPath, "my-proj", dir);
+    const reloaded = loadConfig(cfgPath);
+    expect(resolveEffort(reloaded, "my-proj", dir)).toBe("max");
+  });
+
+  it("rejects invalid value without writing a project override", () => {
+    expect(() => runEffortSet("turbo", cfgPath, "oneplan", dir)).toThrow();
+    const reloaded = loadConfig(cfgPath);
+    // no override was created — falls back to the (untouched) global default
+    expect(resolveEffort(reloaded, "oneplan", dir)).toBe(resolveEffort(reloaded));
+  });
+});
+
+describe("effortScopeLabel (#575 — success line must state actual scope)", () => {
+  it("labels a project-scoped write with the project name", () => {
+    expect(effortScopeLabel("oneplan")).toBe("project: oneplan");
+  });
+
+  it("labels an unscoped write as global", () => {
+    expect(effortScopeLabel(undefined)).toBe("global");
+  });
+});
+
 describe("effort notify (self-notification exclusion)", () => {
   // Records every (captainName, message) the fake driver was asked to send.
   function makeDriver(sent: Array<{ captain: string; message: string }>) {
@@ -156,7 +205,7 @@ describe("effort notify (self-notification exclusion)", () => {
     const sent: Array<{ captain: string; message: string }> = [];
     const spy = makeAppendSpy();
 
-    await notifyCaptainsOfEffort("low", config, makeDriver(sent), projA, spy.fn);
+    await notifyCaptainsOfEffort("low", config, makeDriver(sent), projA, spy.fn, undefined, dir);
 
     // MUST NOT call driver.send
     expect(sent).toHaveLength(0);
@@ -174,7 +223,7 @@ describe("effort notify (self-notification exclusion)", () => {
     const spy = makeAppendSpy();
 
     // cwd given via the symlink should still resolve to projA and skip it.
-    await notifyCaptainsOfEffort("max", config, makeDriver(sent), link, spy.fn);
+    await notifyCaptainsOfEffort("max", config, makeDriver(sent), link, spy.fn, undefined, dir);
 
     expect(sent).toHaveLength(0);
     expect(spy.projects).toHaveLength(0);
@@ -190,7 +239,7 @@ describe("effort notify (self-notification exclusion)", () => {
     const sent: Array<{ captain: string; message: string }> = [];
     const spy = makeAppendSpy();
 
-    await notifyCaptainsOfEffort("balance", config, makeDriver(sent), path.join(dir, "elsewhere"), spy.fn);
+    await notifyCaptainsOfEffort("balance", config, makeDriver(sent), path.join(dir, "elsewhere"), spy.fn, undefined, dir);
 
     expect(sent).toHaveLength(0);
     expect(spy.projects.sort()).toEqual(["a", "b"]);
@@ -204,13 +253,87 @@ describe("effort notify (self-notification exclusion)", () => {
     const driver = {
       status: vi.fn().mockRejectedValue(new Error("daemon unreachable"))
     };
-    
+
     const append = vi.fn();
-    
+
     // Should NOT throw
-    await notifyCaptainsOfEffort("low", config, driver, path.join(dir, "elsewhere"), append);
-    
+    await notifyCaptainsOfEffort("low", config, driver, path.join(dir, "elsewhere"), append, undefined, dir);
+
     // And should not have appended
     expect(append).not.toHaveBeenCalled();
+  });
+});
+
+describe("effort notify — per-recipient truth (#576)", () => {
+  function makeDriver() {
+    return {
+      async status(name: string) {
+        return { id: name };
+      },
+    };
+  }
+
+  function configWithProjects(projects: Record<string, ProjectConfig>): SquadrantConfig {
+    const config = getDefaultConfig();
+    config.projects = projects;
+    return config;
+  }
+
+  function project(p: string, captainName: string): ProjectConfig {
+    return { path: p, captainName, spokeVault: "", host: "" };
+  }
+
+  function makeAppendSpy(): {
+    fn: (project: string, text: string) => Promise<void>;
+    projects: string[];
+    texts: string[];
+  } {
+    const projects: string[] = [];
+    const texts: string[] = [];
+    return {
+      fn: async (project, text) => {
+        projects.push(project);
+        texts.push(text);
+      },
+      projects,
+      texts,
+    };
+  }
+
+  it("a captain whose project has its own override does NOT receive a false global-change notice", async () => {
+    const projA = fs.mkdtempSync(path.join(dir, "projA-")); // has an override — unaffected by global change
+    const projB = fs.mkdtempSync(path.join(dir, "projB-")); // no override — genuinely inherits the change
+    saveProjectOverride("a", { effort: "low" }, dir);
+
+    const config = configWithProjects({
+      a: project(projA, "captain-a"),
+      b: project(projB, "captain-b"),
+    });
+    const spy = makeAppendSpy();
+
+    // A global set to "balance" — project "a" stays "low" per its override.
+    await notifyCaptainsOfEffort("balance", config, makeDriver(), path.join(dir, "elsewhere"), spy.fn, undefined, dir);
+
+    // Sanity: resolveEffort agrees project "a" did not actually change.
+    expect(resolveEffort(config, "a", dir)).toBe("low");
+    expect(resolveEffort(config, "b", dir)).toBe("balance");
+
+    // Only "b" (whose effective effort genuinely changed) gets notified.
+    expect(spy.projects).toEqual(["b"]);
+  });
+
+  it("project-scoped set notifies only the targeted project, not every running captain", async () => {
+    const projA = fs.mkdtempSync(path.join(dir, "projA-"));
+    const projB = fs.mkdtempSync(path.join(dir, "projB-"));
+    const config = configWithProjects({
+      a: project(projA, "captain-a"),
+      b: project(projB, "captain-b"),
+    });
+    const spy = makeAppendSpy();
+
+    // Set was scoped to project "a" only — "b" was never touched.
+    await notifyCaptainsOfEffort("max", config, makeDriver(), path.join(dir, "elsewhere"), spy.fn, "a", dir);
+
+    expect(spy.projects).toEqual(["a"]);
   });
 });

--- a/packages/cli/src/commands/__tests__/effort.test.ts
+++ b/packages/cli/src/commands/__tests__/effort.test.ts
@@ -50,6 +50,40 @@ describe("effort get", () => {
     const result = runEffortGet(cfgPath);
     expect(result.effort).toBe("max");
   });
+
+  it("returns the resolved effort for a registered project", () => {
+    const config = getDefaultConfig();
+    (config.defaults as any).effort = "low";
+    config.projects.oneplan = { path: path.join(dir, "proj-oneplan"), captainName: "captain-oneplan", spokeVault: "", host: "" };
+    saveConfig(config, cfgPath);
+    const result = runEffortGet(cfgPath, "oneplan", dir);
+    expect(result.effort).toBe("low");
+  });
+
+  it("hard-fails on an unknown --project name instead of silently answering with the global value (#576)", () => {
+    const config = getDefaultConfig();
+    config.projects.oneplan = { path: path.join(dir, "proj-oneplan"), captainName: "captain-oneplan", spokeVault: "", host: "" };
+    saveConfig(config, cfgPath);
+
+    // typo: "onplan" instead of "oneplan" — must NOT silently answer with the global default
+    expect(() => runEffortGet(cfgPath, "onplan", dir)).toThrow(/unknown project/i);
+  });
+
+  it("unknown-project error on get lists the registered project names", () => {
+    const config = getDefaultConfig();
+    config.projects.oneplan = { path: path.join(dir, "proj-oneplan"), captainName: "captain-oneplan", spokeVault: "", host: "" };
+    config.projects.brove = { path: path.join(dir, "proj-brove"), captainName: "captain-brove", spokeVault: "", host: "" };
+    saveConfig(config, cfgPath);
+
+    let message = "";
+    try {
+      runEffortGet(cfgPath, "onplan", dir);
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toContain("oneplan");
+    expect(message).toContain("brove");
+  });
 });
 
 describe("effort set", () => {

--- a/packages/cli/src/commands/__tests__/effort.test.ts
+++ b/packages/cli/src/commands/__tests__/effort.test.ts
@@ -105,9 +105,14 @@ describe("effort set", () => {
 });
 
 describe("effort set — per-project scope (#575)", () => {
+  function registerProject(config: SquadrantConfig, name: string): void {
+    config.projects[name] = { path: path.join(dir, `proj-${name}`), captainName: `captain-${name}`, spokeVault: "", host: "" };
+  }
+
   it("writes the override into projects/<name>.json, not defaults.effort", () => {
     const config = getDefaultConfig();
     (config.defaults as any).effort = "low";
+    registerProject(config, "oneplan");
     saveConfig(config, cfgPath);
 
     runEffortSet("balance", cfgPath, "oneplan", dir);
@@ -121,6 +126,7 @@ describe("effort set — per-project scope (#575)", () => {
   it("does not affect a different project's resolved effort", () => {
     const config = getDefaultConfig();
     (config.defaults as any).effort = "low";
+    registerProject(config, "oneplan");
     saveConfig(config, cfgPath);
 
     runEffortSet("max", cfgPath, "oneplan", dir);
@@ -130,16 +136,55 @@ describe("effort set — per-project scope (#575)", () => {
   });
 
   it("round-trips: project-scoped set then resolveEffort for that project returns the new value", () => {
+    const config = getDefaultConfig();
+    registerProject(config, "my-proj");
+    saveConfig(config, cfgPath);
+
     runEffortSet("max", cfgPath, "my-proj", dir);
     const reloaded = loadConfig(cfgPath);
     expect(resolveEffort(reloaded, "my-proj", dir)).toBe("max");
   });
 
   it("rejects invalid value without writing a project override", () => {
+    const config = getDefaultConfig();
+    registerProject(config, "oneplan");
+    saveConfig(config, cfgPath);
+
     expect(() => runEffortSet("turbo", cfgPath, "oneplan", dir)).toThrow();
     const reloaded = loadConfig(cfgPath);
     // no override was created — falls back to the (untouched) global default
     expect(resolveEffort(reloaded, "oneplan", dir)).toBe(resolveEffort(reloaded));
+  });
+
+  it("hard-fails on an unknown --project name instead of silently writing an override", () => {
+    const config = getDefaultConfig();
+    registerProject(config, "oneplan");
+    saveConfig(config, cfgPath);
+
+    // typo: "onplan" instead of "oneplan" — must NOT silently succeed
+    expect(() => runEffortSet("max", cfgPath, "onplan", dir)).toThrow(/unknown project/i);
+
+    // no override file was created for the typo'd name
+    expect(fs.existsSync(path.join(dir, "projects", "onplan.json"))).toBe(false);
+    // the real project's effort is untouched
+    const reloaded = loadConfig(cfgPath);
+    expect(resolveEffort(reloaded, "oneplan", dir)).toBe(resolveEffort(reloaded));
+  });
+
+  it("unknown-project error lists the registered project names", () => {
+    const config = getDefaultConfig();
+    registerProject(config, "oneplan");
+    registerProject(config, "brove");
+    saveConfig(config, cfgPath);
+
+    let message = "";
+    try {
+      runEffortSet("max", cfgPath, "onplan", dir);
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toContain("oneplan");
+    expect(message).toContain("brove");
   });
 });
 

--- a/packages/cli/src/commands/effort.ts
+++ b/packages/cli/src/commands/effort.ts
@@ -26,9 +26,17 @@ export interface EffortGetResult {
   description: string;
 }
 
-export function runEffortGet(configPath = DEFAULT_CONFIG_PATH, projectName?: string): EffortGetResult {
+export function runEffortGet(
+  configPath = DEFAULT_CONFIG_PATH,
+  projectName?: string,
+  projectConfigRoot?: string,
+): EffortGetResult {
   const config = loadConfig(configPath);
-  const effort = resolveEffort(config, projectName);
+  if (projectName && !(projectName in config.projects)) {
+    const known = Object.keys(config.projects).sort().join(", ") || "(no projects registered)";
+    throw new Error(`Unknown project '${projectName}'. Known projects: ${known}`);
+  }
+  const effort = resolveEffort(config, projectName, projectConfigRoot);
   const description = `${effort}: ${EFFORT_MEANING[effort]}`;
   return { effort, description };
 }
@@ -135,10 +143,16 @@ export const effortCommand = new Command("effort")
   .option("--project <name>", "target a specific project (get: show its resolved effort; set: write a per-project override)")
   .action(async (value: string | undefined, options: { project?: string }) => {
     if (value === undefined) {
-      const { effort, description } = runEffortGet(undefined, options.project);
+      let result: EffortGetResult;
+      try {
+        result = runEffortGet(undefined, options.project);
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
       const label = options.project ? `${options.project} project` : "global";
-      console.log(chalk.bold(`Current effort (${label}):`), chalk.cyan(effort));
-      console.log(chalk.dim(EFFORT_MEANING[effort]));
+      console.log(chalk.bold(`Current effort (${label}):`), chalk.cyan(result.effort));
+      console.log(chalk.dim(EFFORT_MEANING[result.effort]));
       return;
     }
 

--- a/packages/cli/src/commands/effort.ts
+++ b/packages/cli/src/commands/effort.ts
@@ -2,7 +2,14 @@ import fs from "node:fs";
 import path from "node:path";
 import { Command } from "commander";
 import chalk from "chalk";
-import { loadConfig, saveConfig, resolveEffort, DEFAULT_CONFIG_PATH } from "@squadrant/shared";
+import {
+  loadConfig,
+  saveConfig,
+  resolveEffort,
+  loadProjectOverride,
+  saveProjectOverride,
+  DEFAULT_CONFIG_PATH,
+} from "@squadrant/shared";
 import type { SquadrantConfig, Effort } from "@squadrant/shared";
 import { appendCaptainMessage } from "@squadrant/core";
 
@@ -26,15 +33,34 @@ export function runEffortGet(configPath = DEFAULT_CONFIG_PATH, projectName?: str
   return { effort, description };
 }
 
-export function runEffortSet(value: string, configPath = DEFAULT_CONFIG_PATH): void {
+/**
+ * Set the effort dial. With `projectName`, writes a per-project override
+ * (projects/<name>.json) instead of the global dial — the two scopes are
+ * mutually exclusive so callers must not fall through to the global write.
+ */
+export function runEffortSet(
+  value: string,
+  configPath = DEFAULT_CONFIG_PATH,
+  projectName?: string,
+  projectConfigRoot?: string,
+): void {
   if (!(VALID_EFFORTS as string[]).includes(value)) {
     throw new Error(
       `Invalid effort '${value}'. Valid values: ${VALID_EFFORTS.join(" | ")}`,
     );
   }
+  if (projectName) {
+    saveProjectOverride(projectName, { effort: value as Effort }, projectConfigRoot);
+    return;
+  }
   const config = loadConfig(configPath);
   config.defaults.effort = value as Effort;
   saveConfig(config, configPath);
+}
+
+/** Scope label for the CLI success line — must state what was actually written (#575). */
+export function effortScopeLabel(projectName?: string): string {
+  return projectName ? `project: ${projectName}` : "global";
 }
 
 /** Minimal slice of RuntimeDriver used to resolve captain status. */
@@ -53,11 +79,17 @@ function canonical(p: string): string {
 }
 
 /**
- * Send the effort-change notice to every running captain via the mailbox.
- * The captain that ran `squadrant effort` already saw stdout, so that project
- * is excluded. Routes through the mailbox so the daemon's delivery-loop drains
- * it with draft protection (#529).
+ * Send the effort-change notice to every running captain whose *effective*
+ * effort actually changed, via the mailbox. The captain that ran
+ * `squadrant effort` already saw stdout, so that project is excluded.
+ * Routes through the mailbox so the daemon's delivery-loop drains it with
+ * draft protection (#529).
  * appendCaptainMessage is a closure capturing stateRoot from the caller.
+ *
+ * `scopeProject` set means the write was project-scoped (#575): only that
+ * project's effective effort changed, so only it is notified. Unset means a
+ * global write: projects with their own override are unaffected and must be
+ * skipped rather than told a value that isn't theirs (#576).
  */
 export async function notifyCaptainsOfEffort(
   effort: Effort,
@@ -65,12 +97,22 @@ export async function notifyCaptainsOfEffort(
   driver: EffortNotifyDriver,
   cwd: string = process.cwd(),
   append: (project: string, text: string) => Promise<void | number>,
+  scopeProject?: string,
+  projectConfigRoot?: string,
 ): Promise<void> {
   const here = canonical(cwd);
   const notice = `🎚️ effort → ${effort}: ${EFFORT_MEANING[effort]}`;
   for (const [projName, proj] of Object.entries(config.projects)) {
     // Skip the captain running in this same directory — it already saw stdout.
     if (canonical(proj.path) === here) continue;
+
+    if (scopeProject) {
+      if (projName !== scopeProject) continue;
+    } else if (loadProjectOverride(projName, projectConfigRoot).effort !== undefined) {
+      // This project pins its own effort — the global change doesn't apply to it.
+      continue;
+    }
+
     try {
       const ref = await driver.status(proj.captainName);
       if (ref) {
@@ -85,7 +127,7 @@ export async function notifyCaptainsOfEffort(
 export const effortCommand = new Command("effort")
   .description("Get or set the global crew tokenomics dial (max | balance | low)")
   .argument("[value]", "effort level to set: max | balance | low")
-  .option("--project <name>", "show resolved effort for a specific project")
+  .option("--project <name>", "target a specific project (get: show its resolved effort; set: write a per-project override)")
   .action(async (value: string | undefined, options: { project?: string }) => {
     if (value === undefined) {
       const { effort, description } = runEffortGet(undefined, options.project);
@@ -96,18 +138,19 @@ export const effortCommand = new Command("effort")
     }
 
     try {
-      runEffortSet(value);
+      runEffortSet(value, undefined, options.project);
     } catch (err) {
       console.error(chalk.red((err as Error).message));
       process.exit(1);
     }
 
     const effort = value as Effort;
-    console.log(chalk.green(`✔ effort → ${effort}`));
+    console.log(chalk.green(`✔ effort → ${effort} (${effortScopeLabel(options.project)})`));
     console.log(chalk.dim(EFFORT_MEANING[effort]));
 
-    // Best-effort active notify: enqueue to the mailbox for every running captain.
-    // Never hard-fails — config is already written above.
+    // Best-effort active notify: enqueue to the mailbox for every running captain
+    // whose effective effort actually changed. Never hard-fails — config is
+    // already written above.
     // Routes through the mailbox (not driver.send) to avoid clobbering user draft (#529).
     try {
       const { createCmuxDriver, RuntimeRegistry } = await import("@squadrant/workspaces");
@@ -117,7 +160,7 @@ export const effortCommand = new Command("effort")
       const stateRoot = path.join(path.dirname(DEFAULT_CONFIG_PATH), "state");
       const append = (project: string, text: string) =>
         appendCaptainMessage({ stateRoot, project, text, source: "daemon" });
-      await notifyCaptainsOfEffort(effort, config, driver, process.cwd(), append);
+      await notifyCaptainsOfEffort(effort, config, driver, process.cwd(), append, options.project);
     } catch {
       // runtime unavailable — config already written, change applies on next launch
       console.log(chalk.dim("(no running captain detected — change applies on next launch)"));

--- a/packages/cli/src/commands/effort.ts
+++ b/packages/cli/src/commands/effort.ts
@@ -50,6 +50,11 @@ export function runEffortSet(
     );
   }
   if (projectName) {
+    const config = loadConfig(configPath);
+    if (!(projectName in config.projects)) {
+      const known = Object.keys(config.projects).sort().join(", ") || "(no projects registered)";
+      throw new Error(`Unknown project '${projectName}'. Known projects: ${known}`);
+    }
     saveProjectOverride(projectName, { effort: value as Effort }, projectConfigRoot);
     return;
   }
@@ -125,7 +130,7 @@ export async function notifyCaptainsOfEffort(
 }
 
 export const effortCommand = new Command("effort")
-  .description("Get or set the global crew tokenomics dial (max | balance | low)")
+  .description("Get or set the crew tokenomics dial (max | balance | low) — global by default, or per-project with --project")
   .argument("[value]", "effort level to set: max | balance | low")
   .option("--project <name>", "target a specific project (get: show its resolved effort; set: write a per-project override)")
   .action(async (value: string | undefined, options: { project?: string }) => {


### PR DESCRIPTION
## Summary
- **#575**: `squadrant effort <value> --project <name>` declared `--project` but the SET branch never read it — it silently rewrote the *global* dial while printing a success line. Now writes a per-project override into `projects/<name>.json` via the existing `saveProjectOverride` layered-config mechanism, and the success line states the actual scope written (`(project: <name>)` vs `(global)`).
- **#576**: `notifyCaptainsOfEffort()` computed one notice from the global value and broadcast it to every running captain, so a captain whose project has its own override was told an untrue value about its own effective effort. Now computes per-recipient: a global set skips any project with its own override (unaffected), and a project-scoped set only notifies that one project.

## Test plan
- [x] TDD: added failing tests reproducing both defects before the fix (6 new tests, confirmed red against unfixed code)
- [x] Verified by behavior via `resolveEffort()`, not file contents or exit codes
- [x] `pnpm test` (heavy-lock bounded): 167 files, 2051 passed / 1 skipped, 0 failed
- [x] No stray vitest processes left running
- [x] No writes to the real `~/.config/squadrant` — all tests use `fs.mkdtempSync` tmp roots

Fixes #575, Fixes #576