### PR TITLE
feat(#599): review gate + staged/unstaged diff (Phase A+B)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (4910 symbols, 7439 relationships, 175 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (4937 symbols, 7472 relationships, 175 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (4910 symbols, 7439 relationships, 175 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (4937 symbols, 7472 relationships, 175 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/packages/cli/src/commands/__tests__/crew-approve.test.ts
+++ b/packages/cli/src/commands/__tests__/crew-approve.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { TaskRecord } from "@squadrant/shared";
+import { resolveApproveTarget } from "../crew-control.js";
+
+// ─── resolveApproveTarget (pure) ───────────────────────────────────────────
+
+function makeTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    id: "task-1",
+    project: "brove",
+    provider: "claude",
+    mode: "interactive",
+    state: "review",
+    task: "add the flag",
+    createdAt: 0,
+    lastHeartbeat: 0,
+    lastEvent: "task.review",
+    heartbeatBudgetMs: 300000,
+    attempts: [],
+    ...overrides,
+  };
+}
+
+describe("resolveApproveTarget (#599)", () => {
+  it("returns null when no task record matches the crew name", () => {
+    expect(resolveApproveTarget([], "fix-579")).toBeNull();
+    expect(resolveApproveTarget([makeTask({ name: "other-crew" })], "fix-579")).toBeNull();
+  });
+
+  it("resolves the matching record", () => {
+    const task = makeTask({ name: "fix-579" });
+    expect(resolveApproveTarget([task], "fix-579")).toEqual(task);
+  });
+
+  it("picks the most-recently-created record when duplicates exist (#574 tie-break)", () => {
+    const older = makeTask({ id: "old", name: "fix-579", createdAt: 100 });
+    const newer = makeTask({ id: "new", name: "fix-579", createdAt: 200 });
+    expect(resolveApproveTarget([older, newer], "fix-579")).toEqual(newer);
+  });
+});
+
+// ─── runCrewApprove (integration, mocked seams) ────────────────────────────
+
+const loadConfig = vi.hoisted(() => vi.fn());
+vi.mock("@squadrant/shared", async () => {
+  const actual = await vi.importActual<typeof import("@squadrant/shared")>("@squadrant/shared");
+  return { ...actual, loadConfig };
+});
+
+describe("runCrewApprove (#599)", () => {
+  beforeEach(() => {
+    loadConfig.mockReset();
+    loadConfig.mockReturnValue({ projects: { brove: { path: "/repo", captainName: "brove-captain" } } });
+  });
+
+  async function runAction(
+    project: string,
+    crew: string,
+    deps: Partial<Parameters<typeof import("../crew-control.js").runCrewApprove>[2]> = {},
+  ) {
+    const { runCrewApprove } = await import("../crew-control.js");
+    return runCrewApprove(project, crew, {
+      call: vi.fn().mockResolvedValue(undefined),
+      pushBranch: vi.fn(),
+      createPr: vi.fn().mockReturnValue("https://github.com/x/y/pull/1"),
+      ...deps,
+    });
+  }
+
+  it("throws the standard 404 when the project isn't registered", async () => {
+    loadConfig.mockReturnValue({ projects: {} });
+    await expect(runAction("ghost", "crew-1")).rejects.toThrow("Project 'ghost' not found. Run 'squadrant projects list'.");
+  });
+
+  it("throws a clear error when the crew name has no task record", async () => {
+    const call = vi.fn().mockResolvedValue([]);
+    await expect(runAction("brove", "ghost-crew", { call })).rejects.toThrow(
+      "Crew 'ghost-crew' not found for brove. Run 'squadrant crew list brove'.",
+    );
+  });
+
+  it("throws when the crew is not in 'review' state — approve is only valid after signal review", async () => {
+    const call = vi.fn().mockResolvedValue([
+      { id: "t1", name: "fix-579", state: "working", cwd: "/repo/.worktrees/brove-fix-579", createdAt: 1 },
+    ]);
+    await expect(runAction("brove", "fix-579", { call })).rejects.toThrow(
+      "Crew 'fix-579' is not awaiting review (state=working). Only a crew that signaled 'review' can be approved.",
+    );
+  });
+
+  it("pushes the branch, opens the PR, then emits task.done to terminalize", async () => {
+    const call = vi.fn()
+      .mockResolvedValueOnce([
+        { id: "t1", name: "fix-579", state: "review", cwd: "/repo/.worktrees/brove-fix-579", task: "add the flag", reviewNote: "done, tests green", createdAt: 1 },
+      ])
+      .mockResolvedValueOnce(undefined);
+    const pushBranch = vi.fn();
+    const createPr = vi.fn().mockReturnValue("https://github.com/x/y/pull/42");
+
+    const prUrl = await runAction("brove", "fix-579", { call, pushBranch, createPr });
+
+    expect(pushBranch).toHaveBeenCalledWith("/repo/.worktrees/brove-fix-579", "crew/fix-579");
+    expect(createPr).toHaveBeenCalledWith("/repo/.worktrees/brove-fix-579", {
+      base: "develop",
+      branch: "crew/fix-579",
+      title: "add the flag",
+      body: "done, tests green",
+    });
+    expect(call).toHaveBeenLastCalledWith({
+      kind: "event",
+      project: "brove",
+      event: { type: "task.done", id: "t1", resultRef: "", message: "Approved — PR opened: https://github.com/x/y/pull/42" },
+    });
+    expect(prUrl).toBe("https://github.com/x/y/pull/42");
+  });
+
+  it("falls back to the task text as the PR body when the crew gave no review note", async () => {
+    const call = vi.fn()
+      .mockResolvedValueOnce([
+        { id: "t1", name: "fix-579", state: "review", cwd: "/repo", task: "add the flag", createdAt: 1 },
+      ])
+      .mockResolvedValueOnce(undefined);
+    const createPr = vi.fn().mockReturnValue("https://x/1");
+    await runAction("brove", "fix-579", { call, createPr });
+    expect(createPr).toHaveBeenCalledWith("/repo", expect.objectContaining({ body: "add the flag" }));
+  });
+
+  it("falls back to the project root as cwd for a --shared crew with no recorded cwd", async () => {
+    const call = vi.fn()
+      .mockResolvedValueOnce([{ id: "t1", name: "quick-fix", state: "review", task: "x", createdAt: 1 }])
+      .mockResolvedValueOnce(undefined);
+    const pushBranch = vi.fn();
+    await runAction("brove", "quick-fix", { call, pushBranch });
+    expect(pushBranch).toHaveBeenCalledWith("/repo", "crew/quick-fix");
+  });
+
+  it("never emits task.done when pushBranch throws (push failure aborts before terminalizing)", async () => {
+    const call = vi.fn().mockResolvedValueOnce([
+      { id: "t1", name: "fix-579", state: "review", cwd: "/repo", task: "x", createdAt: 1 },
+    ]);
+    const pushBranch = vi.fn().mockImplementation(() => { throw new Error("push rejected"); });
+    await expect(runAction("brove", "fix-579", { call, pushBranch })).rejects.toThrow("push rejected");
+    expect(call).toHaveBeenCalledTimes(1); // only the initial list — no task.done emitted
+  });
+});

