### PR TITLE
fix(cli): tokens command must disclose its rolling ~30-day data window

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (5083 symbols, 7662 relationships, 174 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (5174 symbols, 7796 relationships, 174 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **squadrant** (5083 symbols, 7662 relationships, 174 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **squadrant** (5174 symbols, 7796 relationships, 174 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/packages/cli/src/commands/__tests__/tokens.test.ts
+++ b/packages/cli/src/commands/__tests__/tokens.test.ts
@@ -1,21 +1,28 @@
 import { describe, it, expect } from "vitest";
 import {
   parseAssistantUsage,
+  parseTranscriptLine,
   aggregateLines,
   buildRoleReport,
   escapeClaudeProjectPath,
   isCrewDirName,
   formatTokens,
+  formatRange,
+  mergeRanges,
 } from "../tokens.js";
 
-function assistantLine(usage: Partial<{
-  input_tokens: number;
-  output_tokens: number;
-  cache_read_input_tokens: number;
-  cache_creation_input_tokens: number;
-}>): string {
+function assistantLine(
+  usage: Partial<{
+    input_tokens: number;
+    output_tokens: number;
+    cache_read_input_tokens: number;
+    cache_creation_input_tokens: number;
+  }>,
+  timestamp?: string,
+): string {
   return JSON.stringify({
     type: "assistant",
+    timestamp,
     message: {
       role: "assistant",
       usage: {
@@ -96,6 +103,66 @@ describe("aggregateLines", () => {
   });
 });
 
+describe("parseTranscriptLine — timestamp extraction", () => {
+  it("extracts the timestamp from an assistant line alongside usage", () => {
+    const parsed = parseTranscriptLine(assistantLine({ input_tokens: 1 }, "2026-07-28T10:12:23.705Z"));
+    expect(parsed.timestamp).toBe("2026-07-28T10:12:23.705Z");
+    expect(parsed.usage).not.toBeNull();
+  });
+
+  it("extracts the timestamp from a non-assistant line even though usage is null", () => {
+    const line = JSON.stringify({ type: "user", timestamp: "2026-06-29T00:00:00.000Z", message: { role: "user" } });
+    const parsed = parseTranscriptLine(line);
+    expect(parsed.timestamp).toBe("2026-06-29T00:00:00.000Z");
+    expect(parsed.usage).toBeNull();
+  });
+
+  it("returns a null timestamp for line types that omit it (e.g. queue-operation)", () => {
+    const line = JSON.stringify({ type: "queue-operation" });
+    expect(parseTranscriptLine(line).timestamp).toBeNull();
+  });
+});
+
+describe("aggregateLines — date range", () => {
+  it("widens the session's [earliest, latest] from every line, not just assistant turns", () => {
+    const lines = [
+      JSON.stringify({ type: "user", timestamp: "2026-06-29T00:00:00.000Z", message: { role: "user" } }),
+      assistantLine({ input_tokens: 1 }, "2026-06-29T00:05:00.000Z"),
+      assistantLine({ input_tokens: 1 }, "2026-07-29T12:00:00.000Z"),
+    ];
+    const agg = aggregateLines(lines);
+    expect(agg.earliest).toBe("2026-06-29T00:00:00.000Z");
+    expect(agg.latest).toBe("2026-07-29T12:00:00.000Z");
+  });
+
+  it("leaves the range null when no line has a timestamp", () => {
+    const agg = aggregateLines([JSON.stringify({ type: "queue-operation" })]);
+    expect(agg.earliest).toBeNull();
+    expect(agg.latest).toBeNull();
+  });
+});
+
+describe("mergeRanges / formatRange", () => {
+  it("merges the widest earliest and latest across several ranges", () => {
+    const merged = mergeRanges([
+      { earliest: "2026-07-01T00:00:00.000Z", latest: "2026-07-10T00:00:00.000Z" },
+      { earliest: "2026-06-29T00:00:00.000Z", latest: "2026-07-05T00:00:00.000Z" },
+    ]);
+    expect(merged.earliest).toBe("2026-06-29T00:00:00.000Z");
+    expect(merged.latest).toBe("2026-07-10T00:00:00.000Z");
+  });
+
+  it("formats a range as YYYY-MM-DD → YYYY-MM-DD", () => {
+    expect(
+      formatRange({ earliest: "2026-06-29T00:00:00.000Z", latest: "2026-07-29T17:33:00.000Z" }),
+    ).toBe("2026-06-29 → 2026-07-29");
+  });
+
+  it("reports 'no dated turns' rather than a misleading range when nothing has a timestamp", () => {
+    expect(formatRange({ earliest: null, latest: null })).toBe("no dated turns");
+  });
+});
+
 describe("escapeClaudeProjectPath / isCrewDirName", () => {
   it("replaces every non-alphanumeric character with '-'", () => {
     expect(escapeClaudeProjectPath("/Users/q3labsadmin/me/squadrant")).toBe("-Users-q3labsadmin-me-squadrant");
@@ -150,6 +217,14 @@ describe("buildRoleReport", () => {
     expect(report.meanCacheReadPerCall).toBeNull();
     expect(report.accumulated).toBeNull();
     expect(report.accumulatedPct).toBeNull();
+  });
+
+  it("rolls the date range up from sessions — this is what makes the rolling-window disclosure honest", () => {
+    const sessionA = aggregateLines([assistantLine({ input_tokens: 1 }, "2026-06-29T00:00:00.000Z")]);
+    const sessionB = aggregateLines([assistantLine({ input_tokens: 1 }, "2026-07-29T12:00:00.000Z")]);
+    const report = buildRoleReport("captain", [sessionA, sessionB]);
+    expect(report.earliest).toBe("2026-06-29T00:00:00.000Z");
+    expect(report.latest).toBe("2026-07-29T12:00:00.000Z");
   });
 });
 

--- a/packages/cli/src/commands/__tests__/tokens.test.ts
+++ b/packages/cli/src/commands/__tests__/tokens.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseAssistantUsage,
+  aggregateLines,
+  buildRoleReport,
+  escapeClaudeProjectPath,
+  isCrewDirName,
+  formatTokens,
+} from "../tokens.js";
+
+function assistantLine(usage: Partial<{
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_input_tokens: number;
+  cache_creation_input_tokens: number;
+}>): string {
+  return JSON.stringify({
+    type: "assistant",
+    message: {
+      role: "assistant",
+      usage: {
+        input_tokens: usage.input_tokens ?? 0,
+        output_tokens: usage.output_tokens ?? 0,
+        cache_read_input_tokens: usage.cache_read_input_tokens ?? 0,
+        cache_creation_input_tokens: usage.cache_creation_input_tokens ?? 0,
+      },
+    },
+  });
+}
+
+describe("parseAssistantUsage", () => {
+  it("extracts the four token classes from a well-formed assistant line", () => {
+    const usage = parseAssistantUsage(
+      assistantLine({ input_tokens: 2, output_tokens: 70, cache_read_input_tokens: 17088, cache_creation_input_tokens: 34812 }),
+    );
+    expect(usage).toEqual({ input: 2, output: 70, cacheRead: 17088, cacheWrite: 34812 });
+  });
+
+  it("returns null for a user turn (no message.usage of interest)", () => {
+    const line = JSON.stringify({ type: "user", message: { role: "user", content: "hi" } });
+    expect(parseAssistantUsage(line)).toBeNull();
+  });
+
+  it("returns null for an assistant message with no usage block", () => {
+    const line = JSON.stringify({ type: "assistant", message: { role: "assistant" } });
+    expect(parseAssistantUsage(line)).toBeNull();
+  });
+
+  it("returns null for unparsable JSON", () => {
+    expect(parseAssistantUsage("{not json")).toBeNull();
+  });
+
+  it("returns null for a blank line", () => {
+    expect(parseAssistantUsage("   ")).toBeNull();
+  });
+});
+
+describe("aggregateLines", () => {
+  it("sums the four token classes across assistant lines and ignores non-assistant lines", () => {
+    const lines = [
+      assistantLine({ input_tokens: 2, output_tokens: 70, cache_read_input_tokens: 17088, cache_creation_input_tokens: 34812 }),
+      JSON.stringify({ type: "user", message: { role: "user", content: "go" } }),
+      assistantLine({ input_tokens: 5, output_tokens: 30, cache_read_input_tokens: 51900, cache_creation_input_tokens: 0 }),
+    ];
+    const agg = aggregateLines(lines);
+    expect(agg.calls).toBe(2);
+    expect(agg.input).toBe(7);
+    expect(agg.output).toBe(100);
+    expect(agg.cacheRead).toBe(17088 + 51900);
+    expect(agg.cacheWrite).toBe(34812);
+  });
+
+  it("collapses consecutive retries (identical cache_read) into one turn but still counts every call", () => {
+    const lines = [
+      assistantLine({ input_tokens: 2, cache_read_input_tokens: 17088, cache_creation_input_tokens: 34812 }), // turn 1
+      assistantLine({ input_tokens: 2, cache_read_input_tokens: 17088, cache_creation_input_tokens: 34812 }), // retry of turn 1
+      assistantLine({ input_tokens: 3, cache_read_input_tokens: 51900, cache_creation_input_tokens: 0 }), // turn 2
+    ];
+    const agg = aggregateLines(lines);
+    expect(agg.calls).toBe(3);
+    expect(agg.turns).toHaveLength(2);
+    expect(agg.turns[0]).toEqual({ total: 2 + 34812 + 17088, cacheRead: 17088 });
+    expect(agg.turns[1]).toEqual({ total: 3 + 0 + 51900, cacheRead: 51900 });
+  });
+
+  it("reproduces the real-transcript invariant: turn-2 cache_read equals turn-1 total (boot confirmation)", () => {
+    // Mirrors session 7b631cf9 from docs/specs/2026-07-28-captain-context-budget.md:
+    // turn-1 total 51,902, turn-2 cache_read 51,900 (near-exact, confirms the boot prefix).
+    const lines = [
+      assistantLine({ input_tokens: 2, cache_read_input_tokens: 17088, cache_creation_input_tokens: 34812 }), // total 51,902
+      assistantLine({ input_tokens: 6, cache_read_input_tokens: 51900, cache_creation_input_tokens: 4997 }), // turn 2
+    ];
+    const agg = aggregateLines(lines);
+    expect(agg.turns[0].total).toBe(51902);
+    expect(agg.turns[1].cacheRead).toBe(51900);
+  });
+});
+
+describe("escapeClaudeProjectPath / isCrewDirName", () => {
+  it("replaces every non-alphanumeric character with '-'", () => {
+    expect(escapeClaudeProjectPath("/Users/q3labsadmin/me/squadrant")).toBe("-Users-q3labsadmin-me-squadrant");
+  });
+
+  it("a worktree cwd escapes to '<captainSlug>--worktrees-<name>'", () => {
+    const captain = escapeClaudeProjectPath("/Users/q3labsadmin/me/squadrant");
+    const crew = escapeClaudeProjectPath("/Users/q3labsadmin/me/squadrant/.worktrees/squadrant-tokens-cmd");
+    expect(crew).toBe(`${captain}--worktrees-squadrant-tokens-cmd`);
+    expect(isCrewDirName(crew, captain)).toBe(true);
+  });
+
+  it("does not classify the captain's own dir as a crew", () => {
+    const captain = escapeClaudeProjectPath("/Users/q3labsadmin/me/squadrant");
+    expect(isCrewDirName(captain, captain)).toBe(false);
+  });
+
+  it("does not classify an unrelated project that merely shares a string prefix", () => {
+    const captain = escapeClaudeProjectPath("/Users/q3labsadmin/me/app");
+    const other = escapeClaudeProjectPath("/Users/q3labsadmin/me/app2");
+    expect(isCrewDirName(other, captain)).toBe(false);
+  });
+});
+
+describe("buildRoleReport", () => {
+  it("computes mean boot, mean ctx/call, and accumulated split across sessions", () => {
+    // Session A: boot 50,000 (turn 1), turn 2 confirms it (cache_read 50,000), one more turn at 150,000.
+    const sessionA = aggregateLines([
+      assistantLine({ input_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 50000 }),
+      assistantLine({ input_tokens: 0, cache_read_input_tokens: 50000, cache_creation_input_tokens: 0 }),
+      assistantLine({ input_tokens: 0, cache_read_input_tokens: 150000, cache_creation_input_tokens: 0 }),
+    ]);
+    // Session B: boot 50,000 again, no second turn (short session).
+    const sessionB = aggregateLines([
+      assistantLine({ input_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 50000 }),
+    ]);
+
+    const report = buildRoleReport("captain", [sessionA, sessionB]);
+
+    expect(report.sessionFiles).toBe(2);
+    expect(report.calls).toBe(4);
+    expect(report.meanBoot).toBe(50000); // both sessions boot at 50k
+    expect(report.bootSampledSessions).toBe(2);
+    expect(report.bootConfirmedSessions).toBe(1); // only session A had a turn-2 to confirm with
+    expect(report.meanCacheReadPerCall).toBe((0 + 50000 + 150000 + 0) / 4);
+    expect(report.accumulated).toBeCloseTo(report.meanCacheReadPerCall! - 50000);
+  });
+
+  it("returns nulls when no session has any turns", () => {
+    const report = buildRoleReport("crews", []);
+    expect(report.meanBoot).toBeNull();
+    expect(report.meanCacheReadPerCall).toBeNull();
+    expect(report.accumulated).toBeNull();
+    expect(report.accumulatedPct).toBeNull();
+  });
+});
+
+describe("formatTokens", () => {
+  it("formats millions with one decimal", () => {
+    expect(formatTokens(1_457_000_000)).toBe("1457.0M");
+    expect(formatTokens(1_300_000)).toBe("1.3M");
+  });
+
+  it("formats thousands with one decimal", () => {
+    expect(formatTokens(185_500)).toBe("185.5k");
+  });
+
+  it("formats small counts as a plain integer", () => {
+    expect(formatTokens(70)).toBe("70");
+  });
+});

--- a/packages/cli/src/commands/tokens.ts
+++ b/packages/cli/src/commands/tokens.ts
@@ -1,0 +1,416 @@
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import readline from "node:readline";
+import { Command } from "commander";
+import chalk from "chalk";
+import { loadConfig, resolveHome } from "@squadrant/shared";
+
+/**
+ * Attributes token spend across captain vs crews, and boot prefix vs
+ * accumulated conversation, from real Claude Code transcripts
+ * (~/.claude/projects/<slug>/*.jsonl — see docs/specs/2026-07-28-captain-context-budget.md).
+ *
+ * Claude-only today: transcript format (jsonl usage blocks) is Claude Code
+ * specific. squadrant is multi-agent, but no other driver writes an
+ * equivalent transcript yet, so this reads Claude transcripts directly
+ * rather than through a speculative reader interface for a second
+ * implementation that doesn't exist.
+ */
+
+export const CLAUDE_PROJECTS_DIR = path.join(os.homedir(), ".claude", "projects");
+
+export interface AssistantUsage {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+}
+
+/** Pure. Parse one raw JSONL transcript line into usage numbers, or null if
+ *  the line isn't a valid assistant message with a usage block (user turns,
+ *  tool-result lines, and unparsable lines all return null). */
+export function parseAssistantUsage(rawLine: string): AssistantUsage | null {
+  const line = rawLine.trim();
+  if (!line) return null;
+  let obj: unknown;
+  try {
+    obj = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  const entry = obj as { type?: string; message?: { role?: string; usage?: Record<string, number> } };
+  if (entry?.type !== "assistant" || entry.message?.role !== "assistant") return null;
+  const usage = entry.message?.usage;
+  if (!usage) return null;
+  return {
+    input: usage.input_tokens ?? 0,
+    output: usage.output_tokens ?? 0,
+    cacheRead: usage.cache_read_input_tokens ?? 0,
+    cacheWrite: usage.cache_creation_input_tokens ?? 0,
+  };
+}
+
+export interface Turn {
+  /** input + cache_creation + cache_read for this call — the full context sent. */
+  total: number;
+  cacheRead: number;
+}
+
+export interface SessionAggregate {
+  calls: number;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  /** One entry per unique turn — consecutive calls with an identical
+   *  cache_read are retries of the same turn and collapse into one entry
+   *  (confirmed against a real transcript: turn-2 cache_read reproduces
+   *  turn-1's total exactly once retries are collapsed). */
+  turns: Turn[];
+}
+
+export function emptySessionAggregate(): SessionAggregate {
+  return { calls: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0, turns: [] };
+}
+
+/** Mutates `agg` with one raw transcript line. `state.lastCacheRead` tracks
+ *  the previous call's cache_read across the whole session so consecutive
+ *  retries collapse into a single turn. */
+export function foldAssistantLine(
+  agg: SessionAggregate,
+  rawLine: string,
+  state: { lastCacheRead: number | null },
+): void {
+  const usage = parseAssistantUsage(rawLine);
+  if (!usage) return;
+  agg.calls++;
+  agg.input += usage.input;
+  agg.output += usage.output;
+  agg.cacheRead += usage.cacheRead;
+  agg.cacheWrite += usage.cacheWrite;
+  if (usage.cacheRead !== state.lastCacheRead) {
+    state.lastCacheRead = usage.cacheRead;
+    agg.turns.push({ total: usage.input + usage.cacheWrite + usage.cacheRead, cacheRead: usage.cacheRead });
+  }
+}
+
+/** Pure. Aggregate an in-memory list of raw JSONL lines — this is what unit
+ *  tests exercise against fixture lines. Real transcripts go through
+ *  `aggregateTranscriptFile` instead, which streams instead of holding the
+ *  whole file in memory. */
+export function aggregateLines(lines: Iterable<string>): SessionAggregate {
+  const agg = emptySessionAggregate();
+  const state = { lastCacheRead: null as number | null };
+  for (const line of lines) foldAssistantLine(agg, line, state);
+  return agg;
+}
+
+/** Streams one transcript file line-by-line (never loads the whole file
+ *  into memory — transcripts in this repo run up to ~5.7MB each). */
+export async function aggregateTranscriptFile(filePath: string): Promise<SessionAggregate> {
+  const agg = emptySessionAggregate();
+  const state = { lastCacheRead: null as number | null };
+  const rl = readline.createInterface({ input: fs.createReadStream(filePath), crlfDelay: Infinity });
+  for await (const line of rl) {
+    foldAssistantLine(agg, line, state);
+  }
+  return agg;
+}
+
+/** Pure. Mirrors Claude Code's own transcript-path escaping (also used by
+ *  `deriveTranscriptPath` in packages/agents/src/interactive/claude.ts):
+ *  every non-alphanumeric character in the cwd becomes "-". */
+export function escapeClaudeProjectPath(cwd: string): string {
+  return cwd.replace(/[^a-zA-Z0-9]/g, "-");
+}
+
+/** Pure. A crew worktree's escaped cwd is the captain's slug plus the
+ *  escaped worktree subpath, which always starts with "-" (from the path
+ *  separator) — so "<captainSlug>-" is a safe, worktreeDir-agnostic prefix
+ *  that can't collide with an unrelated project slug that merely shares a
+ *  string prefix (that project's next character would not be "-"). */
+export function isCrewDirName(dirName: string, captainSlug: string): boolean {
+  return dirName !== captainSlug && dirName.startsWith(`${captainSlug}-`);
+}
+
+export interface RoleReport {
+  role: "captain" | "crews";
+  sessionFiles: number;
+  calls: number;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  /** Total context per call (input + cache_read + cache_write), averaged. */
+  meanCacheReadPerCall: number | null;
+  /** Mean turn-1 total across sessions — the fixed boot prefix. */
+  meanBoot: number | null;
+  /** meanCacheReadPerCall - meanBoot: the accumulated-conversation portion. */
+  accumulated: number | null;
+  accumulatedPct: number | null;
+  /** Sessions where turn-2 cache_read reproduces turn-1 total within 2%,
+   *  confirming the boot-prefix reading (see captain-context-budget.md §3). */
+  bootConfirmedSessions: number;
+  bootSampledSessions: number;
+}
+
+/** Pure. Rolls per-session aggregates into one role-level report (captain or
+ *  crews) — boot/accumulation math lives here, not spread across callers. */
+export function buildRoleReport(role: RoleReport["role"], sessions: SessionAggregate[]): RoleReport {
+  let calls = 0;
+  let input = 0;
+  let output = 0;
+  let cacheRead = 0;
+  let cacheWrite = 0;
+  const boots: number[] = [];
+  let bootConfirmedSessions = 0;
+
+  for (const s of sessions) {
+    calls += s.calls;
+    input += s.input;
+    output += s.output;
+    cacheRead += s.cacheRead;
+    cacheWrite += s.cacheWrite;
+
+    const [first, second] = s.turns;
+    if (first) {
+      boots.push(first.total);
+      if (second && first.total > 0) {
+        const rel = Math.abs(second.cacheRead - first.total) / first.total;
+        if (rel < 0.02) bootConfirmedSessions++;
+      }
+    }
+  }
+
+  const meanCacheReadPerCall = calls > 0 ? cacheRead / calls : null;
+  const meanBoot = boots.length > 0 ? boots.reduce((a, b) => a + b, 0) / boots.length : null;
+  const accumulated = meanCacheReadPerCall !== null && meanBoot !== null ? meanCacheReadPerCall - meanBoot : null;
+  const accumulatedPct =
+    accumulated !== null && meanCacheReadPerCall ? accumulated / meanCacheReadPerCall : null;
+
+  return {
+    role,
+    sessionFiles: sessions.length,
+    calls,
+    input,
+    output,
+    cacheRead,
+    cacheWrite,
+    meanCacheReadPerCall,
+    meanBoot,
+    accumulated,
+    accumulatedPct,
+    bootConfirmedSessions,
+    bootSampledSessions: boots.length,
+  };
+}
+
+export interface ProjectTokenReport {
+  project: string;
+  path: string;
+  captain: RoleReport;
+  crews: RoleReport;
+}
+
+async function readdirSafe(dir: string): Promise<string[]> {
+  try {
+    return await fs.promises.readdir(dir);
+  } catch {
+    return [];
+  }
+}
+
+async function listJsonlFiles(dir: string): Promise<string[]> {
+  const entries = await readdirSafe(dir);
+  return entries.filter((e) => e.endsWith(".jsonl")).map((e) => path.join(dir, e));
+}
+
+/** Splits `~/.claude/projects/*` into the one captain dir (exact slug match)
+ *  and every crew worktree dir for a given project path. */
+async function findTranscriptDirs(
+  claudeProjectsDir: string,
+  captainSlug: string,
+): Promise<{ captainDirs: string[]; crewDirs: string[] }> {
+  const entries = await readdirSafe(claudeProjectsDir);
+  const captainDirs: string[] = [];
+  const crewDirs: string[] = [];
+  for (const entry of entries) {
+    if (entry === captainSlug) captainDirs.push(path.join(claudeProjectsDir, entry));
+    else if (isCrewDirName(entry, captainSlug)) crewDirs.push(path.join(claudeProjectsDir, entry));
+  }
+  return { captainDirs, crewDirs };
+}
+
+/** Sequential by design: streams one file at a time so this never opens
+ *  more than one read stream (and never holds more than one file's lines)
+ *  at once, even across a project with 100+ crew worktree transcripts. */
+async function aggregateFiles(files: string[]): Promise<SessionAggregate[]> {
+  const sessions: SessionAggregate[] = [];
+  for (const file of files) {
+    sessions.push(await aggregateTranscriptFile(file));
+  }
+  return sessions;
+}
+
+export async function collectProjectTokenReport(
+  name: string,
+  projectPath: string,
+  claudeProjectsDir: string = CLAUDE_PROJECTS_DIR,
+): Promise<ProjectTokenReport> {
+  const captainSlug = escapeClaudeProjectPath(projectPath);
+  const { captainDirs, crewDirs } = await findTranscriptDirs(claudeProjectsDir, captainSlug);
+
+  const captainFiles = (await Promise.all(captainDirs.map(listJsonlFiles))).flat();
+  const crewFiles = (await Promise.all(crewDirs.map(listJsonlFiles))).flat();
+
+  const [captainSessions, crewSessions] = await Promise.all([
+    aggregateFiles(captainFiles),
+    aggregateFiles(crewFiles),
+  ]);
+
+  return {
+    project: name,
+    path: projectPath,
+    captain: buildRoleReport("captain", captainSessions),
+    crews: buildRoleReport("crews", crewSessions),
+  };
+}
+
+/** Pure. "1234567" -> "1.2M", "12345" -> "12.3k", else raw integer string. */
+export function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(Math.round(n));
+}
+
+function formatPct(n: number | null): string {
+  return n === null ? "n/a" : `${Math.round(n * 100)}%`;
+}
+
+function printRoleRow(label: string, r: RoleReport): void {
+  const totalVolume = r.input + r.output + r.cacheRead + r.cacheWrite;
+  console.log(
+    `  ${label.padEnd(10)} ${String(r.sessionFiles).padStart(6)} ${String(r.calls).padStart(8)} ` +
+      `${formatTokens(r.input).padStart(8)} ${formatTokens(r.output).padStart(8)} ` +
+      `${formatTokens(r.cacheRead).padStart(10)} ${formatTokens(r.cacheWrite).padStart(10)} ` +
+      `${formatTokens(totalVolume).padStart(10)}`,
+  );
+}
+
+function printBootLine(label: string, r: RoleReport): void {
+  if (r.meanBoot === null || r.meanCacheReadPerCall === null) {
+    console.log(chalk.dim(`  ${label.padEnd(10)} no sessions with turn data`));
+    return;
+  }
+  const bootPct = r.meanCacheReadPerCall > 0 ? r.meanBoot / r.meanCacheReadPerCall : null;
+  console.log(
+    `  ${label.padEnd(10)} mean ctx/call ${formatTokens(r.meanCacheReadPerCall).padStart(8)}` +
+      `  boot ${formatTokens(r.meanBoot).padStart(8)} (${formatPct(bootPct)})` +
+      `  accumulated ${formatTokens(r.accumulated ?? 0).padStart(8)} (${formatPct(r.accumulatedPct)})` +
+      chalk.dim(`  [boot confirmed ${r.bootConfirmedSessions}/${r.bootSampledSessions} sessions]`),
+  );
+}
+
+function sumRoleReports(role: RoleReport["role"], reports: RoleReport[]): RoleReport {
+  const calls = reports.reduce((a, r) => a + r.calls, 0);
+  const cacheRead = reports.reduce((a, r) => a + r.cacheRead, 0);
+  const bootWeighted = reports.reduce(
+    (a, r) => a + (r.meanBoot !== null ? r.meanBoot * r.bootSampledSessions : 0),
+    0,
+  );
+  const bootSampledSessions = reports.reduce((a, r) => a + r.bootSampledSessions, 0);
+  const meanBoot = bootSampledSessions > 0 ? bootWeighted / bootSampledSessions : null;
+  const meanCacheReadPerCall = calls > 0 ? cacheRead / calls : null;
+  const accumulated = meanCacheReadPerCall !== null && meanBoot !== null ? meanCacheReadPerCall - meanBoot : null;
+  const accumulatedPct =
+    accumulated !== null && meanCacheReadPerCall ? accumulated / meanCacheReadPerCall : null;
+
+  return {
+    role,
+    sessionFiles: reports.reduce((a, r) => a + r.sessionFiles, 0),
+    calls,
+    input: reports.reduce((a, r) => a + r.input, 0),
+    output: reports.reduce((a, r) => a + r.output, 0),
+    cacheRead,
+    cacheWrite: reports.reduce((a, r) => a + r.cacheWrite, 0),
+    meanCacheReadPerCall,
+    meanBoot,
+    accumulated,
+    accumulatedPct,
+    bootConfirmedSessions: reports.reduce((a, r) => a + r.bootConfirmedSessions, 0),
+    bootSampledSessions,
+  };
+}
+
+export const tokensCommand = new Command("tokens")
+  .description(
+    "Attribute token spend across captain vs crews and boot prefix vs accumulated conversation (Claude Code transcripts only)",
+  )
+  .option("--project <name>", "scope to a single registered project")
+  .option("--json", "print machine-readable JSON instead of a table")
+  .action(async (opts: { project?: string; json?: boolean }) => {
+    const config = loadConfig();
+    let entries = Object.entries(config.projects);
+
+    if (opts.project) {
+      if (!(opts.project in config.projects)) {
+        const known = Object.keys(config.projects).sort().join(", ") || "(no projects registered)";
+        console.error(chalk.red(`Unknown project '${opts.project}'. Known projects: ${known}`));
+        process.exit(1);
+      }
+      entries = entries.filter(([name]) => name === opts.project);
+    }
+
+    const reports: ProjectTokenReport[] = [];
+    for (const [name, project] of entries) {
+      reports.push(await collectProjectTokenReport(name, resolveHome(project.path)));
+    }
+
+    const active = reports.filter((r) => r.captain.calls > 0 || r.crews.calls > 0);
+    const skipped = reports.length - active.length;
+
+    if (opts.json) {
+      console.log(JSON.stringify({ projects: active }, null, 2));
+      return;
+    }
+
+    if (active.length === 0) {
+      console.log(chalk.yellow("\nNo Claude Code transcripts found for any registered project.\n"));
+      return;
+    }
+
+    console.log(chalk.bold("\nToken spend by project (Claude Code transcripts only)\n"));
+    console.log(chalk.dim(`  ${"PROJECT/ROLE".padEnd(10)} ${"FILES".padStart(6)} ${"CALLS".padStart(8)} ` +
+      `${"INPUT".padStart(8)} ${"OUTPUT".padStart(8)} ${"CACHE_READ".padStart(10)} ${"CACHE_WRITE".padStart(10)} ${"TOTAL".padStart(10)}`));
+    console.log(chalk.dim("  " + "─".repeat(78)));
+
+    for (const r of active) {
+      console.log(chalk.bold(`  ${r.project}`));
+      if (r.captain.calls > 0) printRoleRow("captain", r.captain);
+      if (r.crews.calls > 0) printRoleRow("crews", r.crews);
+    }
+
+    const totalCaptain = sumRoleReports("captain", active.map((r) => r.captain));
+    const totalCrews = sumRoleReports("crews", active.map((r) => r.crews));
+
+    console.log(chalk.dim("  " + "─".repeat(78)));
+    console.log(chalk.bold("  TOTAL"));
+    printRoleRow("captain", totalCaptain);
+    printRoleRow("crews", totalCrews);
+
+    console.log(chalk.bold("\nBoot prefix vs accumulated conversation\n"));
+    printBootLine("captain", totalCaptain);
+    printBootLine("crews", totalCrews);
+
+    console.log(
+      chalk.dim(
+        "\n  cache_read is ~1/10 the price of fresh input — do not read the TOTAL column as spend.\n" +
+          "  claude-only reader today; squadrant is multi-agent but no other driver writes an equivalent transcript yet.\n",
+      ),
+    );
+
+    if (skipped > 0) {
+      console.log(chalk.dim(`  ${skipped} project(s) with no local Claude transcripts omitted.\n`));
+    }
+  });

--- a/packages/cli/src/commands/tokens.ts
+++ b/packages/cli/src/commands/tokens.ts
@@ -27,28 +27,50 @@ export interface AssistantUsage {
   cacheWrite: number;
 }
 
-/** Pure. Parse one raw JSONL transcript line into usage numbers, or null if
- *  the line isn't a valid assistant message with a usage block (user turns,
- *  tool-result lines, and unparsable lines all return null). */
-export function parseAssistantUsage(rawLine: string): AssistantUsage | null {
+export interface ParsedTranscriptLine {
+  /** Raw ISO timestamp string from the line, if present — every line type
+   *  (user, assistant, attachment, ...) carries one; only a handful of
+   *  metadata-only line types (e.g. "mode", "queue-operation") omit it. */
+  timestamp: string | null;
+  usage: AssistantUsage | null;
+}
+
+/** Pure. Parse one raw JSONL transcript line into its timestamp and (if it's
+ *  an assistant message with a usage block) usage numbers. User turns,
+ *  tool-result lines, and unparsable lines get usage: null. */
+export function parseTranscriptLine(rawLine: string): ParsedTranscriptLine {
   const line = rawLine.trim();
-  if (!line) return null;
+  if (!line) return { timestamp: null, usage: null };
   let obj: unknown;
   try {
     obj = JSON.parse(line);
   } catch {
-    return null;
+    return { timestamp: null, usage: null };
   }
-  const entry = obj as { type?: string; message?: { role?: string; usage?: Record<string, number> } };
-  if (entry?.type !== "assistant" || entry.message?.role !== "assistant") return null;
-  const usage = entry.message?.usage;
-  if (!usage) return null;
-  return {
-    input: usage.input_tokens ?? 0,
-    output: usage.output_tokens ?? 0,
-    cacheRead: usage.cache_read_input_tokens ?? 0,
-    cacheWrite: usage.cache_creation_input_tokens ?? 0,
+  const entry = obj as {
+    type?: string;
+    timestamp?: string;
+    message?: { role?: string; usage?: Record<string, number> };
   };
+  const timestamp = typeof entry?.timestamp === "string" ? entry.timestamp : null;
+  if (entry?.type !== "assistant" || entry.message?.role !== "assistant") return { timestamp, usage: null };
+  const usage = entry.message?.usage;
+  if (!usage) return { timestamp, usage: null };
+  return {
+    timestamp,
+    usage: {
+      input: usage.input_tokens ?? 0,
+      output: usage.output_tokens ?? 0,
+      cacheRead: usage.cache_read_input_tokens ?? 0,
+      cacheWrite: usage.cache_creation_input_tokens ?? 0,
+    },
+  };
+}
+
+/** Pure. Convenience wrapper over `parseTranscriptLine` for callers that only
+ *  need the usage numbers (e.g. unit tests). */
+export function parseAssistantUsage(rawLine: string): AssistantUsage | null {
+  return parseTranscriptLine(rawLine).usage;
 }
 
 export interface Turn {
@@ -68,21 +90,41 @@ export interface SessionAggregate {
    *  (confirmed against a real transcript: turn-2 cache_read reproduces
    *  turn-1's total exactly once retries are collapsed). */
   turns: Turn[];
+  /** Earliest/latest timestamp seen in the file (any line type, not just
+   *  assistant turns) — the actual date range this session's data covers. */
+  earliest: string | null;
+  latest: string | null;
 }
 
 export function emptySessionAggregate(): SessionAggregate {
-  return { calls: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0, turns: [] };
+  return { calls: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0, turns: [], earliest: null, latest: null };
+}
+
+/** Pure. Widens [earliest, latest] with one more (possibly null) timestamp. */
+export function extendRange(
+  range: { earliest: string | null; latest: string | null },
+  timestamp: string | null,
+): void {
+  if (!timestamp) return;
+  if (range.earliest === null || timestamp < range.earliest) range.earliest = timestamp;
+  if (range.latest === null || timestamp > range.latest) range.latest = timestamp;
 }
 
 /** Mutates `agg` with one raw transcript line. `state.lastCacheRead` tracks
  *  the previous call's cache_read across the whole session so consecutive
- *  retries collapse into a single turn. */
-export function foldAssistantLine(
+ *  retries collapse into a single turn. Every line (not just assistant
+ *  turns) widens the session's date range — a transcript's true coverage
+ *  includes user turns too, and this is what makes the rolling-window
+ *  disclosure honest (#626 follow-up: a shrinking file count from Claude
+ *  Code's own transcript retention must never look like a silent all-time
+ *  total — cf. the #630 zombie-status-reader class of bug). */
+export function foldTranscriptLine(
   agg: SessionAggregate,
   rawLine: string,
   state: { lastCacheRead: number | null },
 ): void {
-  const usage = parseAssistantUsage(rawLine);
+  const { timestamp, usage } = parseTranscriptLine(rawLine);
+  extendRange(agg, timestamp);
   if (!usage) return;
   agg.calls++;
   agg.input += usage.input;
@@ -102,7 +144,7 @@ export function foldAssistantLine(
 export function aggregateLines(lines: Iterable<string>): SessionAggregate {
   const agg = emptySessionAggregate();
   const state = { lastCacheRead: null as number | null };
-  for (const line of lines) foldAssistantLine(agg, line, state);
+  for (const line of lines) foldTranscriptLine(agg, line, state);
   return agg;
 }
 
@@ -113,7 +155,7 @@ export async function aggregateTranscriptFile(filePath: string): Promise<Session
   const state = { lastCacheRead: null as number | null };
   const rl = readline.createInterface({ input: fs.createReadStream(filePath), crlfDelay: Infinity });
   for await (const line of rl) {
-    foldAssistantLine(agg, line, state);
+    foldTranscriptLine(agg, line, state);
   }
   return agg;
 }
@@ -153,6 +195,27 @@ export interface RoleReport {
    *  confirming the boot-prefix reading (see captain-context-budget.md §3). */
   bootConfirmedSessions: number;
   bootSampledSessions: number;
+  /** Actual date range covered by the transcripts that produced this report —
+   *  NOT all-time. Claude Code prunes transcripts past `cleanupPeriodDays`
+   *  (default 30d), so this range — and every count above it — narrows over
+   *  time purely from retention, independent of real usage. Always read
+   *  alongside this range; a smaller total next month can mean "less data
+   *  survived", not "less was spent". */
+  earliest: string | null;
+  latest: string | null;
+}
+
+/** Pure. Widens [earliest, latest] across a list of ranges — used to roll
+ *  session-level ranges up to a role, and role-level ranges up to a total. */
+export function mergeRanges(
+  ranges: Array<{ earliest: string | null; latest: string | null }>,
+): { earliest: string | null; latest: string | null } {
+  const merged: { earliest: string | null; latest: string | null } = { earliest: null, latest: null };
+  for (const r of ranges) {
+    extendRange(merged, r.earliest);
+    extendRange(merged, r.latest);
+  }
+  return merged;
 }
 
 /** Pure. Rolls per-session aggregates into one role-level report (captain or
@@ -188,6 +251,7 @@ export function buildRoleReport(role: RoleReport["role"], sessions: SessionAggre
   const accumulated = meanCacheReadPerCall !== null && meanBoot !== null ? meanCacheReadPerCall - meanBoot : null;
   const accumulatedPct =
     accumulated !== null && meanCacheReadPerCall ? accumulated / meanCacheReadPerCall : null;
+  const { earliest, latest } = mergeRanges(sessions);
 
   return {
     role,
@@ -203,6 +267,8 @@ export function buildRoleReport(role: RoleReport["role"], sessions: SessionAggre
     accumulatedPct,
     bootConfirmedSessions,
     bootSampledSessions: boots.length,
+    earliest,
+    latest,
   };
 }
 
@@ -294,7 +360,8 @@ function printRoleRow(label: string, r: RoleReport): void {
     `  ${label.padEnd(10)} ${String(r.sessionFiles).padStart(6)} ${String(r.calls).padStart(8)} ` +
       `${formatTokens(r.input).padStart(8)} ${formatTokens(r.output).padStart(8)} ` +
       `${formatTokens(r.cacheRead).padStart(10)} ${formatTokens(r.cacheWrite).padStart(10)} ` +
-      `${formatTokens(totalVolume).padStart(10)}`,
+      `${formatTokens(totalVolume).padStart(10)} ` +
+      chalk.dim(formatRange(r)),
   );
 }
 
@@ -325,6 +392,7 @@ function sumRoleReports(role: RoleReport["role"], reports: RoleReport[]): RoleRe
   const accumulated = meanCacheReadPerCall !== null && meanBoot !== null ? meanCacheReadPerCall - meanBoot : null;
   const accumulatedPct =
     accumulated !== null && meanCacheReadPerCall ? accumulated / meanCacheReadPerCall : null;
+  const { earliest, latest } = mergeRanges(reports);
 
   return {
     role,
@@ -340,7 +408,25 @@ function sumRoleReports(role: RoleReport["role"], reports: RoleReport[]): RoleRe
     accumulatedPct,
     bootConfirmedSessions: reports.reduce((a, r) => a + r.bootConfirmedSessions, 0),
     bootSampledSessions,
+    earliest,
+    latest,
   };
+}
+
+const ROLLING_WINDOW_NOTE =
+  "Rolling window, not all-time: Claude Code prunes transcripts older than " +
+  "`cleanupPeriodDays` (default 30 days). Totals shrink over time purely from " +
+  "retention as old sessions age out — that is NOT the same as spend going down.";
+
+/** Pure. "2026-06-29" from an ISO timestamp, or "?" if absent. */
+function formatDate(iso: string | null): string {
+  return iso ? iso.slice(0, 10) : "?";
+}
+
+/** Pure. "2026-06-29 → 2026-07-29", or a plain marker if there's no dated data. */
+export function formatRange(r: { earliest: string | null; latest: string | null }): string {
+  if (!r.earliest && !r.latest) return "no dated turns";
+  return `${formatDate(r.earliest)} → ${formatDate(r.latest)}`;
 }
 
 export const tokensCommand = new Command("tokens")
@@ -369,9 +455,10 @@ export const tokensCommand = new Command("tokens")
 
     const active = reports.filter((r) => r.captain.calls > 0 || r.crews.calls > 0);
     const skipped = reports.length - active.length;
+    const dataWindow = mergeRanges(active.flatMap((r) => [r.captain, r.crews]));
 
     if (opts.json) {
-      console.log(JSON.stringify({ projects: active }, null, 2));
+      console.log(JSON.stringify({ dataWindow, rollingWindowNote: ROLLING_WINDOW_NOTE, projects: active }, null, 2));
       return;
     }
 
@@ -381,8 +468,10 @@ export const tokensCommand = new Command("tokens")
     }
 
     console.log(chalk.bold("\nToken spend by project (Claude Code transcripts only)\n"));
+    console.log(chalk.yellow(`  Data window: ${formatRange(dataWindow)}`));
+    console.log(chalk.dim(`  ${ROLLING_WINDOW_NOTE}\n`));
     console.log(chalk.dim(`  ${"PROJECT/ROLE".padEnd(10)} ${"FILES".padStart(6)} ${"CALLS".padStart(8)} ` +
-      `${"INPUT".padStart(8)} ${"OUTPUT".padStart(8)} ${"CACHE_READ".padStart(10)} ${"CACHE_WRITE".padStart(10)} ${"TOTAL".padStart(10)}`));
+      `${"INPUT".padStart(8)} ${"OUTPUT".padStart(8)} ${"CACHE_READ".padStart(10)} ${"CACHE_WRITE".padStart(10)} ${"TOTAL".padStart(10)} WINDOW`));
     console.log(chalk.dim("  " + "─".repeat(78)));
 
     for (const r of active) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -34,6 +34,7 @@ import { pingCommand } from "./commands/ping.js";
 import { dispatchCommand } from "./commands/dispatch.js";
 import { cmuxCommand } from "./commands/cmux.js";
 import { effortCommand } from "./commands/effort.js";
+import { tokensCommand } from "./commands/tokens.js";
 import { telegramCommand } from "./commands/telegram.js";
 import { hooksCommand } from "./commands/hooks.js";
 import { detectDrift } from "@squadrant/shared";
@@ -131,6 +132,7 @@ program.addCommand(pingCommand);
 program.addCommand(dispatchCommand);
 program.addCommand(cmuxCommand);
 program.addCommand(effortCommand);
+program.addCommand(tokensCommand);
 program.addCommand(telegramCommand);
 program.addCommand(hooksCommand());
 


### PR DESCRIPTION
Added rolling-window disclosure: tracks per-line timestamps through session/role/total, prints Data window + explicit rolling-not-all-time note in text and JSON (matches the #630 silent-number class). Root cause of the earlier baseline drift confirmed: Claude Code's own cleanupPeriodDays=30 pruning, not a reader bug. pnpm build+test pass (2279 tests).