### PR TITLE
fix(#611): crew approve — PR title from commit subject, not raw task-prompt

### DIFF
--- a/packages/cli/src/commands/__tests__/crew-approve.test.ts
+++ b/packages/cli/src/commands/__tests__/crew-approve.test.ts
@@ -63,6 +63,7 @@ describe("runCrewApprove (#599)", () => {
       call: vi.fn().mockResolvedValue(undefined),
       pushBranch: vi.fn(),
       createPr: vi.fn().mockReturnValue("https://github.com/x/y/pull/1"),
+      getCommitSubject: vi.fn().mockReturnValue(""),
       ...deps,
     });
   }
@@ -103,7 +104,7 @@ describe("runCrewApprove (#599)", () => {
     expect(createPr).toHaveBeenCalledWith("/repo/.worktrees/brove-fix-579", {
       base: "develop",
       branch: "crew/fix-579",
-      title: "add the flag",
+      title: "done, tests green",
       body: "done, tests green",
     });
     expect(call).toHaveBeenLastCalledWith({
@@ -132,6 +133,46 @@ describe("runCrewApprove (#599)", () => {
     const pushBranch = vi.fn();
     await runAction("brove", "quick-fix", { call, pushBranch });
     expect(pushBranch).toHaveBeenCalledWith("/repo", "crew/quick-fix");
+  });
+
+  it("prefers the branch's last commit subject as the PR title (#611)", async () => {
+    const call = vi.fn()
+      .mockResolvedValueOnce([
+        { id: "t1", name: "fix-579", state: "review", cwd: "/repo/.worktrees/brove-fix-579", task: "REVIEW-GATE DEMO — long noisy task prompt", reviewNote: "done, tests green", createdAt: 1 },
+      ])
+      .mockResolvedValueOnce(undefined);
+    const createPr = vi.fn().mockReturnValue("https://x/1");
+    const getCommitSubject = vi.fn().mockReturnValue("fix: make review state sticky (#608)");
+
+    await runAction("brove", "fix-579", { call, createPr, getCommitSubject });
+
+    expect(getCommitSubject).toHaveBeenCalledWith("/repo/.worktrees/brove-fix-579");
+    expect(createPr).toHaveBeenCalledWith(
+      "/repo/.worktrees/brove-fix-579",
+      expect.objectContaining({ title: "fix: make review state sticky (#608)" }),
+    );
+  });
+
+  it("falls back to reviewNote when there is no commit subject", async () => {
+    const call = vi.fn()
+      .mockResolvedValueOnce([
+        { id: "t1", name: "fix-579", state: "review", cwd: "/repo", task: "long noisy task prompt", reviewNote: "done, tests green", createdAt: 1 },
+      ])
+      .mockResolvedValueOnce(undefined);
+    const createPr = vi.fn().mockReturnValue("https://x/1");
+    await runAction("brove", "fix-579", { call, createPr, getCommitSubject: vi.fn().mockReturnValue("") });
+    expect(createPr).toHaveBeenCalledWith("/repo", expect.objectContaining({ title: "done, tests green" }));
+  });
+
+  it("falls back to the task-prompt first line only as a last resort", async () => {
+    const call = vi.fn()
+      .mockResolvedValueOnce([
+        { id: "t1", name: "fix-579", state: "review", cwd: "/repo", task: "add the flag\nmore detail", createdAt: 1 },
+      ])
+      .mockResolvedValueOnce(undefined);
+    const createPr = vi.fn().mockReturnValue("https://x/1");
+    await runAction("brove", "fix-579", { call, createPr, getCommitSubject: vi.fn().mockReturnValue("") });
+    expect(createPr).toHaveBeenCalledWith("/repo", expect.objectContaining({ title: "add the flag" }));
   });
 
   it("never emits task.done when pushBranch throws (push failure aborts before terminalizing)", async () => {

--- a/packages/cli/src/commands/crew-control.ts
+++ b/packages/cli/src/commands/crew-control.ts
@@ -248,6 +248,18 @@ function defaultCreatePr(cwd: string, o: { base: string; branch: string; title: 
   ).trim();
 }
 
+/** Default commit-subject lookup: the crew worktree's last commit subject, or "" if unavailable. */
+function defaultGetCommitSubject(cwd: string): string {
+  try {
+    return execFileSync("git", ["-C", cwd, "log", "-1", "--format=%s"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
 /**
  * `squadrant crew approve` — the accept side of the #599 review gate. Only
  * valid on a task in 'review' state (set by `squadrant crew signal review`):
@@ -263,6 +275,7 @@ export async function runCrewApprove(
     call: (req: unknown) => Promise<unknown>;
     pushBranch?: (cwd: string, branch: string) => void;
     createPr?: (cwd: string, o: { base: string; branch: string; title: string; body: string }) => string;
+    getCommitSubject?: (cwd: string) => string;
   },
 ): Promise<string> {
   const config = loadConfig();
@@ -281,8 +294,13 @@ export async function runCrewApprove(
   const cwd = task.cwd ?? proj.path;
   const base = resolveWorktreeBase(proj.path);
   const branch = crewBranch(crew);
-  const title = (task.task ?? branch).split(/\r?\n/)[0].trim().slice(0, 100);
   const body = (task.reviewNote ?? task.task ?? "").trim();
+
+  const getCommitSubject = deps.getCommitSubject ?? defaultGetCommitSubject;
+  const commitSubject = getCommitSubject(cwd).trim();
+  const reviewNoteFirstLine = (task.reviewNote ?? "").split(/\r?\n/)[0].trim();
+  const taskFirstLine = (task.task ?? branch).split(/\r?\n/)[0].trim();
+  const title = (commitSubject || reviewNoteFirstLine || taskFirstLine).slice(0, 100);
 
   const pushBranch = deps.pushBranch ?? defaultPushBranch;
   const createPr = deps.createPr ?? defaultCreatePr;


### PR DESCRIPTION
Closes #611. `runCrewApprove` now derives the PR title from (1) the crew branch's last commit subject, (2) reviewNote first line, (3) task-prompt first line — in that order. `getCommitSubject` is dependency-injected for tests. Fixes the noisy titles seen on approve (e.g. PR #610 got the whole demo prompt as its title).

🤖 crew `fix611` (claude)