### PR TITLE
docs: cmux 0.64.17→0.64.20 review + session-tracking swimlanes (#618, #622)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 .worktrees/
 *.local
 *.tgz
+.scratch/

--- a/docs/diagrams/2026-07-24-cmux-session-tracking-swimlane-vi.html
+++ b/docs/diagrams/2026-07-24-cmux-session-tracking-swimlane-vi.html
@@ -1,0 +1,398 @@
+<!DOCTYPE html>
+<!--
+  explainer-reel mode=interactive · swimlane preset — how cmux tracks agent sessions reliably.
+  Source of truth: cmux docs/agent-session-tracking-spec.md (v0.64.20). Verified surfaces on
+  installed cmux 0.64.17 (cmux rpc feed.list, cmux sessions list --json). Self-contained; open in a browser.
+-->
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>cmux session tracking — swimlane</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --bg:#0e1116; --surface:#161c24; --surface2:#1b2330; --border:#263041; --border2:#31405a;
+    --text:#e6edf3; --dim:#93a1b0; --faint:#5b6b7d;
+    --lane-a:#4aa3ff; --lane-a2:#0f2740;
+    --lane-b:#35c46b; --lane-b2:#0e2a1c;
+    --shared:#c6d0da; --shared2:#232c39;
+    --db:#c99bff; --db2:#241733;
+    --store:#e3b341; --device:#8aa0b6;
+    --gold:#e3b341; --crit:#ff5d5d; --crit2:#2c1416;
+    --sans:"IBM Plex Sans",ui-sans-serif,system-ui,sans-serif;
+    --mono:"IBM Plex Mono",ui-monospace,Menlo,monospace;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0}
+  body{background:radial-gradient(1200px 600px at 70% -10%,#141b26,transparent),var(--bg);
+    color:var(--text);font-family:var(--sans);-webkit-font-smoothing:antialiased}
+  .wrap{max-width:1340px;margin:0 auto;padding:26px 22px 80px}
+  header .k{font-family:var(--mono);font-size:11px;letter-spacing:.22em;color:var(--gold);text-transform:uppercase}
+  h1{font-size:27px;margin:6px 0 4px;letter-spacing:-.02em;font-weight:700}
+  .lede{color:var(--dim);font-size:14px;max-width:860px;margin:0}
+  .lede b{color:var(--text)}
+
+  .tabs{display:flex;flex-wrap:wrap;gap:8px;margin:22px 0 6px}
+  .tab{font-family:var(--sans);font-size:13px;font-weight:600;color:var(--dim);background:var(--surface);
+    border:1px solid var(--border);border-radius:999px;padding:8px 15px;cursor:pointer;transition:.18s;display:flex;align-items:center;gap:8px}
+  .tab:hover{border-color:var(--border2);color:var(--text)}
+  .tab.on{color:#0e1116;background:linear-gradient(180deg,#f0d68a,var(--gold));border-color:var(--gold)}
+  .tab .n{font-family:var(--mono);font-size:11px;opacity:.7}
+
+  .bar{display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin:10px 0 4px;color:var(--dim);font-size:12.5px}
+  .btn{font-family:var(--sans);font-size:12.5px;font-weight:600;color:var(--text);background:var(--surface2);
+    border:1px solid var(--border2);border-radius:8px;padding:7px 13px;cursor:pointer;display:inline-flex;align-items:center;gap:7px;transition:.15s}
+  .btn:hover{background:#232d3d;border-color:#3d4f6d}
+  .btn.play{color:#0e1116;background:linear-gradient(180deg,#5ab0ff,var(--lane-a));border-color:var(--lane-a)}
+  .seg{display:inline-flex;border:1px solid var(--border2);border-radius:8px;overflow:hidden}
+  .seg button{font-family:var(--sans);font-size:12px;font-weight:600;color:var(--dim);background:var(--surface);border:0;padding:7px 13px;cursor:pointer;transition:.15s}
+  .seg button.on{color:#0e1116}
+  .seg button.on.a{background:var(--lane-a)} .seg button.on.b{background:var(--lane-b)}
+  .seg.hide{display:none}
+  .leg{display:flex;gap:13px;flex-wrap:wrap;margin-left:auto}
+  .leg span{display:inline-flex;align-items:center;gap:6px}
+  .sw{width:11px;height:11px;border-radius:3px;display:inline-block}
+
+  .flowtitle{font-size:15px;font-weight:600;margin:16px 2px 2px;display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+  .flowtitle .why{font-weight:400;color:var(--dim);font-size:13px}
+  .stagewrap{position:relative;margin-top:12px;border:1px solid var(--border);border-radius:16px;
+    background:linear-gradient(180deg,#12181f,#0f141b);overflow:hidden}
+  .stage{position:relative;padding:16px 18px}
+  .bands{position:absolute;inset:16px 18px;z-index:0;pointer-events:none}
+  .band{position:absolute;left:0;right:0;border-radius:10px;border:1px solid transparent}
+  .bandlabel{position:absolute;left:8px;top:8px;font-family:var(--mono);font-size:10.5px;letter-spacing:.08em;
+    text-transform:uppercase;display:flex;align-items:center;gap:7px;color:var(--dim)}
+  .bandlabel .ic{font-size:13px}
+  svg.edges{position:absolute;inset:16px 18px;z-index:1;pointer-events:none;overflow:visible}
+  .grid{position:relative;display:grid;gap:30px 46px;z-index:2}
+
+  .node{position:relative;border-radius:12px;padding:11px 13px;border:1px solid var(--border2);
+    background:var(--surface);cursor:pointer;transition:transform .16s,box-shadow .16s,border-color .16s,opacity .16s;
+    min-width:0;align-self:center;max-width:230px}
+  .node:hover{transform:translateY(-2px)}
+  .node .lane{position:absolute;top:-1px;left:-1px;bottom:-1px;width:4px;border-radius:12px 0 0 12px}
+  .node .step{position:absolute;top:-9px;left:-9px;width:22px;height:22px;border-radius:50%;
+    font-family:var(--mono);font-size:11px;font-weight:600;display:flex;align-items:center;justify-content:center;
+    background:#0e1116;border:1px solid var(--border2);color:var(--dim);z-index:3}
+  .node .t{font-weight:600;font-size:12.5px;line-height:1.28;display:block}
+  .node .s{font-family:var(--mono);font-size:10px;color:var(--dim);display:block;margin-top:3px;word-break:break-word;line-height:1.4}
+  .node .badge{position:absolute;top:8px;right:9px;font-family:var(--mono);font-size:9px;padding:1px 5px;border-radius:4px}
+  .node .svc{display:inline-block;font-family:var(--mono);font-size:9px;margin-top:6px;padding:1px 6px;border-radius:5px;
+    color:var(--store);background:color-mix(in srgb,var(--store) 14%,transparent);border:1px solid color-mix(in srgb,var(--store) 32%,transparent)}
+  .node.crit .svc{color:var(--crit);background:var(--crit2);border-color:#5c2a2a}
+  .node.a{--c:var(--lane-a)} .node.b{--c:var(--lane-b)} .node.shared{--c:var(--shared)} .node.db{--c:var(--db)} .node.crit{--c:var(--crit)} .node.store{--c:var(--store)}
+  .node .lane{background:var(--c)}
+  .node.on{border-color:var(--c);box-shadow:0 0 0 1px var(--c),0 10px 28px -12px var(--c)}
+  .node.dim{opacity:.3}
+  .node.crit{background:var(--crit2);border-color:#5c2a2a}
+  .node.crit .t{color:#ffd0d0}
+  .node.db{background:var(--db2);border-color:#3d2657}
+  .badge.a{background:var(--lane-a2);color:var(--lane-a)} .badge.b{background:var(--lane-b2);color:var(--lane-b)}
+  .badge.warn{background:var(--crit2);color:var(--crit)} .badge.ok{background:var(--lane-b2);color:var(--lane-b)}
+  .node.pulse .lane{animation:lane 1.6s ease-in-out infinite}
+  @keyframes lane{0%,100%{opacity:.5}50%{opacity:1}}
+
+  .pt{position:absolute;width:7px;height:7px;border-radius:50%;z-index:1;
+    filter:drop-shadow(0 0 5px currentColor);will-change:offset-distance}
+  @keyframes flow{from{offset-distance:0%}to{offset-distance:100%}}
+  .elabel{font-family:var(--mono);font-size:9.5px;fill:var(--dim)}
+  .elabbg{fill:#0f141b;opacity:.9}
+
+  .detail{margin-top:14px;border:1px solid var(--border);border-radius:14px;background:var(--surface);
+    padding:15px 17px;min-height:78px}
+  .detail.empty{color:var(--faint);font-size:13px;display:flex;align-items:center;gap:9px}
+  .detail .dh{display:flex;align-items:center;gap:10px;margin-bottom:7px;flex-wrap:wrap}
+  .detail .dh .dt{font-size:15px;font-weight:700}
+  .detail .sysbadge{font-family:var(--mono);font-size:10.5px;padding:2px 8px;border-radius:5px;border:1px solid currentColor}
+  .detail .path{font-family:var(--mono);font-size:11.5px;color:#a5d6ff;background:#0b1a2b;padding:2px 8px;border-radius:5px}
+  .detail p{margin:6px 0 0;font-size:13px;color:#cdd6e0;line-height:1.55}
+  .detail .writes{font-family:var(--mono);font-size:11px;color:var(--lane-b);margin-top:8px;display:block}
+  .detail .flag{margin-top:9px;font-size:12.5px;color:#ffc0c0;background:var(--crit2);border:1px solid #5c2a2a;border-radius:8px;padding:8px 11px}
+  .detail .flag b{color:var(--crit)}
+  .foot{font-family:var(--mono);font-size:11px;color:var(--faint);margin-top:20px;text-align:center}
+  @media (prefers-reduced-motion: reduce){.pt{display:none!important}.node.pulse .lane{animation:none}}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <div class="k">cmux · theo dõi phiên agent · đã xác minh trên 0.64.17</div>
+    <h1>cmux theo dõi một phiên agent như thế nào — một cách đáng tin</h1>
+    <p class="lede">Mỗi hàng là một <b>hệ thống</b>: shell env của terminal, tiến trình agent, hook/socket của cmux, "authority" trên máy Mac, và một consumer (iOS GUI / squadrant).
+    Mũi tên <b>nhảy qua band là một hop</b>; nhãn cho biết cái gì đi qua. Toàn bộ thiết kế đặt trên một nguyên tắc — <b>bind bằng token ổn định, không bao giờ bằng title/mtime; pull là authoritative, push chỉ là gợi ý.</b> Đây đúng là bài học #567 của squadrant. Bấm vào bất kỳ node nào.</p>
+  </header>
+
+  <div class="tabs" id="tabs"></div>
+
+  <div class="bar">
+    <button class="btn play" id="play">&#9654; Chạy luồng</button>
+    <button class="btn" id="reset">&#8634; Đặt lại</button>
+    <div class="seg hide" id="platseg"></div>
+    <div class="leg">
+      <span><i class="sw" style="background:var(--lane-a)"></i>Agent</span>
+      <span><i class="sw" style="background:var(--store)"></i>hook/socket cmux</span>
+      <span><i class="sw" style="background:var(--db)"></i>Authority (Mac)</span>
+      <span><i class="sw" style="background:var(--lane-b)"></i>Consumer / backstop</span>
+      <span><i class="sw" style="background:var(--crit)"></i>Heuristic đã xoá</span>
+    </div>
+  </div>
+
+  <div class="flowtitle" id="ftitle"></div>
+  <div class="stagewrap">
+    <div class="stage">
+      <div class="bands" id="bands"></div>
+      <svg class="edges" id="edges"></svg>
+      <div class="grid" id="grid"></div>
+    </div>
+  </div>
+
+  <div class="detail empty" id="detail">&#9684; Bấm một node — panel sẽ cho biết hệ thống nào chạy nó và cái gì đi qua đường truyền.</div>
+
+  <div class="foot">squadrant · docs/specs/2026-07-24-cmux-changelog-review · squadrant có thể áp dụng: cmux rpc feed.list + cmux sessions list --json (không cần upgrade)</div>
+</div>
+
+<script>
+const BANDS=[
+  {id:'env',      label:'Shell env · do cmux sở hữu', ic:'🐚', col:'var(--device)'},
+  {id:'agent',    label:'Tiến trình agent',           ic:'🤖', col:'var(--lane-a)'},
+  {id:'cmux',     label:'cmux CLI · socket',           ic:'🔌', col:'var(--store)'},
+  {id:'authority',label:'Authority (Mac)',             ic:'🧠', col:'var(--db)'},
+  {id:'consumer', label:'Consumer · iOS / squadrant',  ic:'📡', col:'var(--lane-b)'}
+];
+const LANECOL={a:'var(--lane-a)',b:'var(--lane-b)',shared:'var(--shared)',db:'var(--db)',crit:'var(--crit)',store:'var(--store)'};
+function n(sys,lane,col,t,s,x={}){return Object.assign({sys,lane,col,t,s},x);}
+
+const FLOWS={
+  bind:{ title:"Bind + trạng thái", why:"một token, tạo một lần, mang theo khắp nơi — không đoán bằng title/mtime",
+    single:{ nodes:[
+      n('env','shared',1,'Chèn CMUX_SURFACE_ID','env key được bảo vệ lúc spawn',{id:'tok',svc:'ổn định · giữ lại khi restore',
+        detail:'cmux sở hữu env của mọi shell terminal và chèn CMUX_SURFACE_ID / WORKSPACE_ID / PANEL_ID / TAB_ID như các key ĐƯỢC BẢO VỆ lúc spawn. Surface id được tạo một lần, lưu bền, và (từ commit 44dc053e, 12/6/2026) được khôi phục nguyên vẹn khi restore. Đây CHÍNH LÀ khoá bind — workspace id thì hay đổi nên không bao giờ dùng làm khoá.'}),
+      n('agent','a',2,'claude / codex kế thừa token','kể cả gõ tay trong shell',{id:'ag',svc:'qua env + cây tiến trình',
+        detail:'Vì token nằm ở tầng shell/env, ngay cả `claude`/`codex` gõ tay cũng kế thừa nó. Không cần wrapper thì binding vẫn tồn tại.'}),
+      n('cmux','store',3,'Hook bắn qua socket','cmux hooks <agent> <event>',{id:'hk',path:'cmux hooks claude postToolUse',
+        detail:'Mỗi sự kiện của agent bắn một hook cmux mang theo surface token. cmux xác định surface theo thứ tự: (1) flag --workspace/--surface tường minh, (2) env token kế thừa, (3) tty → surface qua debug.terminals, (4) cây tiến trình: pid của agent nằm dưới một surface qua system.top. Tín hiệu 3 & 4 không cần env gì cả.'}),
+      n('authority','db',4,'AgentSession mỗi surface','máy trạng thái · version++',{id:'au',
+        writes:'sessionStart→idle · pre/postToolUse→working · askUserQuestion→needsInput · sessionEnd→ended',
+        detail:'Một bản ghi authoritative cho mỗi surface, khoá theo token ổn định. Trạng thái đến từ đúng một kênh — hook event có gắn token — nên không bao giờ có câu hỏi "session nào trong đám cùng cwd đây?". version tăng sau mỗi thay đổi; đó là khoá đối soát cho pull/push.'}),
+      n('consumer','b',5,'Backstop: tiến trình exit → ended','waitpid, không quét kill -0',{id:'bk',ok:true,
+        detail:'cmux đã spawn (hoặc nhận nuôi, qua env token) pid của agent, nên terminationHandler / waitpid của tiến trình con cho `ended` một cách tất định kể cả khi hook sessionEnd không bao giờ tới. Cái này thay cho vòng quét kill(pid,0) cũ. Backstop không bao giờ phụ thuộc vào việc hook có được giao hay không.'})
+    ], edges:[
+      ['tok','ag','a','kế thừa env'],
+      ['ag','hk','a','bắn event (gắn token)'],
+      ['hk','au','store','áp dụng → version++'],
+      ['ag','bk','b','sở hữu pid (backstop)']
+    ]}
+  },
+  reconcile:{ title:"Đối soát", why:"push chỉ là gợi ý; pull là authoritative — và heuristic mà cmux ĐÃ XOÁ",
+    single:{ nodes:[
+      n('authority','db',1,'Push: version = N','gợi ý, giao best-effort',{id:'push',
+        detail:'Sự kiện push Mac→consumer (đổi state/descriptor) đều mang version mới. Không bao giờ giả định là đã giao được — mất hay trùng một push đều không sao.'}),
+      n('consumer','b',2,'Phát hiện lệch version','nhận được ≠ lastSeen + 1',{id:'gap',
+        detail:'Consumer chỉ áp dụng một push nếu version lớn hơn version đã áp dụng lần cuối (đơn điệu → trùng/đảo thứ tự đều vô hại). Bất kỳ version nào không đối soát được sẽ kích hoạt một lần pull.'}),
+      n('consumer','b',3,'PULL snapshot','mobile.chat.sessions',{id:'pull',badge:['ok','authoritative'],path:'cmux sessions list --json',
+        detail:'Consumer lấy lại snapshot authoritative (state + version) bất cứ lúc nào: khi reconnect, foreground, resubscribe, phát hiện lệch, hoặc refresh thủ công. Với squadrant, tương đương không cần socket là `cmux sessions list --json` (đọc ~/.cmuxterm/*-hook-sessions.json). Giao lỗi thì chỉ "hơi cũ đến lần pull kế tiếp", không bao giờ "sai vĩnh viễn".'}),
+      n('authority','db',4,'Thực tại thắng','state cục bộ bị snapshot ghi đè',{id:'win',writes:'pull thay state + version cục bộ',
+        detail:'Khi pull, state cục bộ bị thay bằng snapshot. Đây chính là vòng đối soát mà squadrant #567 đang thiếu: liveness phải để thực tại quan sát được thắng lịch sử event của chính nó, chứ không phải ngược lại.'}),
+      n('cmux','crit',3,'Đoán: transcript mới nhất','title / mtime — ĐÃ XOÁ',{id:'bad',
+        flag:'Lớp heuristic cmux đã bỏ hoàn toàn: newestClaudeTranscript + khớp title + vòng quét kill -0 + hook-sessions.json dùng làm nguồn đọc. Nó có thể hiện SAI cuộc hội thoại giữa các session cùng cwd. Đây đúng là class đằng sau squadrant #499 (glyph drift) và #484 (bắn nhầm modal) — không bao giờ tin một phỏng đoán từ màn hình/tên hơn sự thật gắn-token.'})
+    ], edges:[
+      ['push','gap','b','mang version'],
+      ['gap','pull','b','lấy lại'],
+      ['pull','win','b','snapshot'],
+      ['bad','win','crit','bind sai (đã bỏ)']
+    ]}
+  }
+};
+
+const ORDER=[["bind","Bind + trạng thái"],["reconcile","Đối soát · pull"]];
+let cur="bind", plat="card";
+
+const tabs=document.getElementById('tabs');
+ORDER.forEach(([id,label],i)=>{
+  const b=document.createElement('button');
+  b.className='tab'+(id===cur?' on':''); b.dataset.id=id;
+  b.innerHTML=`<span class="n">${String.fromCharCode(65+i)}</span>${label}`;
+  b.onclick=()=>{cur=id;render();};
+  tabs.appendChild(b);
+});
+const platseg=document.getElementById('platseg');
+
+const grid=document.getElementById('grid'), svg=document.getElementById('edges'),
+      bandsEl=document.getElementById('bands'), detail=document.getElementById('detail'),
+      ftitle=document.getElementById('ftitle');
+
+function variant(){const f=FLOWS[cur];return f.plat?f[plat]:f.single;}
+
+function render(){
+  [...tabs.children].forEach(t=>t.classList.toggle('on',t.dataset.id===cur));
+  const f=FLOWS[cur];
+  platseg.classList.toggle('hide',!f.plat);
+  ftitle.innerHTML=`${f.title} <span class="why">— ${f.why}</span>`;
+  const v=variant();
+  const cols=[...new Set(v.nodes.map(n=>n.col))].sort((a,b)=>a-b);
+  const colMap={}; cols.forEach((c,i)=>colMap[c]=i+1);
+  const usedBands=[...new Set(v.nodes.map(n=>n.sys))];
+  const bandOrder=BANDS.filter(b=>usedBands.includes(b.id));
+  const rowMap={}; bandOrder.forEach((b,i)=>rowMap[b.id]=i+1);
+  grid.style.gridTemplateColumns=`repeat(${cols.length},minmax(150px,1fr))`;
+  grid.style.gridTemplateRows=`repeat(${bandOrder.length},minmax(74px,auto))`;
+  grid.innerHTML='';
+  v.nodes.forEach(nd=>{
+    const el=document.createElement('div');
+    el.className='node '+nd.lane+(nd.flag?' pulse':'');
+    el.style.gridColumn=colMap[nd.col]; el.style.gridRow=rowMap[nd.sys];
+    el.dataset.id=nd.id;
+    const badge=nd.badge?`<span class="badge ${nd.badge[0]}">${nd.badge[1]}</span>`
+      :(nd.ok?`<span class="badge ok">ok</span>`:(nd.flag?`<span class="badge warn">!</span>`:''));
+    const st=stepIndex(v,nd.id);
+    el.innerHTML=`<span class="lane"></span>${st!==''?`<span class="step">${st}</span>`:''}${badge}
+      <span class="t">${nd.t}</span><span class="s">${nd.s}</span>${nd.svc?`<span class="svc">${nd.svc}</span>`:''}`;
+    el.onclick=()=>select(nd.id);
+    grid.appendChild(el);
+  });
+  requestAnimationFrame(()=>{drawBands(bandOrder);drawEdges(v);});
+  detail.className='detail empty';
+  detail.innerHTML='&#9684; Bấm một node — panel sẽ cho biết hệ thống nào chạy nó và cái gì đi qua đường truyền.';
+}
+
+function drawBands(bandOrder){
+  bandsEl.innerHTML='';
+  const host=bandsEl.getBoundingClientRect();
+  const rows={};
+  [...grid.children].forEach(el=>{
+    const r=el.style.gridRow, rr=el.getBoundingClientRect();
+    (rows[r]=rows[r]||[]).push(rr);
+  });
+  Object.keys(rows).forEach(r=>{
+    const rr=rows[r]; const top=Math.min(...rr.map(x=>x.top))-host.top-8;
+    const bot=Math.max(...rr.map(x=>x.bottom))-host.top+8;
+    const b=bandOrder[+r-1];
+    const div=document.createElement('div'); div.className='band';
+    div.style.top=top+'px'; div.style.height=(bot-top)+'px';
+    div.style.background=`color-mix(in srgb, ${b.col} 7%, transparent)`;
+    div.style.borderColor=`color-mix(in srgb, ${b.col} 22%, transparent)`;
+    const lbl=document.createElement('div'); lbl.className='bandlabel';
+    lbl.style.color=b.col; lbl.innerHTML=`<span class="ic">${b.ic}</span>${b.label}`;
+    div.appendChild(lbl); bandsEl.appendChild(div);
+  });
+}
+
+function stepIndex(v,id){
+  const seen=new Set(),order=[];
+  const starts=v.nodes.filter(n=>!v.edges.some(e=>e[1]===n.id)).map(n=>n.id);
+  const adj={}; v.edges.forEach(([a,b])=>{(adj[a]=adj[a]||[]).push(b);});
+  starts.forEach(s=>{let q=[s];while(q.length){const x=q.shift();if(seen.has(x))continue;seen.add(x);order.push(x);(adj[x]||[]).forEach(y=>q.push(y));}});
+  const i=order.indexOf(id);return i<0?'':i+1;
+}
+
+function anchor(el,side){
+  const host=svg.getBoundingClientRect(), r=el.getBoundingClientRect();
+  return {x:(side==='r'?r.right:r.left)-host.left, y:r.top-host.top+r.height/2,
+          t:r.top-host.top, b:r.bottom-host.top, cx:r.left-host.left+r.width/2};
+}
+let particles=[];
+function clearParticles(){particles.forEach(p=>p.remove());particles=[];}
+function drawEdges(v){
+  svg.removeAttribute('viewBox');
+  svg.innerHTML=''; clearParticles();
+  v.edges.forEach(([a,b,style,label],idx)=>{
+    const ea=grid.querySelector(`[data-id="${a}"]`), eb=grid.querySelector(`[data-id="${b}"]`);
+    if(!ea||!eb)return;
+    const ra=ea.getBoundingClientRect(), rb=eb.getBoundingClientRect();
+    let p1,p2,d;
+    if(rb.left>=ra.right-4){
+      p1=anchor(ea,'r'); p2=anchor(eb,'l');
+      const dx=Math.max(34,(p2.x-p1.x)*0.5);
+      d=`M ${p1.x} ${p1.y} C ${p1.x+dx} ${p1.y}, ${p2.x-dx} ${p2.y}, ${p2.x} ${p2.y}`;
+    } else {
+      const A=anchor(ea,'r'),B=anchor(eb,'r');
+      const x=A.cx; const y1=(A.b<B.t)?A.b:A.t, y2=(A.b<B.t)?B.t:B.b;
+      d=`M ${x} ${y1} C ${x} ${(y1+y2)/2}, ${x} ${(y1+y2)/2}, ${x} ${y2}`;
+      p1={x,y:y1};p2={x,y:y2};
+    }
+    const col=LANECOL[style];
+    const path=document.createElementNS('http://www.w3.org/2000/svg','path');
+    path.setAttribute('d',d);path.setAttribute('fill','none');path.setAttribute('stroke',col);
+    path.setAttribute('stroke-width','2');path.setAttribute('stroke-opacity','.5');path.setAttribute('data-edge',a+'>'+b);
+    if(style==='crit')path.setAttribute('stroke-dasharray','6 5');
+    svg.appendChild(path);
+    const ah=document.createElementNS('http://www.w3.org/2000/svg','path');
+    ah.setAttribute('d',`M ${p2.x-8} ${p2.y-4} L ${p2.x} ${p2.y} L ${p2.x-8} ${p2.y+4}`);
+    ah.setAttribute('fill','none');ah.setAttribute('stroke',col);ah.setAttribute('stroke-width','2');ah.setAttribute('stroke-opacity','.75');
+    svg.appendChild(ah);
+    if(label){
+      const mx=(p1.x+p2.x)/2, my=(p1.y+p2.y)/2;
+      const tw=label.length*5.6+8;
+      const bg=document.createElementNS('http://www.w3.org/2000/svg','rect');
+      bg.setAttribute('x',mx-tw/2);bg.setAttribute('y',my-9);bg.setAttribute('width',tw);bg.setAttribute('height',15);
+      bg.setAttribute('rx',4);bg.setAttribute('class','elabbg');svg.appendChild(bg);
+      const tx=document.createElementNS('http://www.w3.org/2000/svg','text');
+      tx.setAttribute('x',mx);tx.setAttribute('y',my+2);tx.setAttribute('text-anchor','middle');
+      tx.setAttribute('class','elabel');tx.textContent=label;svg.appendChild(tx);
+    }
+    spawnParticles(d,col,idx,style);
+  });
+}
+function spawnParticles(d,col,idx,style){
+  const stage=svg.parentElement, N=style==='crit'?1:2;
+  for(let k=0;k<N;k++){
+    const dot=document.createElement('div');dot.className='pt';dot.style.color=col;dot.style.background=col;
+    dot.style.offsetPath=`path('${d}')`;
+    dot.style.animation=`flow ${2.6+(idx%3)*0.3}s linear ${(idx*0.3)+(k*1.2)}s infinite`;
+    if(style==='crit')dot.style.opacity='.65';
+    stage.appendChild(dot);particles.push(dot);
+  }
+}
+
+function select(id){
+  const v=variant(); const nd=v.nodes.find(x=>x.id===id); if(!nd)return;
+  [...grid.children].forEach(el=>{
+    const nid=el.dataset.id;
+    const connected=nid===id||v.edges.some(e=>(e[0]===id&&e[1]===nid)||(e[1]===id&&e[0]===nid));
+    el.classList.toggle('on',nid===id); el.classList.toggle('dim',!connected);
+  });
+  svg.querySelectorAll('path[data-edge]').forEach(p=>{
+    const [a,b]=p.getAttribute('data-edge').split('>');
+    p.setAttribute('stroke-opacity',(a===id||b===id)?'1':'.14');
+  });
+  const band=BANDS.find(b=>b.id===nd.sys);
+  detail.className='detail'; detail.style.borderColor=LANECOL[nd.lane];
+  detail.innerHTML=`<div class="dh"><span class="dt">${nd.t}</span>
+    <span class="sysbadge" style="color:${band.col}">${band.ic} ${band.label}</span>
+    ${nd.path?`<span class="path">${nd.path}</span>`:''}</div>
+    <p>${nd.detail||nd.s}</p>
+    ${nd.writes?`<span class="writes">&#9656; ${nd.writes}</span>`:''}
+    ${nd.flag?`<div class="flag">&#9888; ${nd.flag}</div>`:''}`;
+}
+
+let playTimer=null;
+function play(){
+  reset(); const v=variant();
+  const ordered=[...v.nodes].map(n=>({n,i:stepIndex(v,n.id)})).filter(o=>o.i!=='').sort((a,b)=>a.i-b.i);
+  let k=0; document.getElementById('play').textContent='● Playing…';
+  playTimer=setInterval(()=>{
+    if(k>=ordered.length){clearInterval(playTimer);document.getElementById('play').textContent='▶ Animate flow';return;}
+    select(ordered[k].n.id);k++;
+  },900);
+}
+function reset(){
+  if(playTimer)clearInterval(playTimer);
+  document.getElementById('play').textContent='▶ Animate flow';
+  [...grid.children].forEach(el=>el.classList.remove('on','dim'));
+  svg.querySelectorAll('path[data-edge]').forEach(p=>p.setAttribute('stroke-opacity','.5'));
+  detail.className='detail empty';detail.style.borderColor='';
+  detail.innerHTML='&#9684; Bấm một node — panel sẽ cho biết hệ thống nào chạy nó và cái gì đi qua đường truyền.';
+}
+document.getElementById('play').onclick=play;
+document.getElementById('reset').onclick=reset;
+function redraw(){const v=variant();const bo=BANDS.filter(b=>[...new Set(v.nodes.map(n=>n.sys))].includes(b.id));drawBands(bo);drawEdges(v);}
+let rt;window.addEventListener('resize',()=>{clearTimeout(rt);rt=setTimeout(redraw,120);});
+new ResizeObserver(()=>{clearTimeout(rt);rt=setTimeout(redraw,60);}).observe(grid);
+if(document.fonts&&document.fonts.ready){document.fonts.ready.then(redraw);}
+render();
+</script>
+</body>
+</html>

--- a/docs/diagrams/2026-07-24-cmux-session-tracking-swimlane.html
+++ b/docs/diagrams/2026-07-24-cmux-session-tracking-swimlane.html
@@ -1,0 +1,398 @@
+<!DOCTYPE html>
+<!--
+  explainer-reel mode=interactive · swimlane preset — how cmux tracks agent sessions reliably.
+  Source of truth: cmux docs/agent-session-tracking-spec.md (v0.64.20). Verified surfaces on
+  installed cmux 0.64.17 (cmux rpc feed.list, cmux sessions list --json). Self-contained; open in a browser.
+-->
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>cmux session tracking — swimlane</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --bg:#0e1116; --surface:#161c24; --surface2:#1b2330; --border:#263041; --border2:#31405a;
+    --text:#e6edf3; --dim:#93a1b0; --faint:#5b6b7d;
+    --lane-a:#4aa3ff; --lane-a2:#0f2740;
+    --lane-b:#35c46b; --lane-b2:#0e2a1c;
+    --shared:#c6d0da; --shared2:#232c39;
+    --db:#c99bff; --db2:#241733;
+    --store:#e3b341; --device:#8aa0b6;
+    --gold:#e3b341; --crit:#ff5d5d; --crit2:#2c1416;
+    --sans:"IBM Plex Sans",ui-sans-serif,system-ui,sans-serif;
+    --mono:"IBM Plex Mono",ui-monospace,Menlo,monospace;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0}
+  body{background:radial-gradient(1200px 600px at 70% -10%,#141b26,transparent),var(--bg);
+    color:var(--text);font-family:var(--sans);-webkit-font-smoothing:antialiased}
+  .wrap{max-width:1340px;margin:0 auto;padding:26px 22px 80px}
+  header .k{font-family:var(--mono);font-size:11px;letter-spacing:.22em;color:var(--gold);text-transform:uppercase}
+  h1{font-size:27px;margin:6px 0 4px;letter-spacing:-.02em;font-weight:700}
+  .lede{color:var(--dim);font-size:14px;max-width:860px;margin:0}
+  .lede b{color:var(--text)}
+
+  .tabs{display:flex;flex-wrap:wrap;gap:8px;margin:22px 0 6px}
+  .tab{font-family:var(--sans);font-size:13px;font-weight:600;color:var(--dim);background:var(--surface);
+    border:1px solid var(--border);border-radius:999px;padding:8px 15px;cursor:pointer;transition:.18s;display:flex;align-items:center;gap:8px}
+  .tab:hover{border-color:var(--border2);color:var(--text)}
+  .tab.on{color:#0e1116;background:linear-gradient(180deg,#f0d68a,var(--gold));border-color:var(--gold)}
+  .tab .n{font-family:var(--mono);font-size:11px;opacity:.7}
+
+  .bar{display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin:10px 0 4px;color:var(--dim);font-size:12.5px}
+  .btn{font-family:var(--sans);font-size:12.5px;font-weight:600;color:var(--text);background:var(--surface2);
+    border:1px solid var(--border2);border-radius:8px;padding:7px 13px;cursor:pointer;display:inline-flex;align-items:center;gap:7px;transition:.15s}
+  .btn:hover{background:#232d3d;border-color:#3d4f6d}
+  .btn.play{color:#0e1116;background:linear-gradient(180deg,#5ab0ff,var(--lane-a));border-color:var(--lane-a)}
+  .seg{display:inline-flex;border:1px solid var(--border2);border-radius:8px;overflow:hidden}
+  .seg button{font-family:var(--sans);font-size:12px;font-weight:600;color:var(--dim);background:var(--surface);border:0;padding:7px 13px;cursor:pointer;transition:.15s}
+  .seg button.on{color:#0e1116}
+  .seg button.on.a{background:var(--lane-a)} .seg button.on.b{background:var(--lane-b)}
+  .seg.hide{display:none}
+  .leg{display:flex;gap:13px;flex-wrap:wrap;margin-left:auto}
+  .leg span{display:inline-flex;align-items:center;gap:6px}
+  .sw{width:11px;height:11px;border-radius:3px;display:inline-block}
+
+  .flowtitle{font-size:15px;font-weight:600;margin:16px 2px 2px;display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+  .flowtitle .why{font-weight:400;color:var(--dim);font-size:13px}
+  .stagewrap{position:relative;margin-top:12px;border:1px solid var(--border);border-radius:16px;
+    background:linear-gradient(180deg,#12181f,#0f141b);overflow:hidden}
+  .stage{position:relative;padding:16px 18px}
+  .bands{position:absolute;inset:16px 18px;z-index:0;pointer-events:none}
+  .band{position:absolute;left:0;right:0;border-radius:10px;border:1px solid transparent}
+  .bandlabel{position:absolute;left:8px;top:8px;font-family:var(--mono);font-size:10.5px;letter-spacing:.08em;
+    text-transform:uppercase;display:flex;align-items:center;gap:7px;color:var(--dim)}
+  .bandlabel .ic{font-size:13px}
+  svg.edges{position:absolute;inset:16px 18px;z-index:1;pointer-events:none;overflow:visible}
+  .grid{position:relative;display:grid;gap:30px 46px;z-index:2}
+
+  .node{position:relative;border-radius:12px;padding:11px 13px;border:1px solid var(--border2);
+    background:var(--surface);cursor:pointer;transition:transform .16s,box-shadow .16s,border-color .16s,opacity .16s;
+    min-width:0;align-self:center;max-width:230px}
+  .node:hover{transform:translateY(-2px)}
+  .node .lane{position:absolute;top:-1px;left:-1px;bottom:-1px;width:4px;border-radius:12px 0 0 12px}
+  .node .step{position:absolute;top:-9px;left:-9px;width:22px;height:22px;border-radius:50%;
+    font-family:var(--mono);font-size:11px;font-weight:600;display:flex;align-items:center;justify-content:center;
+    background:#0e1116;border:1px solid var(--border2);color:var(--dim);z-index:3}
+  .node .t{font-weight:600;font-size:12.5px;line-height:1.28;display:block}
+  .node .s{font-family:var(--mono);font-size:10px;color:var(--dim);display:block;margin-top:3px;word-break:break-word;line-height:1.4}
+  .node .badge{position:absolute;top:8px;right:9px;font-family:var(--mono);font-size:9px;padding:1px 5px;border-radius:4px}
+  .node .svc{display:inline-block;font-family:var(--mono);font-size:9px;margin-top:6px;padding:1px 6px;border-radius:5px;
+    color:var(--store);background:color-mix(in srgb,var(--store) 14%,transparent);border:1px solid color-mix(in srgb,var(--store) 32%,transparent)}
+  .node.crit .svc{color:var(--crit);background:var(--crit2);border-color:#5c2a2a}
+  .node.a{--c:var(--lane-a)} .node.b{--c:var(--lane-b)} .node.shared{--c:var(--shared)} .node.db{--c:var(--db)} .node.crit{--c:var(--crit)} .node.store{--c:var(--store)}
+  .node .lane{background:var(--c)}
+  .node.on{border-color:var(--c);box-shadow:0 0 0 1px var(--c),0 10px 28px -12px var(--c)}
+  .node.dim{opacity:.3}
+  .node.crit{background:var(--crit2);border-color:#5c2a2a}
+  .node.crit .t{color:#ffd0d0}
+  .node.db{background:var(--db2);border-color:#3d2657}
+  .badge.a{background:var(--lane-a2);color:var(--lane-a)} .badge.b{background:var(--lane-b2);color:var(--lane-b)}
+  .badge.warn{background:var(--crit2);color:var(--crit)} .badge.ok{background:var(--lane-b2);color:var(--lane-b)}
+  .node.pulse .lane{animation:lane 1.6s ease-in-out infinite}
+  @keyframes lane{0%,100%{opacity:.5}50%{opacity:1}}
+
+  .pt{position:absolute;width:7px;height:7px;border-radius:50%;z-index:1;
+    filter:drop-shadow(0 0 5px currentColor);will-change:offset-distance}
+  @keyframes flow{from{offset-distance:0%}to{offset-distance:100%}}
+  .elabel{font-family:var(--mono);font-size:9.5px;fill:var(--dim)}
+  .elabbg{fill:#0f141b;opacity:.9}
+
+  .detail{margin-top:14px;border:1px solid var(--border);border-radius:14px;background:var(--surface);
+    padding:15px 17px;min-height:78px}
+  .detail.empty{color:var(--faint);font-size:13px;display:flex;align-items:center;gap:9px}
+  .detail .dh{display:flex;align-items:center;gap:10px;margin-bottom:7px;flex-wrap:wrap}
+  .detail .dh .dt{font-size:15px;font-weight:700}
+  .detail .sysbadge{font-family:var(--mono);font-size:10.5px;padding:2px 8px;border-radius:5px;border:1px solid currentColor}
+  .detail .path{font-family:var(--mono);font-size:11.5px;color:#a5d6ff;background:#0b1a2b;padding:2px 8px;border-radius:5px}
+  .detail p{margin:6px 0 0;font-size:13px;color:#cdd6e0;line-height:1.55}
+  .detail .writes{font-family:var(--mono);font-size:11px;color:var(--lane-b);margin-top:8px;display:block}
+  .detail .flag{margin-top:9px;font-size:12.5px;color:#ffc0c0;background:var(--crit2);border:1px solid #5c2a2a;border-radius:8px;padding:8px 11px}
+  .detail .flag b{color:var(--crit)}
+  .foot{font-family:var(--mono);font-size:11px;color:var(--faint);margin-top:20px;text-align:center}
+  @media (prefers-reduced-motion: reduce){.pt{display:none!important}.node.pulse .lane{animation:none}}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <div class="k">cmux · agent-session-tracking · verified on 0.64.17</div>
+    <h1>How cmux tracks an agent session — reliably</h1>
+    <p class="lede">Each row is a <b>system</b>: the terminal's shell env, the agent process, cmux's hook/socket, the Mac authority, and a consumer (iOS GUI / squadrant).
+    An arrow that <b>jumps a band is a hop</b>; its label says what crosses. The whole design rests on one rule — <b>bind by a stable token, never by title/mtime; pull is authoritative, push is a hint.</b> That is exactly squadrant's #567 lesson. Click any node.</p>
+  </header>
+
+  <div class="tabs" id="tabs"></div>
+
+  <div class="bar">
+    <button class="btn play" id="play">&#9654; Animate flow</button>
+    <button class="btn" id="reset">&#8634; Reset</button>
+    <div class="seg hide" id="platseg"></div>
+    <div class="leg">
+      <span><i class="sw" style="background:var(--lane-a)"></i>Agent</span>
+      <span><i class="sw" style="background:var(--store)"></i>cmux hook/socket</span>
+      <span><i class="sw" style="background:var(--db)"></i>Mac authority</span>
+      <span><i class="sw" style="background:var(--lane-b)"></i>Consumer / backstop</span>
+      <span><i class="sw" style="background:var(--crit)"></i>Deleted heuristic</span>
+    </div>
+  </div>
+
+  <div class="flowtitle" id="ftitle"></div>
+  <div class="stagewrap">
+    <div class="stage">
+      <div class="bands" id="bands"></div>
+      <svg class="edges" id="edges"></svg>
+      <div class="grid" id="grid"></div>
+    </div>
+  </div>
+
+  <div class="detail empty" id="detail">&#9684; Click a node — the panel shows which system runs it and what crosses the wire.</div>
+
+  <div class="foot">squadrant · docs/specs/2026-07-24-cmux-changelog-review · what squadrant can adopt: cmux rpc feed.list + cmux sessions list --json (no upgrade)</div>
+</div>
+
+<script>
+const BANDS=[
+  {id:'env',      label:'Shell env · cmux-owned', ic:'🐚', col:'var(--device)'},
+  {id:'agent',    label:'Agent process',          ic:'🤖', col:'var(--lane-a)'},
+  {id:'cmux',     label:'cmux CLI · socket',       ic:'🔌', col:'var(--store)'},
+  {id:'authority',label:'Mac authority',           ic:'🧠', col:'var(--db)'},
+  {id:'consumer', label:'Consumer · iOS / squadrant',ic:'📡', col:'var(--lane-b)'}
+];
+const LANECOL={a:'var(--lane-a)',b:'var(--lane-b)',shared:'var(--shared)',db:'var(--db)',crit:'var(--crit)',store:'var(--store)'};
+function n(sys,lane,col,t,s,x={}){return Object.assign({sys,lane,col,t,s},x);}
+
+const FLOWS={
+  bind:{ title:"Bind + state", why:"one token, minted once, carried everywhere — no title/mtime guessing",
+    single:{ nodes:[
+      n('env','shared',1,'Inject CMUX_SURFACE_ID','protected env key at spawn',{id:'tok',svc:'stable · reused on restore',
+        detail:'cmux owns every terminal shell env and injects CMUX_SURFACE_ID / WORKSPACE_ID / PANEL_ID / TAB_ID as PROTECTED keys at spawn. The surface id is minted once, persisted, and (since commit 44dc053e, 2026-06-12) rehydrated verbatim on restore. This is THE binding key — workspace id is volatile and is never the key.'}),
+      n('agent','a',2,'claude / codex inherits token','even hand-typed in the shell',{id:'ag',svc:'via env + process tree',
+        detail:'Because the token lives at the shell/env layer, even a hand-typed `claude`/`codex` inherits it. No wrapper required for the binding to exist.'}),
+      n('cmux','store',3,'Hook fires over the socket','cmux hooks <agent> <event>',{id:'hk',path:'cmux hooks claude postToolUse',
+        detail:'Every agent event fires a cmux hook carrying the surface token. cmux resolves the surface by, in order: (1) explicit --workspace/--surface flag, (2) inherited env token, (3) tty → surface via debug.terminals, (4) process-tree: the agent pid found under a surface via system.top. Signals 3 & 4 need no env at all.'}),
+      n('authority','db',4,'AgentSession per surface','state machine · version++',{id:'au',
+        writes:'sessionStart→idle · pre/postToolUse→working · askUserQuestion→needsInput · sessionEnd→ended',
+        detail:'One authoritative record per surface, keyed by the stable token. State comes from exactly one channel — token-tagged hook events — so there is never a "which of the same-cwd sessions is this?" question. version increments on every change; it is the reconciliation key for pull/push.'}),
+      n('consumer','b',5,'Backstop: process exit → ended','waitpid, not a kill -0 sweep',{id:'bk',ok:true,
+        detail:'cmux spawned (or adopted, via the env token) the agent pid, so a child terminationHandler / waitpid gives `ended` deterministically even if the sessionEnd hook never arrives. This replaced the old kill(pid,0) polling sweep. Backstops never depend on hook delivery.'})
+    ], edges:[
+      ['tok','ag','a','env inherit'],
+      ['ag','hk','a','fires event (token-tagged)'],
+      ['hk','au','store','apply → version++'],
+      ['ag','bk','b','pid owned (backstop)']
+    ]}
+  },
+  reconcile:{ title:"Reconcile", why:"push is a hint; pull is authoritative — and the heuristic cmux DELETED",
+    single:{ nodes:[
+      n('authority','db',1,'Push: version = N','best-effort delivery hint',{id:'push',
+        detail:'Mac→consumer push events (state/descriptor changes) each carry the new version. Never assumed delivered — a missed or duplicated push is fine.'}),
+      n('consumer','b',2,'Version gap detected','received ≠ lastSeen + 1',{id:'gap',
+        detail:'The consumer applies a push only if its version is greater than the last applied version (monotonic → duplicates/reorderings are no-ops). Any version it cannot reconcile triggers a pull.'}),
+      n('consumer','b',3,'PULL the snapshot','mobile.chat.sessions',{id:'pull',badge:['ok','authoritative'],path:'cmux sessions list --json',
+        detail:'The consumer re-fetches the authoritative snapshot (state + version) at any time: on reconnect, foreground, resubscribe, detected gap, or explicit refresh. For squadrant, the socket-independent equivalent is `cmux sessions list --json` (reads ~/.cmuxterm/*-hook-sessions.json). Delivery failure degrades to "slightly stale until next pull", never "wrong forever".'}),
+      n('authority','db',4,'Reality wins','local state overwritten by snapshot',{id:'win',writes:'pull replaces local state + version',
+        detail:'On pull, local state is replaced by the snapshot. This is the reconcile loop squadrant #567 is missing: liveness must let observable reality win over its own event history, not the other way round.'}),
+      n('cmux','crit',3,'Guess: newest transcript','title / mtime — DELETED',{id:'bad',
+        flag:'The heuristic layer cmux removed entirely: newestClaudeTranscript + title matching + the kill -0 sweep + hook-sessions.json as a read-side source of truth. It could surface the WRONG conversation across same-cwd sessions. This is the exact class behind squadrant #499 (glyph drift) and #484 (modal mis-fire) — never trust a screen/name guess over the token-bound truth.'})
+    ], edges:[
+      ['push','gap','b','carries version'],
+      ['gap','pull','b','refetch'],
+      ['pull','win','b','snapshot'],
+      ['bad','win','crit','mis-binds (removed)']
+    ]}
+  }
+};
+
+const ORDER=[["bind","Bind + state"],["reconcile","Reconcile · pull"]];
+let cur="bind", plat="card";
+
+const tabs=document.getElementById('tabs');
+ORDER.forEach(([id,label],i)=>{
+  const b=document.createElement('button');
+  b.className='tab'+(id===cur?' on':''); b.dataset.id=id;
+  b.innerHTML=`<span class="n">${String.fromCharCode(65+i)}</span>${label}`;
+  b.onclick=()=>{cur=id;render();};
+  tabs.appendChild(b);
+});
+const platseg=document.getElementById('platseg');
+
+const grid=document.getElementById('grid'), svg=document.getElementById('edges'),
+      bandsEl=document.getElementById('bands'), detail=document.getElementById('detail'),
+      ftitle=document.getElementById('ftitle');
+
+function variant(){const f=FLOWS[cur];return f.plat?f[plat]:f.single;}
+
+function render(){
+  [...tabs.children].forEach(t=>t.classList.toggle('on',t.dataset.id===cur));
+  const f=FLOWS[cur];
+  platseg.classList.toggle('hide',!f.plat);
+  ftitle.innerHTML=`${f.title} <span class="why">— ${f.why}</span>`;
+  const v=variant();
+  const cols=[...new Set(v.nodes.map(n=>n.col))].sort((a,b)=>a-b);
+  const colMap={}; cols.forEach((c,i)=>colMap[c]=i+1);
+  const usedBands=[...new Set(v.nodes.map(n=>n.sys))];
+  const bandOrder=BANDS.filter(b=>usedBands.includes(b.id));
+  const rowMap={}; bandOrder.forEach((b,i)=>rowMap[b.id]=i+1);
+  grid.style.gridTemplateColumns=`repeat(${cols.length},minmax(150px,1fr))`;
+  grid.style.gridTemplateRows=`repeat(${bandOrder.length},minmax(74px,auto))`;
+  grid.innerHTML='';
+  v.nodes.forEach(nd=>{
+    const el=document.createElement('div');
+    el.className='node '+nd.lane+(nd.flag?' pulse':'');
+    el.style.gridColumn=colMap[nd.col]; el.style.gridRow=rowMap[nd.sys];
+    el.dataset.id=nd.id;
+    const badge=nd.badge?`<span class="badge ${nd.badge[0]}">${nd.badge[1]}</span>`
+      :(nd.ok?`<span class="badge ok">ok</span>`:(nd.flag?`<span class="badge warn">!</span>`:''));
+    const st=stepIndex(v,nd.id);
+    el.innerHTML=`<span class="lane"></span>${st!==''?`<span class="step">${st}</span>`:''}${badge}
+      <span class="t">${nd.t}</span><span class="s">${nd.s}</span>${nd.svc?`<span class="svc">${nd.svc}</span>`:''}`;
+    el.onclick=()=>select(nd.id);
+    grid.appendChild(el);
+  });
+  requestAnimationFrame(()=>{drawBands(bandOrder);drawEdges(v);});
+  detail.className='detail empty';
+  detail.innerHTML='&#9684; Click a node — the panel shows which system runs it and what crosses the wire.';
+}
+
+function drawBands(bandOrder){
+  bandsEl.innerHTML='';
+  const host=bandsEl.getBoundingClientRect();
+  const rows={};
+  [...grid.children].forEach(el=>{
+    const r=el.style.gridRow, rr=el.getBoundingClientRect();
+    (rows[r]=rows[r]||[]).push(rr);
+  });
+  Object.keys(rows).forEach(r=>{
+    const rr=rows[r]; const top=Math.min(...rr.map(x=>x.top))-host.top-8;
+    const bot=Math.max(...rr.map(x=>x.bottom))-host.top+8;
+    const b=bandOrder[+r-1];
+    const div=document.createElement('div'); div.className='band';
+    div.style.top=top+'px'; div.style.height=(bot-top)+'px';
+    div.style.background=`color-mix(in srgb, ${b.col} 7%, transparent)`;
+    div.style.borderColor=`color-mix(in srgb, ${b.col} 22%, transparent)`;
+    const lbl=document.createElement('div'); lbl.className='bandlabel';
+    lbl.style.color=b.col; lbl.innerHTML=`<span class="ic">${b.ic}</span>${b.label}`;
+    div.appendChild(lbl); bandsEl.appendChild(div);
+  });
+}
+
+function stepIndex(v,id){
+  const seen=new Set(),order=[];
+  const starts=v.nodes.filter(n=>!v.edges.some(e=>e[1]===n.id)).map(n=>n.id);
+  const adj={}; v.edges.forEach(([a,b])=>{(adj[a]=adj[a]||[]).push(b);});
+  starts.forEach(s=>{let q=[s];while(q.length){const x=q.shift();if(seen.has(x))continue;seen.add(x);order.push(x);(adj[x]||[]).forEach(y=>q.push(y));}});
+  const i=order.indexOf(id);return i<0?'':i+1;
+}
+
+function anchor(el,side){
+  const host=svg.getBoundingClientRect(), r=el.getBoundingClientRect();
+  return {x:(side==='r'?r.right:r.left)-host.left, y:r.top-host.top+r.height/2,
+          t:r.top-host.top, b:r.bottom-host.top, cx:r.left-host.left+r.width/2};
+}
+let particles=[];
+function clearParticles(){particles.forEach(p=>p.remove());particles=[];}
+function drawEdges(v){
+  svg.removeAttribute('viewBox');
+  svg.innerHTML=''; clearParticles();
+  v.edges.forEach(([a,b,style,label],idx)=>{
+    const ea=grid.querySelector(`[data-id="${a}"]`), eb=grid.querySelector(`[data-id="${b}"]`);
+    if(!ea||!eb)return;
+    const ra=ea.getBoundingClientRect(), rb=eb.getBoundingClientRect();
+    let p1,p2,d;
+    if(rb.left>=ra.right-4){
+      p1=anchor(ea,'r'); p2=anchor(eb,'l');
+      const dx=Math.max(34,(p2.x-p1.x)*0.5);
+      d=`M ${p1.x} ${p1.y} C ${p1.x+dx} ${p1.y}, ${p2.x-dx} ${p2.y}, ${p2.x} ${p2.y}`;
+    } else {
+      const A=anchor(ea,'r'),B=anchor(eb,'r');
+      const x=A.cx; const y1=(A.b<B.t)?A.b:A.t, y2=(A.b<B.t)?B.t:B.b;
+      d=`M ${x} ${y1} C ${x} ${(y1+y2)/2}, ${x} ${(y1+y2)/2}, ${x} ${y2}`;
+      p1={x,y:y1};p2={x,y:y2};
+    }
+    const col=LANECOL[style];
+    const path=document.createElementNS('http://www.w3.org/2000/svg','path');
+    path.setAttribute('d',d);path.setAttribute('fill','none');path.setAttribute('stroke',col);
+    path.setAttribute('stroke-width','2');path.setAttribute('stroke-opacity','.5');path.setAttribute('data-edge',a+'>'+b);
+    if(style==='crit')path.setAttribute('stroke-dasharray','6 5');
+    svg.appendChild(path);
+    const ah=document.createElementNS('http://www.w3.org/2000/svg','path');
+    ah.setAttribute('d',`M ${p2.x-8} ${p2.y-4} L ${p2.x} ${p2.y} L ${p2.x-8} ${p2.y+4}`);
+    ah.setAttribute('fill','none');ah.setAttribute('stroke',col);ah.setAttribute('stroke-width','2');ah.setAttribute('stroke-opacity','.75');
+    svg.appendChild(ah);
+    if(label){
+      const mx=(p1.x+p2.x)/2, my=(p1.y+p2.y)/2;
+      const tw=label.length*5.6+8;
+      const bg=document.createElementNS('http://www.w3.org/2000/svg','rect');
+      bg.setAttribute('x',mx-tw/2);bg.setAttribute('y',my-9);bg.setAttribute('width',tw);bg.setAttribute('height',15);
+      bg.setAttribute('rx',4);bg.setAttribute('class','elabbg');svg.appendChild(bg);
+      const tx=document.createElementNS('http://www.w3.org/2000/svg','text');
+      tx.setAttribute('x',mx);tx.setAttribute('y',my+2);tx.setAttribute('text-anchor','middle');
+      tx.setAttribute('class','elabel');tx.textContent=label;svg.appendChild(tx);
+    }
+    spawnParticles(d,col,idx,style);
+  });
+}
+function spawnParticles(d,col,idx,style){
+  const stage=svg.parentElement, N=style==='crit'?1:2;
+  for(let k=0;k<N;k++){
+    const dot=document.createElement('div');dot.className='pt';dot.style.color=col;dot.style.background=col;
+    dot.style.offsetPath=`path('${d}')`;
+    dot.style.animation=`flow ${2.6+(idx%3)*0.3}s linear ${(idx*0.3)+(k*1.2)}s infinite`;
+    if(style==='crit')dot.style.opacity='.65';
+    stage.appendChild(dot);particles.push(dot);
+  }
+}
+
+function select(id){
+  const v=variant(); const nd=v.nodes.find(x=>x.id===id); if(!nd)return;
+  [...grid.children].forEach(el=>{
+    const nid=el.dataset.id;
+    const connected=nid===id||v.edges.some(e=>(e[0]===id&&e[1]===nid)||(e[1]===id&&e[0]===nid));
+    el.classList.toggle('on',nid===id); el.classList.toggle('dim',!connected);
+  });
+  svg.querySelectorAll('path[data-edge]').forEach(p=>{
+    const [a,b]=p.getAttribute('data-edge').split('>');
+    p.setAttribute('stroke-opacity',(a===id||b===id)?'1':'.14');
+  });
+  const band=BANDS.find(b=>b.id===nd.sys);
+  detail.className='detail'; detail.style.borderColor=LANECOL[nd.lane];
+  detail.innerHTML=`<div class="dh"><span class="dt">${nd.t}</span>
+    <span class="sysbadge" style="color:${band.col}">${band.ic} ${band.label}</span>
+    ${nd.path?`<span class="path">${nd.path}</span>`:''}</div>
+    <p>${nd.detail||nd.s}</p>
+    ${nd.writes?`<span class="writes">&#9656; ${nd.writes}</span>`:''}
+    ${nd.flag?`<div class="flag">&#9888; ${nd.flag}</div>`:''}`;
+}
+
+let playTimer=null;
+function play(){
+  reset(); const v=variant();
+  const ordered=[...v.nodes].map(n=>({n,i:stepIndex(v,n.id)})).filter(o=>o.i!=='').sort((a,b)=>a.i-b.i);
+  let k=0; document.getElementById('play').textContent='● Playing…';
+  playTimer=setInterval(()=>{
+    if(k>=ordered.length){clearInterval(playTimer);document.getElementById('play').textContent='▶ Animate flow';return;}
+    select(ordered[k].n.id);k++;
+  },900);
+}
+function reset(){
+  if(playTimer)clearInterval(playTimer);
+  document.getElementById('play').textContent='▶ Animate flow';
+  [...grid.children].forEach(el=>el.classList.remove('on','dim'));
+  svg.querySelectorAll('path[data-edge]').forEach(p=>p.setAttribute('stroke-opacity','.5'));
+  detail.className='detail empty';detail.style.borderColor='';
+  detail.innerHTML='&#9684; Click a node — the panel shows which system runs it and what crosses the wire.';
+}
+document.getElementById('play').onclick=play;
+document.getElementById('reset').onclick=reset;
+function redraw(){const v=variant();const bo=BANDS.filter(b=>[...new Set(v.nodes.map(n=>n.sys))].includes(b.id));drawBands(bo);drawEdges(v);}
+let rt;window.addEventListener('resize',()=>{clearTimeout(rt);rt=setTimeout(redraw,120);});
+new ResizeObserver(()=>{clearTimeout(rt);rt=setTimeout(redraw,60);}).observe(grid);
+if(document.fonts&&document.fonts.ready){document.fonts.ready.then(redraw);}
+render();
+</script>
+</body>
+</html>

--- a/docs/specs/2026-07-24-cmux-changelog-review-0.64.17-to-0.64.20.md
+++ b/docs/specs/2026-07-24-cmux-changelog-review-0.64.17-to-0.64.20.md
@@ -1,0 +1,197 @@
+# cmux changelog review — 0.64.17 → 0.64.20
+
+**Date:** 2026-07-24
+**Role:** research side-session
+**Baseline:** `packages/shared/src/lib/compat-manifest.ts:5` → cmux `{ min: "0.64.0", lastVerified: "0.64.17" }`
+
+Legend: **[V]** = verified against the local binary/bundle/logs. **[R]** = read from release notes / PR bodies / issues only.
+
+---
+
+## 0. The version discrepancy — resolved
+
+**cmux did not update. It has been *asking* to update for four days.**
+
+| Fact | Evidence |
+|---|---|
+| Installed: `0.64.17 (97) [9ed29d81a]` | **[V]** `cmux --version`; `CFBundleShortVersionString=0.64.17`, `CFBundleVersion=97` |
+| Bundle untouched since Jun 23 | **[V]** `Contents/` mtime `Jun 23 17:53`; bundle moved into place `Jun 24 08:44` |
+| Latest is `0.64.20` (build 100), 2026-07-19 | **[V]** Sparkle appcast at `.../releases/latest/download/appcast.xml` |
+| We are missing **three** releases | **[V]** `gh release list`: v0.64.18 (Jul 14), v0.64.19 (Jul 14), v0.64.20 (Jul 19) |
+| cmux has known about 0.64.20 since **2026-07-20T03:11:59Z** | **[V]** `~/Library/Logs/cmux-update.log`: `state -> updateAvailable(0.64.20)`, re-confirmed hourly ever since |
+| It will never self-install | **[V]** `defaults read com.cmuxterm.app`: `SUAutomaticallyUpdate = 0`, `SUEnableAutomaticChecks = 1`, `SULastCheckTime` moved 02:32Z → 03:32Z during this session |
+| Nothing was ever downloaded | **[V]** `~/Library/Caches/com.cmuxterm.app/org.sparkle-project.Sparkle/{PersistentDownloads,Installation,Launcher}` all empty, dated Jun 24 08:44 (the last successful install) |
+
+So `lastVerified: "0.64.17"` is still accurate for what is running. **Nothing changed underneath us.**
+
+### Latent hazard: this build's in-app updater is the known-broken one
+
+**[V]** `Contents/Frameworks/Sparkle.framework` → **2.8.1**; `otool -l .../Updater.app/Contents/MacOS/Updater` → `sdk 15.5`. Host is macOS 26 (`DTPlatformVersion 26.5`, Darwin 25.5.0).
+
+That is the exact configuration in cmux issue #5123 / PR #6678 **[R]**: on macOS 26 the kernel's `AppleSystemPolicy` rejects the SDK-mismatched Sparkle progress agent, the `-spkp` service never registers, and the update fails with `SUSparkleErrorDomain(4005)`. Fixed in 0.64.18 by bumping Sparkle to 2.9.3.
+
+**Not verified:** that an update attempt actually failed here. There is no Sparkle download cache and no local log evidence of a 4005. The empty cache is equally consistent with the user simply never accepting the prompt. Either way — **if the in-app update fails, install the 0.64.20 DMG manually**; the fix for the updater itself only ships *in* 0.64.18.
+
+---
+
+## 1. (a) Breaking / behavior-changing for squadrant
+
+All of these are **prospective** — they activate only when we upgrade.
+
+### A1. Blank/absent `--workspace` now resolves to the *caller*, not the focused workspace
+PR #6757 (0.64.18) **[R]**. Resolver order becomes: explicit `--workspace` → caller's `CMUX_WORKSPACE_ID` → focused fallback.
+
+**Touches:** every `cmux()` call in `packages/workspaces/src/runtimes/cmux.ts`. Our wrapper forwards `process.env`, so a squadrant CLI invocation *from inside a cmux pane* would leak `CMUX_WORKSPACE_ID` to the child.
+
+**Risk: low.** **[V]** audited every invocation — all of `send`, `send-key`, `read-screen`, `tree`, `rename-tab`, `close-surface`, `new-surface`, `workspace-action`, `tab-action` pass `--workspace` explicitly. Only `--version` and `workspace list --json` omit it, and neither is workspace-scoped.
+
+**Important negative result:** this does **not** fix #564. The daemon runs under launchd (**[V]** PPID 1, `com.squadrant.daemon`) with no `CMUX_WORKSPACE_ID`, so it lands on the unchanged focused fallback. See §3.
+
+### A2. Control-socket access policy becomes live-reloading and fail-closed
+PR #7988 (0.64.20) **[R]**. Introduces `SocketControlServerConfiguration`; policy changes reconfigure without rebinding, **policy generations revoke stale commands and event streams** after a mode or credential change, restrictive modes verify same-user peers *per command*, permission failures fail closed, and `mode = off` unlinks the listener.
+
+**Touches:** `packages/core/src/daemon/delivery-loop.ts` (daemon-direct delivery) and any long-lived `cmux events` stream. Our daemon holds a long-lived relationship with the socket; a generation bump can now revoke an in-flight command or drop the event stream mid-run. **[V]** current access mode is `automation` (`cmux capabilities` → `"access_mode": "automation"`), which is the permissive end — but a Settings commit or `reload_config` can now change that live.
+
+**Action on upgrade:** verify the delivery loop reconnects on a revoked stream rather than treating it as a dead cmux.
+
+### A3. Surfaces and workspaces become user-reorderable by keyboard
+PR #8080 (0.64.20) **[R]** adds shortcuts for moving the selected surface left/right and workspace up/down.
+
+**Touches:** anything we cache keyed on positional refs (`surface:N`, `workspace:N`). Those refs drift on reorder. Relevant to #567. **Mitigation: key on UUIDs, not positional refs** (`--id-format uuids` / `both`).
+
+### A4. Hidden terminal renderers are reclaimed under memory pressure
+PR #7050 (0.64.18) **[R]** — on a `DispatchSourceMemoryPressure` warning/critical, every *hidden* realized terminal renderer is released immediately (visible ones are never selected).
+
+**Touches:** `readScreen` / `readPaneScreen` against non-visible panes — which is the normal case for us. Notably, PR #7050's own baseline was measured on **this exact version**: `0.64.17 (97)`, 2060 MB app footprint, 4.55 GB child RSS across 150 processes.
+
+**Action on upgrade:** confirm `read-screen` on a hidden pane still returns content after a reclaim, rather than an empty buffer. An empty screen read would be indistinguishable from a stuck agent in our delivery logic.
+
+### A5. Claude hook layer substantially rewritten
+**[V]** `gh api .../compare/v0.64.17...v0.64.20` — six *added* CLI hook files: `AgentHookNotificationPolicy`, `CMUXCLI+AgentHookCatalog`, `CMUXCLI+AgentHookRestoreEvidence`, `CMUXCLI+ClaudeHookDeliveryTarget`, `CMUXCLI+ClaudeHookWorkspaceRouting`, `CMUXCLI+ClaudePushNotificationHook`; plus modified `AgentHookDefinitions` (262 changes) and `CodexFireAndForgetHooks`.
+
+**Touches:** squadrant's own hook-driven confirmation (#470/#471/#473) writes to the same `~/.claude/settings.json` that `cmux hooks claude` manages. Collision/ownership-matcher risk is real and **unassessed**. PR #6798 explicitly notes a known follow-up where re-install leaves stale inline duplicates that "dodge the ownership matcher."
+
+**Action on upgrade:** diff `~/.claude/settings.json` before/after, and re-run the crew-lifecycle checklist.
+
+### A6. Claude argv handling on session restore changed
+PR #8070 (0.64.19) **[R]**. Adds `Policy.booleanOptions` so Claude boolean flags stop swallowing a following positional; `--bg`/`--background` are now **dropped on restore**; interactively-chosen permission mode is persisted and replayed as `--permission-mode <mode>` — but only when the preserved argv doesn't already carry one.
+
+**Touches:** our captain/crew launch argv. **[V]** live example from `cmux sessions list --json`:
+```
+["/Users/q3labsadmin/.local/bin/claude", "--permission-mode", "auto", "--model", "opus",
+ "--append-system-prompt-file", ".../templates/captain.claude.md", "--plugin-dir", ".../plugin"]
+```
+We already pass `--permission-mode` explicitly, so explicit-wins keeps our behavior. Worth a post-upgrade check that `--append-system-prompt-file` and `--plugin-dir` survive a restore intact (a dropped `--append-system-prompt-file` would silently un-brief a restored captain).
+
+---
+
+## 2. (b) New capabilities worth exploiting
+
+### B1. 🔴 The biggest one needs **no upgrade at all** — `feed.list` + reply RPCs
+
+**[V]** on the running 0.64.17:
+
+```
+$ cmux rpc feed.list '{}'
+total items: 1375
+kinds:     {toolUse: 994, stop: 155, toolResult: 91, userPrompt: 82,
+            sessionStart: 23, sessionEnd: 20, question: 10}
+statuses:  {telemetry: 1365, expired: 8, pending: 2}
+fields:    created_at, cwd, id, kind, question_multi_select, question_options,
+           question_prompt, questions, request_id, resolved_at, source, status,
+           text, title, tool_input, tool_name, tool_result, tool_result_is_error,
+           updated_at, workstream_id
+```
+
+A `kind: "question"` item with `status: "pending"` carries `request_id`, `question_prompt`, `question_options[]` (each with `id`/`label`/`description`), `question_multi_select`, `cwd`, `workstream_id`. **[V]** two such items are pending right now.
+
+**[V]** the reply methods already exist in `cmux capabilities`: `feed.question.reply`, `feed.permission.reply`, `feed.exit_plan.reply` (plus `feed.push`, `feed.jump`, `feed.list`).
+
+**Why this matters:** this is a direct, structured answer to *"is this pane safe to write to?"* — the question `#484`'s `hasModalOptionList` currently answers by **screen-scraping**. A `status == "pending"` check is:
+- unambiguous (no "is this a selection list or a ghost draft?" guessing),
+- immune to glyph drift — the failure class that caused **#499** (`Ask anything…` vs `Ask anything...`),
+- and *answerable*: `feed.question.reply(request_id, option)` replaces typing into the pane and pressing Enter, which is what auto-confirmed the modal in **#484**.
+
+Caveat: `feed list` is **not** exposed as a CLI subcommand on 0.64.17 (`cmux feed` only offers `tui`/`clear`) — reach it via `cmux rpc feed.list`. Only `source: "claude"` items were present in this sample; codex/opencode coverage is unverified.
+
+### B2. 🔴 `cmux sessions list --json` — also already available, also undocumented
+
+**[V]** on 0.64.17. Not listed in `cmux --help`; `cmux sessions --help` documents it. Reads `~/.cmuxterm/*-hook-sessions.json` and **explicitly does not require a running cmux socket**.
+
+Per-session fields **[V]**: `agent`, `agent_lifecycle` (`"running"`), `session_id`, `pid`, `cwd`, `launch_working_directory`, `launch_arguments[]`, `started_at`, `active_for_surface`, `active_for_workspace`, `active_surface_session_id`, `active_workspace_session_id`, `active_prompt_turn_id`, `last_prompt_turn_id`, `runtime_status`, `session_dir`. Filters: `--agent --session --workspace --surface --cwd --limit --all --json`.
+
+This is a **third ground-truth source** — exactly the row #567 asks for. `pid` + `agent_lifecycle` give OS-level truth; `started_at` gives generation; `active_prompt_turn_id` is a non-scraped "a turn is in flight" signal (relevant to the #492 turn-boundary class); `launch_arguments` identifies *which* squadrant role a session is (a captain is the one carrying `templates/captain.claude.md`).
+
+### B3. Tree already reports the caller and the tty
+**[V]** `cmux tree --json` returns a top-level `caller` block (`window_ref`/`workspace_ref`/`pane_ref`/`surface_ref`/`tab_ref`/`surface_type`) *alongside* `active`, and each surface carries `tty`. `cmux identify [--no-caller]` exposes the same. Useful for disambiguating "who am I" vs "what's focused" without heuristics.
+
+### B4. Agent-session tracking rewrite — upgrade-gated
+PR #6798 (0.64.18) **[R]**, the most directly relevant upstream work:
+- **tree-aware liveness** — judged from the surface's *process tree*, not one recorded pid, so a dying launcher/`node` shim re-binds to the real agent instead of falsely ending the session;
+- **observe-floor detection** — a throttled process-tree scan binds untracked claude/codex under a surface (claude via `--session-id`/`--resume` argv);
+- the live send/list gate becomes **deterministic pid-liveness instead of the terminal-title heuristic**;
+- resume re-bind keyed on the real `terminalPanel.id`, fired whenever a restored surface carries a resumable binding.
+
+That is our LivenessRegistry problem, solved on the cmux side. Worth re-reading before we build more of #567 ourselves.
+
+### B5. Smaller ones
+- **`notifications.suppressOnlyFocusedSurface`** (PR #6893, 0.64.18) — narrows implicit notification auto-withdraw to the *exact focused surface*. Fits our notifier semantics better than today's workspace-wide withdraw.
+- **Notify on fatal Codex turn errors** (PR #8170, 0.64.20) — a lifecycle signal we currently have no source for.
+- **Diff viewer moved to a Rust sidecar** (PR #7804, 0.64.20) — touches our `showDiff` / `cmux diff -` stdin path (#604). Behavior-compatible per the notes, but our `--focus` handling should be re-smoked.
+- **`workspace list --json` already exposes `latest_submitted_at` / `latest_submitted_message`** **[V]** on 0.64.17 — a per-workspace "last prompt actually submitted" timestamp. A cheap independent confirmation that a delivery landed.
+
+---
+
+## 3. Against the four open problems
+
+### #590 — stuck delivery followed by daemon SIGTERM
+**No cmux change explains this, and structurally none could.**
+
+- We run 0.64.17. Nothing in 0.64.18/19/20 was ever executing on this machine. **[V]**
+- The one cmux mechanism that *can* externally SIGTERM a process is cmux issue **#7490** (closed) **[R]**: macOS's kernel low-swap *"no paging space action"* SIGTERMs processes under swap exhaustion — reported on 0.64.17, with the app silently auto-relaunching. Attractive, because it would explain *both* halves of #590 (a thrashing machine makes deliveries defer *and* gets processes killed) as a common cause rather than cause-and-effect.
+- **Ruled out for the 2026-07-20 12:41:19Z event** **[V]**:
+  - cmux app pid **630 survived** — `cmux-update.log` shows its periodic probes continuing at `13:32:31Z`, `14:32:31Z`, `15:37:05Z`, `16:37:05Z` that day. A swap-exhaustion sweep takes the 2 GB app before a node daemon.
+  - `last reboot` shows no reboot between Mon Jul 20 09:10 and Tue Jul 21 08:57 (local).
+  - No `low swap` entries in 30 days of unified log.
+  - Current state is tight but not swapping: 21 G used / 2.6 G unused, `vm.swapusage total = 0.00M`.
+  - *(One weak signal, not evidence: the 12:20:38Z → 13:32:31Z probe gap is ~72 min against a 3600 s interval. Consistent with sleep or a stall in the window containing 12:41. Not load-bearing.)*
+- cmux has **no process-tree path to our daemon**: **[V]** `squadrantd` is PPID 1, launched by LaunchAgent `com.squadrant.daemon` (`KeepAlive = true`, `ThrottleInterval = 10`). It is not a cmux child, so pane/workspace teardown and the quit watchdog (PR #6837) cannot reach it.
+
+**Conclusion: the suspect list stays launchd-side.** Signal-source logging remains the right next step; cmux is not the culprit.
+
+**Incidental find worth its own note** **[V]**: the LaunchAgent plist bakes a cmux-instance-scoped `PATH` entry —
+`/var/folders/pz/.../T/cmux-cli-shims/66793AB2-FC1A-4017-8581-1EB2C747097E`
+— which goes stale on any cmux restart. `/Applications/cmux.app/Contents/Resources/bin` is also on the path, so cmux resolution still works, but this is a real staleness bug in the #567 neighbourhood.
+
+### Delivery deferral / #484 — better answer exists **today**
+See **B1**. Replace the `hasModalOptionList` screen-scrape with `cmux rpc feed.list` → `kind == "question" && status == "pending"` scoped by `cwd`/`workstream_id`; optionally answer structurally via `feed.question.reply` instead of typing. No upgrade required. This removes a whole failure class (glyph drift, #499) from the delivery path.
+
+### #567 — detecting cmux/system restart and remapping
+Two halves:
+
+1. **Buildable now:** `cmux sessions list --json` (**B2**) supplies pid + `agent_lifecycle` + `started_at` + `active_for_surface` per session, *without the cmux socket*. That is the missing reality column in #567's reconcile table, and it survives the case where cmux itself is down.
+2. **Upgrade-time hazard:** cmux issue **#1984** (open) **[R]** — *"App update kills all terminal sessions — no session persistence across Sparkle restart."* Installing the pending 0.64.20 is precisely the #567 scenario, live and unhandled. **Land a remap-on-restart safety net before upgrading**, or expect the 2026-07-11 incident to repeat.
+3. Key remapped state on **UUIDs**, not positional refs — see **A3**.
+
+### #564 — `runtime read-screen` returns the focused tab
+Solvable now, and **not** solved by upgrading:
+
+- PR #6757 changes the *caller* fallback, which the daemon never hits (**A1**). **[V]**
+- The fix is squadrant-side and the data is already there: resolve the captain's **surface UUID** via `cmux sessions list --json` (the session whose `launch_arguments` include `templates/captain.claude.md` for that project's cwd), then pass `--surface` explicitly. `cmux tree --json` also gives per-workspace surface refs with `title` (e.g. `⚓ scaffold-captain`) and `tty`. **[V]**
+- The issue's proposed output header (`# captain: <name>`) can be populated from the same record, closing the "nothing says which one you got" gap.
+
+---
+
+## 4. (c) Irrelevant to us
+
+The bulk of 0.64.18/0.64.20 by volume: iOS app / TestFlight / App Store lanes / Iroh transport, the web landing pages and SEO/IndexNow work, browser extension settings, Ghostty SSH wrapper paths, remote-tmux and ssh-tmux fixes, sidebar/AppKit rendering work, mobile chat UI, macOS 27 launch crashes, Sleepy Mode, scroll-delta handling, and the CI/Nightly pipeline changes.
+
+---
+
+## 5. Recommended order
+
+1. **Do not upgrade yet.** Land a #567 remap-on-restart safety net first — cmux #1984 makes the upgrade itself the trigger.
+2. **Adopt `feed.list` for delivery deferral (#484).** No upgrade needed; removes a failure class.
+3. **Fix #564 with `sessions list --json` surface targeting.** No upgrade needed.
+4. **Keep #590 on the launchd track.** cmux is exonerated; add signal-source logging.
+5. **When upgrading:** manual DMG (the in-app updater on this build is the known-broken Sparkle 2.8.1/SDK-15.5 combo), then re-run the crew-lifecycle checklist with attention to A2 (socket policy/event-stream revocation), A4 (hidden-pane `read-screen`), A5 (`~/.claude/settings.json` hook collisions), and A6 (captain argv survives restore). Bump `lastVerified` only after that passes.


### PR DESCRIPTION
Commits three artifacts from the **2026-07-24 research side-session** that were left untracked for six days. The decisions they back were filed as #618 and #622 at the time; the evidence behind them was never committed, so both issues have had conclusions without verification attached.

Docs only — no source changes. Plus one line adding `.scratch/` to `.gitignore` (a local scratch dir that has been sitting untracked in `git status` for months).

### Why this is worth committing rather than discarding
The review tags every claim `[V]` (verified against the local binary/bundle/logs) or `[R]` (read from release notes only). Two findings outlive the upgrade question they were collected for:

- **#590 — cmux is exonerated, structurally.** `squadrantd` is a launchd child (PPID 1, `KeepAlive=true`) with no process-tree path from cmux, so pane/workspace teardown cannot reach it. The attractive swap-exhaustion theory (cmux #7490) is ruled out by evidence: the cmux app pid survived past the event, there was no reboot in the window, and there are no low-swap entries in 30 days of unified log. **#590 is currently P0 — this redirects the investigation to the launchd side.**
- **The drift source behind #636.** The LaunchAgent plist bakes a cmux-instance-scoped PATH shim (`/var/folders/.../cmux-cli-shims/<UUID>`) that goes stale on every cmux restart. #636 (merged today, PR #643) stopped the *bouncing*; this is the thing doing the *drifting*, and it is still there.

It also records that **#484, #564 and half of #567 are solvable on 0.64.17 today** — the basis for #618 — and that upgrading is unsafe until a remap-on-restart net exists, because cmux #1984 kills all sessions on Sparkle restart.

The two HTML files are self-contained interactive swimlane diagrams (English + Vietnamese) of cmux's session-tracking architecture, including the heuristics cmux deliberately deleted (title matching, newest-transcript detection, `kill -0` sweeps) and how those map to #499, #484 and #567.