### PR TITLE
fix(daemon): authorize cold-start/post-upgrade self-heal via an operator-initiated command allowlist

### DIFF
--- a/packages/cli/src/__tests__/daemon-lock.test.ts
+++ b/packages/cli/src/__tests__/daemon-lock.test.ts
@@ -197,10 +197,10 @@ describe("ensureDaemon — fail-closed captain gate (#636)", () => {
     }
   });
 
-  async function callEnsureDaemon(): Promise<void> {
+  async function callEnsureDaemon(opts?: { operatorInitiated?: boolean }): Promise<void> {
     const { ensureDaemon, _resetRestartInFlightForTest: reset } = await import("@squadrant/core");
     reset();
-    ensureDaemon();
+    ensureDaemon(undefined, opts);
     reset();
   }
 
@@ -251,5 +251,29 @@ describe("ensureDaemon — fail-closed captain gate (#636)", () => {
     // attempts lock acquisition — it then fails at daemonEntryPath() (no
     // compiled dist under vitest) and is caught/warned, same as #259.
     expect(openSync).toHaveBeenCalled();
+  });
+
+  it("attempts the daemon lock for an operator-initiated invocation with NO captain marker (bare-terminal `squadrant launch`, #636 cold-start fix)", async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(openSync).mockReturnValue(11 as unknown as number);
+
+    delete process.env.SQUADRANT_ROLE;
+    delete process.env.SQUADRANT_CREW_TASK_ID;
+    // index.ts resolves this from process.argv[2] via isOperatorInitiatedCommand;
+    // here we exercise ensureDaemon's own gate directly with that resolved value.
+    await callEnsureDaemon({ operatorInitiated: true });
+
+    expect(openSync).toHaveBeenCalled();
+  });
+
+  it("does NOT authorize an arbitrary subcommand just because operatorInitiated is computed wrong upstream — still requires the flag to actually be true", async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(openSync).mockReturnValue(12 as unknown as number);
+
+    delete process.env.SQUADRANT_ROLE;
+    delete process.env.SQUADRANT_CREW_TASK_ID;
+    await callEnsureDaemon({ operatorInitiated: false });
+
+    expect(openSync).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/__tests__/daemon-lock.test.ts
+++ b/packages/cli/src/__tests__/daemon-lock.test.ts
@@ -175,3 +175,28 @@ describe("in-process restartInFlight dedup", () => {
     reset(); // clean up for other tests
   });
 });
+
+describe("ensureDaemon — crew guard (#636)", () => {
+  it("no-ops for a crew process (SQUADRANT_CREW_TASK_ID set) — never re-registers/kickstarts the shared daemon", async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(openSync).mockReturnValue(8 as unknown as number);
+
+    const { ensureDaemon, _resetRestartInFlightForTest: reset } = await import("@squadrant/core");
+    reset();
+
+    const prevTaskId = process.env.SQUADRANT_CREW_TASK_ID;
+    process.env.SQUADRANT_CREW_TASK_ID = "task-123";
+    try {
+      ensureDaemon();
+    } finally {
+      if (prevTaskId === undefined) delete process.env.SQUADRANT_CREW_TASK_ID;
+      else process.env.SQUADRANT_CREW_TASK_ID = prevTaskId;
+    }
+
+    // Guard returns before any lock acquisition or plist/fs work happens.
+    expect(existsSync).not.toHaveBeenCalled();
+    expect(openSync).not.toHaveBeenCalled();
+
+    reset(); // clean up for other tests
+  });
+});

--- a/packages/cli/src/__tests__/daemon-lock.test.ts
+++ b/packages/cli/src/__tests__/daemon-lock.test.ts
@@ -13,7 +13,7 @@ vi.mock("node:fs", () => ({
   constants: { O_EXCL: 2048, O_CREAT: 512, O_WRONLY: 1 },
 }));
 
-import { existsSync, readFileSync, openSync, writeSync, closeSync, unlinkSync } from "node:fs";
+import { existsSync, readFileSync, openSync, writeSync, closeSync, unlinkSync, writeFileSync } from "node:fs";
 import {
   tryAcquireDaemonLock,
   releaseDaemonLock,
@@ -176,27 +176,80 @@ describe("in-process restartInFlight dedup", () => {
   });
 });
 
