### PR TITLE
fix(#579,#484): never probe/force-deliver into an actively-changing captain draft

### DIFF
--- a/docs/reports/579-freeform-ghost-fixture-1.txt
+++ b/docs/reports/579-freeform-ghost-fixture-1.txt
@@ -1,14 +1,33 @@
-⏺ PR #577 is up and the fix574 task-record selection bug is closed out. Summary posted
-  above with the before/after selection logic and the null-safety follow-up noted for
-  review.
+# Evidence: #574 live repro + unexplained phantom draft
+# captured: 2026-07-12T05:29:37Z
+# daemon version: 0.16.2
 
-✳ Cerebrating… (12s · ↓ 3.1k tokens)
-  ⎿  Tip: Use /rewind to go back to a previous state of your codebase.
+## daemon's view of the task (note: state=working, crew is NOT working)
+361d836d  claude  working  task.progress  Fix #574 and #557 together — they are one bug class: a crew'
 
-──────────────────────────────────────────────────────────────────────────────────────────
-❯ signal done and let the captain merge
-──────────────────────────────────────────────────────────────────────────────────────────
-   Model: Sonnet 5  Ctx Used: 41.0%  Cost: $2.14  Session: 1hr 03m
-   Session ID: d4916c50-11c9-4a1e-9f2a-6e1e6d9c9a01  Thinking: none
-   ⎇ crew/fix574  𖠰 develop
-  ⏵⏵ auto mode on
+## pane tail — idle prompt with UNSUBMITTED draft in the input box
+  
+  Committed 48ffa1e, pushed to crew/fix574, ran 1 shell command 
+
+⏺ Pushed to PR #577. Summary of this follow-up:
+
+  - Added a failing-first test that reproduced the exact TypeError: Cannot read properties of undefined (reading 'state') when the status lookup resolves with no
+  record.
+  - Fixed runCrewSignal to treat a missing record as "not confirmed terminal" and fall through to the normal emit (which surfaces its own clear "unknown task"
+  error if the id truly doesn't exist), instead of crashing.
+  - Reworded the already-terminal error message — it's read by the crew, which can't run crew send on itself — to tell the crew to stop and ask the captain
+  instead.
+  - Full suite re-verified green: 167 files / 2047 tests passed, 1 pre-existing skip. No stray processes.
+
+✻ Worked for 2m 53s
+
+※ recap: Fixed and pushed both parts of PR #577 for the #574/#557 crew-signal bug, including a follow-up fix for a null-guard issue a reviewer flagged. Full test
+  suite is green; next step is waiting for review/merge into develop. (disable recaps in /config)
+
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+❯ signal done and let the captain merge
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+   Model: Sonnet 5  Ctx Used: 16.0%  Cost: $4.67  Session: 12m 
+   Session ID: bf56dc82-f5d5-456e-88f8-7c663f5b3dba  Thinking: high 
+   ⎇ crew/fix574  𖠰 squadrant-fix574 
+  ⏵⏵ auto mode on (shift+tab to cycle) · PR #577 · ← for agents

--- a/docs/reports/579-freeform-ghost-fixture-1.txt
+++ b/docs/reports/579-freeform-ghost-fixture-1.txt
@@ -1,0 +1,14 @@
+⏺ PR #577 is up and the fix574 task-record selection bug is closed out. Summary posted
+  above with the before/after selection logic and the null-safety follow-up noted for
+  review.
+
+✳ Cerebrating… (12s · ↓ 3.1k tokens)
+  ⎿  Tip: Use /rewind to go back to a previous state of your codebase.
+
+──────────────────────────────────────────────────────────────────────────────────────────
+❯ signal done and let the captain merge
+──────────────────────────────────────────────────────────────────────────────────────────
+   Model: Sonnet 5  Ctx Used: 41.0%  Cost: $2.14  Session: 1hr 03m
+   Session ID: d4916c50-11c9-4a1e-9f2a-6e1e6d9c9a01  Thinking: none
+   ⎇ crew/fix574  𖠰 develop
+  ⏵⏵ auto mode on

--- a/docs/reports/579-freeform-ghost-fixture-2.txt
+++ b/docs/reports/579-freeform-ghost-fixture-2.txt
@@ -1,0 +1,13 @@
+⏺ Closed out PR #580 — issue #560's AskUserQuestion detection gap is fixed and merged.
+  Task record shows terminal state; nothing else queued on this branch.
+
+✻ Churned for 6s
+  ⎿  Tip: Press ctrl+z to undo a file edit.
+
+──────────────────────────────────────────────────────────────────────────────────────────
+❯ go ahead and start on #562 now
+──────────────────────────────────────────────────────────────────────────────────────────
+   Model: Sonnet 5  Ctx Used: 38.5%  Cost: $1.87  Session: 47m
+   Session ID: 166baaf7-9c22-4f3e-8a70-2b7c1f0e5b44  Thinking: none
+   ⎇ crew/fix560  𖠰 develop
+  ⏵⏵ auto mode on

--- a/docs/reports/579-freeform-ghost-fixture-2.txt
+++ b/docs/reports/579-freeform-ghost-fixture-2.txt
@@ -1,13 +1,18 @@
-⏺ Closed out PR #580 — issue #560's AskUserQuestion detection gap is fixed and merged.
-  Task record shows terminal state; nothing else queued on this branch.
+# 2nd occurrence of the phantom draft (#579) — crew fix560
+# captured: 2026-07-12T10:47:11Z
+# 1st was crew fix574: 'signal done and let the captain merge'
+# 2nd is crew fix560: 'go ahead and start on #562 now'
+# BOTH: captain-shaped instruction, unsubmitted, appeared right after turn end
 
-✻ Churned for 6s
-  ⎿  Tip: Press ctrl+z to undo a file edit.
 
-──────────────────────────────────────────────────────────────────────────────────────────
-❯ go ahead and start on #562 now
-──────────────────────────────────────────────────────────────────────────────────────────
-   Model: Sonnet 5  Ctx Used: 38.5%  Cost: $1.87  Session: 47m
-   Session ID: 166baaf7-9c22-4f3e-8a70-2b7c1f0e5b44  Thinking: none
-   ⎇ crew/fix560  𖠰 develop
-  ⏵⏵ auto mode on
+  TDD throughout (red confirmed before each fix), full suite green (168 files / 2076 tests), clean typecheck, no stray processes. PR is still open, not merged.
+
+✻ Sautéed for 4m 46s
+
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+❯ go ahead and start on #562 now
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+   Model: Sonnet 5  Ctx Used: 28.0%  Cost: $9.83  Session: 23m 
+   Session ID: 61a88b3e-baf0-4be8-99e3-27a9ef268771  Thinking: high 
+   ⎇ crew/fix560  𖠰 squadrant-fix560 
+  ⏵⏵ auto mode on (shift+tab to cycle) · PR #580 · ← for agents

--- a/packages/cli/src/__tests__/squadrantd-notify-fault.test.ts
+++ b/packages/cli/src/__tests__/squadrantd-notify-fault.test.ts
@@ -1,0 +1,91 @@
+// #579/#484 Gap 1: squadrantd.ts wires opts.notifyFault (or, in production, a
+// real cmux-notifier-backed default) onto ctx.notifyFault, which delivery-loop
+// calls on the DELIVERY STUCK edge — the out-of-band channel that works even
+// when Telegram is unconfigured. This proves the wiring end to end through a
+// real startSquadrantd() boot, not just the unit-level createDelivery() call.
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const loadConfigMock = vi.hoisted(() => vi.fn());
+vi.mock("@squadrant/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@squadrant/shared")>();
+  return {
+    ...actual,
+    loadConfig: loadConfigMock,
+  };
+});
+
+import { startSquadrantd } from "../squadrantd.js";
+import { DeferDelivery } from "@squadrant/core";
+import type { DaemonCmux } from "@squadrant/workspaces";
+import type { PaneRef } from "@squadrant/shared";
+
+function mockConfig(project: string, captainName: string) {
+  loadConfigMock.mockReturnValue({
+    projects: { [project]: { captainName } },
+    commandName: "🏛️ command",
+    delivery: { maxDeferDeliveries: 2, stableProbePolls: 999 },
+    defaults: {},
+  });
+}
+
+describe("squadrantd notifyFault wiring (#579/#484 Gap 1)", () => {
+  let stop: (() => void) | undefined;
+  let dir: string;
+  afterEach(() => { stop?.(); if (dir) rmSync(dir, { recursive: true, force: true }); });
+
+  it("calls opts.notifyFault on the DELIVERY STUCK edge, with no telegramBridge injected at all", async () => {
+    dir = mkdtempSync(join(tmpdir(), "cp-notify-fault-"));
+    const sock = join(dir, "c.sock");
+    const stateRoot = join(dir, "state");
+
+    const project = "p";
+    const captainName = "p-captain";
+    mockConfig(project, captainName);
+
+    let n = 0;
+    const cmux: DaemonCmux = {
+      send: async () => { throw new DeferDelivery(`typing-${n++}`); },
+      listSurfaces: async () => [],
+      readScreen: async () => null,
+      isAvailable: async () => true,
+      findWorkspaceId: async () => "ws:1",
+    } as unknown as DaemonCmux;
+
+    const notifyFault = vi.fn();
+    const handle = startSquadrantd({
+      stateRoot,
+      sockPath: sock,
+      sweepMs: 0,
+      daemonCmux: cmux,
+      notifyFault,
+      captainSurfaces: { [project]: { workspaceId: "ws:1", surfaceId: "s1", title: captainName } as PaneRef },
+    });
+    stop = handle.stop;
+
+    // Seed one queued message so there's something to defer against.
+    const { appendToMailbox, writeCursor } = await import("@squadrant/core");
+    await appendToMailbox({
+      stateRoot, project,
+      taskRecord: {
+        id: "t1", project, provider: "claude", mode: "interactive",
+        state: "done", task: "t", createdAt: 1, lastHeartbeat: 1,
+        lastEvent: "", heartbeatBudgetMs: 1000, attempts: [],
+      },
+      event: { type: "task.done", id: "t1" } as any,
+      message: "CREW DONE t1",
+    });
+    await writeCursor({ stateRoot, project, subscriber: "captain", lastAckedSeq: 0 });
+
+    // maxDeferDeliveries=2 — a handful of ticks with ever-changing content
+    // (never stable) crosses the stuck threshold.
+    for (let i = 0; i < 6; i++) {
+      if (handle.tickDelivery) await handle.tickDelivery();
+    }
+
+    expect(notifyFault).toHaveBeenCalledTimes(1);
+    expect(notifyFault).toHaveBeenCalledWith(project, expect.stringContaining("DELIVERY STUCK"));
+  });
+});

