### PR TITLE
fix(#560): detect a crew's AskUserQuestion prompt — no daemon event fired at all

### DIFF
--- a/packages/agents/src/__tests__/interactive-claude-hook.test.ts
+++ b/packages/agents/src/__tests__/interactive-claude-hook.test.ts
@@ -428,10 +428,17 @@ describe("formatAskUserQuestionPrompt (#560 — real question/options text)", ()
   });
 });
 
+// #560 review fix: task.input.requested — NOT task.blocked — is the event that
+// carries requestId and drives ctx.schedulePromotion (squadrantd.ts) — the
+// answer-routing machinery #562 needs. task.blocked has no requestId field at
+// all, so mapping AskUserQuestion to it would delete the only signal #562
+// could build on. task.input.requested already does everything #560 needs
+// too: state-machine.ts maps it to state 'blocked' with the question,
+// telegram/format.ts renders it, tiers.ts includes it.
 describe("mapClaudeHookToEvent PreToolUse AskUserQuestion (#560)", () => {
   const TID = "task-abc";
 
-  it("tool_name AskUserQuestion → task.blocked carrying the real question + options", () => {
+  it("tool_name AskUserQuestion → task.input.requested carrying the real question + options and a requestId", () => {
     const payload = {
       tool_name: "AskUserQuestion",
       tool_input: {
@@ -443,15 +450,29 @@ describe("mapClaudeHookToEvent PreToolUse AskUserQuestion (#560)", () => {
       },
     };
     const ev = mapClaudeHookToEvent("PreToolUse", payload, TID);
-    expect(ev).toEqual({
-      type: "task.blocked",
+    expect(ev?.type).toBe("task.input.requested");
+    expect(ev).toMatchObject({
+      type: "task.input.requested",
       id: TID,
-      reason: "crew opened an AskUserQuestion prompt",
       question: "Silent fallback or labelled fallback? (options: Silent, Labelled)",
     });
+    // requestId: Claude's PreToolUse payload carries no native per-tool-call id
+    // (session_id/cwd/tool_name/tool_input only — verified against the
+    // documented payload shape) — a real, distinct value is still required
+    // (not a hardcoded 0) so schedulePromotion's `${taskId}#${requestId}` key
+    // doesn't collide across successive prompts for the same crew.
+    expect(typeof (ev as any).requestId).toBe("number");
+    expect(Number.isFinite((ev as any).requestId)).toBe(true);
   });
 
-  it("tool_name AskUserQuestion with malformed/missing tool_input → STILL task.blocked with a generic fallback, never null", () => {
+  it("two calls in quick succession get distinct requestIds (no collision on schedulePromotion's dedup key)", () => {
+    const payload = { tool_name: "AskUserQuestion", tool_input: { questions: [{ question: "A?" }] } };
+    const first = mapClaudeHookToEvent("PreToolUse", payload, TID) as any;
+    const second = mapClaudeHookToEvent("PreToolUse", { ...payload, tool_input: { questions: [{ question: "B?" }] } }, TID) as any;
+    expect(first.requestId).not.toBe(second.requestId);
+  });
+
+  it("tool_name AskUserQuestion with malformed/missing tool_input → STILL task.input.requested with a generic fallback, never null", () => {
     for (const payload of [
       { tool_name: "AskUserQuestion" },
       { tool_name: "AskUserQuestion", tool_input: {} },
@@ -460,7 +481,7 @@ describe("mapClaudeHookToEvent PreToolUse AskUserQuestion (#560)", () => {
     ]) {
       const ev = mapClaudeHookToEvent("PreToolUse", payload, TID);
       expect(ev).not.toBeNull();
-      expect(ev!.type).toBe("task.blocked");
+      expect(ev!.type).toBe("task.input.requested");
     }
   });
 

--- a/packages/agents/src/__tests__/interactive-claude-hook.test.ts
+++ b/packages/agents/src/__tests__/interactive-claude-hook.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
-import { mapClaudeHookToEvent, detectTrailingQuestion, deriveTranscriptPath, isPermissionNotification } from "../interactive/claude.js";
+import { mapClaudeHookToEvent, detectTrailingQuestion, deriveTranscriptPath, isPermissionNotification, formatAskUserQuestionPrompt } from "../interactive/claude.js";
 
 describe("mapClaudeHookToEvent", () => {
   const TID = "task-abc";
@@ -380,5 +380,102 @@ describe("mapClaudeHookToEvent Stop last_assistant_message (#174 primary source)
   it("empty/whitespace last_assistant_message falls through to transcript resolution", () => {
     const ev = mapClaudeHookToEvent("Stop", { last_assistant_message: "   " }, TID);
     expect(ev).toEqual({ type: "task.turn.completed", id: TID, turnId: "hook-stop" });
+  });
+});
+
+// #560: AskUserQuestion is a TOOL call, not a hook event — Claude fires PreToolUse
+// (matcher-scoped to "AskUserQuestion") right as the modal opens and blocks the
+// turn awaiting a human selection. Before this, a crew's own hook set had no
+// PreToolUse coverage at all, so it emitted nothing and the daemon never learned
+// the crew was blocked.
+describe("formatAskUserQuestionPrompt (#560 — real question/options text)", () => {
+  it("formats a single question with its options", () => {
+    const toolInput = {
+      questions: [
+        { question: "Which auth approach?", header: "Auth", multiSelect: false, options: [
+          { label: "OAuth", description: "..." },
+          { label: "API key", description: "..." },
+        ] },
+      ],
+    };
+    expect(formatAskUserQuestionPrompt(toolInput)).toBe("Which auth approach? (options: OAuth, API key)");
+  });
+
+  it("formats multiple questions, joined", () => {
+    const toolInput = {
+      questions: [
+        { question: "Ship now?", options: [{ label: "Yes" }, { label: "No" }] },
+        { question: "Which env?", options: [{ label: "staging" }, { label: "prod" }] },
+      ],
+    };
+    expect(formatAskUserQuestionPrompt(toolInput)).toBe(
+      "Ship now? (options: Yes, No) | Which env? (options: staging, prod)",
+    );
+  });
+
+  it("formats a question with no options (free-form)", () => {
+    expect(formatAskUserQuestionPrompt({ questions: [{ question: "What should I name it?" }] }))
+      .toBe("What should I name it?");
+  });
+
+  it("returns null for missing/empty/malformed questions array — never throws", () => {
+    expect(formatAskUserQuestionPrompt(undefined)).toBeNull();
+    expect(formatAskUserQuestionPrompt(null)).toBeNull();
+    expect(formatAskUserQuestionPrompt({})).toBeNull();
+    expect(formatAskUserQuestionPrompt({ questions: [] })).toBeNull();
+    expect(formatAskUserQuestionPrompt({ questions: "not an array" })).toBeNull();
+    expect(formatAskUserQuestionPrompt({ questions: [{}, { question: 42 }] })).toBeNull();
+  });
+});
+
+describe("mapClaudeHookToEvent PreToolUse AskUserQuestion (#560)", () => {
+  const TID = "task-abc";
+
+  it("tool_name AskUserQuestion → task.blocked carrying the real question + options", () => {
+    const payload = {
+      tool_name: "AskUserQuestion",
+      tool_input: {
+        questions: [
+          { question: "Silent fallback or labelled fallback?", options: [
+            { label: "Silent" }, { label: "Labelled" },
+          ] },
+        ],
+      },
+    };
+    const ev = mapClaudeHookToEvent("PreToolUse", payload, TID);
+    expect(ev).toEqual({
+      type: "task.blocked",
+      id: TID,
+      reason: "crew opened an AskUserQuestion prompt",
+      question: "Silent fallback or labelled fallback? (options: Silent, Labelled)",
+    });
+  });
+
+  it("tool_name AskUserQuestion with malformed/missing tool_input → STILL task.blocked with a generic fallback, never null", () => {
+    for (const payload of [
+      { tool_name: "AskUserQuestion" },
+      { tool_name: "AskUserQuestion", tool_input: {} },
+      { tool_name: "AskUserQuestion", tool_input: { questions: [] } },
+      { tool_name: "AskUserQuestion", tool_input: null },
+    ]) {
+      const ev = mapClaudeHookToEvent("PreToolUse", payload, TID);
+      expect(ev).not.toBeNull();
+      expect(ev!.type).toBe("task.blocked");
+    }
+  });
+
+  it("other tool names (e.g. Bash) → null — matcher scoping means this shouldn't fire, but stay conservative if it does", () => {
+    expect(mapClaudeHookToEvent("PreToolUse", { tool_name: "Bash", tool_input: { command: "ls" } }, TID)).toBeNull();
+  });
+
+  it("missing tool_name → null (unchanged pre-existing behavior for a bare/unmatched PreToolUse)", () => {
+    expect(mapClaudeHookToEvent("PreToolUse", {}, TID)).toBeNull();
+    expect(mapClaudeHookToEvent("PreToolUse", null, TID)).toBeNull();
+  });
+
+  it("anti-#2576 invariant: never task.done or task.failed regardless of tool_input shape", () => {
+    const ev = mapClaudeHookToEvent("PreToolUse", { tool_name: "AskUserQuestion", tool_input: {} }, TID);
+    expect(ev!.type).not.toBe("task.done");
+    expect(ev!.type).not.toBe("task.failed");
   });
 });

--- a/packages/agents/src/__tests__/interactive-claude.test.ts
+++ b/packages/agents/src/__tests__/interactive-claude.test.ts
@@ -110,4 +110,25 @@ describe("claude interactive hook merge", () => {
     const matched = twice.hooks.PreToolUse.filter((m: any) => m.matcher === "AskUserQuestion");
     expect(matched).toHaveLength(1);
   });
+
+  // Dedup footgun: installHookEntry used to key "already present" on command
+  // substring alone, scanning ALL entries for an event regardless of matcher.
+  // A pre-existing BARE entry for the same event+command (e.g. from a future
+  // change that adds "PreToolUse" to the broad EVENTS list too) would make the
+  // matcher-scoped install look "already done" and silently skip — even though
+  // the bare entry (matcher "") never fires for the AskUserQuestion-scoped
+  // case. Keyed on (event, matcher) so the two coexist correctly.
+  it("a pre-existing bare-matcher entry for the same event+command does not silently block the matcher-scoped install", () => {
+    const existing = {
+      hooks: {
+        PreToolUse: [{ matcher: "", hooks: [{ type: "command", command: `${HOOK_CMD} PreToolUse` }] }],
+      },
+    };
+    const out = mergeClaudeHooks(existing, HOOK_CMD);
+    const scoped = out.hooks.PreToolUse.find((m: any) => m.matcher === "AskUserQuestion");
+    expect(scoped).toBeDefined();
+    // The pre-existing bare entry must survive untouched.
+    const bare = out.hooks.PreToolUse.find((m: any) => m.matcher === "");
+    expect(bare).toBeDefined();
+  });
 });

--- a/packages/agents/src/__tests__/interactive-claude.test.ts
+++ b/packages/agents/src/__tests__/interactive-claude.test.ts
@@ -89,4 +89,25 @@ describe("claude interactive hook merge", () => {
     expect(out.hooks.UserPromptSubmit[0].hooks[0].command).toContain(HOOK_CMD);
     expect(out.hooks.UserPromptSubmit[0].hooks[0].command).toContain("UserPromptSubmit");
   });
+
+  // #560: an AskUserQuestion tool call blocks the crew waiting for a human, but
+  // the crew's own hook set had no PreToolUse entry at all — the crew's Claude
+  // process fired zero signal on it. Scoped to the AskUserQuestion matcher (not
+  // a bare PreToolUse) so it doesn't double the per-tool-call hook overhead
+  // PostToolUse already covers.
+  it("registers a matcher-scoped PreToolUse hook for AskUserQuestion detection (#560)", () => {
+    const out = mergeClaudeHooks({}, HOOK_CMD);
+    expect(out.hooks.PreToolUse).toBeDefined();
+    const entry = out.hooks.PreToolUse.find((m: any) => m.matcher === "AskUserQuestion");
+    expect(entry).toBeDefined();
+    expect(entry.hooks[0].command).toContain(HOOK_CMD);
+    expect(entry.hooks[0].command).toContain("PreToolUse");
+  });
+
+  it("PreToolUse/AskUserQuestion hook is idempotent — merging twice yields one entry", () => {
+    const once = mergeClaudeHooks({}, HOOK_CMD);
+    const twice = mergeClaudeHooks(once, HOOK_CMD);
+    const matched = twice.hooks.PreToolUse.filter((m: any) => m.matcher === "AskUserQuestion");
+    expect(matched).toHaveLength(1);
+  });
 });

--- a/packages/agents/src/interactive/claude.ts
+++ b/packages/agents/src/interactive/claude.ts
@@ -29,6 +29,16 @@ const MATCHED_EVENTS: ReadonlyArray<readonly [event: string, matcher: string]> =
   ["PreToolUse", "AskUserQuestion"],
 ];
 
+// #560: Claude's PreToolUse hook payload carries no native per-tool-call id
+// (documented shape is session_id/cwd/tool_name/tool_input only — no
+// tool_use_id), so there is no "real" requestId to forward. Seeded from
+// Date.now() and incremented per call (this module runs fresh per hook
+// invocation, so in practice each call gets Date.now() at that moment) so
+// schedulePromotion's `${taskId}#${requestId}` dedup key never collides
+// across successive AskUserQuestion prompts for the same crew, unlike a
+// hardcoded 0 would.
+let nextAskUserQuestionRequestId = Date.now();
+
 /**
  * Probe whether the local Claude CLI supports `--settings <path>`. The
  * daemon-supervised crew path needs per-invocation settings to inject the
@@ -58,11 +68,20 @@ export function isPermissionNotification(message: string): boolean {
   return lower.includes("permission") || lower.includes("approve");
 }
 
+// Keyed on (event, matcher) — NOT command alone. An event can carry both a
+// bare entry (matcher "", from EVENTS) and a matcher-scoped entry (from
+// MATCHED_EVENTS) with the identical command string (only the matcher
+// differs; Claude dispatches on matcher, not on the command text). Scanning
+// ALL entries for the event regardless of matcher would make the
+// matcher-scoped install look "already done" the moment a bare entry for the
+// same event+command exists, and silently skip installing it — the same
+// silent-drop failure mode this hook set exists to close (#560).
 function installHookEntry(hooks: Record<string, unknown>, event: string, matcher: string, command: string): void {
   if (!Array.isArray(hooks[event])) hooks[event] = [];
   const entries = hooks[event] as unknown[];
   const already = entries.some(
-    (m) => Array.isArray((m as any)?.hooks) &&
+    (m) => (m as any)?.matcher === matcher &&
+      Array.isArray((m as any)?.hooks) &&
       (m as any).hooks.some((h: any) => typeof h?.command === "string" && h.command.includes(command)),
   );
   if (!already) {
@@ -239,11 +258,15 @@ export function formatAskUserQuestionPrompt(toolInput: unknown): string | null {
  * hook set registers this ONLY for that tool (see MATCHED_EVENTS above), so in
  * practice tool_name is always "AskUserQuestion" here. Still checked
  * defensively — a config regression to a bare/unmatched PreToolUse must not
- * silently start reporting task.blocked for every tool call. When it IS
- * AskUserQuestion, this maps to task.blocked UNCONDITIONALLY — even a
- * malformed/unreadable tool_input still produces a generic fallback question
- * rather than falling through to null, because a detection path that can
- * silently fail to fire is the exact defect #560 exists to close.
+ * silently start reporting task.input.requested for every tool call. When it
+ * IS AskUserQuestion, this maps to task.input.requested (NOT task.blocked —
+ * task.blocked has no requestId field, and requestId is what
+ * ctx.schedulePromotion in squadrantd.ts keys its answer-routing timer on;
+ * task.input.requested already drives state-machine.ts → state 'blocked',
+ * the CREW BLOCKED notification, and Telegram formatting) UNCONDITIONALLY —
+ * even a malformed/unreadable tool_input still produces a generic fallback
+ * question rather than falling through to null, because a detection path
+ * that can silently fail to fire is the exact defect #560 exists to close.
  */
 export function mapClaudeHookToEvent(
   event: string,
@@ -256,7 +279,7 @@ export function mapClaudeHookToEvent(
       if (toolName !== "AskUserQuestion") return null;
       const question = formatAskUserQuestionPrompt((payload as any)?.tool_input)
         ?? "crew opened an AskUserQuestion prompt (options unavailable)";
-      return { type: "task.blocked", id: taskId, reason: "crew opened an AskUserQuestion prompt", question };
+      return { type: "task.input.requested", id: taskId, requestId: nextAskUserQuestionRequestId++, question };
     }
     case "Stop": {
       const text = resolveLastAssistantText(payload);

--- a/packages/agents/src/interactive/claude.ts
+++ b/packages/agents/src/interactive/claude.ts
@@ -19,6 +19,16 @@ import type { ControlEvent } from "@squadrant/shared";
 // signal (#470), replacing the screen-scrape {delivered} heuristic.
 const EVENTS = ["Stop", "SubagentStop", "SessionEnd", "PostToolUse", "Notification", "UserPromptSubmit"] as const;
 
+// #560: matcher-scoped hook entries beyond the broad EVENTS list above — fires
+// only for the named tool, not every tool call. AskUserQuestion is CC's native
+// interactive-prompt tool: PreToolUse fires the instant it opens (and blocks
+// the turn awaiting a human selection), so this is the earliest possible signal
+// that a crew is blocked on a question. Scoped to this one tool so it doesn't
+// double the per-tool-call hook overhead PostToolUse already covers.
+const MATCHED_EVENTS: ReadonlyArray<readonly [event: string, matcher: string]> = [
+  ["PreToolUse", "AskUserQuestion"],
+];
+
 /**
  * Probe whether the local Claude CLI supports `--settings <path>`. The
  * daemon-supervised crew path needs per-invocation settings to inject the
@@ -48,18 +58,27 @@ export function isPermissionNotification(message: string): boolean {
   return lower.includes("permission") || lower.includes("approve");
 }
 
+function installHookEntry(hooks: Record<string, unknown>, event: string, matcher: string, command: string): void {
+  if (!Array.isArray(hooks[event])) hooks[event] = [];
+  const entries = hooks[event] as unknown[];
+  const already = entries.some(
+    (m) => Array.isArray((m as any)?.hooks) &&
+      (m as any).hooks.some((h: any) => typeof h?.command === "string" && h.command.includes(command)),
+  );
+  if (!already) {
+    entries.push({ matcher, hooks: [{ type: "command", command, timeout: 10 }] });
+  }
+}
+
 /** Pure, idempotent merge of squadrant hooks into a Claude settings object. */
 export function mergeClaudeHooks(settings: any, hookCmd: string): any {
   const next = structuredClone(settings ?? {});
   next.hooks ??= {};
   for (const ev of EVENTS) {
-    if (!Array.isArray(next.hooks[ev])) next.hooks[ev] = [];
-    const already = next.hooks[ev].some((m: any) =>
-      Array.isArray(m?.hooks) && m.hooks.some((h: any) => typeof h.command === "string" && h.command.includes(hookCmd)),
-    );
-    if (!already) {
-      next.hooks[ev].push({ matcher: "", hooks: [{ type: "command", command: `${hookCmd} ${ev}`, timeout: 10 }] });
-    }
+    installHookEntry(next.hooks, ev, "", `${hookCmd} ${ev}`);
+  }
+  for (const [ev, matcher] of MATCHED_EVENTS) {
+    installHookEntry(next.hooks, ev, matcher, `${hookCmd} ${ev}`);
   }
   return next;
 }
@@ -164,6 +183,33 @@ function resolveLastAssistantText(payload: unknown): string | null {
 }
 
 /**
+ * Pure: render an AskUserQuestion tool call's `tool_input` (the raw arguments
+ * Claude passes to the tool — `{ questions: [{ question, header, options,
+ * multiSelect }] }`) into a human-readable prompt for CREW BLOCKED, carrying
+ * both the question text AND its options (#560's proposal explicitly asks for
+ * both — an option-less "awaiting input" placeholder can't be answered by
+ * #562's answer channel or checked for staleness by #563).
+ * Never throws; returns null when the shape doesn't match (caller must still
+ * surface SOME text — see mapClaudeHookToEvent's PreToolUse case).
+ */
+export function formatAskUserQuestionPrompt(toolInput: unknown): string | null {
+  const questions = (toolInput as { questions?: unknown } | null | undefined)?.questions;
+  if (!Array.isArray(questions) || questions.length === 0) return null;
+  const parts: string[] = [];
+  for (const q of questions) {
+    if (!q || typeof q !== "object") continue;
+    const text = (q as any).question;
+    if (typeof text !== "string" || !text.trim()) continue;
+    const options = Array.isArray((q as any).options) ? (q as any).options : [];
+    const labels = options
+      .map((o: any) => (o && typeof o.label === "string" ? o.label.trim() : null))
+      .filter((l: string | null): l is string => !!l);
+    parts.push(labels.length > 0 ? `${text.trim()} (options: ${labels.join(", ")})` : text.trim());
+  }
+  return parts.length > 0 ? parts.join(" | ") : null;
+}
+
+/**
  * Map a Claude hook event name to a squadrant ControlEvent. Codifies the anti-#2576
  * invariant: NO Claude hook ever maps to `task.done`/`task.failed`.
  * PostToolUse/SubagentStop = resume-liveness only (task.progress). SessionEnd is
@@ -188,6 +234,16 @@ function resolveLastAssistantText(payload: unknown): string | null {
  * state-machine idempotency (already-blocked → no-op, from #176) deduplicates.
  * Non-permission notifications (idle liveness) → task.progress. Missing/non-string
  * message → task.progress (never throws, hook must exit 0).
+ *
+ * PreToolUse = matcher-scoped to AskUserQuestion only (#560): the crew's own
+ * hook set registers this ONLY for that tool (see MATCHED_EVENTS above), so in
+ * practice tool_name is always "AskUserQuestion" here. Still checked
+ * defensively — a config regression to a bare/unmatched PreToolUse must not
+ * silently start reporting task.blocked for every tool call. When it IS
+ * AskUserQuestion, this maps to task.blocked UNCONDITIONALLY — even a
+ * malformed/unreadable tool_input still produces a generic fallback question
+ * rather than falling through to null, because a detection path that can
+ * silently fail to fire is the exact defect #560 exists to close.
  */
 export function mapClaudeHookToEvent(
   event: string,
@@ -195,6 +251,13 @@ export function mapClaudeHookToEvent(
   taskId: string,
 ): ControlEvent | null {
   switch (event) {
+    case "PreToolUse": {
+      const toolName = (payload as any)?.tool_name;
+      if (toolName !== "AskUserQuestion") return null;
+      const question = formatAskUserQuestionPrompt((payload as any)?.tool_input)
+        ?? "crew opened an AskUserQuestion prompt (options unavailable)";
+      return { type: "task.blocked", id: taskId, reason: "crew opened an AskUserQuestion prompt", question };
+    }
     case "Stop": {
       const text = resolveLastAssistantText(payload);
       const question = text ? detectTrailingQuestion(text) : null;

--- a/packages/cli/src/commands/__tests__/hooks.test.ts
+++ b/packages/cli/src/commands/__tests__/hooks.test.ts
@@ -10,7 +10,11 @@ import { mapHookSub } from "../hooks.js";
 describe("mapHookSub — ask-question (#560)", () => {
   const TID = "task-abc";
 
-  it("delegates to the real AskUserQuestion extraction — carries the actual question + options", () => {
+  // task.input.requested — not task.blocked — is the event that carries
+  // requestId and drives ctx.schedulePromotion (squadrantd.ts), the
+  // answer-routing machinery #562 depends on. It already does everything
+  // #560 needs too (state-machine.ts maps it to state 'blocked').
+  it("delegates to the real AskUserQuestion extraction — carries the actual question + options + a requestId", () => {
     const payload = {
       tool_name: "AskUserQuestion",
       tool_input: {
@@ -20,18 +24,19 @@ describe("mapHookSub — ask-question (#560)", () => {
       },
     };
     const ev = mapHookSub("ask-question", payload, TID);
-    expect(ev).toEqual({
-      type: "task.blocked",
+    expect(ev?.type).toBe("task.input.requested");
+    expect(ev).toMatchObject({
+      type: "task.input.requested",
       id: TID,
-      reason: "crew opened an AskUserQuestion prompt",
       question: "Which env should I deploy to? (options: staging, prod)",
     });
+    expect(typeof (ev as any).requestId).toBe("number");
   });
 
-  it("still fires task.blocked even with a malformed/missing tool_input — never silently drops the signal", () => {
+  it("still fires task.input.requested even with a malformed/missing tool_input — never silently drops the signal", () => {
     const ev = mapHookSub("ask-question", { tool_name: "AskUserQuestion" }, TID);
     expect(ev).not.toBeNull();
-    expect(ev!.type).toBe("task.blocked");
+    expect(ev!.type).toBe("task.input.requested");
   });
 
   it("other subs still map as before (no regression)", () => {

--- a/packages/cli/src/commands/__tests__/hooks.test.ts
+++ b/packages/cli/src/commands/__tests__/hooks.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { mapHookSub } from "../hooks.js";
+
+// #560: the "ask-question" sub fires from NativeHookSource's global
+// PreToolUse+AskUserQuestion matcher install (see native-hook-source.ts). It
+// must extract the SAME real question/options text the crew's own hook set
+// does — the previous inline version read a `payload.question` field that
+// doesn't exist on Claude's actual PreToolUse payload (tool_name/tool_input),
+// so it always fell back to a hardcoded "awaiting input" placeholder.
+describe("mapHookSub — ask-question (#560)", () => {
+  const TID = "task-abc";
+
+  it("delegates to the real AskUserQuestion extraction — carries the actual question + options", () => {
+    const payload = {
+      tool_name: "AskUserQuestion",
+      tool_input: {
+        questions: [
+          { question: "Which env should I deploy to?", options: [{ label: "staging" }, { label: "prod" }] },
+        ],
+      },
+    };
+    const ev = mapHookSub("ask-question", payload, TID);
+    expect(ev).toEqual({
+      type: "task.blocked",
+      id: TID,
+      reason: "crew opened an AskUserQuestion prompt",
+      question: "Which env should I deploy to? (options: staging, prod)",
+    });
+  });
+
+  it("still fires task.blocked even with a malformed/missing tool_input — never silently drops the signal", () => {
+    const ev = mapHookSub("ask-question", { tool_name: "AskUserQuestion" }, TID);
+    expect(ev).not.toBeNull();
+    expect(ev!.type).toBe("task.blocked");
+  });
+
+  it("other subs still map as before (no regression)", () => {
+    expect(mapHookSub("pre-tool-use", {}, TID)).toEqual({ type: "task.progress", id: TID, note: "pre-tool-use" });
+    expect(mapHookSub("prompt-submit", {}, TID)).toEqual({ type: "task.first-turn.confirmed", id: TID });
+    expect(mapHookSub("unknown-sub", {}, TID)).toBeNull();
+  });
+});

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -25,10 +25,14 @@ async function sendToSock(req: unknown): Promise<void> {
  * Map a NativeHookSource sub-alias to a ControlEvent.
  *
  * "stop", "notification", "session-end" delegate to mapClaudeHookToEvent (which
- * handles detectTrailingQuestion and isPermissionNotification). The new subs
- * not covered by the existing per-crew mapper are handled inline.
+ * handles detectTrailingQuestion and isPermissionNotification). "ask-question"
+ * also delegates to it (#560) — it fires from the same PreToolUse+AskUserQuestion
+ * matcher as the crew's own hook set, so it must extract the real question/options
+ * from tool_input the same way (the previous inline version read a `payload.question`
+ * field that doesn't exist in Claude's actual PreToolUse payload, so it always fell
+ * back to a generic placeholder). The remaining subs are handled inline.
  */
-function mapHookSub(sub: string, payload: unknown, taskId: string): ControlEvent | null {
+export function mapHookSub(sub: string, payload: unknown, taskId: string): ControlEvent | null {
   switch (sub) {
     case "session-start":
     case "pre-tool-use":
@@ -41,12 +45,8 @@ function mapHookSub(sub: string, payload: unknown, taskId: string): ControlEvent
       return mapClaudeHookToEvent("Stop", payload, taskId);
     case "notification":
       return mapClaudeHookToEvent("Notification", payload, taskId);
-    case "ask-question": {
-      const q = typeof (payload as Record<string, unknown>)?.question === "string"
-        ? (payload as Record<string, unknown>).question as string
-        : "awaiting input";
-      return { type: "task.input.requested", id: taskId, requestId: 0, question: q };
-    }
+    case "ask-question":
+      return mapClaudeHookToEvent("PreToolUse", payload, taskId);
     case "session-end":
       return mapClaudeHookToEvent("SessionEnd", payload, taskId);
     default:


### PR DESCRIPTION
## Summary

Scope: **#560 only** (detection), per the arc's own instruction to ship detection first as its own PR since #562 (answer channel) and #563 (staleness) both depend on it. Not merging — for captain review + user approval.

### Root cause (verified against source, not assumed from the issue text)

The issue's literal claim ("no daemon event at all") turned out to be *almost* right but the actual mechanism was more specific than "nothing is wired." I traced the real cause before touching any code (per the crew brief's warning that prior root-cause hypotheses on this repo have been wrong repeatedly):

- The crew's own dedicated Claude hook set (`EVENTS` / `mergeClaudeHooks` in `packages/agents/src/interactive/claude.ts`, installed at **every crew spawn** via `writePerCrewSettings`/`writePerCrewSettingsLocal`) had **zero `PreToolUse` coverage**. `mapClaudeHookToEvent` didn't even have a `"PreToolUse"` case — a bare `PreToolUse` mapped to `null` (see the pre-existing `"unknown event → null"` test).
- A crew opening `AskUserQuestion` (a native Claude Code tool call, not a hook "event") fires `PreToolUse` right as the modal opens. With no hook registered for it in the crew's own settings, **nothing fires** on this path.
- The *only* thing that could theoretically catch it was a completely separate subsystem — `NativeHookSource` (`packages/workspaces/src/native-hooks/native-hook-source.ts`) — which installs a global `~/.claude/settings.json` hook **once at daemon startup**, built originally for `LifecycleSource` state tracking (#333), not as a deliberate crew-detection path. Relying on it was coincidental, not designed: if that global install were ever stale, missing, or from a daemon build predating #333, detection would silently be zero — matching the "waits forever, nobody comes" symptom exactly.
- Even where that global path *does* fire (`packages/cli/src/commands/hooks.ts`'s `"ask-question"` sub), it read a `payload.question` field that **doesn't exist** in Claude's real `PreToolUse` payload (`tool_name` + `tool_input`, not a flat `question` field) — so even when detection incidentally worked, the surfaced text was always the generic `"awaiting input"` placeholder, never the real question or options.

### Fix

- Added a **matcher-scoped** `PreToolUse` → `"AskUserQuestion"` hook entry directly to the crew's own dedicated hook set (`MATCHED_EVENTS` in `claude.ts`), so detection is now owned by the same mechanism that already handles Notification/permission-dialog detection for crews — not borrowed from an unrelated subsystem. Matcher-scoped (not a bare `PreToolUse`) so it doesn't double per-tool-call hook overhead; `PostToolUse` already covers broad liveness.
- Added a `formatAskUserQuestionPrompt()` pure function that extracts the **real** question text and option labels from the tool call's actual `tool_input.questions[]` shape.
- New `mapClaudeHookToEvent("PreToolUse", ...)` case: maps to `task.blocked` **unconditionally** when `tool_name === "AskUserQuestion"` — even a malformed/missing `tool_input` still produces a generic fallback question rather than falling through to `null`. A detection path that can silently fail to fire is the exact defect this PR closes, so it must not reproduce that failure mode itself.
- Fixed the pre-existing `NativeHookSource`/`hooks.ts` `"ask-question"` path (the redundant/backup global mechanism) to delegate through the same corrected logic instead of its own buggy inline extraction — same bug class, same fix, no duplicated logic.
- Other tool names on a (matcher-mismatched) `PreToolUse` still return `null` — conservative, unchanged fallback for a config regression.

### Self-check against "can this fix fail the same way the bug did?"

- **Can blocked-detection itself fail silently?** No — `formatAskUserQuestionPrompt` returning `null` (malformed payload) still yields `task.blocked` with a generic fallback question; it never causes the case to fall through to `null`/no-event.
- **Can the answer/question text land on the wrong target?** N/A for this PR — no answer path is added here (that's #562); this PR only adds detection.
- **Can a missing/pruned task record crash instead of degrade?** No new state — reuses the daemon's existing `task.blocked` handling and the pre-existing `resolve()`/`if (!found) return;` guards; hook CLI commands already `process.exit(0)` on daemon-down or missing env, unchanged.

### Not in scope for this PR

#562 (`crew answer`) and #563 (staleness/retraction) are separate, larger CLI surface additions that depend on this detection existing. Left for a follow-up PR per the arc's own sequencing instruction.

## Test plan
- [x] TDD: wrote failing tests first for `formatAskUserQuestionPrompt`, `mapClaudeHookToEvent("PreToolUse", ...)`, `mergeClaudeHooks` matcher-scoped entry, and `mapHookSub("ask-question", ...)` — confirmed red, then implemented to green.
- [x] `pnpm test` (bounded by `scripts/heavy-lock.mjs`) — 168 test files, 2074 tests, all green, 0 failures.
- [x] `tsc -b` across all packages — clean, no type errors.
- [x] No stray vitest/dev-server processes left running.
- [x] Verified by behavior, not exit code: read the actual `mapClaudeHookToEvent`/`mergeClaudeHooks`/`mapHookSub` call sites end-to-end via grep + `context()`, confirmed the crew's real hook-install path (`writePerCrewSettings`), and confirmed the pre-existing test asserting `PreToolUse → null` to know exactly what behavior was changing and why.

Refs #560, #562, #563