### PR TITLE
Fix Cluster A lifecycle bookkeeping bugs: GitHub issues #594 and #629. Both are the daemon failing t

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (4937 symbols, 7472 relationships, 175 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (5084 symbols, 7671 relationships, 177 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (4937 symbols, 7472 relationships, 175 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (5084 symbols, 7671 relationships, 177 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/packages/core/src/__tests__/daemon.test.ts
+++ b/packages/core/src/__tests__/daemon.test.ts
@@ -938,6 +938,39 @@ describe("daemon – blocked crew resume path (#183)", () => {
       expect(store.get("p", "t-flood")?.state).toBe("awaiting-input");
       expect(calls.filter((c) => c.message.includes("CREW IDLE"))).toHaveLength(1);
     });
+
+    // #594a: a crew that armed a background Monitor watch and then genuinely
+    // ends its turn (Stop hook, no tool in flight) is not "awaiting the
+    // captain" — it will self-resume on its own Monitor notification. Live
+    // evidence: real crew task 2506214d fired CREW IDLE 3x for the SAME turnId
+    // in a Stop→(auto-resume)→Stop poll loop, 23s and 76s apart, while polling
+    // for a background result — exactly this shape end-to-end.
+    it("a registered background Monitor absorbs a turn-end with ZERO CREW IDLE fires, and repeated Stop reports never flood (#594a)", async () => {
+      const store = createStore(dir);
+      store.put(rec("t-monitor", { state: "working" }));
+      const calls: any[] = [];
+      let nowMs = 100_000;
+      const d = createDaemon({ store, now: () => nowMs, notify: async (a) => { calls.push(a); } });
+      // Monitor is armed — its own PreToolUse/PostToolUse close almost
+      // immediately (unlike a hung tool), but the watch stays outstanding.
+      await d.handle({ kind: "event", project: "p", event: { type: "task.progress", id: "t-monitor", note: "agent.hook.PreToolUse", tool: "Monitor" } });
+      await d.handle({ kind: "event", project: "p", event: { type: "task.progress", id: "t-monitor", note: "posttooluse" } });
+      expect(store.get("p", "t-monitor")?.pendingMonitor).toBeDefined();
+      // Real, repeated Stop→auto-resume cycles land as separate turn.completed
+      // reports while the Monitor is still armed.
+      for (const t of [123_000, 199_000, 275_000]) {
+        nowMs = t;
+        await d.handle({ kind: "event", project: "p", event: { type: "task.turn.completed", id: "t-monitor", turnId: "poll-loop" } });
+      }
+      expect(store.get("p", "t-monitor")?.state).toBe("working");
+      expect(calls.filter((c) => c.message.includes("CREW IDLE"))).toHaveLength(0);
+
+      // Once the crew explicitly signals done, the Monitor exemption does not
+      // block real completion.
+      nowMs = 300_000;
+      await d.handle({ kind: "event", project: "p", event: { type: "task.done", id: "t-monitor", resultRef: "/r" } });
+      expect(store.get("p", "t-monitor")?.state).toBe("done");
+    });
   });
 
   it("awaiting-input + task.started → working + subsequent task.blocked fires CREW BLOCKED (#183)", async () => {
@@ -1155,6 +1188,71 @@ describe("sweep: task-timeout (#225)", () => {
     const timeoutCalls = calls.filter((c) => c.message.includes("CREW TIMEOUT")).length;
     expect(timeoutCalls).toBe(1);
     expect(store.get("p", "t378b")?.state).toBe("cancelled");
+  });
+
+  // ── #629: task-timeout must not cancel a crew awaiting captain review ────────
+  // Live evidence: task ce3113f0 (ctx-budget crew) entered 'review' at
+  // 2026-07-28T16:41:48Z, still correctly idle awaiting `crew approve`, and was
+  // cancelled by this exact ceiling at 2026-07-29T01:56:02Z ("CREW TIMEOUT ...
+  // wall-clock exceeded 8h ... state: review") — permanently closing the
+  // approve path (no push, no PR, no terminal DONE). 'review' (like 'blocked')
+  // is a sticky attention state awaiting a human decision with no natural time
+  // bound; the wall-clock ceiling exists to catch a crew stuck actually
+  // WORKING, not one that already finished and is correctly waiting.
+  it("does NOT cancel a task sitting in 'review' past the ceiling (#629)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    store.put(rec("t629a", {
+      state: "review", reviewNote: "ready for review", createdAt: 0,
+      lastHeartbeat: 1990, heartbeatBudgetMs: 86_400_000,
+    }));
+    const d = createDaemon({ store, now: () => 2000, taskTimeoutMs: 1_000, notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    const r = store.get("p", "t629a");
+    expect(r?.state).toBe("review");
+    expect(r?.lastEvent).not.toBe("sweep.task-timeout");
+    expect(calls.filter((c) => c.message.includes("CREW TIMEOUT"))).toHaveLength(0);
+  });
+
+  it("does NOT cancel a task sitting in 'blocked' past the ceiling (same sticky-attention family as #629)", async () => {
+    const store = createStore(dir);
+    store.put(rec("t629b", {
+      state: "blocked", question: "which env?", createdAt: 0,
+      lastHeartbeat: 1990, heartbeatBudgetMs: 86_400_000,
+    }));
+    const d = createDaemon({ store, now: () => 2000, taskTimeoutMs: 1_000 });
+    await d.sweep();
+    expect(store.get("p", "t629b")?.state).toBe("blocked");
+  });
+
+  it("still cancels a task genuinely stuck 'working' past the ceiling (#629 does not regress #225)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    store.put(rec("t629c", {
+      state: "working", createdAt: 0,
+      lastHeartbeat: 1990, heartbeatBudgetMs: 86_400_000,
+    }));
+    const d = createDaemon({ store, now: () => 2000, taskTimeoutMs: 1_000, notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    const r = store.get("p", "t629c");
+    expect(r?.state).toBe("cancelled");
+    expect(r?.lastEvent).toBe("sweep.task-timeout");
+  });
+
+  it("a 'review' task with a gone surface is still reaped (#599 liveness reap is unaffected by the #629 ceiling exemption)", async () => {
+    const store = createStore(dir);
+    store.put(rec("t629d", {
+      state: "review", mode: "interactive", reviewNote: "n", createdAt: 0,
+      lastHeartbeat: 1990, heartbeatBudgetMs: 86_400_000,
+    }));
+    const d = createDaemon({
+      store, now: () => 2000, taskTimeoutMs: 1_000,
+      isSurfaceAlive: async () => "gone" as const,
+    });
+    await d.sweep();
+    const r = store.get("p", "t629d");
+    expect(r?.state).toBe("cancelled");
+    expect(r?.lastEvent).toBe("sweep.surface-gone");
   });
 });
 