-describe("ensureDaemon — crew guard (#636)", () => {
-  it("no-ops for a crew process (SQUADRANT_CREW_TASK_ID set) — never re-registers/kickstarts the shared daemon", async () => {
+describe("ensureDaemon — fail-closed captain gate (#636)", () => {
+  // Fail-CLOSED, not fail-open: absence of any marker must mean "don't touch
+  // the daemon", never "go ahead". The gate checks POSITIVELY for
+  // SQUADRANT_ROLE=captain (set at exactly one place — the captain-launch
+  // choke point) rather than negatively for a crew marker, so it can't be
+  // bypassed by an unmarked invocation of any kind.
+  const ROLE_ENV_VARS = ["SQUADRANT_ROLE", "SQUADRANT_CREW_TASK_ID", "SQUADRANT_CREW_PROJECT"] as const;
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {};
+    for (const k of ROLE_ENV_VARS) savedEnv[k] = process.env[k];
+  });
+
+  afterEach(() => {
+    for (const k of ROLE_ENV_VARS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+  });
+
+  async function callEnsureDaemon(): Promise<void> {
+    const { ensureDaemon, _resetRestartInFlightForTest: reset } = await import("@squadrant/core");
+    reset();
+    ensureDaemon();
+    reset();
+  }
+
+  // Note: daemonEntryPath() does one harmless existsSync check of its own
+  // (looking for the compiled squadrantd.js) regardless of role — that's not
+  // a mutation. openSync/writeFileSync only ever happen via tryAcquireDaemonLock
+  // + applyDaemonDrift, which live exclusively behind the captain gate, so
+  // they're the real discriminator between "detected drift" and "acted on it".
+
+  it("no-ops for a claude-shaped crew process (SQUADRANT_CREW_TASK_ID set, no captain marker) — never acquires the lock or writes the plist", async () => {
     vi.mocked(existsSync).mockReturnValue(false);
     vi.mocked(openSync).mockReturnValue(8 as unknown as number);
 
-    const { ensureDaemon, _resetRestartInFlightForTest: reset } = await import("@squadrant/core");
-    reset();
-
-    const prevTaskId = process.env.SQUADRANT_CREW_TASK_ID;
+    delete process.env.SQUADRANT_ROLE;
     process.env.SQUADRANT_CREW_TASK_ID = "task-123";
-    try {
-      ensureDaemon();
-    } finally {
-      if (prevTaskId === undefined) delete process.env.SQUADRANT_CREW_TASK_ID;
-      else process.env.SQUADRANT_CREW_TASK_ID = prevTaskId;
-    }
+    await callEnsureDaemon();
 
-    // Guard returns before any lock acquisition or plist/fs work happens.
-    expect(existsSync).not.toHaveBeenCalled();
     expect(openSync).not.toHaveBeenCalled();
+    expect(writeFileSync).not.toHaveBeenCalled();
+  });
 
-    reset(); // clean up for other tests
+  it("no-ops for a codex-shaped crew process (NO env marker at all — codex crews don't get SQUADRANT_CREW_TASK_ID, see crew-control.ts buildSignalRequest) — never acquires the lock or writes the plist", async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(openSync).mockReturnValue(9 as unknown as number);
+
+    delete process.env.SQUADRANT_ROLE;
+    delete process.env.SQUADRANT_CREW_TASK_ID;
+    delete process.env.SQUADRANT_CREW_PROJECT;
+    await callEnsureDaemon();
+
+    // No positive captain marker → the default is "do not mutate", exactly
+    // like the claude-shaped crew case above. This is the case the original
+    // #636 fix missed: a codex crew has no SQUADRANT_CREW_TASK_ID to key off,
+    // so a negative (crew-marker) guard silently failed open for it.
+    expect(openSync).not.toHaveBeenCalled();
+    expect(writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it("attempts the daemon lock for a positively-identified captain invocation (SQUADRANT_ROLE=captain)", async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(openSync).mockReturnValue(10 as unknown as number);
+
+    delete process.env.SQUADRANT_CREW_TASK_ID;
+    process.env.SQUADRANT_ROLE = "captain";
+    await callEnsureDaemon();
+
+    // Only a captain-marked invocation reaches the mutating branch and
+    // attempts lock acquisition — it then fails at daemonEntryPath() (no
+    // compiled dist under vitest) and is caught/warned, same as #259.
+    expect(openSync).toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/__tests__/ensure-daemon-callsite.test.ts
+++ b/packages/cli/src/__tests__/ensure-daemon-callsite.test.ts
@@ -22,13 +22,27 @@ it("index.ts wires ensureDaemon after ensureRuntimeSynced", () => {
 // ~/.config/squadrant/dist path crash-loops the agent with MODULE_NOT_FOUND
 // because runtime-sync never mirrors compiled output there.
 it("no call site recomputes the daemon entry path", () => {
-  for (const f of ["index.ts", "commands/crew-control.ts"]) {
-    const src = read(f);
-    // ensureDaemon is called with no path argument (resolved internally)
-    expect(src).toMatch(/ensureDaemon\(\)/);
-    // and the buggy hardcoded path is absent
-    expect(src).not.toMatch(/"\.config",\s*"squadrant",\s*"dist"/);
-  }
+  // crew-control.ts's on-socket-failure fallback call is deliberately
+  // unchanged (#636): a socket-RPC retry is never operator-initiated, so no
+  // allowlist applies here — it stays gated to the captain marker alone.
+  const crewControlSrc = read("commands/crew-control.ts");
+  expect(crewControlSrc).toMatch(/ensureDaemon\(\)/);
+  expect(crewControlSrc).not.toMatch(/"\.config",\s*"squadrant",\s*"dist"/);
+
+  // index.ts (#636): nodeBin is still passed as `undefined` (resolved
+  // internally by ensureDaemon, never recomputed here) — only the second arg
+  // changed, to carry the operatorInitiated flag computed from real argv.
+  const idxSrc = read("index.ts");
+  expect(idxSrc).toMatch(/ensureDaemon\(undefined,\s*\{\s*operatorInitiated/);
+  expect(idxSrc).not.toMatch(/"\.config",\s*"squadrant",\s*"dist"/);
+});
+
+// #636: index.ts must resolve operatorInitiated from the actual subcommand
+// the human typed (argv[2]), not from a hardcoded true/false or an env var —
+// otherwise the allowlist gate is meaningless.
+it("index.ts derives operatorInitiated from process.argv[2] via isOperatorInitiatedCommand", () => {
+  const idx = read("index.ts");
+  expect(idx).toMatch(/isOperatorInitiatedCommand\(process\.argv\[2\]\)/);
 });
 
 // #259: in vitest context import.meta.url resolves to the src/ tree, so

--- a/packages/cli/src/commands/heal.ts
+++ b/packages/cli/src/commands/heal.ts
@@ -14,7 +14,7 @@ import chalk from "chalk";
 import { queryHealth } from "./health-view.js";
 import { healCmdFor } from "@squadrant/core";
 import type { ComponentHealth, HealthState } from "@squadrant/core";
-import { restartDaemonIfRunning } from "@squadrant/core";
+import { reregisterDaemon } from "@squadrant/core";
 
 // ── pure helpers (fully unit-testable, no I/O) ────────────────────────────────
 
@@ -150,10 +150,10 @@ export const healCommand = new Command("heal")
   )
   .addCommand(
     new Command("daemon")
-      .description("Restart squadrantd via the idempotent launchd kickstart path")
+      .description("Explicitly reconcile + restart squadrantd (#636 operator opt-in — reads current PATH/entry drift and applies it, regardless of role)")
       .action(async () => {
         const code = await runHealDaemon({
-          ensureDaemon: () => restartDaemonIfRunning({ reason: "heal", isRunning: () => true }),
+          ensureDaemon: () => reregisterDaemon(),
           stdout: process.stdout,
           stderr: process.stderr,
         });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 import { ensureRuntimeSynced } from "@squadrant/shared";
-import { ensureDaemon } from "@squadrant/core";
+import { ensureDaemon, isOperatorInitiatedCommand } from "@squadrant/core";
 import { doctorCommand } from "./commands/doctor.js";
 import { initCommand } from "./commands/init.js";
 import { projectsCommand } from "./commands/projects.js";
@@ -92,8 +92,13 @@ if (process.argv[2] !== "config") {
 // path is passed here so no call site can get it wrong.
 // SQUADRANT_DAEMON_SKIP short-circuits this for read-only / CI invocations that must
 // not attempt to boot the daemon (e.g. config-check tests on Linux without launchctl).
+// #636: `process.argv[2]` is the top-level subcommand the human actually typed
+// (e.g. "launch", "init", "crew") — passed through isOperatorInitiatedCommand
+// so ensureDaemon can authorize a first-run/cold-start self-heal for those two
+// commands specifically, without weakening the fail-closed default for anything
+// else (crew, side-session, dashboard, cron, or any other bare subcommand).
 if (!process.env.SQUADRANT_DAEMON_SKIP) {
-  ensureDaemon();
+  ensureDaemon(undefined, { operatorInitiated: isOperatorInitiatedCommand(process.argv[2]) });
 }
 
 const program = new Command();

--- a/packages/core/src/__tests__/launch-workspace.test.ts
+++ b/packages/core/src/__tests__/launch-workspace.test.ts
@@ -93,3 +93,43 @@ describe("launchOneWorkspace --keep (#534)", () => {
     expect(onFreshReason).toHaveBeenCalledWith("first launch");
   });
 });
+
+describe("launchOneWorkspace — captain marker (#636)", () => {
+  // ensureDaemon's fail-closed captain gate (launchd.ts) only mutates the
+  // shared daemon's registration when SQUADRANT_ROLE=captain is present in
+  // the inherited env. This is the ONLY place that marker is set, so it must
+  // land on the captain role and must NOT leak onto any other role.
+  it("prefixes the spawned command with SQUADRANT_ROLE=captain for role='captain'", async () => {
+    const runtime = makeRuntime();
+    await launchOneWorkspace({
+      workspaceName: "ws-captain",
+      role: "captain",
+      cwd: tmpDir,
+      sessionsPath,
+      templatesDir,
+      agentCmdFactory: () => "claude --permission-mode auto",
+      runtime,
+    });
+
+    expect(runtime.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({ command: "SQUADRANT_ROLE=captain claude --permission-mode auto" }),
+    );
+  });
+
+  it("does not add a role marker for role='command'", async () => {
+    const runtime = makeRuntime();
+    await launchOneWorkspace({
+      workspaceName: "ws-command",
+      role: "command",
+      cwd: tmpDir,
+      sessionsPath,
+      templatesDir,
+      agentCmdFactory: () => "claude --permission-mode auto",
+      runtime,
+    });
+
+    expect(runtime.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({ command: "claude --permission-mode auto" }),
+    );
+  });
+});

--- a/packages/core/src/__tests__/launchd.test.ts
+++ b/packages/core/src/__tests__/launchd.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("node:child_process", () => ({ execFileSync: vi.fn() }));
 import { execFileSync } from "node:child_process";
-import { renderPlist, LABEL, kickstartArgv, sanitizePathForPlist, programArgsBlock, AGENT_BINS, resolveAgentBinDirs, buildDaemonPath } from "../launchd.js";
+import { renderPlist, LABEL, kickstartArgv, sanitizePathForPlist, programArgsBlock, AGENT_BINS, resolveAgentBinDirs, buildDaemonPath, isOperatorInitiatedCommand, OPERATOR_INITIATED_COMMANDS } from "../launchd.js";
 
 describe("launchd plist", () => {
   it("renders a KeepAlive RunAtLoad plist pointing at the daemon entry", () => {
@@ -90,6 +90,34 @@ describe("launchd plist", () => {
   it("programArgsBlock matches the actual array emitted by renderPlist", () => {
     const xml = renderPlist("/nvm/v24/bin/node", "/dist/squadrantd.js");
     expect(xml).toContain(programArgsBlock("/nvm/v24/bin/node", "/dist/squadrantd.js"));
+  });
+});
+
+// #636: cold-start / post-upgrade escape hatch — a human explicitly typing
+// `squadrant launch` or `squadrant init` is authorized the same as a captain
+// marker, even with no SQUADRANT_ROLE set. Everything else stays unauthorized.
+describe("isOperatorInitiatedCommand (#636)", () => {
+  it("authorizes 'launch' and 'init'", () => {
+    expect(isOperatorInitiatedCommand("launch")).toBe(true);
+    expect(isOperatorInitiatedCommand("init")).toBe(true);
+  });
+
+  it("does NOT authorize 'heal' — heal daemon bypasses this gate entirely via reregisterDaemon", () => {
+    expect(isOperatorInitiatedCommand("heal")).toBe(false);
+  });
+
+  it("does NOT authorize crew, status, or any other subcommand", () => {
+    expect(isOperatorInitiatedCommand("crew")).toBe(false);
+    expect(isOperatorInitiatedCommand("status")).toBe(false);
+    expect(isOperatorInitiatedCommand("dashboard")).toBe(false);
+  });
+
+  it("does NOT authorize a missing/undefined argv[2] (bare `squadrant` invocation)", () => {
+    expect(isOperatorInitiatedCommand(undefined)).toBe(false);
+  });
+
+  it("OPERATOR_INITIATED_COMMANDS is exactly {launch, init} — deliberately small", () => {
+    expect([...OPERATOR_INITIATED_COMMANDS].sort()).toEqual(["init", "launch"]);
   });
 });
 

--- a/packages/core/src/launch-workspace.ts
+++ b/packages/core/src/launch-workspace.ts
@@ -227,7 +227,13 @@ export async function launchOneWorkspace(opts: LaunchOneOpts): Promise<void> {
     }
   }
 
-  const agentCmd = opts.agentCmdFactory(forceFresh);
+  const builtCmd = opts.agentCmdFactory(forceFresh);
+  // #636: this is the ONLY place a captain session is spawned, so it's the
+  // one place we can positively mark a process tree as "captain" — inherited
+  // by the agent CLI and every `squadrant` subcommand later run from inside
+  // this pane. ensureDaemon() requires this marker before it will mutate the
+  // shared daemon's registration; every other role is deliberately unmarked.
+  const agentCmd = opts.role === "captain" ? `SQUADRANT_ROLE=captain ${builtCmd}` : builtCmd;
   recordSession(opts.workspaceName, opts.role, {
     sessionsPath: opts.sessionsPath,
     templatesDir: opts.templatesDir,

--- a/packages/core/src/launchd.ts
+++ b/packages/core/src/launchd.ts
@@ -207,15 +207,88 @@ export function releaseDaemonLock(): void {
   try { unlinkSync(daemonLockPath()); } catch { /* already cleaned up */ }
 }
 
+interface DaemonDrift {
+  plistPath: string;
+  target: string;
+  desired: string;
+  current: string | null;
+  changed: boolean;
+  programChanged: boolean;
+}
+
+/**
+ * Read-only: render what the plist SHOULD look like for this environment and
+ * diff it against what's on disk. Never writes and never touches launchctl —
+ * safe to call from any role purely to detect and report drift. Throws if the
+ * compiled daemon entry can't be resolved (see daemonEntryPath).
+ */
+function computeDaemonDrift(nodeBin: string): DaemonDrift {
+  const p = plistPath();
+  const entry = daemonEntryPath();
+  const desired = renderPlist(nodeBin, entry, buildDaemonPath(process.env.PATH ?? ""));
+  const current = existsSync(p) ? readFileSync(p, "utf-8") : null;
+  const uid = process.getuid?.() ?? 0;
+  const target = `gui/${uid}/${LABEL}`;
+
+  const changed = current !== desired;
+  // Semantic comparison: was the program-arg block itself different (not just
+  // PATH)?  Program-arg changes are rare (rebuild/reinstall) and merit a full
+  // bootout+reload; PATH varies across terminals so it must NOT trigger a
+  // bounce (would orphan in-flight RPCs).
+  const programChanged = current !== null && changed
+    && !current.includes(programArgsBlock(nodeBin, entry));
+
+  return { plistPath: p, target, desired, current, changed, programChanged };
+}
+
+/**
+ * The dangerous part: write the plist (if changed), bootout on program-arg
+ * drift, bootstrap, and a plain kickstart (never -k, to avoid racing bootout's
+ * exit handler — see the comment at the call site). Callers MUST already be
+ * authorized to mutate the shared daemon: only ensureDaemon's captain-gated
+ * branch and the explicit reregisterDaemon call this.
+ */
+function applyDaemonDrift(drift: DaemonDrift): void {
+  if (drift.changed) {
+    mkdirSync(dirname(drift.plistPath), { recursive: true });
+    writeFileSync(drift.plistPath, drift.desired);
+  }
+
+  if (drift.programChanged) {
+    // unload the old instance so bootstrap picks up the new program args
+    try { execFileSync("launchctl", ["bootout", drift.target], { stdio: "ignore" }); }
+    catch { /* not loaded */ }
+  }
+
+  const uid = process.getuid?.() ?? 0;
+  try { execFileSync("launchctl", ["bootstrap", `gui/${uid}`, drift.plistPath], { stdio: "ignore" }); }
+  catch { /* already bootstrapped */ }
+
+  // Plain kickstart (never -k): no-op on a healthy daemon, starts one that
+  // was booted-out above or that stopped for other reasons.  -k is avoided
+  // because it races with bootout's exit handler and produces exit-113 when
+  // the service hasn't finished unloading.
+  execFileSync("launchctl", ["kickstart", drift.target], { stdio: "ignore" });
+}
+
 /**
  * Idempotent & cheap. Never throws fatally. Writes/reloads the plist ONLY when
- * its content actually changed; Distinguishes program-argument drift (warrants
- * a full restart via bootout + bootstrap + kickstart) from PATH-only drift
- * (write the plist for the next natural restart but never bounce a healthy
- * daemon). Uses plain `kickstart` (never -k) to avoid the race between -k and
- * bootout's exit handler that produced exit-113 "service not loaded" errors.
- * The daemon entry is resolved internally (see daemonEntryPath) so no caller
- * can pass a wrong path.
+ * its content actually changed, and ONLY from a positively-identified captain
+ * invocation.
+ *
+ * #636: fail-CLOSED, not fail-open. Absence of a marker must never grant
+ * permission to mutate a daemon shared by 26 projects — that was the shape of
+ * the original bug (crew-marker absent → act), and it's the same class as
+ * #499 (marker-absence treated as a positive signal). So the gate checks for
+ * captain, not against crew: SQUADRANT_ROLE=captain is set at exactly one
+ * place (the captain-launch choke point in launch-workspace.ts) and nowhere
+ * else. Any invocation without it — a claude or codex-shaped crew (codex
+ * crews never get SQUADRANT_CREW_TASK_ID either, see crew-control.ts's
+ * buildSignalRequest), a side-session, the dashboard, cron, or a bare
+ * terminal — defaults to "do not touch the daemon", not "go ahead". Drift is
+ * still detected and surfaced (stderr note) from every role; only the apply
+ * step requires the captain marker. Real drift stays fixable on purpose via
+ * the explicit `squadrant heal daemon` path (reregisterDaemon below).
  *
  * Concurrency guards:
  *   - restartInFlight flag: prevents sequential re-calls within this process.
@@ -223,18 +296,23 @@ export function releaseDaemonLock(): void {
  *     via a filesystem lock so only one runs bootout/bootstrap at a time.
  */
 export function ensureDaemon(nodeBin: string = process.execPath): void {
-  // #636: never let a crew process re-register/kickstart the shared daemon.
-  // A crew inherits SQUADRANT_CREW_TASK_ID (see crew-spawn.ts) and typically
-  // runs with a different PATH/build than the captain (worktree, different
-  // node/pnpm resolution), so its view of "did the plist drift" is unreliable
-  // — a false-positive bounce hits every in-flight task on all 26 registered
-  // projects, not just the crew's own. Re-registration stays an implicit
-  // self-heal for the captain's own invocations only; a crew that can't reach
-  // the daemon fails loud instead (see squadrantdCall's retry-then-throw).
-  if (process.env.SQUADRANT_CREW_TASK_ID) return;
-
   if (restartInFlight) return;
   restartInFlight = true;
+
+  if (process.env.SQUADRANT_ROLE !== "captain") {
+    // Read-only diagnostic path: never acquires the lock, never writes,
+    // never calls launchctl — just tells a human real drift exists.
+    try {
+      if (computeDaemonDrift(nodeBin).changed) {
+        process.stderr.write(
+          "[squadrant] note: daemon registration drift detected but NOT applied " +
+          "(this invocation is not a captain) — run `squadrant heal daemon` to " +
+          "re-register intentionally.\n",
+        );
+      }
+    } catch { /* best-effort diagnostic only */ }
+    return;
+  }
 
   if (!tryAcquireDaemonLock()) {
     // Another process is handling the restart; it will be done by the time the
@@ -243,43 +321,26 @@ export function ensureDaemon(nodeBin: string = process.execPath): void {
   }
 
   try {
-    const p = plistPath();
-    const entry = daemonEntryPath();
-    const desired = renderPlist(nodeBin, entry, buildDaemonPath(process.env.PATH ?? ""));
-    const current = existsSync(p) ? readFileSync(p, "utf-8") : null;
-    const uid = process.getuid?.() ?? 0;
-    const target = `gui/${uid}/${LABEL}`;
-
-    const changed = current !== desired;
-    // Semantic comparison: was the program-arg block itself different (not just
-    // PATH)?  Program-arg changes are rare (rebuild/reinstall) and merit a full
-    // bootout+reload; PATH varies across terminals so it must NOT trigger a
-    // bounce (would orphan in-flight RPCs).
-    const programChanged = current !== null && changed
-      && !current.includes(programArgsBlock(nodeBin, entry));
-
-    if (changed) {
-      mkdirSync(dirname(p), { recursive: true });
-      writeFileSync(p, desired);
-    }
-
-    if (programChanged) {
-      // unload the old instance so bootstrap picks up the new program args
-      try { execFileSync("launchctl", ["bootout", target], { stdio: "ignore" }); }
-      catch { /* not loaded */ }
-    }
-
-    try { execFileSync("launchctl", ["bootstrap", `gui/${uid}`, p], { stdio: "ignore" }); }
-    catch { /* already bootstrapped */ }
-
-    // Plain kickstart (never -k): no-op on a healthy daemon, starts one that
-    // was booted-out above or that stopped for other reasons.  -k is avoided
-    // because it races with bootout's exit handler and produces exit-113 when
-    // the service hasn't finished unloading.
-    execFileSync("launchctl", ["kickstart", target], { stdio: "ignore" });
+    applyDaemonDrift(computeDaemonDrift(nodeBin));
   } catch (e) {
     // daemon ensure is best-effort (still don't throw); CLI fails loud on socket miss
     process.stderr.write(`[squadrant] warn: ensureDaemon failed (${e instanceof Error ? e.message : e})\n`);
+  } finally {
+    releaseDaemonLock();
+  }
+}
+
+/**
+ * Explicit operator path for #636: `squadrant heal daemon` calls this
+ * directly, regardless of role, to intentionally reconcile the plist against
+ * the current environment (PATH drift, entry-path drift) and apply it. This
+ * is the opt-in the issue asks for — a deliberate human action, never an
+ * implicit side effect of an arbitrary CLI invocation.
+ */
+export function reregisterDaemon(nodeBin: string = process.execPath): void {
+  if (!tryAcquireDaemonLock()) return;
+  try {
+    applyDaemonDrift(computeDaemonDrift(nodeBin));
   } finally {
     releaseDaemonLock();
   }

--- a/packages/core/src/launchd.ts
+++ b/packages/core/src/launchd.ts
@@ -272,42 +272,82 @@ function applyDaemonDrift(drift: DaemonDrift): void {
 }
 
 /**
+ * #636: commands where a human's own act of typing them is itself the
+ * authorization to reconcile/start the daemon — distinct from a captain
+ * marker, but equally deliberate (never inferred, never incidental):
+ *   - `launch`: boots a captain from a bare terminal. It never touches the
+ *     daemon socket itself (cmux only), so without this the daemon would
+ *     only get registered "one hop later" once the freshly-launched captain
+ *     (now SQUADRANT_ROLE=captain-marked) runs its own first command — fine
+ *     once a captain exists, but a needless extra step on a fresh install.
+ *   - `init`: first-run scaffolding. Doesn't touch the daemon itself either,
+ *     but authorizing it means the daemon can be registered as early as the
+ *     very first `squadrant` invocation on a new machine.
+ * `heal daemon` is deliberately NOT here: it calls reregisterDaemon()
+ * directly (see heal.ts), bypassing this gate entirely, so it needs no
+ * allowlist entry and works even for an unmarked/pre-upgrade process.
+ * Nothing else is on this list on purpose — a crew, a side-session, the
+ * dashboard, or cron are incidental, not operator-initiated, and must stay
+ * fail-closed even though they too are "a human's system doing something".
+ */
+export const OPERATOR_INITIATED_COMMANDS = new Set(["launch", "init"]);
+
+/** Pure: was this process's top-level subcommand one of the operator-initiated ones above? */
+export function isOperatorInitiatedCommand(topLevelArg: string | undefined): boolean {
+  return topLevelArg !== undefined && OPERATOR_INITIATED_COMMANDS.has(topLevelArg);
+}
+
+/**
  * Idempotent & cheap. Never throws fatally. Writes/reloads the plist ONLY when
- * its content actually changed, and ONLY from a positively-identified captain
- * invocation.
+ * its content actually changed, and ONLY when authorized (see below).
  *
- * #636: fail-CLOSED, not fail-open. Absence of a marker must never grant
+ * #636: fail-CLOSED, not fail-open. Absence of authorization must never grant
  * permission to mutate a daemon shared by 26 projects — that was the shape of
  * the original bug (crew-marker absent → act), and it's the same class as
- * #499 (marker-absence treated as a positive signal). So the gate checks for
- * captain, not against crew: SQUADRANT_ROLE=captain is set at exactly one
- * place (the captain-launch choke point in launch-workspace.ts) and nowhere
- * else. Any invocation without it — a claude or codex-shaped crew (codex
- * crews never get SQUADRANT_CREW_TASK_ID either, see crew-control.ts's
- * buildSignalRequest), a side-session, the dashboard, cron, or a bare
- * terminal — defaults to "do not touch the daemon", not "go ahead". Drift is
- * still detected and surfaced (stderr note) from every role; only the apply
- * step requires the captain marker. Real drift stays fixable on purpose via
- * the explicit `squadrant heal daemon` path (reregisterDaemon below).
+ * #499 (marker-absence treated as a positive signal). So the gate checks
+ * POSITIVELY for one of two deliberate signals:
+ *   - SQUADRANT_ROLE=captain, set at exactly one place (the captain-launch
+ *     choke point in launch-workspace.ts) and nowhere else; or
+ *   - opts.operatorInitiated, true only when index.ts resolves the running
+ *     subcommand against isOperatorInitiatedCommand (a human explicitly typed
+ *     `squadrant launch` or `squadrant init` at a terminal).
+ * Any invocation with neither — a claude or codex-shaped crew (codex crews
+ * never get SQUADRANT_CREW_TASK_ID either, see crew-control.ts's
+ * buildSignalRequest), a side-session, the dashboard, cron, or any other bare
+ * CLI subcommand — defaults to "do not touch the daemon", not "go ahead".
+ * Drift is still detected and surfaced (stderr note) from every unauthorized
+ * call; only the apply step is gated. Real drift stays fixable on purpose via
+ * the explicit `squadrant heal daemon` path (reregisterDaemon below), which
+ * works regardless of role or authorization.
  *
  * Concurrency guards:
- *   - restartInFlight flag: prevents sequential re-calls within this process.
+ *   - restartInFlight flag: prevents sequential re-calls within this process
+ *     from doing repeat work — including a repeat diagnostic print, since
+ *     index.ts's unconditional call and crew-control.ts's on-failure fallback
+ *     call can both fire in one process; a second identical stderr note adds
+ *     no information, so the flag intentionally covers both the apply path
+ *     and the warn-only path, not just the apply path.
  *   - tryAcquireDaemonLock: serialises concurrent SEPARATE squadrant processes
  *     via a filesystem lock so only one runs bootout/bootstrap at a time.
  */
-export function ensureDaemon(nodeBin: string = process.execPath): void {
+export function ensureDaemon(nodeBin: string = process.execPath, opts: { operatorInitiated?: boolean } = {}): void {
   if (restartInFlight) return;
   restartInFlight = true;
 
-  if (process.env.SQUADRANT_ROLE !== "captain") {
+  const authorized = process.env.SQUADRANT_ROLE === "captain" || opts.operatorInitiated === true;
+
+  if (!authorized) {
     // Read-only diagnostic path: never acquires the lock, never writes,
     // never calls launchctl — just tells a human real drift exists.
     try {
       if (computeDaemonDrift(nodeBin).changed) {
         process.stderr.write(
-          "[squadrant] note: daemon registration drift detected but NOT applied " +
-          "(this invocation is not a captain) — run `squadrant heal daemon` to " +
-          "re-register intentionally.\n",
+          "[squadrant] note: this machine's registered squadrant daemon config is out " +
+          "of date for the version/PATH running right now (common right after an `npm " +
+          "update -g squadrant`) — NOT applying it automatically because this command " +
+          "isn't the captain and isn't `launch`/`init`. This is usually harmless: the " +
+          "next captain command reconciles it on its own. If something looks stale or " +
+          "broken right now, run `squadrant heal daemon` to fix it immediately.\n",
         );
       }
     } catch { /* best-effort diagnostic only */ }

--- a/packages/core/src/launchd.ts
+++ b/packages/core/src/launchd.ts
@@ -223,6 +223,16 @@ export function releaseDaemonLock(): void {
  *     via a filesystem lock so only one runs bootout/bootstrap at a time.
  */
 export function ensureDaemon(nodeBin: string = process.execPath): void {
+  // #636: never let a crew process re-register/kickstart the shared daemon.
+  // A crew inherits SQUADRANT_CREW_TASK_ID (see crew-spawn.ts) and typically
+  // runs with a different PATH/build than the captain (worktree, different
+  // node/pnpm resolution), so its view of "did the plist drift" is unreliable
+  // — a false-positive bounce hits every in-flight task on all 26 registered
+  // projects, not just the crew's own. Re-registration stays an implicit
+  // self-heal for the captain's own invocations only; a crew that can't reach
+  // the daemon fails loud instead (see squadrantdCall's retry-then-throw).
+  if (process.env.SQUADRANT_CREW_TASK_ID) return;
+
   if (restartInFlight) return;
   restartInFlight = true;
 


### PR DESCRIPTION
Addressed the cold-start/post-upgrade gap. Verified both claims first: launch.ts never calls sendRequest/squadrantdCall (cmux only) — confirmed the 'one hop later' self-heal via the captain's marked first command, not a hard failure; init.ts has zero daemon/socket references. Also found heal daemon didn't need adding to any allowlist — it already calls reregisterDaemon() directly, bypassing ensureDaemon's gate entirely, so it's unconditionally authorized regardless of role or upgrade state.

Implementation: added isOperatorInitiatedCommand(argv[2]) in launchd.ts, authorizing exactly {launch, init} as a second, equally-deliberate trust tier alongside SQUADRANT_ROLE=captain — index.ts computes it from real process.argv[2] and passes it through ensureDaemon's new opts param. crew-control.ts's on-socket-failure fallback call is untouched (a retry isn't operator-initiated, stays captain-only). Nothing else was added to the allowlist.

Also made your two smaller notes deliberate rather than incidental: restartInFlight's doc comment now explains why it dedupes the warn-only path too (avoids a duplicate stderr note across index.ts's unconditional call + crew-control.ts's fallback call in one process), and the stderr note is rewritten to explain what drift means in plain terms and what to do about it, instead of assuming the reader already knows.

Tests: unit tests for isOperatorInitiatedCommand (launch/init authorized, heal explicitly not since it bypasses the gate, crew/status/dashboard/undefined not), an ensureDaemon test proving operatorInitiated:true authorizes the mutating branch with zero env markers set, and updated the two guard tests in ensure-daemon-callsite.test.ts for index.ts's new call shape. Full core+cli suite: 1379/1380 passing (1 pre-existing unrelated skip), tsc -b clean across all 5 packages. Commit 0ac42d2 on crew/daemon-guard.