### PR TITLE
fix(state-machine): enforce review gate at the transition (#605)

### DIFF
--- a/packages/cli/src/commands/__tests__/crew-approve.test.ts
+++ b/packages/cli/src/commands/__tests__/crew-approve.test.ts
@@ -88,7 +88,7 @@ describe("runCrewApprove (#599)", () => {
     );
   });
 
-  it("pushes the branch, opens the PR, then emits task.done to terminalize", async () => {
+  it("pushes the branch, opens the PR, then emits task.done with source:'approve' to terminalize (#605)", async () => {
     const call = vi.fn()
       .mockResolvedValueOnce([
         { id: "t1", name: "fix-579", state: "review", cwd: "/repo/.worktrees/brove-fix-579", task: "add the flag", reviewNote: "done, tests green", createdAt: 1 },
@@ -109,7 +109,7 @@ describe("runCrewApprove (#599)", () => {
     expect(call).toHaveBeenLastCalledWith({
       kind: "event",
       project: "brove",
-      event: { type: "task.done", id: "t1", resultRef: "", message: "Approved — PR opened: https://github.com/x/y/pull/42" },
+      event: { type: "task.done", id: "t1", resultRef: "", message: "Approved — PR opened: https://github.com/x/y/pull/42", source: "approve" },
     });
     expect(prUrl).toBe("https://github.com/x/y/pull/42");
   });

--- a/packages/cli/src/commands/crew-control.ts
+++ b/packages/cli/src/commands/crew-control.ts
@@ -292,7 +292,7 @@ export async function runCrewApprove(
   await deps.call({
     kind: "event",
     project,
-    event: { type: "task.done", id: task.id, resultRef: "", message: `Approved — PR opened: ${prUrl}` },
+    event: { type: "task.done", id: task.id, resultRef: "", message: `Approved — PR opened: ${prUrl}`, source: "approve" },
   });
 
   return prUrl;

--- a/packages/core/src/__tests__/daemon.test.ts
+++ b/packages/core/src/__tests__/daemon.test.ts
@@ -792,15 +792,28 @@ describe("daemon – blocked crew resume path (#183)", () => {
       expect(calls[0].message).toContain("addressed feedback");
     });
 
-    it("approve path: task.done from 'review' terminalizes to done and fires CREW DONE, not CREW REVIEW", async () => {
+    it("approve path: task.done with source:'approve' from 'review' terminalizes to done and fires CREW DONE, not CREW REVIEW", async () => {
       const store = createStore(dir);
       store.put(rec("t-rv4", { state: "review", reviewNote: "ready" }));
       const calls: any[] = [];
       const d = createDaemon({ store, now: () => 2000, notify: async (a) => { calls.push(a); } });
-      await d.handle({ kind: "event", project: "p", event: { type: "task.done", id: "t-rv4", resultRef: "", message: "Approved — PR opened: https://x/1" } });
+      await d.handle({ kind: "event", project: "p", event: { type: "task.done", id: "t-rv4", resultRef: "", message: "Approved — PR opened: https://x/1", source: "approve" } });
       expect(store.get("p", "t-rv4")?.state).toBe("done");
       expect(calls).toHaveLength(1);
       expect(calls[0].message).toContain("CREW DONE");
+    });
+
+    // #605: the review gate must be ENFORCING — a crew's own completion-protocol
+    // task.done (no provenance) must not bypass 'review', or `crew approve`
+    // becomes unreachable (state already 'done').
+    it("crew-originated task.done (no source) from 'review' is vetoed — stays review, no CREW DONE", async () => {
+      const store = createStore(dir);
+      store.put(rec("t-rv6", { state: "review", reviewNote: "ready" }));
+      const calls: any[] = [];
+      const d = createDaemon({ store, now: () => 2000, notify: async (a) => { calls.push(a); } });
+      await d.handle({ kind: "event", project: "p", event: { type: "task.done", id: "t-rv6", resultRef: "" } });
+      expect(store.get("p", "t-rv6")?.state).toBe("review");
+      expect(calls).toHaveLength(0);
     });
 
     it("review is debounced the same as every other attention state EXCEPT awaiting-input — never suppressed near a captain turn", async () => {

--- a/packages/core/src/__tests__/state-machine.test.ts
+++ b/packages/core/src/__tests__/state-machine.test.ts
@@ -104,10 +104,24 @@ describe("state-machine reduce", () => {
     expect(next.state).toBe("working");
   });
 
-  it("review + task.done (captain approve path) → done", () => {
+  // #605: the review gate must be ENFORCING, not advisory. A crew's own
+  // completion-protocol task.done (no provenance) must not bypass review —
+  // only `squadrant crew approve`'s task.done (source: 'approve') terminalizes.
+  it("review + crew-originated task.done (no source) → stays review, vetoed (#605)", () => {
     const next = reduce(rec({ state: "review", reviewNote: "ready" }), { type: "task.done", id: "t1", resultRef: "/r" }, 5200);
+    expect(next.state).toBe("review");
+    expect(next.reviewNote).toBe("ready");
+  });
+
+  it("review + task.done with source: 'approve' (captain approve path) → done", () => {
+    const next = reduce(rec({ state: "review", reviewNote: "ready" }), { type: "task.done", id: "t1", resultRef: "/r", source: "approve" }, 5200);
     expect(next.state).toBe("done");
     expect(next.resultRef).toBe("/r");
+  });
+
+  it("review + task.turn.started (crew resumes after feedback) → working (#605)", () => {
+    const next = reduce(rec({ state: "review", reviewNote: "ready" }), { type: "task.turn.started", id: "t1", turnId: "ses_x" }, 5300);
+    expect(next.state).toBe("working");
   });
 
   it("review clears pendingTool (mirrors task.blocked's turn-boundary reset)", () => {

--- a/packages/core/src/state-machine.ts
+++ b/packages/core/src/state-machine.ts
@@ -102,6 +102,17 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
       // or `crew approve` (task.done) are the only ways out.
       return { ...base, state: "review", reviewNote: ev.message, pendingTool: undefined };
     case "task.done":
+      // #605: the review gate must be ENFORCING, not advisory. A crew's normal
+      // completion protocol always signals done at turn end — if that alone
+      // could terminalize a task sitting in 'review', the gate is bypassed by
+      // crew habit and `crew approve` becomes unreachable (state is already
+      // 'done'). Per #492: gate at the transition, not on crew discipline.
+      // Only `squadrant crew approve`'s task.done (source: 'approve') is a
+      // distinct terminal channel the veto does not block; any other task.done
+      // while in review is liveness-only and the record stays in review.
+      if (rec.state === "review" && ev.source !== "approve") {
+        return { ...rec, lastHeartbeat: now, lastEvent: ev.type };
+      }
       return { ...base, state: "done", resultRef: ev.resultRef, parseWarning: ev.parseWarning };
     case "task.failed":
       return { ...base, state: "failed", error: ev.error, exitCode: ev.exitCode };

--- a/packages/shared/src/types/control.ts
+++ b/packages/shared/src/types/control.ts
@@ -112,7 +112,12 @@ export type ControlEvent =
   // before it is pushed/PR'd. `message` is an optional crew summary (parity
   // with task.done's optional message).
   | { type: "task.review"; id: string; message?: string }
-  | { type: "task.done"; id: string; resultRef: string; message?: string; parseWarning?: boolean }
+  // #605: `source: 'approve'` is the review-gate's distinct terminal channel —
+  // stamped only by `squadrant crew approve` (runCrewApprove). reduce() vetoes
+  // any OTHER task.done while state === 'review' (a crew's own completion
+  // protocol), so the gate can't be bypassed by crew habit; approve's stamped
+  // done is the one path the veto lets through.
+  | { type: "task.done"; id: string; resultRef: string; message?: string; parseWarning?: boolean; source?: "approve" }
   | { type: "task.failed"; id: string; error: string; exitCode?: number }
   | { type: "task.session"; id: string; resumeRef: string }
   | { type: "task.turn.started"; id: string; turnId: string }


### PR DESCRIPTION
## Summary
- The #599/#602 review gate was advisory: a crew's own completion-protocol `task.done` (crews are trained to signal done at turn end) unconditionally overrode `review` → `done`, so `crew approve` became unreachable (`state=done` already).
- Fixes at the state-machine transition per the #492 lesson (gate on authoritative state, not crew discipline): `reduce()` now vetoes any `task.done` while `state === 'review'` unless it carries `source: 'approve'`.
- `runCrewApprove` (the only caller that should terminalize from review) now stamps `source: 'approve'` on the `task.done` event it emits — a distinct terminal channel the veto doesn't block.
- Verified `task.turn.started` (crew resuming after captain feedback) still moves `review` → `working` unaffected — the veto is scoped to `task.done` only.

## Changes
- `packages/shared/src/types/control.ts`: add optional `source?: 'approve'` to the `task.done` event.
- `packages/core/src/state-machine.ts`: `reduce()` vetoes crew-originated `task.done` while in `review`.
- `packages/cli/src/commands/crew-control.ts`: `runCrewApprove` stamps `source: 'approve'`.
- Tests (TDD, written first): `state-machine.test.ts`, `daemon.test.ts`, `crew-approve.test.ts` — cover (a) review + crew done (no source) ⇒ stays review, (b) review + approve-done ⇒ done, (c) review + turn.started ⇒ working.

## Test plan
- [x] `pnpm build` green
- [x] `pnpm test` green — 172 files / 2213 tests
- [x] New failing tests written first (TDD), then implementation made them pass
- [x] Manually verified blast radius of `reduce()`/`runCrewApprove` (GitNexus index was stale for this worktree — 0 upstream callers reported for `reduce`, contradicted by direct grep showing it's the sole transition function used by every control-plane event via `daemon/reduce.ts:applyEvent`)

Closes #605