--- a/packages/core/src/__tests__/delivery-loop.test.ts
+++ b/packages/core/src/__tests__/delivery-loop.test.ts
@@ -5,9 +5,10 @@ import { join } from "node:path";
 import { createDelivery } from "../daemon/delivery-loop.js";
 import { createStore } from "../store.js";
 import { LivenessRegistry } from "../daemon/liveness-registry.js";
-import { appendCaptainMessage, appendToMailbox, readCursor } from "../mailbox.js";
+import { appendCaptainMessage, appendToMailbox, readCursor, mailboxStats } from "../mailbox.js";
 import { STALE_THRESHOLD_MS } from "../daemon/interactive-probe.js";
 import { DeferDelivery } from "../delivery/defer-delivery.js";
+import type { TaskRecord } from "@squadrant/shared";
 
 function freshState(): string {
   return mkdtempSync(join(tmpdir(), "deliv-"));
@@ -243,5 +244,114 @@ describe("delivery-loop", () => {
     expect(sent).not.toContain("daemon message");
 
     vi.useRealTimers();
+  });
+});
+
+// ── #594b: CREW IDLE (or any attention-state push) arriving for a task that ──
+// has already been closed. `firePush` decides to notify synchronously off a
+// TaskRecord snapshot, but `defaultNotify`'s mailbox write is awaited I/O — a
+// concurrent `crew close` (task.cancelled) can land on the daemon's store in
+// that gap, terminalizing the record. The already-in-flight notify has no way
+// to know that by the time it actually executes. Fix: re-check the daemon's
+// own CURRENT record right before writing to the mailbox, and drop a
+// notification that the authoritative state has since superseded — the same
+// "gate on the daemon's own evidence" shape as #492's pendingTool veto, applied
+// at the delivery chokepoint instead of the state-transition chokepoint (this
+// specific race survives the state machine's terminal-absorb guard because the
+// notify was already decided BEFORE the close event was even applied).
+describe("defaultNotify staleness guard (#594b)", () => {
+  function record(overrides: Partial<TaskRecord> = {}): TaskRecord {
+    return {
+      id: "t1", project: "demo", provider: "claude", mode: "interactive",
+      state: "awaiting-input", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "task.turn.completed", heartbeatBudgetMs: 1000, attempts: [],
+      ...overrides,
+    };
+  }
+
+  it("drops a CREW IDLE notify for a task that was closed in the gap before delivery", async () => {
+    const stateRoot = freshState();
+    const store = createStore(stateRoot);
+    const snapshot = record(); // what firePush decided to announce (awaiting-input)
+    // By the time defaultNotify actually runs, `crew close` has already
+    // terminalized the SAME task in the daemon's store.
+    store.put({ ...snapshot, state: "cancelled", lastEvent: "task.cancelled" });
+
+    const { defaultNotify } = createDelivery(
+      { stateRoot, store, log: () => {}, isPidAlive: () => true, opts: {} } as any,
+      undefined,
+    );
+    await defaultNotify({
+      project: "demo",
+      message: "CREW IDLE [claude/t1]: turn ended, awaiting your reply.",
+      record: snapshot,
+      event: { type: "task.turn.completed", id: "t1", turnId: "x" },
+    });
+
+    const stats = await mailboxStats(stateRoot, "demo");
+    expect(stats.maxSeq).toBe(0); // nothing was ever written to the inbox
+  });
+
+  it("still delivers a genuine notification when the task's current state matches the snapshot", async () => {
+    const stateRoot = freshState();
+    const store = createStore(stateRoot);
+    const snapshot = record();
+    store.put(snapshot); // no race — the store agrees with what we're announcing
+
+    const { defaultNotify } = createDelivery(
+      { stateRoot, store, log: () => {}, isPidAlive: () => true, opts: {} } as any,
+      undefined,
+    );
+    await defaultNotify({
+      project: "demo",
+      message: "CREW IDLE [claude/t1]: turn ended, awaiting your reply.",
+      record: snapshot,
+      event: { type: "task.turn.completed", id: "t1", turnId: "x" },
+    });
+
+    const stats = await mailboxStats(stateRoot, "demo");
+    expect(stats.maxSeq).toBe(1);
+  });
+
+  it("still delivers a genuine terminal notification (e.g. CREW DONE) even though the state IS terminal", async () => {
+    const stateRoot = freshState();
+    const store = createStore(stateRoot);
+    const snapshot = record({ state: "done", resultRef: "/r" });
+    store.put(snapshot); // the store agrees: this IS the done transition
+
+    const { defaultNotify } = createDelivery(
+      { stateRoot, store, log: () => {}, isPidAlive: () => true, opts: {} } as any,
+      undefined,
+    );
+    await defaultNotify({
+      project: "demo",
+      message: "CREW DONE [claude/t1]: finished.",
+      record: snapshot,
+      event: { type: "task.done", id: "t1", resultRef: "/r" },
+    });
+
+    const stats = await mailboxStats(stateRoot, "demo");
+    expect(stats.maxSeq).toBe(1);
+  });
+
+  it("delivers when the store has no record at all (e.g. purged) — fails open rather than silently dropping", async () => {
+    const stateRoot = freshState();
+    const store = createStore(stateRoot);
+    const snapshot = record();
+    // No store.put — the record is absent entirely.
+
+    const { defaultNotify } = createDelivery(
+      { stateRoot, store, log: () => {}, isPidAlive: () => true, opts: {} } as any,
+      undefined,
+    );
+    await defaultNotify({
+      project: "demo",
+      message: "CREW IDLE [claude/t1]: turn ended, awaiting your reply.",
+      record: snapshot,
+      event: { type: "task.turn.completed", id: "t1", turnId: "x" },
+    });
+
+    const stats = await mailboxStats(stateRoot, "demo");
+    expect(stats.maxSeq).toBe(1);
   });
 });