--- a/packages/cli/src/commands/__tests__/crew-signal.test.ts
+++ b/packages/cli/src/commands/__tests__/crew-signal.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { buildSignalRequest } from "../crew-control.js";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { buildSignalRequest, runCrewSignal } from "../crew-control.js";
 
 describe("buildSignalRequest", () => {
   const SAVED = { ...process.env };
@@ -57,6 +57,17 @@ describe("buildSignalRequest", () => {
     expect(req.event).toEqual({ type: "task.failed", id: "task-xyz", error: "build broke" });
   });
 
+  // #599: review-gate checkpoint — parallel to done/blocked, not terminal.
+  it("review + message → task.review event carrying the crew's summary", () => {
+    const req = buildSignalRequest("review", { message: "added the flag, tests green" });
+    expect(req.event).toEqual({ type: "task.review", id: "task-xyz", message: "added the flag, tests green" });
+  });
+
+  it("review without message → task.review event with no message field", () => {
+    const req = buildSignalRequest("review", {});
+    expect(req.event).toEqual({ type: "task.review", id: "task-xyz" });
+  });
+
   it("blocked without question → empty question string", () => {
     const req = buildSignalRequest("blocked", {});
     expect((req.event as { type: string; question: string }).question).toBe("");
@@ -99,5 +110,37 @@ describe("buildSignalRequest", () => {
     const req = buildSignalRequest("done", { taskId: "flag-id", project: "flag-proj" });
     expect(req.project).toBe("flag-proj");
     expect((req.event as { id: string }).id).toBe("flag-id");
+  });
+});
+
+describe("runCrewSignal('review') (#599)", () => {
+  const SAVED = { ...process.env };
+  beforeEach(() => {
+    process.env.SQUADRANT_CREW_TASK_ID = "task-xyz";
+    process.env.SQUADRANT_CREW_PROJECT = "alpha";
+  });
+  afterEach(() => { process.env = { ...SAVED }; });
+
+  it("status check passes (like blocked) — 'review' is not a terminal state, so the signal always emits", async () => {
+    const call = vi.fn()
+      .mockResolvedValueOnce({ state: "working" }) // status check
+      .mockResolvedValueOnce(undefined); // the emitted event
+    await runCrewSignal("review", { message: "ready" }, { call });
+    expect(call).toHaveBeenCalledTimes(2);
+    expect(call).toHaveBeenLastCalledWith({
+      kind: "event", project: "alpha", event: { type: "task.review", id: "task-xyz", message: "ready" },
+    });
+  });
+
+  it("re-signaling review from an already-'review' task is allowed (not terminal, re-request after feedback)", async () => {
+    const call = vi.fn()
+      .mockResolvedValueOnce({ state: "review" })
+      .mockResolvedValueOnce(undefined);
+    await expect(runCrewSignal("review", { message: "addressed feedback" }, { call })).resolves.toBeUndefined();
+  });
+
+  it("throws if the task is already terminal (mirrors done/blocked/failed behavior)", async () => {
+    const call = vi.fn().mockResolvedValueOnce({ state: "done" });
+    await expect(runCrewSignal("review", {}, { call })).rejects.toThrow(/already terminal/);
   });
 });

--- a/packages/cli/src/commands/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/__tests__/diff.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { TaskRecord } from "@squadrant/shared";
-import { resolveDiffTarget } from "../diff.js";
+import { resolveDiffTarget, resolveDiffSources } from "../diff.js";
 import type { DiffOptions } from "../diff.js";
 
 // ─── resolveDiffTarget (pure) ──────────────────────────────────────────────
@@ -55,6 +55,30 @@ describe("resolveDiffTarget (#596)", () => {
   it("falls back to projectPath when a matched task has no cwd recorded", () => {
     const tasks = [makeTask({ name: "headless-crew", cwd: undefined })];
     expect(resolveDiffTarget(tasks, "headless-crew", "/repo")).toEqual({ cwd: "/repo", isShared: true });
+  });
+});
+
+describe("resolveDiffSources (#599)", () => {
+  const base: DiffOptions = { layout: "split", focus: true };
+
+  it("no working-tree flag → empty array (falls back to branch-vs-base)", () => {
+    expect(resolveDiffSources(base)).toEqual([]);
+  });
+
+  it("--staged → ['staged']", () => {
+    expect(resolveDiffSources({ ...base, staged: true })).toEqual(["staged"]);
+  });
+
+  it("--unstaged → ['unstaged']", () => {
+    expect(resolveDiffSources({ ...base, unstaged: true })).toEqual(["unstaged"]);
+  });
+
+  it("--working → both, unstaged first (VSCode 'Changes' before 'Staged Changes')", () => {
+    expect(resolveDiffSources({ ...base, working: true })).toEqual(["unstaged", "staged"]);
+  });
+
+  it("--working wins when combined with --staged/--unstaged", () => {
+    expect(resolveDiffSources({ ...base, working: true, staged: true, unstaged: true })).toEqual(["unstaged", "staged"]);
   });
 });
 
@@ -134,6 +158,7 @@ describe("diffCommand action", () => {
       layout: "unified",
       focus: false,
       lastTurn: true,
+      source: "branch",
     });
   });
 
@@ -158,5 +183,69 @@ describe("diffCommand action", () => {
     await expect(runAction("brove", "fix-579")).rejects.toThrow(
       "Runtime 'tmux' has no native diff viewer yet — Phase 1 supports cmux only.",
     );
+  });
+
+  // ── #599 Phase A: --staged/--unstaged/--working working-tree peek ──────
+
+  beforeEach(() => {
+    loadConfig.mockReturnValue({ projects: { brove: { path: "/repo", captainName: "brove-captain" } } });
+    squadrantdCall.mockResolvedValue([
+      { id: "t1", name: "fix-579", cwd: "/repo/.worktrees/brove-fix-579", createdAt: 1 },
+    ]);
+  });
+
+  it("--staged opens a single 'staged' diff gated on `git diff --cached --stat`", async () => {
+    execFileSync.mockReturnValue(" 1 file changed, 1 insertion(+)\n");
+    await runAction("brove", "fix-579", { staged: true });
+    expect(execFileSync).toHaveBeenCalledWith(
+      "git", ["-C", "/repo/.worktrees/brove-fix-579", "diff", "--stat", "--cached"], expect.any(Object),
+    );
+    expect(showDiff).toHaveBeenCalledWith(expect.objectContaining({ source: "staged", cwd: "/repo/.worktrees/brove-fix-579" }));
+    expect(showDiff).toHaveBeenCalledTimes(1);
+  });
+
+  it("--unstaged opens a single 'unstaged' diff gated on `git diff --stat`", async () => {
+    execFileSync.mockReturnValue(" 1 file changed, 1 insertion(+)\n");
+    await runAction("brove", "fix-579", { unstaged: true });
+    expect(execFileSync).toHaveBeenCalledWith(
+      "git", ["-C", "/repo/.worktrees/brove-fix-579", "diff", "--stat"], expect.any(Object),
+    );
+    expect(showDiff).toHaveBeenCalledWith(expect.objectContaining({ source: "unstaged" }));
+    expect(showDiff).toHaveBeenCalledTimes(1);
+  });
+
+  it("--working opens BOTH unstaged and staged diffs when both have changes", async () => {
+    execFileSync.mockReturnValue(" 1 file changed\n");
+    await runAction("brove", "fix-579", { working: true });
+    expect(showDiff).toHaveBeenCalledTimes(2);
+    expect(showDiff).toHaveBeenNthCalledWith(1, expect.objectContaining({ source: "unstaged" }));
+    expect(showDiff).toHaveBeenNthCalledWith(2, expect.objectContaining({ source: "staged" }));
+  });
+
+  it("--working skips a source with no changes and still opens the other", async () => {
+    execFileSync.mockImplementation((_bin: string, args: string[]) =>
+      args.includes("--cached") ? "" : " 1 file changed\n",
+    );
+    await runAction("brove", "fix-579", { working: true });
+    expect(showDiff).toHaveBeenCalledTimes(1);
+    expect(showDiff).toHaveBeenCalledWith(expect.objectContaining({ source: "unstaged" }));
+  });
+
+  it("--working prints a no-changes message and never opens the viewer when both sources are empty", async () => {
+    execFileSync.mockReturnValue("");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await runAction("brove", "fix-579", { working: true });
+    expect(logSpy).toHaveBeenCalledWith("No staged or unstaged changes on crew/fix-579.");
+    expect(showDiff).not.toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
+
+  it("--staged prints a source-specific no-changes message when empty", async () => {
+    execFileSync.mockReturnValue("");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await runAction("brove", "fix-579", { staged: true });
+    expect(logSpy).toHaveBeenCalledWith("No staged changes on crew/fix-579.");
+    expect(showDiff).not.toHaveBeenCalled();
+    logSpy.mockRestore();
   });
 });