--- a/packages/cli/src/__tests__/squadrantd-telegram.test.ts
+++ b/packages/cli/src/__tests__/squadrantd-telegram.test.ts
@@ -58,7 +58,7 @@ describe("squadrantd telegram bridge wiring", () => {
     dir = mkdtempSync(join(tmpdir(), "cp-tg-wired-"));
     const notify = vi.fn();
     const bridge = {
-      start: vi.fn(), stop: vi.fn(), pushLifecycle: vi.fn(),
+      start: vi.fn(), stop: vi.fn(), pushLifecycle: vi.fn(), pushRaw: vi.fn(),
       health: vi.fn(() => ({ polling: false, lastSuccessfulPollAt: null, lastError: null, lastErrorAt: null })),
     };
     const handle = startSquadrantd({

--- a/packages/cli/src/squadrantd.ts
+++ b/packages/cli/src/squadrantd.ts
@@ -25,6 +25,7 @@ import { runHeadless, CodexInteractiveDriver, OpencodeSseBridge, CodexAppServerS
 import { CmuxEventsBridge, DaemonCmux, CmuxStoreSource, NativeHookSource, resendCrewFirstTurn, RuntimeRegistry } from "@squadrant/workspaces";
 import { loadConfig, TERMINAL_STATES } from "@squadrant/shared";
 import { createCmuxDriver } from "@squadrant/workspaces";
+import { createCmuxNotifier, NotifierRegistry } from "@squadrant/workspaces";
 import { maybeBroadcastDaemonRestart } from "./lib/daemon-restart-broadcast.js";
 
 const SELF_PATH = fileURLToPath(import.meta.url);
@@ -69,6 +70,23 @@ function buildTelegramBridge(
     cfg, stateRoot, configRoot: dirname(stateRoot), client, appendCaptainMessage, log,
     ensureCaptainAlive, runCommand, sendReply,
   });
+}
+
+/** Construct the real out-of-band fault-alert channel (#579/#484 Gap 1) via the
+ *  notifier plugin slot — cmux by default (@squadrant/workspaces), or whichever
+ *  provider `config.notifier` names, so this works with ZERO extra config for
+ *  the vast majority of installs (cmux is squadrant's own runtime, not an
+ *  opt-in integration like Telegram). Best-effort: a notify failure is logged,
+ *  never thrown into the daemon's delivery loop. */
+function buildNotifyFault(log: (m: string) => void): (project: string, text: string) => Promise<void> {
+  const registry = new NotifierRegistry({ cmux: createCmuxNotifier });
+  return async (project: string, text: string) => {
+    try {
+      await registry.get(loadConfig()).notify(`[${project}] ${text}`);
+    } catch (e) {
+      log(`fault notify failed project=${project}: ${(e as Error).message}`);
+    }
+  };
 }
 
 export function startSquadrantd(opts: import("@squadrant/core").SquadrantdOpts = {}) {
@@ -157,6 +175,12 @@ export function startSquadrantd(opts: import("@squadrant/core").SquadrantdOpts =
   const tgCfg = loadConfig().telegram;
   ctx.telegramBridge = opts.telegramBridge
     ?? (tgCfg && !process.env.VITEST ? buildTelegramBridge(tgCfg, stateRoot, log) : undefined);
+
+  // ── Out-of-band fault-alert channel (#579/#484 Gap 1) ─────────────────────
+  // Skipped under vitest (would shell out to the real `squadrant` CLI); tests
+  // inject opts.notifyFault, or fall back to buildContext()'s no-op default.
+  if (opts.notifyFault) ctx.notifyFault = opts.notifyFault;
+  else if (!process.env.VITEST) ctx.notifyFault = buildNotifyFault(log);
 
   // ── daemonCmux resolution ─────────────────────────────────────────────────
   ctx.daemonCmux = opts.daemonCmux

--- a/packages/core/src/__tests__/delivery-loop.stuck-alert.test.ts
+++ b/packages/core/src/__tests__/delivery-loop.stuck-alert.test.ts
@@ -131,6 +131,54 @@ describe("delivery-loop stuck-delivery alert (#579/#484)", () => {
     expect(texts.some((t) => t.includes("DELIVERY STUCK"))).toBe(false);
   });
 
+  it("pushes the alert out-of-band via telegramBridge — reaches the operator WHILE still stuck, not queued behind the same blocked pane", async () => {
+    // The mailbox entry alone doesn't work: it's drained by this same stuck
+    // delivery pipeline, so it queues behind the very block it's reporting.
+    // telegramBridge.pushRaw never touches the pane/mailbox, so it must fire
+    // on the SAME tick that crosses maxDefers — before the draft ever clears.
+    const stateRoot = freshState();
+    const project = "delta";
+    const captainName = `${project}-captain`;
+    mockConfig({ projects: { [project]: { captainName } } });
+    const store = createStore(stateRoot);
+    store.put({
+      id: "t1", project, provider: "claude", mode: "interactive",
+      state: "done", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000, attempts: [],
+    });
+    await appendToMailbox({
+      stateRoot, project, taskRecord: store.list(project)[0],
+      event: { type: "task.done", id: "t1" } as any,
+      message: "CREW DONE t1",
+    });
+    const livenessRegistry = new LivenessRegistry({ path: join(stateRoot, "live.json") });
+    livenessRegistry.apply({
+      project, role: "captain", pid: 123, sessionId: "s1",
+      startedAt: Date.now(), lastState: "start", lastSeenAt: Date.now(),
+      pidAlive: true, source: "runtime",
+    });
+
+    let n = 0;
+    const cmux = {
+      listSurfaces: async () => [{ id: "s1", title: captainName, command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => `${captainName}> `,
+      send: async () => { throw new DeferDelivery(`typing-${n++}`); },
+    };
+    const pushRaw = vi.fn();
+    const telegramBridge = { start: vi.fn(), stop: vi.fn(), pushLifecycle: vi.fn(), pushRaw, health: vi.fn() };
+    const deliv = createDelivery({
+      stateRoot, store, livenessRegistry, log: () => {}, isPidAlive: () => true, opts: {}, telegramBridge,
+    } as any, cmux as any);
+
+    // Still stuck (draft never clears) — the mailbox alert would still be
+    // queued behind the block, but pushRaw must already have fired.
+    for (let i = 0; i < 6; i++) await deliv.deliveryTick!();
+
+    expect(pushRaw).toHaveBeenCalledTimes(1);
+    expect(pushRaw).toHaveBeenCalledWith(project, expect.stringContaining("DELIVERY STUCK"));
+  });
+
   it("re-arms after recovery — a second, later stall episode alerts again", async () => {
     const stateRoot = freshState();
     const project = "gamma";

--- a/packages/core/src/__tests__/delivery-loop.stuck-alert.test.ts
+++ b/packages/core/src/__tests__/delivery-loop.stuck-alert.test.ts
@@ -179,6 +179,54 @@ describe("delivery-loop stuck-delivery alert (#579/#484)", () => {
     expect(pushRaw).toHaveBeenCalledWith(project, expect.stringContaining("DELIVERY STUCK"));
   });
 
+  it("#579/#484 Gap 1: pushes the alert via notifyFault even with NO telegramBridge configured — the config-free channel every install has", async () => {
+    // Most installs have no Telegram set up. Before this fix, the ONLY
+    // out-of-band channel was `telegramBridge?.pushRaw` — undefined bridge
+    // meant that call silently no-op'd, leaving the alert with no channel
+    // that could reach the operator while still stuck (appendCaptainMessage
+    // queues behind the same block). notifyFault must be resolved and called
+    // regardless of whether telegramBridge is injected at all.
+    const stateRoot = freshState();
+    const project = "epsilon";
+    const captainName = `${project}-captain`;
+    mockConfig({ projects: { [project]: { captainName } } });
+    const store = createStore(stateRoot);
+    store.put({
+      id: "t1", project, provider: "claude", mode: "interactive",
+      state: "done", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000, attempts: [],
+    });
+    await appendToMailbox({
+      stateRoot, project, taskRecord: store.list(project)[0],
+      event: { type: "task.done", id: "t1" } as any,
+      message: "CREW DONE t1",
+    });
+    const livenessRegistry = new LivenessRegistry({ path: join(stateRoot, "live.json") });
+    livenessRegistry.apply({
+      project, role: "captain", pid: 123, sessionId: "s1",
+      startedAt: Date.now(), lastState: "start", lastSeenAt: Date.now(),
+      pidAlive: true, source: "runtime",
+    });
+
+    let n = 0;
+    const cmux = {
+      listSurfaces: async () => [{ id: "s1", title: captainName, command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => `${captainName}> `,
+      send: async () => { throw new DeferDelivery(`typing-${n++}`); },
+    };
+    const notifyFault = vi.fn();
+    const deliv = createDelivery({
+      // NOTE: no telegramBridge key at all — proves this doesn't depend on it.
+      stateRoot, store, livenessRegistry, log: () => {}, isPidAlive: () => true, opts: {}, notifyFault,
+    } as any, cmux as any);
+
+    for (let i = 0; i < 6; i++) await deliv.deliveryTick!();
+
+    expect(notifyFault).toHaveBeenCalledTimes(1);
+    expect(notifyFault).toHaveBeenCalledWith(project, expect.stringContaining("DELIVERY STUCK"));
+  });
+
   it("re-arms after recovery — a second, later stall episode alerts again", async () => {
     const stateRoot = freshState();
     const project = "gamma";

--- a/packages/core/src/__tests__/delivery-loop.stuck-alert.test.ts
+++ b/packages/core/src/__tests__/delivery-loop.stuck-alert.test.ts
@@ -1,0 +1,198 @@
+// #579/#484: probe escalation now defers FOREVER while a captain's draft (real
+// or ghost) is actively changing — the correct, safe behaviour. But safe-and-
+// silent is exactly #560's disease ("stalls silently, forever, invisible unless
+// a human happens to open the dashboard"). These tests assert the daemon fails
+// LOUD instead: a real, edge-triggered captain.message alert once delivery
+// crosses maxDefers for a project — never per-poll (the #492 flood class), and
+// re-arms so a LATER stall episode alerts again.
+import { describe, it, expect, vi } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const loadConfigMock = vi.hoisted(() => vi.fn());
+vi.mock("@squadrant/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@squadrant/shared")>();
+  return {
+    ...actual,
+    loadConfig: loadConfigMock,
+  };
+});
+
+import { createDelivery } from "../daemon/delivery-loop.js";
+import { createStore } from "../store.js";
+import { LivenessRegistry } from "../daemon/liveness-registry.js";
+import { appendToMailbox, readFromCursor } from "../mailbox.js";
+import { DeferDelivery } from "../delivery/defer-delivery.js";
+
+function freshState(): string {
+  return mkdtempSync(join(tmpdir(), "deliv-stuck-"));
+}
+
+// Small maxDefers/high stableProbePolls so a handful of ticks with CHANGING
+// content (never stable) crosses the stuck threshold without ever escalating
+// to a probe — isolates the "stuck" alert from the #484 probe-escalation logic.
+function mockConfig(overrides?: Record<string, unknown>) {
+  loadConfigMock.mockReturnValue({
+    projects: {}, commandName: "🏛️ command",
+    delivery: { maxDeferDeliveries: 2, stableProbePolls: 999 },
+    ...overrides,
+  });
+}
+
+async function rawMailboxTexts(stateRoot: string, project: string): Promise<string[]> {
+  const texts: string[] = [];
+  for await (const entry of readFromCursor({ stateRoot, project, fromSeq: 1 })) {
+    if (entry.message) texts.push(entry.message);
+  }
+  return texts;
+}
+
+describe("delivery-loop stuck-delivery alert (#579/#484)", () => {
+  it("emits exactly one captain.message alert once deferCount crosses maxDefers — not once per poll", async () => {
+    const stateRoot = freshState();
+    const project = "alpha";
+    const captainName = `${project}-captain`;
+    mockConfig({ projects: { [project]: { captainName } } });
+    const store = createStore(stateRoot);
+    store.put({
+      id: "t1", project, provider: "claude", mode: "interactive",
+      state: "done", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000, attempts: [],
+    });
+    await appendToMailbox({
+      stateRoot, project, taskRecord: store.list(project)[0],
+      event: { type: "task.done", id: "t1" } as any,
+      message: "CREW DONE t1",
+    });
+    const livenessRegistry = new LivenessRegistry({ path: join(stateRoot, "live.json") });
+    livenessRegistry.apply({
+      project, role: "captain", pid: 123, sessionId: "s1",
+      startedAt: Date.now(), lastState: "start", lastSeenAt: Date.now(),
+      pidAlive: true, source: "runtime",
+    });
+
+    let n = 0;
+    const cmux = {
+      listSurfaces: async () => [{ id: "s1", title: captainName, command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => `${captainName}> `,
+      // Content changes every call — an actively-typing captain, never stable —
+      // so only the maxDefers-crossing edge can trip the alert, never a probe.
+      send: async () => { throw new DeferDelivery(`typing-${n++}`); },
+    };
+    const deliv = createDelivery({
+      stateRoot, store, livenessRegistry, log: () => {}, isPidAlive: () => true, opts: {},
+    } as any, cmux as any);
+
+    // 6 ticks: well past maxDefers=2 — the alert must fire exactly once, not 4+ times.
+    for (let i = 0; i < 6; i++) await deliv.deliveryTick!();
+
+    const texts = await rawMailboxTexts(stateRoot, project);
+    const alerts = texts.filter((t) => t.includes("DELIVERY STUCK"));
+    expect(alerts).toHaveLength(1);
+  });
+
+  it("does not alert while delivery is healthy (never stuck)", async () => {
+    const stateRoot = freshState();
+    const project = "beta";
+    const captainName = `${project}-captain`;
+    mockConfig({ projects: { [project]: { captainName } } });
+    const store = createStore(stateRoot);
+    store.put({
+      id: "t1", project, provider: "claude", mode: "interactive",
+      state: "done", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000, attempts: [],
+    });
+    await appendToMailbox({
+      stateRoot, project, taskRecord: store.list(project)[0],
+      event: { type: "task.done", id: "t1" } as any,
+      message: "CREW DONE t1",
+    });
+    const livenessRegistry = new LivenessRegistry({ path: join(stateRoot, "live.json") });
+    livenessRegistry.apply({
+      project, role: "captain", pid: 123, sessionId: "s1",
+      startedAt: Date.now(), lastState: "start", lastSeenAt: Date.now(),
+      pidAlive: true, source: "runtime",
+    });
+    const cmux = {
+      listSurfaces: async () => [{ id: "s1", title: captainName, command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => `${captainName}> `,
+      send: async () => {}, // delivers immediately, every time
+    };
+    const deliv = createDelivery({
+      stateRoot, store, livenessRegistry, log: () => {}, isPidAlive: () => true, opts: {},
+    } as any, cmux as any);
+
+    for (let i = 0; i < 5; i++) await deliv.deliveryTick!();
+
+    const texts = await rawMailboxTexts(stateRoot, project);
+    expect(texts.some((t) => t.includes("DELIVERY STUCK"))).toBe(false);
+  });
+
+  it("re-arms after recovery — a second, later stall episode alerts again", async () => {
+    const stateRoot = freshState();
+    const project = "gamma";
+    const captainName = `${project}-captain`;
+    mockConfig({ projects: { [project]: { captainName } } });
+    const store = createStore(stateRoot);
+    store.put({
+      id: "t1", project, provider: "claude", mode: "interactive",
+      state: "done", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000, attempts: [],
+    });
+    await appendToMailbox({
+      stateRoot, project, taskRecord: store.list(project)[0],
+      event: { type: "task.done", id: "t1" } as any,
+      message: "CREW DONE t1",
+    });
+    const livenessRegistry = new LivenessRegistry({ path: join(stateRoot, "live.json") });
+    livenessRegistry.apply({
+      project, role: "captain", pid: 123, sessionId: "s1",
+      startedAt: Date.now(), lastState: "start", lastSeenAt: Date.now(),
+      pidAlive: true, source: "runtime",
+    });
+
+    let stuck = true;
+    let n = 0;
+    const cmux = {
+      listSurfaces: async () => [{ id: "s1", title: captainName, command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => `${captainName}> `,
+      send: async (_s: any, text: string) => {
+        if (stuck) throw new DeferDelivery(`typing-${n++}`);
+        // recovered: delivers normally
+      },
+    };
+    const deliv = createDelivery({
+      stateRoot, store, livenessRegistry, log: () => {}, isPidAlive: () => true, opts: {},
+    } as any, cmux as any);
+
+    // First stall episode: crosses maxDefers=2, alerts once.
+    for (let i = 0; i < 4; i++) await deliv.deliveryTick!();
+    let texts = await rawMailboxTexts(stateRoot, project);
+    expect(texts.filter((t) => t.includes("DELIVERY STUCK"))).toHaveLength(1);
+
+    // Recover: the original entry finally delivers, clearing the stuck flag.
+    stuck = false;
+    await deliv.deliveryTick!();
+
+    // New task, new stall episode.
+    store.put({
+      id: "t2", project, provider: "claude", mode: "interactive",
+      state: "done", task: "t2", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000, attempts: [],
+    });
+    await appendToMailbox({
+      stateRoot, project, taskRecord: store.list(project)[0],
+      event: { type: "task.done", id: "t2" } as any,
+      message: "CREW DONE t2",
+    });
+    stuck = true;
+    for (let i = 0; i < 4; i++) await deliv.deliveryTick!();
+
+    texts = await rawMailboxTexts(stateRoot, project);
+    expect(texts.filter((t) => t.includes("DELIVERY STUCK"))).toHaveLength(2);
+  });
+});

--- a/packages/core/src/__tests__/liveness.classify.test.ts
+++ b/packages/core/src/__tests__/liveness.classify.test.ts
@@ -51,6 +51,40 @@ describe("projectHealth (pure projection)", () => {
     expect(captain.detail).toMatch(/closed/i);
   });
 
+  // #579/#484 Gap 3: a stuck captain-delivery deferral must surface as a
+  // human-visible `detail` on the (otherwise "alive") captain row — the
+  // config-free, un-muteable pull surface for `squadrant doctor` /
+  // `squadrant status --detailed`.
+  it("captainDeferral.stuck=true → captain row carries a DELIVERY STUCK detail even though the captain is alive", () => {
+    const cs = projectHealth({
+      ...base, now: 1_000, captainStopped: false,
+      captainDeferral: { stuck: true, maxDeferCount: 300 },
+    });
+    const captain = find(cs, "captain")!;
+    expect(captain.state).toBe("alive"); // captain itself is fine — delivery is what's stuck
+    expect(captain.detail).toMatch(/delivery stuck/i);
+    expect(captain.detail).toContain("300");
+  });
+
+  it("captainDeferral.stuck=false (or omitted) → no stuck detail on an otherwise-healthy captain", () => {
+    const withStats = projectHealth({
+      ...base, now: 1_000, captainStopped: false,
+      captainDeferral: { stuck: false, maxDeferCount: 2 },
+    });
+    expect(find(withStats, "captain")!.detail).toBeUndefined();
+
+    const omitted = projectHealth({ ...base, now: 1_000, captainStopped: false });
+    expect(find(omitted, "captain")!.detail).toBeUndefined();
+  });
+
+  it("captainStopped=true wins over a stuck deferral — an intentional close explains the detail, not a stale defer count", () => {
+    const cs = projectHealth({
+      ...base, now: 1_000, captainStopped: true,
+      captainDeferral: { stuck: true, maxDeferCount: 300 },
+    });
+    expect(find(cs, "captain")!.detail).toMatch(/closed/i);
+  });
+
   it("captainStopped=null → captain unknown (no signal yet)", () => {
     const cs = projectHealth({ ...base, now: 1_000, captainStopped: null });
     expect(find(cs, "captain")!.state).toBe("unknown");

--- a/packages/core/src/daemon/context.ts
+++ b/packages/core/src/daemon/context.ts
@@ -78,6 +78,14 @@ export interface SquadrantdOpts {
    *  fake for tests. See DaemonDeps.resendFirstTurn (daemon/reduce.ts) for the
    *  full contract. */
   resendFirstTurn?: (rec: TaskRecord) => Promise<{ delivered: boolean }>;
+  /** #579/#484 Gap 1: config-free, out-of-band fault-alert channel — routed
+   *  through the notifier plugin slot (@squadrant/workspaces' NotifierRegistry,
+   *  cmux by default) rather than hardwired to Telegram, so it works for every
+   *  install (most have no Telegram configured) and for any future notifier
+   *  provider. core can't import @squadrant/workspaces (one-way DAG), so the
+   *  host (squadrantd.ts) builds the real implementation and injects it here —
+   *  mirrors how telegramBridge is wired. Must never throw/block; best-effort. */
+  notifyFault?: (project: string, text: string) => Promise<void> | void;
 }
 
 export function defaultIsPidAlive(pid: number): boolean {
@@ -132,6 +140,14 @@ export interface DaemonContext {
   cmuxEventsBridge: CmuxEventsBridge;
   /** Resolved Telegram bridge — undefined when config.telegram is absent. */
   telegramBridge?: TelegramBridge;
+  /** Resolved out-of-band fault-alert function (#579/#484 Gap 1) — ALWAYS a
+   *  real function, never undefined: defaults to a no-op here (core has no
+   *  notifier implementation to fall back to) but squadrantd.ts (the host)
+   *  always overrides it with the real notifier-registry-backed one before any
+   *  event can fire, so production never silently no-ops. Tests that construct
+   *  DaemonContext directly (bypassing squadrantd.ts) keep the no-op, which is
+   *  correct for isolated unit tests. */
+  notifyFault: (project: string, text: string) => Promise<void> | void;
   /** B4: registered LifecycleSource instances for per-source health aggregation. */
   lifecycleSources: LifecycleSource[];
   /** Fan-out to attach clients (set by createAttach). */
@@ -193,6 +209,7 @@ export function buildContext(opts: SquadrantdOpts): DaemonContext {
     opencodeBridge: null as unknown as OpencodeBridge,
     cmuxEventsBridge: null as unknown as CmuxEventsBridge,
     telegramBridge: undefined,
+    notifyFault: opts.notifyFault ?? (() => {}),
     lifecycleSources: opts.lifecycleSources ?? [],
     broadcast: () => {},
     schedulePromotion: () => {},

--- a/packages/core/src/daemon/delivery-loop.ts
+++ b/packages/core/src/daemon/delivery-loop.ts
@@ -157,7 +157,7 @@ export function createDelivery(
   ctx: DaemonContext,
   daemonCmux: DaemonSurfaceDriver | undefined,
 ): DeliveryResult {
-  const { stateRoot, store, log, livenessRegistry, isPidAlive, opts } = ctx;
+  const { stateRoot, store, log, livenessRegistry, isPidAlive, opts, telegramBridge } = ctx;
 
   // ── Default push-notification wiring (mailbox-injector spec) ─────────────
   const defaultNotify = async (args: {
@@ -299,21 +299,24 @@ export function createDelivery(
 
       // #579/#484: fail LOUD, not silent, once this project's delivery is
       // stuck (deferCount crossed maxDefers — an actively-changing draft that
-      // never stabilizes, so the structural probe never gets to run). This is
-      // a real mailbox entry (queued behind the block like any other daemon→
-      // captain message, e.g. #529's restart broadcast), not just a dashboard
-      // stat — it gives the operator a discoverable trail even if they never
-      // open the dashboard. Fires once per stall episode.
+      // never stabilizes, so the structural probe never gets to run).
+      //
+      // The mailbox entry alone is NOT enough: it's drained by this same
+      // stuck delivery pipeline, so it queues behind the very block it's
+      // reporting and only surfaces once the stall has already resolved
+      // (fail-silent-then-apologize). Kept here as a post-resolution audit
+      // trail, discoverable even if the operator never opens the dashboard.
+      // The operator-facing alert is the out-of-band Telegram push below,
+      // which never touches the stuck pane and reaches them WHILE stuck.
       const stuck = d.stats().stuck;
       if (stuck && !stuckNotified.has(project)) {
         stuckNotified.add(project);
         const { maxDeferCount } = d.stats();
         log(`delivery stuck project=${project} deferCount=${maxDeferCount}`);
-        appendCaptainMessage({
-          stateRoot, project,
-          text: `⚠️ DELIVERY STUCK: an in-progress draft (or ghost text) in your input box has blocked pending notification(s) for ${maxDeferCount}+ retries. Your input is never touched — this keeps retrying safely and will deliver automatically once you submit or clear it.`,
-          source: "daemon",
-        }).catch((e) => log(`delivery stuck alert failed project=${project}: ${(e as Error).message}`));
+        const text = `⚠️ DELIVERY STUCK: an in-progress draft (or ghost text) in your input box has blocked pending notification(s) for ${maxDeferCount}+ retries. Your input is never touched — this keeps retrying safely and will deliver automatically once you submit or clear it.`;
+        appendCaptainMessage({ stateRoot, project, text, source: "daemon" })
+          .catch((e) => log(`delivery stuck alert failed project=${project}: ${(e as Error).message}`));
+        telegramBridge?.pushRaw(project, text);
       } else if (!stuck && stuckNotified.has(project)) {
         stuckNotified.delete(project);
       }

--- a/packages/core/src/daemon/delivery-loop.ts
+++ b/packages/core/src/daemon/delivery-loop.ts
@@ -158,6 +158,10 @@ export function createDelivery(
   daemonCmux: DaemonSurfaceDriver | undefined,
 ): DeliveryResult {
   const { stateRoot, store, log, livenessRegistry, isPidAlive, opts, telegramBridge } = ctx;
+  // Default to a no-op so tests that construct a bare ctx object (not via
+  // buildContext) don't need to inject this. squadrantd.ts always overrides
+  // ctx.notifyFault with the real one in production (see context.ts).
+  const notifyFault = ctx.notifyFault ?? (() => {});
 
   // ── Default push-notification wiring (mailbox-injector spec) ─────────────
   const defaultNotify = async (args: {
@@ -306,8 +310,20 @@ export function createDelivery(
       // reporting and only surfaces once the stall has already resolved
       // (fail-silent-then-apologize). Kept here as a post-resolution audit
       // trail, discoverable even if the operator never opens the dashboard.
-      // The operator-facing alert is the out-of-band Telegram push below,
-      // which never touches the stuck pane and reaches them WHILE stuck.
+      //
+      // Two independent out-of-band channels fire alongside it, neither of
+      // which touches the stuck pane/mailbox:
+      //  - notifyFault: the notifier plugin slot (cmux by default — see
+      //    @squadrant/workspaces' NotifierRegistry). ALWAYS resolved in
+      //    production (never undefined), so it's the channel that works with
+      //    ZERO Telegram configuration — closing the gap where Telegram alone
+      //    left every non-Telegram install silent.
+      //  - telegramBridge.pushRaw: reaches a phone even when the operator
+      //    isn't watching a terminal. Optional — only when Telegram is set up.
+      // The daemon's own health snapshot (`deferral.stuck`) is also surfaced
+      // as `detail` on the captain's ComponentHealth row (see liveness.ts),
+      // so `squadrant doctor` / `squadrant status --detailed` show it too —
+      // a third, pull-based, zero-configuration surface.
       const stuck = d.stats().stuck;
       if (stuck && !stuckNotified.has(project)) {
         stuckNotified.add(project);
@@ -316,6 +332,8 @@ export function createDelivery(
         const text = `⚠️ DELIVERY STUCK: an in-progress draft (or ghost text) in your input box has blocked pending notification(s) for ${maxDeferCount}+ retries. Your input is never touched — this keeps retrying safely and will deliver automatically once you submit or clear it.`;
         appendCaptainMessage({ stateRoot, project, text, source: "daemon" })
           .catch((e) => log(`delivery stuck alert failed project=${project}: ${(e as Error).message}`));
+        Promise.resolve(notifyFault(project, text))
+          .catch((e) => log(`delivery stuck fault-notify failed project=${project}: ${(e as Error).message}`));
         telegramBridge?.pushRaw(project, text);
       } else if (!stuck && stuckNotified.has(project)) {
         stuckNotified.delete(project);

--- a/packages/core/src/daemon/delivery-loop.ts
+++ b/packages/core/src/daemon/delivery-loop.ts
@@ -1,6 +1,6 @@
 // src/control/daemon/delivery.ts
 // Mailbox notification + daemon-direct captain delivery loop (#332).
-import { appendToMailbox, readCursor, writeCursor, readFromCursor } from "../mailbox.js";
+import { appendToMailbox, appendCaptainMessage, readCursor, writeCursor, readFromCursor } from "../mailbox.js";
 import { CaptainDelivery, type CaptainDeliveryStats } from "../delivery/captain-delivery.js";
 import { loadConfig, TERMINAL_STATES } from "@squadrant/shared";
 import { STALE_THRESHOLD_MS } from "./interactive-probe.js";
@@ -190,6 +190,13 @@ export function createDelivery(
   const cfg = loadConfig();
   const deliveries = new Map<string, CaptainDelivery>();
   const deliveryStats = (project: string): CaptainDeliveryStats | undefined => deliveries.get(project)?.stats();
+  // #579/#484: deferring forever behind an actively-changing draft is the
+  // correct, SAFE behaviour — but safe-and-silent is #560's disease. Track
+  // which projects we've already alerted on for the CURRENT stall episode so
+  // the alert fires exactly once per episode (edge-triggered, mirrors the
+  // #354 quietNotifiedAt / #492 anti-flood pattern), not once per poll. Clears
+  // when stats().stuck drops back to false, re-arming for a later episode.
+  const stuckNotified = new Set<string>();
   // Captured once at delivery-loop setup. Entries older than
   // sessionStartMs - STALE_THRESHOLD_MS are silently acked (cursor advanced)
   // without delivery. This stops a fresh/empty cursor from re-delivering the
@@ -288,6 +295,27 @@ export function createDelivery(
           log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=deferred`);
           break;
         }
+      }
+
+      // #579/#484: fail LOUD, not silent, once this project's delivery is
+      // stuck (deferCount crossed maxDefers — an actively-changing draft that
+      // never stabilizes, so the structural probe never gets to run). This is
+      // a real mailbox entry (queued behind the block like any other daemon→
+      // captain message, e.g. #529's restart broadcast), not just a dashboard
+      // stat — it gives the operator a discoverable trail even if they never
+      // open the dashboard. Fires once per stall episode.
+      const stuck = d.stats().stuck;
+      if (stuck && !stuckNotified.has(project)) {
+        stuckNotified.add(project);
+        const { maxDeferCount } = d.stats();
+        log(`delivery stuck project=${project} deferCount=${maxDeferCount}`);
+        appendCaptainMessage({
+          stateRoot, project,
+          text: `⚠️ DELIVERY STUCK: an in-progress draft (or ghost text) in your input box has blocked pending notification(s) for ${maxDeferCount}+ retries. Your input is never touched — this keeps retrying safely and will deliver automatically once you submit or clear it.`,
+          source: "daemon",
+        }).catch((e) => log(`delivery stuck alert failed project=${project}: ${(e as Error).message}`));
+      } else if (!stuck && stuckNotified.has(project)) {
+        stuckNotified.delete(project);
       }
     }
   };

--- a/packages/core/src/daemon/start.ts
+++ b/packages/core/src/daemon/start.ts
@@ -111,6 +111,11 @@ export function startDaemon(ctx: DaemonContext, opts: SquadrantdOpts, pkgVersion
           captainState: deriveCaptainState(capEntry),
           commandPresent: null,
           crews: store.list(project),
+          // #579/#484 Gap 3: surface the same deferral stats already exposed to
+          // the snapshot (line ~135 below) on the health row too, so `squadrant
+          // doctor` / `squadrant status --detailed` show a stuck delivery with
+          // zero configuration.
+          captainDeferral: deliveryStats(project),
         }),
       );
     }

--- a/packages/core/src/delivery/__tests__/captain-delivery.test.ts
+++ b/packages/core/src/delivery/__tests__/captain-delivery.test.ts
@@ -26,16 +26,54 @@ describe("CaptainDelivery defer-while-typing (#258/#302)", () => {
     expect(probes[probes.length - 1]).toBe(true);
   });
 
-  it("force-delivers (probe) after maxDefers regardless of stability", async () => {
+  // #484 reopened (compose-box variant): the old `deferCount >= maxDefers` OR
+  // clause escalated to a probe purely on defer COUNT, even while the draft was
+  // still actively changing every poll — i.e. a human genuinely typing. Once
+  // probe=true, sendToSurface sends a REAL backspace keystroke into the live
+  // pane to run the structural liveness test (#258/#302); doing that against a
+  // draft that hasn't stabilized risks racing the human's next keystroke and,
+  // per #484's own root-cause analysis, eventually misclassifying and
+  // force-delivering into it. An actively-changing draft must keep deferring
+  // FOREVER (never probed) until it goes stable (paused) or empty (submitted) —
+  // maxDefers alone must never be sufficient to escalate.
+  it("never escalates to a probe while draft content keeps changing every poll, even long past maxDefers (#484 reopened fix)", async () => {
     const probes: boolean[] = [];
     const d = new CaptainDelivery({ maxDefers: 2, stableProbePolls: 999 });
     let n = 0;
     const send = async (_t: string, opts?: { probe?: boolean }) => {
       probes.push(!!opts?.probe);
-      if (!opts?.probe && n++ < 5) throw new DeferDelivery(`draft-${n}`);
+      // Content changes on every single poll — an actively-typing human, never stable.
+      if (!opts?.probe) throw new DeferDelivery(`draft-${n++}`);
     };
-    for (let i = 0; i < 4; i++) await d.deliver({ seq: 9, message: "x" }, send);
-    expect(probes.includes(true)).toBe(true);
+    for (let i = 0; i < 10; i++) await d.deliver({ seq: 9, message: "x" }, send);
+    expect(probes.every((p) => !p)).toBe(true);
+    // Health-visibility metric still fires independently — maxDefers stays
+    // meaningful as a "stuck" dashboard alarm, just not as a delivery trigger.
+    expect(d.stats().stuck).toBe(true);
+  });
+
+  it("only escalates once content stops changing — a low maxDefers does not shortcut the stableProbePolls path", async () => {
+    const probes: boolean[] = [];
+    // maxDefers is deliberately LOW (past it in the first two "changing" polls
+    // alone) to prove escalation still waits for stability, not defer count.
+    const d = new CaptainDelivery({ maxDefers: 2, stableProbePolls: 3 });
+    let changing = true;
+    let n = 0;
+    const send = async (_t: string, opts?: { probe?: boolean }) => {
+      probes.push(!!opts?.probe);
+      if (opts?.probe) return;
+      throw new DeferDelivery(changing ? `draft-${n++}` : "settled-draft");
+    };
+    // Changing content past maxDefers=2 — must never probe.
+    for (let i = 0; i < 4; i++) await d.deliver({ seq: 5, message: "x" }, send);
+    expect(probes.every((p) => !p)).toBe(true);
+    // The human pauses: content goes byte-identical across consecutive polls.
+    // Once stableCounts reaches stableProbePolls, escalation fires.
+    changing = false;
+    for (let i = 0; i < 6 && !probes[probes.length - 1]; i++) {
+      await d.deliver({ seq: 5, message: "x" }, send);
+    }
+    expect(probes[probes.length - 1]).toBe(true);
   });
 
   it("returns { delivered: true } for null message (nothing to deliver)", async () => {
@@ -46,24 +84,27 @@ describe("CaptainDelivery defer-while-typing (#258/#302)", () => {
     expect(sent).toEqual([]);
   });
 
-  // #477: null-draft means the captain pane has no visible input box — delivery
-  // MUST keep deferring (safe). stableCounts never accumulates on null content
-  // so the probe-escalation path (#302) is never triggered. Only the maxDefers
-  // backstop eventually forces delivery.
-  it("null-draft DeferDelivery never escalates early — maxDefers backstop only (#477)", async () => {
+  // #477/#484: null-draft means the captain pane has no visible input box (an
+  // overlay/menu/scrolled-away screen, #268) — delivery MUST keep deferring
+  // forever (safe). stableCounts never accumulates on null content so the
+  // stable-triggered probe path (#302) never fires either. Unlike a real or
+  // ghost-shaped draft, an unconfirmed/unknown screen has no maxDefers escape
+  // hatch: sendToSurface throws DeferDelivery(null) unconditionally regardless
+  // of the probe flag (cmux.ts:633, checked before opts.probe is even read), so
+  // probe escalation here would be dead code anyway — removing it (the #484 fix)
+  // costs nothing for this case and keeps the "never deliver into an unknown
+  // screen state" guarantee (#268) unconditional, not count-dependent.
+  it("null-draft DeferDelivery never escalates to a probe, no matter how many defers (#477/#484)", async () => {
     const probes: boolean[] = [];
     const d = new CaptainDelivery({ maxDefers: 5, stableProbePolls: 3 });
     const send = async (_t: string, opts?: { probe?: boolean }) => {
       probes.push(!!opts?.probe);
       if (!opts?.probe) throw new DeferDelivery(null);
     };
-    // After stableProbePolls+1 polls, probe must NOT have fired (stableCounts stays 0 on null)
-    for (let i = 0; i < 4; i++) await d.deliver({ seq: 1, message: "x" }, send);
+    for (let i = 0; i < 10; i++) await d.deliver({ seq: 1, message: "x" }, send);
     expect(probes.every((p) => !p)).toBe(true);
-    // maxDefers backstop fires at poll 6 (deferCount reaches maxDefers=5)
-    await d.deliver({ seq: 1, message: "x" }, send);
-    await d.deliver({ seq: 1, message: "x" }, send);
-    expect(probes.some((p) => p)).toBe(true);
+    // The stuck dashboard alarm still fires independently of probe escalation.
+    expect(d.stats().stuck).toBe(true);
   });
 });
 

--- a/packages/core/src/delivery/captain-delivery.ts
+++ b/packages/core/src/delivery/captain-delivery.ts
@@ -59,11 +59,19 @@ export class CaptainDelivery {
 
     const seq = entry.seq;
     const deferCount = this.deferCounts.get(seq) ?? 0;
-    // #302: probe early once content has been stable for stableProbePolls
-    // polls (captain not typing) — kills the ~5min stall; the 300-defer
-    // backstop still guarantees delivery never hangs forever.
+    // #302/#484: probe ONLY once content has been stable for stableProbePolls
+    // polls (captain not typing / a ghost that isn't re-rendering). A probe
+    // send makes sendToSurface inject a REAL backspace keystroke into the live
+    // pane to run the structural liveness test (#258) — safe against a stable
+    // box, but unsafe against one that's still actively changing: repeatedly
+    // backspacing a genuinely-typing human's draft risks racing their next
+    // keystroke and, per #484's reopened root-cause, eventually misclassifying
+    // and force-delivering into it. deferCount alone must NEVER trigger a
+    // probe — an actively-changing draft defers indefinitely until it goes
+    // stable (paused) or empty (submitted); maxDefers stays meaningful only as
+    // the `stuck` dashboard signal in stats() below, decoupled from escalation.
     const stable = (this.stableCounts.get(seq) ?? 0) >= this.opts.stableProbePolls;
-    const probe = stable || deferCount >= this.opts.maxDefers;
+    const probe = stable;
 
     try {
       await send(msg, probe ? { probe: true } : undefined);

--- a/packages/core/src/liveness.ts
+++ b/packages/core/src/liveness.ts
@@ -100,6 +100,13 @@ export function projectHealth(input: {
   /** true/false when a command workspace is expected; null = not applicable. */
   commandPresent: boolean | null;
   crews: CrewLiveness[];
+  /** #579/#484 Gap 3: this project's captain-delivery deferral state (from
+   *  CaptainDelivery.stats() — see delivery/captain-delivery.ts), surfaced as
+   *  `detail` on the captain row so `squadrant doctor` / `squadrant status
+   *  --detailed` show a stuck delivery with zero extra configuration (no
+   *  Telegram, no mute state to fight) — a pull-based fallback that can never
+   *  be silenced, unlike the push alerts in delivery-loop.ts. */
+  captainDeferral?: { stuck: boolean; maxDeferCount: number };
 }): ComponentHealth[] {
   const { project, now, captainName, captainStopped, commandPresent, crews } = input;
   const out: ComponentHealth[] = [];
@@ -110,6 +117,7 @@ export function projectHealth(input: {
     captainStopped === false ? "alive" :
     "unknown"
   );
+  const deferral = input.captainDeferral;
   out.push({
     kind: "captain",
     project,
@@ -119,6 +127,7 @@ export function projectHealth(input: {
     detail:
       captainState === "stopped" ? "captain workspace closed — crews reaped; delivery paused" :
       captainState === "gone" ? "captain process died (crash) — crews reaped" :
+      deferral?.stuck ? `⚠️ delivery stuck (${deferral.maxDeferCount}+ retries) — draft/ghost text blocking captain pane; input never touched, delivers automatically once cleared` :
       undefined,
   });
 

--- a/packages/core/src/telegram/__tests__/bridge.test.ts
+++ b/packages/core/src/telegram/__tests__/bridge.test.ts
@@ -167,6 +167,85 @@ describe("pushLifecycle notify gate", () => {
   });
 });
 
+describe("pushRaw (out-of-band system alert, #579/#484 DELIVERY STUCK)", () => {
+  it("sends raw text to the project's topic, bypassing formatLifecycle/crew-tier", async () => {
+    const root = freshRoot();
+    setTopic(root, "demo", 55);
+    setNotify(root, "demo", true);
+    const sent = deferred();
+    const sendCalls: Array<[number, number | undefined, string]> = [];
+    const client: TelegramClient = {
+      getUpdates: async () => [],
+      createForumTopic: async () => 1,
+      sendMessage: async (c, th, text) => { sendCalls.push([c, th, text]); sent.resolve(); },
+      getMe: async () => ({ id: 0, username: "" }),
+      setMyCommands: async () => {},
+      answerCallbackQuery: async () => {},
+      editMessageReplyMarkup: async () => {},
+      sendChatAction: async () => {},
+    };
+    const bridge = createTelegramBridge({ cfg, stateRoot: root, client, appendCaptainMessage: async () => {}, log: () => {} });
+    active = bridge;
+
+    bridge.pushRaw("demo", "⚠️ DELIVERY STUCK: test");
+    await sent.promise;
+
+    expect(sendCalls).toEqual([[-100500, 55, "⚠️ DELIVERY STUCK: test"]]);
+  });
+
+  it("drops the alert when the project is MUTED (mute state still respected)", async () => {
+    const root = freshRoot();
+    const sendMessage = vi.fn();
+    const createForumTopic = vi.fn();
+    const client: TelegramClient = {
+      getUpdates: async () => [],
+      createForumTopic,
+      sendMessage,
+      getMe: async () => ({ id: 0, username: "" }),
+      setMyCommands: async () => {},
+      answerCallbackQuery: async () => {},
+      editMessageReplyMarkup: async () => {},
+      sendChatAction: async () => {},
+    };
+    const bridge = createTelegramBridge({ cfg, stateRoot: root, client, appendCaptainMessage: async () => {}, log: () => {} });
+    active = bridge;
+
+    bridge.pushRaw("squadrant", "⚠️ DELIVERY STUCK: test");
+    await new Promise<void>((r) => setTimeout(r, 20));
+
+    expect(createForumTopic).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("swallows a rejecting sendMessage (crash-contained, logged, never throws)", async () => {
+    const root = freshRoot();
+    setTopic(root, "demo", 55);
+    setNotify(root, "demo", true);
+    const logged = deferred();
+    const logs: string[] = [];
+    const client: TelegramClient = {
+      getUpdates: async () => [],
+      createForumTopic: async () => 1,
+      sendMessage: async () => { throw new Error("network down"); },
+      getMe: async () => ({ id: 0, username: "" }),
+      setMyCommands: async () => {},
+      answerCallbackQuery: async () => {},
+      editMessageReplyMarkup: async () => {},
+      sendChatAction: async () => {},
+    };
+    const bridge = createTelegramBridge({
+      cfg, stateRoot: root, client,
+      appendCaptainMessage: async () => {},
+      log: (m) => { logs.push(m); logged.resolve(); },
+    });
+    active = bridge;
+
+    expect(() => bridge.pushRaw("demo", "⚠️ DELIVERY STUCK: test")).not.toThrow();
+    await logged.promise;
+    expect(logs.some((m) => m.includes("network down"))).toBe(true);
+  });
+});
+
 describe("auto-unmute + in-topic /mute /unmute", () => {
   const USER_ID = 42;
   const cfgWithControl: TelegramConfig = {

--- a/packages/core/src/telegram/__tests__/bridge.test.ts
+++ b/packages/core/src/telegram/__tests__/bridge.test.ts
@@ -193,14 +193,19 @@ describe("pushRaw (out-of-band system alert, #579/#484 DELIVERY STUCK)", () => {
     expect(sendCalls).toEqual([[-100500, 55, "⚠️ DELIVERY STUCK: test"]]);
   });
 
-  it("drops the alert when the project is MUTED (mute state still respected)", async () => {
-    const root = freshRoot();
-    const sendMessage = vi.fn();
-    const createForumTopic = vi.fn();
+  it("still sends even when the project is MUTED — a fault is not routine notification noise", async () => {
+    // Decision (per #579/#484 review): mute silences routine crew noise
+    // (progress/done/blocked), not operational faults. A muted project with a
+    // stuck delivery must still alert, or muting silently reintroduces the
+    // exact silent-stall bug this alert exists to prevent (Gap 2).
+    const root = freshRoot(); // fresh root == default-muted (absent live state)
+    const sent = deferred();
+    const sendCalls: Array<[number, number | undefined, string]> = [];
+    const createForumTopic = vi.fn(async () => 42);
     const client: TelegramClient = {
       getUpdates: async () => [],
       createForumTopic,
-      sendMessage,
+      sendMessage: async (c, th, text) => { sendCalls.push([c, th, text]); sent.resolve(); },
       getMe: async () => ({ id: 0, username: "" }),
       setMyCommands: async () => {},
       answerCallbackQuery: async () => {},
@@ -211,10 +216,10 @@ describe("pushRaw (out-of-band system alert, #579/#484 DELIVERY STUCK)", () => {
     active = bridge;
 
     bridge.pushRaw("squadrant", "⚠️ DELIVERY STUCK: test");
-    await new Promise<void>((r) => setTimeout(r, 20));
+    await sent.promise;
 
-    expect(createForumTopic).not.toHaveBeenCalled();
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(createForumTopic).toHaveBeenCalled();
+    expect(sendCalls).toEqual([[-100500, 42, "⚠️ DELIVERY STUCK: test"]]);
   });
 
   it("swallows a rejecting sendMessage (crash-contained, logged, never throws)", async () => {

--- a/packages/core/src/telegram/bridge.ts
+++ b/packages/core/src/telegram/bridge.ts
@@ -36,6 +36,12 @@ export interface TelegramBridge {
   stop(): void;
   /** Outbound, best-effort: a Telegram failure is swallowed (logged), never thrown. */
   pushLifecycle(project: string, ev: ControlEvent): void;
+  /** Outbound, best-effort, out-of-band: raw text alert not tied to a crew
+   *  lifecycle event (so it bypasses the crew-tier filter — mute state still
+   *  applies). For alerts that must reach the operator even while the
+   *  captain pane's own delivery path (mailbox → pane) is itself stuck
+   *  (#579/#484's DELIVERY STUCK), since it never touches that path. */
+  pushRaw(project: string, text: string): void;
   health(): TelegramBridgeHealth;
 }
 
@@ -114,6 +120,16 @@ export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridg
     saveState(stateRoot, s);
   }
 
+  // Resolve (or lazily create) a project's topic and send raw text into it.
+  async function sendToTopic(project: string, text: string): Promise<void> {
+    let threadId = loadState(stateRoot).topics[topicKey(project)];
+    if (threadId === undefined) {
+      threadId = await client.createForumTopic(cfg.supergroupId, topicName(project));
+      setTopic(stateRoot, project, threadId);
+    }
+    await client.sendMessage(cfg.supergroupId, threadId, text);
+  }
+
   // Outbound: resolve active (live state wins over config default) + crew-tier
   // filter, then resolve (or lazily create) the project's topic and send.
   async function deliverOutbound(project: string, ev: ControlEvent): Promise<void> {
@@ -122,12 +138,17 @@ export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridg
     const active = live ?? resolved.active;
     if (!active) return;                                // muted → no topic create, no send
     if (!tierIncludes(resolved.crew, ev.type)) return; // tier filter
-    let threadId = loadState(stateRoot).topics[topicKey(project)];
-    if (threadId === undefined) {
-      threadId = await client.createForumTopic(cfg.supergroupId, topicName(project));
-      setTopic(stateRoot, project, threadId);
-    }
-    await client.sendMessage(cfg.supergroupId, threadId, formatLifecycle(project, ev));
+    await sendToTopic(project, formatLifecycle(project, ev));
+  }
+
+  // Outbound, out-of-band: a system-level alert not tied to a crew lifecycle
+  // event type, so the crew-tier filter doesn't apply — mute state still does.
+  async function deliverRawOutbound(project: string, text: string): Promise<void> {
+    const resolved = resolveNotify(cfg.notify, loadProjectOverride(project, configRoot));
+    const live = loadState(stateRoot).notify[project]; // boolean | undefined
+    const active = live ?? resolved.active;
+    if (!active) return; // muted → no topic create, no send
+    await sendToTopic(project, text);
   }
 
   // Live notify state for a project: resolved config (built-in→global→override)
@@ -496,6 +517,11 @@ export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridg
       // the daemon's notify path.
       void deliverOutbound(project, ev).catch((e) => {
         log(`telegram outbound failed project=${project}: ${(e as Error).message}`);
+      });
+    },
+    pushRaw(project, text) {
+      void deliverRawOutbound(project, text).catch((e) => {
+        log(`telegram raw push failed project=${project}: ${(e as Error).message}`);
       });
     },
     health() {

--- a/packages/core/src/telegram/bridge.ts
+++ b/packages/core/src/telegram/bridge.ts
@@ -36,11 +36,15 @@ export interface TelegramBridge {
   stop(): void;
   /** Outbound, best-effort: a Telegram failure is swallowed (logged), never thrown. */
   pushLifecycle(project: string, ev: ControlEvent): void;
-  /** Outbound, best-effort, out-of-band: raw text alert not tied to a crew
-   *  lifecycle event (so it bypasses the crew-tier filter — mute state still
-   *  applies). For alerts that must reach the operator even while the
-   *  captain pane's own delivery path (mailbox → pane) is itself stuck
-   *  (#579/#484's DELIVERY STUCK), since it never touches that path. */
+  /** Outbound, best-effort, out-of-band, fault-class alert — for system faults
+   *  (e.g. #579/#484's DELIVERY STUCK), not routine crew notifications. Bypasses
+   *  BOTH the crew-tier filter AND per-project mute: mute is a user's choice to
+   *  silence routine notification *noise* (crew progress/done/blocked), a
+   *  choice about volume. It was never a choice to hide "your instructions
+   *  can't reach the captain" — an operational fault, not noise. A muted
+   *  project with a stuck delivery must still alert, or muting silently
+   *  reintroduces the exact silent-stall bug this alert exists to prevent.
+   *  Never touches the mailbox/pane path (so it can't itself get stuck). */
   pushRaw(project: string, text: string): void;
   health(): TelegramBridgeHealth;
 }
@@ -141,13 +145,9 @@ export function createTelegramBridge(opts: TelegramBridgeOptions): TelegramBridg
     await sendToTopic(project, formatLifecycle(project, ev));
   }
 
-  // Outbound, out-of-band: a system-level alert not tied to a crew lifecycle
-  // event type, so the crew-tier filter doesn't apply — mute state still does.
+  // Outbound, out-of-band, fault-class: bypasses BOTH the crew-tier filter AND
+  // mute (see the pushRaw docstring for why mute must not silence a fault).
   async function deliverRawOutbound(project: string, text: string): Promise<void> {
-    const resolved = resolveNotify(cfg.notify, loadProjectOverride(project, configRoot));
-    const live = loadState(stateRoot).notify[project]; // boolean | undefined
-    const active = live ?? resolved.active;
-    if (!active) return; // muted → no topic create, no send
     await sendToTopic(project, text);
   }
 

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -87,7 +87,9 @@ export interface SquadrantConfig {
     targets?: string[];
   };
   delivery?: {
-    /** Max consecutive defers before force-delivering a message (~1s poll cadence). Default: 300 (~5min). */
+    /** Defer count at which a stuck delivery is flagged on the dashboard (B1). Does NOT
+     *  force delivery on its own — probing an actively-changing draft is unsafe (#484); only
+     *  content stability (stableProbePolls) escalates to a probe. Default: 300 (~5min). */
     maxDeferDeliveries?: number;
     /** Consecutive stable-content polls before probing early to avoid a stall (#302). Default: 3 (~3s). */
     stableProbePolls?: number;

--- a/packages/workspaces/src/notifiers/__tests__/cmux.test.ts
+++ b/packages/workspaces/src/notifiers/__tests__/cmux.test.ts
@@ -5,8 +5,8 @@ const execMock = vi.hoisted(() => vi.fn());
 const execFileMock = vi.hoisted(() => vi.fn());
 vi.mock("node:child_process", () => ({
   execSync: execMock,
-  execFileSync: execFileMock,
-  execFile: vi.fn(),
+  // Node-callback shape: util.promisify(execFile) awaits (err, stdout, stderr).
+  execFile: execFileMock,
 }));
 
 describe("CmuxNotifier", () => {
@@ -20,12 +20,13 @@ describe("CmuxNotifier", () => {
   });
 
   it("notify invokes 'squadrant runtime send --command' with the message as one argv element", async () => {
-    execFileMock.mockReturnValue("");
+    execFileMock.mockImplementation((_file, _args, _opts, cb) => cb(null, "", ""));
     await createCmuxNotifier({}).notify("hello world");
     expect(execFileMock).toHaveBeenCalledWith(
       "squadrant",
       ["runtime", "send", "--command", "hello world"],
       expect.anything(),
+      expect.any(Function),
     );
   });
 
@@ -33,7 +34,7 @@ describe("CmuxNotifier", () => {
   // commands must reach the spawn as a single literal argv element, never parsed
   // by a shell. Same class as #118/#119.
   it("notify delivers backtick/$() shell metacharacters as a literal argv element, not executed", async () => {
-    execFileMock.mockReturnValue("");
+    execFileMock.mockImplementation((_file, _args, _opts, cb) => cb(null, "", ""));
     const malicious = 'done `cmux close-workspace` and $(rm -rf /)';
     await createCmuxNotifier({}).notify(malicious);
     const call = execFileMock.mock.calls[0];
@@ -45,8 +46,25 @@ describe("CmuxNotifier", () => {
   });
 
   it("notify throws when squadrant runtime send fails", async () => {
-    execFileMock.mockImplementation(() => { throw new Error("send failed"); });
+    execFileMock.mockImplementation((_file, _args, _opts, cb) => cb(new Error("send failed")));
     await expect(createCmuxNotifier({}).notify("x")).rejects.toThrow(/send failed/);
+  });
+
+  // #579/#484 Gap 1: the daemon calls notify() from inside its own event loop
+  // (the DELIVERY STUCK fault alert) — it must never block that loop the way
+  // execFileSync would. Proves notify() doesn't return/resolve synchronously.
+  it("notify does not block synchronously — resolves only after the async callback fires", async () => {
+    let resolved = false;
+    let fireCallback!: () => void;
+    execFileMock.mockImplementation((_file, _args, _opts, cb) => {
+      fireCallback = () => cb(null, "", "");
+    });
+    const p = createCmuxNotifier({}).notify("x").then(() => { resolved = true; });
+    await Promise.resolve(); // let the notify() call proceed to the execFile mock
+    expect(resolved).toBe(false); // still pending — proves no sync execFileSync-style block
+    fireCallback();
+    await p;
+    expect(resolved).toBe(true);
   });
 
   it("probe returns installed+reachable=true when status succeeds (exit 0)", async () => {

--- a/packages/workspaces/src/notifiers/cmux.ts
+++ b/packages/workspaces/src/notifiers/cmux.ts
@@ -1,10 +1,13 @@
-import { execFileSync, execSync } from "node:child_process";
+import { execFile as execFileCb, execSync } from "node:child_process";
+import { promisify } from "node:util";
 import type {
   NotifierDriver,
   NotifierProbeResult,
   NotifierScope,
 } from "./types.js";
 import { CMUX_TIMEOUT } from "../runtimes/cmux.js";
+
+const execFile = promisify(execFileCb);
 
 export function createCmuxNotifier(_scope: NotifierScope): NotifierDriver {
   return {
@@ -26,10 +29,14 @@ export function createCmuxNotifier(_scope: NotifierScope): NotifierDriver {
     },
 
     async notify(message: string): Promise<void> {
-      // execFileSync with an argv array and NO shell: the message is one literal
-      // argv element, so backticks / $() in notification text are never parsed
-      // by a shell. See #120 (same class as #118/#119).
-      execFileSync("squadrant", ["runtime", "send", "--command", message], { encoding: "utf-8", timeout: CMUX_TIMEOUT });
+      // execFile (async, NOT execFileSync) with an argv array and NO shell: the
+      // message is one literal argv element, so backticks / $() in notification
+      // text are never parsed by a shell (#120, same class as #118/#119). Async
+      // is required, not stylistic — a caller running inside the daemon's own
+      // event loop (the #579/#484 DELIVERY STUCK fault alert) would otherwise
+      // block ALL projects' delivery/health/socket serving for up to
+      // CMUX_TIMEOUT on every call.
+      await execFile("squadrant", ["runtime", "send", "--command", message], { encoding: "utf-8", timeout: CMUX_TIMEOUT });
     },
   };
 }

--- a/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
+++ b/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
@@ -867,6 +867,83 @@ describe("sendToSurface draft-preservation", () => {
   });
 });
 
+// #579/#484 chain: a FREE-FORM suggested-prompt ghost (no "Press ... to ..."
+// shape, doesn't match #294's content regex) is misread by parseDraftFromScreen
+// as literal draft text (see the "parseDraftFromScreen" describe block above).
+// The safety net for this is NOT content matching — it's the SAME structural
+// backspace-invariance probe (#258/#302/classifyDraftLiveness) that already
+// protects against every other non-editable ghost shape. These tests use the
+// two real captured strings from #579 to prove the probe delivers past them
+// exactly like it does the enumerated #294 shape, and that the hot (non-probe)
+// path still never keystrokes into them — the ghost's CONTENT is irrelevant to
+// safety; only its structural (backspace-invariant) behavior is.
+describe("sendToSurface #579 free-form ghost (structural backspace-invariance, not content regex)", () => {
+  const driver = createCmuxDriver();
+
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  function probeMock(initial: string, onBackspace: (s: string) => string) {
+    let box = initial;
+    execFileMock.mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes("read-screen")) return makeTestScreen(`❯ ${box}`);
+      if (args.includes("send-key") && args.includes("backspace")) { box = onBackspace(box); return ""; }
+      return "";
+    });
+  }
+
+  it("hot path (no probe): a free-form ghost is deferred WITHOUT any keystroke, same as any other draft-shaped content", async () => {
+    const GHOST = "signal done and let the captain merge";
+    probeMock(GHOST, (s) => s);
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done"),
+    ).rejects.toBeInstanceOf(DeferDelivery);
+    const calls = execFileMock.mock.calls.map(argvOf);
+    expect(calls.some((a) => a.includes("backspace"))).toBe(false);
+    expect(calls.some((a) => a[0] === "send")).toBe(false);
+  });
+
+  it("probe: free-form ghost #1 ('signal done and let the captain merge') invariant under backspace → DELIVERS, never re-typed", async () => {
+    const GHOST = "signal done and let the captain merge";
+    probeMock(GHOST, (s) => s); // non-editable: backspace is a no-op, exactly like #294's shape
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done", { probe: true }),
+    ).resolves.toBeUndefined();
+    const calls = execFileMock.mock.calls.map(argvOf);
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes(GHOST)))).toBe(false);
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")))).toBe(true);
+    expect(calls.some((a) => a.includes("send-key") && a.includes("Enter"))).toBe(true);
+  });
+
+  it("probe: free-form ghost #2 ('go ahead and start on #562 now') invariant under backspace → DELIVERS, never re-typed", async () => {
+    const GHOST = "go ahead and start on #562 now";
+    probeMock(GHOST, (s) => s);
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done", { probe: true }),
+    ).resolves.toBeUndefined();
+    const calls = execFileMock.mock.calls.map(argvOf);
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes(GHOST)))).toBe(false);
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")))).toBe(true);
+    expect(calls.some((a) => a.includes("send-key") && a.includes("Enter"))).toBe(true);
+  });
+
+  // Adversarial check on this fix itself: if a free-form ghost happened to be
+  // EDITABLE (backspace actually removes a character — e.g. a future CC version
+  // renders it as real pre-filled buffer content instead of a display overlay),
+  // the probe must classify it as a real draft and defer — never execute an
+  // unauthored instruction. Structural detection must fail CLOSED, not open.
+  it("probe: a ghost-shaped string that turns out to be backspace-EDITABLE is treated as a real draft — defers, never delivers (fail-closed)", async () => {
+    const LOOKS_LIKE_GHOST = "go ahead and start on #562 now";
+    probeMock(LOOKS_LIKE_GHOST, (s) => s.slice(0, -1)); // hypothetically editable
+    await expect(
+      driver.sendToSurface({ workspaceId: "workspace:3", surfaceId: "surface:8" }, "crew done", { probe: true }),
+    ).rejects.toBeInstanceOf(DeferDelivery);
+    const calls = execFileMock.mock.calls.map(argvOf);
+    expect(calls.some((a) => a[0] === "send" && a.some((s: string) => s.includes("crew done")))).toBe(false);
+  });
+});
+
 // #339: debug-gated send instrumentation. The DONE→captain submit is a text
 // burst then a SEPARATE send-key Enter; intermittently the Enter mis-lands as a
 // newline, stranding the payload in the input box. SQUADRANT_DEBUG_SEND turns on a
@@ -1123,6 +1200,42 @@ describe("parseDraftFromScreen", () => {
       "utf-8",
     );
     expect(parseDraftFromScreen(fixture)).toBe("");
+  });
+
+  // #579: Claude Code also renders FREE-FORM suggested-next-prompt ghost text
+  // (not the "Press ... to ..." UI-hint shape #294 catches). Two real captures:
+  // "signal done and let the captain merge" and "go ahead and start on #562 now",
+  // both observed the instant a crew's turn ended, neither typed by anyone.
+  // parseDraftFromScreen has ONE content-regex ghost filter (#294's shape) and
+  // these do NOT match it, so they fall through and come back as literal draft
+  // text — this is the documented trap, not a bug in parseDraftFromScreen itself:
+  // safety for THIS class lives downstream in the structural backspace-invariance
+  // probe (classifyDraftLiveness), not in enumerating ghost content here. See the
+  // "sendToSurface #579 free-form ghost" describe block below for the safety net.
+  it("does NOT filter a free-form suggested-prompt ghost — returns it as literal draft text (#579 trap, by design — safety is downstream)", () => {
+    const screen = makeTestScreen("❯ signal done and let the captain merge");
+    expect(parseDraftFromScreen(screen)).toBe("signal done and let the captain merge");
+  });
+
+  it("does NOT filter a second free-form suggested-prompt ghost shape either (#579 — proves the gap isn't a single enumerable string)", () => {
+    const screen = makeTestScreen("❯ go ahead and start on #562 now");
+    expect(parseDraftFromScreen(screen)).toBe("go ahead and start on #562 now");
+  });
+
+  it("returns the real fixture-1 free-form ghost as literal draft text (#579 captured evidence)", () => {
+    const fixture = readFileSync(
+      join(process.cwd(), "docs/reports/579-freeform-ghost-fixture-1.txt"),
+      "utf-8",
+    );
+    expect(parseDraftFromScreen(fixture)).toBe("signal done and let the captain merge");
+  });
+
+  it("returns the real fixture-2 free-form ghost as literal draft text (#579 captured evidence)", () => {
+    const fixture = readFileSync(
+      join(process.cwd(), "docs/reports/579-freeform-ghost-fixture-2.txt"),
+      "utf-8",
+    );
+    expect(parseDraftFromScreen(fixture)).toBe("go ahead and start on #562 now");
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #579 and #484 together — they are one chain and fixing either alone leaves the danger intact.

**Root cause (verified against source, not assumed):**
- `parseDraftFromScreen` (`packages/workspaces/src/runtimes/cmux.ts:196`) only filters ONE ghost shape: `/^Press (up|down|enter|esc|...) to /`. Claude Code also renders free-form suggested-next-prompt ghost text that doesn't match this regex, so it comes back as literal draft text (confirmed with the two real captured strings from #579: `"signal done and let the captain merge"`, `"go ahead and start on #562 now"`).
- That's safe on its own — `sendToSurface` always defers non-empty drafts on the hot (non-probe) path regardless of content. The actual danger is downstream in `captain-delivery.ts`: `const probe = stable || deferCount >= this.opts.maxDefers;` escalated to a live backspace-invariance probe purely on defer **count**, even while the draft was still **actively changing** every poll. Once probed, `sendToSurface` sends a real backspace keystroke into the live pane — safe against a *stable* box, but against a still-changing one (an actively-typing human, or a re-rendering ghost) it risks racing the next real keystroke and, per #484's reopened root-cause analysis, eventually misclassifying and force-delivering into a live draft.

**Fix:** probe escalation now requires content **stability** only (`stableProbePolls` byte-identical polls) — the `deferCount >= maxDefers` OR-clause is removed. `maxDefers` remains meaningful only as the dashboard `stuck` alarm (`CaptainDeliveryStats`), fully decoupled from delivery escalation.

This closes the #579 gap **structurally**: the existing backspace-invariance probe (`classifyDraftLiveness`, #258/#302) already safely handles *any* ghost shape — known or unknown — once it's safely escalated to. No change was needed to the content-regex fast path (`parseDraftFromScreen:196`); it's left as a harmless, non-load-bearing optimization for the one enumerated shape it already covers. Landmine avoided: `hasModalOptionList` (the #484 modal-hijack fix, already shipped) is untouched.

## Adversarial check on this fix (per task instructions: "can this fix fail the same way the bug did?")
- Added a fail-closed regression test: a ghost-shaped string that turns out to be backspace-*editable* is still classified as a real draft and deferred — never delivered. Structural detection fails closed, not open.
- Verified by **behavior**, not just test exit code — see the two runtime scenarios exercised against the built `dist` output:
  - An actively-typing draft across 500 polls (well past the old `maxDefers=300` default) never triggers a probe (0 backspaces injected), while the `stuck` dashboard alarm still fires.
  - A static free-form ghost (the real #579 captured text) still delivers within ~5 polls via the stability path, not stuck waiting on the old count-based backstop.

## Test plan
- [x] TDD: RED tests added first for the `captain-delivery.ts` escalation gate (`packages/core/src/delivery/__tests__/captain-delivery.test.ts`), confirmed failing against pre-fix code, then GREEN after the fix.
- [x] Regression tests in `packages/workspaces/src/runtimes/__tests__/cmux.test.ts` using the two real captured ghost strings as fixtures (`docs/reports/579-freeform-ghost-fixture-{1,2}.txt`), proving the structural probe (not content matching) delivers past them.
- [x] Full suite green: `pnpm test` — 167 files / 2053 tests passed.
- [x] Manual behavioral verification against the built `dist` (see above) — not just relying on mocked unit tests.
- [x] No stray processes left running.

Branch off `develop`; does not touch version numbers/CHANGELOG (a release crew is cutting v0.16.3 off develop in parallel). **Not merging** — leaving for review per task instructions.

Closes #579, closes #484 (pending review).