### PR TITLE
diff: --pr, --base/--head/--against, and list+pick modes (#604)

### DIFF
--- a/packages/cli/src/commands/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/__tests__/diff.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { TaskRecord } from "@squadrant/shared";
-import { resolveDiffTarget, resolveDiffSources } from "../diff.js";
+import { resolveDiffTarget, resolveDiffSources, resolveDiffMode, buildCrewDiffStats, parseCrewPick } from "../diff.js";
 import type { DiffOptions } from "../diff.js";
 
 // ─── resolveDiffTarget (pure) ──────────────────────────────────────────────
@@ -82,6 +82,142 @@ describe("resolveDiffSources (#599)", () => {
   });
 });
 
+// ─── resolveDiffMode (#604) ─────────────────────────────────────────────────
+
+describe("resolveDiffMode (#604)", () => {
+  it("crew arg only → crew mode", () => {
+    expect(resolveDiffMode("fix-579", {})).toEqual({ mode: "crew", crew: "fix-579" });
+  });
+
+  it("--pr only → pr mode", () => {
+    expect(resolveDiffMode(undefined, { pr: "603" })).toEqual({ mode: "pr", pr: "603" });
+  });
+
+  it("--base + --head → refs mode", () => {
+    expect(resolveDiffMode(undefined, { base: "develop", head: "some/branch" })).toEqual({
+      mode: "refs",
+      base: "develop",
+      head: "some/branch",
+    });
+  });
+
+  it("--against <ref> → refs mode, base=ref, head=HEAD", () => {
+    expect(resolveDiffMode(undefined, { against: "develop" })).toEqual({
+      mode: "refs",
+      base: "develop",
+      head: "HEAD",
+    });
+  });
+
+  it("no crew, no flags → pick mode", () => {
+    expect(resolveDiffMode(undefined, {})).toEqual({ mode: "pick" });
+  });
+
+  it("crew + --pr → throws mutually-exclusive error", () => {
+    expect(() => resolveDiffMode("fix-579", { pr: "603" })).toThrow(/mutually exclusive/);
+  });
+
+  it("crew + --base → throws mutually-exclusive error", () => {
+    expect(() => resolveDiffMode("fix-579", { base: "develop", head: "x" })).toThrow(/mutually exclusive/);
+  });
+
+  it("--pr + --base → throws mutually-exclusive error", () => {
+    expect(() => resolveDiffMode(undefined, { pr: "603", base: "develop", head: "x" })).toThrow(/mutually exclusive/);
+  });
+
+  it("--against + --base → throws (ambiguous)", () => {
+    expect(() => resolveDiffMode(undefined, { against: "develop", base: "other" })).toThrow(/--against/);
+  });
+
+  it("--base without --head → throws (must be used together)", () => {
+    expect(() => resolveDiffMode(undefined, { base: "develop" })).toThrow(/--base and --head/);
+  });
+
+  it("--head without --base → throws (must be used together)", () => {
+    expect(() => resolveDiffMode(undefined, { head: "some/branch" })).toThrow(/--base and --head/);
+  });
+});
+
+// ─── buildCrewDiffStats (#604) ──────────────────────────────────────────────
+
+describe("buildCrewDiffStats (#604)", () => {
+  function makeLiveTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+    return {
+      id: "t1", project: "brove", provider: "claude", mode: "interactive", state: "working",
+      task: "fix", createdAt: 1, lastHeartbeat: 1, lastEvent: "task.started",
+      heartbeatBudgetMs: 300000, attempts: [], ...overrides,
+    };
+  }
+
+  it("filters out terminal-state tasks", () => {
+    const tasks = [
+      makeLiveTask({ name: "alive", state: "working" }),
+      makeLiveTask({ id: "t2", name: "dead", state: "done" }),
+    ];
+    const stats = buildCrewDiffStats(tasks, "/repo", "develop", () => "1 file changed");
+    expect(stats.map((s) => s.name)).toEqual(["alive"]);
+  });
+
+  it("dedups by name, keeping the most-recently-created record", () => {
+    const tasks = [
+      makeLiveTask({ id: "old", name: "fix-579", cwd: "/repo/.worktrees/old", createdAt: 100 }),
+      makeLiveTask({ id: "new", name: "fix-579", cwd: "/repo/.worktrees/new", createdAt: 200 }),
+    ];
+    const stats = buildCrewDiffStats(tasks, "/repo", "develop", () => "");
+    expect(stats).toHaveLength(1);
+    expect(stats[0].cwd).toBe("/repo/.worktrees/new");
+  });
+
+  it("falls back to projectPath when a task has no cwd", () => {
+    const tasks = [makeLiveTask({ name: "shared-crew", cwd: undefined })];
+    const stats = buildCrewDiffStats(tasks, "/repo", "develop", () => "");
+    expect(stats[0].cwd).toBe("/repo");
+  });
+
+  it("calls getStat with (cwd, base) and trims the result", () => {
+    const tasks = [makeLiveTask({ name: "fix-579", cwd: "/repo/.worktrees/fix-579" })];
+    const getStat = vi.fn().mockReturnValue("  1 file changed, 2 insertions(+)  \n");
+    const stats = buildCrewDiffStats(tasks, "/repo", "develop", getStat);
+    expect(getStat).toHaveBeenCalledWith("/repo/.worktrees/fix-579", "develop");
+    expect(stats[0].stat).toBe("1 file changed, 2 insertions(+)");
+  });
+
+  it("skips tasks with no name (unnamed/legacy records)", () => {
+    const tasks = [makeLiveTask({ name: undefined })];
+    expect(buildCrewDiffStats(tasks, "/repo", "develop", () => "")).toEqual([]);
+  });
+});
+
+// ─── parseCrewPick (#604) ───────────────────────────────────────────────────
+
+describe("parseCrewPick (#604)", () => {
+  const stats = [
+    { name: "fix-579", cwd: "/a", stat: "1 file" },
+    { name: "fix-580", cwd: "/b", stat: "2 files" },
+  ];
+
+  it("parses a 1-based numeric index", () => {
+    expect(parseCrewPick("1", stats)).toBe("fix-579");
+    expect(parseCrewPick("2", stats)).toBe("fix-580");
+  });
+
+  it("parses a crew name directly", () => {
+    expect(parseCrewPick("fix-580", stats)).toBe("fix-580");
+  });
+
+  it("throws on an out-of-range index", () => {
+    expect(() => parseCrewPick("3", stats)).toThrow(/Invalid selection/);
+  });
+
+  it("throws on an unknown name", () => {
+    expect(() => parseCrewPick("ghost", stats)).toThrow(/Invalid selection/);
+  });
+
+  it("throws on empty input", () => {
+    expect(() => parseCrewPick("", stats)).toThrow(/Invalid selection/);
+  });
+});
+
 // ─── diff command action (integration, mocked seams) ──────────────────────
 
 const loadConfig = vi.hoisted(() => vi.fn());
