### PR TITLE
fix(#586): Telegram /launch must pass --headless

### DIFF
--- a/packages/core/src/telegram/commands.test.ts
+++ b/packages/core/src/telegram/commands.test.ts
@@ -17,7 +17,20 @@ describe("parseCommand", () => {
 
   it("requires a project for /launch", () => {
     expect(parseCommand("/launch").kind).toBe("usage");
-    expect(parseCommand("/launch brove")).toEqual({ kind: "ok", name: "launch", argv: ["launch", "brove"] });
+    expect(parseCommand("/launch brove")).toEqual({
+      kind: "ok",
+      name: "launch",
+      argv: ["launch", "brove", "--headless"],
+    });
+  });
+
+  // #586: runCommand execs this argv from the daemon, which has no
+  // CMUX_WORKSPACE_ID and no terminal — without --headless, ensureCmuxReady
+  // opens cmux.app and exits 0 before the workspace is ever launched.
+  it("passes --headless on /launch so the daemon can boot without a terminal", () => {
+    const parsed = parseCommand("/launch brove");
+    expect(parsed.kind).toBe("ok");
+    expect((parsed as { argv: string[] }).argv).toContain("--headless");
   });
 
   it("reads and sets the effort dial", () => {

--- a/packages/core/src/telegram/commands.ts
+++ b/packages/core/src/telegram/commands.ts
@@ -6,7 +6,7 @@
 //
 // argv tokens are verified against the real CLI (packages/cli/src/commands/):
 //   status → `status`, projects → `projects list`, crews → `crew list <p>`,
-//   launch → `launch <p>`, effort → `effort [mode]`, config → `config get|set`,
+//   launch → `launch <p> --headless`, effort → `effort [mode]`, config → `config get|set`,
 //   spawn → `crew spawn <p> <task>`.
 
 export type ParsedCommand =
@@ -42,8 +42,13 @@ const REGISTRY: Record<string, Entry> = {
     build: (a) => (a[0] ? ok("crews", ["crew", "list", a[0]]) : usage("crews", "usage: /crews <project>")),
   },
   launch: {
+    // --headless (#586, same reason as #520 on the boot-if-down path): runCommand
+    // execs this argv from the daemon, which has no CMUX_WORKSPACE_ID and no
+    // terminal — a plain `launch` would open the cmux GUI app and exit 0 before
+    // the workspace is ever launched.
     usage: "/launch <project>",
-    build: (a) => (a[0] ? ok("launch", ["launch", a[0]]) : usage("launch", "usage: /launch <project>")),
+    build: (a) =>
+      a[0] ? ok("launch", ["launch", a[0], "--headless"]) : usage("launch", "usage: /launch <project>"),
   },
   effort: {
     usage: "/effort [max|balance|low]",


### PR DESCRIPTION
Closes #586.

## Problem

`/launch <project>` from Telegram never opens the workspace. The bot replies with a confusing `Run \`squadrant launch\` from inside a cmux workspace` message.

`runCommand` (`control.ts:33`) execs the curated argv verbatim from the daemon, which has no `CMUX_WORKSPACE_ID` and no terminal. Without `--headless`, `ensureCmuxReady(false)` (`launch.ts:38`) hits the `isInsideCmux()` gate → `open /Applications/cmux.app` → `process.exit(0)`, before `launchOneWorkspace` ever runs.

This is #520, missed on one path: `createLaunch` (`control.ts:80`) already passes `--headless` on the boot-if-down path, with a comment describing this exact failure.

## Fix

Pass `--headless` in the `/launch` argv build (`commands.ts:46`). One-line change; `launch` without `--fresh` re-focuses an existing workspace, so this restores a closed window rather than restarting a live captain.

## Audit of the other curated commands

Asked of each: does the argv assume a terminal/cmux context it won't have when exec'd from the daemon?

**No other instance.** `launch` is the only CLI command behind a terminal/cmux gate — `ensureCmuxReady`/`isInsideCmux` appear nowhere else in a curated command's path.

| Command | argv | Verdict |
|---|---|---|
| `/status` | `status` | Clean — daemon socket + config reads |
| `/projects` | `projects list` | Clean — config read |
| `/crews` | `crew list <p>` | Clean — daemon socket |
| `/spawn` | `crew spawn <p> <task>` | Clean — already the daemon's own path |
| `/config` | `config get\|set` | Clean — file I/O |
| `/mute` `/unmute` | `telegram notify <p> on\|off` | Clean — config write |
| `/effort` | `effort [mode]` | Clean — reaches cmux via socket (reachable from any process), and the notify block is already best-effort try/catch |

The interactive readline/TTY paths that do exist (`init`, `telegram setup`, `telegram send` stdin, `crew attach`) are not reachable from any curated command.

No speculative refactors: only `launch` changed.

## Testing

TDD — updated the existing `/launch` argv assertion and added a dedicated `--headless` regression test, watched both fail (`expected [ 'launch', 'brove' ] to include '--headless'`), then fixed.

Full repo gate green: `pnpm build` + `pnpm test` → **167 files, 2045 tests passed**.