### PR TITLE
Fix GitHub issue #617 — make defer/stuck delivery diagnosable. Read it in full first: gh issue view 

### DIFF
--- a/packages/core/src/__tests__/delivery-loop.stuck-alert.test.ts
+++ b/packages/core/src/__tests__/delivery-loop.stuck-alert.test.ts
@@ -291,4 +291,90 @@ describe("delivery-loop stuck-delivery alert (#579/#484)", () => {
     texts = await rawMailboxTexts(stateRoot, project);
     expect(texts.filter((t) => t.includes("DELIVERY STUCK"))).toHaveLength(2);
   });
+
+  // #617: the stuck message hardcoded "an in-progress draft (or ghost text)
+  // in your input box" even when the actual blocker was a modal (#484) — an
+  // open AskUserQuestion/permission picker, not the operator's input box.
+  // Pointing the operator at the wrong place is actively misleading.
+  it("reports 'a modal question is open' when the blocker classification is modal, not the input-box wording (#617)", async () => {
+    const stateRoot = freshState();
+    const project = "zeta";
+    const captainName = `${project}-captain`;
+    mockConfig({ projects: { [project]: { captainName } } });
+    const store = createStore(stateRoot);
+    store.put({
+      id: "t1", project, provider: "claude", mode: "interactive",
+      state: "done", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000, attempts: [],
+    });
+    await appendToMailbox({
+      stateRoot, project, taskRecord: store.list(project)[0],
+      event: { type: "task.done", id: "t1" } as any,
+      message: "CREW DONE t1",
+    });
+    const livenessRegistry = new LivenessRegistry({ path: join(stateRoot, "live.json") });
+    livenessRegistry.apply({
+      project, role: "captain", pid: 123, sessionId: "s1",
+      startedAt: Date.now(), lastState: "start", lastSeenAt: Date.now(),
+      pidAlive: true, source: "runtime",
+    });
+
+    const cmux = {
+      listSurfaces: async () => [{ id: "s1", title: captainName, command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => `${captainName}> `,
+      send: async () => { throw new DeferDelivery(null, "modal"); },
+    };
+    const deliv = createDelivery({
+      stateRoot, store, livenessRegistry, log: () => {}, isPidAlive: () => true, opts: {},
+    } as any, cmux as any);
+
+    for (let i = 0; i < 6; i++) await deliv.deliveryTick!();
+
+    const texts = await rawMailboxTexts(stateRoot, project);
+    const alert = texts.find((t) => t.includes("DELIVERY STUCK"));
+    expect(alert).toContain("a modal question is open in your captain pane");
+    expect(alert).not.toContain("input box");
+  });
+
+  it("keeps the input-box wording when the blocker classification is draft/ghost (#617)", async () => {
+    const stateRoot = freshState();
+    const project = "eta";
+    const captainName = `${project}-captain`;
+    mockConfig({ projects: { [project]: { captainName } } });
+    const store = createStore(stateRoot);
+    store.put({
+      id: "t1", project, provider: "claude", mode: "interactive",
+      state: "done", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000, attempts: [],
+    });
+    await appendToMailbox({
+      stateRoot, project, taskRecord: store.list(project)[0],
+      event: { type: "task.done", id: "t1" } as any,
+      message: "CREW DONE t1",
+    });
+    const livenessRegistry = new LivenessRegistry({ path: join(stateRoot, "live.json") });
+    livenessRegistry.apply({
+      project, role: "captain", pid: 123, sessionId: "s1",
+      startedAt: Date.now(), lastState: "start", lastSeenAt: Date.now(),
+      pidAlive: true, source: "runtime",
+    });
+
+    let n = 0;
+    const cmux = {
+      listSurfaces: async () => [{ id: "s1", title: captainName, command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => `${captainName}> `,
+      send: async () => { throw new DeferDelivery(`typing-${n++}`, "draft"); },
+    };
+    const deliv = createDelivery({
+      stateRoot, store, livenessRegistry, log: () => {}, isPidAlive: () => true, opts: {},
+    } as any, cmux as any);
+
+    for (let i = 0; i < 6; i++) await deliv.deliveryTick!();
+
+    const texts = await rawMailboxTexts(stateRoot, project);
+    const alert = texts.find((t) => t.includes("DELIVERY STUCK"));
+    expect(alert).toContain("an in-progress draft (or ghost text) in your input box");
+  });
 });

--- a/packages/core/src/__tests__/delivery-loop.test.ts
+++ b/packages/core/src/__tests__/delivery-loop.test.ts
@@ -244,4 +244,94 @@ describe("delivery-loop", () => {
 
     vi.useRealTimers();
   });
+
+  // #617: the defer log line was `delivery seq=… kind=… outcome=deferred` —
+  // no project, no cause. Across a 57MB log with 8150 deferred lines there was
+  // no way to tell which project stalled or why. project= is already known in
+  // the loop; reason= is the classification sendToSurface already computed
+  // (DeferDelivery.reason) to decide to defer, not a new one.
+  it("logs project= and reason= on the defer outcome line (#617)", async () => {
+    const stateRoot = freshState();
+    const project = "gitnexus";
+    const captainName = `${project}-captain`;
+    const store = createStore(stateRoot);
+    store.put({
+      id: "t1", project, provider: "claude", mode: "interactive",
+      state: "done", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000, attempts: [],
+    });
+    await appendToMailbox({
+      stateRoot, project, taskRecord: store.list(project)[0],
+      event: { type: "task.done", id: "t1" } as any,
+      message: "CREW DONE t1",
+    });
+    const livenessRegistry = new LivenessRegistry({ path: join(stateRoot, "live.json") });
+    livenessRegistry.apply({
+      project, role: "captain", pid: 123, sessionId: "s1",
+      startedAt: Date.now(), lastState: "start", lastSeenAt: Date.now(),
+      pidAlive: true, source: "runtime",
+    });
+
+    const logs: string[] = [];
+    const cmux = {
+      listSurfaces: async () => [{ id: "s1", title: captainName, command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => `${captainName}> `,
+      send: async () => { throw new DeferDelivery(null, "modal"); },
+    };
+    const deliv = createDelivery({
+      stateRoot, store, livenessRegistry, log: (m: string) => logs.push(m), isPidAlive: () => true, opts: {},
+    } as any, cmux as any);
+
+    await deliv.deliveryTick!();
+
+    const deferLine = logs.find((l) => l.includes("outcome=deferred"));
+    expect(deferLine).toBeDefined();
+    expect(deferLine).toContain(`project=${project}`);
+    expect(deferLine).toContain("reason=modal");
+  });
+
+  // Logging every 1s tick for the full ~300-tick (~30min) maxDefers window
+  // would flood the log for no forensic gain once the cause is known — only
+  // the onset (1st defer) and every 30th tick after should log.
+  it("throttles the defer log line to the onset + every 30th tick, not every tick (#617)", async () => {
+    const stateRoot = freshState();
+    const project = "throttle-proj";
+    const captainName = `${project}-captain`;
+    const store = createStore(stateRoot);
+    store.put({
+      id: "t1", project, provider: "claude", mode: "interactive",
+      state: "done", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000, attempts: [],
+    });
+    await appendToMailbox({
+      stateRoot, project, taskRecord: store.list(project)[0],
+      event: { type: "task.done", id: "t1" } as any,
+      message: "CREW DONE t1",
+    });
+    const livenessRegistry = new LivenessRegistry({ path: join(stateRoot, "live.json") });
+    livenessRegistry.apply({
+      project, role: "captain", pid: 123, sessionId: "s1",
+      startedAt: Date.now(), lastState: "start", lastSeenAt: Date.now(),
+      pidAlive: true, source: "runtime",
+    });
+
+    let n = 0;
+    const logs: string[] = [];
+    const cmux = {
+      listSurfaces: async () => [{ id: "s1", title: captainName, command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => `${captainName}> `,
+      send: async () => { throw new DeferDelivery(`typing-${n++}`, "draft"); },
+    };
+    const deliv = createDelivery({
+      stateRoot, store, livenessRegistry, log: (m: string) => logs.push(m), isPidAlive: () => true, opts: {},
+    } as any, cmux as any);
+
+    for (let i = 0; i < 32; i++) await deliv.deliveryTick!();
+
+    const deferLines = logs.filter((l) => l.includes("outcome=deferred"));
+    // Tick 1 (onset) and tick 30 — not ticks 2-29 or 31-32.
+    expect(deferLines).toHaveLength(2);
+  });
 });

--- a/packages/core/src/daemon/delivery-loop.ts
+++ b/packages/core/src/daemon/delivery-loop.ts
@@ -296,7 +296,17 @@ export function createDelivery(
           log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=delivered`);
           await writeCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER, lastAckedSeq: entry.seq });
         } else {
-          log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=deferred`);
+          // #617: project+reason make a defer episode attributable after the
+          // fact (previously: no project, no cause — see issue). Logging every
+          // 1s tick for up to maxDefers (~300, ~30min) would flood the log for
+          // no forensic gain once the cause is known, so we log the onset
+          // (first defer of this seq) and then every 30th tick (~30s cadence)
+          // — enough resolution to correlate a later stuck/SIGTERM event
+          // without adding meaningful volume.
+          const { maxDeferCount } = d.stats();
+          if (maxDeferCount === 1 || maxDeferCount % 30 === 0) {
+            log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=deferred project=${project} reason=${result.reason}`);
+          }
           break;
         }
       }
@@ -327,9 +337,14 @@ export function createDelivery(
       const stuck = d.stats().stuck;
       if (stuck && !stuckNotified.has(project)) {
         stuckNotified.add(project);
-        const { maxDeferCount } = d.stats();
-        log(`delivery stuck project=${project} deferCount=${maxDeferCount}`);
-        const text = `⚠️ DELIVERY STUCK: an in-progress draft (or ghost text) in your input box has blocked pending notification(s) for ${maxDeferCount}+ retries. Your input is never touched — this keeps retrying safely and will deliver automatically once you submit or clear it.`;
+        const { maxDeferCount, reason } = d.stats();
+        log(`delivery stuck project=${project} deferCount=${maxDeferCount} reason=${reason ?? "unknown"}`);
+        // #617: report the actual blocker instead of always blaming the input
+        // box — a modal (#484) isn't a draft/ghost and pointing the operator at
+        // their input box is actively misleading when a question is open.
+        const text = reason === "modal"
+          ? `⚠️ DELIVERY STUCK: a modal question is open in your captain pane and has blocked pending notification(s) for ${maxDeferCount}+ retries. This keeps retrying safely and will deliver automatically once you answer or dismiss it.`
+          : `⚠️ DELIVERY STUCK: an in-progress draft (or ghost text) in your input box has blocked pending notification(s) for ${maxDeferCount}+ retries. Your input is never touched — this keeps retrying safely and will deliver automatically once you submit or clear it.`;
         appendCaptainMessage({ stateRoot, project, text, source: "daemon" })
           .catch((e) => log(`delivery stuck alert failed project=${project}: ${(e as Error).message}`));
         Promise.resolve(notifyFault(project, text))

--- a/packages/core/src/delivery/__tests__/captain-delivery.test.ts
+++ b/packages/core/src/delivery/__tests__/captain-delivery.test.ts
@@ -120,7 +120,7 @@ describe("CaptainDelivery.stats (B1 — read-only deferral visibility)", () => {
     await d.deliver({ seq: 1, message: "a" }, send);
     await d.deliver({ seq: 1, message: "a" }, send);
     await d.deliver({ seq: 2, message: "b" }, send);
-    expect(d.stats()).toEqual({ maxDeferCount: 2, stuck: false });
+    expect(d.stats()).toEqual({ maxDeferCount: 2, stuck: false, reason: "draft" });
   });
 
   it("flags stuck once the max in-flight defer count reaches maxDefers", async () => {
@@ -128,7 +128,7 @@ describe("CaptainDelivery.stats (B1 — read-only deferral visibility)", () => {
     const send = async () => { throw new DeferDelivery("draft"); };
     await d.deliver({ seq: 1, message: "a" }, send);
     await d.deliver({ seq: 1, message: "a" }, send);
-    expect(d.stats()).toEqual({ maxDeferCount: 2, stuck: true });
+    expect(d.stats()).toEqual({ maxDeferCount: 2, stuck: true, reason: "draft" });
   });
 
   it("clears a seq's defer count once it delivers", async () => {
@@ -139,5 +139,53 @@ describe("CaptainDelivery.stats (B1 — read-only deferral visibility)", () => {
     fail = false;
     await d.deliver({ seq: 1, message: "a" }, send);
     expect(d.stats()).toEqual({ maxDeferCount: 0, stuck: false });
+  });
+});
+
+// #617: defer/stuck delivery must be diagnosable — the daemon already decides
+// WHY a send deferred (modal per #484 / no-box per #268 / draft / stable-hold
+// per #302); deliver()/stats() must surface that existing classification
+// rather than the caller having to re-derive it.
+describe("CaptainDelivery deferral reason classification (#617)", () => {
+  it("surfaces the DeferDelivery reason verbatim for modal", async () => {
+    const d = new CaptainDelivery({ maxDefers: 300, stableProbePolls: 3 });
+    const send = async () => { throw new DeferDelivery(null, "modal"); };
+    const result = await d.deliver({ seq: 1, message: "a" }, send);
+    expect(result).toEqual({ deferred: true, reason: "modal" });
+    expect(d.stats().reason).toBe("modal");
+  });
+
+  it("surfaces the DeferDelivery reason verbatim for no-box", async () => {
+    const d = new CaptainDelivery({ maxDefers: 300, stableProbePolls: 3 });
+    const send = async () => { throw new DeferDelivery(null, "no-box"); };
+    const result = await d.deliver({ seq: 1, message: "a" }, send);
+    expect(result).toEqual({ deferred: true, reason: "no-box" });
+  });
+
+  it("classifies a fresh/changing draft as \"draft\" before it stabilizes", async () => {
+    const d = new CaptainDelivery({ maxDefers: 300, stableProbePolls: 2 });
+    const send = async () => { throw new DeferDelivery("typing", "draft"); };
+    const result = await d.deliver({ seq: 1, message: "a" }, send);
+    expect(result).toEqual({ deferred: true, reason: "draft" });
+  });
+
+  it("upgrades \"draft\" to \"stable\" once content holds byte-identical for stableProbePolls polls (#302 signal, not a new classifier)", async () => {
+    const d = new CaptainDelivery({ maxDefers: 300, stableProbePolls: 2 });
+    const send = async () => { throw new DeferDelivery("held-content", "draft"); };
+    const r1 = await d.deliver({ seq: 1, message: "a" }, send);
+    expect(r1).toEqual({ deferred: true, reason: "draft" });
+    const r2 = await d.deliver({ seq: 1, message: "a" }, send);
+    expect(r2).toEqual({ deferred: true, reason: "draft" }); // stableCount=1 < stableProbePolls=2
+    const r3 = await d.deliver({ seq: 1, message: "a" }, send);
+    expect(r3).toEqual({ deferred: true, reason: "stable" }); // stableCount=2 >= 2
+    expect(d.stats().reason).toBe("stable");
+  });
+
+  it("does not let a stable-content streak override modal — modal always wins regardless of content history", async () => {
+    const d = new CaptainDelivery({ maxDefers: 300, stableProbePolls: 1 });
+    const send = async () => { throw new DeferDelivery(null, "modal"); };
+    await d.deliver({ seq: 1, message: "a" }, send);
+    const result = await d.deliver({ seq: 1, message: "a" }, send);
+    expect(result).toEqual({ deferred: true, reason: "modal" });
   });
 });

--- a/packages/core/src/delivery/captain-delivery.ts
+++ b/packages/core/src/delivery/captain-delivery.ts
@@ -1,4 +1,4 @@
-import { DeferDelivery } from "./defer-delivery.js";
+import { DeferDelivery, type DeferReason } from "./defer-delivery.js";
 
 /**
  * #332: extracted defer-while-typing state machine (#258/#302).
@@ -14,7 +14,15 @@ export interface CaptainDeliveryOptions {
 }
 
 export type SendFn = (text: string, opts?: { probe?: boolean }) => Promise<void>;
-export type DeliverResult = { delivered: true } | { deferred: true };
+
+/** #617: the deferral classification surfaced for logging/alerting. Mostly the
+ *  DeferReason sendToSurface already decided (see defer-delivery.ts), plus
+ *  "stable" — CaptainDelivery's own byte-identical-across-polls signal (#302)
+ *  that upgrades a "draft" into the more precise "content stopped changing,
+ *  likely a paused human or a ghost, about to be probed" classification.
+ *  "unknown" covers a non-DeferDelivery throw, which carries no classification. */
+export type DeliverDeferReason = DeferReason | "stable" | "unknown";
+export type DeliverResult = { delivered: true } | { deferred: true; reason: DeliverDeferReason };
 
 /** Read-only deferral snapshot (B1 — dashboard visibility into #484/#466-class stalls). */
 export interface CaptainDeliveryStats {
@@ -23,6 +31,8 @@ export interface CaptainDeliveryStats {
   /** true once maxDeferCount has reached the configured maxDefers threshold — the same
    *  point at which delivery force-escalates to a probe send. */
   stuck: boolean;
+  /** Classification for the seq at maxDeferCount (#617). undefined when nothing is deferred. */
+  reason?: DeliverDeferReason;
 }
 
 /**
@@ -41,6 +51,7 @@ export class CaptainDelivery {
   private deferCounts = new Map<number, number>();
   private lastContent = new Map<number, string | null>();
   private stableCounts = new Map<number, number>();
+  private lastReason = new Map<number, DeliverDeferReason>();
 
   constructor(private readonly opts: CaptainDeliveryOptions) {}
 
@@ -78,6 +89,7 @@ export class CaptainDelivery {
       this.deferCounts.delete(seq);
       this.stableCounts.delete(seq);
       this.lastContent.delete(seq);
+      this.lastReason.delete(seq);
       return { delivered: true };
     } catch (e) {
       if (e instanceof DeferDelivery) {
@@ -85,23 +97,42 @@ export class CaptainDelivery {
         // Track content stability: byte-identical non-empty draft across
         // consecutive polls means the captain isn't actively typing (#302).
         const content = e.draft;
+        let stableCount: number;
         if (content && content === this.lastContent.get(seq)) {
-          this.stableCounts.set(seq, (this.stableCounts.get(seq) ?? 0) + 1);
+          stableCount = (this.stableCounts.get(seq) ?? 0) + 1;
+          this.stableCounts.set(seq, stableCount);
         } else {
+          stableCount = 0;
           this.stableCounts.set(seq, 0);
         }
         this.lastContent.set(seq, content);
-        return { deferred: true };
+        // #617: "stable" (byte-identical for stableProbePolls polls) is a more
+        // precise classification than the raw "draft" reason once it applies —
+        // it's the same signal that gates probe escalation just above, not a
+        // new classifier. modal/no-box always win: they don't depend on content.
+        const reason: DeliverDeferReason =
+          e.reason !== "draft" ? e.reason
+          : stableCount >= this.opts.stableProbePolls ? "stable"
+          : "draft";
+        this.lastReason.set(seq, reason);
+        return { deferred: true, reason };
       }
       // Non-DeferDelivery errors: don't advance cursor, retry next poll.
-      return { deferred: true };
+      this.lastReason.set(seq, "unknown");
+      return { deferred: true, reason: "unknown" };
     }
   }
 
   /** Read-only. Never mutates — safe to poll from the snapshot assembler every tick. */
   stats(): CaptainDeliveryStats {
     let maxDeferCount = 0;
-    for (const c of this.deferCounts.values()) if (c > maxDeferCount) maxDeferCount = c;
-    return { maxDeferCount, stuck: maxDeferCount >= this.opts.maxDefers };
+    let reason: DeliverDeferReason | undefined;
+    for (const [seq, c] of this.deferCounts) {
+      if (c > maxDeferCount) {
+        maxDeferCount = c;
+        reason = this.lastReason.get(seq);
+      }
+    }
+    return { maxDeferCount, stuck: maxDeferCount >= this.opts.maxDefers, reason };
   }
 }

--- a/packages/core/src/delivery/defer-delivery.ts
+++ b/packages/core/src/delivery/defer-delivery.ts
@@ -1,6 +1,16 @@
+/** #617: the classification sendToSurface already decides at each throw site —
+ *  surfaced so callers can log *why* a send deferred, not just that it did.
+ *  "no-box": input box not confirmed visible (overlay/unreadable screen, #268).
+ *  "modal": an AskUserQuestion/permission selection modal is open (#484).
+ *  "draft": a real (or not-yet-disambiguated) draft is present in the input box. */
+export type DeferReason = "no-box" | "modal" | "draft";
+
 /** Thrown by sendToSurface when the captain has a draft — delivery defers (#258/#302). */
 export class DeferDelivery extends Error {
-  constructor(public readonly draft: string | null = null) {
+  constructor(
+    public readonly draft: string | null = null,
+    public readonly reason: DeferReason = "draft",
+  ) {
     super("deferred: captain composing");
     this.name = "DeferDelivery";
   }

--- a/packages/workspaces/src/runtimes/cmux.ts
+++ b/packages/workspaces/src/runtimes/cmux.ts
@@ -654,7 +654,7 @@ export function createCmuxDriver(): RuntimeDriver {
       const draft = parseDraftFromScreen(screen);
 
       // null = box not confirmed visible → never keystroke into an overlay (#268).
-      if (draft === null) throw new DeferDelivery(null);
+      if (draft === null) throw new DeferDelivery(null, "no-box");
 
       // #484: an AskUserQuestion / permission-approval SELECTION MODAL — never
       // deliver into it, regardless of what parseDraftFromScreen returned or
@@ -664,7 +664,7 @@ export function createCmuxDriver(): RuntimeDriver {
       // against both) and would otherwise call deliver(), typing the message
       // and pressing Enter into the picker — auto-confirming whichever option
       // is highlighted.
-      if (hasModalOptionList(screen)) throw new DeferDelivery(null);
+      if (hasModalOptionList(screen)) throw new DeferDelivery(null, "modal");
 
       // Empty input — nothing to protect, deliver directly.
       if (draft === "") { await deliver(); return; }


### PR DESCRIPTION
Fixed #617: defer log line now has project=+reason= (throttled to onset+every 30th tick); stuck alert now says 'a modal question is open' vs the input-box wording, driven by the DeferDelivery classification already computed in sendToSurface (modal/no-box/draft) plus CaptainDelivery's existing stable-hold signal — no new classifier invented. 2 files changed (delivery-loop.ts, captain-delivery.ts) + defer-delivery.ts reason field + 2 cmux.ts throw-site labels. Added/extended tests in captain-delivery.test.ts, delivery-loop.test.ts, delivery-loop.stuck-alert.test.ts. Full pnpm build+test green (172 files, 2228 tests). Note: gitnexus_detect_changes returned stale/unrelated results (index behind by several commits, showed AGENTS.md/CLAUDE.md diffs not present in this worktree) — verified impact manually via gitnexus_impact pre-edit (all LOW risk) instead.