--- a/packages/cli/src/commands/crew-control.ts
+++ b/packages/cli/src/commands/crew-control.ts
@@ -2,13 +2,14 @@
 import { Command } from "commander";
 import { createConnection } from "node:net";
 import { randomUUID } from "node:crypto";
+import { execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { sendRequest } from "@squadrant/core";
 import { ensureDaemon } from "@squadrant/core";
 import type { ControlEvent, Mode, Provider, TaskRecord } from "@squadrant/shared";
-import { TERMINAL_STATES } from "@squadrant/shared";
+import { TERMINAL_STATES, loadConfig, crewBranch, resolveWorktreeBase } from "@squadrant/shared";
 import { mapClaudeHookToEvent } from "@squadrant/agents";
 import { filterTasks, formatCompactTasks } from "./crew-output.js";
 import { crewAttachCommand } from "./crew-attach.js";
@@ -127,7 +128,7 @@ export async function squadrantdCall(req: unknown): Promise<unknown> {
  * has *intentionally* declared terminal state after its own settle-check.
  */
 export function buildSignalRequest(
-  signal: "done" | "blocked" | "failed",
+  signal: "done" | "blocked" | "failed" | "review",
   o: {
     message?: string;
     question?: string;
@@ -157,6 +158,10 @@ export function buildSignalRequest(
     };
   } else if (signal === "blocked") {
     event = { type: "task.blocked", id: taskId, reason: "crew signaled blocked", question: o.question ?? "" };
+  } else if (signal === "review") {
+    // #599: review-gate checkpoint — crew has committed to crew/<name> and
+    // wants the captain to inspect the diff before push+PR. Not terminal.
+    event = { type: "task.review", id: taskId, ...(o.message !== undefined ? { message: o.message } : {}) };
   } else {
     event = { type: "task.failed", id: taskId, error: o.error ?? "crew signaled failed" };
   }
@@ -184,7 +189,7 @@ function defaultWriteResult(id: string, payload: string): string {
  * so the CLI throws instead of emitting an event doomed to be ignored.
  */
 export async function runCrewSignal(
-  signal: "done" | "blocked" | "failed",
+  signal: "done" | "blocked" | "failed" | "review",
   o: {
     message?: string;
     question?: string;
@@ -217,6 +222,80 @@ export async function runCrewSignal(
   }
   const req = buildSignalRequest(signal, { ...o, writeResult: o.writeResult ?? defaultWriteResult });
   await deps.call(req);
+}
+
+/**
+ * Pure. Resolve a crew name to its most-recent task record (#574 tie-break —
+ * same rule as diff.ts's resolveDiffTarget / crew-spawn.ts's pickMostRecentTask).
+ * Approve needs the full record (id + state), not just the worktree cwd.
+ */
+export function resolveApproveTarget(tasks: TaskRecord[], crew: string): TaskRecord | null {
+  const matches = tasks.filter((t) => t.name === crew);
+  if (matches.length === 0) return null;
+  return matches.reduce((a, b) => ((b.createdAt ?? 0) > (a.createdAt ?? 0) ? b : a));
+}
+
+/** Default push: `git push -u origin <branch>` from the crew's worktree. */
+function defaultPushBranch(cwd: string, branch: string): void {
+  execFileSync("git", ["-C", cwd, "push", "-u", "origin", branch], { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+/** Default PR creation via `gh pr create`; returns the created PR's URL (gh's stdout). */
+function defaultCreatePr(cwd: string, o: { base: string; branch: string; title: string; body: string }): string {
+  return execFileSync(
+    "gh", ["pr", "create", "--base", o.base, "--head", o.branch, "--title", o.title, "--body", o.body],
+    { cwd, encoding: "utf-8" },
+  ).trim();
+}
+
+/**
+ * `squadrant crew approve` — the accept side of the #599 review gate. Only
+ * valid on a task in 'review' state (set by `squadrant crew signal review`):
+ * pushes crew/<name> to origin, opens the PR via `gh pr create`, then emits
+ * task.done to terminalize. The reject path is the EXISTING `crew send`
+ * feedback loop — no new machinery there (runCrewSend already clears
+ * 'review' back to 'working' before delivering the captain's message).
+ */
+export async function runCrewApprove(
+  project: string,
+  crew: string,
+  deps: {
+    call: (req: unknown) => Promise<unknown>;
+    pushBranch?: (cwd: string, branch: string) => void;
+    createPr?: (cwd: string, o: { base: string; branch: string; title: string; body: string }) => string;
+  },
+): Promise<string> {
+  const config = loadConfig();
+  const proj = config.projects[project];
+  if (!proj) throw new Error(`Project '${project}' not found. Run 'squadrant projects list'.`);
+
+  const tasks = (await deps.call({ kind: "list", project })) as TaskRecord[];
+  const task = resolveApproveTarget(tasks, crew);
+  if (!task) throw new Error(`Crew '${crew}' not found for ${project}. Run 'squadrant crew list ${project}'.`);
+  if (task.state !== "review") {
+    throw new Error(
+      `Crew '${crew}' is not awaiting review (state=${task.state}). Only a crew that signaled 'review' can be approved.`,
+    );
+  }
+
+  const cwd = task.cwd ?? proj.path;
+  const base = resolveWorktreeBase(proj.path);
+  const branch = crewBranch(crew);
+  const title = (task.task ?? branch).split(/\r?\n/)[0].trim().slice(0, 100);
+  const body = (task.reviewNote ?? task.task ?? "").trim();
+
+  const pushBranch = deps.pushBranch ?? defaultPushBranch;
+  const createPr = deps.createPr ?? defaultCreatePr;
+  pushBranch(cwd, branch);
+  const prUrl = createPr(cwd, { base, branch, title, body });
+
+  await deps.call({
+    kind: "event",
+    project,
+    event: { type: "task.done", id: task.id, resultRef: "", message: `Approved — PR opened: ${prUrl}` },
+  });
+
+  return prUrl;
 }
 
 /**
@@ -342,19 +421,19 @@ export function addControlPlaneCrewCommands(crew: Command): void {
   // (git status clean, etc.) to declare terminal state to the captain.
   crew
     .command("signal <state>")
-    .description("Emit explicit terminal signal from a crew session: done|blocked|failed (reads SQUADRANT_CREW_* env, or --task-id/--project for codex)")
-    .option("--message <m>", "Summary written to resultRef (done)")
+    .description("Emit explicit terminal/review signal from a crew session: done|blocked|failed|review (reads SQUADRANT_CREW_* env, or --task-id/--project for codex)")
+    .option("--message <m>", "Summary written to resultRef (done), or review summary (review)")
     .option("--question <q>", "Question to surface to captain (blocked)")
     .option("--error <e>", "Error message (failed)")
     .option("--task-id <id>", "Explicit task id (codex; overrides SQUADRANT_CREW_TASK_ID env)")
     .option("--project <p>", "Explicit project (codex; overrides SQUADRANT_CREW_PROJECT env)")
     .action(async (state: string, opts: { message?: string; question?: string; error?: string; taskId?: string; project?: string }) => {
-      if (state !== "done" && state !== "blocked" && state !== "failed") {
-        process.stderr.write(`unknown signal '${state}' (expected: done|blocked|failed)\n`);
+      if (state !== "done" && state !== "blocked" && state !== "failed" && state !== "review") {
+        process.stderr.write(`unknown signal '${state}' (expected: done|blocked|failed|review)\n`);
         process.exit(2);
       }
       try {
-        await runCrewSignal(state as "done" | "blocked" | "failed", {
+        await runCrewSignal(state as "done" | "blocked" | "failed" | "review", {
           ...(opts.message !== undefined ? { message: opts.message } : {}),
           ...(opts.question !== undefined ? { question: opts.question } : {}),
           ...(opts.error !== undefined ? { error: opts.error } : {}),
@@ -363,6 +442,22 @@ export function addControlPlaneCrewCommands(crew: Command): void {
           writeResult: defaultWriteResult,
         }, { call: squadrantdCall });
         process.exit(0);
+      } catch (e) {
+        process.stderr.write(`${(e as Error).message}\n`);
+        process.exit(1);
+      }
+    });
+
+  // #599: accept side of the review gate. `squadrant crew signal review` puts
+  // the task in 'review'; this command is the only path out besides `crew send`
+  // (reject/feedback) — push + open the PR, then terminalize DONE.
+  crew
+    .command("approve <project> <crew>")
+    .description("Approve a crew's reviewed work: push crew/<name> + open a PR, then terminalize DONE (#599)")
+    .action(async (project: string, crewName: string) => {
+      try {
+        const prUrl = await runCrewApprove(project, crewName, { call: squadrantdCall });
+        process.stdout.write(`✔ Approved ${crewBranch(crewName)} — pushed + PR opened: ${prUrl}\n`);
       } catch (e) {
         process.stderr.write(`${(e as Error).message}\n`);
         process.exit(1);

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -30,6 +30,23 @@ export interface DiffOptions {
   layout: "split" | "unified";
   lastTurn?: boolean;
   focus: boolean;
+  // #599 Phase A: peek at a crew's uncommitted working tree mid-task, instead
+  // of the default branch-vs-base review surface. --working shows both panels
+  // (VSCode's "Changes" + "Staged Changes" split); --staged/--unstaged show
+  // just one. Mutually exclusive; --working wins if more than one is passed.
+  staged?: boolean;
+  unstaged?: boolean;
+  working?: boolean;
+}
+
+// Pure. Which working-tree sources to open for the given flags, in display
+// order. Empty array means "no working-tree flag was passed" — the caller
+// falls back to the default branch-vs-base behavior.
+export function resolveDiffSources(opts: DiffOptions): Array<"staged" | "unstaged"> {
+  if (opts.working) return ["unstaged", "staged"];
+  if (opts.staged) return ["staged"];
+  if (opts.unstaged) return ["unstaged"];
+  return [];
 }
 
 export async function runDiff(project: string, crew: string, opts: DiffOptions): Promise<void> {
@@ -48,6 +65,40 @@ export async function runDiff(project: string, crew: string, opts: DiffOptions):
   const base = resolveWorktreeBase(proj.path);
   const branchLabel = crewBranch(crew);
 
+  const { runtime, workspaceId } = await resolveCaptainWorkspace(project);
+  if (!runtime.showDiff) {
+    throw new Error(`Runtime '${runtime.name}' has no native diff viewer yet — Phase 1 supports cmux only.`);
+  }
+
+  const sources = resolveDiffSources(opts);
+  if (sources.length > 0) {
+    // Working-tree peek (#599): each source is gated on its OWN emptiness —
+    // there is no single base...HEAD comparison for uncommitted changes.
+    let opened = 0;
+    for (const source of sources) {
+      const statArgs = source === "staged" ? ["diff", "--stat", "--cached"] : ["diff", "--stat"];
+      const stat = execFileSync("git", ["-C", target.cwd, ...statArgs], { encoding: "utf-8" }).trim();
+      if (!stat) continue;
+      await runtime.showDiff({
+        workspaceId,
+        cwd: target.cwd,
+        base,
+        title: `${branchLabel} — ${source}`,
+        layout: opts.layout,
+        focus: opts.focus,
+        source,
+      });
+      opened++;
+    }
+    if (opened === 0) {
+      const label = sources.length > 1 ? "staged or unstaged" : sources[0];
+      console.log(`No ${label} changes on ${branchLabel}.`);
+    } else {
+      console.log(chalk.dim(`Opened ${opened} working-tree diff(s) (${sources.join(", ")}) for ${branchLabel}.`));
+    }
+    return;
+  }
+
   // Empty-diff guard (#596): a crew that made no changes yet shouldn't pop a
   // diff viewer with nothing in it. `target.cwd` is already checked out on
   // the right ref for both cases — the crew's own branch in an isolated
@@ -61,10 +112,6 @@ export async function runDiff(project: string, crew: string, opts: DiffOptions):
     return;
   }
 
-  const { runtime, workspaceId } = await resolveCaptainWorkspace(project);
-  if (!runtime.showDiff) {
-    throw new Error(`Runtime '${runtime.name}' has no native diff viewer yet — Phase 1 supports cmux only.`);
-  }
   await runtime.showDiff({
     workspaceId,
     cwd: target.cwd,
@@ -73,6 +120,7 @@ export async function runDiff(project: string, crew: string, opts: DiffOptions):
     layout: opts.layout,
     focus: opts.focus,
     lastTurn: opts.lastTurn,
+    source: "branch",
   });
   console.log(chalk.dim(`Opened ${branchLabel} vs ${base} in cmux diff.`));
 }
@@ -84,4 +132,7 @@ export const diffCommand = new Command("diff")
   .option("--layout <mode>", "split (default) or unified", "split")
   .option("--last-turn", "diff only changes since the crew's last agent turn", false)
   .option("--no-focus", "open the diff pane without stealing focus")
+  .option("--staged", "show only staged (index) changes — VSCode's 'Staged Changes' panel (#599)", false)
+  .option("--unstaged", "show only unstaged working-tree changes — VSCode's 'Changes' panel (#599)", false)
+  .option("--working", "show both staged and unstaged changes (mid-task working-tree review, #599)", false)
   .action(runDiff);

--- a/packages/core/src/__tests__/crew-spawn.test.ts
+++ b/packages/core/src/__tests__/crew-spawn.test.ts
@@ -647,6 +647,22 @@ describe("runCrewSend", () => {
     expect(emitEvent).toHaveBeenCalledWith(PROJECT, { type: "task.started", id: "t1" });
   });
 
+  // #599: feedback on a crew awaiting review is the reject path — must clear
+  // 'review' back to 'working' the same way an answer clears 'blocked', so the
+  // crew's next hook doesn't leave a stale 'review' record lying around.
+  it("emits task.started for a 'review' task before sending (reject/feedback path, #599)", async () => {
+    const existing = { ...makePaneRef("5"), title: "🔧 myproj:crew-1" };
+    const runtime = makeRuntime("workspace:1", [existing]);
+    const emitEvent = vi.fn().mockResolvedValue(undefined);
+    const task = { id: "t1", name: "crew-1", state: "review" } as Partial<TaskRecord>;
+    await runCrewSend(PROJECT, "crew-1", "please also add a test", runtime, "workspace:1", {
+      listTasks: vi.fn().mockResolvedValue([task]),
+      emitEvent,
+    });
+    expect(emitEvent).toHaveBeenCalledWith(PROJECT, { type: "task.started", id: "t1" });
+    expect(runtime.sendToPane).toHaveBeenCalledWith(expect.anything(), "please also add a test");
+  });
+
   it("swallows daemon errors and still delivers the message", async () => {
     const existing = { ...makePaneRef("5"), title: "🔧 myproj:crew-1" };
     const runtime = makeRuntime("workspace:1", [existing]);

--- a/packages/core/src/__tests__/daemon.test.ts
+++ b/packages/core/src/__tests__/daemon.test.ts
@@ -423,6 +423,14 @@ describe("daemon handler", () => {
     expect(store.get("p", "g3")?.state).toBe("cancelled");
   });
 
+  it("sweep: interactive REVIEW record with a gone surface → cancelled, not left awaiting an approval that never comes (#599)", async () => {
+    const store = createStore(dir);
+    store.put(rec("g4", { mode: "interactive", state: "review", reviewNote: "ready", lastHeartbeat: 990, heartbeatBudgetMs: 86_400_000 }));
+    const d = createDaemon({ store, now: () => 1000, isSurfaceAlive: async () => "gone" });
+    await d.sweep();
+    expect(store.get("p", "g4")?.state).toBe("cancelled");
+  });
+
   // The critical non-regression: a LEGITIMATELY-IDLE live crew (surface alive)
   // that is over its heartbeat budget must NEVER be reaped. Post-#354 a quiet
   // thinking crew stays `working` (CREW QUIET, not awaiting-input); the point of
@@ -745,6 +753,74 @@ describe("daemon – blocked crew resume path (#183)", () => {
     const d = createDaemon({ store, now: () => 2000, notify: async (a) => { calls.push(a); } });
     await d.handle({ kind: "event", project: "p", event: { type: "task.done", id: "t-ds", resultRef: "/r" } });
     expect(calls[0].message).toBe("CREW DONE [claude/t-ds]: implement the thing");
+  });
+
+  // ── #599: review-gate checkpoint ───────────────────────────────────────────
+  describe("CREW REVIEW (#599)", () => {
+    it("working + task.review → state 'review' (NOT terminal) and fires CREW REVIEW with the crew's summary", async () => {
+      const store = createStore(dir);
+      store.put(rec("t-rv", { state: "working", project: "p", name: "review-1" }));
+      const calls: any[] = [];
+      const d = createDaemon({ store, now: () => 2000, notify: async (a) => { calls.push(a); } });
+      await d.handle({ kind: "event", project: "p", event: { type: "task.review", id: "t-rv", message: "added the CLI flag, tests green" } });
+      expect(store.get("p", "t-rv")?.state).toBe("review");
+      expect(calls).toHaveLength(1);
+      expect(calls[0].message).toContain("CREW REVIEW");
+      expect(calls[0].message).toContain("added the CLI flag, tests green");
+    });
+
+    it("task.review is NOT in TERMINAL_STATES — the task stays alive, unlike done/failed/cancelled", async () => {
+      const store = createStore(dir);
+      store.put(rec("t-rv2", { state: "working" }));
+      const d = createDaemon({ store, now: () => 2000 });
+      await d.handle({ kind: "event", project: "p", event: { type: "task.review", id: "t-rv2" } });
+      // A terminal task would silently absorb a further event; 'review' must not.
+      const next = await d.handle({ kind: "event", project: "p", event: { type: "task.progress", id: "t-rv2", note: "posttooluse" } });
+      expect((next as TaskRecord).lastEvent).toBe("task.progress");
+    });
+
+    it("captain feedback (task.started, the crew-send reject path) clears review → working, then a re-signal fires CREW REVIEW again", async () => {
+      const store = createStore(dir);
+      store.put(rec("t-rv3", { state: "review", reviewNote: "first pass" }));
+      const calls: any[] = [];
+      const d = createDaemon({ store, now: () => 2000, notify: async (a) => { calls.push(a); } });
+      await d.handle({ kind: "event", project: "p", event: { type: "task.started", id: "t-rv3" } });
+      expect(store.get("p", "t-rv3")?.state).toBe("working");
+      await d.handle({ kind: "event", project: "p", event: { type: "task.review", id: "t-rv3", message: "addressed feedback" } });
+      expect(calls).toHaveLength(1); // task.started is not an attention state — only the re-review notifies
+      expect(calls[0].message).toContain("CREW REVIEW");
+      expect(calls[0].message).toContain("addressed feedback");
+    });
+
+    it("approve path: task.done from 'review' terminalizes to done and fires CREW DONE, not CREW REVIEW", async () => {
+      const store = createStore(dir);
+      store.put(rec("t-rv4", { state: "review", reviewNote: "ready" }));
+      const calls: any[] = [];
+      const d = createDaemon({ store, now: () => 2000, notify: async (a) => { calls.push(a); } });
+      await d.handle({ kind: "event", project: "p", event: { type: "task.done", id: "t-rv4", resultRef: "", message: "Approved — PR opened: https://x/1" } });
+      expect(store.get("p", "t-rv4")?.state).toBe("done");
+      expect(calls).toHaveLength(1);
+      expect(calls[0].message).toContain("CREW DONE");
+    });
+
+    it("review is debounced the same as every other attention state EXCEPT awaiting-input — never suppressed near a captain turn", async () => {
+      const store = createStore(dir);
+      store.put(rec("t-rv5", { state: "working" }));
+      const calls: any[] = [];
+      const d = createDaemon({ store, now: () => 1000, notify: async (a) => { calls.push(a); } });
+      await d.handle({ kind: "event", project: "p", event: { type: "task.started", id: "t-rv5" } }); // captain turn @1000
+      await d.handle({ kind: "event", project: "p", event: { type: "task.review", id: "t-rv5" } }); // @1000, same tick
+      expect(calls.filter((c) => c.message.includes("CREW REVIEW"))).toHaveLength(1);
+    });
+
+    it("unknown event type 'task.review' would be rejected before this feature — sanity: it is now a KNOWN_EVENT_TYPE", async () => {
+      const store = createStore(dir);
+      store.put(rec("t-rv6", { state: "working" }));
+      const d = createDaemon({ store, now: () => 2000 });
+      await expect(
+        d.handle({ kind: "event", project: "p", event: { type: "task.review", id: "t-rv6" } }),
+      ).resolves.toBeTruthy();
+    });
   });
 
   // ── #210: CREW IDLE debounce ──────────────────────────────────────────────

--- a/packages/core/src/__tests__/state-machine.test.ts
+++ b/packages/core/src/__tests__/state-machine.test.ts
@@ -83,6 +83,38 @@ describe("state-machine reduce", () => {
     expect(next.lastEvent).toBe("task.progress"); // lastEvent stays consistent
   });
 
+  // #599: review-gate checkpoint. Not terminal — crew commits, signals review,
+  // captain either approves (task.done) or sends feedback (task.started).
+  it("working + task.review → review, carries the crew's summary as reviewNote", () => {
+    const next = reduce(rec({ state: "working" }), { type: "task.review", id: "t1", message: "ready: added the flag" }, 5000);
+    expect(next.state).toBe("review");
+    expect(next.reviewNote).toBe("ready: added the flag");
+    expect(next.lastHeartbeat).toBe(5000);
+    expect(next.lastEvent).toBe("task.review");
+  });
+
+  it("working + task.review with no message → reviewNote is undefined", () => {
+    const next = reduce(rec({ state: "working" }), { type: "task.review", id: "t1" }, 5000);
+    expect(next.state).toBe("review");
+    expect(next.reviewNote).toBeUndefined();
+  });
+
+  it("review + task.started (captain feedback/reject path) → working", () => {
+    const next = reduce(rec({ state: "review", reviewNote: "ready" }), { type: "task.started", id: "t1" }, 5100);
+    expect(next.state).toBe("working");
+  });
+
+  it("review + task.done (captain approve path) → done", () => {
+    const next = reduce(rec({ state: "review", reviewNote: "ready" }), { type: "task.done", id: "t1", resultRef: "/r" }, 5200);
+    expect(next.state).toBe("done");
+    expect(next.resultRef).toBe("/r");
+  });
+
+  it("review clears pendingTool (mirrors task.blocked's turn-boundary reset)", () => {
+    const next = reduce(rec({ state: "working", pendingTool: { name: "Bash", since: 100 } }), { type: "task.review", id: "t1" }, 5000);
+    expect(next.pendingTool).toBeUndefined();
+  });
+
   it("stalled + task.done → done", () => {
     const next = reduce(rec({ state: "stalled" }), { type: "task.done", id: "t1", resultRef: "/r" }, 4500);
     expect(next.state).toBe("done");

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -512,7 +512,9 @@ export async function runCrewSend(
     if (task) {
       if (TERMINAL_STATES.has(task.state)) {
         await deps.emitEvent(project, { type: "task.reopened", id: task.id });
-      } else if (task.state === "blocked" || task.state === "awaiting-input") {
+      } else if (task.state === "blocked" || task.state === "awaiting-input" || task.state === "review") {
+        // #599: feedback on a 'review' task is the reject path — clear it back
+        // to working the same way an answer clears 'blocked'.
         await deps.emitEvent(project, { type: "task.started", id: task.id });
       }
     }

--- a/packages/core/src/daemon/reduce.ts
+++ b/packages/core/src/daemon/reduce.ts
@@ -107,13 +107,17 @@ export const TERMINAL_RECORD_KEEP_PER_PROJECT = 20;
 // 'awaiting-input' is an attention state: entering it (idle watchdog OR a
 // Stop-hook turn boundary) fires exactly one accurate CREW IDLE push. The
 // firePush prev===next guard keeps it from re-firing while the task sits idle.
-const ATTENTION_STATES: ReadonlySet<TaskState> = new Set(["done", "blocked", "failed", "stalled", "awaiting-input"]);
+// #599: 'review' joins the attention states — a CREW REVIEW push fires exactly
+// like CREW DONE/BLOCKED, just without terminalizing the task.
+const ATTENTION_STATES: ReadonlySet<TaskState> = new Set(["done", "blocked", "review", "failed", "stalled", "awaiting-input"]);
 
 // #139: non-terminal, post-launch states an interactive crew can be sitting in
 // while its session has actually died. Any of these with a provably-gone surface
 // is a zombie → reap to 'cancelled'. 'submitted' is excluded: it is pre-launch
 // (no surface yet), so reaping it would race the spawn.
-const REAPABLE_SURFACE_STATES: ReadonlySet<TaskState> = new Set(["working", "stalled", "awaiting-input", "blocked"]);
+// #599: 'review' included — a crew that signaled review then crashed/closed
+// must not linger forever awaiting an approval that will never come.
+const REAPABLE_SURFACE_STATES: ReadonlySet<TaskState> = new Set(["working", "stalled", "awaiting-input", "blocked", "review"]);
 
 // #210: CREW IDLE (awaiting-input) is debounced — suppressed when the turn-end
 // lands within this window of the captain's own last turn to the crew (a
@@ -158,6 +162,11 @@ function formatMessage(rec: TaskRecord, event?: ControlEvent): string | null {
     }
     case "blocked":
       return `CREW BLOCKED ${tag}: ${(rec.question ?? "(no question)").trim()}`;
+    case "review": {
+      // #599: crew has committed and is awaiting the captain's review verdict.
+      const note = (rec.reviewNote ?? "").trim();
+      return `CREW REVIEW ${tag}: ${note || "ready for review"} — run 'squadrant diff ${rec.project} ${rec.name ?? rec.id}' then 'squadrant crew approve' or send feedback.`;
+    }
     case "failed":
       return `CREW FAILED ${tag}: ${(rec.error ?? "(no error)").trim()}`;
     case "stalled": {
@@ -269,7 +278,7 @@ type Req =
 // a clean structured error before it can reach reduce() or the store.
 const KNOWN_EVENT_TYPES: ReadonlySet<string> = new Set([
   "task.started", "task.progress", "heartbeat",
-  "task.blocked", "task.done", "task.failed",
+  "task.blocked", "task.review", "task.done", "task.failed",
   "task.session", "task.turn.started", "task.turn.completed",
   "task.delta", "task.input.requested", "task.approval.requested",
   "task.reattached", "task.reopened",

--- a/packages/core/src/state-machine.ts
+++ b/packages/core/src/state-machine.ts
@@ -97,6 +97,10 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
       // BLOCKED fires. Terminal states are already absorbed above.
       if (rec.state === "blocked") return { ...rec, lastHeartbeat: now, lastEvent: ev.type };
       return { ...base, state: "blocked", question: ev.question, pendingTool: undefined };
+    case "task.review":
+      // #599: review-gate checkpoint. Not terminal — `crew send` (feedback)
+      // or `crew approve` (task.done) are the only ways out.
+      return { ...base, state: "review", reviewNote: ev.message, pendingTool: undefined };
     case "task.done":
       return { ...base, state: "done", resultRef: ev.resultRef, parseWarning: ev.parseWarning };
     case "task.failed":

--- a/packages/core/src/telegram/__tests__/format.test.ts
+++ b/packages/core/src/telegram/__tests__/format.test.ts
@@ -24,6 +24,16 @@ describe("formatLifecycle", () => {
     expect(formatLifecycle("squadrant", ev)).toBe("🚧 [squadrant] CREW BLOCKED · def456\nWhich DB?");
   });
 
+  it("renders a task.review event with its message (#599)", () => {
+    const ev: ControlEvent = { type: "task.review", id: "rev1", message: "ready for review" };
+    expect(formatLifecycle("squadrant", ev)).toBe("👀 [squadrant] CREW REVIEW · rev1\nready for review");
+  });
+
+  it("renders a task.review event without a message", () => {
+    const ev: ControlEvent = { type: "task.review", id: "rev2" };
+    expect(formatLifecycle("squadrant", ev)).toBe("👀 [squadrant] CREW REVIEW · rev2");
+  });
+
   it("renders a task.idle event", () => {
     const ev: ControlEvent = { type: "task.idle", id: "ghi789", heartbeatBudgetMs: 60000 };
     expect(formatLifecycle("squadrant", ev)).toBe("💤 [squadrant] CREW IDLE · ghi789");

--- a/packages/core/src/telegram/__tests__/tiers.test.ts
+++ b/packages/core/src/telegram/__tests__/tiers.test.ts
@@ -21,6 +21,11 @@ describe("tierIncludes", () => {
     expect(tierIncludes("alert_only", "task.progress")).toBe(false);
     expect(tierIncludes("alert_only", "task.idle")).toBe(false);
   });
+  it("task.review (#599) is an alert like task.blocked — needs a captain decision, excluded from done_only", () => {
+    expect(tierIncludes("alert_only", "task.review")).toBe(true);
+    expect(tierIncludes("done_only", "task.review")).toBe(false);
+    expect(tierIncludes("none", "task.review")).toBe(false);
+  });
   it("all lets everything through", () => {
     expect(tierIncludes("all", "task.progress")).toBe(true);
     expect(tierIncludes("all", "heartbeat")).toBe(true);

--- a/packages/core/src/telegram/format.ts
+++ b/packages/core/src/telegram/format.ts
@@ -13,6 +13,8 @@ export function formatLifecycle(project: string, ev: ControlEvent): string {
       return `✅ [${project}] CREW DONE · ${ev.id}` + (ev.message ? `\n${ev.message}` : "");
     case "task.blocked":
       return `🚧 [${project}] CREW BLOCKED · ${ev.id}\n${ev.question}`;
+    case "task.review":
+      return `👀 [${project}] CREW REVIEW · ${ev.id}` + (ev.message ? `\n${ev.message}` : "");
     case "task.idle":
       return `💤 [${project}] CREW IDLE · ${ev.id}`;
     case "task.failed":

--- a/packages/core/src/telegram/tiers.ts
+++ b/packages/core/src/telegram/tiers.ts
@@ -6,6 +6,7 @@ const DONE_ONLY = new Set(["task.done", "task.failed"]);
 const ALERTS = new Set([
   ...DONE_ONLY,
   "task.blocked",
+  "task.review",
   "task.approval.requested",
   "task.input.requested",
   "task.timeout",

--- a/packages/shared/src/types/control.ts
+++ b/packages/shared/src/types/control.ts
@@ -6,6 +6,11 @@ export type TaskState =
   | "submitted"
   | "working"
   | "blocked"
+  // #599: crew has committed to crew/<name> and is paused awaiting the
+  // captain's review verdict (approve → push+PR+done, or feedback → crew
+  // send reopens to 'working'). NOT terminal — mirrors 'blocked', but the
+  // crew is waiting on a review decision rather than an answer to a question.
+  | "review"
   | "done"
   | "failed"
   | "stalled"
@@ -49,6 +54,9 @@ export interface TaskRecord {
   cwd?: string;            // working dir for the spawned headless child (project/worktree); unset → daemon cwd
   pid?: number;            // headless child pid (daemon-owned)
   question?: string;       // populated when state === "blocked"
+  /** #599: the crew's own summary carried on `signal review`; populated when
+   *  state === "review". Surfaced in the CREW REVIEW notification. */
+  reviewNote?: string;
   error?: string;          // populated when state === "failed"
   exitCode?: number;
   resultRef?: string;      // filesystem path to captured output/artifact
@@ -98,6 +106,12 @@ export type ControlEvent =
   | { type: "task.progress"; id: string; note?: string; tool?: string }
   | { type: "heartbeat"; id: string }
   | { type: "task.blocked"; id: string; reason: string; question: string }
+  // #599: explicit review-gate checkpoint — parallel to task.blocked/task.done
+  // but NOT terminal. Emitted by `squadrant crew signal review` once the crew
+  // has committed to crew/<name> and wants the captain to inspect the diff
+  // before it is pushed/PR'd. `message` is an optional crew summary (parity
+  // with task.done's optional message).
+  | { type: "task.review"; id: string; message?: string }
   | { type: "task.done"; id: string; resultRef: string; message?: string; parseWarning?: boolean }
   | { type: "task.failed"; id: string; error: string; exitCode?: number }
   | { type: "task.session"; id: string; resumeRef: string }

--- a/packages/shared/src/types/runtime.ts
+++ b/packages/shared/src/types/runtime.ts
@@ -98,5 +98,10 @@ export interface RuntimeDriver {
     layout?: "split" | "unified";
     focus?: boolean;
     lastTurn?: boolean;   // maps to cmux --last-turn
+    // #599: which diff source to render. 'branch' (default) is the existing
+    // branch-vs-base review surface; 'staged'/'unstaged' peek at a crew's
+    // uncommitted working tree (VSCode's "Staged Changes"/"Changes" panels)
+    // mid-task, before it has committed anything to review.
+    source?: "branch" | "staged" | "unstaged";
   }): Promise<void>;
 }

--- a/packages/web/src/__tests__/read-status.test.ts
+++ b/packages/web/src/__tests__/read-status.test.ts
@@ -101,6 +101,16 @@ describe("readAllStatuses", () => {
     expect(rows[0].state).toBe("blocked");
   });
 
+  it("maps state to blocked when any task is awaiting review (#599)", async () => {
+    const rows = await readAllStatuses({
+      config: makeConfig(),
+      call: makeAliveCall(),
+      listTasks: async () => [mkTask({ state: "review" })],
+    });
+
+    expect(rows[0].state).toBe("blocked");
+  });
+
   it("maps state to errored when any task has failed", async () => {
     const rows = await readAllStatuses({
       config: makeConfig(),
@@ -188,6 +198,17 @@ describe("readAllStatuses", () => {
     expect(rows[0].excerpt).toContain("1 blocked");
     expect(rows[0].excerpt).toContain("feat-x");
     expect(rows[0].excerpt).toContain("fix-y");
+  });
+
+  it("counts a 'review' task into the blocked bucket and its title into the excerpt (#599)", async () => {
+    const rows = await readAllStatuses({
+      config: makeConfig(),
+      call: makeAliveCall(),
+      listTasks: async () => [mkTask({ state: "review", name: "fix-579", task: "add the flag" })],
+    });
+
+    expect(rows[0].excerpt).toContain("1 blocked");
+    expect(rows[0].excerpt).toContain("fix-579");
   });
 
   it("builds summary-only excerpt when no active tasks", async () => {

--- a/packages/web/src/read-status.ts
+++ b/packages/web/src/read-status.ts
@@ -21,7 +21,9 @@ export interface ReadStatusDeps {
 }
 
 function deriveState(tasks: TaskRecord[]): DashboardState {
-  if (tasks.some(t => t.state === "blocked" || t.state === "awaiting-input")) return "blocked";
+  // #599: a crew awaiting review needs the captain's attention exactly like
+  // blocked/awaiting-input — group it into the same dashboard bucket.
+  if (tasks.some(t => t.state === "blocked" || t.state === "awaiting-input" || t.state === "review")) return "blocked";
   if (tasks.some(t => t.state === "failed" || t.state === "stalled")) return "errored";
   if (tasks.some(t => t.state === "working")) return "busy";
   return "idle";
@@ -36,14 +38,14 @@ export function deriveRowState(tasks: TaskRecord[], captainState: HealthState): 
 
 function buildExcerpt(tasks: TaskRecord[]): string {
   const working = tasks.filter(t => t.state === "working").length;
-  const blocked = tasks.filter(t => t.state === "blocked" || t.state === "awaiting-input").length;
+  const blocked = tasks.filter(t => t.state === "blocked" || t.state === "awaiting-input" || t.state === "review").length;
   const parts: string[] = [];
   if (working > 0) parts.push(`${working} working`);
   if (blocked > 0) parts.push(`${blocked} blocked`);
   const summary = parts.length > 0 ? parts.join(", ") : "idle";
 
   const active = tasks.filter(t =>
-    ["working", "blocked", "awaiting-input", "submitted"].includes(t.state)
+    ["working", "blocked", "awaiting-input", "review", "submitted"].includes(t.state)
   );
   const titles = active.slice(0, 3).map(t => {
     const firstLine = t.task ? t.task.split("\n")[0] : "";

--- a/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
+++ b/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
@@ -1674,3 +1674,54 @@ describe("classifyDraftLiveness (#258 probe false-negative detection)", () => {
     expect(classifyDraftLiveness("hello 😀", "hello")).toBe("real-draft");
   });
 });
+
+// #599 Phase A: showDiff's `source` opt selects which cmux diff flags are
+// emitted. 'branch' (default/omitted) is the existing #596 behavior;
+// 'staged'/'unstaged' open the crew's uncommitted working-tree changes and
+// drop --base/--last-turn, which have no meaning for those sources.
+describe("showDiff source mapping (#599)", () => {
+  const driver = createCmuxDriver();
+
+  beforeEach(() => {
+    execFileMock.mockReset();
+    execFileMock.mockImplementation(() => "");
+  });
+
+  it("defaults to --branch --base when source is omitted (#596 back-compat)", async () => {
+    await driver.showDiff!({ workspaceId: "workspace:1", cwd: "/repo", base: "develop" });
+    const args = argvOf(execFileMock.mock.calls[0]);
+    expect(args).toEqual(
+      expect.arrayContaining(["diff", "--branch", "--base", "develop", "--cwd", "/repo", "--workspace", "workspace:1"]),
+    );
+    expect(args).not.toContain("--staged");
+    expect(args).not.toContain("--unstaged");
+  });
+
+  it("source: 'staged' emits --staged and omits --branch/--base", async () => {
+    await driver.showDiff!({ workspaceId: "workspace:1", cwd: "/repo", base: "develop", source: "staged" });
+    const args = argvOf(execFileMock.mock.calls[0]);
+    expect(args).toContain("--staged");
+    expect(args).not.toContain("--branch");
+    expect(args).not.toContain("--base");
+  });
+
+  it("source: 'unstaged' emits --unstaged and omits --branch/--base", async () => {
+    await driver.showDiff!({ workspaceId: "workspace:1", cwd: "/repo", base: "develop", source: "unstaged" });
+    const args = argvOf(execFileMock.mock.calls[0]);
+    expect(args).toContain("--unstaged");
+    expect(args).not.toContain("--branch");
+    expect(args).not.toContain("--base");
+  });
+
+  it("--last-turn is dropped for staged/unstaged sources (meaningless there)", async () => {
+    await driver.showDiff!({ workspaceId: "workspace:1", cwd: "/repo", base: "develop", source: "staged", lastTurn: true });
+    const args = argvOf(execFileMock.mock.calls[0]);
+    expect(args).not.toContain("--last-turn");
+  });
+
+  it("--last-turn still applies to the default branch source", async () => {
+    await driver.showDiff!({ workspaceId: "workspace:1", cwd: "/repo", base: "develop", lastTurn: true });
+    const args = argvOf(execFileMock.mock.calls[0]);
+    expect(args).toContain("--last-turn");
+  });
+});

--- a/packages/workspaces/src/runtimes/cmux.ts
+++ b/packages/workspaces/src/runtimes/cmux.ts
@@ -710,16 +710,22 @@ export function createCmuxDriver(): RuntimeDriver {
       layout?: "split" | "unified";
       focus?: boolean;
       lastTurn?: boolean;
+      source?: "branch" | "staged" | "unstaged";
     }): Promise<void> {
-      const args = [
-        "diff", "--branch",
-        "--base", opts.base,
-        "--cwd", opts.cwd,
-        "--workspace", opts.workspaceId,
-        "--layout", opts.layout ?? "split",
-      ];
+      const source = opts.source ?? "branch";
+      const args = ["diff"];
+      if (source === "staged") {
+        args.push("--staged");
+      } else if (source === "unstaged") {
+        args.push("--unstaged");
+      } else {
+        args.push("--branch", "--base", opts.base);
+        // --last-turn refines the branch-vs-base surface (#596); it has no
+        // meaning against the staged/unstaged working-tree sources.
+        if (opts.lastTurn) args.push("--last-turn");
+      }
+      args.push("--cwd", opts.cwd, "--workspace", opts.workspaceId, "--layout", opts.layout ?? "split");
       if (opts.title) args.push("--title", opts.title);
-      if (opts.lastTurn) args.push("--last-turn");
       args.push(opts.focus === false ? "--no-focus" : "--focus");
       await cmux(args);
     },

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -228,6 +228,23 @@ This is the captain-side backstop: even if the completion-protocol imperative is
 
 When a crew sends you a status message via `squadrant runtime send <project> "<message>"`, it lands in your captain pane. Acknowledge, then update your handoff if a meaningful decision was made.
 
+### Handling CREW REVIEW (#599 review gate)
+
+CREW REVIEW is **unambiguous** — a crew ran `squadrant crew signal review` after committing its work to `crew/<name>`. Unlike CREW IDLE, this is never a stray heartbeat miss: the crew has explicitly paused and is waiting for your verdict. The task is **NOT terminal** — don't treat it like CREW DONE.
+
+On CREW REVIEW:
+
+1. **Open the diff** — `squadrant diff <project> <crew>` (branch-vs-base; the default is exactly the review surface). Use `--staged`/`--unstaged`/`--working` if you also want to peek at anything left uncommitted.
+2. **Classify:**
+
+| Diff looks | Captain action |
+|-----------|-----------------|
+| Good — matches the task, tests pass, no scope creep | `squadrant crew approve <project> <crew>` — pushes `crew/<name>` to origin, opens the PR, terminalizes DONE. |
+| Needs changes | `squadrant crew send <project> <crew> "<feedback>"` — the crew iterates, re-commits, and re-signals `review`. Loop until approved. |
+
+3. **Never auto-terminalize a CREW REVIEW yourself** by emitting `task.done` directly — always go through `squadrant crew approve` so the push+PR actually happens before the task closes.
+4. Do **not** re-send the original task or close the crew while it's awaiting review — `crew close` on a `review`-state task discards work that hasn't been pushed anywhere yet.
+
 ## When Crew Finishes
 
 After a crew task completes:


### PR DESCRIPTION
## Summary

Implements #599 on top of the merged #596 Phase 1 (`squadrant diff`).

**Phase A — live working-tree review** (thin extension of #596):
- `squadrant diff <project> <crew> --staged|--unstaged|--working` peeks at a crew's uncommitted working tree mid-task (VSCode's "Changes"/"Staged Changes" split), instead of only the branch-vs-base surface.
- `RuntimeDriver.showDiff` gains a `source: 'branch'|'staged'|'unstaged'` opt; the cmux driver maps it to `--staged`/`--unstaged`, dropping `--base`/`--last-turn` (meaningless for those sources). Default behavior is unchanged.

**Phase B — the review-gate handshake** (commit-then-review, decided model from the issue):
- New non-terminal `TaskState` `"review"` + `ControlEvent` `"task.review"`, wired through the *existing* signal/event lifecycle machinery — no new parallel system:
  - `squadrant crew signal review --message "..."` (parallel to `done`/`blocked`).
  - Daemon treats `review` as an `ATTENTION_STATE` (fires `CREW REVIEW`, same as `CREW BLOCKED`/`CREW DONE`) and a `REAPABLE_SURFACE_STATE` (a crew that signals review then dies doesn't strand the task forever).
  - `squadrant crew send` (existing feedback loop) now also clears `review` → `working` — the reject path needed no new code.
- New `squadrant crew approve <project> <crew>`: only valid on a `review`-state task — pushes `crew/<name>` to origin, opens the PR via `gh pr create`, then emits `task.done` to terminalize.
- Telegram: `task.review` classified into `alert_only` tier with its own `CREW REVIEW` line.
- Web dashboard: a `review` task groups into the existing "blocked" (needs-you) bucket.
- `captain-ops` skill: new "Handling CREW REVIEW" section — open the diff, classify, approve or send feedback; never auto-terminalize.

## Notes for the reviewer

- Branch is `crew/review-gate` (the crew's actual auto-assigned worktree branch), not the `feat/599-review-gate` name mentioned in the task — renaming mid-flight would have broken the crew's own task-tracking (`crewBranch(name)` convention the review-gate design itself relies on).
- `gitnexus_impact` on `formatMessage` (daemon/reduce.ts) came back **HIGH** risk (fans into `handle`/`sweep`/`reconcile` — 3 execution flows). This is structural to that function being the central notify dispatcher; the change here is purely additive (one new `switch` case, one new state added to two existing sets) with no modification to existing branches. Full daemon test suite (99 tests) still green.
- GSD (`/gsd:plan-phase`/`/gsd:execute-phase`) was requested in the task, but it was fully removed from this machine on 2026-07-08 (too slow for crew work per prior user feedback) — proceeded with direct TDD instead.

## Test plan

- [x] `pnpm build` — green (tsc -b + tsup)
- [x] `pnpm test` — 2172/2172 tests green across all packages
- [x] `node dist/index.js diff --help` shows `--staged`/`--unstaged`/`--working`
- [x] `node dist/index.js crew approve --help` / `crew signal --help` show the new command/state
- [x] New unit tests for: state-machine `task.review` reducer, daemon `CREW REVIEW` notify/reap/debounce, `crew send` review→working transition, `buildSignalRequest`/`runCrewSignal` review path, `runCrewApprove` (push/PR/terminalize + error paths), Telegram tier/format, web dashboard `review` bucket, cmux driver `showDiff` source mapping, `diff` command `--staged`/`--unstaged`/`--working` behavior