@@ -94,23 +230,36 @@ const squadrantdCall = vi.hoisted(() => vi.fn());
 vi.mock("../crew-control.js", () => ({ squadrantdCall }));
 
 const showDiff = vi.hoisted(() => vi.fn());
+const showPatch = vi.hoisted(() => vi.fn());
 const resolveCaptainWorkspace = vi.hoisted(() => vi.fn());
 vi.mock("@squadrant/workspaces", () => ({ resolveCaptainWorkspace }));
 
 const execFileSync = vi.hoisted(() => vi.fn());
 vi.mock("node:child_process", () => ({ execFileSync }));
 
+const readlineQuestion = vi.hoisted(() => vi.fn());
+vi.mock("node:readline", () => ({
+  default: {
+    createInterface: () => ({
+      question: (_q: string, cb: (a: string) => void) => cb(readlineQuestion()),
+      close: vi.fn(),
+    }),
+  },
+}));
+
 describe("diffCommand action", () => {
   beforeEach(() => {
     loadConfig.mockReset();
     squadrantdCall.mockReset();
     showDiff.mockReset();
+    showPatch.mockReset();
     resolveCaptainWorkspace.mockReset();
     execFileSync.mockReset();
-    resolveCaptainWorkspace.mockResolvedValue({ runtime: { name: "cmux", showDiff }, workspaceId: "workspace:1" });
+    readlineQuestion.mockReset();
+    resolveCaptainWorkspace.mockResolvedValue({ runtime: { name: "cmux", showDiff, showPatch }, workspaceId: "workspace:1" });
   });
 
-  async function runAction(project: string, crew: string, opts: Partial<DiffOptions> = {}) {
+  async function runAction(project: string, crew: string | undefined, opts: Partial<DiffOptions> = {}) {
     const { runDiff } = await import("../diff.js");
     await runDiff(project, crew, { layout: "split", focus: true, ...opts });
   }
@@ -247,5 +396,158 @@ describe("diffCommand action", () => {
     expect(logSpy).toHaveBeenCalledWith("No staged changes on crew/fix-579.");
     expect(showDiff).not.toHaveBeenCalled();
     logSpy.mockRestore();
+  });
+
+  // ── #604 mode 1: --pr <N> ──────────────────────────────────────────────
+
+  describe("--pr <N> (#604)", () => {
+    beforeEach(() => {
+      loadConfig.mockReturnValue({ projects: { brove: { path: "/repo", captainName: "brove-captain" } } });
+    });
+
+    it("runs `gh pr diff <n>` from the project path and feeds the patch to showPatch", async () => {
+      execFileSync.mockReturnValue("diff --git a/x b/x\n+hi\n");
+      await runAction("brove", undefined, { pr: "603" });
+      expect(execFileSync).toHaveBeenCalledWith("gh", ["pr", "diff", "603"], { cwd: "/repo", encoding: "utf-8" });
+      expect(showPatch).toHaveBeenCalledWith({
+        workspaceId: "workspace:1",
+        patch: "diff --git a/x b/x\n+hi\n",
+        title: "PR #603",
+        layout: "split",
+        focus: true,
+      });
+      expect(showDiff).not.toHaveBeenCalled();
+    });
+
+    it("prints a no-changes message and never opens the viewer when the PR patch is empty", async () => {
+      execFileSync.mockReturnValue("");
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      await runAction("brove", undefined, { pr: "603" });
+      expect(logSpy).toHaveBeenCalledWith("No changes in PR #603.");
+      expect(showPatch).not.toHaveBeenCalled();
+      logSpy.mockRestore();
+    });
+
+    it("throws a clear error when `gh pr diff` fails (unknown PR)", async () => {
+      execFileSync.mockImplementation(() => {
+        throw new Error("no pull requests found for branch");
+      });
+      await expect(runAction("brove", undefined, { pr: "9999" })).rejects.toThrow(
+        /Could not fetch PR #9999 diff/,
+      );
+      expect(showPatch).not.toHaveBeenCalled();
+    });
+
+    it("throws mutually-exclusive error when combined with a crew arg", async () => {
+      await expect(runAction("brove", "fix-579", { pr: "603" })).rejects.toThrow(/mutually exclusive/);
+      expect(squadrantdCall).not.toHaveBeenCalled();
+    });
+
+    it("errors clearly when the runtime has no showPatch capability", async () => {
+      resolveCaptainWorkspace.mockResolvedValue({ runtime: { name: "tmux" }, workspaceId: "workspace:1" });
+      await expect(runAction("brove", undefined, { pr: "603" })).rejects.toThrow(
+        "Runtime 'tmux' has no native patch viewer yet — Phase 1 supports cmux only.",
+      );
+    });
+  });
+
+  // ── #604 mode 2: --base/--head, --against alias ────────────────────────
+
+  describe("--base/--head and --against (#604)", () => {
+    beforeEach(() => {
+      loadConfig.mockReturnValue({ projects: { brove: { path: "/repo", captainName: "brove-captain" } } });
+    });
+
+    it("runs `git diff <base>...<head>` (merge-base form) and feeds the patch to showPatch", async () => {
+      execFileSync.mockReturnValue("diff --git a/y b/y\n+yo\n");
+      await runAction("brove", undefined, { base: "develop", head: "some/branch" });
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git", ["-C", "/repo", "diff", "develop...some/branch"], { encoding: "utf-8" },
+      );
+      expect(showPatch).toHaveBeenCalledWith({
+        workspaceId: "workspace:1",
+        patch: "diff --git a/y b/y\n+yo\n",
+        title: "develop...some/branch",
+        layout: "split",
+        focus: true,
+      });
+    });
+
+    it("--against <ref> diffs <ref>...HEAD without needing --head", async () => {
+      execFileSync.mockReturnValue("diff --git a/z b/z\n+z\n");
+      await runAction("brove", undefined, { against: "develop" });
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git", ["-C", "/repo", "diff", "develop...HEAD"], { encoding: "utf-8" },
+      );
+      expect(showPatch).toHaveBeenCalledWith(expect.objectContaining({ title: "develop...HEAD" }));
+    });
+
+    it("prints a no-changes message and never opens the viewer when the ref diff is empty", async () => {
+      execFileSync.mockReturnValue("");
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      await runAction("brove", undefined, { base: "develop", head: "develop" });
+      expect(logSpy).toHaveBeenCalledWith("No changes in develop...develop.");
+      expect(showPatch).not.toHaveBeenCalled();
+      logSpy.mockRestore();
+    });
+
+    it("throws a clear error on a bad ref", async () => {
+      execFileSync.mockImplementation(() => {
+        throw new Error("unknown revision or path not in the working tree");
+      });
+      await expect(runAction("brove", undefined, { base: "ghost-ref", head: "develop" })).rejects.toThrow(
+        /Could not diff ghost-ref\.\.\.develop/,
+      );
+    });
+
+    it("throws when --base is given without --head", async () => {
+      await expect(runAction("brove", undefined, { base: "develop" })).rejects.toThrow(/--base and --head/);
+      expect(squadrantdCall).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── #604 mode 3: no crew, no flags → list + pick ────────────────────────
+
+  describe("no crew, no flags — list + pick (#604 Phase 2 of #596)", () => {
+    beforeEach(() => {
+      loadConfig.mockReturnValue({ projects: { brove: { path: "/repo", captainName: "brove-captain" } } });
+    });
+
+    it("lists live crews with a diffstat, prompts, and opens the picked crew's diff", async () => {
+      squadrantdCall.mockResolvedValue([
+        { id: "t1", name: "fix-579", cwd: "/repo/.worktrees/fix-579", createdAt: 1, state: "working" },
+        { id: "t2", name: "fix-580", cwd: "/repo/.worktrees/fix-580", createdAt: 2, state: "working" },
+      ]);
+      execFileSync.mockImplementation((_bin: string, args: string[]) => {
+        if (args.includes("--stat")) {
+          return args.includes("/repo/.worktrees/fix-580") ? "2 files changed" : "1 file changed";
+        }
+        return "";
+      });
+      readlineQuestion.mockReturnValue("2");
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      await runAction("brove", undefined, {});
+      expect(logSpy).toHaveBeenCalledWith("Live crews for brove (vs develop):");
+      expect(showDiff).toHaveBeenCalledWith(expect.objectContaining({ cwd: "/repo/.worktrees/fix-580", title: "crew/fix-580 vs develop" }));
+      logSpy.mockRestore();
+    });
+
+    it("throws a clear error when there are no live crews", async () => {
+      squadrantdCall.mockResolvedValue([
+        { id: "t1", name: "done-crew", cwd: "/repo/.worktrees/done-crew", createdAt: 1, state: "done" },
+      ]);
+      await expect(runAction("brove", undefined, {})).rejects.toThrow(/No live crews for brove/);
+      expect(showDiff).not.toHaveBeenCalled();
+    });
+
+    it("throws a clear error on an invalid pick", async () => {
+      squadrantdCall.mockResolvedValue([
+        { id: "t1", name: "fix-579", cwd: "/repo/.worktrees/fix-579", createdAt: 1, state: "working" },
+      ]);
+      execFileSync.mockReturnValue("1 file changed");
+      readlineQuestion.mockReturnValue("99");
+      vi.spyOn(console, "log").mockImplementation(() => {});
+      await expect(runAction("brove", undefined, {})).rejects.toThrow(/Invalid selection/);
+    });
   });
 });

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -1,8 +1,10 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { execFileSync } from "node:child_process";
-import { loadConfig, crewBranch, resolveWorktreeBase } from "@squadrant/shared";
-import type { TaskRecord } from "@squadrant/shared";
+import readline from "node:readline";
+import { loadConfig, crewBranch, resolveWorktreeBase, TERMINAL_STATES } from "@squadrant/shared";
+import type { TaskRecord, ProjectConfig } from "@squadrant/shared";
+import type { RuntimeDriver } from "@squadrant/shared";
 import { resolveCaptainWorkspace } from "@squadrant/workspaces";
 import { squadrantdCall } from "./crew-control.js";
 
@@ -37,6 +39,13 @@ export interface DiffOptions {
   staged?: boolean;
   unstaged?: boolean;
   working?: boolean;
+  // #604: review a PR (`gh pr diff <n>`), mutually exclusive with crew/base/head.
+  pr?: string;
+  // #604: compare two arbitrary refs (`git diff base...head`). --against is an
+  // alias for --base that diffs against current HEAD (no --head needed).
+  base?: string;
+  head?: string;
+  against?: string;
 }
 
 // Pure. Which working-tree sources to open for the given flags, in display
@@ -49,13 +58,123 @@ export function resolveDiffSources(opts: DiffOptions): Array<"staged" | "unstage
   return [];
 }
 
-export async function runDiff(project: string, crew: string, opts: DiffOptions): Promise<void> {
-  const config = loadConfig();
-  const proj = config.projects[project];
-  if (!proj) {
-    throw new Error(`Project '${project}' not found. Run 'squadrant projects list'.`);
-  }
+export type DiffMode =
+  | { mode: "crew"; crew: string }
+  | { mode: "pr"; pr: string }
+  | { mode: "refs"; base: string; head: string }
+  | { mode: "pick" };
 
+/**
+ * Pure. Decides which of the four #604 modes a `squadrant diff` invocation
+ * requests, and validates they were not combined. `--against <ref>` is sugar
+ * for `--base <ref> --head HEAD` — diff the given ref against current HEAD
+ * without needing a second flag.
+ */
+export function resolveDiffMode(
+  crew: string | undefined,
+  opts: { pr?: string; base?: string; head?: string; against?: string },
+): DiffMode {
+  const requestedModes = [crew !== undefined, opts.pr !== undefined, opts.base !== undefined || opts.head !== undefined || opts.against !== undefined];
+  if (requestedModes.filter(Boolean).length > 1) {
+    throw new Error(
+      "squadrant diff: a crew argument, --pr, and --base/--head/--against are mutually exclusive.",
+    );
+  }
+  if (opts.against !== undefined && (opts.base !== undefined || opts.head !== undefined)) {
+    throw new Error("squadrant diff: --against cannot be combined with --base/--head.");
+  }
+  if (crew !== undefined) return { mode: "crew", crew };
+  if (opts.pr !== undefined) return { mode: "pr", pr: opts.pr };
+  if (opts.against !== undefined) return { mode: "refs", base: opts.against, head: "HEAD" };
+  if (opts.base !== undefined || opts.head !== undefined) {
+    if (opts.base === undefined || opts.head === undefined) {
+      throw new Error(
+        "squadrant diff: --base and --head must be used together (or use --against <ref> to diff against HEAD).",
+      );
+    }
+    return { mode: "refs", base: opts.base, head: opts.head };
+  }
+  return { mode: "pick" };
+}
+
+export interface CrewDiffStat {
+  name: string;
+  cwd: string;
+  stat: string;
+}
+
+/**
+ * Pure (given an injected `getStat`). Builds the pick-list for #604 mode 3:
+ * one entry per live (non-terminal) named crew, de-duped by name via the same
+ * most-recently-created tie-break as resolveDiffTarget/pickMostRecentTask.
+ */
+export function buildCrewDiffStats(
+  tasks: TaskRecord[],
+  projectPath: string,
+  base: string,
+  getStat: (cwd: string, base: string) => string,
+): CrewDiffStat[] {
+  const live = new Map<string, TaskRecord>();
+  for (const t of tasks) {
+    if (!t.name || TERMINAL_STATES.has(t.state)) continue;
+    const prev = live.get(t.name);
+    if (!prev || (t.createdAt ?? 0) > (prev.createdAt ?? 0)) live.set(t.name, t);
+  }
+  return [...live.values()].map((t) => {
+    const cwd = t.cwd ?? projectPath;
+    return { name: t.name!, cwd, stat: getStat(cwd, base).trim() };
+  });
+}
+
+/** Pure. Resolves a user's raw pick-list answer (1-based index or crew name) to a crew name. */
+export function parseCrewPick(raw: string, stats: CrewDiffStat[]): string {
+  const trimmed = raw.trim();
+  const idx = Number(trimmed);
+  if (Number.isInteger(idx) && idx >= 1 && idx <= stats.length) {
+    return stats[idx - 1].name;
+  }
+  const byName = stats.find((s) => s.name === trimmed);
+  if (byName) return byName.name;
+  throw new Error(`Invalid selection '${raw}'. Enter a number 1-${stats.length} or a crew name.`);
+}
+
+function promptLine(question: string): Promise<string> {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer);
+    });
+  });
+}
+
+/** `gh pr diff <n>` run from the project's root checkout (not a crew worktree — a PR is project-wide). */
+function getPrDiff(projectPath: string, pr: string): string {
+  try {
+    return execFileSync("gh", ["pr", "diff", pr], { cwd: projectPath, encoding: "utf-8" });
+  } catch (e) {
+    throw new Error(`Could not fetch PR #${pr} diff (gh pr diff failed): ${(e as Error).message}`);
+  }
+}
+
+/** `git diff <base>...<head>` (merge-base form, consistent with the crew branch-vs-base review). */
+function getRefsDiff(projectPath: string, base: string, head: string): string {
+  try {
+    return execFileSync("git", ["-C", projectPath, "diff", `${base}...${head}`], { encoding: "utf-8" });
+  } catch (e) {
+    throw new Error(`Could not diff ${base}...${head}: ${(e as Error).message}`);
+  }
+}
+
+/** Existing crew-review path (#596/#599): branch-vs-base or working-tree peek for one named crew. */
+async function openCrewDiff(
+  project: string,
+  proj: ProjectConfig,
+  crew: string,
+  opts: DiffOptions,
+  runtime: RuntimeDriver,
+  workspaceId: string,
+): Promise<void> {
   const tasks = (await squadrantdCall({ kind: "list", project })) as TaskRecord[];
   const target = resolveDiffTarget(tasks, crew, proj.path);
   if (!target) {
@@ -65,7 +184,6 @@ export async function runDiff(project: string, crew: string, opts: DiffOptions):
   const base = resolveWorktreeBase(proj.path);
   const branchLabel = crewBranch(crew);
 
-  const { runtime, workspaceId } = await resolveCaptainWorkspace(project);
   if (!runtime.showDiff) {
     throw new Error(`Runtime '${runtime.name}' has no native diff viewer yet — Phase 1 supports cmux only.`);
   }
@@ -125,10 +243,64 @@ export async function runDiff(project: string, crew: string, opts: DiffOptions):
   console.log(chalk.dim(`Opened ${branchLabel} vs ${base} in cmux diff.`));
 }
 
+export async function runDiff(project: string, crewArg: string | undefined, opts: DiffOptions): Promise<void> {
+  const config = loadConfig();
+  const proj = config.projects[project];
+  if (!proj) {
+    throw new Error(`Project '${project}' not found. Run 'squadrant projects list'.`);
+  }
+
+  const mode = resolveDiffMode(crewArg, opts);
+  const { runtime, workspaceId } = await resolveCaptainWorkspace(project);
+
+  if (mode.mode === "pr" || mode.mode === "refs") {
+    if (!runtime.showPatch) {
+      throw new Error(`Runtime '${runtime.name}' has no native patch viewer yet — Phase 1 supports cmux only.`);
+    }
+    const title = mode.mode === "pr" ? `PR #${mode.pr}` : `${mode.base}...${mode.head}`;
+    const patch = mode.mode === "pr" ? getPrDiff(proj.path, mode.pr) : getRefsDiff(proj.path, mode.base, mode.head);
+    if (!patch.trim()) {
+      console.log(`No changes in ${title}.`);
+      return;
+    }
+    await runtime.showPatch({ workspaceId, patch, title, layout: opts.layout, focus: opts.focus });
+    console.log(chalk.dim(`Opened ${title} in cmux diff.`));
+    return;
+  }
+
+  let crew: string;
+  if (mode.mode === "pick") {
+    const tasks = (await squadrantdCall({ kind: "list", project })) as TaskRecord[];
+    const base = resolveWorktreeBase(proj.path);
+    const stats = buildCrewDiffStats(tasks, proj.path, base, (cwd, b) => {
+      try {
+        return execFileSync("git", ["-C", cwd, "diff", "--stat", `${b}...HEAD`], { encoding: "utf-8" });
+      } catch {
+        return "";
+      }
+    });
+    if (stats.length === 0) {
+      throw new Error(`No live crews for ${project}. Run 'squadrant crew list ${project}' to check, or 'squadrant crew spawn' one.`);
+    }
+    console.log(`Live crews for ${project} (vs ${base}):`);
+    stats.forEach((s, i) => console.log(`  ${i + 1}. ${s.name} — ${s.stat || "no changes"}`));
+    const raw = await promptLine("Pick a crew to diff (number or name): ");
+    crew = parseCrewPick(raw, stats);
+  } else {
+    crew = mode.crew;
+  }
+
+  await openCrewDiff(project, proj, crew, opts, runtime, workspaceId);
+}
+
 export const diffCommand = new Command("diff")
-  .description("Open a crew's branch diff in cmux's native diff viewer — no VSCode required (#596)")
+  .description("Open a crew's branch diff, a PR, or a ref comparison in cmux's native diff viewer — no VSCode required (#596/#604)")
   .argument("<project>", "Project name (must be registered)")
-  .argument("<crew>", "Crew name (e.g. crew-1)")
+  .argument("[crew]", "Crew name (e.g. crew-1); omit with no other flags to pick from live crews")
+  .option("--pr <n>", "Review a PR: wraps `gh pr diff <n>` (mutually exclusive with crew/--base/--head)")
+  .option("--base <ref>", "Base ref for a --head ref comparison (merge-base diff)")
+  .option("--head <ref>", "Head ref for a --base ref comparison")
+  .option("--against <ref>", "Alias: diff <ref>...HEAD (mutually exclusive with --base/--head)")
   .option("--layout <mode>", "split (default) or unified", "split")
   .option("--last-turn", "diff only changes since the crew's last agent turn", false)
   .option("--no-focus", "open the diff pane without stealing focus")

--- a/packages/shared/src/types/runtime.ts
+++ b/packages/shared/src/types/runtime.ts
@@ -104,4 +104,18 @@ export interface RuntimeDriver {
     // mid-task, before it has committed anything to review.
     source?: "branch" | "staged" | "unstaged";
   }): Promise<void>;
