### PR TITLE
chore(release): v0.16.6

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,19 @@ Two-way Telegram lives in `@squadrant/core` (`src/telegram/*`: `client`/`format`
 
 **⚠️ Security gap (v1):** chat membership implies captain control — anyone who can post in the linked supergroup can steer the captain. Inbound is filtered only by a `chat_id` allowlist; a per-user-id allowlist is deferred to [#321](https://github.com/tu11aa/squadrant/issues/321). Inbound text is always data (a captain message), never an executed command.
 
+## Managed `~/.claude/settings.json` (#615)
+
+squadrant owns and reconciles `~/.claude/settings.json` via `installClaudeHooks` (`packages/workspaces/src/native-hooks/native-hook-source.ts`), called by `NativeHookSource.install()` on every daemon boot. It is idempotent and non-clobbering — unrelated top-level fields and non-squadrant hook entries (yours, cmux's, etc.) are always preserved.
+
+- **Hooks — always verified + repaired, unconditional.** The full squadrant-owned hook set (`SessionStart` / `UserPromptSubmit` / `PreToolUse` incl. the `AskUserQuestion` tool matcher / `Stop` / `Notification` / `SessionEnd`) is checked on every run. A missing hook is repaired and a one-line warning is logged. The `AskUserQuestion` → `squadrant hooks claude ask-question` mapping is what makes crew-blocked signalling work (#560); a machine that never had it — or had it clobbered — used to lose blocked-signalling silently. It no longer does.
+- **`env` overlay — opt-in only, `defaults.claudeEnv`.** Set `defaults.claudeEnv` in `~/.config/squadrant/config.json` to deep-merge extra keys into settings.json's `env` block. Absent ⇒ nothing is written to `env`. The merge is non-clobbering: a key already present with a different value is never overwritten, just logged.
+
+  ```json
+  { "defaults": { "claudeEnv": { "CLAUDE_AFK_TIMEOUT_MS": "240000", "CLAUDE_AFK_COUNTDOWN_MS": "30000" } } }
+  ```
+
+  Motivating example: Claude Code's AFK auto-continue mode (`CLAUDE_AFK_TIMEOUT_MS` / `CLAUDE_AFK_COUNTDOWN_MS`) auto-resolves prompts after an idle timeout — the same risk class as auto-answering approval prompts while unattended (#484/#516). squadrant does **not** enable this by default for anyone; it's opt-in per machine only, via `claudeEnv`.
+
 ## Coding Discipline: Karpathy Principles
 
 Every coding task in this repo follows [`plugin/skills/karpathy-principles/SKILL.md`](plugin/skills/karpathy-principles/SKILL.md):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (4937 symbols, 7472 relationships, 175 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (5084 symbols, 7671 relationships, 177 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (4937 symbols, 7472 relationships, 175 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (5084 symbols, 7671 relationships, 177 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/docs/notes/review-gate-final.md
+++ b/docs/notes/review-gate-final.md
@@ -1,0 +1,15 @@
+# Review Gate — Fully Enforcing (#608)
+
+As of #608, the review gate is comprehensively sticky. While a task is in the
+`review` state, every turn-boundary and idle event — `task.turn.completed`,
+heartbeat, `task.progress`, `task.delta` — is treated as liveness-only and
+cannot move the task out of `review`.
+
+This closes the gap left by #605, where `review` was only protected in the
+`task.done` handler: a crew's turn ending could still silently clobber
+`review` back to `awaiting-input`, letting work slip past the gate unseen.
+
+`review` now shares the same preservation semantics as `blocked` via a
+shared `isStickyAttention(state)` check applied at every transition site.
+The only ways out of `review` are `squadrant crew approve` or explicit
+captain feedback.

--- a/docs/notes/review-gate-final.md
+++ b/docs/notes/review-gate-final.md
@@ -13,3 +13,5 @@ This closes the gap left by #605, where `review` was only protected in the
 shared `isStickyAttention(state)` check applied at every transition site.
 The only ways out of `review` are `squadrant crew approve` or explicit
 captain feedback.
+
+例: squadrant crew approve <project> <crew>

--- a/docs/specs/2026-07-28-captain-context-budget.md
+++ b/docs/specs/2026-07-28-captain-context-budget.md
@@ -1,0 +1,128 @@
+# Captain per-turn context budget
+
+**Read-only analysis.** Data: 3 most recent captain transcripts in
+`~/.claude/projects/-Users-q3labsadmin-me-squadrant/*.jsonl` by mtime
+(`7b631cf9…` Jul 28, `a2534d64…` Jul 24, `d2000c3e…` Jul 24). All token
+figures are **chars/4 approximations** unless pulled directly from a
+transcript's `usage` block (those are exact, API-reported). Where a
+component could not be located in the transcript at all, it's called out
+explicitly rather than guessed.
+
+## 1. Ranked table — composition of the first API call
+
+Claude Code transcripts do **not** store the raw system prompt or tool JSON
+schemas — only the first assistant `usage` block (exact) and a handful of
+`attachment` records for hook/skill/MCP injections (their `content` is
+recoverable). The very first call already shows `cache_read_input_tokens` >
+0 (17,088–16,921 across all 3 sessions) because Claude Code's system
+prompt + tool schemas are stable across sessions and hit the 1h prompt
+cache from a prior process. Total first-call context = `input_tokens +
+cache_creation_input_tokens + cache_read_input_tokens`.
+
+| Session | First-call total (exact, API-reported) |
+|---|---|
+| 7b631cf9 (Jul 28) | 51,902 tok |
+| a2534d64 (Jul 24) | 52,104 tok |
+| d2000c3e (Jul 24) | 53,298 tok |
+
+Component breakdown for 7b631cf9 (numbers consistent within ~5% across all
+3 sessions — see §2 caveats):
+
+| Component | Source | Est. tokens | % of first-call ctx (51,902) |
+|---|---|---:|---:|
+| Claude Code base system prompt + always-loaded tool schemas | **residual, not measurable from transcript** | ~29,196 | 56.3% |
+| MEMORY.md (auto-memory index) | measured on disk | 4,930 | 9.5% |
+| Available-skills listing (`skill_listing` attachment) | measured, transcript | 7,408 | 14.3% |
+| AGENTS.md | measured on disk — **unconfirmed if Claude Code auto-loads it** | 3,515 | 6.8% |
+| claude-mem injected observations + `using-superpowers` skill (`hook_additional_context`) | measured, transcript | 2,733 | 5.3% |
+| CLAUDE.md | measured on disk | 1,260 | 2.4% |
+| `--append-system-prompt-file` captain role template (`templates/captain.claude.md`) | measured on disk | 720 | 1.4% |
+| Deferred-tool name list (86 names, schemas NOT loaded) | measured, transcript | 652 | 1.3% |
+| Agent-type listing (`agent_listing_delta`) | measured, transcript | 636 | 1.2% |
+| SessionStart hook system message | measured, transcript | 554 | 1.1% |
+| MCP server instructions (gitnexus/context7/chrome deltas) | measured, transcript | 246 | 0.5% |
+| Startup-checklist first user message | measured, transcript | 28 | 0.05% |
+| Misc hook stdout (PATH export, cmux hook) | measured, transcript | 24 | 0.05% |
+
+**The single largest identified line item is the skills listing (~7.4k
+tokens), followed by MEMORY.md (~4.9k) and AGENTS.md (~3.5k).** The
+"residual" row (56%) is everything the transcript cannot show directly:
+Claude Code's own system prompt plus the JSON schemas for every
+always-loaded (non-deferred) tool — Bash, Read, Edit, Write, Agent,
+AskUserQuestion, Skill, Workflow, ToolSearch, ScheduleWakeup,
+ReportFindings, and any MCP tools not covered by the deferred-tool
+mechanism. This cannot be sized without live API request logging; it is
+reported as a residual, not silently folded into another line.
+
+## 2. Caveats on the estimate
+
+- chars/4 is a rough proxy; real tokenization (especially for structured
+  JSON tool schemas) runs denser than English prose, so the residual
+  55–56% is likely a **lower bound**, not an upper bound.
+- AGENTS.md's presence in context is inferred from file size only — it was
+  never observed as a distinct transcript attachment (only CLAUDE.md +
+  MEMORY.md are visibly bundled into the `claudeMd` system-reminder in
+  this exact harness, per direct observation of this session's own
+  system-reminder). Treat the AGENTS.md line as a candidate, not a
+  confirmed cost.
+- The deferred-tool mechanism observed in this very session (86 tool names
+  listed, schemas fetched on demand via `ToolSearch`) already keeps most
+  MCP tool schemas (gitnexus, claude-mem, chrome, figma, context7) **out**
+  of the always-loaded residual — so that 56% residual is smaller than a
+  naive "all MCP servers loaded" estimate would suggest, but still opaque.
+
+## 3. Cache-read growth within a session (first vs. median vs. last)
+
+Unique-turn `cache_read_input_tokens` sequence per session (collapsing
+consecutive identical values, which are retries of the same API call):
+
+| Session | Turns (unique) | First | Median | Last | Compaction resets (>50% drop) |
+|---|---:|---:|---:|---:|---:|
+| 7b631cf9 (Jul 28, ~6h span) | 29 | 17,088 | 84,854 | 112,477 | 2 |
+| a2534d64 (Jul 24) | 105 | 16,921 | 133,334 | 188,832 | 4 |
+| d2000c3e (Jul 24) | 101 | 16,921 | 191,101 | 298,465 | 2 |
+
+**This directly answers the "fixed boot vs. accumulated" question: boot
+overhead is ~17k tokens — under 10% of the reported 185k average.** The
+other 90%+ is accumulated conversation history that gets re-sent (and
+cache-read) on every subsequent turn for as long as the session runs
+without a compaction reset. Sessions that run long (100+ turns) push
+median/last cache_read into the 130k–300k range, which is what pulls the
+system-wide average up to ~185k. Compaction events (2–4 observed per
+session) drop `cache_read_input_tokens` back down to the ~17k floor, but
+only 2 of the 3 sessions show this reset near their end — most of a
+session's lifetime is spent in the high-accumulation regime.
+
+Sanity check: mean `cache_read_input_tokens` across all 553 assistant
+calls in these 3 sessions = **139,319** (median 133,472) — same order of
+magnitude as the reported 185.5k account-wide average; the gap is expected
+since the account-wide figure includes longer-running sessions than these
+3 (d2000c3e alone averages 175,437, closest to the reported figure).
+
+## 4. Recommendations
+
+**Highest-leverage, lowest-risk cut: the skills listing (~7.4k tok/turn,
+14% of boot, and paid again on every single turn for the rest of the
+session since it never leaves the cached prefix).** Unlike the 86
+deferred MCP tools (already loaded on-demand via `ToolSearch`), all ~85
+skill descriptions are dumped into the system-reminder up front every
+session, whether or not that session ever touches them (career/resume
+skills, GCP skills, Solana skills are all listed in a squadrant captain
+session that will never use them). A deferred-skill-listing mechanism
+mirroring the existing deferred-tool pattern (list names only, fetch full
+description via a search call when relevant) would cut this to a small
+fraction of 7.4k tokens for a typical captain session, and — because it's
+part of the fixed prefix — the saving compounds on **every turn for the
+life of the session**, not just at boot.
+
+Other candidates, roughly ranked by savings-per-session-length:
+1. **Skills listing → on-demand** (~7.4k/turn, compounds all session): highest value, matches an already-proven pattern in this harness.
+2. **MEMORY.md → trim or summarize** (~4.9k/turn): the auto-memory index has grown to 19.7KB; consider archiving older entries out of the always-loaded index.
+3. **AGENTS.md** (~3.5k/turn, *if* actually loaded — unconfirmed, see §2): worth confirming with Anthropic docs/support before treating as a cut target.
+4. **claude-mem observations block** (part of the 2.7k `hook_additional_context`): already fairly small; low priority.
+5. The 56% residual (base prompt + core tool schemas) is not shrinkable without changing which tools are always-loaded vs. deferred — Bash/Read/Edit/Write/Agent/Skill/Workflow are core-loop tools and poor candidates for deferral.
+
+**Not measurable, flagged rather than estimated:** exact size of Claude
+Code's own system prompt and the individual JSON schema cost per
+always-loaded tool. Sizing these precisely would require intercepting the
+literal API request body, which is outside what the transcript records.

--- a/docs/specs/2026-07-28-captain-context-budget.md
+++ b/docs/specs/2026-07-28-captain-context-budget.md
@@ -30,10 +30,9 @@ Component breakdown for 7b631cf9 (numbers consistent within ~5% across all
 
 | Component | Source | Est. tokens | % of first-call ctx (51,902) |
 |---|---|---:|---:|
-| Claude Code base system prompt + always-loaded tool schemas | **residual, not measurable from transcript** | ~29,196 | 56.3% |
-| MEMORY.md (auto-memory index) | measured on disk | 4,930 | 9.5% |
+| Claude Code base system prompt + always-loaded tool schemas | **residual, not measurable from transcript** | ~32,711 | 63.0% |
 | Available-skills listing (`skill_listing` attachment) | measured, transcript | 7,408 | 14.3% |
-| AGENTS.md | measured on disk — **unconfirmed if Claude Code auto-loads it** | 3,515 | 6.8% |
+| MEMORY.md (auto-memory index) | measured on disk | 4,930 | 9.5% |
 | claude-mem injected observations + `using-superpowers` skill (`hook_additional_context`) | measured, transcript | 2,733 | 5.3% |
 | CLAUDE.md | measured on disk | 1,260 | 2.4% |
 | `--append-system-prompt-file` captain role template (`templates/captain.claude.md`) | measured on disk | 720 | 1.4% |
@@ -45,53 +44,70 @@ Component breakdown for 7b631cf9 (numbers consistent within ~5% across all
 | Misc hook stdout (PATH export, cmux hook) | measured, transcript | 24 | 0.05% |
 
 **The single largest identified line item is the skills listing (~7.4k
-tokens), followed by MEMORY.md (~4.9k) and AGENTS.md (~3.5k).** The
-"residual" row (56%) is everything the transcript cannot show directly:
-Claude Code's own system prompt plus the JSON schemas for every
-always-loaded (non-deferred) tool — Bash, Read, Edit, Write, Agent,
-AskUserQuestion, Skill, Workflow, ToolSearch, ScheduleWakeup,
-ReportFindings, and any MCP tools not covered by the deferred-tool
-mechanism. This cannot be sized without live API request logging; it is
-reported as a residual, not silently folded into another line.
+tokens), followed by MEMORY.md (~4.9k).** AGENTS.md is confirmed **not**
+auto-loaded by Claude Code in this harness (only CLAUDE.md + MEMORY.md are
+bundled into the `claudeMd` system-reminder — directly observed in this
+session's own system-reminder), so it is excluded from this table
+entirely rather than estimated. The "residual" row (63%) is everything the
+transcript cannot show directly: Claude Code's own system prompt plus the
+JSON schemas for every always-loaded (non-deferred) tool — Bash, Read,
+Edit, Write, Agent, AskUserQuestion, Skill, Workflow, ToolSearch,
+ScheduleWakeup, ReportFindings, and any MCP tools not covered by the
+deferred-tool mechanism. This cannot be sized without live API request
+logging; it is reported as a residual, not silently folded into another
+line.
 
 ## 2. Caveats on the estimate
 
 - chars/4 is a rough proxy; real tokenization (especially for structured
   JSON tool schemas) runs denser than English prose, so the residual
-  55–56% is likely a **lower bound**, not an upper bound.
-- AGENTS.md's presence in context is inferred from file size only — it was
-  never observed as a distinct transcript attachment (only CLAUDE.md +
-  MEMORY.md are visibly bundled into the `claudeMd` system-reminder in
-  this exact harness, per direct observation of this session's own
-  system-reminder). Treat the AGENTS.md line as a candidate, not a
-  confirmed cost.
+  ~63% is likely a **lower bound**, not an upper bound.
+- AGENTS.md is confirmed excluded (see §1) — not a candidate for the
+  "droppable" list in §4 since it was never in context to begin with.
 - The deferred-tool mechanism observed in this very session (86 tool names
   listed, schemas fetched on demand via `ToolSearch`) already keeps most
   MCP tool schemas (gitnexus, claude-mem, chrome, figma, context7) **out**
-  of the always-loaded residual — so that 56% residual is smaller than a
+  of the always-loaded residual — so that 63% residual is smaller than a
   naive "all MCP servers loaded" estimate would suggest, but still opaque.
 
-## 3. Cache-read growth within a session (first vs. median vs. last)
+## 3. Cache-read growth within a session (boot vs. median vs. last)
+
+**Correction: boot overhead is the full first-call total from §1
+(51,902–53,298 tokens, ~28% of the 185k average) — not the 17k
+`cache_read_input_tokens` floor.** The 17,088–16,921 value at turn 1 is
+only the *pre-warmed subset* of the boot payload (the stable system
+prompt + tool schemas, already cache-hit from a prior session within the
+1h TTL); the remaining ~34.8k–36.4k tokens of turn 1 (memory index, skills
+listing, hook injections, project files) show up as
+`cache_creation_input_tokens` — a cache **write**, not a read, because
+that content is new to this session. By turn 2 the entire boot payload
+becomes a cache-read hit: session 7b631cf9's turn-2 `cache_read` is
+51,900, matching turn-1's total (51,902) almost exactly; the same holds
+for the other two sessions (52,102≈52,104; 53,296≈53,298). This confirms
+boot cost is fixed at ~52–53k from turn 2 onward, not 17k.
 
 Unique-turn `cache_read_input_tokens` sequence per session (collapsing
 consecutive identical values, which are retries of the same API call):
 
-| Session | Turns (unique) | First | Median | Last | Compaction resets (>50% drop) |
-|---|---:|---:|---:|---:|---:|
-| 7b631cf9 (Jul 28, ~6h span) | 29 | 17,088 | 84,854 | 112,477 | 2 |
-| a2534d64 (Jul 24) | 105 | 16,921 | 133,334 | 188,832 | 4 |
-| d2000c3e (Jul 24) | 101 | 16,921 | 191,101 | 298,465 | 2 |
+| Session | Turns (unique) | Boot (turn-1 total, exact) | Turn-2 cache_read (boot, cache-hit) | Median | Last | Compaction resets (>50% drop) |
+|---|---:|---:|---:|---:|---:|---:|
+| 7b631cf9 (Jul 28, ~6h span) | 29 | 51,902 | 51,900 | 84,854 | 112,477 | 2 |
+| a2534d64 (Jul 24) | 105 | 52,104 | 52,102 | 133,334 | 188,832 | 4 |
+| d2000c3e (Jul 24) | 101 | 53,298 | 53,296 | 191,101 | 298,465 | 2 |
 
-**This directly answers the "fixed boot vs. accumulated" question: boot
-overhead is ~17k tokens — under 10% of the reported 185k average.** The
-other 90%+ is accumulated conversation history that gets re-sent (and
-cache-read) on every subsequent turn for as long as the session runs
-without a compaction reset. Sessions that run long (100+ turns) push
-median/last cache_read into the 130k–300k range, which is what pulls the
-system-wide average up to ~185k. Compaction events (2–4 observed per
-session) drop `cache_read_input_tokens` back down to the ~17k floor, but
-only 2 of the 3 sessions show this reset near their end — most of a
-session's lifetime is spent in the high-accumulation regime.
+**This directly answers the "fixed boot vs. accumulated" question: boot is
+~28% of the 185k average (~52k of ~185k); the remaining ~72% is
+accumulated conversation history** re-sent (and cache-read) on every
+subsequent turn for as long as the session runs without a compaction
+reset. Sessions that run long (100+ turns) push median/last cache_read
+well past the 185k average — d2000c3e's last turn hits 298,465 (161% of
+185k) — which is what pulls the system-wide average up from a ~52k floor
+to ~185k. Compaction events (2–4 observed per session) drop
+`cache_read_input_tokens` back down near the ~17k pre-warmed floor
+(re-establishing the ~52k boot baseline on the next turn), but only 2 of
+the 3 sessions show this reset near their end — most of a session's
+lifetime is spent well above the boot baseline, in the high-accumulation
+regime.
 
 Sanity check: mean `cache_read_input_tokens` across all 553 assistant
 calls in these 3 sessions = **139,319** (median 133,472) — same order of
@@ -118,9 +134,8 @@ life of the session**, not just at boot.
 Other candidates, roughly ranked by savings-per-session-length:
 1. **Skills listing → on-demand** (~7.4k/turn, compounds all session): highest value, matches an already-proven pattern in this harness.
 2. **MEMORY.md → trim or summarize** (~4.9k/turn): the auto-memory index has grown to 19.7KB; consider archiving older entries out of the always-loaded index.
-3. **AGENTS.md** (~3.5k/turn, *if* actually loaded — unconfirmed, see §2): worth confirming with Anthropic docs/support before treating as a cut target.
-4. **claude-mem observations block** (part of the 2.7k `hook_additional_context`): already fairly small; low priority.
-5. The 56% residual (base prompt + core tool schemas) is not shrinkable without changing which tools are always-loaded vs. deferred — Bash/Read/Edit/Write/Agent/Skill/Workflow are core-loop tools and poor candidates for deferral.
+3. **claude-mem observations block** (part of the 2.7k `hook_additional_context`): already fairly small; low priority.
+4. The 63% residual (base prompt + core tool schemas) is not shrinkable without changing which tools are always-loaded vs. deferred — Bash/Read/Edit/Write/Agent/Skill/Workflow are core-loop tools and poor candidates for deferral.
 
 **Not measurable, flagged rather than estimated:** exact size of Claude
 Code's own system prompt and the individual JSON schema cost per

--- a/docs/specs/2026-07-29-provider-independence-two-phase-plan.md
+++ b/docs/specs/2026-07-29-provider-independence-two-phase-plan.md
@@ -1,0 +1,197 @@
+# Provider independence — 2-phase plan
+
+**Status:** approved direction, not started
+**Date:** 2026-07-29
+**Owner:** captain (squadrant)
+
+## Why this exists
+
+Squadrant was built as a long-horizon orchestration layer: one captain coordinating
+many crews, with learning, handoff, reporting and Telegram on top. Today the captain
+role only runs on Claude Code. If Claude access goes away — budget exhaustion, or the
+company dropping Claude entirely — **the whole project stops**, because the coordinator
+itself cannot boot.
+
+Two distinct pressures, deliberately kept separate:
+
+1. **Cost** — the orchestrator burns more tokens than working manually. True, and now
+   measured (below). Needs a frugal path, not a rewrite.
+2. **Dependency** — one provider is a single point of failure for the entire product.
+   Needs a real driver seam for the captain role, not just for crews.
+
+Phase 1 addresses cost and gives an escape hatch. Phase 2 removes the dependency.
+
+## Measured baseline (2026-07-29)
+
+Measured from real Claude Code transcripts in
+`~/.claude/projects/-Users-q3labsadmin-me-squadrant/*.jsonl`. Full breakdown:
+[`2026-07-28-captain-context-budget.md`](2026-07-28-captain-context-budget.md).
+
+| | Sessions | Turns | Total volume |
+|---|---:|---:|---:|
+| Captain (main repo) | 66 | 7,439 | 1,457M |
+| Crews (103 worktrees) | 107 | 10,400 | 1,463M |
+
+Findings that shaped this plan:
+
+- **The captain costs as much as all 103 crews combined** (~50/50, ~53/47 cost-weighted).
+  Crew *count* is not the main driver — the orchestrator itself is.
+- **~95% of volume is cache read** (~1/10 the price of fresh input), so raw token
+  totals overstate spend considerably.
+- **~185k tokens are re-read on every captain turn.** Of that, **~52k is fixed boot
+  prefix (28%)** and **~72% is accumulated conversation**. Proven by turn-2
+  `cache_read` (51,900) matching turn-1 total (51,902) across all 3 sampled sessions.
+- Boot prefix composition: skills listing **7.4k**, MEMORY.md **4.9k**, claude-mem
+  observations **2.7k**, CLAUDE.md 1.3k, captain role template 0.7k, and a **~29k
+  residual** (Claude Code base prompt + core tool schemas) that is not shrinkable.
+- `AGENTS.md` is **confirmed not auto-loaded** by Claude Code — only `CLAUDE.md` and
+  `MEMORY.md` are bundled. Not a cut target.
+
+**Key consequence:** the boot prefix is re-read every turn, so trimming it saves on
+*every turn of every session*. And a spurious lifecycle event (e.g. #594 CREW IDLE
+flood) is not a one-off cost — it appends to history that is re-read for the rest of
+the session. Junk turns compound.
+
+## Phase 1 — short term
+
+Ordered by leverage. Each item is independently shippable.
+
+### 1.1 Stop the junk turns (#594 CREW IDLE flood)
+
+Highest leverage and already the top user-facing annoyance. Two distinct bugs sharing
+one root (activity-tracking bookkeeping):
+
+- a crew waiting on a registered background Monitor is classified idle → CREW IDLE
+  fires mid-turn
+- a CREW IDLE arrives *after* `crew close` succeeded (event for a dead crew)
+
+Related, same root: #542 (false CREW STALLED from stale `pendingTool`), #515
+(Agent-tool subagent finished but report never delivered).
+
+**Method: reproduce first.** #492 was closed once and the symptom returned — do not
+reason from code alone. Use a throwaway test project, never a real one
+(cf. the 2026-07-07 brove-mobile handoff loss).
+
+### 1.2 Trim the boot prefix
+
+Target ~12.3k of the ~52k prefix, saved on every turn:
+
+- **Skills listing → on-demand (~7.4k).** All ~85 skill descriptions are dumped
+  upfront every session, including ones a squadrant captain will never touch (resume,
+  GCP, Solana). Mirror the existing deferred-tool pattern: list names, fetch the
+  description when relevant. Keep a small always-loaded set (`captain-ops`,
+  `karpathy-principles`).
+- **MEMORY.md → trim/archive (~4.9k).** The auto-memory index has grown to 19.7KB.
+  Archive older entries out of the always-loaded index.
+
+**Explicitly kept:** claude-mem injection stays. It is small (2.7k) and it is the
+memory the user wants. Not a cut target.
+
+### 1.3 `squadrant tokens`
+
+Package the measurement so the next decision is not guesswork. Attribute spend across
+captain vs crews, boot vs accumulation, and per-component prefix cost. The analysis
+script from 2026-07-29 already works and is the starting point.
+
+### 1.4 Manual mode
+
+The escape hatch: when Claude is unavailable or budget is nearly gone, boot a captain
+on another provider.
+
+- `squadrant launch <project> --agent <x> --model <y>` — explicit flags. Today the
+  agent is config-only (`defaults.roles.captain.agent`), with no CLI override
+  (`packages/cli/src/commands/launch.ts:89`).
+- **Guard against the Anthropic default.** `ensureGlobalOpencodeConfig` writes
+  `model: "anthropic/claude-sonnet-4-5"` (`per-crew-settings.ts:225`). An opencode
+  captain on the default config dies in exactly the outage it exists to survive. Warn
+  or refuse when the fallback resolves to an Anthropic model.
+- **Boot brief, pre-rendered.** Today the captain gets one line ("run your startup
+  checklist") and is trusted to execute 8 steps. A cheaper model is less reliable at
+  that. Squadrant should assemble the brief itself: handoff, status, live crews, open
+  PRs, relevant learnings — plus, when resuming, a **digest of the last Claude
+  session**. Keep it short; length is a per-turn cost.
+- **`squadrant mem`** — CLI over `~/.claude-mem/claude-mem.db` (plain SQLite), so any
+  agent can query memory via bash. Preferred over per-agent MCP registration because it
+  matches how the rest of the coordination surface already works.
+- **Point projection at the captain role** — `squadrant projection emit --target
+  opencode` already inlines instructions + skills into `AGENTS.md`. It has simply never
+  been wired to the captain role.
+
+**Both takeover modes are in scope**, and the digest is what makes the second one
+viable:
+
+| Mode | What it needs |
+|---|---|
+| Cold start | boot fresh, read handoff + status. Mostly assembling existing parts. |
+| Warm takeover | read the dead Claude session's transcript. Feasible because sessions are plain JSONL — but 55MB/dir, 5.7MB/file, so it **must** go through a digest, never raw. |
+
+## Phase 2 — long term
+
+Goal: the captain role is genuinely driver-agnostic. opencode first, codex after.
+
+### 2.1 Lift the lifecycle layer
+
+The three layers, and only one is real work:
+
+| Layer | State |
+|---|---|
+| Role prompt + playbook | ✅ projection emitter exists |
+| Coordination surface (`crew spawn/send/close`, `diff`, git, `gh`) | ✅ all bash, already agent-agnostic |
+| Lifecycle (interactive boot, readiness gate, turn-end, resume) | ❌ the work |
+
+Half of the third row is already solved on the **crew** path and can be reused:
+interactive TUI with `--port`, SSE `/event` bridge for turn-end, splash-marker gate
+(`splashMarker: "Ask anything"`, the #499 fix). The captain role was never wired to any
+of it — `buildAgentCmd`'s non-Claude branch still emits a one-shot `opencode run "…"`.
+
+Concretely:
+- interactive boot for the captain role (reuse the crew recipe)
+- readiness gate per agent (`CC_INITIALIZED_RE` is Claude-specific;
+  `packages/workspaces/src/runtimes/cmux.ts:324`)
+- turn-end detection per agent (SSE for opencode)
+- cross-day resume — opencode's equivalent of `claude -c`. **Unverified; needs a spike.**
+
+### 2.2 What cannot be ported
+
+State plainly rather than discover it late:
+
+- **`UserPromptSubmit` hook** — Claude Code's authoritative first-turn confirmation,
+  the fix that closed the whole first-turn-drop class (#471/#473). Other agents have no
+  equivalent. For opencode the SSE `/event` stream can substitute, but that is a
+  *different mechanism*, not a port — it must be re-validated against a real repro, not
+  assumed.
+- **`AskUserQuestion` modal** — no equivalent. Fallback is plain-text prompting.
+- **Judgment quality** — the captain role is mostly decisions, not code. A cheaper
+  model degrades coordination quality in ways token counts do not show.
+
+### 2.3 Later
+
+Codex. Then other harnesses (user mentioned "openharness" — scope deferred, not yet
+specified). Explicitly out of scope until Phase 1 and 2.1 land.
+
+## Decisions already made — do not re-litigate
+
+1. **Cold start *and* warm takeover** are both in scope, warm via digest only.
+2. **claude-mem stays injected.** It is the memory the user wants; it is small.
+3. **`squadrant mem` CLI over per-agent MCP config** — matches the existing
+   agent-agnostic coordination surface.
+4. **Measure before cutting.** The 17k-vs-52k error in the first context report is
+   exactly the failure mode to avoid.
+5. **Reproduce before fixing #594.** It was closed once already and came back.
+6. **"openharness" deferred** until the rest lands.
+
+## Open questions
+
+- Does opencode have a usable cross-day session resume? (blocks 2.1)
+- Is SSE turn-end trustworthy enough to replace hook-based confirmation for captain
+  turns? Needs a real repro, not a code read.
+- How much context can the boot brief carry before it becomes the problem it solves?
+  `squadrant tokens` (1.3) should answer this before the brief is designed (1.4).
+- Does the "always spawn a crew, even for one line" rule need an escape hatch in
+  frugal mode? Each crew re-derives repo context the captain already holds.
+
+## Evidence
+
+- [`2026-07-28-captain-context-budget.md`](2026-07-28-captain-context-budget.md) — per-component prefix breakdown, boot vs accumulation
+- [`2026-04-24-multi-agent-direction.md`](2026-04-24-multi-agent-direction.md) — standing direction statement
+- Issues: #594 (idle flood), #542, #515 (same bookkeeping root), #31 (projection layer)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "squadrant",
   "packageManager": "pnpm@10.30.3",
-  "version": "0.16.5",
+  "version": "0.16.6",
   "description": "Multi-project orchestration for your coding agents (Claude, Codex, opencode, Gemini)",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/__tests__/crew-approve.test.ts
+++ b/packages/cli/src/commands/__tests__/crew-approve.test.ts
@@ -63,6 +63,7 @@ describe("runCrewApprove (#599)", () => {
       call: vi.fn().mockResolvedValue(undefined),
       pushBranch: vi.fn(),
       createPr: vi.fn().mockReturnValue("https://github.com/x/y/pull/1"),
+      getCommitSubject: vi.fn().mockReturnValue(""),
       ...deps,
     });
   }
@@ -103,7 +104,7 @@ describe("runCrewApprove (#599)", () => {
     expect(createPr).toHaveBeenCalledWith("/repo/.worktrees/brove-fix-579", {
       base: "develop",
       branch: "crew/fix-579",
-      title: "add the flag",
+      title: "done, tests green",
       body: "done, tests green",
     });
     expect(call).toHaveBeenLastCalledWith({
@@ -132,6 +133,46 @@ describe("runCrewApprove (#599)", () => {
     const pushBranch = vi.fn();
     await runAction("brove", "quick-fix", { call, pushBranch });
     expect(pushBranch).toHaveBeenCalledWith("/repo", "crew/quick-fix");
+  });
+
+  it("prefers the branch's last commit subject as the PR title (#611)", async () => {
+    const call = vi.fn()
+      .mockResolvedValueOnce([
+        { id: "t1", name: "fix-579", state: "review", cwd: "/repo/.worktrees/brove-fix-579", task: "REVIEW-GATE DEMO — long noisy task prompt", reviewNote: "done, tests green", createdAt: 1 },
+      ])
+      .mockResolvedValueOnce(undefined);
+    const createPr = vi.fn().mockReturnValue("https://x/1");
+    const getCommitSubject = vi.fn().mockReturnValue("fix: make review state sticky (#608)");
+
+    await runAction("brove", "fix-579", { call, createPr, getCommitSubject });
+
+    expect(getCommitSubject).toHaveBeenCalledWith("/repo/.worktrees/brove-fix-579");
+    expect(createPr).toHaveBeenCalledWith(
+      "/repo/.worktrees/brove-fix-579",
+      expect.objectContaining({ title: "fix: make review state sticky (#608)" }),
+    );
+  });
+
+  it("falls back to reviewNote when there is no commit subject", async () => {
+    const call = vi.fn()
+      .mockResolvedValueOnce([
+        { id: "t1", name: "fix-579", state: "review", cwd: "/repo", task: "long noisy task prompt", reviewNote: "done, tests green", createdAt: 1 },
+      ])
+      .mockResolvedValueOnce(undefined);
+    const createPr = vi.fn().mockReturnValue("https://x/1");
+    await runAction("brove", "fix-579", { call, createPr, getCommitSubject: vi.fn().mockReturnValue("") });
+    expect(createPr).toHaveBeenCalledWith("/repo", expect.objectContaining({ title: "done, tests green" }));
+  });
+
+  it("falls back to the task-prompt first line only as a last resort", async () => {
+    const call = vi.fn()
+      .mockResolvedValueOnce([
+        { id: "t1", name: "fix-579", state: "review", cwd: "/repo", task: "add the flag\nmore detail", createdAt: 1 },
+      ])
+      .mockResolvedValueOnce(undefined);
+    const createPr = vi.fn().mockReturnValue("https://x/1");
+    await runAction("brove", "fix-579", { call, createPr, getCommitSubject: vi.fn().mockReturnValue("") });
+    expect(createPr).toHaveBeenCalledWith("/repo", expect.objectContaining({ title: "add the flag" }));
   });
 
   it("never emits task.done when pushBranch throws (push failure aborts before terminalizing)", async () => {

--- a/packages/cli/src/commands/crew-control.ts
+++ b/packages/cli/src/commands/crew-control.ts
@@ -248,6 +248,18 @@ function defaultCreatePr(cwd: string, o: { base: string; branch: string; title: 
   ).trim();
 }
 
+/** Default commit-subject lookup: the crew worktree's last commit subject, or "" if unavailable. */
+function defaultGetCommitSubject(cwd: string): string {
+  try {
+    return execFileSync("git", ["-C", cwd, "log", "-1", "--format=%s"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
 /**
  * `squadrant crew approve` — the accept side of the #599 review gate. Only
  * valid on a task in 'review' state (set by `squadrant crew signal review`):
@@ -263,6 +275,7 @@ export async function runCrewApprove(
     call: (req: unknown) => Promise<unknown>;
     pushBranch?: (cwd: string, branch: string) => void;
     createPr?: (cwd: string, o: { base: string; branch: string; title: string; body: string }) => string;
+    getCommitSubject?: (cwd: string) => string;
   },
 ): Promise<string> {
   const config = loadConfig();
@@ -281,8 +294,13 @@ export async function runCrewApprove(
   const cwd = task.cwd ?? proj.path;
   const base = resolveWorktreeBase(proj.path);
   const branch = crewBranch(crew);
-  const title = (task.task ?? branch).split(/\r?\n/)[0].trim().slice(0, 100);
   const body = (task.reviewNote ?? task.task ?? "").trim();
+
+  const getCommitSubject = deps.getCommitSubject ?? defaultGetCommitSubject;
+  const commitSubject = getCommitSubject(cwd).trim();
+  const reviewNoteFirstLine = (task.reviewNote ?? "").split(/\r?\n/)[0].trim();
+  const taskFirstLine = (task.task ?? branch).split(/\r?\n/)[0].trim();
+  const title = (commitSubject || reviewNoteFirstLine || taskFirstLine).slice(0, 100);
 
   const pushBranch = deps.pushBranch ?? defaultPushBranch;
   const createPr = deps.createPr ?? defaultCreatePr;

--- a/packages/cli/src/squadrantd.ts
+++ b/packages/cli/src/squadrantd.ts
@@ -158,7 +158,9 @@ export function startSquadrantd(opts: import("@squadrant/core").SquadrantdOpts =
   });
 
   const cmuxStoreSource = new CmuxStoreSource({ log });
-  const nativeHookSource = new NativeHookSource({ log });
+  // #615: opt-in env overlay — defaults.claudeEnv deep-merges into ~/.claude/settings.json
+  // 'env' (e.g. AFK timeouts). Absent ⇒ installClaudeHooks writes nothing to env.
+  const nativeHookSource = new NativeHookSource({ log, hookInstall: { claudeEnv: loadConfig().defaults.claudeEnv } });
 
   ctx.codexDriver = codexDriver;
   ctx.opencodeBridge = opencodeBridge;

--- a/packages/core/src/__tests__/daemon.test.ts
+++ b/packages/core/src/__tests__/daemon.test.ts
@@ -938,6 +938,39 @@ describe("daemon – blocked crew resume path (#183)", () => {
       expect(store.get("p", "t-flood")?.state).toBe("awaiting-input");
       expect(calls.filter((c) => c.message.includes("CREW IDLE"))).toHaveLength(1);
     });
+
+    // #594a: a crew that armed a background Monitor watch and then genuinely
+    // ends its turn (Stop hook, no tool in flight) is not "awaiting the
+    // captain" — it will self-resume on its own Monitor notification. Live
+    // evidence: real crew task 2506214d fired CREW IDLE 3x for the SAME turnId
+    // in a Stop→(auto-resume)→Stop poll loop, 23s and 76s apart, while polling
+    // for a background result — exactly this shape end-to-end.
+    it("a registered background Monitor absorbs a turn-end with ZERO CREW IDLE fires, and repeated Stop reports never flood (#594a)", async () => {
+      const store = createStore(dir);
+      store.put(rec("t-monitor", { state: "working" }));
+      const calls: any[] = [];
+      let nowMs = 100_000;
+      const d = createDaemon({ store, now: () => nowMs, notify: async (a) => { calls.push(a); } });
+      // Monitor is armed — its own PreToolUse/PostToolUse close almost
+      // immediately (unlike a hung tool), but the watch stays outstanding.
+      await d.handle({ kind: "event", project: "p", event: { type: "task.progress", id: "t-monitor", note: "agent.hook.PreToolUse", tool: "Monitor" } });
+      await d.handle({ kind: "event", project: "p", event: { type: "task.progress", id: "t-monitor", note: "posttooluse" } });
+      expect(store.get("p", "t-monitor")?.pendingMonitor).toBeDefined();
+      // Real, repeated Stop→auto-resume cycles land as separate turn.completed
+      // reports while the Monitor is still armed.
+      for (const t of [123_000, 199_000, 275_000]) {
+        nowMs = t;
+        await d.handle({ kind: "event", project: "p", event: { type: "task.turn.completed", id: "t-monitor", turnId: "poll-loop" } });
+      }
+      expect(store.get("p", "t-monitor")?.state).toBe("working");
+      expect(calls.filter((c) => c.message.includes("CREW IDLE"))).toHaveLength(0);
+
+      // Once the crew explicitly signals done, the Monitor exemption does not
+      // block real completion.
+      nowMs = 300_000;
+      await d.handle({ kind: "event", project: "p", event: { type: "task.done", id: "t-monitor", resultRef: "/r" } });
+      expect(store.get("p", "t-monitor")?.state).toBe("done");
+    });
   });
 
   it("awaiting-input + task.started → working + subsequent task.blocked fires CREW BLOCKED (#183)", async () => {
@@ -1155,6 +1188,71 @@ describe("sweep: task-timeout (#225)", () => {
     const timeoutCalls = calls.filter((c) => c.message.includes("CREW TIMEOUT")).length;
     expect(timeoutCalls).toBe(1);
     expect(store.get("p", "t378b")?.state).toBe("cancelled");
+  });
+
+  // ── #629: task-timeout must not cancel a crew awaiting captain review ────────
+  // Live evidence: task ce3113f0 (ctx-budget crew) entered 'review' at
+  // 2026-07-28T16:41:48Z, still correctly idle awaiting `crew approve`, and was
+  // cancelled by this exact ceiling at 2026-07-29T01:56:02Z ("CREW TIMEOUT ...
+  // wall-clock exceeded 8h ... state: review") — permanently closing the
+  // approve path (no push, no PR, no terminal DONE). 'review' (like 'blocked')
+  // is a sticky attention state awaiting a human decision with no natural time
+  // bound; the wall-clock ceiling exists to catch a crew stuck actually
+  // WORKING, not one that already finished and is correctly waiting.
+  it("does NOT cancel a task sitting in 'review' past the ceiling (#629)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    store.put(rec("t629a", {
+      state: "review", reviewNote: "ready for review", createdAt: 0,
+      lastHeartbeat: 1990, heartbeatBudgetMs: 86_400_000,
+    }));
+    const d = createDaemon({ store, now: () => 2000, taskTimeoutMs: 1_000, notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    const r = store.get("p", "t629a");
+    expect(r?.state).toBe("review");
+    expect(r?.lastEvent).not.toBe("sweep.task-timeout");
+    expect(calls.filter((c) => c.message.includes("CREW TIMEOUT"))).toHaveLength(0);
+  });
+
+  it("does NOT cancel a task sitting in 'blocked' past the ceiling (same sticky-attention family as #629)", async () => {
+    const store = createStore(dir);
+    store.put(rec("t629b", {
+      state: "blocked", question: "which env?", createdAt: 0,
+      lastHeartbeat: 1990, heartbeatBudgetMs: 86_400_000,
+    }));
+    const d = createDaemon({ store, now: () => 2000, taskTimeoutMs: 1_000 });
+    await d.sweep();
+    expect(store.get("p", "t629b")?.state).toBe("blocked");
+  });
+
+  it("still cancels a task genuinely stuck 'working' past the ceiling (#629 does not regress #225)", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    store.put(rec("t629c", {
+      state: "working", createdAt: 0,
+      lastHeartbeat: 1990, heartbeatBudgetMs: 86_400_000,
+    }));
+    const d = createDaemon({ store, now: () => 2000, taskTimeoutMs: 1_000, notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    const r = store.get("p", "t629c");
+    expect(r?.state).toBe("cancelled");
+    expect(r?.lastEvent).toBe("sweep.task-timeout");
+  });
+
+  it("a 'review' task with a gone surface is still reaped (#599 liveness reap is unaffected by the #629 ceiling exemption)", async () => {
+    const store = createStore(dir);
+    store.put(rec("t629d", {
+      state: "review", mode: "interactive", reviewNote: "n", createdAt: 0,
+      lastHeartbeat: 1990, heartbeatBudgetMs: 86_400_000,
+    }));
+    const d = createDaemon({
+      store, now: () => 2000, taskTimeoutMs: 1_000,
+      isSurfaceAlive: async () => "gone" as const,
+    });
+    await d.sweep();
+    const r = store.get("p", "t629d");
+    expect(r?.state).toBe("cancelled");
+    expect(r?.lastEvent).toBe("sweep.surface-gone");
   });
 });
 

--- a/packages/core/src/__tests__/delivery-loop.stuck-alert.test.ts
+++ b/packages/core/src/__tests__/delivery-loop.stuck-alert.test.ts
@@ -291,4 +291,90 @@ describe("delivery-loop stuck-delivery alert (#579/#484)", () => {
     texts = await rawMailboxTexts(stateRoot, project);
     expect(texts.filter((t) => t.includes("DELIVERY STUCK"))).toHaveLength(2);
   });
+
+  // #617: the stuck message hardcoded "an in-progress draft (or ghost text)
+  // in your input box" even when the actual blocker was a modal (#484) — an
+  // open AskUserQuestion/permission picker, not the operator's input box.
+  // Pointing the operator at the wrong place is actively misleading.
+  it("reports 'a modal question is open' when the blocker classification is modal, not the input-box wording (#617)", async () => {
+    const stateRoot = freshState();
+    const project = "zeta";
+    const captainName = `${project}-captain`;
+    mockConfig({ projects: { [project]: { captainName } } });
+    const store = createStore(stateRoot);
+    store.put({
+      id: "t1", project, provider: "claude", mode: "interactive",
+      state: "done", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000, attempts: [],
+    });
+    await appendToMailbox({
+      stateRoot, project, taskRecord: store.list(project)[0],
+      event: { type: "task.done", id: "t1" } as any,
+      message: "CREW DONE t1",
+    });
+    const livenessRegistry = new LivenessRegistry({ path: join(stateRoot, "live.json") });
+    livenessRegistry.apply({
+      project, role: "captain", pid: 123, sessionId: "s1",
+      startedAt: Date.now(), lastState: "start", lastSeenAt: Date.now(),
+      pidAlive: true, source: "runtime",
+    });
+
+    const cmux = {
+      listSurfaces: async () => [{ id: "s1", title: captainName, command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => `${captainName}> `,
+      send: async () => { throw new DeferDelivery(null, "modal"); },
+    };
+    const deliv = createDelivery({
+      stateRoot, store, livenessRegistry, log: () => {}, isPidAlive: () => true, opts: {},
+    } as any, cmux as any);
+
+    for (let i = 0; i < 6; i++) await deliv.deliveryTick!();
+
+    const texts = await rawMailboxTexts(stateRoot, project);
+    const alert = texts.find((t) => t.includes("DELIVERY STUCK"));
+    expect(alert).toContain("a modal question is open in your captain pane");
+    expect(alert).not.toContain("input box");
+  });
+
+  it("keeps the input-box wording when the blocker classification is draft/ghost (#617)", async () => {
+    const stateRoot = freshState();
+    const project = "eta";
+    const captainName = `${project}-captain`;
+    mockConfig({ projects: { [project]: { captainName } } });
+    const store = createStore(stateRoot);
+    store.put({
+      id: "t1", project, provider: "claude", mode: "interactive",
+      state: "done", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000, attempts: [],
+    });
+    await appendToMailbox({
+      stateRoot, project, taskRecord: store.list(project)[0],
+      event: { type: "task.done", id: "t1" } as any,
+      message: "CREW DONE t1",
+    });
+    const livenessRegistry = new LivenessRegistry({ path: join(stateRoot, "live.json") });
+    livenessRegistry.apply({
+      project, role: "captain", pid: 123, sessionId: "s1",
+      startedAt: Date.now(), lastState: "start", lastSeenAt: Date.now(),
+      pidAlive: true, source: "runtime",
+    });
+
+    let n = 0;
+    const cmux = {
+      listSurfaces: async () => [{ id: "s1", title: captainName, command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => `${captainName}> `,
+      send: async () => { throw new DeferDelivery(`typing-${n++}`, "draft"); },
+    };
+    const deliv = createDelivery({
+      stateRoot, store, livenessRegistry, log: () => {}, isPidAlive: () => true, opts: {},
+    } as any, cmux as any);
+
+    for (let i = 0; i < 6; i++) await deliv.deliveryTick!();
+
+    const texts = await rawMailboxTexts(stateRoot, project);
+    const alert = texts.find((t) => t.includes("DELIVERY STUCK"));
+    expect(alert).toContain("an in-progress draft (or ghost text) in your input box");
+  });
 });

--- a/packages/core/src/__tests__/delivery-loop.test.ts
+++ b/packages/core/src/__tests__/delivery-loop.test.ts
@@ -244,4 +244,94 @@ describe("delivery-loop", () => {
 
     vi.useRealTimers();
   });
+
+  // #617: the defer log line was `delivery seq=… kind=… outcome=deferred` —
+  // no project, no cause. Across a 57MB log with 8150 deferred lines there was
+  // no way to tell which project stalled or why. project= is already known in
+  // the loop; reason= is the classification sendToSurface already computed
+  // (DeferDelivery.reason) to decide to defer, not a new one.
+  it("logs project= and reason= on the defer outcome line (#617)", async () => {
+    const stateRoot = freshState();
+    const project = "gitnexus";
+    const captainName = `${project}-captain`;
+    const store = createStore(stateRoot);
+    store.put({
+      id: "t1", project, provider: "claude", mode: "interactive",
+      state: "done", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000, attempts: [],
+    });
+    await appendToMailbox({
+      stateRoot, project, taskRecord: store.list(project)[0],
+      event: { type: "task.done", id: "t1" } as any,
+      message: "CREW DONE t1",
+    });
+    const livenessRegistry = new LivenessRegistry({ path: join(stateRoot, "live.json") });
+    livenessRegistry.apply({
+      project, role: "captain", pid: 123, sessionId: "s1",
+      startedAt: Date.now(), lastState: "start", lastSeenAt: Date.now(),
+      pidAlive: true, source: "runtime",
+    });
+
+    const logs: string[] = [];
+    const cmux = {
+      listSurfaces: async () => [{ id: "s1", title: captainName, command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => `${captainName}> `,
+      send: async () => { throw new DeferDelivery(null, "modal"); },
+    };
+    const deliv = createDelivery({
+      stateRoot, store, livenessRegistry, log: (m: string) => logs.push(m), isPidAlive: () => true, opts: {},
+    } as any, cmux as any);
+
+    await deliv.deliveryTick!();
+
+    const deferLine = logs.find((l) => l.includes("outcome=deferred"));
+    expect(deferLine).toBeDefined();
+    expect(deferLine).toContain(`project=${project}`);
+    expect(deferLine).toContain("reason=modal");
+  });
+
+  // Logging every 1s tick for the full ~300-tick (~30min) maxDefers window
+  // would flood the log for no forensic gain once the cause is known — only
+  // the onset (1st defer) and every 30th tick after should log.
+  it("throttles the defer log line to the onset + every 30th tick, not every tick (#617)", async () => {
+    const stateRoot = freshState();
+    const project = "throttle-proj";
+    const captainName = `${project}-captain`;
+    const store = createStore(stateRoot);
+    store.put({
+      id: "t1", project, provider: "claude", mode: "interactive",
+      state: "done", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "", heartbeatBudgetMs: 1000, attempts: [],
+    });
+    await appendToMailbox({
+      stateRoot, project, taskRecord: store.list(project)[0],
+      event: { type: "task.done", id: "t1" } as any,
+      message: "CREW DONE t1",
+    });
+    const livenessRegistry = new LivenessRegistry({ path: join(stateRoot, "live.json") });
+    livenessRegistry.apply({
+      project, role: "captain", pid: 123, sessionId: "s1",
+      startedAt: Date.now(), lastState: "start", lastSeenAt: Date.now(),
+      pidAlive: true, source: "runtime",
+    });
+
+    let n = 0;
+    const logs: string[] = [];
+    const cmux = {
+      listSurfaces: async () => [{ id: "s1", title: captainName, command: "bash" }],
+      findWorkspaceId: async () => "w1",
+      readScreen: async () => `${captainName}> `,
+      send: async () => { throw new DeferDelivery(`typing-${n++}`, "draft"); },
+    };
+    const deliv = createDelivery({
+      stateRoot, store, livenessRegistry, log: (m: string) => logs.push(m), isPidAlive: () => true, opts: {},
+    } as any, cmux as any);
+
+    for (let i = 0; i < 32; i++) await deliv.deliveryTick!();
+
+    const deferLines = logs.filter((l) => l.includes("outcome=deferred"));
+    // Tick 1 (onset) and tick 30 — not ticks 2-29 or 31-32.
+    expect(deferLines).toHaveLength(2);
+  });
 });

--- a/packages/core/src/__tests__/delivery-loop.test.ts
+++ b/packages/core/src/__tests__/delivery-loop.test.ts
@@ -5,9 +5,10 @@ import { join } from "node:path";
 import { createDelivery } from "../daemon/delivery-loop.js";
 import { createStore } from "../store.js";
 import { LivenessRegistry } from "../daemon/liveness-registry.js";
-import { appendCaptainMessage, appendToMailbox, readCursor } from "../mailbox.js";
+import { appendCaptainMessage, appendToMailbox, readCursor, mailboxStats } from "../mailbox.js";
 import { STALE_THRESHOLD_MS } from "../daemon/interactive-probe.js";
 import { DeferDelivery } from "../delivery/defer-delivery.js";
+import type { TaskRecord } from "@squadrant/shared";
 
 function freshState(): string {
   return mkdtempSync(join(tmpdir(), "deliv-"));
@@ -243,5 +244,114 @@ describe("delivery-loop", () => {
     expect(sent).not.toContain("daemon message");
 
     vi.useRealTimers();
+  });
+});
+
+// ── #594b: CREW IDLE (or any attention-state push) arriving for a task that ──
+// has already been closed. `firePush` decides to notify synchronously off a
+// TaskRecord snapshot, but `defaultNotify`'s mailbox write is awaited I/O — a
+// concurrent `crew close` (task.cancelled) can land on the daemon's store in
+// that gap, terminalizing the record. The already-in-flight notify has no way
+// to know that by the time it actually executes. Fix: re-check the daemon's
+// own CURRENT record right before writing to the mailbox, and drop a
+// notification that the authoritative state has since superseded — the same
+// "gate on the daemon's own evidence" shape as #492's pendingTool veto, applied
+// at the delivery chokepoint instead of the state-transition chokepoint (this
+// specific race survives the state machine's terminal-absorb guard because the
+// notify was already decided BEFORE the close event was even applied).
+describe("defaultNotify staleness guard (#594b)", () => {
+  function record(overrides: Partial<TaskRecord> = {}): TaskRecord {
+    return {
+      id: "t1", project: "demo", provider: "claude", mode: "interactive",
+      state: "awaiting-input", task: "t", createdAt: 1, lastHeartbeat: 1,
+      lastEvent: "task.turn.completed", heartbeatBudgetMs: 1000, attempts: [],
+      ...overrides,
+    };
+  }
+
+  it("drops a CREW IDLE notify for a task that was closed in the gap before delivery", async () => {
+    const stateRoot = freshState();
+    const store = createStore(stateRoot);
+    const snapshot = record(); // what firePush decided to announce (awaiting-input)
+    // By the time defaultNotify actually runs, `crew close` has already
+    // terminalized the SAME task in the daemon's store.
+    store.put({ ...snapshot, state: "cancelled", lastEvent: "task.cancelled" });
+
+    const { defaultNotify } = createDelivery(
+      { stateRoot, store, log: () => {}, isPidAlive: () => true, opts: {} } as any,
+      undefined,
+    );
+    await defaultNotify({
+      project: "demo",
+      message: "CREW IDLE [claude/t1]: turn ended, awaiting your reply.",
+      record: snapshot,
+      event: { type: "task.turn.completed", id: "t1", turnId: "x" },
+    });
+
+    const stats = await mailboxStats(stateRoot, "demo");
+    expect(stats.maxSeq).toBe(0); // nothing was ever written to the inbox
+  });
+
+  it("still delivers a genuine notification when the task's current state matches the snapshot", async () => {
+    const stateRoot = freshState();
+    const store = createStore(stateRoot);
+    const snapshot = record();
+    store.put(snapshot); // no race — the store agrees with what we're announcing
+
+    const { defaultNotify } = createDelivery(
+      { stateRoot, store, log: () => {}, isPidAlive: () => true, opts: {} } as any,
+      undefined,
+    );
+    await defaultNotify({
+      project: "demo",
+      message: "CREW IDLE [claude/t1]: turn ended, awaiting your reply.",
+      record: snapshot,
+      event: { type: "task.turn.completed", id: "t1", turnId: "x" },
+    });
+
+    const stats = await mailboxStats(stateRoot, "demo");
+    expect(stats.maxSeq).toBe(1);
+  });
+
+  it("still delivers a genuine terminal notification (e.g. CREW DONE) even though the state IS terminal", async () => {
+    const stateRoot = freshState();
+    const store = createStore(stateRoot);
+    const snapshot = record({ state: "done", resultRef: "/r" });
+    store.put(snapshot); // the store agrees: this IS the done transition
+
+    const { defaultNotify } = createDelivery(
+      { stateRoot, store, log: () => {}, isPidAlive: () => true, opts: {} } as any,
+      undefined,
+    );
+    await defaultNotify({
+      project: "demo",
+      message: "CREW DONE [claude/t1]: finished.",
+      record: snapshot,
+      event: { type: "task.done", id: "t1", resultRef: "/r" },
+    });
+
+    const stats = await mailboxStats(stateRoot, "demo");
+    expect(stats.maxSeq).toBe(1);
+  });
+
+  it("delivers when the store has no record at all (e.g. purged) — fails open rather than silently dropping", async () => {
+    const stateRoot = freshState();
+    const store = createStore(stateRoot);
+    const snapshot = record();
+    // No store.put — the record is absent entirely.
+
+    const { defaultNotify } = createDelivery(
+      { stateRoot, store, log: () => {}, isPidAlive: () => true, opts: {} } as any,
+      undefined,
+    );
+    await defaultNotify({
+      project: "demo",
+      message: "CREW IDLE [claude/t1]: turn ended, awaiting your reply.",
+      record: snapshot,
+      event: { type: "task.turn.completed", id: "t1", turnId: "x" },
+    });
+
+    const stats = await mailboxStats(stateRoot, "demo");
+    expect(stats.maxSeq).toBe(1);
   });
 });

--- a/packages/core/src/__tests__/state-machine.test.ts
+++ b/packages/core/src/__tests__/state-machine.test.ts
@@ -319,6 +319,65 @@ describe("state-machine reduce", () => {
     expect(ended.pendingTool).toBeUndefined();
   });
 
+  // ── #594a: CREW IDLE flood — turn.completed while a registered background ──
+  // Monitor is still armed. Calling the `Monitor` tool arms a background watch
+  // and returns almost immediately (its own PreToolUse/PostToolUse close fast),
+  // but the watch itself keeps running and delivers async notifications later —
+  // during that gap the crew's own turn genuinely ends (Stop hook fires) with NO
+  // tool in flight. Squadrant must not read that as "awaiting the captain": the
+  // crew will self-resume on its own Monitor notification. Live evidence: a real
+  // brove-mobile crew (task 2506214d) fired CREW IDLE 3x for the SAME turnId
+  // while polling in a Stop→(auto-resume)→Stop loop, 23s and 76s apart.
+  it("task.progress PreToolUse for Monitor opens a pendingMonitor window", () => {
+    const next = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Monitor" }, 7000);
+    expect(next.pendingMonitor).toEqual({ since: 7000 });
+  });
+
+  it("Monitor's own PostToolUse does NOT close the pendingMonitor window (unlike pendingTool)", () => {
+    const open = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Monitor" }, 7000);
+    const afterPost = reduce(open, { type: "task.progress", id: "t1", note: "posttooluse" }, 7100);
+    expect(afterPost.pendingMonitor).toEqual({ since: 7000 }); // still armed
+    expect(afterPost.pendingTool).toBeUndefined(); // ordinary tool tracking closes as usual
+  });
+
+  it("task.turn.completed while a Monitor is armed is NOT trusted as a turn boundary (#594a)", () => {
+    const open = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Monitor" }, 7000);
+    const closed = reduce(open, { type: "task.progress", id: "t1", note: "posttooluse" }, 7100); // Monitor's own quick PostToolUse
+    const stillOpen = reduce(closed, { type: "task.turn.completed", id: "t1", turnId: "x" }, 8000);
+    expect(stillOpen.state).toBe("working"); // never flips to awaiting-input
+    expect(stillOpen.pendingMonitor).toEqual({ since: 7000 }); // watch window untouched
+    expect(stillOpen.lastHeartbeat).toBe(8000); // still counts as liveness
+  });
+
+  it("repeated contradicted task.turn.completed reports while Monitor is armed never re-enter awaiting-input (flood guard)", () => {
+    const armed = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Monitor" }, 7000);
+    let cur = reduce(armed, { type: "task.progress", id: "t1", note: "posttooluse" }, 7100);
+    for (const t of [8000, 8023000 - 8000000, 9000, 10000]) {
+      cur = reduce(cur, { type: "task.turn.completed", id: "t1", turnId: "x" }, t);
+      expect(cur.state).toBe("working");
+    }
+  });
+
+  it("a genuine turn boundary clears pendingMonitor on task.started", () => {
+    const armed = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Monitor" }, 7000);
+    const started = reduce(armed, { type: "task.started", id: "t1" }, 9000);
+    expect(started.pendingMonitor).toBeUndefined();
+  });
+
+  it("task.blocked and task.review clear pendingMonitor (mirrors pendingTool's turn-boundary reset)", () => {
+    const armed = reduce(rec({ state: "working" }), { type: "task.progress", id: "t1", note: "agent.hook.PreToolUse", tool: "Monitor" }, 7000);
+    const blocked = reduce(armed, { type: "task.blocked", id: "t1", reason: "r", question: "q?" }, 8000);
+    expect(blocked.pendingMonitor).toBeUndefined();
+    const reviewed = reduce(armed, { type: "task.review", id: "t1", message: "done" }, 8000);
+    expect(reviewed.pendingMonitor).toBeUndefined();
+  });
+
+  it("once no Monitor is armed, a real task.turn.completed IS a real boundary", () => {
+    const next = reduce(rec({ state: "working" }), { type: "task.turn.completed", id: "t1", turnId: "x" }, 8000);
+    expect(next.state).toBe("awaiting-input");
+    expect(next.pendingMonitor).toBeUndefined();
+  });
+
   it("stalled + task.progress (matching PostToolUse) recovers to working AND clears pendingTool (#354 auto-clear)", () => {
     const stalledHung = rec({ state: "stalled", pendingTool: { name: "Bash", since: 1000 } });
     const recovered = reduce(stalledHung, { type: "task.progress", id: "t1", note: "posttooluse" }, 9000);

--- a/packages/core/src/__tests__/watchdog.test.ts
+++ b/packages/core/src/__tests__/watchdog.test.ts
@@ -55,6 +55,27 @@ describe("evaluateStall", () => {
     expect(evaluateStall(rec({ state: "blocked" }), 999999)).toBeNull();
     expect(evaluateStall(rec({ state: "done" }), 999999)).toBeNull();
   });
+
+  // ── #594a: pendingMonitor stall budget (backstop against permanent suppression) ──
+  it("working INTERACTIVE with a Monitor armed WITHIN the monitor-stall budget → null (legit long watch)", () => {
+    const out = evaluateStall(rec({ mode: "interactive", pendingMonitor: { since: 0 } }), 30 * 60_000);
+    expect(out).toBeNull();
+  });
+
+  it("working INTERACTIVE with a Monitor armed past the monitor-stall budget → stalled", () => {
+    const out = evaluateStall(rec({ mode: "interactive", pendingMonitor: { since: 0 } }), 61 * 60_000);
+    expect(out?.state).toBe("stalled");
+    expect(out?.lastEvent).toBe("watchdog.monitor-stall");
+  });
+
+  it("a hung pendingTool is checked before pendingMonitor (pendingTool budget applies when both are set)", () => {
+    const out = evaluateStall(
+      rec({ mode: "interactive", pendingTool: { name: "Bash", since: 0 }, pendingMonitor: { since: 0 } }),
+      11 * 60_000,
+    );
+    expect(out?.state).toBe("stalled");
+    expect(out?.lastEvent).toBe("watchdog.tool-stall");
+  });
 });
 
 describe("recoverStall", () => {
@@ -68,6 +89,12 @@ describe("recoverStall", () => {
 
   it("recoverStall: non-stalled → null", () => {
     expect(recoverStall(rec({ state: "working" }), 7000)).toBeNull();
+  });
+
+  it("recoverStall clears a stale pendingMonitor too (#594a)", () => {
+    const stalled = rec({ state: "stalled", pendingMonitor: { since: 0 } });
+    const out = recoverStall(stalled, 7000);
+    expect(out?.pendingMonitor).toBeUndefined();
   });
 });
 

--- a/packages/core/src/daemon/delivery-loop.ts
+++ b/packages/core/src/daemon/delivery-loop.ts
@@ -296,7 +296,17 @@ export function createDelivery(
           log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=delivered`);
           await writeCursor({ stateRoot, project, subscriber: CURSOR_SUBSCRIBER, lastAckedSeq: entry.seq });
         } else {
-          log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=deferred`);
+          // #617: project+reason make a defer episode attributable after the
+          // fact (previously: no project, no cause — see issue). Logging every
+          // 1s tick for up to maxDefers (~300, ~30min) would flood the log for
+          // no forensic gain once the cause is known, so we log the onset
+          // (first defer of this seq) and then every 30th tick (~30s cadence)
+          // — enough resolution to correlate a later stuck/SIGTERM event
+          // without adding meaningful volume.
+          const { maxDeferCount } = d.stats();
+          if (maxDeferCount === 1 || maxDeferCount % 30 === 0) {
+            log(`delivery seq=${entry.seq} kind=${entry.kind} outcome=deferred project=${project} reason=${result.reason}`);
+          }
           break;
         }
       }
@@ -327,9 +337,14 @@ export function createDelivery(
       const stuck = d.stats().stuck;
       if (stuck && !stuckNotified.has(project)) {
         stuckNotified.add(project);
-        const { maxDeferCount } = d.stats();
-        log(`delivery stuck project=${project} deferCount=${maxDeferCount}`);
-        const text = `⚠️ DELIVERY STUCK: an in-progress draft (or ghost text) in your input box has blocked pending notification(s) for ${maxDeferCount}+ retries. Your input is never touched — this keeps retrying safely and will deliver automatically once you submit or clear it.`;
+        const { maxDeferCount, reason } = d.stats();
+        log(`delivery stuck project=${project} deferCount=${maxDeferCount} reason=${reason ?? "unknown"}`);
+        // #617: report the actual blocker instead of always blaming the input
+        // box — a modal (#484) isn't a draft/ghost and pointing the operator at
+        // their input box is actively misleading when a question is open.
+        const text = reason === "modal"
+          ? `⚠️ DELIVERY STUCK: a modal question is open in your captain pane and has blocked pending notification(s) for ${maxDeferCount}+ retries. This keeps retrying safely and will deliver automatically once you answer or dismiss it.`
+          : `⚠️ DELIVERY STUCK: an in-progress draft (or ghost text) in your input box has blocked pending notification(s) for ${maxDeferCount}+ retries. Your input is never touched — this keeps retrying safely and will deliver automatically once you submit or clear it.`;
         appendCaptainMessage({ stateRoot, project, text, source: "daemon" })
           .catch((e) => log(`delivery stuck alert failed project=${project}: ${(e as Error).message}`));
         Promise.resolve(notifyFault(project, text))

--- a/packages/core/src/daemon/delivery-loop.ts
+++ b/packages/core/src/daemon/delivery-loop.ts
@@ -170,6 +170,22 @@ export function createDelivery(
     record: TaskRecord;
     event: ControlEvent;
   }): Promise<void> => {
+    // #594b: firePush decides to notify off a TaskRecord snapshot captured
+    // synchronously at the state transition, but this mailbox write is
+    // awaited I/O — a concurrent `crew close` (task.cancelled) can land on the
+    // daemon's store in that gap and terminalize the SAME task. The reducer's
+    // own terminal-absorb guard can't help here (the close is a separate,
+    // later applyEvent call; this notify was already decided before it ran).
+    // Re-check the daemon's own CURRENT record right before writing: if the
+    // crew has since reached a terminal state different from what we're about
+    // to announce, the notification is stale — the crew is gone — so drop it
+    // rather than deliver e.g. "CREW IDLE" for a task that's already closed.
+    // A terminal notification (CREW DONE/FAILED) always matches its own fresh
+    // state and is unaffected; a missing record (e.g. purged) fails open.
+    const fresh = store.get(args.project, args.record.id);
+    if (fresh && TERMINAL_STATES.has(fresh.state) && fresh.state !== args.record.state) {
+      return;
+    }
     try {
       await appendToMailbox({
         stateRoot,

--- a/packages/core/src/daemon/reduce.ts
+++ b/packages/core/src/daemon/reduce.ts
@@ -2,7 +2,7 @@
 import type { Store } from "../store.js";
 import type { ControlEvent, TaskRecord, TaskState } from "@squadrant/shared";
 import { TERMINAL_STATES } from "@squadrant/shared";
-import { reduce } from "../state-machine.js";
+import { reduce, isStickyAttention } from "../state-machine.js";
 import { evaluateStall, recoverStall } from "../watchdog.js";
 export interface DaemonDeps {
   store: Store;
@@ -501,7 +501,14 @@ export function createDaemon(deps: DaemonDeps) {
         // ceiling. Terminalization is the persistent dedup — a daemon restart sees
         // the cancelled record and the TERMINAL_STATES gate above blocks re-fire.
         // The volatile firedTimeout Set is removed; terminal state replaces it.
-        if (!TERMINAL_STATES.has(r.state)) {
+        // #629: 'blocked'/'review' (isStickyAttention) are exempt — they pause a
+        // crew pending a human decision with no natural time bound (the captain
+        // might not look for hours). The ceiling exists to catch a crew stuck
+        // actually WORKING; applying it here cancelled a crew that had already
+        // finished and was correctly waiting on `crew approve`, permanently
+        // closing that path. A still-live surface keeps waiting indefinitely;
+        // a dead one is still caught by the surface-gone reap right below.
+        if (!TERMINAL_STATES.has(r.state) && !isStickyAttention(r.state)) {
           const ceiling = deps.taskTimeoutMs ?? DEFAULT_TASK_TIMEOUT_MS;
           if (t - r.createdAt > ceiling) {
             const prevState = r.state; // capture BEFORE terminalization (shown in message)
@@ -569,10 +576,14 @@ export function createDaemon(deps: DaemonDeps) {
         if (idle) {
           store.put(idle);
           // The synth event only carries the notify payload; the reducer treats
-          // it as a no-op (state already updated above). A hung-tool stall carries
-          // the tool name + elapsed so the notifier renders the accurate message.
+          // it as a no-op (state already updated above). A hung-tool or expired-
+          // Monitor stall carries the tool name + elapsed so the notifier renders
+          // the accurate message (#594a: idle.pendingTool is already cleared by
+          // the time a Monitor-only stall fires, so the two branches don't overlap).
           const synthEvent: ControlEvent = idle.pendingTool
             ? { type: "task.stalled", id: r.id, heartbeatBudgetMs: r.heartbeatBudgetMs, tool: idle.pendingTool.name, elapsedMs: t - idle.pendingTool.since }
+            : idle.pendingMonitor
+            ? { type: "task.stalled", id: r.id, heartbeatBudgetMs: r.heartbeatBudgetMs, tool: "Monitor", elapsedMs: t - idle.pendingMonitor.since }
             : { type: "task.stalled", id: r.id, heartbeatBudgetMs: r.heartbeatBudgetMs };
           firePush(deps, r.project, r.state, idle, synthEvent, lastCaptainTurnAt.get(r.id));
           continue;

--- a/packages/core/src/delivery/__tests__/captain-delivery.test.ts
+++ b/packages/core/src/delivery/__tests__/captain-delivery.test.ts
@@ -120,7 +120,7 @@ describe("CaptainDelivery.stats (B1 — read-only deferral visibility)", () => {
     await d.deliver({ seq: 1, message: "a" }, send);
     await d.deliver({ seq: 1, message: "a" }, send);
     await d.deliver({ seq: 2, message: "b" }, send);
-    expect(d.stats()).toEqual({ maxDeferCount: 2, stuck: false });
+    expect(d.stats()).toEqual({ maxDeferCount: 2, stuck: false, reason: "draft" });
   });
 
   it("flags stuck once the max in-flight defer count reaches maxDefers", async () => {
@@ -128,7 +128,7 @@ describe("CaptainDelivery.stats (B1 — read-only deferral visibility)", () => {
     const send = async () => { throw new DeferDelivery("draft"); };
     await d.deliver({ seq: 1, message: "a" }, send);
     await d.deliver({ seq: 1, message: "a" }, send);
-    expect(d.stats()).toEqual({ maxDeferCount: 2, stuck: true });
+    expect(d.stats()).toEqual({ maxDeferCount: 2, stuck: true, reason: "draft" });
   });
 
   it("clears a seq's defer count once it delivers", async () => {
@@ -139,5 +139,53 @@ describe("CaptainDelivery.stats (B1 — read-only deferral visibility)", () => {
     fail = false;
     await d.deliver({ seq: 1, message: "a" }, send);
     expect(d.stats()).toEqual({ maxDeferCount: 0, stuck: false });
+  });
+});
+
+// #617: defer/stuck delivery must be diagnosable — the daemon already decides
+// WHY a send deferred (modal per #484 / no-box per #268 / draft / stable-hold
+// per #302); deliver()/stats() must surface that existing classification
+// rather than the caller having to re-derive it.
+describe("CaptainDelivery deferral reason classification (#617)", () => {
+  it("surfaces the DeferDelivery reason verbatim for modal", async () => {
+    const d = new CaptainDelivery({ maxDefers: 300, stableProbePolls: 3 });
+    const send = async () => { throw new DeferDelivery(null, "modal"); };
+    const result = await d.deliver({ seq: 1, message: "a" }, send);
+    expect(result).toEqual({ deferred: true, reason: "modal" });
+    expect(d.stats().reason).toBe("modal");
+  });
+
+  it("surfaces the DeferDelivery reason verbatim for no-box", async () => {
+    const d = new CaptainDelivery({ maxDefers: 300, stableProbePolls: 3 });
+    const send = async () => { throw new DeferDelivery(null, "no-box"); };
+    const result = await d.deliver({ seq: 1, message: "a" }, send);
+    expect(result).toEqual({ deferred: true, reason: "no-box" });
+  });
+
+  it("classifies a fresh/changing draft as \"draft\" before it stabilizes", async () => {
+    const d = new CaptainDelivery({ maxDefers: 300, stableProbePolls: 2 });
+    const send = async () => { throw new DeferDelivery("typing", "draft"); };
+    const result = await d.deliver({ seq: 1, message: "a" }, send);
+    expect(result).toEqual({ deferred: true, reason: "draft" });
+  });
+
+  it("upgrades \"draft\" to \"stable\" once content holds byte-identical for stableProbePolls polls (#302 signal, not a new classifier)", async () => {
+    const d = new CaptainDelivery({ maxDefers: 300, stableProbePolls: 2 });
+    const send = async () => { throw new DeferDelivery("held-content", "draft"); };
+    const r1 = await d.deliver({ seq: 1, message: "a" }, send);
+    expect(r1).toEqual({ deferred: true, reason: "draft" });
+    const r2 = await d.deliver({ seq: 1, message: "a" }, send);
+    expect(r2).toEqual({ deferred: true, reason: "draft" }); // stableCount=1 < stableProbePolls=2
+    const r3 = await d.deliver({ seq: 1, message: "a" }, send);
+    expect(r3).toEqual({ deferred: true, reason: "stable" }); // stableCount=2 >= 2
+    expect(d.stats().reason).toBe("stable");
+  });
+
+  it("does not let a stable-content streak override modal — modal always wins regardless of content history", async () => {
+    const d = new CaptainDelivery({ maxDefers: 300, stableProbePolls: 1 });
+    const send = async () => { throw new DeferDelivery(null, "modal"); };
+    await d.deliver({ seq: 1, message: "a" }, send);
+    const result = await d.deliver({ seq: 1, message: "a" }, send);
+    expect(result).toEqual({ deferred: true, reason: "modal" });
   });
 });

--- a/packages/core/src/delivery/captain-delivery.ts
+++ b/packages/core/src/delivery/captain-delivery.ts
@@ -1,4 +1,4 @@
-import { DeferDelivery } from "./defer-delivery.js";
+import { DeferDelivery, type DeferReason } from "./defer-delivery.js";
 
 /**
  * #332: extracted defer-while-typing state machine (#258/#302).
@@ -14,7 +14,15 @@ export interface CaptainDeliveryOptions {
 }
 
 export type SendFn = (text: string, opts?: { probe?: boolean }) => Promise<void>;
-export type DeliverResult = { delivered: true } | { deferred: true };
+
+/** #617: the deferral classification surfaced for logging/alerting. Mostly the
+ *  DeferReason sendToSurface already decided (see defer-delivery.ts), plus
+ *  "stable" — CaptainDelivery's own byte-identical-across-polls signal (#302)
+ *  that upgrades a "draft" into the more precise "content stopped changing,
+ *  likely a paused human or a ghost, about to be probed" classification.
+ *  "unknown" covers a non-DeferDelivery throw, which carries no classification. */
+export type DeliverDeferReason = DeferReason | "stable" | "unknown";
+export type DeliverResult = { delivered: true } | { deferred: true; reason: DeliverDeferReason };
 
 /** Read-only deferral snapshot (B1 — dashboard visibility into #484/#466-class stalls). */
 export interface CaptainDeliveryStats {
@@ -23,6 +31,8 @@ export interface CaptainDeliveryStats {
   /** true once maxDeferCount has reached the configured maxDefers threshold — the same
    *  point at which delivery force-escalates to a probe send. */
   stuck: boolean;
+  /** Classification for the seq at maxDeferCount (#617). undefined when nothing is deferred. */
+  reason?: DeliverDeferReason;
 }
 
 /**
@@ -41,6 +51,7 @@ export class CaptainDelivery {
   private deferCounts = new Map<number, number>();
   private lastContent = new Map<number, string | null>();
   private stableCounts = new Map<number, number>();
+  private lastReason = new Map<number, DeliverDeferReason>();
 
   constructor(private readonly opts: CaptainDeliveryOptions) {}
 
@@ -78,6 +89,7 @@ export class CaptainDelivery {
       this.deferCounts.delete(seq);
       this.stableCounts.delete(seq);
       this.lastContent.delete(seq);
+      this.lastReason.delete(seq);
       return { delivered: true };
     } catch (e) {
       if (e instanceof DeferDelivery) {
@@ -85,23 +97,42 @@ export class CaptainDelivery {
         // Track content stability: byte-identical non-empty draft across
         // consecutive polls means the captain isn't actively typing (#302).
         const content = e.draft;
+        let stableCount: number;
         if (content && content === this.lastContent.get(seq)) {
-          this.stableCounts.set(seq, (this.stableCounts.get(seq) ?? 0) + 1);
+          stableCount = (this.stableCounts.get(seq) ?? 0) + 1;
+          this.stableCounts.set(seq, stableCount);
         } else {
+          stableCount = 0;
           this.stableCounts.set(seq, 0);
         }
         this.lastContent.set(seq, content);
-        return { deferred: true };
+        // #617: "stable" (byte-identical for stableProbePolls polls) is a more
+        // precise classification than the raw "draft" reason once it applies —
+        // it's the same signal that gates probe escalation just above, not a
+        // new classifier. modal/no-box always win: they don't depend on content.
+        const reason: DeliverDeferReason =
+          e.reason !== "draft" ? e.reason
+          : stableCount >= this.opts.stableProbePolls ? "stable"
+          : "draft";
+        this.lastReason.set(seq, reason);
+        return { deferred: true, reason };
       }
       // Non-DeferDelivery errors: don't advance cursor, retry next poll.
-      return { deferred: true };
+      this.lastReason.set(seq, "unknown");
+      return { deferred: true, reason: "unknown" };
     }
   }
 
   /** Read-only. Never mutates — safe to poll from the snapshot assembler every tick. */
   stats(): CaptainDeliveryStats {
     let maxDeferCount = 0;
-    for (const c of this.deferCounts.values()) if (c > maxDeferCount) maxDeferCount = c;
-    return { maxDeferCount, stuck: maxDeferCount >= this.opts.maxDefers };
+    let reason: DeliverDeferReason | undefined;
+    for (const [seq, c] of this.deferCounts) {
+      if (c > maxDeferCount) {
+        maxDeferCount = c;
+        reason = this.lastReason.get(seq);
+      }
+    }
+    return { maxDeferCount, stuck: maxDeferCount >= this.opts.maxDefers, reason };
   }
 }

--- a/packages/core/src/delivery/defer-delivery.ts
+++ b/packages/core/src/delivery/defer-delivery.ts
@@ -1,6 +1,16 @@
+/** #617: the classification sendToSurface already decides at each throw site —
+ *  surfaced so callers can log *why* a send deferred, not just that it did.
+ *  "no-box": input box not confirmed visible (overlay/unreadable screen, #268).
+ *  "modal": an AskUserQuestion/permission selection modal is open (#484).
+ *  "draft": a real (or not-yet-disambiguated) draft is present in the input box. */
+export type DeferReason = "no-box" | "modal" | "draft";
+
 /** Thrown by sendToSurface when the captain has a draft — delivery defers (#258/#302). */
 export class DeferDelivery extends Error {
-  constructor(public readonly draft: string | null = null) {
+  constructor(
+    public readonly draft: string | null = null,
+    public readonly reason: DeferReason = "draft",
+  ) {
     super("deferred: captain composing");
     this.name = "DeferDelivery";
   }

--- a/packages/core/src/state-machine.ts
+++ b/packages/core/src/state-machine.ts
@@ -23,9 +23,11 @@ function stampAttempt(
  * pending a human decision — neither may be knocked out by a liveness or
  * turn-boundary event, only by their own explicit exits (reply/feedback or
  * approve). Every stickiness guard below must treat them identically, or a
- * future attention state repeats this bug a fourth time (#492 → #605 → #608).
+ * future attention state repeats this bug a fourth time (#492 → #605 → #608
+ * → #629, which reused this exact predicate to also exempt the sweep's
+ * wall-clock task-timeout ceiling — see reduce.ts).
  */
-function isStickyAttention(state: TaskRecord["state"]): boolean {
+export function isStickyAttention(state: TaskRecord["state"]): boolean {
   return state === "blocked" || state === "review";
 }
 
@@ -45,6 +47,26 @@ function nextPendingTool(
 ): TaskRecord["pendingTool"] {
   if (ev.note === "agent.hook.PreToolUse") return { name: ev.tool ?? "tool", since: now };
   if (ev.note === "posttooluse" || ev.note === "agent.hook.UserPromptSubmit") return undefined;
+  return current;
+}
+
+/**
+ * #594a: compute the next pendingMonitor marker. A PreToolUse naming the
+ * `Monitor` tool arms a background watch. Unlike pendingTool, this is
+ * deliberately NOT closed by that same call's own PostToolUse: Monitor's tool
+ * call returns almost immediately after arming (it doesn't block), but the
+ * watch — and its async notifications — keeps running well past that. Only a
+ * genuine new turn boundary (handled by the reduce() cases that clear it
+ * explicitly, mirroring pendingTool) or the watchdog's own stall budget ends
+ * the exemption, so a crew whose turn ends while a Monitor is still armed is
+ * not misread as "awaiting the captain".
+ */
+function nextPendingMonitor(
+  current: TaskRecord["pendingMonitor"],
+  ev: Extract<ControlEvent, { type: "task.progress" }>,
+  now: number,
+): TaskRecord["pendingMonitor"] {
+  if (ev.note === "agent.hook.PreToolUse" && ev.tool === "Monitor") return { since: now };
   return current;
 }
 
@@ -74,6 +96,7 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
         sessionId: ev.sessionId ?? rec.sessionId,
         question: undefined, // resuming after a blocked→reply clears the question
         pendingTool: undefined, // #354: a new turn closes any prior tool window
+        pendingMonitor: undefined, // #594a: same reset — a new turn moots any prior watch
       };
     case "task.progress": {
       // task.progress is a real-activity signal (stdout chunk for headless,
@@ -82,12 +105,15 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
       // (#89) can key off it without false-stalling long-running headless tasks.
       // #354: also track the in-flight tool (PreToolUse opens, PostToolUse closes)
       // so a hung tool call is distinguishable from a quiet thinking turn.
+      // #594a: also track a registered background Monitor watch (PreToolUse
+      // opens, but — unlike pendingTool — its own PostToolUse does NOT close it).
       // From blocked: liveness only — do not auto-unblock (explicit reply required).
       // From awaiting-input OR stalled: resume to working — the next real activity
       // (e.g. the matching PostToolUse) auto-clears a hung-tool warn instantly.
       const pendingTool = nextPendingTool(rec.pendingTool, ev, now);
-      if (isStickyAttention(rec.state)) return { ...rec, lastHeartbeat: now, lastEvent: ev.type, pendingTool };
-      const b = { ...base, pendingTool };
+      const pendingMonitor = nextPendingMonitor(rec.pendingMonitor, ev, now);
+      if (isStickyAttention(rec.state)) return { ...rec, lastHeartbeat: now, lastEvent: ev.type, pendingTool, pendingMonitor };
+      const b = { ...base, pendingTool, pendingMonitor };
       if (rec.state === "awaiting-input" || rec.state === "stalled") return { ...stampAttempt(b, {}, now), state: "working" };
       return stampAttempt(b, {}, now);
     }
@@ -107,11 +133,11 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
       // no-op so the FIRST (explicit) question wins and no duplicate CREW
       // BLOCKED fires. Terminal states are already absorbed above.
       if (rec.state === "blocked") return { ...rec, lastHeartbeat: now, lastEvent: ev.type };
-      return { ...base, state: "blocked", question: ev.question, pendingTool: undefined };
+      return { ...base, state: "blocked", question: ev.question, pendingTool: undefined, pendingMonitor: undefined };
     case "task.review":
       // #599: review-gate checkpoint. Not terminal — `crew send` (feedback)
       // or `crew approve` (task.done) are the only ways out.
-      return { ...base, state: "review", reviewNote: ev.message, pendingTool: undefined };
+      return { ...base, state: "review", reviewNote: ev.message, pendingTool: undefined, pendingMonitor: undefined };
     case "task.done":
       // #605: the review gate must be ENFORCING, not advisory. A crew's normal
       // completion protocol always signals done at turn end — if that alone
@@ -137,7 +163,7 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
     case "task.session":
       return stampAttempt(base, { resumeRef: ev.resumeRef }, now);
     case "task.turn.started":
-      return { ...stampAttempt(base, {}, now), state: "working", pendingTool: undefined };
+      return { ...stampAttempt(base, {}, now), state: "working", pendingTool: undefined, pendingMonitor: undefined };
     case "task.turn.completed":
       // Anti-#2576 invariant: TurnCompleted is liveness, NEVER completion. Spec §4.8.
       // A turn ending while blocked must NOT unblock — only the captain's answer
@@ -156,13 +182,20 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
       // evidence (no matching PostToolUse yet), so it is not a genuine turn
       // boundary. Treat it as liveness only; the real turn-end arrives once the
       // tool actually returns and pendingTool clears.
-      if (rec.pendingTool) return stampAttempt(base, {}, now);
-      return { ...stampAttempt(base, {}, now), state: "awaiting-input", pendingTool: undefined };
+      // #594a: a registered background Monitor (pendingMonitor) gets the same
+      // veto. Its own tool call closes almost immediately (pendingTool clears
+      // fast), but the watch it armed keeps running — a Stop hook firing while
+      // it's still outstanding means the crew is asleep awaiting its OWN
+      // notification, not the captain's. Without this, that turn-end reads as
+      // genuine and floods CREW IDLE on every self-resume (live evidence: task
+      // 2506214d fired CREW IDLE 3x for the same turnId, 23s/76s apart).
+      if (rec.pendingTool || rec.pendingMonitor) return stampAttempt(base, {}, now);
+      return { ...stampAttempt(base, {}, now), state: "awaiting-input", pendingTool: undefined, pendingMonitor: undefined };
     case "task.delta":
       return stampAttempt(base, {}, now);  // heartbeat-only
     case "task.input.requested":
     case "task.approval.requested":
-      return { ...stampAttempt(base, {}, now), state: "blocked", question: ev.question, pendingTool: undefined };
+      return { ...stampAttempt(base, {}, now), state: "blocked", question: ev.question, pendingTool: undefined, pendingMonitor: undefined };
     case "task.reattached":
       return stampAttempt(base, {}, now);
     case "task.first-turn.confirmed":

--- a/packages/core/src/watchdog.ts
+++ b/packages/core/src/watchdog.ts
@@ -13,6 +13,17 @@ import type { TaskRecord } from "@squadrant/shared";
 export const TOOL_STALL_BUDGET_MS = 10 * 60 * 1000;
 
 /**
+ * #594a: how long a registered background Monitor watch may sit outstanding
+ * before the daemon gives up on the exemption and treats it as abandoned.
+ * Deliberately generous — well above Monitor's own documented max timeout_ms
+ * (1h) for a non-persistent watch — so a legitimate long CI/deploy poll is
+ * never false-stalled mid-watch. This is a backstop, not the primary fix: it
+ * exists only so a crew that armed a Monitor once and then went genuinely
+ * silent forever doesn't suppress real idle detection permanently.
+ */
+export const MONITOR_STALL_BUDGET_MS = 60 * 60 * 1000;
+
+/**
  * Pure. Returns a stalled-transitioned record if a `working` task is genuinely
  * stuck at time `now` (epoch ms), else null. No I/O, no clock. #354 splits the
  * old single wall-clock timeout by what we can actually prove:
@@ -23,7 +34,10 @@ export const TOOL_STALL_BUDGET_MS = 10 * 60 * 1000;
  *    has been outstanding past `toolStallMs`. A PreToolUse with no matching
  *    PostToolUse is a hung tool call (we know which tool). Recoverable: the next
  *    PostToolUse recovers it to `working` (state-machine / recoverStall).
- *  - interactive with NO tool in flight → null. A quiet thinking turn is alive,
+ *  - interactive with NO tool in flight but a Monitor armed (pendingMonitor) →
+ *    'stalled' once that watch has been outstanding past `monitorStallMs`
+ *    (#594a backstop against permanent suppression — see MONITOR_STALL_BUDGET_MS).
+ *  - interactive with neither in flight → null. A quiet thinking turn is alive,
  *    not stalled and NOT awaiting-input (the turn never ended — real CREW IDLE
  *    comes only from the Stop hook). The daemon sweep surfaces this as a
  *    distinct, non-alarming CREW QUIET notify instead (#354), keeping the crew
@@ -36,14 +50,22 @@ export function evaluateStall(
   rec: TaskRecord,
   now: number,
   toolStallMs: number = TOOL_STALL_BUDGET_MS,
+  monitorStallMs: number = MONITOR_STALL_BUDGET_MS,
 ): TaskRecord | null {
   if (rec.state !== "working") return null;
   if (rec.mode === "interactive") {
-    // Only a hung tool call is a stall for an interactive crew; a quiet thinking
-    // turn (no pendingTool) is alive and handled by the sweep's CREW QUIET path.
-    if (!rec.pendingTool) return null;
-    if (now - rec.pendingTool.since <= toolStallMs) return null;
-    return { ...rec, state: "stalled", lastEvent: "watchdog.tool-stall" };
+    // A hung tool call takes priority over a registered Monitor watch.
+    if (rec.pendingTool) {
+      if (now - rec.pendingTool.since <= toolStallMs) return null;
+      return { ...rec, state: "stalled", lastEvent: "watchdog.tool-stall" };
+    }
+    if (rec.pendingMonitor) {
+      if (now - rec.pendingMonitor.since <= monitorStallMs) return null;
+      return { ...rec, state: "stalled", lastEvent: "watchdog.monitor-stall" };
+    }
+    // Neither a hung tool nor a Monitor watch — a quiet thinking turn is alive
+    // and handled by the sweep's CREW QUIET path.
+    return null;
   }
   // headless: key off the latest attempt's lastHeartbeatAt so a stale event from
   // a dead prior attempt cannot refresh the liveness clock of the new dispatch (#89).
@@ -62,7 +84,7 @@ export function evaluateStall(
  */
 export function recoverStall(rec: TaskRecord, now: number): TaskRecord | null {
   if (rec.state !== "stalled") return null;
-  // #354: clear any hung-tool marker on recovery so a recovered crew never
-  // carries a stale pendingTool into its next quiet window.
-  return { ...rec, state: "working", lastHeartbeat: now, lastEvent: "watchdog.recover", pendingTool: undefined };
+  // #354/#594a: clear any hung-tool or stale-Monitor marker on recovery so a
+  // recovered crew never carries either into its next quiet window.
+  return { ...rec, state: "working", lastHeartbeat: now, lastEvent: "watchdog.recover", pendingTool: undefined, pendingMonitor: undefined };
 }

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -125,6 +125,10 @@ export interface SquadrantConfig {
     /** #536 startup npm-registry update check. Default true (absent ⇒ enabled);
      *  set false to opt out. NO_UPDATE_NOTIFIER env var also opts out. */
     updateCheck?: boolean;
+    /** #615 opt-in: env vars deep-merged into ~/.claude/settings.json's 'env' block by
+     *  installClaudeHooks, non-clobbering (a key the user already set is never overwritten).
+     *  Absent ⇒ nothing written. e.g. { CLAUDE_AFK_TIMEOUT_MS: "240000" } for Claude's AFK mode. */
+    claudeEnv?: Record<string, string>;
   };
   metrics: {
     enabled: boolean;

--- a/packages/shared/src/types/control.ts
+++ b/packages/shared/src/types/control.ts
@@ -93,6 +93,18 @@ export interface TaskRecord {
    *  (no pendingTool → CREW QUIET). Auto-clears: the next PostToolUse recovers
    *  the record to `working` (state-machine + recoverStall). */
   pendingTool?: { name: string; since: number };
+  /** #594a: a registered background Monitor watch, if any. Set when a PreToolUse
+   *  liveness signal names the `Monitor` tool. Unlike pendingTool, this is NOT
+   *  cleared by that call's own PostToolUse — Monitor's tool call returns almost
+   *  immediately after arming the watch, but the watch itself (and its async
+   *  notifications) keeps running well past that. A crew whose turn genuinely
+   *  ends (Stop hook) while a Monitor is still armed is not awaiting the
+   *  captain — it will self-resume on its own notification — so the
+   *  turn.completed veto treats pendingMonitor the same as pendingTool. Cleared
+   *  only by a genuine new turn boundary (task.started/blocked/review/
+   *  turn.started/input-approval-requested), or by the watchdog once it has been
+   *  outstanding past MONITOR_STALL_BUDGET_MS (treated as abandoned). */
+  pendingMonitor?: { since: number };
   /** #466: epoch ms when the spawn path positively confirmed the first turn was
    *  delivered (paste rendered in the box → box emptied = submitted). Unset means
    *  either the crew was spawned before this field existed, OR delivery was never

--- a/packages/workspaces/src/native-hooks/__tests__/native-hook-source.test.ts
+++ b/packages/workspaces/src/native-hooks/__tests__/native-hook-source.test.ts
@@ -230,6 +230,109 @@ describe("installClaudeHooks — non-clobbering (D4: preserves existing hooks)",
   });
 });
 
+// ── installClaudeHooks — #615 always verify + repair ──────────────────────────
+
+describe("installClaudeHooks — #615 drift repair on an existing settings file", () => {
+  it("repairs a squadrant hook missing from an existing settings file and logs a warning", () => {
+    // Baseline: a full install, then simulate drift by dropping the
+    // AskUserQuestion hook entry (#560 — the one that makes blocked-signalling work).
+    const { opts, written } = makeInstallOpts();
+    installClaudeHooks(opts);
+    const drifted = JSON.parse(written[0].content);
+    drifted.hooks.PreToolUse = (drifted.hooks.PreToolUse as Array<Record<string, unknown>>).filter(
+      (e) => e.matcher !== "AskUserQuestion",
+    );
+
+    const log = vi.fn();
+    const { opts: opts2, written: written2 } = makeInstallOpts({ existingSettings: drifted });
+    opts2.log = log;
+    installClaudeHooks(opts2);
+
+    expect(written2).toHaveLength(1);
+    const result = JSON.parse(written2[0].content);
+    const hasAskQuestion = (result.hooks.PreToolUse as Array<Record<string, unknown>>).some(
+      (e) => e.matcher === "AskUserQuestion",
+    );
+    expect(hasAskQuestion).toBe(true);
+    expect(log).toHaveBeenCalled();
+    expect(log.mock.calls.some(([msg]) => /repaired/i.test(msg) && /warning/i.test(msg))).toBe(true);
+  });
+
+  it("does not log a repair warning on a fresh install (no prior settings file)", () => {
+    const log = vi.fn();
+    const { opts } = makeInstallOpts();
+    opts.log = log;
+    installClaudeHooks(opts);
+
+    expect(log.mock.calls.some(([msg]) => /repaired/i.test(msg))).toBe(false);
+  });
+});
+
+// ── installClaudeHooks — #615 opt-in claudeEnv overlay ─────────────────────────
+
+describe("installClaudeHooks — #615 opt-in claudeEnv overlay", () => {
+  it("deep-merges claudeEnv into settings.json env when configured", () => {
+    const { opts, written } = makeInstallOpts();
+    opts.claudeEnv = { CLAUDE_AFK_TIMEOUT_MS: "240000" };
+    installClaudeHooks(opts);
+
+    const result = JSON.parse(written[0].content);
+    expect(result.env).toEqual({ CLAUDE_AFK_TIMEOUT_MS: "240000" });
+  });
+
+  it("writes nothing to env when claudeEnv is absent", () => {
+    const { opts, written } = makeInstallOpts();
+    installClaudeHooks(opts);
+
+    const result = JSON.parse(written[0].content);
+    expect(result.env).toBeUndefined();
+  });
+
+  it("does not overwrite an existing conflicting user env key, and logs a warning", () => {
+    const log = vi.fn();
+    const { opts, written } = makeInstallOpts({
+      existingSettings: { env: { CLAUDE_AFK_TIMEOUT_MS: "60000" } },
+    });
+    opts.claudeEnv = { CLAUDE_AFK_TIMEOUT_MS: "240000" };
+    opts.log = log;
+    installClaudeHooks(opts);
+
+    const result = JSON.parse(written[0].content);
+    expect(result.env.CLAUDE_AFK_TIMEOUT_MS).toBe("60000");
+    expect(log.mock.calls.some(([msg]) => /CLAUDE_AFK_TIMEOUT_MS/.test(msg))).toBe(true);
+  });
+
+  it("preserves an existing user env key that matches the claudeEnv value (no clobber, no warning)", () => {
+    // Baseline: install hooks first so the second call has nothing left to repair —
+    // isolates the assertion to env-only behavior.
+    const { opts: baseline, written: baselineWritten } = makeInstallOpts();
+    installClaudeHooks(baseline);
+    const settled = JSON.parse(baselineWritten[0].content);
+    settled.env = { CLAUDE_AFK_TIMEOUT_MS: "240000" };
+
+    const log = vi.fn();
+    const { opts, written } = makeInstallOpts({ existingSettings: settled });
+    opts.claudeEnv = { CLAUDE_AFK_TIMEOUT_MS: "240000" };
+    opts.log = log;
+    installClaudeHooks(opts);
+
+    // No hook drift and no env change ⇒ nothing to write.
+    expect(written).toHaveLength(0);
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("adds new claudeEnv keys alongside preserved unrelated user env keys", () => {
+    const { opts, written } = makeInstallOpts({
+      existingSettings: { env: { SOME_OTHER_VAR: "keep-me" } },
+    });
+    opts.claudeEnv = { CLAUDE_AFK_TIMEOUT_MS: "240000" };
+    installClaudeHooks(opts);
+
+    const result = JSON.parse(written[0].content);
+    expect(result.env).toEqual({ SOME_OTHER_VAR: "keep-me", CLAUDE_AFK_TIMEOUT_MS: "240000" });
+  });
+});
+
 // ── mapSubToLifecycle ─────────────────────────────────────────────────────────
 
 describe("mapSubToLifecycle — pure mapping", () => {
@@ -504,6 +607,23 @@ describe("NativeHookSource — install()", () => {
 
     expect(returned).toBe(SETTINGS_PATH);
     expect(written).toHaveLength(1);
+  });
+
+  it("#615: forwards the source-level log into installClaudeHooks when hookInstall.log is unset", () => {
+    const log = vi.fn();
+    const written: Array<{ path: string; content: string }> = [];
+    const src = new NativeHookSource({
+      log,
+      hookInstall: {
+        settingsPath: SETTINGS_PATH,
+        hookCmd: HOOK_CMD,
+        readFile: () => "not-valid-json{{",
+        writeFile: (p, c) => written.push({ path: p, content: c }),
+      },
+    });
+    src.install();
+
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("failed to parse"));
   });
 
   it("install() is idempotent when called twice", () => {

--- a/packages/workspaces/src/native-hooks/native-hook-source.ts
+++ b/packages/workspaces/src/native-hooks/native-hook-source.ts
@@ -47,6 +47,13 @@ export interface ClaudeHooksInstallOpts {
   /** Injectable: write file (caller responsible for creating parent dirs). */
   writeFile?: (path: string, content: string) => void;
   log?: (msg: string) => void;
+  /**
+   * #615 opt-in: deep-merged into settings.json's 'env' block, non-clobbering —
+   * a key already present in the user's settings is never overwritten (logged
+   * instead). Absent or empty ⇒ nothing written to env. Sourced from
+   * squadrant config's defaults.claudeEnv.
+   */
+  claudeEnv?: Record<string, string>;
 }
 
 /**
@@ -67,6 +74,7 @@ export function installClaudeHooks(opts: ClaudeHooksInstallOpts = {}): string {
   // Parse existing settings (start fresh if absent or malformed).
   let settings: Record<string, unknown> = {};
   const raw = readFile(settingsPath);
+  const hadExistingSettings = raw !== undefined;
   if (raw) {
     try {
       settings = JSON.parse(raw) as Record<string, unknown>;
@@ -82,6 +90,7 @@ export function installClaudeHooks(opts: ClaudeHooksInstallOpts = {}): string {
   const hooks = settings.hooks as Record<string, unknown>;
 
   let changed = false;
+  const repaired: string[] = [];
   for (const [eventName, sub, matcher] of CLAUDE_HOOK_EVENTS) {
     if (!Array.isArray(hooks[eventName])) {
       hooks[eventName] = [];
@@ -102,6 +111,37 @@ export function installClaudeHooks(opts: ClaudeHooksInstallOpts = {}): string {
     );
     if (!alreadyPresent) {
       entries.push({ matcher: hookMatcher, hooks: [{ type: "command", command, timeout: 10 }] });
+      changed = true;
+      repaired.push(`${eventName}/${sub}`);
+    }
+  }
+
+  // #615: a hook missing from an already-existing settings file is drift (e.g. the
+  // file was hand-edited or clobbered) — surface it, since a missing AskUserQuestion
+  // hook silently kills crew-blocked signalling (#560). A fresh install where nothing
+  // existed yet is not drift, so it stays quiet.
+  if (repaired.length > 0 && hadExistingSettings) {
+    log(
+      `native-hook: repaired ${repaired.length} missing squadrant hook(s) in ${settingsPath} [${repaired.join(", ")}] — WARNING: blocked-signalling or lifecycle tracking may have been broken until this run`,
+    );
+  }
+
+  // #615 opt-in: deep-merge defaults.claudeEnv into settings.json 'env', non-clobbering.
+  if (opts.claudeEnv && Object.keys(opts.claudeEnv).length > 0) {
+    if (typeof settings.env !== "object" || settings.env === null || Array.isArray(settings.env)) {
+      settings.env = {};
+    }
+    const env = settings.env as Record<string, unknown>;
+    for (const [key, value] of Object.entries(opts.claudeEnv)) {
+      if (key in env) {
+        if (env[key] !== value) {
+          log(
+            `native-hook: claudeEnv key '${key}' already set to '${String(env[key])}' in ${settingsPath} — not overwriting with '${value}'`,
+          );
+        }
+        continue;
+      }
+      env[key] = value;
       changed = true;
     }
   }
@@ -167,8 +207,10 @@ export class NativeHookSource implements LifecycleSource {
   private active = false;
 
   constructor(opts: NativeHookSourceOpts = {}) {
-    this.hookInstall = opts.hookInstall ?? {};
     this.log = opts.log ?? (() => {});
+    // Forward the source-level log into installClaudeHooks by default so #615
+    // repair/non-clobber warnings surface — an explicit hookInstall.log still wins.
+    this.hookInstall = { log: this.log, ...opts.hookInstall };
   }
 
   start(deps: LifecycleSourceDeps): void {

--- a/packages/workspaces/src/runtimes/cmux.ts
+++ b/packages/workspaces/src/runtimes/cmux.ts
@@ -654,7 +654,7 @@ export function createCmuxDriver(): RuntimeDriver {
       const draft = parseDraftFromScreen(screen);
 
       // null = box not confirmed visible → never keystroke into an overlay (#268).
-      if (draft === null) throw new DeferDelivery(null);
+      if (draft === null) throw new DeferDelivery(null, "no-box");
 
       // #484: an AskUserQuestion / permission-approval SELECTION MODAL — never
       // deliver into it, regardless of what parseDraftFromScreen returned or
@@ -664,7 +664,7 @@ export function createCmuxDriver(): RuntimeDriver {
       // against both) and would otherwise call deliver(), typing the message
       // and pressing Enter into the picker — auto-confirming whichever option
       // is highlighted.
-      if (hasModalOptionList(screen)) throw new DeferDelivery(null);
+      if (hasModalOptionList(screen)) throw new DeferDelivery(null, "modal");
 
       // Empty input — nothing to protect, deliver directly.
       if (draft === "") { await deliver(); return; }

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -232,15 +232,21 @@ When a crew sends you a status message via `squadrant runtime send <project> "<m
 
 CREW REVIEW is **unambiguous** — a crew ran `squadrant crew signal review` after committing its work to `crew/<name>`. Unlike CREW IDLE, this is never a stray heartbeat miss: the crew has explicitly paused and is waiting for your verdict. The task is **NOT terminal** — don't treat it like CREW DONE.
 
+**Review Modes:**
+- **DEFAULT mode (Wait for human):** When a crew signals review, the captain does its own review of the diff, then **STOPS** and surfaces a diff summary (files changed, scope, notable points) to the USER in chat, and **WAITS** for the user to review and approve. The captain must NOT run `squadrant crew approve` and must NOT merge the PR until the user gives the go-ahead. Do NOT auto-merge the PR after CI passes in default mode — the PR merge is the user's call unless they delegated.
+- **DELEGATED mode (Captain auto):** ONLY when the user explicitly delegates for that review (e.g. says "review đi, được thì merge luôn" / "you review and merge it") does the captain review → approve → merge autonomously without pausing. Delegation is per-request; it does not become the standing default.
+
+*Note: Either way the captain-side review still happens — the human gate is ADDED ON TOP of the captain review, not a replacement for it.*
+
 On CREW REVIEW:
 
 1. **Open the diff** — `squadrant diff <project> <crew>` (branch-vs-base; the default is exactly the review surface). Use `--staged`/`--unstaged`/`--working` if you also want to peek at anything left uncommitted.
-2. **Classify:**
+2. **Classify (Captain-side review):**
 
 | Diff looks | Captain action |
 |-----------|-----------------|
-| Good — matches the task, tests pass, no scope creep | `squadrant crew approve <project> <crew>` — pushes `crew/<name>` to origin, opens the PR, terminalizes DONE. |
-| Needs changes | `squadrant crew send <project> <crew> "<feedback>"` — the crew iterates, re-commits, and re-signals `review`. Loop until approved. |
+| Good — matches the task, tests pass, no scope creep | **DEFAULT mode:** Surface diff summary to user and WAIT for go-ahead. Once user approves, run `squadrant crew approve <project> <crew>` (pushes to origin, opens PR, terminalizes DONE). Wait for user to decide on merging.<br><br>**DELEGATED mode:** Run `squadrant crew approve <project> <crew>`, then merge autonomously. |
+| Needs changes | `squadrant crew send <project> <crew> "<feedback>"` — the crew iterates, re-commits, and re-signals `review`. Loop until approved. (No user gate needed for rejecting back to crew). |
 
 3. **Never auto-terminalize a CREW REVIEW yourself** by emitting `task.done` directly — always go through `squadrant crew approve` so the push+PR actually happens before the task closes.
 4. Do **not** re-send the original task or close the crew while it's awaiting review — `crew close` on a `review`-state task discards work that hasn't been pushed anywhere yet.


### PR DESCRIPTION
## v0.16.6 — Cluster A lifecycle fixes + provider-independence planning

### Fixed
- **#631** — Cluster A daemon lifecycle bookkeeping bugs: **#594a** (Monitor watch misread as idle → CREW IDLE flood), **#594b** (stale CREW IDLE delivered after crew close), **#629** (sweep.task-timeout cancelling review-state crews). All reproduced with live production evidence before fixing; 11 new failing→passing tests.

### Docs
- **#623** — captain per-turn context budget analysis: boot prefix ~52k tokens (28% of ~185k avg); skills listing (~7.4k/turn) and MEMORY.md (~4.9k/turn) are the largest cuttable line items.
- **#624** — two-phase provider-independence plan: Phase 1 (cost + escape hatch via manual/opencode mode), Phase 2 (driver-agnostic captain lifecycle).

Merging to main triggers the tag + gh-release + npm publish.