--- a/packages/core/src/__tests__/state-machine.test.ts
+++ b/packages/core/src/__tests__/state-machine.test.ts
@@ -319,6 +319,65 @@ describe("state-machine reduce", () => {
     expect(ended.pendingTool).toBeUndefined();
   });
 
+  // ── #594a: CREW IDLE flood — turn.completed while a registered background ──
+  // Monitor is still armed. Calling the `Monitor` tool arms a background watch
+  // and returns almost immediately (its own PreToolUse/PostToolUse close fast),
+  // but the watch itself keeps running and delivers async notifications later —
+  // during that gap the crew's own turn genuinely ends (Stop hook fires) with NO
+  // tool in flight. Squadrant must not read that as "awaiting the captain": the
+  // crew will self-resume on its own Monitor notification. Live evidence: a real
+  // brove-mobile crew (task 2506214d) fired CREW IDLE 3x for the SAME turnId
+  // while polling in a Stop→(auto-resume)→Stop loop, 23s and 76s apart.
+  it("task.progress PreToolUse for Monitor opens a pendingMonitor window", () => {
+    const next = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Monitor" }, 7000);
+    expect(next.pendingMonitor).toEqual({ since: 7000 });
+  });
+
+  it("Monitor's own PostToolUse does NOT close the pendingMonitor window (unlike pendingTool)", () => {
+    const open = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Monitor" }, 7000);
+    const afterPost = reduce(open, { type: "task.progress", id: "t1", note: "posttooluse" }, 7100);
+    expect(afterPost.pendingMonitor).toEqual({ since: 7000 }); // still armed
+    expect(afterPost.pendingTool).toBeUndefined(); // ordinary tool tracking closes as usual
+  });
+
+  it("task.turn.completed while a Monitor is armed is NOT trusted as a turn boundary (#594a)", () => {
+    const open = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Monitor" }, 7000);
+    const closed = reduce(open, { type: "task.progress", id: "t1", note: "posttooluse" }, 7100); // Monitor's own quick PostToolUse
+    const stillOpen = reduce(closed, { type: "task.turn.completed", id: "t1", turnId: "x" }, 8000);
+    expect(stillOpen.state).toBe("working"); // never flips to awaiting-input
+    expect(stillOpen.pendingMonitor).toEqual({ since: 7000 }); // watch window untouched
+    expect(stillOpen.lastHeartbeat).toBe(8000); // still counts as liveness
+  });
+
+  it("repeated contradicted task.turn.completed reports while Monitor is armed never re-enter awaiting-input (flood guard)", () => {
+    const armed = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Monitor" }, 7000);
+    let cur = reduce(armed, { type: "task.progress", id: "t1", note: "posttooluse" }, 7100);
+    for (const t of [8000, 8023000 - 8000000, 9000, 10000]) {
+      cur = reduce(cur, { type: "task.turn.completed", id: "t1", turnId: "x" }, t);
+      expect(cur.state).toBe("working");
+    }
+  });
+
+  it("a genuine turn boundary clears pendingMonitor on task.started", () => {
+    const armed = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Monitor" }, 7000);
+    const started = reduce(armed, { type: "task.started", id: "t1" }, 9000);
+    expect(started.pendingMonitor).toBeUndefined();
+  });
+
+  it("task.blocked and task.review clear pendingMonitor (mirrors pendingTool's turn-boundary reset)", () => {
+    const armed = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Monitor" }, 7000);
+    const blocked = reduce(armed, { type: "task.blocked", id: "t1", reason: "r", question: "q?" }, 8000);
+    expect(blocked.pendingMonitor).toBeUndefined();
+    const reviewed = reduce(armed, { type: "task.review", id: "t1", message: "done" }, 8000);
+    expect(reviewed.pendingMonitor).toBeUndefined();
+  });
+
+  it("once no Monitor is armed, a real task.turn.completed IS a real boundary", () => {
+    const next = reduce(rec({ state: "working" }), { type: "task.turn.completed", id: "t1", turnId: "x" }, 8000);
+    expect(next.state).toBe("awaiting-input");
+    expect(next.pendingMonitor).toBeUndefined();
+  });
+
   it("stalled + task.progress (matching PostToolUse) recovers to working AND clears pendingTool (#354 auto-clear)", () => {
     const stalledHung = rec({ state: "stalled", pendingTool: { name: "Bash", since: 1000 } });
     const recovered = reduce(stalledHung, { type: "task.progress", id: "t1", note: "posttooluse" }, 9000);

--- a/packages/core/src/__tests__/watchdog.test.ts
+++ b/packages/core/src/__tests__/watchdog.test.ts
@@ -55,6 +55,27 @@ describe("evaluateStall", () => {
     expect(evaluateStall(rec({ state: "blocked" }), 999999)).toBeNull();
     expect(evaluateStall(rec({ state: "done" }), 999999)).toBeNull();
   });
+
+  // ── #594a: pendingMonitor stall budget (backstop against permanent suppression) ──
+  it("working INTERACTIVE with a Monitor armed WITHIN the monitor-stall budget → null (legit long watch)", () => {
+    const out = evaluateStall(rec({ mode: "interactive", pendingMonitor: { since: 0 } }), 30 * 60_000);
+    expect(out).toBeNull();
+  });
+
+  it("working INTERACTIVE with a Monitor armed past the monitor-stall budget → stalled", () => {
+    const out = evaluateStall(rec({ mode: "interactive", pendingMonitor: { since: 0 } }), 61 * 60_000);
+    expect(out?.state).toBe("stalled");
+    expect(out?.lastEvent).toBe("watchdog.monitor-stall");
+  });
+
+  it("a hung pendingTool is checked before pendingMonitor (pendingTool budget applies when both are set)", () => {
+    const out = evaluateStall(
+      rec({ mode: "interactive", pendingTool: { name: "Bash", since: 0 }, pendingMonitor: { since: 0 } }),
+      11 * 60_000,
+    );
+    expect(out?.state).toBe("stalled");
+    expect(out?.lastEvent).toBe("watchdog.tool-stall");
+  });
 });
 
 describe("recoverStall", () => {
@@ -68,6 +89,12 @@ describe("recoverStall", () => {
 
   it("recoverStall: non-stalled → null", () => {
     expect(recoverStall(rec({ state: "working" }), 7000)).toBeNull();
+  });
+
+  it("recoverStall clears a stale pendingMonitor too (#594a)", () => {
+    const stalled = rec({ state: "stalled", pendingMonitor: { since: 0 } });
+    const out = recoverStall(stalled, 7000);
+    expect(out?.pendingMonitor).toBeUndefined();
   });
 });
 

--- a/packages/core/src/daemon/delivery-loop.ts
+++ b/packages/core/src/daemon/delivery-loop.ts
@@ -170,6 +170,22 @@ export function createDelivery(
     record: TaskRecord;
     event: ControlEvent;
   }): Promise<void> => {
+    // #594b: firePush decides to notify off a TaskRecord snapshot captured
+    // synchronously at the state transition, but this mailbox write is
+    // awaited I/O — a concurrent `crew close` (task.cancelled) can land on the
+    // daemon's store in that gap and terminalize the SAME task. The reducer's
+    // own terminal-absorb guard can't help here (the close is a separate,
+    // later applyEvent call; this notify was already decided before it ran).
+    // Re-check the daemon's own CURRENT record right before writing: if the
+    // crew has since reached a terminal state different from what we're about
+    // to announce, the notification is stale — the crew is gone — so drop it
+    // rather than deliver e.g. "CREW IDLE" for a task that's already closed.
+    // A terminal notification (CREW DONE/FAILED) always matches its own fresh
+    // state and is unaffected; a missing record (e.g. purged) fails open.
+    const fresh = store.get(args.project, args.record.id);
+    if (fresh && TERMINAL_STATES.has(fresh.state) && fresh.state !== args.record.state) {
+      return;
+    }
     try {
       await appendToMailbox({
         stateRoot,

--- a/packages/core/src/daemon/reduce.ts
+++ b/packages/core/src/daemon/reduce.ts
@@ -2,7 +2,7 @@
 import type { Store } from "../store.js";
 import type { ControlEvent, TaskRecord, TaskState } from "@squadrant/shared";
 import { TERMINAL_STATES } from "@squadrant/shared";
-import { reduce } from "../state-machine.js";
+import { reduce, isStickyAttention } from "../state-machine.js";
 import { evaluateStall, recoverStall } from "../watchdog.js";
 export interface DaemonDeps {
   store: Store;
@@ -501,7 +501,14 @@ export function createDaemon(deps: DaemonDeps) {
         // ceiling. Terminalization is the persistent dedup — a daemon restart sees
         // the cancelled record and the TERMINAL_STATES gate above blocks re-fire.
         // The volatile firedTimeout Set is removed; terminal state replaces it.
-        if (!TERMINAL_STATES.has(r.state)) {
+        // #629: 'blocked'/'review' (isStickyAttention) are exempt — they pause a
+        // crew pending a human decision with no natural time bound (the captain
+        // might not look for hours). The ceiling exists to catch a crew stuck
+        // actually WORKING; applying it here cancelled a crew that had already
+        // finished and was correctly waiting on `crew approve`, permanently
+        // closing that path. A still-live surface keeps waiting indefinitely;
+        // a dead one is still caught by the surface-gone reap right below.
+        if (!TERMINAL_STATES.has(r.state) && !isStickyAttention(r.state)) {
           const ceiling = deps.taskTimeoutMs ?? DEFAULT_TASK_TIMEOUT_MS;
           if (t - r.createdAt > ceiling) {
             const prevState = r.state; // capture BEFORE terminalization (shown in message)
@@ -569,10 +576,14 @@ export function createDaemon(deps: DaemonDeps) {
         if (idle) {
           store.put(idle);
           // The synth event only carries the notify payload; the reducer treats
-          // it as a no-op (state already updated above). A hung-tool stall carries
-          // the tool name + elapsed so the notifier renders the accurate message.
+          // it as a no-op (state already updated above). A hung-tool or expired-
+          // Monitor stall carries the tool name + elapsed so the notifier renders
+          // the accurate message (#594a: idle.pendingTool is already cleared by
+          // the time a Monitor-only stall fires, so the two branches don't overlap).
           const synthEvent: ControlEvent = idle.pendingTool
             ? { type: "task.stalled", id: r.id, heartbeatBudgetMs: r.heartbeatBudgetMs, tool: idle.pendingTool.name, elapsedMs: t - idle.pendingTool.since }
+            : idle.pendingMonitor
+            ? { type: "task.stalled", id: r.id, heartbeatBudgetMs: r.heartbeatBudgetMs, tool: "Monitor", elapsedMs: t - idle.pendingMonitor.since }
             : { type: "task.stalled", id: r.id, heartbeatBudgetMs: r.heartbeatBudgetMs };
           firePush(deps, r.project, r.state, idle, synthEvent, lastCaptainTurnAt.get(r.id));
           continue;

--- a/packages/core/src/state-machine.ts
+++ b/packages/core/src/state-machine.ts
@@ -23,9 +23,11 @@ function stampAttempt(
  * pending a human decision — neither may be knocked out by a liveness or
  * turn-boundary event, only by their own explicit exits (reply/feedback or
  * approve). Every stickiness guard below must treat them identically, or a
- * future attention state repeats this bug a fourth time (#492 → #605 → #608).
+ * future attention state repeats this bug a fourth time (#492 → #605 → #608
+ * → #629, which reused this exact predicate to also exempt the sweep's
+ * wall-clock task-timeout ceiling — see reduce.ts).
  */
-function isStickyAttention(state: TaskRecord["state"]): boolean {
+export function isStickyAttention(state: TaskRecord["state"]): boolean {
   return state === "blocked" || state === "review";
 }
 
@@ -45,6 +47,26 @@ function nextPendingTool(
 ): TaskRecord["pendingTool"] {
   if (ev.note === "agent.hook.PreToolUse") return { name: ev.tool ?? "tool", since: now };
   if (ev.note === "posttooluse" || ev.note === "agent.hook.UserPromptSubmit") return undefined;
+  return current;
+}
+
+/**
+ * #594a: compute the next pendingMonitor marker. A PreToolUse naming the
+ * `Monitor` tool arms a background watch. Unlike pendingTool, this is
+ * deliberately NOT closed by that same call's own PostToolUse: Monitor's tool
+ * call returns almost immediately after arming (it doesn't block), but the
+ * watch — and its async notifications — keeps running well past that. Only a
+ * genuine new turn boundary (handled by the reduce() cases that clear it
+ * explicitly, mirroring pendingTool) or the watchdog's own stall budget ends
+ * the exemption, so a crew whose turn ends while a Monitor is still armed is
+ * not misread as "awaiting the captain".
+ */
+function nextPendingMonitor(
+  current: TaskRecord["pendingMonitor"],
+  ev: Extract<ControlEvent, { type: "task.progress" }>,
+  now: number,
+): TaskRecord["pendingMonitor"] {
+  if (ev.note === "agent.hook.PreToolUse" && ev.tool === "Monitor") return { since: now };
   return current;
 }
 
@@ -74,6 +96,7 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
         sessionId: ev.sessionId ?? rec.sessionId,
         question: undefined, // resuming after a blocked→reply clears the question
         pendingTool: undefined, // #354: a new turn closes any prior tool window
+        pendingMonitor: undefined, // #594a: same reset — a new turn moots any prior watch
       };
     case "task.progress": {
       // task.progress is a real-activity signal (stdout chunk for headless,
@@ -82,12 +105,15 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
       // (#89) can key off it without false-stalling long-running headless tasks.
       // #354: also track the in-flight tool (PreToolUse opens, PostToolUse closes)
       // so a hung tool call is distinguishable from a quiet thinking turn.
+      // #594a: also track a registered background Monitor watch (PreToolUse
+      // opens, but — unlike pendingTool — its own PostToolUse does NOT close it).
       // From blocked: liveness only — do not auto-unblock (explicit reply required).
       // From awaiting-input OR stalled: resume to working — the next real activity
       // (e.g. the matching PostToolUse) auto-clears a hung-tool warn instantly.
       const pendingTool = nextPendingTool(rec.pendingTool, ev, now);
-      if (isStickyAttention(rec.state)) return { ...rec, lastHeartbeat: now, lastEvent: ev.type, pendingTool };
-      const b = { ...base, pendingTool };
+      const pendingMonitor = nextPendingMonitor(rec.pendingMonitor, ev, now);
+      if (isStickyAttention(rec.state)) return { ...rec, lastHeartbeat: now, lastEvent: ev.type, pendingTool, pendingMonitor };
+      const b = { ...base, pendingTool, pendingMonitor };
       if (rec.state === "awaiting-input" || rec.state === "stalled") return { ...stampAttempt(b, {}, now), state: "working" };
       return stampAttempt(b, {}, now);
     }
@@ -107,11 +133,11 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
       // no-op so the FIRST (explicit) question wins and no duplicate CREW
       // BLOCKED fires. Terminal states are already absorbed above.
       if (rec.state === "blocked") return { ...rec, lastHeartbeat: now, lastEvent: ev.type };
-      return { ...base, state: "blocked", question: ev.question, pendingTool: undefined };
+      return { ...base, state: "blocked", question: ev.question, pendingTool: undefined, pendingMonitor: undefined };
     case "task.review":
       // #599: review-gate checkpoint. Not terminal — `crew send` (feedback)
       // or `crew approve` (task.done) are the only ways out.
-      return { ...base, state: "review", reviewNote: ev.message, pendingTool: undefined };
+      return { ...base, state: "review", reviewNote: ev.message, pendingTool: undefined, pendingMonitor: undefined };
     case "task.done":
       // #605: the review gate must be ENFORCING, not advisory. A crew's normal
       // completion protocol always signals done at turn end — if that alone
@@ -137,7 +163,7 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
     case "task.session":
       return stampAttempt(base, { resumeRef: ev.resumeRef }, now);
     case "task.turn.started":
-      return { ...stampAttempt(base, {}, now), state: "working", pendingTool: undefined };
+      return { ...stampAttempt(base, {}, now), state: "working", pendingTool: undefined, pendingMonitor: undefined };
     case "task.turn.completed":
       // Anti-#2576 invariant: TurnCompleted is liveness, NEVER completion. Spec §4.8.
       // A turn ending while blocked must NOT unblock — only the captain's answer
@@ -156,13 +182,20 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
       // evidence (no matching PostToolUse yet), so it is not a genuine turn
       // boundary. Treat it as liveness only; the real turn-end arrives once the
       // tool actually returns and pendingTool clears.
-      if (rec.pendingTool) return stampAttempt(base, {}, now);
-      return { ...stampAttempt(base, {}, now), state: "awaiting-input", pendingTool: undefined };
+      // #594a: a registered background Monitor (pendingMonitor) gets the same
+      // veto. Its own tool call closes almost immediately (pendingTool clears
+      // fast), but the watch it armed keeps running — a Stop hook firing while
+      // it's still outstanding means the crew is asleep awaiting its OWN
+      // notification, not the captain's. Without this, that turn-end reads as
+      // genuine and floods CREW IDLE on every self-resume (live evidence: task
+      // 2506214d fired CREW IDLE 3x for the same turnId, 23s/76s apart).
+      if (rec.pendingTool || rec.pendingMonitor) return stampAttempt(base, {}, now);
+      return { ...stampAttempt(base, {}, now), state: "awaiting-input", pendingTool: undefined, pendingMonitor: undefined };
     case "task.delta":
       return stampAttempt(base, {}, now);  // heartbeat-only
     case "task.input.requested":
     case "task.approval.requested":
-      return { ...stampAttempt(base, {}, now), state: "blocked", question: ev.question, pendingTool: undefined };
+      return { ...stampAttempt(base, {}, now), state: "blocked", question: ev.question, pendingTool: undefined, pendingMonitor: undefined };
     case "task.reattached":
       return stampAttempt(base, {}, now);
     case "task.first-turn.confirmed":

--- a/packages/core/src/watchdog.ts
+++ b/packages/core/src/watchdog.ts
@@ -13,6 +13,17 @@ import type { TaskRecord } from "@squadrant/shared";
 export const TOOL_STALL_BUDGET_MS = 10 * 60 * 1000;
 
 /**
+ * #594a: how long a registered background Monitor watch may sit outstanding
+ * before the daemon gives up on the exemption and treats it as abandoned.
+ * Deliberately generous — well above Monitor's own documented max timeout_ms
+ * (1h) for a non-persistent watch — so a legitimate long CI/deploy poll is
+ * never false-stalled mid-watch. This is a backstop, not the primary fix: it
+ * exists only so a crew that armed a Monitor once and then went genuinely
+ * silent forever doesn't suppress real idle detection permanently.
+ */
+export const MONITOR_STALL_BUDGET_MS = 60 * 60 * 1000;
+
+/**
  * Pure. Returns a stalled-transitioned record if a `working` task is genuinely
  * stuck at time `now` (epoch ms), else null. No I/O, no clock. #354 splits the
  * old single wall-clock timeout by what we can actually prove:
@@ -23,7 +34,10 @@ export const TOOL_STALL_BUDGET_MS = 10 * 60 * 1000;
  *    has been outstanding past `toolStallMs`. A PreToolUse with no matching
  *    PostToolUse is a hung tool call (we know which tool). Recoverable: the next
  *    PostToolUse recovers it to `working` (state-machine / recoverStall).
- *  - interactive with NO tool in flight → null. A quiet thinking turn is alive,
+ *  - interactive with NO tool in flight but a Monitor armed (pendingMonitor) →
+ *    'stalled' once that watch has been outstanding past `monitorStallMs`
+ *    (#594a backstop against permanent suppression — see MONITOR_STALL_BUDGET_MS).
+ *  - interactive with neither in flight → null. A quiet thinking turn is alive,
  *    not stalled and NOT awaiting-input (the turn never ended — real CREW IDLE
  *    comes only from the Stop hook). The daemon sweep surfaces this as a
  *    distinct, non-alarming CREW QUIET notify instead (#354), keeping the crew
@@ -36,14 +50,22 @@ export function evaluateStall(
   rec: TaskRecord,
   now: number,
   toolStallMs: number = TOOL_STALL_BUDGET_MS,
+  monitorStallMs: number = MONITOR_STALL_BUDGET_MS,
 ): TaskRecord | null {
   if (rec.state !== "working") return null;
   if (rec.mode === "interactive") {
-    // Only a hung tool call is a stall for an interactive crew; a quiet thinking
-    // turn (no pendingTool) is alive and handled by the sweep's CREW QUIET path.
-    if (!rec.pendingTool) return null;
-    if (now - rec.pendingTool.since <= toolStallMs) return null;
-    return { ...rec, state: "stalled", lastEvent: "watchdog.tool-stall" };
+    // A hung tool call takes priority over a registered Monitor watch.
+    if (rec.pendingTool) {
+      if (now - rec.pendingTool.since <= toolStallMs) return null;
+      return { ...rec, state: "stalled", lastEvent: "watchdog.tool-stall" };
+    }
+    if (rec.pendingMonitor) {
+      if (now - rec.pendingMonitor.since <= monitorStallMs) return null;
+      return { ...rec, state: "stalled", lastEvent: "watchdog.monitor-stall" };
+    }
+    // Neither a hung tool nor a Monitor watch — a quiet thinking turn is alive
+    // and handled by the sweep's CREW QUIET path.
+    return null;
   }
   // headless: key off the latest attempt's lastHeartbeatAt so a stale event from
   // a dead prior attempt cannot refresh the liveness clock of the new dispatch (#89).
@@ -62,7 +84,7 @@ export function evaluateStall(
  */
 export function recoverStall(rec: TaskRecord, now: number): TaskRecord | null {
   if (rec.state !== "stalled") return null;
-  // #354: clear any hung-tool marker on recovery so a recovered crew never
-  // carries a stale pendingTool into its next quiet window.
-  return { ...rec, state: "working", lastHeartbeat: now, lastEvent: "watchdog.recover", pendingTool: undefined };
+  // #354/#594a: clear any hung-tool or stale-Monitor marker on recovery so a
+  // recovered crew never carries either into its next quiet window.
+  return { ...rec, state: "working", lastHeartbeat: now, lastEvent: "watchdog.recover", pendingTool: undefined, pendingMonitor: undefined };
 }

--- a/packages/shared/src/types/control.ts
+++ b/packages/shared/src/types/control.ts
@@ -93,6 +93,18 @@ export interface TaskRecord {
    *  (no pendingTool → CREW QUIET). Auto-clears: the next PostToolUse recovers
    *  the record to `working` (state-machine + recoverStall). */
   pendingTool?: { name: string; since: number };
+  /** #594a: a registered background Monitor watch, if any. Set when a PreToolUse
+   *  liveness signal names the `Monitor` tool. Unlike pendingTool, this is NOT
+   *  cleared by that call's own PostToolUse — Monitor's tool call returns almost
+   *  immediately after arming the watch, but the watch itself (and its async
+   *  notifications) keeps running well past that. A crew whose turn genuinely
+   *  ends (Stop hook) while a Monitor is still armed is not awaiting the
+   *  captain — it will self-resume on its own notification — so the
+   *  turn.completed veto treats pendingMonitor the same as pendingTool. Cleared
+   *  only by a genuine new turn boundary (task.started/blocked/review/
+   *  turn.started/input-approval-requested), or by the watchdog once it has been
+   *  outstanding past MONITOR_STALL_BUDGET_MS (treated as abandoned). */
+  pendingMonitor?: { since: number };
   /** #466: epoch ms when the spawn path positively confirmed the first turn was
    *  delivered (paste rendered in the box → box emptied = submitted). Unset means
    *  either the crew was spawned before this field existed, OR delivery was never


### PR DESCRIPTION
Fixed #594a (Monitor watch misread as idle → CREW IDLE flood), #594b (stale CREW IDLE delivered after crew close), #629 (sweep.task-timeout cancelling review-state crews). All 3 reproduced with live production evidence before fixing, per the reproduce-first requirement; 11 new failing→passing tests; #542/#515 NOT covered (different root cause, documented in commit). Full pnpm build + pnpm test green (2239 tests).