### PR TITLE
fix(work): keep unfinished children visible when their parent is marked done

### DIFF
--- a/packages/cli/src/__tests__/work.test.ts
+++ b/packages/cli/src/__tests__/work.test.ts
@@ -1,6 +1,6 @@
 // packages/cli/src/__tests__/work.test.ts
 import { describe, it, expect } from "vitest";
-import { detectCurrentProject, groupByParent } from "../commands/work.js";
+import { detectCurrentProject, groupByParent, visibleItems } from "../commands/work.js";
 import type { SquadrantConfig, WorkItem } from "@squadrant/shared";
 
 function item(overrides: Partial<WorkItem>): WorkItem {
@@ -63,5 +63,46 @@ describe("groupByParent — out-of-order wave completion is the point of the des
     const childOf1 = item({ id: "c1", parent: "w1" });
     const { roots } = groupByParent([wave2, wave1, childOf1]);
     expect(roots.map((r) => r.id).sort()).toEqual(["w1", "w2"]);
+  });
+});
+
+describe("visibleItems — a done parent must not orphan an unfinished child", () => {
+  it("keeps a done parent visible when a direct child is still open", () => {
+    const wave = item({ id: "wave", state: "done" });
+    const child = item({ id: "child", parent: "wave", state: "working" });
+    const kept = visibleItems([wave, child], false);
+    expect(kept.map((i) => i.id).sort()).toEqual(["child", "wave"]);
+  });
+
+  it("hides a done parent whose children are all terminal too", () => {
+    const wave = item({ id: "wave", state: "done" });
+    const child = item({ id: "child", parent: "wave", state: "cancelled" });
+    const kept = visibleItems([wave, child], false);
+    expect(kept).toEqual([]);
+  });
+
+  it("hides a standalone done item with no children, same as before the fix", () => {
+    const done = item({ id: "done-1", state: "done" });
+    expect(visibleItems([done], false)).toEqual([]);
+  });
+
+  it("keeps every ancestor in a multi-level chain when the leaf is still open", () => {
+    const grandparent = item({ id: "gp", state: "done" });
+    const parent = item({ id: "p", parent: "gp", state: "done" });
+    const leaf = item({ id: "leaf", parent: "p", state: "blocked" });
+    const kept = visibleItems([grandparent, parent, leaf], false);
+    expect(kept.map((i) => i.id).sort()).toEqual(["gp", "leaf", "p"]);
+  });
+
+  it("a parentless incident (not a wave) is unaffected — normal non-terminal visibility", () => {
+    const incident = item({ id: "incident", parent: null, state: "working" });
+    expect(visibleItems([incident], false)).toEqual([incident]);
+  });
+
+  it("--include-done bypasses pruning entirely, including all-terminal subtrees", () => {
+    const wave = item({ id: "wave", state: "done" });
+    const child = item({ id: "child", parent: "wave", state: "cancelled" });
+    const kept = visibleItems([wave, child], true);
+    expect(kept.map((i) => i.id).sort()).toEqual(["child", "wave"]);
   });
 });

--- a/packages/cli/src/__tests__/work.test.ts
+++ b/packages/cli/src/__tests__/work.test.ts
@@ -1,0 +1,67 @@
+// packages/cli/src/__tests__/work.test.ts
+import { describe, it, expect } from "vitest";
+import { detectCurrentProject, groupByParent } from "../commands/work.js";
+import type { SquadrantConfig, WorkItem } from "@squadrant/shared";
+
+function item(overrides: Partial<WorkItem>): WorkItem {
+  return {
+    id: "w_0000", project: "proj", title: "t", state: "working", parent: null,
+    tags: [], note: "", crewTaskIds: [], issue: null,
+    createdAt: 0, updatedAt: 0, closedAt: null,
+    ...overrides,
+  };
+}
+
+describe("detectCurrentProject", () => {
+  const config = {
+    projects: {
+      friendslop: { path: "/repo/friendslop-factory" },
+      oneplan: { path: "/repo/oneplan" },
+    },
+  } as unknown as SquadrantConfig;
+
+  it("matches when cwd is exactly the project path", () => {
+    expect(detectCurrentProject(config, "/repo/friendslop-factory")).toBe("friendslop");
+  });
+
+  it("matches when cwd is a subdirectory of the project path", () => {
+    expect(detectCurrentProject(config, "/repo/oneplan/packages/api")).toBe("oneplan");
+  });
+
+  it("does not match a sibling path with a shared string prefix", () => {
+    // /repo/oneplan-extra is NOT under /repo/oneplan
+    expect(detectCurrentProject(config, "/repo/oneplan-extra")).toBeUndefined();
+  });
+
+  it("returns undefined outside any registered project", () => {
+    expect(detectCurrentProject(config, "/tmp/somewhere")).toBeUndefined();
+  });
+});
+
+describe("groupByParent — out-of-order wave completion is the point of the design", () => {
+  it("nests children under their wave and leaves a parentless incident flat at top level", () => {
+    const wave3 = item({ id: "wave-3", title: "Wave 3" });
+    const child = item({ id: "child-1", title: "matchmaking", parent: "wave-3" });
+    const incident = item({ id: "incident-1", title: "prod fire", parent: null });
+
+    const { roots, childrenOf } = groupByParent([wave3, child, incident]);
+
+    expect(roots.map((r) => r.id).sort()).toEqual(["incident-1", "wave-3"]);
+    expect(childrenOf.get("wave-3")?.map((c) => c.id)).toEqual(["child-1"]);
+  });
+
+  it("treats a dangling parent reference (parent item not in the set) as top-level, not lost", () => {
+    const orphan = item({ id: "orphan", parent: "does-not-exist" });
+    const { roots, childrenOf } = groupByParent([orphan]);
+    expect(roots.map((r) => r.id)).toEqual(["orphan"]);
+    expect(childrenOf.size).toBe(0);
+  });
+
+  it("waves finishing out of order does not affect grouping — order is never encoded", () => {
+    const wave1 = item({ id: "w1" });
+    const wave2 = item({ id: "w2", state: "done" });
+    const childOf1 = item({ id: "c1", parent: "w1" });
+    const { roots } = groupByParent([wave2, wave1, childOf1]);
+    expect(roots.map((r) => r.id).sort()).toEqual(["w1", "w2"]);
+  });
+});

