### PR TITLE
STEP A of GitHub issue #630 — zombie cleanup. Small, standalone, independent of the rest of #630. Do

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (5084 symbols, 7671 relationships, 177 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (5112 symbols, 7692 relationships, 169 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (5112 symbols, 7692 relationships, 169 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (5083 symbols, 7662 relationships, 174 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (5084 symbols, 7671 relationships, 177 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (5112 symbols, 7692 relationships, 169 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (5112 symbols, 7692 relationships, 169 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (5083 symbols, 7662 relationships, 174 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1003,7 +1003,7 @@ plugin/templates/            # Role templates (7 files)
   crew.opencode.md       # Crew template (OpenCode)
   learnings.claude.md    # Learnings template
 plugin/skills/           # Portable markdown skills (Karpathy, etc.)
-scripts/                 # Shell scripts (read-handoff, write-status, etc.)
+scripts/                 # Shell scripts (read-handoff, write-handoff, wiki-query, etc.)
 </code></pre>
 
 <h3>Runtime / State (~/.config/squadrant)</h3>

--- a/docs/architecture.vi.html
+++ b/docs/architecture.vi.html
@@ -917,7 +917,7 @@ plugin/templates/            # Mẫu vai trò (7 tệp)
   crew.opencode.md       # Mẫu Crew (OpenCode)
   learnings.claude.md    # Mẫu Learnings
 plugin/skills/           # Kỹ năng markdown di động (Karpathy, v.v.)
-scripts/                 # Script shell (read-handoff, write-status, v.v.)
+scripts/                 # Script shell (read-handoff, write-handoff, wiki-query, v.v.)
 </code></pre>
 
 <h3>Runtime / Trạng thái (~/.config/squadrant)</h3>

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -199,7 +199,7 @@ The user-level projection now also inlines `templates/captain.generic.md` and `t
 
 ### Knowledge System (opt-in writes)
 
-- **Status (opt-in)** — captains record `{spokeVault}/status.md` via `write-status.sh` (also written by the captain session-end hook) when there's something worth noting (a blocker, "starting work on X"). Not on a schedule.
+- **Status** — `write-status.sh` does not exist and nothing else writes `status.md` today; existing files are left in place as history but are no longer read by `squadrant status`/`standup`/`retro` ([#630](https://github.com/tu11aa/squadrant/issues/630) tracks a real persisted work-tracking store).
 - **Dashboard** — `squadrant dashboard --pane` opens a refreshing sidebar pane in cmux that lists every project's live state, queried from the squadrant daemon's task records. `squadrant dashboard sync-hub` mirrors each spoke `status.md` into `{hubVault}/projects/` so the hub vault's `dashboard.md` Dataview query renders the same data inside Obsidian.
 - **Handoff files** — captain writes when in-flight work needs to survive into tomorrow; skipped on uneventful sessions.
 - **Daily logs** — captain writes when the day produced something worth a log; not on a schedule.

--- a/packages/cli/src/commands/__tests__/status.test.ts
+++ b/packages/cli/src/commands/__tests__/status.test.ts
@@ -45,55 +45,25 @@ describe("captainIndicator — stopped vs gone (#549)", () => {
 
 // #549: a project without status.md used to be dropped from the table entirely
 // ("no status.md", no health marker), hiding a captain that was demonstrably
-// alive in the daemon's liveness registry. status.md is an opt-in human note,
-// not the source of truth for whether the row renders — captain liveness must
-// show regardless of whether status.md exists.
-describe("formatProjectRow (#549)", () => {
-  it("renders a live captain indicator even when status.md is missing", () => {
-    const row = formatProjectRow("friendslop-factory", "friendslop-factory-captain", {}, "missing", "alive");
+// alive in the daemon's liveness registry. Captain liveness must show
+// regardless of status.md.
+// #630: status.md/write-status.sh are dead (the script doesn't exist, nothing
+// writes the file) — formatProjectRow no longer reads it at all, so there's
+// no "ok"/"missing"/"unreadable" distinction left to render.
+describe("formatProjectRow (#549, #630)", () => {
+  it("renders a live captain indicator", () => {
+    const row = formatProjectRow("friendslop-factory", "friendslop-factory-captain", "alive");
     expect(row).toContain("friendslop-factory");
     expect(row).toContain("●");
-    expect(row).not.toContain("no status.md");
   });
 
-  it("renders a dead captain indicator when status.md is missing and captain is gone", () => {
-    const row = formatProjectRow("bet2fun-app", "bet2fun-app-captain", {}, "missing", "gone");
+  it("renders a dead captain indicator when captain is gone", () => {
+    const row = formatProjectRow("bet2fun-app", "bet2fun-app-captain", "gone");
     expect(row).toContain("○");
   });
 
-  it("still renders task/crew data from status.md when present", () => {
-    const row = formatProjectRow(
-      "squadrant",
-      "squadrant-captain",
-      { active_crew: 2, tasks_completed: 1, tasks_total: 4 },
-      "ok",
-      "alive",
-    );
-    expect(row).toContain("squadrant");
-    expect(row).toContain("2");
-  });
-});
-
-// #549 follow-up: an unreadable/corrupt status.md used to be swallowed by an
-// empty catch block that fell through to the same "missing" rendering as a
-// project that never had a status.md at all — the operator silently lost the
-// fact that their file was broken. A corrupt file must stay visibly distinct
-// from an absent one.
-describe("formatProjectRow — unreadable status.md must stay visible (#549)", () => {
-  it("renders distinctly from a missing status.md", () => {
-    const missingRow = formatProjectRow("p", "p-captain", {}, "missing", "alive");
-    const unreadableRow = formatProjectRow("p", "p-captain", {}, "unreadable", "alive");
-    expect(unreadableRow).not.toBe(missingRow);
-  });
-
-  it("flags the row as unreadable, not silently as 'no notes'", () => {
-    const row = formatProjectRow("p", "p-captain", {}, "unreadable", "alive");
-    expect(row).toContain("unreadable");
-    expect(row).not.toContain("no notes");
-  });
-
-  it("still shows live captain state on an unreadable status.md, not dropped", () => {
-    const row = formatProjectRow("p", "p-captain", {}, "unreadable", "alive");
-    expect(row).toContain("●");
+  it("renders the unknown-liveness glyph when the daemon has no entry", () => {
+    const row = formatProjectRow("p", "p-captain", undefined);
+    expect(row).toContain("?");
   });
 });

--- a/packages/cli/src/commands/retro.ts
+++ b/packages/cli/src/commands/retro.ts
@@ -1,9 +1,6 @@
 import { Command } from "commander";
-import fs from "node:fs";
-import path from "node:path";
 import chalk from "chalk";
-import matter from "gray-matter";
-import { loadConfig, resolveHome, type ProjectConfig, type SquadrantConfig } from "@squadrant/shared";
+import { loadConfig, type ProjectConfig, type SquadrantConfig } from "@squadrant/shared";
 import {
   readDailyLog,
   parseSection,
@@ -15,12 +12,6 @@ import {
 } from "@squadrant/shared";
 import { createObsidianDriver, WorkspaceRegistry } from "@squadrant/workspaces";
 
-interface StatusFrontmatter {
-  tasks_total?: number;
-  tasks_completed?: number;
-  tasks_in_progress?: number;
-}
-
 interface ProjectRetro {
   name: string;
   shipped: string[];
@@ -29,19 +20,6 @@ interface ProjectRetro {
   decisions: string[];
   commits: string[];
   mergedPRs: string[];
-  tasksCompletedNow: number;
-  tasksInProgressNow: number;
-}
-
-// TODO(workspace): status.md still read via raw fs — migrate to workspace driver (see #24)
-function readStatus(spokeVault: string): StatusFrontmatter {
-  const statusFile = path.join(spokeVault, "status.md");
-  if (!fs.existsSync(statusFile)) return {};
-  try {
-    return matter(fs.readFileSync(statusFile, "utf-8")).data as StatusFrontmatter;
-  } catch {
-    return {};
-  }
 }
 
 function dedupe(items: string[]): string[] {
@@ -66,8 +44,6 @@ async function getProjectRetro(
   config: SquadrantConfig,
 ): Promise<ProjectRetro> {
   const workspace = registry.forProject(name, config);
-  const spokeVault = resolveHome(project.spokeVault);
-  const status = readStatus(spokeVault);
 
   const shipped: string[] = [];
   const inProgress: string[] = [];
@@ -102,8 +78,6 @@ async function getProjectRetro(
     decisions: dedupe(decisions),
     commits,
     mergedPRs,
-    tasksCompletedNow: status.tasks_completed ?? 0,
-    tasksInProgressNow: status.tasks_in_progress ?? 0,
   };
 }
 

--- a/packages/cli/src/commands/standup.ts
+++ b/packages/cli/src/commands/standup.ts
@@ -1,26 +1,11 @@
 import { Command } from "commander";
-import fs from "node:fs";
-import path from "node:path";
 import chalk from "chalk";
-import matter from "gray-matter";
-import { loadConfig, resolveHome, type ProjectConfig, type SquadrantConfig } from "@squadrant/shared";
+import { loadConfig, type ProjectConfig, type SquadrantConfig } from "@squadrant/shared";
 import { readDailyLog, getGitCommits, iso, daysAgo } from "@squadrant/shared";
 import { createObsidianDriver, WorkspaceRegistry } from "@squadrant/workspaces";
 
-interface StatusFrontmatter {
-  project?: string;
-  captain_session?: string;
-  last_updated?: string;
-  active_crew?: number;
-  tasks_total?: number;
-  tasks_completed?: number;
-  tasks_in_progress?: number;
-  tasks_pending?: number;
-}
-
 interface ProjectStandup {
   name: string;
-  status: StatusFrontmatter;
   dailyLog: string | null;
   gitCommits: string[];
   blockers: string[];
@@ -38,23 +23,11 @@ async function getProjectStandup(
   config: SquadrantConfig,
 ): Promise<ProjectStandup> {
   const workspace = registry.forProject(name, config);
-  // TODO(workspace): status.md still read via raw fs — migrate to workspace driver (see #24)
-  const spokeVault = resolveHome(project.spokeVault);
-  const statusFile = path.join(spokeVault, "status.md");
-
-  let status: StatusFrontmatter = {};
-  if (fs.existsSync(statusFile)) {
-    try {
-      status = matter(fs.readFileSync(statusFile, "utf-8")).data as StatusFrontmatter;
-    } catch { /* empty */ }
-  }
-
   const log = await readDailyLog(workspace, dateStr);
   const gitCommits = getGitCommits(project.path, dateStr);
 
   return {
     name,
-    status,
     dailyLog: log?.content ?? null,
     gitCommits,
     blockers: log?.blockers ?? [],
@@ -74,10 +47,6 @@ function formatStandup(standups: ProjectStandup[], dateStr: string, raw: boolean
   let hasBlockers = false;
 
   for (const s of standups) {
-    const tasksDone = s.status.tasks_completed ?? 0;
-    const tasksTotal = s.status.tasks_total ?? 0;
-    const tasksInProgress = s.status.tasks_in_progress ?? 0;
-
     if (!raw) {
       lines.push(chalk.cyan.bold(`## ${s.name}`));
     } else {
@@ -85,20 +54,11 @@ function formatStandup(standups: ProjectStandup[], dateStr: string, raw: boolean
     }
 
     // What was done
-    if (s.gitCommits.length > 0 || tasksDone > 0) {
+    if (s.gitCommits.length > 0) {
       lines.push(!raw ? chalk.green("Done:") : "**Done:**");
       for (const commit of s.gitCommits) {
         lines.push(`  - ${commit}`);
       }
-      if (tasksDone > 0 && s.gitCommits.length === 0) {
-        lines.push(`  - ${tasksDone}/${tasksTotal} tasks completed`);
-      }
-    }
-
-    // In progress
-    if (tasksInProgress > 0) {
-      lines.push(!raw ? chalk.yellow("In Progress:") : "**In Progress:**");
-      lines.push(`  - ${tasksInProgress} task(s) active`);
     }
 
     // Extract sections from daily log
@@ -126,21 +86,21 @@ function formatStandup(standups: ProjectStandup[], dateStr: string, raw: boolean
     }
 
     // No activity
-    if (s.gitCommits.length === 0 && tasksDone === 0 && !s.dailyLog) {
+    if (s.gitCommits.length === 0 && !s.dailyLog) {
       lines.push(!raw ? chalk.dim("  (no activity)") : "  (no activity)");
     }
 
     lines.push("");
   }
 
-  // Summary line
+  // Summary line. Task counts have no data source yet (#630) — say so plainly
+  // instead of reporting a silent, always-zero count.
   const totalCommits = standups.reduce((sum, s) => sum + s.gitCommits.length, 0);
-  const totalDone = standups.reduce((sum, s) => sum + (s.status.tasks_completed ?? 0), 0);
 
   if (!raw) {
-    lines.push(chalk.dim(`--- ${totalCommits} commits, ${totalDone} tasks done${hasBlockers ? ", HAS BLOCKERS" : ""} ---\n`));
+    lines.push(chalk.dim(`--- ${totalCommits} commits${hasBlockers ? ", HAS BLOCKERS" : ""} (task tracking: no data source — #630) ---\n`));
   } else {
-    lines.push(`---\n*${totalCommits} commits, ${totalDone} tasks done${hasBlockers ? ", HAS BLOCKERS" : ""}*\n`);
+    lines.push(`---\n*${totalCommits} commits${hasBlockers ? ", HAS BLOCKERS" : ""} (task tracking: no data source — #630)*\n`);
   }
 
   return lines.join("\n");

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,44 +1,8 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import matter from "gray-matter";
 import { loadConfig } from "@squadrant/shared";
-import { createObsidianDriver, WorkspaceRegistry } from "@squadrant/workspaces";
 import { queryHealth, printServiceHealth } from "./health-view.js";
 import type { ComponentHealth } from "@squadrant/core";
-
-interface StatusFrontmatter {
-  project?: string;
-  last_updated?: string;
-  active_crew?: number;
-  tasks_total?: number;
-  tasks_completed?: number;
-  tasks_in_progress?: number;
-  tasks_pending?: number;
-}
-
-function timeAgo(dateStr: string | undefined): string {
-  if (!dateStr) return chalk.dim("—");
-  const date = new Date(dateStr);
-  if (isNaN(date.getTime())) return chalk.dim("—");
-
-  const diff = Date.now() - date.getTime();
-  const mins = Math.floor(diff / 60_000);
-  const hours = Math.floor(diff / 3_600_000);
-  const days = Math.floor(diff / 86_400_000);
-
-  if (mins < 1) return "just now";
-  if (mins < 60) return `${mins}m ago`;
-  if (hours < 24) return `${hours}h ago`;
-  return `${days}d ago`;
-}
-
-function progressBar(completed: number, total: number): string {
-  if (total === 0) return chalk.dim("no tasks");
-  const pct = Math.round((completed / total) * 100);
-  const filled = Math.round(pct / 10);
-  const bar = "█".repeat(filled) + "░".repeat(10 - filled);
-  return `${bar} ${pct}%`;
-}
 
 /**
  * Pure. Render the captain liveness indicator from the daemon's registry-derived
@@ -60,45 +24,28 @@ export function captainIndicator(state: ComponentHealth["state"] | undefined): s
   return chalk.dim("○");
 }
 
-/** Result of attempting to read a project's status.md — "ok" only when it
- *  exists and parsed cleanly; "missing" and "unreadable" must render
- *  distinctly so a corrupt file is never silently mistaken for an absent one. */
-export type StatusMdState = "ok" | "missing" | "unreadable";
-
 /**
- * Pure. Render one project's status row. status.md is an optional human note
- * layered on top of daemon-derived captain liveness (#549) — a project with
- * no status.md, or an unreadable one, still renders with its real captain
- * state, rather than being dropped from the table entirely.
+ * Pure. Render one project's status row — captain liveness only. Task/crew
+ * counts used to come from status.md, but nothing writes that file (the
+ * write-status.sh it depended on doesn't exist) — rather than render stale
+ * or fabricated numbers, this command doesn't claim to have them (#630).
  */
 export function formatProjectRow(
   name: string,
   captainName: string,
-  fm: StatusFrontmatter,
-  statusMdState: StatusMdState,
   captainState: ComponentHealth["state"] | undefined,
 ): string {
   const sessionIndicator = captainIndicator(captainState);
   const captainDisplay = `${captainName.padEnd(11)} ${sessionIndicator}`;
-  const crew = statusMdState === "ok" ? String(fm.active_crew ?? 0).padEnd(6) : chalk.dim("?").padEnd(6);
-  const progress =
-    statusMdState === "ok"
-      ? progressBar(fm.tasks_completed ?? 0, fm.tasks_total ?? 0).padEnd(25)
-      : statusMdState === "unreadable"
-        ? chalk.red("status.md unreadable").padEnd(25)
-        : chalk.dim("no notes").padEnd(25);
-  const updated = statusMdState === "ok" ? timeAgo(fm.last_updated) : chalk.dim("—");
-
-  return `  ${name.padEnd(18)} ${captainDisplay}  ${crew} ${progress} ${updated}`;
+  return `  ${name.padEnd(18)} ${captainDisplay}`;
 }
 
 export const statusCommand = new Command("status")
-  .description("Show status of all projects from spoke vault status files")
+  .description("Show captain liveness for all projects (task/crew counts have no data source — #630)")
   .option("--detailed", "also show live per-component service health from the daemon (#77)")
   .action(async (opts: { detailed?: boolean }) => {
     const config = loadConfig();
     const projects = Object.entries(config.projects);
-    const registry = new WorkspaceRegistry({ obsidian: createObsidianDriver });
 
     if (projects.length === 0) {
       console.log(chalk.yellow("\nNo projects registered. Use: squadrant projects add <name> <path>\n"));
@@ -119,37 +66,14 @@ export const statusCommand = new Command("status")
     }
 
     console.log(chalk.bold("\nProject Status\n"));
-    console.log(
-      chalk.dim(
-        `  ${"PROJECT".padEnd(18)} ${"CAPTAIN".padEnd(12)} ${"CREW".padEnd(6)} ${"PROGRESS".padEnd(25)} LAST UPDATE`,
-      ),
-    );
-    console.log(chalk.dim("  " + "─".repeat(85)));
+    console.log(chalk.dim(`  ${"PROJECT".padEnd(18)} CAPTAIN`));
+    console.log(chalk.dim("  " + "─".repeat(35)));
 
     for (const [name, project] of projects) {
-      const workspace = registry.forProject(name, config);
-
-      let fm: StatusFrontmatter = {};
-      let statusMdState: StatusMdState = "missing";
-      if (await workspace.exists("status.md")) {
-        try {
-          const raw = await workspace.read("status.md");
-          fm = matter(raw).data as StatusFrontmatter;
-          statusMdState = "ok";
-        } catch {
-          // Corrupt/unreadable status.md — render distinctly from "missing"
-          // (formatProjectRow) so the operator doesn't lose the fact that the
-          // file is broken, while still showing live captain state (#549).
-          statusMdState = "unreadable";
-        }
-      }
-
-      console.log(
-        formatProjectRow(name, project.captainName, fm, statusMdState, captainStateByProject.get(name)),
-      );
+      console.log(formatProjectRow(name, project.captainName, captainStateByProject.get(name)));
     }
 
-    console.log("");
+    console.log(chalk.dim("\n  Task/crew counts: no data source yet — see squadrant/squadrant#630\n"));
 
     // #77: --detailed adds the live service-health view (relay/captain/crew/
     // command per-component last-seen + state) queried from the daemon.

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -30,8 +30,6 @@ The handoff file is auto-deleted after reading. Use this as your primary context
 If relevant pages exist, read them for context before starting work.
 8. Crew lifecycle events (done / blocked / idle) are delivered to your captain pane automatically by the squadrant daemon via daemon-direct cmux delivery (#332). No relay setup required.
 
-9. (Opt-in) Status writes are not required on every event. Only run `~/.config/squadrant/scripts/write-status.sh` when you have a meaningful note worth recording (a blocker, a deliberate "starting work on X", etc.) — not on a schedule.
-
 ## Crew Setup
 
 You do NOT create an Agent Team. You spawn each crew session on demand as a **new tab** in your workspace via `squadrant crew spawn` (use `--direction right|down|...` to split into a pane instead). The surface is a fresh CLI session with the crew template loaded as system prompt — disposable, restartable, runtime-agnostic.
@@ -261,8 +259,6 @@ After a crew task completes:
 4. After closing a crew, VERIFY no orphaned processes remain — e.g. `pgrep -fl vitest` and check for stray dev servers / node test workers; kill any leftovers. `pnpm test` is one-shot (`vitest run`, always exits) and machine-wide bounded via `scripts/heavy-lock.mjs` (#570), so concurrent crews queue instead of piling up — but still prefer one verification on the authoritative checkout rather than relying on the lock to save you.
 5. Record learnings if any (see "Recording Learnings" below).
 6. Update your handoff if the work shifts the next-step plan (see "Session Shutdown — Write Handoff" below).
-
-Status writes (`write-status.sh`) are opt-in; you don't need to write status after every event.
 
 ## Status Board (show after substantive turns)
 


### PR DESCRIPTION
Step A of #630 done: removed dead write-status.sh instructions from captain-ops SKILL.md/docs/reference.md/architecture.html(.vi), and status.ts/standup.ts/retro.ts no longer read dead status.md — they now state plainly there's no task-count data source instead of silently reporting 0/stale numbers. Build + full test suite (172 files/2253 tests) pass. 2 commits on crew/zombie-status.