+
+  // Render a patch string (not a git source) in the runtime's native diff
+  // surface (#604). Used for `squadrant diff --pr <N>` (gh pr diff output) and
+  // `--base/--head` (merge-base diff output) — both produce a self-contained
+  // patch with no associated cwd/base ref, unlike showDiff's git-source review.
+  // cmux: pipes the patch to `cmux diff -` via stdin. Optional: runtimes
+  // without a native diff viewer simply omit it.
+  showPatch?(opts: {
+    workspaceId: string;
+    patch: string;      // unified diff / patch text (e.g. `gh pr diff` or `git diff` output)
+    title?: string;
+    layout?: "split" | "unified";
+    focus?: boolean;
+  }): Promise<void>;
 }

--- a/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
+++ b/packages/workspaces/src/runtimes/__tests__/cmux.test.ts
@@ -5,9 +5,15 @@ import { createCmuxDriver, sanitizeForCmuxSend, parseDraftFromScreen, hasModalOp
 import { DeferDelivery } from "@squadrant/core";
 
 const execFileMock = vi.hoisted(() => vi.fn());
+// showPatch (#604) pipes its patch to the child's stdin instead of an argv
+// entry — captured here so tests can assert the patch text was actually
+// written, not just that some args were passed.
+const stdinEndMock = vi.hoisted(() => vi.fn());
 vi.mock("node:child_process", () => ({
   // Bridge: execFileMock is kept synchronous so assertions on mock.calls stay
   // unchanged; this wrapper adapts it to the callback-based execFile signature.
+  // Returns a fake ChildProcess (stdin.end only) — real execFile's async
+  // return value is the child process, and showPatch writes to its stdin.
   execFile: (bin: string, args: string[], opts: unknown, cb: (err: Error | null, stdout: string) => void) => {
     try {
       const result = execFileMock(bin, args, opts);
@@ -15,6 +21,7 @@ vi.mock("node:child_process", () => ({
     } catch (err) {
       cb(err as Error, "");
     }
+    return { stdin: { end: stdinEndMock } };
   },
 }));
 
@@ -702,6 +709,50 @@ describe("cmux driver", () => {
       await driver.showDiff!({ workspaceId: "workspace:10", cwd: "/repo/wt", base: "develop" });
       expect(argvOf(execFileMock.mock.calls[0])).not.toContain("--last-turn");
     });
+  });
+});
+
+describe("showPatch (#604)", () => {
+  const driver = createCmuxDriver();
+
+  beforeEach(() => {
+    execFileMock.mockReset();
+    stdinEndMock.mockReset();
+    execFileMock.mockReturnValue("");
+  });
+
+  it("pipes the patch to `cmux diff -` via stdin — not as an argv entry", async () => {
+    await driver.showPatch!({ workspaceId: "workspace:10", patch: "diff --git a/x b/x\n+hi\n" });
+    expect(cmdOf(execFileMock.mock.calls[0])).toBe(
+      "diff - --workspace workspace:10 --layout split --focus true",
+    );
+    expect(stdinEndMock).toHaveBeenCalledWith("diff --git a/x b/x\n+hi\n");
+  });
+
+  it("passes --layout unified when requested", async () => {
+    await driver.showPatch!({ workspaceId: "workspace:10", patch: "p", layout: "unified" });
+    const args = argvOf(execFileMock.mock.calls[0]);
+    expect(args).toContain("unified");
+    expect(args).not.toContain("split");
+  });
+
+  it("passes --no-focus when focus:false", async () => {
+    await driver.showPatch!({ workspaceId: "workspace:10", patch: "p", focus: false });
+    const args = argvOf(execFileMock.mock.calls[0]);
+    expect(args).toContain("--no-focus");
+    expect(args).not.toContain("--focus");
+  });
+
+  it("includes --title only when a title is given (no literal 'undefined' arg)", async () => {
+    await driver.showPatch!({ workspaceId: "workspace:10", patch: "p" });
+    expect(argvOf(execFileMock.mock.calls[0])).not.toContain("--title");
+
+    execFileMock.mockReset();
+    execFileMock.mockReturnValue("");
+    await driver.showPatch!({ workspaceId: "workspace:10", patch: "p", title: "PR #603" });
+    const args = argvOf(execFileMock.mock.calls[0]);
+    expect(args).toContain("--title");
+    expect(args).toContain("PR #603");
   });
 });
 

