### PR TITLE
perf(crew): scope crew --plugin-dir to a karpathy-only plugin subset (#625)

### DIFF
--- a/packages/agents/src/drivers/__tests__/claude.test.ts
+++ b/packages/agents/src/drivers/__tests__/claude.test.ts
@@ -78,6 +78,25 @@ describe("claude driver", () => {
     expect(cmd).not.toContain("--permission-mode");
   });
 
+  it("points --plugin-dir at the crew-scoped subset for role crew", () => {
+    const cmd = driver.buildCommand({
+      prompt: "do something",
+      workdir: "/tmp/test",
+      role: "crew",
+    });
+    expect(cmd).toContain("/.config/squadrant/plugin-crew");
+  });
+
+  it("points --plugin-dir at the full plugin dir for non-crew roles", () => {
+    const cmd = driver.buildCommand({
+      prompt: "do something",
+      workdir: "/tmp/test",
+      role: "command",
+    });
+    expect(cmd).toContain("/.config/squadrant/plugin");
+    expect(cmd).not.toContain("plugin-crew");
+  });
+
   it("adds --settings when settingsPath specified", () => {
     const cmd = driver.buildCommand({
       prompt: "do something",

--- a/packages/agents/src/drivers/claude.ts
+++ b/packages/agents/src/drivers/claude.ts
@@ -48,8 +48,12 @@ export function createClaudeDriver(): AgentDriver {
         cmd += ` --settings ${opts.settingsPath}`;
       }
 
-      // Load squadrant plugin for skills
-      const pluginDir = `${process.env.HOME}/.config/squadrant/plugin`;
+      // Load squadrant plugin for skills. Crews get a subset plugin dir
+      // (crew.generic.md/crew.claude.md only ever reference karpathy-principles)
+      // synced by ensureRuntimeSynced — the harness lists only skills that
+      // role actually needs, instead of all 16 squadrant ships.
+      const pluginSubdir = opts.role === "crew" ? "plugin-crew" : "plugin";
+      const pluginDir = `${process.env.HOME}/.config/squadrant/${pluginSubdir}`;
       cmd += ` --plugin-dir ${pluginDir}`;
 
       if (!opts.interactive) {

--- a/packages/shared/src/lib/__tests__/runtime-sync.test.ts
+++ b/packages/shared/src/lib/__tests__/runtime-sync.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { mirrorDir, mirrorFlat, ensureRuntimeSynced } from "../runtime-sync.js";
+import { mirrorDir, mirrorFlat, ensureRuntimeSynced, CREW_SKILLS } from "../runtime-sync.js";
 
 let tmp: string;
 
@@ -148,6 +148,7 @@ describe("ensureRuntimeSynced", () => {
     const runtimeRoot = path.join(tmp, "rt-root");
     // plugin: tree target
     write(path.join(sourceRoot, "plugin", "skills", "captain-ops", "SKILL.md"), "captain");
+    write(path.join(sourceRoot, "plugin", "skills", "karpathy-principles", "SKILL.md"), "karpathy");
     write(path.join(sourceRoot, "plugin", ".claude-plugin", "plugin.json"), '{"name":"squadrant"}');
     // templates: flat target sourced from templates/, filtered by extension
     write(path.join(sourceRoot, "templates", "captain.claude.md"), "tmpl");
@@ -240,5 +241,30 @@ describe("ensureRuntimeSynced", () => {
     const { sourceRoot, runtimeRoot } = setupSource();
     ensureRuntimeSynced({ sourceRoot, runtimeRoot });
     expect(fs.existsSync(path.join(runtimeRoot, ".sync-state.json"))).toBe(false);
+  });
+
+  it("syncs plugin-crew as a strict subset of plugin (only CREW_SKILLS)", () => {
+    const { sourceRoot, runtimeRoot } = setupSource();
+
+    ensureRuntimeSynced({ sourceRoot, runtimeRoot });
+
+    for (const skill of CREW_SKILLS) {
+      expect(fs.existsSync(path.join(runtimeRoot, "plugin-crew", "skills", skill, "SKILL.md"))).toBe(true);
+    }
+    expect(fs.existsSync(path.join(runtimeRoot, "plugin-crew", "skills", "captain-ops"))).toBe(false);
+    expect(
+      fs.readFileSync(path.join(runtimeRoot, "plugin-crew", ".claude-plugin", "plugin.json"), "utf-8"),
+    ).toBe('{"name":"squadrant"}');
+  });
+
+  it("prunes a stale plugin-crew skill dir if CREW_SKILLS shrinks", () => {
+    const { sourceRoot, runtimeRoot } = setupSource();
+    ensureRuntimeSynced({ sourceRoot, runtimeRoot });
+    // simulate a previously-synced skill that's no longer in the allowlist
+    write(path.join(runtimeRoot, "plugin-crew", "skills", "stale-skill", "SKILL.md"), "old");
+
+    ensureRuntimeSynced({ sourceRoot, runtimeRoot });
+
+    expect(fs.existsSync(path.join(runtimeRoot, "plugin-crew", "skills", "stale-skill"))).toBe(false);
   });
 });

--- a/packages/shared/src/lib/runtime-sync.ts
+++ b/packages/shared/src/lib/runtime-sync.ts
@@ -81,6 +81,30 @@ export function mirrorFlat(
 }
 
 /**
+ * Mirror a plugin dir's `.claude-plugin/` manifest verbatim, but only the
+ * allow-listed subdirectories of `skills/` — pruning any dest skill dir not
+ * in the list. Used to produce a role-scoped plugin dir (e.g. crew's) that
+ * is a strict subset of the full squadrant plugin, so the harness's
+ * `--plugin-dir` only ever lists skills that role actually needs.
+ */
+function mirrorPluginSubset(src: string, dest: string, skills: string[]): void {
+  fs.mkdirSync(dest, { recursive: true });
+  mirrorDir(path.join(src, ".claude-plugin"), path.join(dest, ".claude-plugin"));
+
+  const skillsDest = path.join(dest, "skills");
+  fs.mkdirSync(skillsDest, { recursive: true });
+  for (const name of skills) {
+    const skillSrc = path.join(src, "skills", name);
+    if (fs.existsSync(skillSrc)) mirrorDir(skillSrc, path.join(skillsDest, name));
+  }
+  for (const entry of fs.readdirSync(skillsDest, { withFileTypes: true })) {
+    if (!skills.includes(entry.name)) {
+      fs.rmSync(path.join(skillsDest, entry.name), { recursive: true, force: true });
+    }
+  }
+}
+
+/**
  * A source-managed runtime dir. `name` is the dir under the runtime root;
  * `srcRel` is its source dir relative to the package root (note: the
  * runtime `templates/` is sourced from `templates/`).
@@ -93,10 +117,18 @@ export type ManagedTarget =
       mode: "flat";
       match: RegExp;
       chmod?: number;
-    };
+    }
+  | { name: string; srcRel: string; mode: "subset"; skills: string[] };
+
+// Crew CLAUDE.md templates only ever tell a crew to apply karpathy-principles
+// (see templates/crew.claude.md, templates/crew.generic.md) — captain-ops,
+// telegram, wiki-ops, etc. are captain/command-only. Keep this list in sync
+// with what the crew templates actually reference.
+export const CREW_SKILLS = ["karpathy-principles"];
 
 export const MANAGED_TARGETS: ManagedTarget[] = [
   { name: "plugin", srcRel: "plugin", mode: "tree" },
+  { name: "plugin-crew", srcRel: "plugin", mode: "subset", skills: CREW_SKILLS },
   { name: "scripts", srcRel: "scripts", mode: "flat", match: /\.sh$/, chmod: 0o755 },
   {
     name: "templates",
@@ -134,8 +166,10 @@ export function ensureRuntimeSynced(opts: EnsureRuntimeSyncedOptions): void {
       const destDir = path.join(opts.runtimeRoot, t.name);
       if (t.mode === "tree") {
         mirrorDir(srcDir, destDir);
-      } else {
+      } else if (t.mode === "flat") {
         mirrorFlat(srcDir, destDir, t.match, t.chmod);
+      } else {
+        mirrorPluginSubset(srcDir, destDir, t.skills);
       }
     } catch (err) {
       process.stderr.write(


### PR DESCRIPTION
Implements #625 for the crew side.

**Mechanism answer (the thing #625 asked to establish first):** per-role plugin scoping IS possible without fighting the harness — `opts.role` is already threaded into `buildCommand` at every crew-spawn callsite, so the claude driver can branch on it. `ensureRuntimeSynced` gains a `subset` mode that generates `~/.config/squadrant/plugin-crew` as a strict, self-healing subset of the full plugin dir. Captain/command/side keep all 16 skills.

**Measured:** 33,436 → 32,079 tokens on the boot turn (**−1,357/spawn**), via matched headless `claude` invocations differing only in `--plugin-dir`.

**Honest magnitude:** this is a small win, and that is expected — squadrant ships only 16 of the ~85 listed skills. The bulk of the prefix is Claude Code's own base prompt plus the user's `~/.claude/skills/` (53) and marketplace plugins, none of which squadrant can touch. −1,357 per spawn, at ~5 spawns/day, is real but modest. The lasting value is arguably the per-role seam itself.

**Behavioural change to know about:** a crew can no longer load squadrant skills other than `karpathy-principles`. If a captain instructs a crew to use e.g. `wiki-ops`, it will not be there. Fix is one entry in `CREW_SKILLS`, and the constant carries a comment saying to keep it in sync with the crew templates.

**Found while measuring — filed separately as #636:** the live measurement attempt tripped a latent path in `ensureDaemon`'s PATH-drift plist check that bounced the shared production daemon. No data loss (verified: the one in-flight task on another project ended on its own `task.done`), but a crew must never be able to restart the daemon every project shares.