### PR TITLE
fix(state-machine): review-gate must survive ALL non-terminal events, not just task.done (#608)

### DIFF
--- a/packages/core/src/__tests__/state-machine.test.ts
+++ b/packages/core/src/__tests__/state-machine.test.ts
@@ -124,6 +124,36 @@ describe("state-machine reduce", () => {
     expect(next.state).toBe("working");
   });
 
+  // #608: review must be as sticky as blocked against every non-terminal
+  // turn-boundary/heartbeat event, not just task.done (#605 only closed
+  // that one path). A crew's normal turn-end (task.turn.completed) always
+  // fires after signalling review — if that knocked the record out of
+  // review, `crew approve` becomes unreachable (state already moved on).
+  it("review + task.turn.completed does NOT auto-exit review (#608)", () => {
+    const next = reduce(
+      rec({ state: "review", reviewNote: "ready" }),
+      { type: "task.turn.completed", id: "t1", turnId: "ses_x" },
+      5400,
+    );
+    expect(next.state).toBe("review");
+    expect(next.reviewNote).toBe("ready");
+    expect(next.lastHeartbeat).toBe(5400); // liveness still updates
+  });
+
+  it("review + heartbeat does NOT auto-exit review (#608)", () => {
+    const next = reduce(rec({ state: "review", reviewNote: "ready" }), { type: "heartbeat", id: "t1" }, 5500);
+    expect(next.state).toBe("review");
+    expect(next.reviewNote).toBe("ready");
+    expect(next.lastHeartbeat).toBe(5500);
+  });
+
+  it("review + task.progress does NOT auto-exit review (#608)", () => {
+    const next = reduce(rec({ state: "review", reviewNote: "ready" }), { type: "task.progress", id: "t1" }, 5600);
+    expect(next.state).toBe("review");
+    expect(next.reviewNote).toBe("ready");
+    expect(next.lastHeartbeat).toBe(5600);
+  });
+
   it("review clears pendingTool (mirrors task.blocked's turn-boundary reset)", () => {
     const next = reduce(rec({ state: "working", pendingTool: { name: "Bash", since: 100 } }), { type: "task.review", id: "t1" }, 5000);
     expect(next.pendingTool).toBeUndefined();

--- a/packages/core/src/state-machine.ts
+++ b/packages/core/src/state-machine.ts
@@ -19,6 +19,17 @@ function stampAttempt(
 }
 
 /**
+ * #608: 'blocked' and 'review' are both attention states that pause a crew
+ * pending a human decision — neither may be knocked out by a liveness or
+ * turn-boundary event, only by their own explicit exits (reply/feedback or
+ * approve). Every stickiness guard below must treat them identically, or a
+ * future attention state repeats this bug a fourth time (#492 → #605 → #608).
+ */
+function isStickyAttention(state: TaskRecord["state"]): boolean {
+  return state === "blocked" || state === "review";
+}
+
+/**
  * #354: compute the next pendingTool marker for a task.progress liveness signal.
  * A PreToolUse (carried from the cmux events-bridge, with the tool name) opens a
  * tool-in-flight window; a PostToolUse or a new UserPromptSubmit closes it. Other
@@ -75,7 +86,7 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
       // From awaiting-input OR stalled: resume to working — the next real activity
       // (e.g. the matching PostToolUse) auto-clears a hung-tool warn instantly.
       const pendingTool = nextPendingTool(rec.pendingTool, ev, now);
-      if (rec.state === "blocked") return { ...rec, lastHeartbeat: now, lastEvent: ev.type, pendingTool };
+      if (isStickyAttention(rec.state)) return { ...rec, lastHeartbeat: now, lastEvent: ev.type, pendingTool };
       const b = { ...base, pendingTool };
       if (rec.state === "awaiting-input" || rec.state === "stalled") return { ...stampAttempt(b, {}, now), state: "working" };
       return stampAttempt(b, {}, now);
@@ -84,7 +95,7 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
       // Raw liveness ping — intentionally does NOT stamp the attempt so a late
       // heartbeat from a dead dispatch cannot mask stalls on the new one (#89).
       // From awaiting-input: resume to working (mirrors task.progress).
-      if (rec.state === "blocked") return { ...rec, lastHeartbeat: now, lastEvent: ev.type };
+      if (isStickyAttention(rec.state)) return { ...rec, lastHeartbeat: now, lastEvent: ev.type };
       if (rec.state === "awaiting-input") return { ...base, state: "working" };
       return base;
     case "task.blocked":
@@ -133,7 +144,10 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
       // (task.started via `crew send`) clears blocked. Mirrors task.progress: the
       // opencode SSE bridge emits task.turn.completed right after an explicit
       // `signal blocked`, and that trailing turn-end must not drop the question.
-      if (rec.state === "blocked") return { ...rec, lastHeartbeat: now, lastEvent: ev.type };
+      // #608: 'review' needs the identical guard — a crew's normal turn-end always
+      // fires right after `signal review`, and without this it fell through to
+      // 'awaiting-input' below, making `crew approve` unreachable.
+      if (isStickyAttention(rec.state)) return { ...rec, lastHeartbeat: now, lastEvent: ev.type };
       // #492: several parallel lifecycle sources (cmux store-file watch, native
       // claude hooks, cmux's forwarded event stream) each independently report
       // turn-end for the same crew. A stale/heuristic report can assert


### PR DESCRIPTION
## Summary
- #605 made `review` sticky only against `task.done` — every other non-terminal turn-boundary/heartbeat event (`task.turn.completed`, `heartbeat`, `task.progress`) still had (or could hit) the `blocked`-only guard, so a crew's normal turn-end knocked `review` down to `awaiting-input` and `crew approve` became unreachable.
- Factors a tiny `isStickyAttention(state)` helper (`blocked | review`) and uses it at every liveness-absorb guard in `reduce()` so the two attention states stay in lock-step — the actual behavioral fix is the `task.turn.completed` guard, since `task.progress`/`heartbeat` already preserved `review` implicitly (they never explicitly re-set state away from it).
- `task.turn.started` is untouched — it must still resume `review`/`blocked` to `working` for the feedback (`crew send`) path, per the invariant: while in `review`, only `crew approve` (`task.done` source:`approve` → `done`) or feedback (`crew send` → `task.turn.started` → `working`) exits.

Closes #608.

## Test plan
- [x] New failing-first tests in `state-machine.test.ts`: `review + task.turn.completed ⇒ still review`, `review + heartbeat ⇒ still review`, `review + task.progress ⇒ still review` (regression guards, already passed pre-fix), plus existing `review + task.turn.started ⇒ working` and `review + task.done{source:'approve'} ⇒ done` (#605 regression guard) still pass.
- [x] `pnpm build` — green
- [x] `pnpm test` — 172 files / 2216 tests green (full monorepo suite)