--- a/packages/workspaces/src/runtimes/cmux.ts
+++ b/packages/workspaces/src/runtimes/cmux.ts
@@ -62,6 +62,30 @@ function cmux(args: string[]): Promise<string> {
   });
 }
 
+// Same as cmux() but writes `input` to the child's stdin before it exits —
+// used by showPatch (#604) for cmux's stdin-based diff mode (`cmux diff -`).
+// execFile's callback form still returns the underlying ChildProcess
+// synchronously, so its stdin is available immediately.
+function cmuxStdin(args: string[], input: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = execFile(
+      resolveCmuxBin(),
+      args,
+      { encoding: "utf-8", timeout: CMUX_TIMEOUT, env: { ...process.env, CMUX_QUIET: "1" } },
+      (err, stdout) => {
+        if (err) {
+          reject((err as NodeJS.ErrnoException).code === "ETIMEDOUT"
+            ? new CmuxTimeoutError(args.join(" "))
+            : err);
+          return;
+        }
+        resolve((stdout as string).trim());
+      },
+    );
+    child.stdin!.end(input);
+  });
+}
+
 // Shape of `cmux workspace list --json` (cmux 0.64.16). Only the fields we
 // consume are typed; everything else in the payload is ignored.
 interface CmuxWorkspaceListJson {
@@ -731,6 +755,21 @@ export function createCmuxDriver(): RuntimeDriver {
       if (opts.focus === false) args.push("--no-focus");
       else args.push("--focus", "true");
       await cmux(args);
+    },
+
+    async showPatch(opts: {
+      workspaceId: string;
+      patch: string;
+      title?: string;
+      layout?: "split" | "unified";
+      focus?: boolean;
+    }): Promise<void> {
+      const args = ["diff", "-", "--workspace", opts.workspaceId, "--layout", opts.layout ?? "split"];
+      if (opts.title) args.push("--title", opts.title);
+      // Same --focus <true|false> contract as showDiff (#603): only --no-focus is bare.
+      if (opts.focus === false) args.push("--no-focus");
+      else args.push("--focus", "true");
+      await cmuxStdin(args, opts.patch);
     },
 
     async listSurfaces(workspaceId: string): Promise<PaneRef[]> {


### PR DESCRIPTION
## Summary
- `squadrant diff <project> --pr <N>` — wraps `gh pr diff <N>` and feeds the patch to cmux's stdin diff (`cmux diff -`).
- `squadrant diff <project> --base <A> --head <B>` (alias `--against <ref>` = base vs current HEAD) — merge-base `git diff <A>...<B>` piped the same way.
- `squadrant diff <project>` (no crew, no flags) — Phase 2 of #596: lists live crews with a diffstat, prompts an interactive pick, then opens that crew's diff via the existing crew-review path.
- New `RuntimeDriver.showPatch` seam, distinct from the git-source `showDiff`; cmux impl pipes the patch to `cmux diff -` via stdin (`execFile` + `child.stdin.end()`).
- `<crew>` is now optional; the three new modes are validated mutually exclusive with each other and with the crew arg.
- Honors the #603 `--focus true` fix and `--layout` passthrough.

## Test plan
- [x] `pnpm build` — clean
- [x] `pnpm test` — 2210/2210 passing (172 files)
- [x] `node dist/index.js diff --help` shows `--pr`/`--base`/`--head`/`--against`
- [x] New unit tests: `resolveDiffMode`, `buildCrewDiffStats`, `parseCrewPick` (pure, TDD'd)
- [x] New `showPatch` cmux driver tests assert exact argv AND that the patch is written to the child's stdin (not just loosely mocked — per the #603 lesson)
- [x] Integration tests for `--pr` (happy path, empty patch, unknown PR, runtime-lacks-showPatch), `--base/--head`/`--against` (happy path, empty diff, bad ref, base-without-head), and list+pick (happy path, no live crews, invalid pick)
- [x] GitNexus impact analysis on `runDiff`/`showDiff` before editing: LOW risk, 0 upstream callers
- [x] GitNexus `detect_changes`: LOW risk, only expected symbols touched