### PR TITLE
chore(release): v0.16.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.3] - 2026-07-12
+
+### Fixed
+
+- **A crew's blocked `AskUserQuestion` prompt could go completely unnoticed — no `CREW BLOCKED` ever fired (#560).** A crew's own per-crew Claude hook set had no `PreToolUse` coverage at all, so opening the question modal emitted nothing to the daemon; detection had accidentally been leaning on an unrelated hook subsystem that didn't reliably cover crews. Crews now get a dedicated `PreToolUse → AskUserQuestion` hook that extracts the real question and options from the tool call and reports it as blocked-on-input, even falling back to a generic message if the tool payload is malformed — so a stalled crew is always surfaced instead of silently waiting forever.
+- **`CREW DONE` could be lost because the send and close paths disagreed on which task record was "the" active one, and a signal on an already-finished task reported success while doing nothing (#574, #557).** When a crew had duplicate task records under the same name, sending and closing picked different ones, so the two ends of a crew's lifecycle could silently drift onto different task ids. Task-record selection is now shared logic used everywhere, and `crew signal done|blocked|failed` now fails loudly instead of quietly no-opping when the target task is already in a terminal state.
+- **`effort set --project` silently rewrote the global effort dial instead of the named project's override, and captains could be told about an effort change that didn't actually apply to them (#575, #576).** The `--project` flag was accepted but ignored, so a per-project effort request landed globally; notifications were also broadcast as one blanket message, so a project running its own override could be told a value that wasn't actually its effective effort. `effort set --project` now writes a scoped per-project override (and rejects an unknown project name outright instead of writing a stray file), and change notices are computed per recipient so only captains whose effective effort actually changed hear about it.
+
 ## [0.16.2] - 2026-07-12
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "squadrant",
   "packageManager": "pnpm@10.30.3",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "Multi-project orchestration for your coding agents (Claude, Codex, opencode, Gemini)",
   "type": "module",
   "bin": {

--- a/packages/agents/src/__tests__/interactive-claude-hook.test.ts
+++ b/packages/agents/src/__tests__/interactive-claude-hook.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
-import { mapClaudeHookToEvent, detectTrailingQuestion, deriveTranscriptPath, isPermissionNotification } from "../interactive/claude.js";
+import { mapClaudeHookToEvent, detectTrailingQuestion, deriveTranscriptPath, isPermissionNotification, formatAskUserQuestionPrompt } from "../interactive/claude.js";
 
 describe("mapClaudeHookToEvent", () => {
   const TID = "task-abc";
@@ -380,5 +380,123 @@ describe("mapClaudeHookToEvent Stop last_assistant_message (#174 primary source)
   it("empty/whitespace last_assistant_message falls through to transcript resolution", () => {
     const ev = mapClaudeHookToEvent("Stop", { last_assistant_message: "   " }, TID);
     expect(ev).toEqual({ type: "task.turn.completed", id: TID, turnId: "hook-stop" });
+  });
+});
+
+// #560: AskUserQuestion is a TOOL call, not a hook event — Claude fires PreToolUse
+// (matcher-scoped to "AskUserQuestion") right as the modal opens and blocks the
+// turn awaiting a human selection. Before this, a crew's own hook set had no
+// PreToolUse coverage at all, so it emitted nothing and the daemon never learned
+// the crew was blocked.
+describe("formatAskUserQuestionPrompt (#560 — real question/options text)", () => {
+  it("formats a single question with its options", () => {
+    const toolInput = {
+      questions: [
+        { question: "Which auth approach?", header: "Auth", multiSelect: false, options: [
+          { label: "OAuth", description: "..." },
+          { label: "API key", description: "..." },
+        ] },
+      ],
+    };
+    expect(formatAskUserQuestionPrompt(toolInput)).toBe("Which auth approach? (options: OAuth, API key)");
+  });
+
+  it("formats multiple questions, joined", () => {
+    const toolInput = {
+      questions: [
+        { question: "Ship now?", options: [{ label: "Yes" }, { label: "No" }] },
+        { question: "Which env?", options: [{ label: "staging" }, { label: "prod" }] },
+      ],
+    };
+    expect(formatAskUserQuestionPrompt(toolInput)).toBe(
+      "Ship now? (options: Yes, No) | Which env? (options: staging, prod)",
+    );
+  });
+
+  it("formats a question with no options (free-form)", () => {
+    expect(formatAskUserQuestionPrompt({ questions: [{ question: "What should I name it?" }] }))
+      .toBe("What should I name it?");
+  });
+
+  it("returns null for missing/empty/malformed questions array — never throws", () => {
+    expect(formatAskUserQuestionPrompt(undefined)).toBeNull();
+    expect(formatAskUserQuestionPrompt(null)).toBeNull();
+    expect(formatAskUserQuestionPrompt({})).toBeNull();
+    expect(formatAskUserQuestionPrompt({ questions: [] })).toBeNull();
+    expect(formatAskUserQuestionPrompt({ questions: "not an array" })).toBeNull();
+    expect(formatAskUserQuestionPrompt({ questions: [{}, { question: 42 }] })).toBeNull();
+  });
+});
+
+// #560 review fix: task.input.requested — NOT task.blocked — is the event that
+// carries requestId and drives ctx.schedulePromotion (squadrantd.ts) — the
+// answer-routing machinery #562 needs. task.blocked has no requestId field at
+// all, so mapping AskUserQuestion to it would delete the only signal #562
+// could build on. task.input.requested already does everything #560 needs
+// too: state-machine.ts maps it to state 'blocked' with the question,
+// telegram/format.ts renders it, tiers.ts includes it.
+describe("mapClaudeHookToEvent PreToolUse AskUserQuestion (#560)", () => {
+  const TID = "task-abc";
+
+  it("tool_name AskUserQuestion → task.input.requested carrying the real question + options and a requestId", () => {
+    const payload = {
+      tool_name: "AskUserQuestion",
+      tool_input: {
+        questions: [
+          { question: "Silent fallback or labelled fallback?", options: [
+            { label: "Silent" }, { label: "Labelled" },
+          ] },
+        ],
+      },
+    };
+    const ev = mapClaudeHookToEvent("PreToolUse", payload, TID);
+    expect(ev?.type).toBe("task.input.requested");
+    expect(ev).toMatchObject({
+      type: "task.input.requested",
+      id: TID,
+      question: "Silent fallback or labelled fallback? (options: Silent, Labelled)",
+    });
+    // requestId: Claude's PreToolUse payload carries no native per-tool-call id
+    // (session_id/cwd/tool_name/tool_input only — verified against the
+    // documented payload shape) — a real, distinct value is still required
+    // (not a hardcoded 0) so schedulePromotion's `${taskId}#${requestId}` key
+    // doesn't collide across successive prompts for the same crew.
+    expect(typeof (ev as any).requestId).toBe("number");
+    expect(Number.isFinite((ev as any).requestId)).toBe(true);
+  });
+
+  it("two calls in quick succession get distinct requestIds (no collision on schedulePromotion's dedup key)", () => {
+    const payload = { tool_name: "AskUserQuestion", tool_input: { questions: [{ question: "A?" }] } };
+    const first = mapClaudeHookToEvent("PreToolUse", payload, TID) as any;
+    const second = mapClaudeHookToEvent("PreToolUse", { ...payload, tool_input: { questions: [{ question: "B?" }] } }, TID) as any;
+    expect(first.requestId).not.toBe(second.requestId);
+  });
+
+  it("tool_name AskUserQuestion with malformed/missing tool_input → STILL task.input.requested with a generic fallback, never null", () => {
+    for (const payload of [
+      { tool_name: "AskUserQuestion" },
+      { tool_name: "AskUserQuestion", tool_input: {} },
+      { tool_name: "AskUserQuestion", tool_input: { questions: [] } },
+      { tool_name: "AskUserQuestion", tool_input: null },
+    ]) {
+      const ev = mapClaudeHookToEvent("PreToolUse", payload, TID);
+      expect(ev).not.toBeNull();
+      expect(ev!.type).toBe("task.input.requested");
+    }
+  });
+
+  it("other tool names (e.g. Bash) → null — matcher scoping means this shouldn't fire, but stay conservative if it does", () => {
+    expect(mapClaudeHookToEvent("PreToolUse", { tool_name: "Bash", tool_input: { command: "ls" } }, TID)).toBeNull();
+  });
+
+  it("missing tool_name → null (unchanged pre-existing behavior for a bare/unmatched PreToolUse)", () => {
+    expect(mapClaudeHookToEvent("PreToolUse", {}, TID)).toBeNull();
+    expect(mapClaudeHookToEvent("PreToolUse", null, TID)).toBeNull();
+  });
+
+  it("anti-#2576 invariant: never task.done or task.failed regardless of tool_input shape", () => {
+    const ev = mapClaudeHookToEvent("PreToolUse", { tool_name: "AskUserQuestion", tool_input: {} }, TID);
+    expect(ev!.type).not.toBe("task.done");
+    expect(ev!.type).not.toBe("task.failed");
   });
 });

--- a/packages/agents/src/__tests__/interactive-claude.test.ts
+++ b/packages/agents/src/__tests__/interactive-claude.test.ts
@@ -89,4 +89,46 @@ describe("claude interactive hook merge", () => {
     expect(out.hooks.UserPromptSubmit[0].hooks[0].command).toContain(HOOK_CMD);
     expect(out.hooks.UserPromptSubmit[0].hooks[0].command).toContain("UserPromptSubmit");
   });
+
+  // #560: an AskUserQuestion tool call blocks the crew waiting for a human, but
+  // the crew's own hook set had no PreToolUse entry at all — the crew's Claude
+  // process fired zero signal on it. Scoped to the AskUserQuestion matcher (not
+  // a bare PreToolUse) so it doesn't double the per-tool-call hook overhead
+  // PostToolUse already covers.
+  it("registers a matcher-scoped PreToolUse hook for AskUserQuestion detection (#560)", () => {
+    const out = mergeClaudeHooks({}, HOOK_CMD);
+    expect(out.hooks.PreToolUse).toBeDefined();
+    const entry = out.hooks.PreToolUse.find((m: any) => m.matcher === "AskUserQuestion");
+    expect(entry).toBeDefined();
+    expect(entry.hooks[0].command).toContain(HOOK_CMD);
+    expect(entry.hooks[0].command).toContain("PreToolUse");
+  });
+
+  it("PreToolUse/AskUserQuestion hook is idempotent — merging twice yields one entry", () => {
+    const once = mergeClaudeHooks({}, HOOK_CMD);
+    const twice = mergeClaudeHooks(once, HOOK_CMD);
+    const matched = twice.hooks.PreToolUse.filter((m: any) => m.matcher === "AskUserQuestion");
+    expect(matched).toHaveLength(1);
+  });
+
+  // Dedup footgun: installHookEntry used to key "already present" on command
+  // substring alone, scanning ALL entries for an event regardless of matcher.
+  // A pre-existing BARE entry for the same event+command (e.g. from a future
+  // change that adds "PreToolUse" to the broad EVENTS list too) would make the
+  // matcher-scoped install look "already done" and silently skip — even though
+  // the bare entry (matcher "") never fires for the AskUserQuestion-scoped
+  // case. Keyed on (event, matcher) so the two coexist correctly.
+  it("a pre-existing bare-matcher entry for the same event+command does not silently block the matcher-scoped install", () => {
+    const existing = {
+      hooks: {
+        PreToolUse: [{ matcher: "", hooks: [{ type: "command", command: `${HOOK_CMD} PreToolUse` }] }],
+      },
+    };
+    const out = mergeClaudeHooks(existing, HOOK_CMD);
+    const scoped = out.hooks.PreToolUse.find((m: any) => m.matcher === "AskUserQuestion");
+    expect(scoped).toBeDefined();
+    // The pre-existing bare entry must survive untouched.
+    const bare = out.hooks.PreToolUse.find((m: any) => m.matcher === "");
+    expect(bare).toBeDefined();
+  });
 });

--- a/packages/agents/src/interactive/claude.ts
+++ b/packages/agents/src/interactive/claude.ts
@@ -19,6 +19,26 @@ import type { ControlEvent } from "@squadrant/shared";
 // signal (#470), replacing the screen-scrape {delivered} heuristic.
 const EVENTS = ["Stop", "SubagentStop", "SessionEnd", "PostToolUse", "Notification", "UserPromptSubmit"] as const;
 
+// #560: matcher-scoped hook entries beyond the broad EVENTS list above — fires
+// only for the named tool, not every tool call. AskUserQuestion is CC's native
+// interactive-prompt tool: PreToolUse fires the instant it opens (and blocks
+// the turn awaiting a human selection), so this is the earliest possible signal
+// that a crew is blocked on a question. Scoped to this one tool so it doesn't
+// double the per-tool-call hook overhead PostToolUse already covers.
+const MATCHED_EVENTS: ReadonlyArray<readonly [event: string, matcher: string]> = [
+  ["PreToolUse", "AskUserQuestion"],
+];
+
+// #560: Claude's PreToolUse hook payload carries no native per-tool-call id
+// (documented shape is session_id/cwd/tool_name/tool_input only — no
+// tool_use_id), so there is no "real" requestId to forward. Seeded from
+// Date.now() and incremented per call (this module runs fresh per hook
+// invocation, so in practice each call gets Date.now() at that moment) so
+// schedulePromotion's `${taskId}#${requestId}` dedup key never collides
+// across successive AskUserQuestion prompts for the same crew, unlike a
+// hardcoded 0 would.
+let nextAskUserQuestionRequestId = Date.now();
+
 /**
  * Probe whether the local Claude CLI supports `--settings <path>`. The
  * daemon-supervised crew path needs per-invocation settings to inject the
@@ -48,18 +68,36 @@ export function isPermissionNotification(message: string): boolean {
   return lower.includes("permission") || lower.includes("approve");
 }
 
+// Keyed on (event, matcher) — NOT command alone. An event can carry both a
+// bare entry (matcher "", from EVENTS) and a matcher-scoped entry (from
+// MATCHED_EVENTS) with the identical command string (only the matcher
+// differs; Claude dispatches on matcher, not on the command text). Scanning
+// ALL entries for the event regardless of matcher would make the
+// matcher-scoped install look "already done" the moment a bare entry for the
+// same event+command exists, and silently skip installing it — the same
+// silent-drop failure mode this hook set exists to close (#560).
+function installHookEntry(hooks: Record<string, unknown>, event: string, matcher: string, command: string): void {
+  if (!Array.isArray(hooks[event])) hooks[event] = [];
+  const entries = hooks[event] as unknown[];
+  const already = entries.some(
+    (m) => (m as any)?.matcher === matcher &&
+      Array.isArray((m as any)?.hooks) &&
+      (m as any).hooks.some((h: any) => typeof h?.command === "string" && h.command.includes(command)),
+  );
+  if (!already) {
+    entries.push({ matcher, hooks: [{ type: "command", command, timeout: 10 }] });
+  }
+}
+
 /** Pure, idempotent merge of squadrant hooks into a Claude settings object. */
 export function mergeClaudeHooks(settings: any, hookCmd: string): any {
   const next = structuredClone(settings ?? {});
   next.hooks ??= {};
   for (const ev of EVENTS) {
-    if (!Array.isArray(next.hooks[ev])) next.hooks[ev] = [];
-    const already = next.hooks[ev].some((m: any) =>
-      Array.isArray(m?.hooks) && m.hooks.some((h: any) => typeof h.command === "string" && h.command.includes(hookCmd)),
-    );
-    if (!already) {
-      next.hooks[ev].push({ matcher: "", hooks: [{ type: "command", command: `${hookCmd} ${ev}`, timeout: 10 }] });
-    }
+    installHookEntry(next.hooks, ev, "", `${hookCmd} ${ev}`);
+  }
+  for (const [ev, matcher] of MATCHED_EVENTS) {
+    installHookEntry(next.hooks, ev, matcher, `${hookCmd} ${ev}`);
   }
   return next;
 }
@@ -164,6 +202,33 @@ function resolveLastAssistantText(payload: unknown): string | null {
 }
 
 /**
+ * Pure: render an AskUserQuestion tool call's `tool_input` (the raw arguments
+ * Claude passes to the tool — `{ questions: [{ question, header, options,
+ * multiSelect }] }`) into a human-readable prompt for CREW BLOCKED, carrying
+ * both the question text AND its options (#560's proposal explicitly asks for
+ * both — an option-less "awaiting input" placeholder can't be answered by
+ * #562's answer channel or checked for staleness by #563).
+ * Never throws; returns null when the shape doesn't match (caller must still
+ * surface SOME text — see mapClaudeHookToEvent's PreToolUse case).
+ */
+export function formatAskUserQuestionPrompt(toolInput: unknown): string | null {
+  const questions = (toolInput as { questions?: unknown } | null | undefined)?.questions;
+  if (!Array.isArray(questions) || questions.length === 0) return null;
+  const parts: string[] = [];
+  for (const q of questions) {
+    if (!q || typeof q !== "object") continue;
+    const text = (q as any).question;
+    if (typeof text !== "string" || !text.trim()) continue;
+    const options = Array.isArray((q as any).options) ? (q as any).options : [];
+    const labels = options
+      .map((o: any) => (o && typeof o.label === "string" ? o.label.trim() : null))
+      .filter((l: string | null): l is string => !!l);
+    parts.push(labels.length > 0 ? `${text.trim()} (options: ${labels.join(", ")})` : text.trim());
+  }
+  return parts.length > 0 ? parts.join(" | ") : null;
+}
+
+/**
  * Map a Claude hook event name to a squadrant ControlEvent. Codifies the anti-#2576
  * invariant: NO Claude hook ever maps to `task.done`/`task.failed`.
  * PostToolUse/SubagentStop = resume-liveness only (task.progress). SessionEnd is
@@ -188,6 +253,20 @@ function resolveLastAssistantText(payload: unknown): string | null {
  * state-machine idempotency (already-blocked → no-op, from #176) deduplicates.
  * Non-permission notifications (idle liveness) → task.progress. Missing/non-string
  * message → task.progress (never throws, hook must exit 0).
+ *
+ * PreToolUse = matcher-scoped to AskUserQuestion only (#560): the crew's own
+ * hook set registers this ONLY for that tool (see MATCHED_EVENTS above), so in
+ * practice tool_name is always "AskUserQuestion" here. Still checked
+ * defensively — a config regression to a bare/unmatched PreToolUse must not
+ * silently start reporting task.input.requested for every tool call. When it
+ * IS AskUserQuestion, this maps to task.input.requested (NOT task.blocked —
+ * task.blocked has no requestId field, and requestId is what
+ * ctx.schedulePromotion in squadrantd.ts keys its answer-routing timer on;
+ * task.input.requested already drives state-machine.ts → state 'blocked',
+ * the CREW BLOCKED notification, and Telegram formatting) UNCONDITIONALLY —
+ * even a malformed/unreadable tool_input still produces a generic fallback
+ * question rather than falling through to null, because a detection path
+ * that can silently fail to fire is the exact defect #560 exists to close.
  */
 export function mapClaudeHookToEvent(
   event: string,
@@ -195,6 +274,13 @@ export function mapClaudeHookToEvent(
   taskId: string,
 ): ControlEvent | null {
   switch (event) {
+    case "PreToolUse": {
+      const toolName = (payload as any)?.tool_name;
+      if (toolName !== "AskUserQuestion") return null;
+      const question = formatAskUserQuestionPrompt((payload as any)?.tool_input)
+        ?? "crew opened an AskUserQuestion prompt (options unavailable)";
+      return { type: "task.input.requested", id: taskId, requestId: nextAskUserQuestionRequestId++, question };
+    }
     case "Stop": {
       const text = resolveLastAssistantText(payload);
       const question = text ? detectTrailingQuestion(text) : null;

--- a/packages/cli/src/__tests__/crew-control.test.ts
+++ b/packages/cli/src/__tests__/crew-control.test.ts
@@ -1,6 +1,7 @@
 // src/control/__tests__/crew-control.test.ts
 import { describe, it, expect, vi } from "vitest";
-import { buildDispatchRequest, buildStatusRequest, buildGateResolveRequest } from "../commands/crew-control.js";
+import { buildDispatchRequest, buildStatusRequest, buildGateResolveRequest, runCrewSignal } from "../commands/crew-control.js";
+import type { TaskRecord } from "@squadrant/shared";
 
 describe("crew-control request builders", () => {
   it("dispatch request carries project/provider/mode/task and a generated id", () => {
@@ -47,5 +48,47 @@ describe("crew-control request builders", () => {
     expect(r.kind).toBe("gate-resolve");
     expect(r.gateId).toBe("g1");
     expect(r.payload).toEqual({ text: "approve", decision: "approve" });
+  });
+});
+
+// #557: `crew signal done` returned exit 0 for a task that was already terminal
+// (e.g. a duplicate/stale record picked by #574's divergent selection) — the
+// daemon's reduce() silently absorbs any event on a terminal record, and the
+// CLI never inspected the resulting state, so a signal that changed nothing
+// still reported success. runCrewSignal must check current state FIRST and
+// fail loudly instead of emitting an event that will be silently ignored.
+describe("runCrewSignal (#557)", () => {
+  it("fails loudly instead of silently succeeding when the target task is already terminal", async () => {
+    const call = vi.fn().mockResolvedValue({ id: "t1", state: "done" } as Partial<TaskRecord>);
+    await expect(
+      runCrewSignal("done", { taskId: "t1", project: "p", message: "finished" }, { call }),
+    ).rejects.toThrow(/already terminal/i);
+    // Only the status check ran — no task.done event was sent for the no-op.
+    expect(call).toHaveBeenCalledTimes(1);
+    expect(call).toHaveBeenCalledWith(buildStatusRequest("p", "t1"));
+  });
+
+  it("sends the event normally when the target task is not yet terminal", async () => {
+    const call = vi.fn().mockImplementation(async (req: any) => {
+      if (req.kind === "status") return { id: "t1", state: "working" };
+      return { ok: true };
+    });
+    await runCrewSignal("done", { taskId: "t1", project: "p", message: "finished", writeResult: () => "ref" }, { call });
+    expect(call).toHaveBeenCalledWith(expect.objectContaining({ kind: "event", event: expect.objectContaining({ type: "task.done", id: "t1" }) }));
+  });
+
+  // Pre-merge review: the status call can resolve with no record at all — a
+  // dropped/pruned task id (#554: terminal records are pruned past a 20-record
+  // cap; the record can also simply not exist yet on a fresh/racy daemon). A
+  // missing record is NOT evidence of "already terminal" — treating it as such
+  // (or worse, dereferencing .state on it) must never crash `crew signal done`.
+  // A crash here drops CREW DONE exactly like #574 did, just via a new door.
+  it("does not throw a TypeError and still sends the event when status resolves with no record (dropped/pruned task, #554)", async () => {
+    const call = vi.fn().mockImplementation(async (req: any) => {
+      if (req.kind === "status") return undefined;
+      return { ok: true };
+    });
+    await runCrewSignal("done", { taskId: "gone-id", project: "p", message: "finished", writeResult: () => "ref" }, { call });
+    expect(call).toHaveBeenCalledWith(expect.objectContaining({ kind: "event", event: expect.objectContaining({ type: "task.done", id: "gone-id" }) }));
   });
 });

--- a/packages/cli/src/commands/__tests__/effort.test.ts
+++ b/packages/cli/src/commands/__tests__/effort.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { getDefaultConfig, saveConfig } from "@squadrant/shared";
+import { getDefaultConfig, saveConfig, loadConfig, resolveEffort, saveProjectOverride } from "@squadrant/shared";
 import type { SquadrantConfig, ProjectConfig } from "@squadrant/shared";
-import { runEffortGet, runEffortSet, notifyCaptainsOfEffort, effortCommand } from "../effort.js";
+import { runEffortGet, runEffortSet, notifyCaptainsOfEffort, effortScopeLabel, effortCommand } from "../effort.js";
 
 const requireDaemon = vi.hoisted(() => vi.fn());
 vi.mock("../../lib/require-daemon.js", () => ({
@@ -49,6 +49,40 @@ describe("effort get", () => {
     saveConfig(config, cfgPath);
     const result = runEffortGet(cfgPath);
     expect(result.effort).toBe("max");
+  });
+
+  it("returns the resolved effort for a registered project", () => {
+    const config = getDefaultConfig();
+    (config.defaults as any).effort = "low";
+    config.projects.oneplan = { path: path.join(dir, "proj-oneplan"), captainName: "captain-oneplan", spokeVault: "", host: "" };
+    saveConfig(config, cfgPath);
+    const result = runEffortGet(cfgPath, "oneplan", dir);
+    expect(result.effort).toBe("low");
+  });
+
+  it("hard-fails on an unknown --project name instead of silently answering with the global value (#576)", () => {
+    const config = getDefaultConfig();
+    config.projects.oneplan = { path: path.join(dir, "proj-oneplan"), captainName: "captain-oneplan", spokeVault: "", host: "" };
+    saveConfig(config, cfgPath);
+
+    // typo: "onplan" instead of "oneplan" — must NOT silently answer with the global default
+    expect(() => runEffortGet(cfgPath, "onplan", dir)).toThrow(/unknown project/i);
+  });
+
+  it("unknown-project error on get lists the registered project names", () => {
+    const config = getDefaultConfig();
+    config.projects.oneplan = { path: path.join(dir, "proj-oneplan"), captainName: "captain-oneplan", spokeVault: "", host: "" };
+    config.projects.brove = { path: path.join(dir, "proj-brove"), captainName: "captain-brove", spokeVault: "", host: "" };
+    saveConfig(config, cfgPath);
+
+    let message = "";
+    try {
+      runEffortGet(cfgPath, "onplan", dir);
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toContain("oneplan");
+    expect(message).toContain("brove");
   });
 });
 
@@ -104,6 +138,100 @@ describe("effort set", () => {
   });
 });
 
+describe("effort set — per-project scope (#575)", () => {
+  function registerProject(config: SquadrantConfig, name: string): void {
+    config.projects[name] = { path: path.join(dir, `proj-${name}`), captainName: `captain-${name}`, spokeVault: "", host: "" };
+  }
+
+  it("writes the override into projects/<name>.json, not defaults.effort", () => {
+    const config = getDefaultConfig();
+    (config.defaults as any).effort = "low";
+    registerProject(config, "oneplan");
+    saveConfig(config, cfgPath);
+
+    runEffortSet("balance", cfgPath, "oneplan", dir);
+
+    const reloaded = loadConfig(cfgPath);
+    expect(resolveEffort(reloaded, "oneplan", dir)).toBe("balance");
+    // global dial must be untouched
+    expect(resolveEffort(reloaded)).toBe("low");
+  });
+
+  it("does not affect a different project's resolved effort", () => {
+    const config = getDefaultConfig();
+    (config.defaults as any).effort = "low";
+    registerProject(config, "oneplan");
+    saveConfig(config, cfgPath);
+
+    runEffortSet("max", cfgPath, "oneplan", dir);
+
+    const reloaded = loadConfig(cfgPath);
+    expect(resolveEffort(reloaded, "other-project", dir)).toBe("low");
+  });
+
+  it("round-trips: project-scoped set then resolveEffort for that project returns the new value", () => {
+    const config = getDefaultConfig();
+    registerProject(config, "my-proj");
+    saveConfig(config, cfgPath);
+
+    runEffortSet("max", cfgPath, "my-proj", dir);
+    const reloaded = loadConfig(cfgPath);
+    expect(resolveEffort(reloaded, "my-proj", dir)).toBe("max");
+  });
+
+  it("rejects invalid value without writing a project override", () => {
+    const config = getDefaultConfig();
+    registerProject(config, "oneplan");
+    saveConfig(config, cfgPath);
+
+    expect(() => runEffortSet("turbo", cfgPath, "oneplan", dir)).toThrow();
+    const reloaded = loadConfig(cfgPath);
+    // no override was created — falls back to the (untouched) global default
+    expect(resolveEffort(reloaded, "oneplan", dir)).toBe(resolveEffort(reloaded));
+  });
+
+  it("hard-fails on an unknown --project name instead of silently writing an override", () => {
+    const config = getDefaultConfig();
+    registerProject(config, "oneplan");
+    saveConfig(config, cfgPath);
+
+    // typo: "onplan" instead of "oneplan" — must NOT silently succeed
+    expect(() => runEffortSet("max", cfgPath, "onplan", dir)).toThrow(/unknown project/i);
+
+    // no override file was created for the typo'd name
+    expect(fs.existsSync(path.join(dir, "projects", "onplan.json"))).toBe(false);
+    // the real project's effort is untouched
+    const reloaded = loadConfig(cfgPath);
+    expect(resolveEffort(reloaded, "oneplan", dir)).toBe(resolveEffort(reloaded));
+  });
+
+  it("unknown-project error lists the registered project names", () => {
+    const config = getDefaultConfig();
+    registerProject(config, "oneplan");
+    registerProject(config, "brove");
+    saveConfig(config, cfgPath);
+
+    let message = "";
+    try {
+      runEffortSet("max", cfgPath, "onplan", dir);
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toContain("oneplan");
+    expect(message).toContain("brove");
+  });
+});
+
+describe("effortScopeLabel (#575 — success line must state actual scope)", () => {
+  it("labels a project-scoped write with the project name", () => {
+    expect(effortScopeLabel("oneplan")).toBe("project: oneplan");
+  });
+
+  it("labels an unscoped write as global", () => {
+    expect(effortScopeLabel(undefined)).toBe("global");
+  });
+});
+
 describe("effort notify (self-notification exclusion)", () => {
   // Records every (captainName, message) the fake driver was asked to send.
   function makeDriver(sent: Array<{ captain: string; message: string }>) {
@@ -156,7 +284,7 @@ describe("effort notify (self-notification exclusion)", () => {
     const sent: Array<{ captain: string; message: string }> = [];
     const spy = makeAppendSpy();
 
-    await notifyCaptainsOfEffort("low", config, makeDriver(sent), projA, spy.fn);
+    await notifyCaptainsOfEffort("low", config, makeDriver(sent), projA, spy.fn, undefined, dir);
 
     // MUST NOT call driver.send
     expect(sent).toHaveLength(0);
@@ -174,7 +302,7 @@ describe("effort notify (self-notification exclusion)", () => {
     const spy = makeAppendSpy();
 
     // cwd given via the symlink should still resolve to projA and skip it.
-    await notifyCaptainsOfEffort("max", config, makeDriver(sent), link, spy.fn);
+    await notifyCaptainsOfEffort("max", config, makeDriver(sent), link, spy.fn, undefined, dir);
 
     expect(sent).toHaveLength(0);
     expect(spy.projects).toHaveLength(0);
@@ -190,7 +318,7 @@ describe("effort notify (self-notification exclusion)", () => {
     const sent: Array<{ captain: string; message: string }> = [];
     const spy = makeAppendSpy();
 
-    await notifyCaptainsOfEffort("balance", config, makeDriver(sent), path.join(dir, "elsewhere"), spy.fn);
+    await notifyCaptainsOfEffort("balance", config, makeDriver(sent), path.join(dir, "elsewhere"), spy.fn, undefined, dir);
 
     expect(sent).toHaveLength(0);
     expect(spy.projects.sort()).toEqual(["a", "b"]);
@@ -204,13 +332,87 @@ describe("effort notify (self-notification exclusion)", () => {
     const driver = {
       status: vi.fn().mockRejectedValue(new Error("daemon unreachable"))
     };
-    
+
     const append = vi.fn();
-    
+
     // Should NOT throw
-    await notifyCaptainsOfEffort("low", config, driver, path.join(dir, "elsewhere"), append);
-    
+    await notifyCaptainsOfEffort("low", config, driver, path.join(dir, "elsewhere"), append, undefined, dir);
+
     // And should not have appended
     expect(append).not.toHaveBeenCalled();
+  });
+});
+
+describe("effort notify — per-recipient truth (#576)", () => {
+  function makeDriver() {
+    return {
+      async status(name: string) {
+        return { id: name };
+      },
+    };
+  }
+
+  function configWithProjects(projects: Record<string, ProjectConfig>): SquadrantConfig {
+    const config = getDefaultConfig();
+    config.projects = projects;
+    return config;
+  }
+
+  function project(p: string, captainName: string): ProjectConfig {
+    return { path: p, captainName, spokeVault: "", host: "" };
+  }
+
+  function makeAppendSpy(): {
+    fn: (project: string, text: string) => Promise<void>;
+    projects: string[];
+    texts: string[];
+  } {
+    const projects: string[] = [];
+    const texts: string[] = [];
+    return {
+      fn: async (project, text) => {
+        projects.push(project);
+        texts.push(text);
+      },
+      projects,
+      texts,
+    };
+  }
+
+  it("a captain whose project has its own override does NOT receive a false global-change notice", async () => {
+    const projA = fs.mkdtempSync(path.join(dir, "projA-")); // has an override — unaffected by global change
+    const projB = fs.mkdtempSync(path.join(dir, "projB-")); // no override — genuinely inherits the change
+    saveProjectOverride("a", { effort: "low" }, dir);
+
+    const config = configWithProjects({
+      a: project(projA, "captain-a"),
+      b: project(projB, "captain-b"),
+    });
+    const spy = makeAppendSpy();
+
+    // A global set to "balance" — project "a" stays "low" per its override.
+    await notifyCaptainsOfEffort("balance", config, makeDriver(), path.join(dir, "elsewhere"), spy.fn, undefined, dir);
+
+    // Sanity: resolveEffort agrees project "a" did not actually change.
+    expect(resolveEffort(config, "a", dir)).toBe("low");
+    expect(resolveEffort(config, "b", dir)).toBe("balance");
+
+    // Only "b" (whose effective effort genuinely changed) gets notified.
+    expect(spy.projects).toEqual(["b"]);
+  });
+
+  it("project-scoped set notifies only the targeted project, not every running captain", async () => {
+    const projA = fs.mkdtempSync(path.join(dir, "projA-"));
+    const projB = fs.mkdtempSync(path.join(dir, "projB-"));
+    const config = configWithProjects({
+      a: project(projA, "captain-a"),
+      b: project(projB, "captain-b"),
+    });
+    const spy = makeAppendSpy();
+
+    // Set was scoped to project "a" only — "b" was never touched.
+    await notifyCaptainsOfEffort("max", config, makeDriver(), path.join(dir, "elsewhere"), spy.fn, "a", dir);
+
+    expect(spy.projects).toEqual(["a"]);
   });
 });

--- a/packages/cli/src/commands/__tests__/hooks.test.ts
+++ b/packages/cli/src/commands/__tests__/hooks.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { mapHookSub } from "../hooks.js";
+
+// #560: the "ask-question" sub fires from NativeHookSource's global
+// PreToolUse+AskUserQuestion matcher install (see native-hook-source.ts). It
+// must extract the SAME real question/options text the crew's own hook set
+// does — the previous inline version read a `payload.question` field that
+// doesn't exist on Claude's actual PreToolUse payload (tool_name/tool_input),
+// so it always fell back to a hardcoded "awaiting input" placeholder.
+describe("mapHookSub — ask-question (#560)", () => {
+  const TID = "task-abc";
+
+  // task.input.requested — not task.blocked — is the event that carries
+  // requestId and drives ctx.schedulePromotion (squadrantd.ts), the
+  // answer-routing machinery #562 depends on. It already does everything
+  // #560 needs too (state-machine.ts maps it to state 'blocked').
+  it("delegates to the real AskUserQuestion extraction — carries the actual question + options + a requestId", () => {
+    const payload = {
+      tool_name: "AskUserQuestion",
+      tool_input: {
+        questions: [
+          { question: "Which env should I deploy to?", options: [{ label: "staging" }, { label: "prod" }] },
+        ],
+      },
+    };
+    const ev = mapHookSub("ask-question", payload, TID);
+    expect(ev?.type).toBe("task.input.requested");
+    expect(ev).toMatchObject({
+      type: "task.input.requested",
+      id: TID,
+      question: "Which env should I deploy to? (options: staging, prod)",
+    });
+    expect(typeof (ev as any).requestId).toBe("number");
+  });
+
+  it("still fires task.input.requested even with a malformed/missing tool_input — never silently drops the signal", () => {
+    const ev = mapHookSub("ask-question", { tool_name: "AskUserQuestion" }, TID);
+    expect(ev).not.toBeNull();
+    expect(ev!.type).toBe("task.input.requested");
+  });
+
+  it("other subs still map as before (no regression)", () => {
+    expect(mapHookSub("pre-tool-use", {}, TID)).toEqual({ type: "task.progress", id: TID, note: "pre-tool-use" });
+    expect(mapHookSub("prompt-submit", {}, TID)).toEqual({ type: "task.first-turn.confirmed", id: TID });
+    expect(mapHookSub("unknown-sub", {}, TID)).toBeNull();
+  });
+});

--- a/packages/cli/src/commands/crew-control.ts
+++ b/packages/cli/src/commands/crew-control.ts
@@ -173,6 +173,53 @@ function defaultWriteResult(id: string, payload: string): string {
 }
 
 /**
+ * #557: `squadrant crew signal <state>` used to emit its event and exit 0
+ * unconditionally — but the daemon's reduce() treats terminal states as
+ * absorbing (any event on an already-terminal task record is a silent no-op,
+ * see state-machine.ts). A signal that lands on a task record which is
+ * already done/failed/cancelled therefore changed nothing while still
+ * reporting success, exactly the class of bug #566 fixed for `crew send`:
+ * a call site must confirm its effect landed or fail loudly, never
+ * silent-succeed. This wraps buildSignalRequest with an upfront status check
+ * so the CLI throws instead of emitting an event doomed to be ignored.
+ */
+export async function runCrewSignal(
+  signal: "done" | "blocked" | "failed",
+  o: {
+    message?: string;
+    question?: string;
+    error?: string;
+    taskId?: string;
+    project?: string;
+    writeResult?: (id: string, payload: string) => string;
+  },
+  deps: { call: (req: unknown) => Promise<unknown> },
+): Promise<void> {
+  const taskId = o.taskId ?? process.env.SQUADRANT_CREW_TASK_ID;
+  const project = o.project ?? process.env.SQUADRANT_CREW_PROJECT;
+  if (!taskId)
+    throw new Error("not running under a crew (SQUADRANT_CREW_TASK_ID unset)");
+  if (!project)
+    throw new Error("not running under a crew (SQUADRANT_CREW_PROJECT unset)");
+  // The record can legitimately be missing (a dropped/pruned task id, #554 —
+  // terminal records are pruned past a per-project cap, or a fresh daemon
+  // hasn't registered it yet). That is NOT evidence the task is terminal, so
+  // it must never be treated as such — and never dereferenced blindly, or a
+  // crash here drops CREW DONE exactly like #574 did, just via a new door.
+  // Fall through to the normal emit, which surfaces its own clear error if the
+  // id truly doesn't exist.
+  const current = (await deps.call(buildStatusRequest(project, taskId))) as TaskRecord | null | undefined;
+  if (current && TERMINAL_STATES.has(current.state)) {
+    throw new Error(
+      `Task ${taskId} is already terminal (state=${current.state}) — signal '${signal}' would be silently ignored by the daemon. ` +
+        `Stop here: your task record was never reopened for this turn. Ask the captain to run 'squadrant crew send' to reopen it before signaling again.`,
+    );
+  }
+  const req = buildSignalRequest(signal, { ...o, writeResult: o.writeResult ?? defaultWriteResult });
+  await deps.call(req);
+}
+
+/**
  * Attach the control-plane verbs onto an existing `squadrant crew` command so
  * they coexist with the legacy cmux-scrape verbs (spawn/send/read/close/list).
  * The control-plane task listing is `tasks` (not `list`) to avoid colliding
@@ -307,15 +354,14 @@ export function addControlPlaneCrewCommands(crew: Command): void {
         process.exit(2);
       }
       try {
-        const req = buildSignalRequest(state as "done" | "blocked" | "failed", {
+        await runCrewSignal(state as "done" | "blocked" | "failed", {
           ...(opts.message !== undefined ? { message: opts.message } : {}),
           ...(opts.question !== undefined ? { question: opts.question } : {}),
           ...(opts.error !== undefined ? { error: opts.error } : {}),
           ...(opts.taskId !== undefined ? { taskId: opts.taskId } : {}),
           ...(opts.project !== undefined ? { project: opts.project } : {}),
           writeResult: defaultWriteResult,
-        });
-        await squadrantdCall(req);
+        }, { call: squadrantdCall });
         process.exit(0);
       } catch (e) {
         process.stderr.write(`${(e as Error).message}\n`);

--- a/packages/cli/src/commands/effort.ts
+++ b/packages/cli/src/commands/effort.ts
@@ -2,7 +2,14 @@ import fs from "node:fs";
 import path from "node:path";
 import { Command } from "commander";
 import chalk from "chalk";
-import { loadConfig, saveConfig, resolveEffort, DEFAULT_CONFIG_PATH } from "@squadrant/shared";
+import {
+  loadConfig,
+  saveConfig,
+  resolveEffort,
+  loadProjectOverride,
+  saveProjectOverride,
+  DEFAULT_CONFIG_PATH,
+} from "@squadrant/shared";
 import type { SquadrantConfig, Effort } from "@squadrant/shared";
 import { appendCaptainMessage } from "@squadrant/core";
 
@@ -19,22 +26,54 @@ export interface EffortGetResult {
   description: string;
 }
 
-export function runEffortGet(configPath = DEFAULT_CONFIG_PATH, projectName?: string): EffortGetResult {
+export function runEffortGet(
+  configPath = DEFAULT_CONFIG_PATH,
+  projectName?: string,
+  projectConfigRoot?: string,
+): EffortGetResult {
   const config = loadConfig(configPath);
-  const effort = resolveEffort(config, projectName);
+  if (projectName && !(projectName in config.projects)) {
+    const known = Object.keys(config.projects).sort().join(", ") || "(no projects registered)";
+    throw new Error(`Unknown project '${projectName}'. Known projects: ${known}`);
+  }
+  const effort = resolveEffort(config, projectName, projectConfigRoot);
   const description = `${effort}: ${EFFORT_MEANING[effort]}`;
   return { effort, description };
 }
 
-export function runEffortSet(value: string, configPath = DEFAULT_CONFIG_PATH): void {
+/**
+ * Set the effort dial. With `projectName`, writes a per-project override
+ * (projects/<name>.json) instead of the global dial — the two scopes are
+ * mutually exclusive so callers must not fall through to the global write.
+ */
+export function runEffortSet(
+  value: string,
+  configPath = DEFAULT_CONFIG_PATH,
+  projectName?: string,
+  projectConfigRoot?: string,
+): void {
   if (!(VALID_EFFORTS as string[]).includes(value)) {
     throw new Error(
       `Invalid effort '${value}'. Valid values: ${VALID_EFFORTS.join(" | ")}`,
     );
   }
+  if (projectName) {
+    const config = loadConfig(configPath);
+    if (!(projectName in config.projects)) {
+      const known = Object.keys(config.projects).sort().join(", ") || "(no projects registered)";
+      throw new Error(`Unknown project '${projectName}'. Known projects: ${known}`);
+    }
+    saveProjectOverride(projectName, { effort: value as Effort }, projectConfigRoot);
+    return;
+  }
   const config = loadConfig(configPath);
   config.defaults.effort = value as Effort;
   saveConfig(config, configPath);
+}
+
+/** Scope label for the CLI success line — must state what was actually written (#575). */
+export function effortScopeLabel(projectName?: string): string {
+  return projectName ? `project: ${projectName}` : "global";
 }
 
 /** Minimal slice of RuntimeDriver used to resolve captain status. */
@@ -53,11 +92,17 @@ function canonical(p: string): string {
 }
 
 /**
- * Send the effort-change notice to every running captain via the mailbox.
- * The captain that ran `squadrant effort` already saw stdout, so that project
- * is excluded. Routes through the mailbox so the daemon's delivery-loop drains
- * it with draft protection (#529).
+ * Send the effort-change notice to every running captain whose *effective*
+ * effort actually changed, via the mailbox. The captain that ran
+ * `squadrant effort` already saw stdout, so that project is excluded.
+ * Routes through the mailbox so the daemon's delivery-loop drains it with
+ * draft protection (#529).
  * appendCaptainMessage is a closure capturing stateRoot from the caller.
+ *
+ * `scopeProject` set means the write was project-scoped (#575): only that
+ * project's effective effort changed, so only it is notified. Unset means a
+ * global write: projects with their own override are unaffected and must be
+ * skipped rather than told a value that isn't theirs (#576).
  */
 export async function notifyCaptainsOfEffort(
   effort: Effort,
@@ -65,12 +110,22 @@ export async function notifyCaptainsOfEffort(
   driver: EffortNotifyDriver,
   cwd: string = process.cwd(),
   append: (project: string, text: string) => Promise<void | number>,
+  scopeProject?: string,
+  projectConfigRoot?: string,
 ): Promise<void> {
   const here = canonical(cwd);
   const notice = `🎚️ effort → ${effort}: ${EFFORT_MEANING[effort]}`;
   for (const [projName, proj] of Object.entries(config.projects)) {
     // Skip the captain running in this same directory — it already saw stdout.
     if (canonical(proj.path) === here) continue;
+
+    if (scopeProject) {
+      if (projName !== scopeProject) continue;
+    } else if (loadProjectOverride(projName, projectConfigRoot).effort !== undefined) {
+      // This project pins its own effort — the global change doesn't apply to it.
+      continue;
+    }
+
     try {
       const ref = await driver.status(proj.captainName);
       if (ref) {
@@ -83,31 +138,38 @@ export async function notifyCaptainsOfEffort(
 }
 
 export const effortCommand = new Command("effort")
-  .description("Get or set the global crew tokenomics dial (max | balance | low)")
+  .description("Get or set the crew tokenomics dial (max | balance | low) — global by default, or per-project with --project")
   .argument("[value]", "effort level to set: max | balance | low")
-  .option("--project <name>", "show resolved effort for a specific project")
+  .option("--project <name>", "target a specific project (get: show its resolved effort; set: write a per-project override)")
   .action(async (value: string | undefined, options: { project?: string }) => {
     if (value === undefined) {
-      const { effort, description } = runEffortGet(undefined, options.project);
+      let result: EffortGetResult;
+      try {
+        result = runEffortGet(undefined, options.project);
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
       const label = options.project ? `${options.project} project` : "global";
-      console.log(chalk.bold(`Current effort (${label}):`), chalk.cyan(effort));
-      console.log(chalk.dim(EFFORT_MEANING[effort]));
+      console.log(chalk.bold(`Current effort (${label}):`), chalk.cyan(result.effort));
+      console.log(chalk.dim(EFFORT_MEANING[result.effort]));
       return;
     }
 
     try {
-      runEffortSet(value);
+      runEffortSet(value, undefined, options.project);
     } catch (err) {
       console.error(chalk.red((err as Error).message));
       process.exit(1);
     }
 
     const effort = value as Effort;
-    console.log(chalk.green(`✔ effort → ${effort}`));
+    console.log(chalk.green(`✔ effort → ${effort} (${effortScopeLabel(options.project)})`));
     console.log(chalk.dim(EFFORT_MEANING[effort]));
 
-    // Best-effort active notify: enqueue to the mailbox for every running captain.
-    // Never hard-fails — config is already written above.
+    // Best-effort active notify: enqueue to the mailbox for every running captain
+    // whose effective effort actually changed. Never hard-fails — config is
+    // already written above.
     // Routes through the mailbox (not driver.send) to avoid clobbering user draft (#529).
     try {
       const { createCmuxDriver, RuntimeRegistry } = await import("@squadrant/workspaces");
@@ -117,7 +179,7 @@ export const effortCommand = new Command("effort")
       const stateRoot = path.join(path.dirname(DEFAULT_CONFIG_PATH), "state");
       const append = (project: string, text: string) =>
         appendCaptainMessage({ stateRoot, project, text, source: "daemon" });
-      await notifyCaptainsOfEffort(effort, config, driver, process.cwd(), append);
+      await notifyCaptainsOfEffort(effort, config, driver, process.cwd(), append, options.project);
     } catch {
       // runtime unavailable — config already written, change applies on next launch
       console.log(chalk.dim("(no running captain detected — change applies on next launch)"));

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -25,10 +25,14 @@ async function sendToSock(req: unknown): Promise<void> {
  * Map a NativeHookSource sub-alias to a ControlEvent.
  *
  * "stop", "notification", "session-end" delegate to mapClaudeHookToEvent (which
- * handles detectTrailingQuestion and isPermissionNotification). The new subs
- * not covered by the existing per-crew mapper are handled inline.
+ * handles detectTrailingQuestion and isPermissionNotification). "ask-question"
+ * also delegates to it (#560) — it fires from the same PreToolUse+AskUserQuestion
+ * matcher as the crew's own hook set, so it must extract the real question/options
+ * from tool_input the same way (the previous inline version read a `payload.question`
+ * field that doesn't exist in Claude's actual PreToolUse payload, so it always fell
+ * back to a generic placeholder). The remaining subs are handled inline.
  */
-function mapHookSub(sub: string, payload: unknown, taskId: string): ControlEvent | null {
+export function mapHookSub(sub: string, payload: unknown, taskId: string): ControlEvent | null {
   switch (sub) {
     case "session-start":
     case "pre-tool-use":
@@ -41,12 +45,8 @@ function mapHookSub(sub: string, payload: unknown, taskId: string): ControlEvent
       return mapClaudeHookToEvent("Stop", payload, taskId);
     case "notification":
       return mapClaudeHookToEvent("Notification", payload, taskId);
-    case "ask-question": {
-      const q = typeof (payload as Record<string, unknown>)?.question === "string"
-        ? (payload as Record<string, unknown>).question as string
-        : "awaiting input";
-      return { type: "task.input.requested", id: taskId, requestId: 0, question: q };
-    }
+    case "ask-question":
+      return mapClaudeHookToEvent("PreToolUse", payload, taskId);
     case "session-end":
       return mapClaudeHookToEvent("SessionEnd", payload, taskId);
     default:

--- a/packages/core/src/__tests__/crew-spawn.test.ts
+++ b/packages/core/src/__tests__/crew-spawn.test.ts
@@ -657,6 +657,29 @@ describe("runCrewSend", () => {
     expect(runtime.sendToPane).toHaveBeenCalledWith(expect.anything(), "msg");
   });
 
+  // #574: runCrewSend picked tasks.find() = FIRST same-name match, while
+  // runCrewClose (#513) picks the MOST RECENT same-name match. With duplicate
+  // records (e.g. an orphaned record from a prior close/respawn race), the two
+  // call sites disagreed on which record is "the" live one — send would reopen
+  // a stale record instead of the one the live crew actually reports against,
+  // so a later `crew signal done` targeting the live (already-terminal) record
+  // never observably reopened, silently dropping CREW DONE. Send must pick the
+  // same most-recent-by-createdAt record as close.
+  it("reopens the MOST RECENT same-name record, not the first match (duplicate same-name records, #574)", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:cv-qa" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    const emitEvent = vi.fn().mockResolvedValue(undefined);
+    // Stale orphaned record (non-terminal, earlier) listed BEFORE the live
+    // crew's own record (terminal, later) — array order must not matter.
+    const stale = { id: "old-id", name: "cv-qa", state: "working", createdAt: 1000 } as Partial<TaskRecord>;
+    const live = { id: "new-id", name: "cv-qa", state: "done", createdAt: 2000 } as Partial<TaskRecord>;
+    await runCrewSend(PROJECT, "cv-qa", "msg", runtime, "workspace:1", {
+      listTasks: vi.fn().mockResolvedValue([stale, live]),
+      emitEvent,
+    });
+    expect(emitEvent).toHaveBeenCalledWith(PROJECT, { type: "task.reopened", id: "new-id" });
+  });
+
   // #448: when deps.sendToPane is injected, it is used instead of runtime.sendToPane
   // so the CLI can supply the paste-settle-Enter confirmed-submit helper.
   it("uses deps.sendToPane when provided, bypassing runtime.sendToPane", async () => {

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -459,6 +459,17 @@ export async function runCrewSpawn(
 
 // ─── crew session operations ──────────────────────────────────────────────────
 
+// #574: the single record-selection rule for "which task record is THE record
+// for this crew name" when duplicates exist (e.g. an orphaned record left by a
+// close/respawn race, #513). Every call site that resolves a crew name to a
+// task record MUST go through this helper — runCrewSend and runCrewClose used
+// to each inline their own pick (first-match vs most-recent), and disagreed on
+// live vs. stale duplicates, causing the two sides of a crew's lifecycle to
+// silently track different ids.
+function pickMostRecentTask(tasks: TaskRecord[]): TaskRecord {
+  return tasks.reduce((a, b) => ((b.createdAt ?? 0) > (a.createdAt ?? 0) ? b : a));
+}
+
 export async function runCrewSend(
   project: string,
   name: string,
@@ -496,8 +507,8 @@ export async function runCrewSend(
   // Blocked task: emit task.started to clear blocked→working so a subsequent real
   // permission prompt re-fires CREW BLOCKED (#182).
   try {
-    const tasks = await deps.listTasks(project);
-    const task = tasks.find((t) => t.name === name);
+    const matches = (await deps.listTasks(project)).filter((t) => t.name === name);
+    const task = matches.length > 0 ? pickMostRecentTask(matches) : undefined;
     if (task) {
       if (TERMINAL_STATES.has(task.state)) {
         await deps.emitEvent(project, { type: "task.reopened", id: task.id });
@@ -591,7 +602,7 @@ export async function runCrewClose(
       // respawn). Terminalize every non-terminal match so none linger to fire
       // a phantom CREW STALLED/IDLE later. Reap/worktree cleanup below anchors
       // on the most-recently-dispatched match — the one the live pane belongs to.
-      const primary = matches.reduce((a, b) => ((b.createdAt ?? 0) > (a.createdAt ?? 0) ? b : a));
+      const primary = pickMostRecentTask(matches);
       taskId = primary.id;
       if (primary.cwd && projRoot && primary.cwd !== projRoot) {
         worktreeCwd = primary.cwd;


### PR DESCRIPTION
## Summary
Patch release carrying 3 merged fixes from develop:

- fix(#574,#557): shared task-record selection (`pickMostRecentTask`) + `crew signal` fails loudly on an already-terminal task instead of silently no-opping
- fix(#575,#576): `effort set --project` writes a scoped per-project override (and validates the project name) instead of silently rewriting the global dial; change notices are computed per-recipient
- fix(#560): crews now get dedicated `PreToolUse → AskUserQuestion` hook coverage — a blocked crew always emits a daemon event instead of stalling forever with no signal

## Test plan
- [x] CHANGELOG.md and package.json version bumped to 0.16.3
- [ ] CI green on this PR
- [ ] npm registry confirms `dist-tags.latest` = 0.16.3 after merge (verify by `curl`, not `npm view`)
- [ ] Back-merge main → develop after merge