### PR TITLE
fix(#549): squadrant status must render captain liveness without status.md

### DIFF
--- a/packages/cli/src/commands/__tests__/status.test.ts
+++ b/packages/cli/src/commands/__tests__/status.test.ts
@@ -14,12 +14,8 @@ describe("captainIndicator (#538)", () => {
     expect(captainIndicator("stale")).toContain("●");
   });
 
-  it("gone → dim empty circle", () => {
+  it("gone → dim empty circle (a fault — the captain crashed)", () => {
     expect(captainIndicator("gone")).toContain("○");
-  });
-
-  it("stopped → dim empty circle", () => {
-    expect(captainIndicator("stopped")).toContain("○");
   });
 
   it("unknown state → dim '?' (never asserts offline on missing data)", () => {
@@ -31,6 +27,22 @@ describe("captainIndicator (#538)", () => {
   });
 });
 
+// #549 follow-up: 'stopped' (clean, deliberate shutdown) and 'gone' (crashed /
+// dark past the gone window) used to render identically (both dim ○), so an
+// operator who deliberately closed a captain could not tell that apart from
+// one that died on them. liveness.ts already separates the two states (#324:
+// "clean close — magenta, not a fault") — the CLI must reflect that distinction
+// instead of collapsing both into the same fault-looking glyph.
+describe("captainIndicator — stopped vs gone (#549)", () => {
+  it("stopped renders a distinct glyph from gone", () => {
+    expect(captainIndicator("stopped")).not.toBe(captainIndicator("gone"));
+  });
+
+  it("stopped is NOT the fault-looking empty circle", () => {
+    expect(captainIndicator("stopped")).not.toContain("○");
+  });
+});
+
 // #549: a project without status.md used to be dropped from the table entirely
 // ("no status.md", no health marker), hiding a captain that was demonstrably
 // alive in the daemon's liveness registry. status.md is an opt-in human note,
@@ -38,14 +50,14 @@ describe("captainIndicator (#538)", () => {
 // show regardless of whether status.md exists.
 describe("formatProjectRow (#549)", () => {
   it("renders a live captain indicator even when status.md is missing", () => {
-    const row = formatProjectRow("friendslop-factory", "friendslop-factory-captain", {}, false, "alive");
+    const row = formatProjectRow("friendslop-factory", "friendslop-factory-captain", {}, "missing", "alive");
     expect(row).toContain("friendslop-factory");
     expect(row).toContain("●");
     expect(row).not.toContain("no status.md");
   });
 
   it("renders a dead captain indicator when status.md is missing and captain is gone", () => {
-    const row = formatProjectRow("bet2fun-app", "bet2fun-app-captain", {}, false, "gone");
+    const row = formatProjectRow("bet2fun-app", "bet2fun-app-captain", {}, "missing", "gone");
     expect(row).toContain("○");
   });
 
@@ -54,10 +66,34 @@ describe("formatProjectRow (#549)", () => {
       "squadrant",
       "squadrant-captain",
       { active_crew: 2, tasks_completed: 1, tasks_total: 4 },
-      true,
+      "ok",
       "alive",
     );
     expect(row).toContain("squadrant");
     expect(row).toContain("2");
+  });
+});
+
+// #549 follow-up: an unreadable/corrupt status.md used to be swallowed by an
+// empty catch block that fell through to the same "missing" rendering as a
+// project that never had a status.md at all — the operator silently lost the
+// fact that their file was broken. A corrupt file must stay visibly distinct
+// from an absent one.
+describe("formatProjectRow — unreadable status.md must stay visible (#549)", () => {
+  it("renders distinctly from a missing status.md", () => {
+    const missingRow = formatProjectRow("p", "p-captain", {}, "missing", "alive");
+    const unreadableRow = formatProjectRow("p", "p-captain", {}, "unreadable", "alive");
+    expect(unreadableRow).not.toBe(missingRow);
+  });
+
+  it("flags the row as unreadable, not silently as 'no notes'", () => {
+    const row = formatProjectRow("p", "p-captain", {}, "unreadable", "alive");
+    expect(row).toContain("unreadable");
+    expect(row).not.toContain("no notes");
+  });
+
+  it("still shows live captain state on an unreadable status.md, not dropped", () => {
+    const row = formatProjectRow("p", "p-captain", {}, "unreadable", "alive");
+    expect(row).toContain("●");
   });
 });

--- a/packages/cli/src/commands/__tests__/status.test.ts
+++ b/packages/cli/src/commands/__tests__/status.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { captainIndicator } from "../status.js";
+import { captainIndicator, formatProjectRow } from "../status.js";
 
 // #538: default `squadrant status` used to derive the ●/○ indicator from
 // status.md's `captain_session` frontmatter, which nothing in the codebase
@@ -28,5 +28,36 @@ describe("captainIndicator (#538)", () => {
 
   it("no entry at all (daemon unreachable) → dim '?', not offline", () => {
     expect(captainIndicator(undefined)).toContain("?");
+  });
+});
+
+// #549: a project without status.md used to be dropped from the table entirely
+// ("no status.md", no health marker), hiding a captain that was demonstrably
+// alive in the daemon's liveness registry. status.md is an opt-in human note,
+// not the source of truth for whether the row renders — captain liveness must
+// show regardless of whether status.md exists.
+describe("formatProjectRow (#549)", () => {
+  it("renders a live captain indicator even when status.md is missing", () => {
+    const row = formatProjectRow("friendslop-factory", "friendslop-factory-captain", {}, false, "alive");
+    expect(row).toContain("friendslop-factory");
+    expect(row).toContain("●");
+    expect(row).not.toContain("no status.md");
+  });
+
+  it("renders a dead captain indicator when status.md is missing and captain is gone", () => {
+    const row = formatProjectRow("bet2fun-app", "bet2fun-app-captain", {}, false, "gone");
+    expect(row).toContain("○");
+  });
+
+  it("still renders task/crew data from status.md when present", () => {
+    const row = formatProjectRow(
+      "squadrant",
+      "squadrant-captain",
+      { active_crew: 2, tasks_completed: 1, tasks_total: 4 },
+      true,
+      "alive",
+    );
+    expect(row).toContain("squadrant");
+    expect(row).toContain("2");
   });
 });

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -54,6 +54,30 @@ export function captainIndicator(state: ComponentHealth["state"] | undefined): s
   return chalk.dim("○");
 }
 
+/**
+ * Pure. Render one project's status row. status.md is an optional human note
+ * layered on top of daemon-derived captain liveness (#549) — a project with
+ * no status.md (or an unparseable one) still renders with its real captain
+ * state, rather than being dropped from the table entirely.
+ */
+export function formatProjectRow(
+  name: string,
+  captainName: string,
+  fm: StatusFrontmatter,
+  hasStatusMd: boolean,
+  captainState: ComponentHealth["state"] | undefined,
+): string {
+  const sessionIndicator = captainIndicator(captainState);
+  const captainDisplay = `${captainName.padEnd(11)} ${sessionIndicator}`;
+  const crew = hasStatusMd ? String(fm.active_crew ?? 0).padEnd(6) : chalk.dim("?").padEnd(6);
+  const progress = hasStatusMd
+    ? progressBar(fm.tasks_completed ?? 0, fm.tasks_total ?? 0).padEnd(25)
+    : chalk.dim("no notes").padEnd(25);
+  const updated = hasStatusMd ? timeAgo(fm.last_updated) : chalk.dim("—");
+
+  return `  ${name.padEnd(18)} ${captainDisplay}  ${crew} ${progress} ${updated}`;
+}
+
 export const statusCommand = new Command("status")
   .description("Show status of all projects from spoke vault status files")
   .option("--detailed", "also show live per-component service health from the daemon (#77)")
@@ -91,31 +115,21 @@ export const statusCommand = new Command("status")
     for (const [name, project] of projects) {
       const workspace = registry.forProject(name, config);
 
-      if (!(await workspace.exists("status.md"))) {
-        console.log(`  ${name.padEnd(18)} ${chalk.dim("no status.md")}`);
-        continue;
-      }
-
       let fm: StatusFrontmatter = {};
-      try {
-        const raw = await workspace.read("status.md");
-        fm = matter(raw).data as StatusFrontmatter;
-      } catch {
-        console.log(`  ${name.padEnd(18)} ${chalk.red("error reading status.md")}`);
-        continue;
+      let hasStatusMd = false;
+      if (await workspace.exists("status.md")) {
+        try {
+          const raw = await workspace.read("status.md");
+          fm = matter(raw).data as StatusFrontmatter;
+          hasStatusMd = true;
+        } catch {
+          // Unreadable status.md — fall through and render with hasStatusMd=false
+          // so the row still shows live captain state instead of being dropped.
+        }
       }
-
-      const sessionIndicator = captainIndicator(captainStateByProject.get(name));
-      const captainDisplay = `${project.captainName.padEnd(11)} ${sessionIndicator}`;
-      const crew = String(fm.active_crew ?? 0).padEnd(6);
-      const progress = progressBar(
-        fm.tasks_completed ?? 0,
-        fm.tasks_total ?? 0,
-      ).padEnd(25);
-      const updated = timeAgo(fm.last_updated);
 
       console.log(
-        `  ${name.padEnd(18)} ${captainDisplay}  ${crew} ${progress} ${updated}`,
+        formatProjectRow(name, project.captainName, fm, hasStatusMd, captainStateByProject.get(name)),
       );
     }
 

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -47,33 +47,47 @@ function progressBar(completed: number, total: number): string {
  * registered / not yet probed); together with "unknown" it renders "?" rather
  * than the offline glyph, since asserting offline on missing data is a false
  * negative (#538's core ask).
+ * "stopped" (deliberate, clean shutdown) gets its own magenta glyph, distinct
+ * from "gone" (crashed / dark past the gone window — a genuine fault) — see
+ * liveness.ts's #324 comment ("clean close — magenta, not a fault"). Collapsing
+ * both into the same dim ○ left the operator unable to tell "I stopped this"
+ * from "this died on me" (#549).
  */
 export function captainIndicator(state: ComponentHealth["state"] | undefined): string {
   if (state === "alive" || state === "stale") return chalk.green("●");
+  if (state === "stopped") return chalk.magenta("⏻");
   if (state === undefined || state === "unknown") return chalk.dim("?");
   return chalk.dim("○");
 }
 
+/** Result of attempting to read a project's status.md — "ok" only when it
+ *  exists and parsed cleanly; "missing" and "unreadable" must render
+ *  distinctly so a corrupt file is never silently mistaken for an absent one. */
+export type StatusMdState = "ok" | "missing" | "unreadable";
+
 /**
  * Pure. Render one project's status row. status.md is an optional human note
  * layered on top of daemon-derived captain liveness (#549) — a project with
- * no status.md (or an unparseable one) still renders with its real captain
+ * no status.md, or an unreadable one, still renders with its real captain
  * state, rather than being dropped from the table entirely.
  */
 export function formatProjectRow(
   name: string,
   captainName: string,
   fm: StatusFrontmatter,
-  hasStatusMd: boolean,
+  statusMdState: StatusMdState,
   captainState: ComponentHealth["state"] | undefined,
 ): string {
   const sessionIndicator = captainIndicator(captainState);
   const captainDisplay = `${captainName.padEnd(11)} ${sessionIndicator}`;
-  const crew = hasStatusMd ? String(fm.active_crew ?? 0).padEnd(6) : chalk.dim("?").padEnd(6);
-  const progress = hasStatusMd
-    ? progressBar(fm.tasks_completed ?? 0, fm.tasks_total ?? 0).padEnd(25)
-    : chalk.dim("no notes").padEnd(25);
-  const updated = hasStatusMd ? timeAgo(fm.last_updated) : chalk.dim("—");
+  const crew = statusMdState === "ok" ? String(fm.active_crew ?? 0).padEnd(6) : chalk.dim("?").padEnd(6);
+  const progress =
+    statusMdState === "ok"
+      ? progressBar(fm.tasks_completed ?? 0, fm.tasks_total ?? 0).padEnd(25)
+      : statusMdState === "unreadable"
+        ? chalk.red("status.md unreadable").padEnd(25)
+        : chalk.dim("no notes").padEnd(25);
+  const updated = statusMdState === "ok" ? timeAgo(fm.last_updated) : chalk.dim("—");
 
   return `  ${name.padEnd(18)} ${captainDisplay}  ${crew} ${progress} ${updated}`;
 }
@@ -116,20 +130,22 @@ export const statusCommand = new Command("status")
       const workspace = registry.forProject(name, config);
 
       let fm: StatusFrontmatter = {};
-      let hasStatusMd = false;
+      let statusMdState: StatusMdState = "missing";
       if (await workspace.exists("status.md")) {
         try {
           const raw = await workspace.read("status.md");
           fm = matter(raw).data as StatusFrontmatter;
-          hasStatusMd = true;
+          statusMdState = "ok";
         } catch {
-          // Unreadable status.md — fall through and render with hasStatusMd=false
-          // so the row still shows live captain state instead of being dropped.
+          // Corrupt/unreadable status.md — render distinctly from "missing"
+          // (formatProjectRow) so the operator doesn't lose the fact that the
+          // file is broken, while still showing live captain state (#549).
+          statusMdState = "unreadable";
         }
       }
 
       console.log(
-        formatProjectRow(name, project.captainName, fm, hasStatusMd, captainStateByProject.get(name)),
+        formatProjectRow(name, project.captainName, fm, statusMdState, captainStateByProject.get(name)),
       );
     }
 


### PR DESCRIPTION
## Summary
- `squadrant status` used `status.md` existence as the gate for whether a project's row rendered at all. A project with no `status.md` (or an unreadable one) was silently dropped with `no status.md` — even when the daemon's liveness registry showed its captain demonstrably alive (live-repro'd today: friendslop-factory, pid 4354, `lastState=start`, recent heartbeat, yet invisible in `squadrant status`).
- Extracted a pure `formatProjectRow()` so the captain-liveness indicator (already fetched from the daemon on every render via `queryHealth()`) always shows, regardless of `status.md`. `status.md` now only supplies the optional crew/task/progress columns layered on top, matching the web dashboard's existing `read-status.ts` pattern (#538) where captain liveness already dominates task-derived state.

## Test plan
- [x] TDD: added failing tests for `formatProjectRow` first (missing `status.md` + alive/gone captain, and status.md-present case), confirmed red (no export), then green after the fix.
- [x] `pnpm test` — full suite green: 167 files / 2047 tests.
- [x] Verified by behavior against the real project config (read-only `squadrant status` / `doctor`, no captain launch/close): previously-invisible projects (`friendslop-factory`, `bet2fun-app`, `bet2fun-kb`, `career-stack`, `liveness-lab`, `agent-tasks`, `claude-skills`) now render a row with the captain indicator and `no notes` instead of disappearing.
- [x] Directly exercised `formatProjectRow` with `alive`/`gone` states for a `status.md`-less project to confirm `●`/`○` render correctly (screenshot-equivalent console output in PR discussion if needed).

Closes #549.

DO NOT MERGE — captain review + user approval required.