### PR TITLE
fix(cmux): squadrant diff — push --focus true, not bare --focus

### DIFF
--- a/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
+++ b/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
@@ -648,11 +648,19 @@ describe("cmux driver", () => {
   });
 
   describe("showDiff (#596)", () => {
+    // cmux's `diff` subcommand defines --focus <true|false> (value required);
+    // only --no-focus is a bare flag. A prior version of this assertion expected
+    // a bare "--focus", which passed here (execFile is mocked, so the args array
+    // is never handed to real cmux) but broke the actual CLI with
+    // "Error: --focus requires a value". Assert the value explicitly so this
+    // mock can't drift from cmux's real flag contract again.
     it("calls cmux diff --branch with base/cwd/workspace and defaults layout=split, focused", async () => {
       execFileMock.mockReturnValue("");
       await driver.showDiff!({ workspaceId: "workspace:10", cwd: "/repo/wt", base: "develop" });
       const cmd = cmdOf(execFileMock.mock.calls[0]);
-      expect(cmd).toBe("diff --branch --base develop --cwd /repo/wt --workspace workspace:10 --layout split --focus");
+      expect(cmd).toBe(
+        "diff --branch --base develop --cwd /repo/wt --workspace workspace:10 --layout split --focus true",
+      );
     });
 
     it("passes --layout unified when requested", async () => {

--- a/packages/workspaces/src/runtimes/cmux.ts
+++ b/packages/workspaces/src/runtimes/cmux.ts
@@ -726,7 +726,10 @@ export function createCmuxDriver(): RuntimeDriver {
       }
       args.push("--cwd", opts.cwd, "--workspace", opts.workspaceId, "--layout", opts.layout ?? "split");
       if (opts.title) args.push("--title", opts.title);
-      args.push(opts.focus === false ? "--no-focus" : "--focus");
+      // cmux's diff subcommand defines --focus <true|false> (value required);
+      // only --no-focus is bare.
+      if (opts.focus === false) args.push("--no-focus");
+      else args.push("--focus", "true");
       await cmux(args);
     },
 


### PR DESCRIPTION
Real defect in `squadrant diff`, found by dogfooding the merged #596/#599 feature.

## Bug
Running `squadrant diff <project> <crew> [--staged|--unstaged]` failed at runtime:
```
cmux diff ... --focus
Error: --focus requires a value
```
cmux's `diff` subcommand defines `--focus <true|false>` (value required); only `--no-focus` is bare. `showDiff()` pushed a bare `--focus`, so **every** `squadrant diff` that opened a viewer (branch AND staged/unstaged paths) was broken.

## Why CI stayed green
`cmux.test.ts` mocks the cmux invocation and asserted the buggy bare `--focus` in the args array — the mock never runs real cmux, so it validated the wrong shape. **Test-fidelity gap:** a green mock hid a command that fails against the real binary.

## Fix
```ts
if (opts.focus === false) args.push('--no-focus');
else args.push('--focus', 'true');
```
One line + comment. Test updated to assert `['--focus','true']`.

Covers both #596 (branch-vs-base) and #599 (staged/unstaged) — same code path.

🤖 crew `fix-focus` (claude)