--- a/packages/cli/src/commands/work.ts
+++ b/packages/cli/src/commands/work.ts
@@ -7,6 +7,7 @@ import {
   createWorkItem,
   closeWorkItem,
   findWorkItemById,
+  findOpenChildren,
   purgeExpiredWorkItems,
   type TerminalWorkState,
 } from "@squadrant/core";
@@ -42,6 +43,29 @@ export function groupByParent(items: WorkItem[]): { roots: WorkItem[]; childrenO
   return { roots, childrenOf };
 }
 
+/** Pure. The default (non `--include-done`) view hides terminal items — but
+ *  hiding a done/cancelled item that still has an unfinished descendant
+ *  would orphan that descendant: it'd render as a parentless root with no
+ *  sign it belonged to a wave. That defeats the exact scenario --parent
+ *  exists for ("wave finished out of order, what's left?"), so a terminal
+ *  item stays visible whenever any descendant, at any depth, is still open.
+ *  Parent links are resolved from the full (unfiltered) item set so
+ *  multi-level chains work. */
+export function visibleItems(items: WorkItem[], includeDone: boolean): WorkItem[] {
+  if (includeDone) return items;
+  const { childrenOf } = groupByParent(items);
+  const memo = new Map<string, boolean>();
+  const keep = (item: WorkItem): boolean => {
+    const cached = memo.get(item.id);
+    if (cached !== undefined) return cached;
+    memo.set(item.id, false); // cycle guard: a malformed parent chain can't infinite-loop
+    const result = !TERMINAL_WORK_STATES.has(item.state) || (childrenOf.get(item.id) ?? []).some(keep);
+    memo.set(item.id, result);
+    return result;
+  };
+  return items.filter(keep);
+}
+
 function stateColor(state: WorkItem["state"]): (s: string) => string {
   switch (state) {
     case "done": return chalk.green;
@@ -54,11 +78,14 @@ function stateColor(state: WorkItem["state"]): (s: string) => string {
 
 function printItem(item: WorkItem, indent: number): void {
   const color = stateColor(item.state);
-  console.log(
+  const line =
     "  ".repeat(indent) +
-      `${chalk.dim(item.id)}  ${item.title}  ${color(`[${item.state}]`)}` +
-      (indent === 0 ? chalk.dim(`  (${item.project})`) : ""),
-  );
+    `${chalk.dim(item.id)}  ${item.title}  ${color(`[${item.state}]`)}` +
+    (indent === 0 ? chalk.dim(`  (${item.project})`) : "");
+  // A terminal item only survives the default (non --include-done) view when
+  // it still has an open descendant (see visibleItems) — dim it so it reads
+  // as "closed, kept for context" rather than an active item.
+  console.log(TERMINAL_WORK_STATES.has(item.state) ? chalk.dim(line) : line);
 }
 
 function printTree(items: WorkItem[]): void {
@@ -125,7 +152,7 @@ const listCmd = new Command("list")
       items = store.list(project);
     }
 
-    if (!opts.includeDone) items = items.filter((i) => !TERMINAL_WORK_STATES.has(i.state));
+    items = visibleItems(items, opts.includeDone ?? false);
 
     if (items.length === 0) {
       console.log(chalk.dim("\nNo work items.\n"));
@@ -153,6 +180,16 @@ function closeCommand(name: string, state: TerminalWorkState, flag: string, key:
         process.exit(1);
       }
       console.log(chalk.green(`✓ ${item.id}`) + `  ${item.title}  ${chalk.dim(`[${item.state}]`)}`);
+
+      // Warn, don't refuse (enforcement is out of scope) — but "done" without
+      // this would silently orphan open children in the default list view.
+      if (state === "done") {
+        const openChildren = findOpenChildren(store, item.id);
+        if (openChildren.length > 0) {
+          const names = openChildren.map((c) => `${c.id} [${c.state}]`).join(", ");
+          console.log(chalk.yellow(`⚠ still has ${openChildren.length} unfinished child item(s): ${names}`));
+        }
+      }
     });
 }
 

--- a/packages/cli/src/commands/work.ts
+++ b/packages/cli/src/commands/work.ts
@@ -1,0 +1,167 @@
+import path from "node:path";
+import { Command } from "commander";
+import chalk from "chalk";
+import { loadConfig, resolveHome, TERMINAL_WORK_STATES, type SquadrantConfig, type WorkItem } from "@squadrant/shared";
+import {
+  createWorkStore,
+  createWorkItem,
+  closeWorkItem,
+  findWorkItemById,
+  purgeExpiredWorkItems,
+  type TerminalWorkState,
+} from "@squadrant/core";
+
+/** Pure. Resolves the registered project whose path contains `cwd`, if any —
+ *  `work list`/`work start` default to it (spec §4.5); `--all`/`--project`
+ *  override. */
+export function detectCurrentProject(config: SquadrantConfig, cwd: string = process.cwd()): string | undefined {
+  for (const [name, proj] of Object.entries(config.projects)) {
+    const projPath = resolveHome(proj.path);
+    if (cwd === projPath || cwd.startsWith(projPath + path.sep)) return name;
+  }
+  return undefined;
+}
+
+/** Pure. Groups items into top-level roots (parent is null, or points at an
+ *  item not in this set) plus a parent-id -> children index. This is the
+ *  literal test of the design's point: an incident with no parent — or a
+ *  dangling parent — renders flat, not lost. */
+export function groupByParent(items: WorkItem[]): { roots: WorkItem[]; childrenOf: Map<string, WorkItem[]> } {
+  const byId = new Map(items.map((i) => [i.id, i]));
+  const childrenOf = new Map<string, WorkItem[]>();
+  const roots: WorkItem[] = [];
+  for (const item of items) {
+    if (item.parent && byId.has(item.parent)) {
+      const list = childrenOf.get(item.parent) ?? [];
+      list.push(item);
+      childrenOf.set(item.parent, list);
+    } else {
+      roots.push(item);
+    }
+  }
+  return { roots, childrenOf };
+}
+
+function stateColor(state: WorkItem["state"]): (s: string) => string {
+  switch (state) {
+    case "done": return chalk.green;
+    case "cancelled": return chalk.dim;
+    case "blocked": return chalk.red;
+    case "paused": return chalk.yellow;
+    default: return chalk.cyan;
+  }
+}
+
+function printItem(item: WorkItem, indent: number): void {
+  const color = stateColor(item.state);
+  console.log(
+    "  ".repeat(indent) +
+      `${chalk.dim(item.id)}  ${item.title}  ${color(`[${item.state}]`)}` +
+      (indent === 0 ? chalk.dim(`  (${item.project})`) : ""),
+  );
+}
+
+function printTree(items: WorkItem[]): void {
+  const { roots, childrenOf } = groupByParent(items);
+  const walk = (item: WorkItem, depth: number) => {
+    printItem(item, depth);
+    for (const child of childrenOf.get(item.id) ?? []) walk(child, depth + 1);
+  };
+  for (const root of roots) walk(root, 0);
+}
+
+function printFlat(items: WorkItem[]): void {
+  for (const item of items) printItem(item, 0);
+}
+
+const startCmd = new Command("start")
+  .description("Start a new work item")
+  .argument("<title>", "what you're doing")
+  .option("--project <name>", "project this work belongs to (defaults to the current registered project)")
+  .option("--parent <id>", "id of the wave/parent item this nests under")
+  .option("--tag <tag>", "attach a tag (repeatable)", (v: string, prev: string[]) => [...prev, v], [] as string[])
+  .action((title: string, opts: { project?: string; parent?: string; tag: string[] }) => {
+    const config = loadConfig();
+    const store = createWorkStore();
+    purgeExpiredWorkItems(store);
+
+    const project = opts.project ?? detectCurrentProject(config);
+    if (!project) {
+      console.error(chalk.red("No --project given and cwd is not inside a registered project."));
+      process.exit(1);
+    }
+
+    if (opts.parent && !findWorkItemById(store, opts.parent)) {
+      console.error(chalk.red(`Parent work item '${opts.parent}' not found.`));
+      process.exit(1);
+    }
+
+    const item = createWorkItem(store, { project, title, parent: opts.parent ?? null, tags: opts.tag });
+    console.log(chalk.green(`✓ ${item.id}`) + `  ${item.title}` + chalk.dim(`  (${item.project})`));
+  });
+
+const listCmd = new Command("list")
+  .description("List work items")
+  .option("--project <name>", "scope to one project")
+  .option("--all", "list across every project")
+  .option("--tree", "render parent/child nesting")
+  .option("--include-done", "include done/cancelled items")
+  .action((opts: { project?: string; all?: boolean; tree?: boolean; includeDone?: boolean }) => {
+    const config = loadConfig();
+    const store = createWorkStore();
+    purgeExpiredWorkItems(store);
+
+    let items: WorkItem[];
+    if (opts.project) {
+      items = store.list(opts.project);
+    } else if (opts.all) {
+      items = store.listAll();
+    } else {
+      const project = detectCurrentProject(config);
+      if (!project) {
+        console.error(chalk.red("cwd is not inside a registered project — pass --project or --all."));
+        process.exit(1);
+      }
+      items = store.list(project);
+    }
+
+    if (!opts.includeDone) items = items.filter((i) => !TERMINAL_WORK_STATES.has(i.state));
+
+    if (items.length === 0) {
+      console.log(chalk.dim("\nNo work items.\n"));
+      return;
+    }
+
+    console.log();
+    if (opts.tree) printTree(items);
+    else printFlat(items);
+    console.log();
+  });
+
+function closeCommand(name: string, state: TerminalWorkState, flag: string, key: "note" | "why", desc: string): Command {
+  return new Command(name)
+    .description(`Mark a work item ${state}`)
+    .argument("<id>", "work item id")
+    .option(flag, desc)
+    .action((id: string, opts: Record<string, string | undefined>) => {
+      const store = createWorkStore();
+      purgeExpiredWorkItems(store);
+
+      const item = closeWorkItem(store, id, state, { note: opts[key] });
+      if (!item) {
+        console.error(chalk.red(`Work item '${id}' not found.`));
+        process.exit(1);
+      }
+      console.log(chalk.green(`✓ ${item.id}`) + `  ${item.title}  ${chalk.dim(`[${item.state}]`)}`);
+    });
+}
+
+const doneCmd = closeCommand("done", "done", "--note <text>", "note", "closing note");
+const cancelCmd = closeCommand("cancel", "cancelled", "--why <text>", "why", "reason");
+
+export const workCommand = new Command("work")
+  .description("Track your own in-flight work — persisted, cross-project, cross-session")
+  .addCommand(startCmd)
+  .addCommand(listCmd)
+  .addCommand(doneCmd)
+  .addCommand(cancelCmd);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -37,6 +37,7 @@ import { effortCommand } from "./commands/effort.js";
 import { tokensCommand } from "./commands/tokens.js";
 import { telegramCommand } from "./commands/telegram.js";
 import { hooksCommand } from "./commands/hooks.js";
+import { workCommand } from "./commands/work.js";
 import { detectDrift } from "@squadrant/shared";
 import { needsCheck, withStamp } from "@squadrant/shared";
 import { getDefaultConfig } from "@squadrant/shared";
@@ -135,6 +136,7 @@ program.addCommand(effortCommand);
 program.addCommand(tokensCommand);
 program.addCommand(telegramCommand);
 program.addCommand(hooksCommand());
+program.addCommand(workCommand);
 
 program.parseAsync().catch((e) => {
   process.stderr.write(`error: ${e instanceof Error ? e.message : String(e)}\n`);

--- a/packages/core/src/__tests__/work-store.test.ts
+++ b/packages/core/src/__tests__/work-store.test.ts
@@ -7,6 +7,7 @@ import {
   createWorkStore,
   createWorkItem,
   findWorkItemById,
+  findOpenChildren,
   closeWorkItem,
   purgeExpiredWorkItems,
   WORK_ITEM_TTL_MS,
@@ -17,7 +18,7 @@ describe("work-store", () => {
   beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "cp-work-store-")); });
   afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
 
-  it("createWorkItem then get round-trips through the generic Store<WorkItem>", () => {
+  it("createWorkItem then get round-trips through the WorkStore", () => {
     const store = createWorkStore(dir);
     const item = createWorkItem(store, { project: "proj", title: "Wave 3", now: 1000 });
     expect(item.state).toBe("working");
@@ -44,6 +45,29 @@ describe("work-store", () => {
     const item = createWorkItem(store, { project: "friendslop-factory", title: "incident", now: 1000 });
     expect(findWorkItemById(store, item.id)?.project).toBe("friendslop-factory");
     expect(findWorkItemById(store, "w_nope")).toBeUndefined();
+  });
+
+  describe("findOpenChildren", () => {
+    it("returns only direct children still in a non-terminal state", () => {
+      const store = createWorkStore(dir);
+      const wave = createWorkItem(store, { project: "proj", title: "wave", now: 0 });
+      const openChild = createWorkItem(store, { project: "proj", title: "a", parent: wave.id, now: 1 });
+      const closedChild = createWorkItem(store, { project: "proj", title: "b", parent: wave.id, now: 2 });
+      closeWorkItem(store, closedChild.id, "done", { now: 3 });
+
+      const open = findOpenChildren(store, wave.id);
+      expect(open.map((i) => i.id)).toEqual([openChild.id]);
+    });
+
+    it("returns an empty array when a parent has no children or all are terminal", () => {
+      const store = createWorkStore(dir);
+      const wave = createWorkItem(store, { project: "proj", title: "wave", now: 0 });
+      expect(findOpenChildren(store, wave.id)).toEqual([]);
+
+      const child = createWorkItem(store, { project: "proj", title: "a", parent: wave.id, now: 1 });
+      closeWorkItem(store, child.id, "cancelled", { now: 2 });
+      expect(findOpenChildren(store, wave.id)).toEqual([]);
+    });
   });
 
   describe("closeWorkItem", () => {

--- a/packages/core/src/__tests__/work-store.test.ts
+++ b/packages/core/src/__tests__/work-store.test.ts
@@ -1,0 +1,129 @@
+// packages/core/src/__tests__/work-store.test.ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createWorkStore,
+  createWorkItem,
+  findWorkItemById,
+  closeWorkItem,
+  purgeExpiredWorkItems,
+  WORK_ITEM_TTL_MS,
+} from "../work-store.js";
+
+describe("work-store", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "cp-work-store-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it("createWorkItem then get round-trips through the generic Store<WorkItem>", () => {
+    const store = createWorkStore(dir);
+    const item = createWorkItem(store, { project: "proj", title: "Wave 3", now: 1000 });
+    expect(item.state).toBe("working");
+    expect(item.parent).toBeNull();
+    expect(item.closedAt).toBeNull();
+    expect(store.get("proj", item.id)).toEqual(item);
+  });
+
+  it("assigns a short w_-prefixed id", () => {
+    const store = createWorkStore(dir);
+    const item = createWorkItem(store, { project: "proj", title: "t", now: 1000 });
+    expect(item.id).toMatch(/^w_[0-9a-f]{4}$/);
+  });
+
+  it("--parent survives round-trip and does not require same-project scoping", () => {
+    const store = createWorkStore(dir);
+    const wave = createWorkItem(store, { project: "proj", title: "Wave 3", now: 1000 });
+    const child = createWorkItem(store, { project: "proj", title: "matchmaking", parent: wave.id, now: 1001 });
+    expect(child.parent).toBe(wave.id);
+  });
+
+  it("findWorkItemById finds an item across projects with no --project given", () => {
+    const store = createWorkStore(dir);
+    const item = createWorkItem(store, { project: "friendslop-factory", title: "incident", now: 1000 });
+    expect(findWorkItemById(store, item.id)?.project).toBe("friendslop-factory");
+    expect(findWorkItemById(store, "w_nope")).toBeUndefined();
+  });
+
+  describe("closeWorkItem", () => {
+    it("transitions to done and stamps closedAt", () => {
+      const store = createWorkStore(dir);
+      const item = createWorkItem(store, { project: "proj", title: "t", now: 1000 });
+      const closed = closeWorkItem(store, item.id, "done", { note: "shipped", now: 2000 });
+      expect(closed?.state).toBe("done");
+      expect(closed?.closedAt).toBe(2000);
+      expect(closed?.note).toBe("shipped");
+      expect(store.get("proj", item.id)?.state).toBe("done");
+    });
+
+    it("transitions to cancelled", () => {
+      const store = createWorkStore(dir);
+      const item = createWorkItem(store, { project: "proj", title: "t", now: 1000 });
+      const closed = closeWorkItem(store, item.id, "cancelled", { now: 2000 });
+      expect(closed?.state).toBe("cancelled");
+    });
+
+    it("returns undefined for an unknown id", () => {
+      const store = createWorkStore(dir);
+      expect(closeWorkItem(store, "w_nope", "done")).toBeUndefined();
+    });
+  });
+
+  describe("purgeExpiredWorkItems (30-day TTL)", () => {
+    it("does not purge an open (non-terminal) item no matter how old", () => {
+      const store = createWorkStore(dir);
+      const item = createWorkItem(store, { project: "proj", title: "t", now: 0 });
+      const purged = purgeExpiredWorkItems(store, WORK_ITEM_TTL_MS * 10);
+      expect(purged).toBe(0);
+      expect(store.get("proj", item.id)).toBeDefined();
+    });
+
+    it("keeps a done item exactly at the TTL boundary", () => {
+      const store = createWorkStore(dir);
+      const item = createWorkItem(store, { project: "proj", title: "t", now: 0 });
+      closeWorkItem(store, item.id, "done", { now: 0 });
+      // now - closedAt === TTL exactly: purge condition is strictly '>', so this survives.
+      const purged = purgeExpiredWorkItems(store, WORK_ITEM_TTL_MS);
+      expect(purged).toBe(0);
+      expect(store.get("proj", item.id)).toBeDefined();
+    });
+
+    it("purges a done item one ms past the TTL boundary", () => {
+      const store = createWorkStore(dir);
+      const item = createWorkItem(store, { project: "proj", title: "t", now: 0 });
+      closeWorkItem(store, item.id, "done", { now: 0 });
+      const purged = purgeExpiredWorkItems(store, WORK_ITEM_TTL_MS + 1);
+      expect(purged).toBe(1);
+      expect(store.get("proj", item.id)).toBeUndefined();
+    });
+
+    it("purges an expired cancelled item the same as an expired done item", () => {
+      const store = createWorkStore(dir);
+      const item = createWorkItem(store, { project: "proj", title: "t", now: 0 });
+      closeWorkItem(store, item.id, "cancelled", { now: 0 });
+      const purged = purgeExpiredWorkItems(store, WORK_ITEM_TTL_MS + 1);
+      expect(purged).toBe(1);
+    });
+
+    it("leaves a recently-closed item alone", () => {
+      const store = createWorkStore(dir);
+      const item = createWorkItem(store, { project: "proj", title: "t", now: 0 });
+      closeWorkItem(store, item.id, "done", { now: 0 });
+      const purged = purgeExpiredWorkItems(store, WORK_ITEM_TTL_MS / 2);
+      expect(purged).toBe(0);
+      expect(store.get("proj", item.id)).toBeDefined();
+    });
+
+    it("purges across multiple projects in one pass", () => {
+      const store = createWorkStore(dir);
+      const a = createWorkItem(store, { project: "p1", title: "a", now: 0 });
+      const b = createWorkItem(store, { project: "p2", title: "b", now: 0 });
+      closeWorkItem(store, a.id, "done", { now: 0 });
+      closeWorkItem(store, b.id, "done", { now: 0 });
+      const purged = purgeExpiredWorkItems(store, WORK_ITEM_TTL_MS + 1);
+      expect(purged).toBe(2);
+      expect(store.listAll()).toEqual([]);
+    });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export * from "./state-machine.js";
 export * from "./liveness.js";
 export * from "./watchdog.js";
 export * from "./store.js";
+export * from "./work-store.js";
 export * from "./snapshot.js";
 export * from "./launchd.js";
 export * from "./crew-pane-reader.js";

--- a/packages/core/src/work-store.ts
+++ b/packages/core/src/work-store.ts
@@ -19,7 +19,7 @@ import {
   mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync, existsSync,
   rmSync, statSync,
 } from "node:fs";
-import type { WorkItem, WorkState } from "@squadrant/shared";
+import { TERMINAL_WORK_STATES, type WorkItem, type WorkState } from "@squadrant/shared";
 
 /** done/cancelled items are deleted 30 days after closedAt (spec §4.4). */
 export const WORK_ITEM_TTL_MS = 30 * 24 * 60 * 60 * 1000;
@@ -165,6 +165,13 @@ export function createWorkItem(store: WorkStore, opts: CreateWorkItemOpts): Work
  *  --project for these). */
 export function findWorkItemById(store: WorkStore, id: string): WorkItem | undefined {
   return store.listAll().find((i) => i.id === id);
+}
+
+/** Direct children of `id` still in a non-terminal state — used by the CLI
+ *  to warn (never refuse; enforcement is out of scope) when `work done` is
+ *  run on a parent that still has open work underneath it. */
+export function findOpenChildren(store: WorkStore, id: string): WorkItem[] {
+  return store.listAll().filter((i) => i.parent === id && !TERMINAL_WORK_STATES.has(i.state));
 }
 
 export type TerminalWorkState = Extract<WorkState, "done" | "cancelled">;

--- a/packages/core/src/work-store.ts
+++ b/packages/core/src/work-store.ts
@@ -1,0 +1,199 @@
+// The user's work-item store — durable, per-project JSON, outside the
+// daemon's state/ dir on purpose (spec §4.1): sweep() never sees these
+// records, so work items survive daemon downtime.
+//
+// Mirrors store.ts's createStore (atomic write+rename, path-traversal guard,
+// TTL GC) rather than sharing it. The spec's preferred route was generalizing
+// createStore<T>, but ReturnType<typeof createStore> is embedded in
+// DaemonContext.store and re-derived across ~10 daemon-core files (attach.ts,
+// delivery-loop.ts, gates.ts, probes.ts, start.ts, squadrantd.ts) — TS does
+// not apply createStore's default type param through that ReturnType alias,
+// so making it generic breaks all of them (confirmed via `pnpm build`, not
+// speculation: see PR description). That is real daemon-core blast radius
+// for a task scoped to be a minimal, standalone primitive — out of bounds
+// here, so this duplicates the ~20-line guard instead of risking it.
+import { homedir } from "node:os";
+import { join, resolve, sep } from "node:path";
+import { randomBytes } from "node:crypto";
+import {
+  mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync, existsSync,
+  rmSync, statSync,
+} from "node:fs";
+import type { WorkItem, WorkState } from "@squadrant/shared";
+
+/** done/cancelled items are deleted 30 days after closedAt (spec §4.4). */
+export const WORK_ITEM_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+export function defaultWorkRoot(): string {
+  return join(homedir(), ".config", "squadrant", "work");
+}
+
+export interface WorkStore {
+  put(item: WorkItem): void;
+  get(project: string, id: string): WorkItem | undefined;
+  list(project: string): WorkItem[];
+  listAll(): WorkItem[];
+  delete(project: string, id: string): void;
+}
+
+// Same guard as store.ts's safeSegment/assertUnderRoot: project/id become a
+// path segment, so a crafted value ("..", "/", NUL) must never escape root.
+function safeSegment(kind: "project" | "id", s: unknown): string {
+  if (typeof s !== "string" || s.length === 0) {
+    throw new Error(`invalid ${kind}: must be a non-empty string`);
+  }
+  if (s.includes("\0")) throw new Error(`invalid ${kind}: NUL byte not allowed`);
+  if (s === "." || s === ".." || /[/\\]/.test(s)) {
+    throw new Error(`invalid ${kind}: '${s}' — path separators/traversal not allowed`);
+  }
+  return s;
+}
+
+export function createWorkStore(root: string = defaultWorkRoot()): WorkStore {
+  const rootResolved = resolve(root);
+
+  const assertUnderRoot = (target: string): string => {
+    const r = resolve(target);
+    if (r !== rootResolved && !r.startsWith(rootResolved + sep)) {
+      throw new Error(`path escapes state root: ${target}`);
+    }
+    return target;
+  };
+
+  const projDir = (p: string) => assertUnderRoot(join(root, safeSegment("project", p)));
+  const itemFile = (p: string, id: string) =>
+    assertUnderRoot(join(projDir(p), `${safeSegment("id", id)}.json`));
+
+  return {
+    put(item) {
+      mkdirSync(projDir(item.project), { recursive: true });
+      const dest = itemFile(item.project, item.id);
+      const tmp = `${dest}.tmp`;
+      writeFileSync(tmp, JSON.stringify(item, null, 2));
+      renameSync(tmp, dest); // atomic replace
+    },
+    get(project, id) {
+      const f = itemFile(project, id);
+      if (!existsSync(f)) return undefined;
+      try {
+        return JSON.parse(readFileSync(f, "utf-8")) as WorkItem;
+      } catch {
+        return undefined; // corrupt file: caller sees "not found"
+      }
+    },
+    list(project) {
+      const d = projDir(project);
+      if (!existsSync(d)) return [];
+      return readdirSync(d)
+        .filter((n) => n.endsWith(".json") && !n.endsWith(".json.tmp"))
+        .map((n) => {
+          try { return JSON.parse(readFileSync(join(d, n), "utf-8")) as WorkItem; }
+          catch { return undefined; }
+        })
+        .filter((r): r is WorkItem => r !== undefined);
+    },
+    listAll() {
+      if (!existsSync(root)) return [];
+      return readdirSync(root)
+        .filter((p) => { try { return statSync(join(root, p)).isDirectory(); } catch { return false; } })
+        .flatMap((p) => this.list(p));
+    },
+    delete(project, id) {
+      const f = itemFile(project, id);
+      if (existsSync(f)) rmSync(f);
+    },
+  };
+}
+
+/** Deletes done/cancelled items whose closedAt is older than the 30-day TTL.
+ *  Called lazily on every `work` CLI invocation (spec §4.4) — purge is not
+ *  wired into the daemon sweep, so work tracking never depends on the daemon
+ *  being up. `now` is injectable so tests don't need to wait 30 real days. */
+export function purgeExpiredWorkItems(store: WorkStore, now: number = Date.now()): number {
+  let purged = 0;
+  for (const item of store.listAll()) {
+    if (item.closedAt !== null && now - item.closedAt > WORK_ITEM_TTL_MS) {
+      store.delete(item.project, item.id);
+      purged++;
+    }
+  }
+  return purged;
+}
+
+/** Generates a short, human-typeable id ("w_3f2a") unique across every
+ *  project in the store — `work done <id>` takes no --project, so ids must
+ *  be globally unique to be looked up alone. */
+function generateWorkId(store: WorkStore): string {
+  const existing = new Set(store.listAll().map((i) => i.id));
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const id = `w_${randomBytes(2).toString("hex")}`;
+    if (!existing.has(id)) return id;
+  }
+  throw new Error("could not generate a unique work item id");
+}
+
+export interface CreateWorkItemOpts {
+  project: string;
+  title: string;
+  parent?: string | null;
+  tags?: string[];
+  now?: number;
+}
+
+export function createWorkItem(store: WorkStore, opts: CreateWorkItemOpts): WorkItem {
+  const now = opts.now ?? Date.now();
+  const item: WorkItem = {
+    id: generateWorkId(store),
+    project: opts.project,
+    title: opts.title,
+    state: "working",
+    parent: opts.parent ?? null,
+    tags: opts.tags ?? [],
+    note: "",
+    crewTaskIds: [],
+    issue: null,
+    createdAt: now,
+    updatedAt: now,
+    closedAt: null,
+  };
+  store.put(item);
+  return item;
+}
+
+/** Finds a work item by id alone, across every project — the shape every
+ *  id-only CLI verb (done/cancel) needs (spec §4.5 commands take no
+ *  --project for these). */
+export function findWorkItemById(store: WorkStore, id: string): WorkItem | undefined {
+  return store.listAll().find((i) => i.id === id);
+}
+
+export type TerminalWorkState = Extract<WorkState, "done" | "cancelled">;
+
+export interface CloseWorkItemOpts {
+  note?: string;
+  now?: number;
+}
+
+/** Transitions an item to a terminal state (done/cancelled) and stamps
+ *  closedAt, which is what the TTL purge keys off. Only the user closes an
+ *  item (spec §4.6) — this function has no notion of "who"; that rule is
+ *  enforced by the CLI requiring an explicit id, not by this layer. */
+export function closeWorkItem(
+  store: WorkStore,
+  id: string,
+  state: TerminalWorkState,
+  opts: CloseWorkItemOpts = {},
+): WorkItem | undefined {
+  const item = findWorkItemById(store, id);
+  if (!item) return undefined;
+  const now = opts.now ?? Date.now();
+  const updated: WorkItem = {
+    ...item,
+    state,
+    note: opts.note ?? item.note,
+    updatedAt: now,
+    closedAt: now,
+  };
+  store.put(updated);
+  return updated;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,6 +5,7 @@ export * from "./effort.js";
 export * from "./types/runtime.js";
 export * from "./types/liveness.js";
 export * from "./types/control.js";
+export * from "./types/work.js";
 export * from "./types/projection.js";
 export * from "./types/workspaces.js";
 export * from "./lib/cmux-autoconfig.js";

--- a/packages/shared/src/types/work.ts
+++ b/packages/shared/src/types/work.ts
@@ -1,0 +1,26 @@
+// The user's own work items — durable, cross-project, cross-session.
+// NOT crew tasks (see TaskRecord in ./control.ts): no heartbeat, no
+// auto-timeout. A work item may sit open for days; staleness is surfaced,
+// never acted on. See docs/specs/2026-07-29-persisted-work-tracking.md §4.2.
+export type WorkState = "working" | "blocked" | "paused" | "done" | "cancelled";
+
+export const TERMINAL_WORK_STATES: ReadonlySet<WorkState> = new Set(["done", "cancelled"]);
+
+export interface WorkItem {
+  id: string;
+  project: string;
+  title: string;
+  state: WorkState;
+  /** The item this one nests under, or null. A wave is a parent; work inside
+   *  it is a child (`--parent <wave-id>`); an incident with no parent sits
+   *  flat at the top level — this is what lets waves finish out of order
+   *  without the board becoming a lie (spec §4.3). */
+  parent: string | null;
+  tags: string[];
+  note: string;
+  crewTaskIds: string[];
+  issue: number | null;
+  createdAt: number;
+  updatedAt: number;
+  closedAt: number | null;
+}


### PR DESCRIPTION
Fixed the orphaning bug: default 'work list' now keeps a done/cancelled parent visible (dimmed) whenever any descendant, at any depth, is still open — verified live with wave/child/grandchild scenarios plus unit tests (13+2 new). 'work done <id>' now warns (not refuses) when the item has open children. Build+test green (175 files/2311 tests). Re-signaling review per instructions.