### PR TITLE
Embed the human review gate in templates + audit all templates and skills (#656)

### DIFF
--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -225,7 +225,7 @@ On CREW IDLE, do a **single on-demand spot-check** (allowed — not a polling lo
 
 | Spot-check shows | Captain action |
 |-----------------|----------------|
-| Completed work (PR opened, commits pushed, results reported) but no CREW DONE | Treat as the #278 case — review; if good, terminalize (`merge` + `crew close`). If not actually done, **re-task**: send the next instruction via `crew send` (the #148 re-open flow). |
+| Completed work (PR opened, commits pushed, results reported) but no CREW DONE | Treat as the #278 case — review, then follow the HUMAN REVIEW GATE contract: surface the diff and wait for operator go-ahead; never merge unprompted. If not actually done, **re-task**: send the next instruction via `crew send` (the #148 re-open flow). |
 | Crew asked a question or is waiting for a decision | Respond via `crew send`. Do NOT terminalize — it will signal done after the next turn. |
 | Still mid-task / transient idle | Leave it; wait for the next daemon event. |
 

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -237,13 +237,15 @@ When a crew sends you a status message via `squadrant runtime send <project> "<m
 
 ### Handling CREW REVIEW or CREW DONE (Assessment Gate)
 
-CREW REVIEW and CREW DONE both mean the crew has paused and is waiting for your verdict (either explicitly asking for review, or claiming the work is done). The task is **NOT terminal** until you approve it.
+CREW REVIEW and CREW DONE both mean the crew has paused and is waiting for your verdict (either explicitly asking for review, or claiming the work is done). Treat neither as final until you have reviewed.
 
 **Follow the HUMAN REVIEW GATE contract from your system prompt.** The template defines *what* you must do (never auto-merge without permission); this playbook defines *how* to do it.
 
 **Review Modes (per contract):**
 - **DEFAULT mode (Wait for human):** You review the diff, then **STOP** and surface a diff summary to the USER. You **WAIT** for the user to approve. You do NOT run `squadrant crew approve` or merge until they say so.
 - **DELEGATED mode (Captain auto):** ONLY when the user explicitly delegates (e.g. "you review and merge it"). You review, run `squadrant crew approve`, and merge autonomously.
+
+*Note: Either way the captain-side review still happens — the human gate is ADDED ON TOP of the captain review, not a replacement for it.*
 
 On CREW REVIEW or CREW DONE:
 
@@ -252,18 +254,18 @@ On CREW REVIEW or CREW DONE:
 
 | Diff looks | Captain action |
 |-----------|-----------------|
-| Good — matches the task, tests pass | **DEFAULT mode:** Surface diff summary to user and WAIT. Once user approves, run `squadrant crew approve <project> <crew>`, then ask about merging (or merge if they already approved it).<br><br>**DELEGATED mode:** Run `squadrant crew approve <project> <crew>`, then merge autonomously. |
+| Good — matches the task, tests pass, no scope creep | **DEFAULT mode:** Surface diff summary to user and WAIT. Once user approves, run `squadrant crew approve <project> <crew>`, then ask about merging (or merge if they already approved it).<br><br>**DELEGATED mode:** Run `squadrant crew approve <project> <crew>`, then merge autonomously. |
 | Needs changes | `squadrant crew send <project> <crew> "<feedback>"` — the crew iterates and re-signals. Loop until approved. |
 
 3. **Never auto-terminalize** by emitting `task.done` directly — always go through `squadrant crew approve`.
-4. Do **not** re-send the original task or close the crew while it's awaiting review.
+4. Do **not** re-send the original task or close the crew while it's awaiting review — `crew close` on a `review`-state task discards work that hasn't been pushed anywhere yet.
 
 ## When Crew is Fully Finished (After Approval)
 
 After a crew task is approved and optionally merged:
 
 1. Close the crew with `squadrant crew close <project> <name>` once the work track is done.
-2. VERIFY no orphaned processes remain — e.g. `pgrep -fl vitest` and check for stray dev servers. Kill any leftovers.
+2. VERIFY no orphaned processes remain — e.g. `pgrep -fl vitest` and check for stray dev servers. Kill any leftovers. `pnpm test` is one-shot (`vitest run`, always exits) and machine-wide bounded via `scripts/heavy-lock.mjs` (#570), so concurrent crews queue instead of piling up — but still prefer one verification on the authoritative checkout rather than relying on the lock to save you.
 3. Record learnings if any (see "Recording Learnings" below).
 4. Update your handoff if the work shifts the next-step plan (see "Session Shutdown").
 

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -235,39 +235,37 @@ This is the captain-side backstop: even if the completion-protocol imperative is
 
 When a crew sends you a status message via `squadrant runtime send <project> "<message>"`, it lands in your captain pane. Acknowledge, then update your handoff if a meaningful decision was made.
 
-### Handling CREW REVIEW (#599 review gate)
+### Handling CREW REVIEW or CREW DONE (Assessment Gate)
 
-CREW REVIEW is **unambiguous** — a crew ran `squadrant crew signal review` after committing its work to `crew/<name>`. Unlike CREW IDLE, this is never a stray heartbeat miss: the crew has explicitly paused and is waiting for your verdict. The task is **NOT terminal** — don't treat it like CREW DONE.
+CREW REVIEW and CREW DONE both mean the crew has paused and is waiting for your verdict (either explicitly asking for review, or claiming the work is done). The task is **NOT terminal** until you approve it.
 
-**Review Modes:**
-- **DEFAULT mode (Wait for human):** When a crew signals review, the captain does its own review of the diff, then **STOPS** and surfaces a diff summary (files changed, scope, notable points) to the USER in chat, and **WAITS** for the user to review and approve. The captain must NOT run `squadrant crew approve` and must NOT merge the PR until the user gives the go-ahead. Do NOT auto-merge the PR after CI passes in default mode — the PR merge is the user's call unless they delegated.
-- **DELEGATED mode (Captain auto):** ONLY when the user explicitly delegates for that review (e.g. says "review đi, được thì merge luôn" / "you review and merge it") does the captain review → approve → merge autonomously without pausing. Delegation is per-request; it does not become the standing default.
+**Follow the HUMAN REVIEW GATE contract from your system prompt.** The template defines *what* you must do (never auto-merge without permission); this playbook defines *how* to do it.
 
-*Note: Either way the captain-side review still happens — the human gate is ADDED ON TOP of the captain review, not a replacement for it.*
+**Review Modes (per contract):**
+- **DEFAULT mode (Wait for human):** You review the diff, then **STOP** and surface a diff summary to the USER. You **WAIT** for the user to approve. You do NOT run `squadrant crew approve` or merge until they say so.
+- **DELEGATED mode (Captain auto):** ONLY when the user explicitly delegates (e.g. "you review and merge it"). You review, run `squadrant crew approve`, and merge autonomously.
 
-On CREW REVIEW:
+On CREW REVIEW or CREW DONE:
 
-1. **Open the diff** — `squadrant diff <project> <crew>` (branch-vs-base; the default is exactly the review surface). Use `--staged`/`--unstaged`/`--working` if you also want to peek at anything left uncommitted.
+1. **Open the diff** — `squadrant diff <project> <crew>` (branch-vs-base). Use `--staged`/`--unstaged`/`--working` if you want to peek at uncommitted work.
 2. **Classify (Captain-side review):**
 
 | Diff looks | Captain action |
 |-----------|-----------------|
-| Good — matches the task, tests pass, no scope creep | **DEFAULT mode:** Surface diff summary to user and WAIT for go-ahead. Once user approves, run `squadrant crew approve <project> <crew>` (pushes to origin, opens PR, terminalizes DONE). Wait for user to decide on merging.<br><br>**DELEGATED mode:** Run `squadrant crew approve <project> <crew>`, then merge autonomously. |
-| Needs changes | `squadrant crew send <project> <crew> "<feedback>"` — the crew iterates, re-commits, and re-signals `review`. Loop until approved. (No user gate needed for rejecting back to crew). |
+| Good — matches the task, tests pass | **DEFAULT mode:** Surface diff summary to user and WAIT. Once user approves, run `squadrant crew approve <project> <crew>`, then ask about merging (or merge if they already approved it).<br><br>**DELEGATED mode:** Run `squadrant crew approve <project> <crew>`, then merge autonomously. |
+| Needs changes | `squadrant crew send <project> <crew> "<feedback>"` — the crew iterates and re-signals. Loop until approved. |
 
-3. **Never auto-terminalize a CREW REVIEW yourself** by emitting `task.done` directly — always go through `squadrant crew approve` so the push+PR actually happens before the task closes.
-4. Do **not** re-send the original task or close the crew while it's awaiting review — `crew close` on a `review`-state task discards work that hasn't been pushed anywhere yet.
+3. **Never auto-terminalize** by emitting `task.done` directly — always go through `squadrant crew approve`.
+4. Do **not** re-send the original task or close the crew while it's awaiting review.
 
-## When Crew Finishes
+## When Crew is Fully Finished (After Approval)
 
-After a crew task completes:
+After a crew task is approved and optionally merged:
 
-1. Review the work — read the diff, check the branch.
-2. Merge their branch if appropriate.
-3. Close the crew with `squadrant crew close <project> <name>` once the work track is done. (Or let the crew exit itself — the tab closes when the CLI ends.)
-4. After closing a crew, VERIFY no orphaned processes remain — e.g. `pgrep -fl vitest` and check for stray dev servers / node test workers; kill any leftovers. `pnpm test` is one-shot (`vitest run`, always exits) and machine-wide bounded via `scripts/heavy-lock.mjs` (#570), so concurrent crews queue instead of piling up — but still prefer one verification on the authoritative checkout rather than relying on the lock to save you.
-5. Record learnings if any (see "Recording Learnings" below).
-6. Update your handoff if the work shifts the next-step plan (see "Session Shutdown — Write Handoff" below).
+1. Close the crew with `squadrant crew close <project> <name>` once the work track is done.
+2. VERIFY no orphaned processes remain — e.g. `pgrep -fl vitest` and check for stray dev servers. Kill any leftovers.
+3. Record learnings if any (see "Recording Learnings" below).
+4. Update your handoff if the work shifts the next-step plan (see "Session Shutdown").
 
 ## Status Board (show after substantive turns)
 

--- a/plugin/skills/command-ops/SKILL.md
+++ b/plugin/skills/command-ops/SKILL.md
@@ -64,7 +64,7 @@ Never skip this gate when a workspace was found by name — that's how stale cap
 ```bash
 ~/.config/squadrant/scripts/spawn-workspace.sh "{captainName}" "{projectPath}"
 ```
-Wait a few seconds, then `list-workspaces` again to get its ref. Confirm the spawn logged `↻ new day — starting fresh session` (or a clean first-launch) before sending work.
+Wait a few seconds, then `squadrant runtime list` again to get its ref. Confirm the spawn logged `↻ new day — starting fresh session` (or a clean first-launch) before sending work.
 
 ### 5. Send the task
 ```bash
@@ -95,7 +95,7 @@ squadrant projects add {name}-docs {path/to/docs} --group {group} --group-role "
 
 ## Monitoring Captains
 
-Captains will send you reports via `cmux send` when tasks complete or blockers arise. When you receive a captain report:
+Captains will send you reports via `squadrant runtime send` when tasks complete or blockers arise. When you receive a captain report:
 
 1. Acknowledge the report
 2. Update your dashboard / briefing notes

--- a/plugin/skills/command-ops/SKILL.md
+++ b/plugin/skills/command-ops/SKILL.md
@@ -29,9 +29,8 @@ for vault in $(cat ~/.config/squadrant/config.json | python3 -c "import json,sys
   cat "$vault/daily-logs/${YESTERDAY}.md" 2>/dev/null || echo "(no log)"
 done
 ```
-4. Read current status: `~/.config/squadrant/scripts/read-status.sh`
-5. Run quick standup for context: `squadrant standup --yesterday --raw`
-6. Present briefing, then save to `{hubVault}/daily-logs/YYYY-MM-DD.md`
+4. Run quick standup for context: `squadrant standup --yesterday --raw`
+5. Present briefing, then save to `{hubVault}/daily-logs/YYYY-MM-DD.md`
 
 ## Delegation Workflow
 
@@ -42,7 +41,7 @@ Match to `~/.config/squadrant/config.json`.
 
 ### 2. Check for captain workspace
 ```bash
-/Applications/cmux.app/Contents/Resources/bin/cmux list-workspaces
+squadrant runtime list
 ```
 **CRITICAL:** Match the EXACT `captainName` from config. `Brove` ≠ `⚓ brove-captain`.
 
@@ -56,7 +55,7 @@ LAST=$(python3 -c "import json; d=json.load(open('$HOME/.config/squadrant/sessio
 - `fresh` → reuse the existing workspace, proceed to step 5.
 - `stale` (or no entry) → close the existing workspace, then go to step 4 to respawn so `spawn-workspace.sh` runs its `↻ new day — starting fresh session` path:
   ```bash
-  /Applications/cmux.app/Contents/Resources/bin/cmux close-workspace --workspace "workspace:N"
+  squadrant runtime stop <project>
   ```
 
 Never skip this gate when a workspace was found by name — that's how stale captains get reused.
@@ -69,8 +68,7 @@ Wait a few seconds, then `list-workspaces` again to get its ref. Confirm the spa
 
 ### 5. Send the task
 ```bash
-/Applications/cmux.app/Contents/Resources/bin/cmux send --workspace "workspace:N" "Task description with all context"
-/Applications/cmux.app/Contents/Resources/bin/cmux send-key --workspace "workspace:N" Enter
+squadrant runtime send <project> "Task description with all context"
 ```
 
 ### 6. Report back
@@ -78,12 +76,9 @@ Wait a few seconds, then `list-workspaces` again to get its ref. Confirm the spa
 
 ## Checking Status
 
+Read a captain's screen:
 ```bash
-~/.config/squadrant/scripts/read-status.sh
-```
-Or read a captain's screen:
-```bash
-/Applications/cmux.app/Contents/Resources/bin/cmux read-screen --workspace "workspace:N"
+squadrant runtime read-screen <project>
 ```
 
 ## Registering Projects
@@ -107,13 +102,10 @@ Captains will send you reports via `cmux send` when tasks complete or blockers a
 3. If the captain reported a blocker — escalate to the user
 4. If all tasks for a project are done — inform the user
 
-You can also **proactively check** captain progress:
+You can also **proactively check** captain progress by reading their screens:
 ```bash
-# Read all captain statuses at once
-for vault in $(cat ~/.config/squadrant/config.json | python3 -c "import json,sys; [print(p['spokeVault']) for p in json.loads(sys.stdin.read())['projects'].values()]"); do
-  echo "=== $(basename $vault) ==="
-  head -15 "$vault/status.md" 2>/dev/null || echo "(no status)"
-done
+# Read a specific captain's screen
+squadrant runtime read-screen <project>
 ```
 
 Do this when:

--- a/plugin/skills/karpathy-principles/SKILL.md
+++ b/plugin/skills/karpathy-principles/SKILL.md
@@ -74,7 +74,7 @@ These principles bias toward **caution over speed**. For trivial tasks (typo fix
 
 - Squadrant already uses TDD via the `superpowers:test-driven-development` skill — principle 4 complements it, does not replace it
 - Captains applying these principles during review: if a crew member violates principle 3 (drive-by refactors), request they split the commit
-- Crew should report blockers in status.md when principle 1 triggers ("unclear" / "multiple interpretations")
+- Crew should run `squadrant crew signal blocked` when principle 1 triggers ("unclear" / "multiple interpretations")
 
 ## Attribution
 

--- a/templates/captain.claude.md
+++ b/templates/captain.claude.md
@@ -6,8 +6,9 @@ You are a **project captain** for Squadrant. You lead ONE project. You are a **c
 
 1. **NEVER** edit, write, or modify project source code yourself. You are a coordinator.
 2. **ALWAYS** spawn a crew session for ANY coding task — no matter how small.
-3. Even a one-line fix gets a crew session. You plan, delegate, review, merge.
-4. **ALWAYS** spawn crew via `squadrant crew spawn` — never via the `Agent` tool, never via `TeamCreate`. Crew opens as a new tab in your workspace and works for any agent (claude, codex, gemini, opencode).
+3. Even a one-line fix gets a crew session. You plan, delegate, review.
+4. **HUMAN REVIEW GATE**: You must NOT run `squadrant crew approve` or merge a PR without explicit operator go-ahead. The default is pause-and-show-the-diff. Delegated auto-merge is ONLY allowed when the operator explicitly says so per-request.
+5. **ALWAYS** spawn crew via `squadrant crew spawn` — never via the `Agent` tool, never via `TeamCreate`. Crew opens as a new tab in your workspace and works for any agent (claude, codex, gemini, opencode).
 
 ## ALWAYS do on session start
 

--- a/templates/captain.generic.md
+++ b/templates/captain.generic.md
@@ -20,7 +20,7 @@ You are a project captain coordinating work via cmux workspaces. You are a coord
    ```bash
    squadrant runtime send <project> "<message>"
    ```
-5. When a crew task completes, review the diff and merge if appropriate.
+5. **HUMAN REVIEW GATE**: When a crew task completes (signals review or done), you must NOT run `squadrant crew approve` or merge a PR without explicit operator go-ahead. The default is pause-and-show-the-diff. Delegated auto-merge is ONLY allowed when the operator explicitly says so per-request.
 6. Record learnings (script: `~/.config/squadrant/scripts/record-learning.sh`).
 
 ## Crew Spawning

--- a/templates/command.claude.md
+++ b/templates/command.claude.md
@@ -15,8 +15,8 @@ You are spawned **on-demand** by `squadrant command [--task ...]` for a single t
 
 - Read/write files in your hub vault only
 - Read `~/.config/squadrant/config.json`
-- Run squadrant CLI commands and cmux commands
-- Read captain screens via `cmux read-screen`
+- Run squadrant CLI commands
+- Read captain screens via `squadrant runtime read-screen <project>`
 - Aggregate status and write dashboards
 
 ## ALWAYS do on session start

--- a/templates/crew.generic.md
+++ b/templates/crew.generic.md
@@ -20,7 +20,7 @@ Your working directory is a git worktree. Your branch is isolated from main. Wor
 When done:
 1. Commit all changes
 2. Write a brief summary of what you did and any issues encountered
-3. Your captain will review and merge your branch
+3. Your captain will review your branch
 
 ## How You Were Spawned
 

--- a/templates/crew.opencode.md
+++ b/templates/crew.opencode.md
@@ -20,7 +20,7 @@ Your working directory is a git worktree. Your branch is isolated from main. Wor
 When done:
 1. Commit all changes
 2. Write a brief summary of what you did and any issues encountered
-3. Your captain will review and merge your branch
+3. Your captain will review your branch
 
 ## How You Were Spawned
 

--- a/templates/learnings.claude.md
+++ b/templates/learnings.claude.md
@@ -26,7 +26,7 @@ When a skill's instructions are broken or outdated:
 
 ## Quality Tracking
 
-- `mark-learning-useful.sh` — increment usefulness counter
+- `~/.config/squadrant/scripts/mark-learning-useful.sh` — increment usefulness counter
 - Loaded 5+ times but never useful → stale, skip it
 - Skill used 3+ times but never successful → flag for FIX
 


### PR DESCRIPTION
Closes #656. Follows on from #653/#655 (same root cause: rules authored into skills instead of templates).

## #656 — the human review gate

The gate previously existed **only** in `plugin/skills/captain-ops/SKILL.md`, which loads only if a captain voluntarily invokes the skill — and never for non-Claude captains, which have no Skill tool. Meanwhile the always-loaded system prompts said the opposite (`captain.claude.md` "plan, delegate, review, merge"; `captain.generic.md` "merge if appropriate").

- Gate contract added to **both** `templates/captain.claude.md` and `templates/captain.generic.md`; contradicting wording removed.
- Gate is now **signal-agnostic**, covering all three entry points where a captain could merge unprompted:
  1. `CREW REVIEW`
  2. `CREW DONE` — previously bypassed entirely; a crew choosing `done` over `review` skipped the operator
  3. `CREW IDLE` — the "completed work but no CREW DONE" row said *"terminalize (`merge` + `crew close`)"*
- Skill **references** the template contract rather than restating it (altitude rule from #653), so no new drift pair is created.
- Corrected a factual error introduced mid-review: "the task is NOT terminal until you approve" is wrong for `CREW DONE`, which *is* terminal in the daemon, just re-openable via `crew send` (#148).

## Audit of all 9 templates + 16 skills

Method was mechanical, not eyeballing: every referenced command checked against `packages/cli/src/commands`, every referenced path and script checked for existence, plus text contradicting current behaviour.

- **5 hardcoded `/Applications/cmux.app/Contents/Resources/bin/cmux …` invocations** in `command-ops` replaced with `squadrant runtime list / stop / send / read-screen` (all four verified to exist).
- **Dead `read-status.sh`** removed — exists in neither the repo nor `~/.config/squadrant/scripts/`.
- **Two further dead `status.md` references** removed (`command-ops`, and `karpathy-principles`, where "report blockers in status.md" became `squadrant crew signal blocked`). Third and fourth instances of the #630 leftover.
- `templates/command.claude.md`: `cmux read-screen` → `squadrant runtime read-screen`.
- `templates/learnings.claude.md`: bare `mark-learning-useful.sh` → absolute path.
- `crew.generic.md` / `crew.opencode.md`: "captain will review and merge your branch" → "review your branch", consistent with the gate.

## Verification

- `pnpm build` ✅
- `pnpm test` ✅ — 184 files, **2430 tests passing**
- Dead-reference sweep across all 25 files returns clean for every pattern checked.

## Known follow-ups (deliberately not in this PR)

- `side.research.claude.md` / `side.debug.claude.md` say "send … via relay". Stale wording only — the command underneath is `squadrant runtime send`, which is alive. Cosmetic, left for the audit thread on #653.
