### PR TITLE
feat: operator takeover protocol (#649) + worktree base fix (#661)

### DIFF
--- a/packages/cli/src/commands/__tests__/crew-takeover.test.ts
+++ b/packages/cli/src/commands/__tests__/crew-takeover.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { runCrewTakeover } from "../crew-control.js";
+import type { TaskRecord, ControlEvent } from "@squadrant/shared";
+
+describe("crew takeover", () => {
+  let envSnapshot: NodeJS.ProcessEnv;
+  beforeEach(() => {
+    envSnapshot = { ...process.env };
+    delete process.env.SQUADRANT_CREW_TASK_ID;
+    delete process.env.SQUADRANT_CREW_PROJECT;
+  });
+  afterEach(() => {
+    process.env = { ...envSnapshot };
+  });
+
+  const fakeTask: TaskRecord = {
+    id: "t1", project: "p", provider: "claude", mode: "interactive",
+    name: "c1",
+    state: "working", task: "do something", createdAt: 1000,
+    lastHeartbeat: 1000, lastEvent: "task.started", heartbeatBudgetMs: 300000,
+    attempts: [],
+  };
+
+  it("emits takeover.started by project and name", async () => {
+    let emitted: ControlEvent | undefined;
+    let printed = "";
+    let sent = false;
+    
+    await runCrewTakeover("start", { project: "p", crew: "c1", note: "manual fix" }, {
+      listTasks: async () => [fakeTask],
+      emitEvent: async (_p, ev) => { emitted = ev; },
+      runtimeSend: async () => { sent = true; },
+      printError: () => {},
+      printSuccess: (msg) => { printed = msg; }
+    });
+
+    expect(emitted).toEqual({ type: "crew.takeover.started", id: "t1", note: "manual fix" });
+    expect(printed).toMatch(/CREW TAKEOVER/);
+    expect(sent).toBe(true);
+  });
+
+  it("emits takeover.started by --task-id", async () => {
+    let emitted: ControlEvent | undefined;
+    let printed = "";
+    let sent = false;
+
+    process.env.SQUADRANT_CREW_PROJECT = "p";
+
+    await runCrewTakeover("start", { taskId: "t1" }, {
+      listTasks: async () => [fakeTask],
+      emitEvent: async (_p, ev) => { emitted = ev; },
+      runtimeSend: async () => { sent = true; },
+      printError: () => {},
+      printSuccess: (msg) => { printed = msg; }
+    });
+
+    expect(emitted).toEqual({ type: "crew.takeover.started", id: "t1" });
+    expect(printed).toMatch(/CREW TAKEOVER/);
+    expect(sent).toBe(true);
+  });
+
+  it("emits takeover.ended for handback", async () => {
+    let emitted: ControlEvent | undefined;
+    let printed = "";
+    let sent = false;
+
+    process.env.SQUADRANT_CREW_PROJECT = "p";
+
+    await runCrewTakeover("end", { taskId: "t1" }, {
+      listTasks: async () => [fakeTask],
+      emitEvent: async (_p, ev) => { emitted = ev; },
+      runtimeSend: async () => { sent = true; },
+      printError: () => {},
+      printSuccess: (msg) => { printed = msg; }
+    });
+
+    expect(emitted).toEqual({ type: "crew.takeover.ended", id: "t1" });
+    expect(printed).toMatch(/CREW HANDBACK/);
+    expect(sent).toBe(true);
+  });
+
+  it("rejects unknown crew name", async () => {
+    await expect(
+      runCrewTakeover("start", { project: "p", crew: "unknown" }, {
+        listTasks: async () => [],
+        emitEvent: async () => {},
+        runtimeSend: async () => {},
+        printError: () => {},
+        printSuccess: () => {}
+      })
+    ).rejects.toThrow(/not found.*squadrant crew list/);
+  });
+});

--- a/packages/cli/src/commands/__tests__/crew.test.ts
+++ b/packages/cli/src/commands/__tests__/crew.test.ts
@@ -66,10 +66,11 @@ vi.mock("@squadrant/workspaces", () => ({
 const loadConfig = vi.hoisted(() => vi.fn());
 const addWorktree = vi.hoisted(() => vi.fn());
 const removeWorktree = vi.hoisted(() => vi.fn());
+const worktreeDirtyFiles = vi.hoisted(() => vi.fn().mockReturnValue([]));
 const resolveWorktreeBase = vi.hoisted(() => vi.fn().mockReturnValue("develop"));
 vi.mock("@squadrant/shared", async () => {
   const actual = await vi.importActual<typeof import("@squadrant/shared")>("@squadrant/shared");
-  return { ...actual, loadConfig, resolveHome: (p: string) => p, addWorktree, removeWorktree, resolveWorktreeBase };
+  return { ...actual, loadConfig, resolveHome: (p: string) => p, addWorktree, removeWorktree, resolveWorktreeBase, worktreeDirtyFiles };
 });
 
 const claudeDriver = vi.hoisted(() => ({
@@ -969,7 +970,7 @@ describe("squadrant crew send/read/close/list", () => {
 
     await runCrewClose("brove", "crew-1");
 
-    expect(removeWorktree).toHaveBeenCalledWith("/tmp/brove", wtPath);
+    expect(removeWorktree).toHaveBeenCalledWith("/tmp/brove", wtPath, undefined);
     expect(closePane).toHaveBeenCalled();
   });
 

--- a/packages/cli/src/commands/__tests__/crew.test.ts
+++ b/packages/cli/src/commands/__tests__/crew.test.ts
@@ -955,6 +955,28 @@ describe("squadrant crew send/read/close/list", () => {
     });
   });
 
+  it("close refuses to close pane or emit event if the worktree is dirty, throwing instead", async () => {
+    listSurfaces.mockResolvedValue([
+      { workspaceId: "workspace:5", surfaceId: "surface:10", title: "🔧 brove:crew-1" },
+    ]);
+    const wtPath = "/tmp/brove/.worktrees/brove-crew-1";
+    squadrantdCall.mockImplementation(async (req: unknown) => {
+      const r = req as { kind: string };
+      if (r.kind === "list") {
+        return [{ id: "task-wt-1", name: "crew-1", project: "brove", state: "done", provider: "claude", mode: "interactive", task: "task", cwd: wtPath, createdAt: 1000, lastHeartbeat: 1000, lastEvent: "task.done", heartbeatBudgetMs: 300000, attempts: [] }];
+      }
+      return undefined;
+    });
+
+    worktreeDirtyFiles.mockReturnValueOnce(["uncommitted.txt"]);
+
+    await expect(runCrewClose("brove", "crew-1")).rejects.toThrow(/uncommitted files/i);
+
+    expect(squadrantdCall).not.toHaveBeenCalledWith(expect.objectContaining({ kind: "event", event: { type: "task.cancelled", id: "task-wt-1" } }));
+    expect(closePane).not.toHaveBeenCalled();
+    expect(removeWorktree).not.toHaveBeenCalled();
+  });
+
   it("close removes the crew's worktree when its task ran in one (cwd != root)", async () => {
     listSurfaces.mockResolvedValue([
       { workspaceId: "workspace:5", surfaceId: "surface:10", title: "🔧 brove:crew-1" },

--- a/packages/cli/src/commands/__tests__/crew.test.ts
+++ b/packages/cli/src/commands/__tests__/crew.test.ts
@@ -963,7 +963,7 @@ describe("squadrant crew send/read/close/list", () => {
     squadrantdCall.mockImplementation(async (req: unknown) => {
       const r = req as { kind: string };
       if (r.kind === "list") {
-        return [{ id: "task-wt-1", name: "crew-1", project: "brove", state: "done", provider: "claude", mode: "interactive", task: "task", cwd: wtPath, createdAt: 1000, lastHeartbeat: 1000, lastEvent: "task.done", heartbeatBudgetMs: 300000, attempts: [] }];
+        return [{ id: "task-wt-1", name: "crew-1", project: "brove", state: "working", provider: "claude", mode: "interactive", task: "task", cwd: wtPath, createdAt: 1000, lastHeartbeat: 1000, lastEvent: "task.started", heartbeatBudgetMs: 300000, attempts: [] }];
       }
       return undefined;
     });
@@ -972,7 +972,10 @@ describe("squadrant crew send/read/close/list", () => {
 
     await expect(runCrewClose("brove", "crew-1")).rejects.toThrow(/uncommitted files/i);
 
-    expect(squadrantdCall).not.toHaveBeenCalledWith(expect.objectContaining({ kind: "event", event: { type: "task.cancelled", id: "task-wt-1" } }));
+    // Verify it NEVER emitted an event
+    expect(squadrantdCall).not.toHaveBeenCalledWith(expect.objectContaining({ 
+      kind: "event", 
+    }));
     expect(closePane).not.toHaveBeenCalled();
     expect(removeWorktree).not.toHaveBeenCalled();
   });

--- a/packages/cli/src/commands/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/__tests__/diff.test.ts
@@ -297,7 +297,10 @@ describe("diffCommand action", () => {
     squadrantdCall.mockResolvedValue([
       { id: "t1", name: "fix-579", cwd: "/repo/.worktrees/brove-fix-579", createdAt: 1 },
     ]);
-    execFileSync.mockReturnValue(" 1 file changed, 2 insertions(+)\n");
+    execFileSync.mockImplementation((_cmd: string, args: string[]) => {
+      if (args.includes("rev-parse")) return "develop\n";
+      return " 1 file changed, 2 insertions(+)\n";
+    });
     await runAction("brove", "fix-579", { layout: "unified", lastTurn: true, focus: false });
     expect(showDiff).toHaveBeenCalledWith({
       workspaceId: "workspace:1",
@@ -314,7 +317,10 @@ describe("diffCommand action", () => {
   it("diffs base...HEAD on the root checkout for a --shared crew", async () => {
     loadConfig.mockReturnValue({ projects: { brove: { path: "/repo", captainName: "brove-captain" } } });
     squadrantdCall.mockResolvedValue([{ id: "t1", name: "quick-fix", cwd: "/repo", createdAt: 1 }]);
-    execFileSync.mockReturnValue(" 1 file changed, 1 insertion(+)\n");
+    execFileSync.mockImplementation((_cmd: string, args: string[]) => {
+      if (args.includes("rev-parse")) return "develop\n";
+      return " 1 file changed, 1 insertion(+)\n";
+    });
     await runAction("brove", "quick-fix");
     expect(execFileSync).toHaveBeenCalledWith(
       "git", ["-C", "/repo", "diff", "--stat", "develop...HEAD"], expect.any(Object),

--- a/packages/cli/src/commands/crew-control.ts
+++ b/packages/cli/src/commands/crew-control.ts
@@ -91,6 +91,56 @@ export function buildGateResolveRequest(o: { project: string; gateId: string; me
   };
 }
 
+export async function runCrewTakeover(
+  mode: "start" | "end",
+  opts: { project?: string; crew?: string; taskId?: string; note?: string },
+  deps: {
+    listTasks: (project?: string) => Promise<TaskRecord[]>;
+    emitEvent: (project: string, event: ControlEvent) => Promise<void>;
+    runtimeSend: (project: string, message: string) => Promise<void>;
+    printError: (msg: string) => void;
+    printSuccess: (msg: string) => void;
+  }
+): Promise<TaskRecord> {
+  const taskId = opts.taskId ?? process.env.SQUADRANT_CREW_TASK_ID;
+  let project = opts.project ?? process.env.SQUADRANT_CREW_PROJECT;
+  let target: TaskRecord | undefined;
+
+  if (taskId) {
+    if (!project) {
+       // if we don't have project, list all tasks across all projects? No, `squadrant crew signal` requires both to be set from env or explicitly.
+       throw new Error("not running under a crew (SQUADRANT_CREW_PROJECT unset)");
+    }
+    const tasks = await deps.listTasks(project);
+    target = tasks.find(t => t.id === taskId);
+    if (!target) throw new Error(`Task '${taskId}' not found for project '${project}'`);
+  } else if (project && opts.crew) {
+    const tasks = await deps.listTasks(project);
+    target = resolveApproveTarget(tasks, opts.crew) || undefined;
+    if (!target) throw new Error(`Crew '${opts.crew}' not found for ${project}. Run 'squadrant crew list ${project}'.`);
+  } else {
+    throw new Error("must provide either <project> <crew> or --task-id");
+  }
+
+  const nameDisp = (project && opts.crew) ? `${project}/${opts.crew}` : (target.name ? `${target.project}/${target.name}` : `${target.project}/${target.id}`);
+
+  if (mode === "start") {
+    const event: ControlEvent = { type: "crew.takeover.started", id: target.id, ...(opts.note !== undefined ? { note: opts.note } : {}) };
+    await deps.emitEvent(target.project, event);
+    const msg = `CREW TAKEOVER [${nameDisp}] — operator is driving this tab. Do not send, do not close, do not act on its signals until handback.`;
+    await deps.runtimeSend(target.project, msg);
+    deps.printSuccess(msg);
+  } else {
+    const event: ControlEvent = { type: "crew.takeover.ended", id: target.id };
+    await deps.emitEvent(target.project, event);
+    const msg = `CREW HANDBACK [${nameDisp}] — operator returned control. State: ${target.state}. Run 'squadrant crew read ${target.project} ${target.name || target.id}' before acting; the tab has history you did not see.`;
+    await deps.runtimeSend(target.project, msg);
+    deps.printSuccess(msg);
+  }
+
+  return target;
+}
+
 export async function squadrantdCall(req: unknown): Promise<unknown> {
   try {
     return await sendRequest(SOCK, req);
@@ -476,6 +526,54 @@ export function addControlPlaneCrewCommands(crew: Command): void {
       try {
         const prUrl = await runCrewApprove(project, crewName, { call: squadrantdCall });
         process.stdout.write(`✔ Approved ${crewBranch(crewName)} — pushed + PR opened: ${prUrl}\n`);
+      } catch (e) {
+        process.stderr.write(`${(e as Error).message}\n`);
+        process.exit(1);
+      }
+    });
+
+  // #649: operator takeover and handback
+  crew
+    .command("takeover [project] [crewName]")
+    .description("Take over a crew's tab explicitly, suppressing captain action until handback (#649)")
+    .option("--task-id <id>", "Explicit task id (overrides SQUADRANT_CREW_TASK_ID env)")
+    .option("--note <note>", "Optional note explaining the takeover")
+    .action(async (project: string | undefined, crewName: string | undefined, opts: { taskId?: string; note?: string }) => {
+      try {
+        await runCrewTakeover("start", { project, crew: crewName, taskId: opts.taskId, note: opts.note }, {
+          listTasks: async (p) => (await squadrantdCall({ kind: "list", project: p })) as TaskRecord[],
+          emitEvent: async (p, event) => { await squadrantdCall({ kind: "event", project: p, event }); },
+          runtimeSend: async (p, msg) => {
+            const { runRuntimeSend } = await import("./runtime.js");
+            await runRuntimeSend(p, msg, {});
+          },
+          printError: (msg) => { process.stderr.write(`${msg}\n`); },
+          printSuccess: (msg) => { process.stdout.write(`✔ ${msg}\n`); }
+        });
+        process.exit(0);
+      } catch (e) {
+        process.stderr.write(`${(e as Error).message}\n`);
+        process.exit(1);
+      }
+    });
+
+  crew
+    .command("handback [project] [crewName]")
+    .description("Return control of a held crew tab to the captain (#649)")
+    .option("--task-id <id>", "Explicit task id (overrides SQUADRANT_CREW_TASK_ID env)")
+    .action(async (project: string | undefined, crewName: string | undefined, opts: { taskId?: string }) => {
+      try {
+        await runCrewTakeover("end", { project, crew: crewName, taskId: opts.taskId }, {
+          listTasks: async (p) => (await squadrantdCall({ kind: "list", project: p })) as TaskRecord[],
+          emitEvent: async (p, event) => { await squadrantdCall({ kind: "event", project: p, event }); },
+          runtimeSend: async (p, msg) => {
+            const { runRuntimeSend } = await import("./runtime.js");
+            await runRuntimeSend(p, msg, {});
+          },
+          printError: (msg) => { process.stderr.write(`${msg}\n`); },
+          printSuccess: (msg) => { process.stdout.write(`✔ ${msg}\n`); }
+        });
+        process.exit(0);
       } catch (e) {
         process.stderr.write(`${(e as Error).message}\n`);
         process.exit(1);

--- a/packages/cli/src/commands/crew-output.ts
+++ b/packages/cli/src/commands/crew-output.ts
@@ -63,5 +63,23 @@ export function formatCompactTasks(
   if (opts.compact === false) {
     return JSON.stringify(records, null, 2);
   }
-  return records.map(formatTaskLine).join("\n");
+  const active = records.filter(r => !r.operatorHold);
+  const held = records.filter(r => r.operatorHold);
+  
+  let out = "";
+  if (active.length > 0) {
+    if (held.length > 0) out += `active (${active.length}):\n`;
+    out += active.map(r => (held.length > 0 ? "  " : "") + formatTaskLine(r)).join("\n");
+  }
+  if (held.length > 0) {
+    if (out) out += "\n";
+    out += `HELD BY OPERATOR (${held.length}) — not counted toward maxCrew:\n`;
+    out += held.map(r => {
+      const m = Math.round((Date.now() - r.operatorHold!.since) / 60000);
+      const hm = m >= 60 ? `${Math.floor(m / 60)}h${m % 60}m` : `${m}m`;
+      const note = r.operatorHold!.note ? ` · "${r.operatorHold!.note}"` : "";
+      return `  ${formatTaskLine(r)} · held ${hm}${note}`;
+    }).join("\n");
+  }
+  return out;
 }

--- a/packages/cli/src/commands/crew.ts
+++ b/packages/cli/src/commands/crew.ts
@@ -56,6 +56,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<{ title?: str
           `routed: tier=${route.tier} → ${route.agent}${route.model ? `/${route.model}` : ""} (rule: "${route.matchedRule}")`,
         ),
       ),
+    onBaseResolved: (base) => console.log(chalk.dim(`base: ${base}`)),
   });
 }
 

--- a/packages/cli/src/commands/crew.ts
+++ b/packages/cli/src/commands/crew.ts
@@ -14,7 +14,7 @@ import {
   type ResolvedAgent,
 } from "@squadrant/core";
 import type { TaskRecord } from "@squadrant/shared";
-import { buildDispatchRequest, squadrantdCall, sendCodexFirstTurn } from "./crew-control.js";
+import { buildDispatchRequest, squadrantdCall, sendCodexFirstTurn, resolveApproveTarget } from "./crew-control.js";
 import { tailLines } from "./crew-output.js";
 import { writePerCrewSettingsLocal, writePerCrewOpencodeConfig } from "../lib/per-crew-settings.js";
 
@@ -156,8 +156,35 @@ crewCommand
         console.log(chalk.yellow(`No live crew sessions for ${project}.`));
         return;
       }
+      
+      const tasks = await squadrantdCall({ kind: "list", project }).catch(() => []) as TaskRecord[];
+      const active: any[] = [];
+      const held: any[] = [];
+
       for (const c of crews) {
-        console.log(`  ${c.name}  (${c.surfaceId})`);
+        const task = tasks.find(t => t.name === c.name); // pickMostRecent?
+        const t = task ? resolveApproveTarget(tasks, c.name) : undefined;
+        if (t?.operatorHold) {
+          held.push({ c, t });
+        } else {
+          active.push({ c, t });
+        }
+      }
+
+      if (active.length > 0) {
+        console.log(`active (${active.length}):`);
+        for (const { c, t } of active) {
+          console.log(`  ${c.name.padEnd(10)} ${t ? t.state : "unknown"}  (${c.surfaceId})`);
+        }
+      }
+      if (held.length > 0) {
+        console.log(`HELD BY OPERATOR (${held.length}) — not counted toward maxCrew:`);
+        for (const { c, t } of held) {
+          const m = Math.round((Date.now() - t.operatorHold.since) / 60000);
+          const hm = m >= 60 ? `${Math.floor(m / 60)}h${m % 60}m` : `${m}m`;
+          const note = t.operatorHold.note ? ` · "${t.operatorHold.note}"` : "";
+          console.log(`  ${c.name.padEnd(10)} ${t.state} · held ${hm}${note}  (${c.surfaceId})`);
+        }
       }
     } catch (err) {
       console.error(chalk.red((err as Error).message));

--- a/packages/cli/src/commands/crew.ts
+++ b/packages/cli/src/commands/crew.ts
@@ -59,7 +59,7 @@ export async function runCrewSpawn(input: CrewSpawnInput): Promise<{ title?: str
   });
 }
 
-export async function runCrewSend(project: string, name: string, message: string): Promise<void> {
+export async function runCrewSend(project: string, name: string, message: string, opts?: { force?: boolean }): Promise<void> {
   const { runtime, workspaceId } = await resolveCaptainWorkspace(project);
   return coreRunCrewSend(project, name, message, runtime, workspaceId, {
     listTasks: async (p) => (await squadrantdCall({ kind: "list", project: p })) as TaskRecord[],
@@ -69,7 +69,7 @@ export async function runCrewSend(project: string, name: string, message: string
     sendToPane: (pane, msg) => confirmedSendToPane(runtime, pane, msg),
     // #516: side-effect-free modal precheck, run before any daemon-state emit.
     isBlockedByModal: (pane) => paneHasOpenModal(runtime, pane),
-  });
+  }, opts);
 }
 
 export async function runCrewRead(project: string, name: string): Promise<string> {
@@ -77,13 +77,13 @@ export async function runCrewRead(project: string, name: string): Promise<string
   return coreRunCrewRead(project, name, runtime, workspaceId);
 }
 
-export async function runCrewClose(project: string, name: string): Promise<void> {
+export async function runCrewClose(project: string, name: string, opts?: { force?: boolean }): Promise<void> {
   const { runtime, workspaceId } = await resolveCaptainWorkspace(project);
   return coreRunCrewClose(project, name, runtime, workspaceId, {
     listTasks: async (p) => (await squadrantdCall({ kind: "list", project: p })) as TaskRecord[],
     emitEvent: async (p, event) => { await squadrantdCall({ kind: "event", project: p, event }); },
     closeCodexThread: async (taskId) => { await squadrantdCall({ kind: "codex-close", taskId }); },
-  });
+  }, opts);
 }
 
 export async function runCrewList(project: string): Promise<Array<{ name: string; surfaceId: string }>> {
@@ -172,13 +172,14 @@ crewCommand
   .argument("<name>", "Crew name (e.g. crew-1)")
   .argument("[message]", "Message to send (omit with --message-file)")
   .option("--message-file <path>", "Read message from file instead of positional arg ('-' for stdin)")
-  .action(async (project: string, name: string, message: string | undefined, opts: { messageFile?: string }) => {
+  .option("--force", "override an operator takeover (only when the operator told you to)", false)
+  .action(async (project: string, name: string, message: string | undefined, opts: { messageFile?: string; force?: boolean }) => {
     try {
       const resolvedMessage = await resolveTextInput({ positional: message, filePath: opts.messageFile, label: "message" });
-      await runCrewSend(project, name, resolvedMessage);
+      await runCrewSend(project, name, resolvedMessage, opts);
       console.log(chalk.green(`✔ Sent to ${project}:${name}`));
-    } catch (err) {
-      console.error(chalk.red((err as Error).message));
+    } catch (e) {
+      console.error(chalk.red((e as Error).message));
       process.exit(1);
     }
   });
@@ -206,9 +207,10 @@ crewCommand
   .description("Shutdown a crew session (closes its tab)")
   .argument("<project>", "Project name")
   .argument("<name>", "Crew name")
-  .action(async (project: string, name: string) => {
+  .option("--force", "override an operator takeover (only when the operator told you to)", false)
+  .action(async (project: string, name: string, opts: { force?: boolean }) => {
     try {
-      await runCrewClose(project, name);
+      await runCrewClose(project, name, opts);
       console.log(chalk.green(`✔ Closed ${project}:${name}`));
     } catch (err) {
       console.error(chalk.red((err as Error).message));

--- a/packages/cli/src/lib/handoff-facts.ts
+++ b/packages/cli/src/lib/handoff-facts.ts
@@ -35,6 +35,7 @@ export interface LiveCrewSummary {
   state: string;
   task: string;
   question?: string;
+  operatorHold?: { since: number; note?: string; lastNudgeAt?: number };
 }
 
 export interface HandoffConflict {

--- a/packages/cli/src/lib/handoff-live-repo.ts
+++ b/packages/cli/src/lib/handoff-live-repo.ts
@@ -93,7 +93,7 @@ function gatherOpenPRs(runner: CommandRunner, projectPath: string): LiveOpenPR[]
 function gatherLiveCrews(tasks: TaskRecord[]): LiveCrewSummary[] {
   return tasks
     .filter((t) => !TERMINAL_STATES.has(t.state))
-    .map((t) => ({ name: t.name ?? t.id, state: t.state, task: t.task, question: t.question }));
+    .map((t) => ({ name: t.name ?? t.id, state: t.state, task: t.task, question: t.question, operatorHold: t.operatorHold }));
 }
 
 /** ahead_by from GitHub's compare API — exact, server-computed, no local objects needed. Only meaningful for a PUSHED branch. */

--- a/packages/core/src/__tests__/crew-spawn.test.ts
+++ b/packages/core/src/__tests__/crew-spawn.test.ts
@@ -602,6 +602,16 @@ describe("runCrewSpawn", () => {
 // ─── runCrewSend ─────────────────────────────────────────────────────────────
 
 describe("runCrewSend", () => {
+  it("refuses to send to a crew under operator takeover", async () => {
+    const held = { id: "t1", name: "c1", state: "working", operatorHold: { since: 1000 } } as TaskRecord;
+    await expect(
+      runCrewSend(PROJECT, "c1", "message", makeRuntime("ws:1", [{ workspaceId: "ws:1", surfaceId: "p:1", title: "🔧 myproj:c1", type: "pane" } as any]), "ws:1", {
+        listTasks: async () => [held],
+        emitEvent: vi.fn(),
+      }),
+    ).rejects.toThrow(/operator takeover/i);
+  });
+
   it("throws when crew pane not found", async () => {
     const runtime = makeRuntime("ws:1", []);
     await expect(
@@ -821,6 +831,39 @@ describe("runCrewList", () => {
 // ─── runCrewClose ────────────────────────────────────────────────────────────
 
 describe("runCrewClose", () => {
+  it("refuses to close a crew under operator takeover", async () => {
+    const held = { id: "t1", name: "c1", state: "done", operatorHold: { since: 1000 } } as TaskRecord;
+    await expect(
+      runCrewClose(PROJECT, "c1", makeRuntime("ws:1", [{ workspaceId: "ws:1", surfaceId: "p:1", title: "🔧 myproj:c1", type: "pane" } as any]), "ws:1", {
+        listTasks: async () => [held],
+        emitEvent: vi.fn(),
+        closeCodexThread: vi.fn(),
+      }),
+    ).rejects.toThrow(/operator takeover/i);
+  });
+
+  it("emits no event when it refuses to close", async () => {
+    const held = { id: "t1", name: "c1", state: "done", operatorHold: { since: 1000 } } as TaskRecord;
+    const emitted: ControlEvent[] = [];
+    await runCrewClose(PROJECT, "c1", makeRuntime("ws:1", [{ workspaceId: "ws:1", surfaceId: "p:1", title: "🔧 myproj:c1", type: "pane" } as any]), "ws:1", {
+      listTasks: async () => [held],
+      emitEvent: async (_p, e) => { emitted.push(e); },
+      closeCodexThread: vi.fn(),
+    }).catch(() => {});
+    expect(emitted).toEqual([]);   // must not terminalize then bail
+  });
+
+  it("closes a held crew when force is set", async () => {
+    const held = { id: "t1", name: "c1", state: "working", operatorHold: { since: 1000 }, cwd: "/tmp/foo" } as TaskRecord;
+    const emitted: ControlEvent[] = [];
+    await runCrewClose(PROJECT, "c1", makeRuntime("ws:1", [{ workspaceId: "ws:1", surfaceId: "p:1", title: "🔧 myproj:c1", type: "pane" } as any]), "ws:1", {
+      listTasks: async () => [held],
+      emitEvent: async (_p, e) => { emitted.push(e); },
+      closeCodexThread: vi.fn(),
+    }, { force: true });
+    expect(emitted).not.toEqual([]);
+  });
+
   it("throws when neither pane nor daemon task found", async () => {
     const runtime = makeRuntime("ws:1", []);
     await expect(

--- a/packages/core/src/__tests__/crew-spawn.test.ts
+++ b/packages/core/src/__tests__/crew-spawn.test.ts
@@ -15,6 +15,8 @@ const resolveWorktreeBaseMock = vi.hoisted(() => vi.fn().mockReturnValue("main")
 const removeWorktreeMock = vi.hoisted(() => vi.fn());
 const loadConfigMock = vi.hoisted(() => vi.fn());
 
+const worktreeDirtyFilesMock = vi.hoisted(() => vi.fn().mockReturnValue([]));
+
 vi.mock("@squadrant/shared", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@squadrant/shared")>();
   return {
@@ -22,6 +24,7 @@ vi.mock("@squadrant/shared", async (importOriginal) => {
     addWorktree: addWorktreeMock,
     resolveWorktreeBase: resolveWorktreeBaseMock,
     removeWorktree: removeWorktreeMock,
+    worktreeDirtyFiles: worktreeDirtyFilesMock,
     loadConfig: loadConfigMock,
   };
 });
@@ -1049,7 +1052,7 @@ describe("runCrewClose", () => {
       sleep: vi.fn().mockResolvedValue(undefined),
     });
 
-    expect(removeWorktreeMock).toHaveBeenCalledWith(PROJ_PATH, newWorktree);
-    expect(removeWorktreeMock).not.toHaveBeenCalledWith(PROJ_PATH, oldWorktree);
+    expect(removeWorktreeMock).toHaveBeenCalledWith(PROJ_PATH, newWorktree, undefined);
+    expect(removeWorktreeMock).not.toHaveBeenCalledWith(PROJ_PATH, oldWorktree, undefined);
   });
 });

--- a/packages/core/src/__tests__/daemon.test.ts
+++ b/packages/core/src/__tests__/daemon.test.ts
@@ -1531,6 +1531,70 @@ describe("sweep: terminal record overflow prune (#457)", () => {
 
 // ── Issue #457: suppress ghost CREW TIMEOUT when surface is gone ────────────
 
+describe("sweep: operatorHold nudge (#649)", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "cp-daemon-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it("never auto-releases a takeover, however old", async () => {
+    const store = createStore(dir);
+    const ancient = rec("t1", { state: "done", operatorHold: { since: 0 } });
+    store.put(ancient);
+    const d = createDaemon({ store, now: () => 1000 * 60 * 60 * 24 * 6 }); // 6 days
+    await d.sweep();
+    const after = store.get("p", "t1")!;
+    expect(after.operatorHold).toBeDefined();
+    expect(after.operatorHold?.since).toBe(0);
+  });
+
+  it("nudges once past the threshold, stamps lastNudgeAt, and does not re-nudge before the interval", async () => {
+    const store = createStore(dir);
+    const held = rec("t1", { state: "done", operatorHold: { since: 1000 }, firstTurnConfirmedAt: 1000 });
+    store.put(held);
+    const calls: any[] = [];
+    const d = createDaemon({ 
+      store, 
+      now: () => 1000 + 7 * 3600000, // 7h (past 6h default threshold)
+      notify: async (a) => { calls.push(a); },
+      takeoverNudgeHours: 6
+    });
+
+    await d.sweep();
+    expect(calls.length).toBe(1);
+    expect(calls[0].message).toMatch(/CREW HELD-LONG.*held 7h/);
+
+    const afterFirst = store.get("p", "t1")!;
+    expect(afterFirst.operatorHold?.lastNudgeAt).toBe(1000 + 7 * 3600000);
+
+    // Second sweep before interval
+    const d2 = createDaemon({ 
+      store, 
+      now: () => 1000 + 10 * 3600000, // 10h (only 3h since last nudge)
+      notify: async (a) => { calls.push(a); },
+      takeoverNudgeHours: 6
+    });
+    await d2.sweep();
+    expect(calls.length).toBe(1); // No new nudges
+  });
+
+  it("re-nudges after the interval elapses again", async () => {
+    const store = createStore(dir);
+    const held = rec("t1", { state: "done", operatorHold: { since: 1000, lastNudgeAt: 1000 + 7 * 3600000 }, firstTurnConfirmedAt: 1000 });
+    store.put(held);
+    const calls: any[] = [];
+    const d = createDaemon({ 
+      store, 
+      now: () => 1000 + 14 * 3600000, // 14h (7h since last nudge)
+      notify: async (a) => { calls.push(a); },
+      takeoverNudgeHours: 6
+    });
+
+    await d.sweep();
+    expect(calls.length).toBe(1);
+    expect(calls[0].message).toMatch(/CREW HELD-LONG.*held 14h/);
+  });
+});
+
 describe("sweep: ghost CREW TIMEOUT suppression (#457)", () => {
   let dir: string;
   beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "cp-ghost-")); });

--- a/packages/core/src/__tests__/daemon.test.ts
+++ b/packages/core/src/__tests__/daemon.test.ts
@@ -755,6 +755,17 @@ describe("daemon – blocked crew resume path (#183)", () => {
     expect(calls[0].message).toBe("CREW DONE [claude/t-ds]: implement the thing");
   });
 
+  it("does not push CREW DONE for a crew under operator takeover (#649)", async () => {
+    // A held crew finishing the OPERATOR's ad-hoc work must not tell the captain
+    // the delegated task is done — that is the exact misleading signal from prism-app.
+    const store = createStore(dir);
+    store.put(rec("t-held", { state: "working", operatorHold: { since: 1000 } }));
+    const calls: any[] = [];
+    const d = createDaemon({ store, now: () => 2000, notify: async (a) => { calls.push(a); } });
+    await d.handle({ kind: "event", project: "p", event: { type: "task.done", id: "t-held", resultRef: "/r" } });
+    expect(calls).toEqual([]);
+  });
+
   // ── #599: review-gate checkpoint ───────────────────────────────────────────
   describe("CREW REVIEW (#599)", () => {
     it("working + task.review → state 'review' (NOT terminal) and fires CREW REVIEW with the crew's summary", async () => {

--- a/packages/core/src/__tests__/daemon.test.ts
+++ b/packages/core/src/__tests__/daemon.test.ts
@@ -1536,6 +1536,26 @@ describe("sweep: operatorHold nudge (#649)", () => {
   beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "cp-daemon-")); });
   afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
 
+  it("handles crew.takeover.started and crew.takeover.ended without throwing unknown event type", async () => {
+    const store = createStore(dir);
+    store.put(rec("t1", { state: "working" }));
+    const d = createDaemon({ store, now: () => 2000 });
+    
+    await expect(
+      d.handle({ kind: "event", project: "p", event: { type: "crew.takeover.started", id: "t1" } })
+    ).resolves.not.toThrow();
+
+    const afterStart = store.get("p", "t1")!;
+    expect(afterStart.operatorHold).toBeDefined();
+
+    await expect(
+      d.handle({ kind: "event", project: "p", event: { type: "crew.takeover.ended", id: "t1" } })
+    ).resolves.not.toThrow();
+
+    const afterEnd = store.get("p", "t1")!;
+    expect(afterEnd.operatorHold).toBeUndefined();
+  });
+
   it("never auto-releases a takeover, however old", async () => {
     const store = createStore(dir);
     const ancient = rec("t1", { state: "done", operatorHold: { since: 0 } });

--- a/packages/core/src/__tests__/state-machine.test.ts
+++ b/packages/core/src/__tests__/state-machine.test.ts
@@ -509,3 +509,42 @@ describe("reducer · resumeRef-on-every-transition", () => {
     expect(r.state).toBe("working");
   });
 });
+
+describe("operator takeover (#649)", () => {
+  const base = (over: Partial<TaskRecord> = {}): TaskRecord => ({
+    id: "t1", project: "p", provider: "claude", mode: "interactive",
+    state: "working", task: "x", createdAt: 0, lastHeartbeat: 0,
+    lastEvent: "task.started", heartbeatBudgetMs: 1000, attempts: [],
+    ...over,
+  });
+
+  it("records a takeover on a working task without changing state", () => {
+    const next = reduce(base(), { type: "crew.takeover.started", id: "t1", note: "local stack" }, 5000);
+    expect(next.state).toBe("working");
+    expect(next.operatorHold).toEqual({ since: 5000, note: "local stack" });
+  });
+
+  // THE load-bearing case: prism-app's crew was `done` when the operator adopted it.
+  it("records a takeover on a DONE (terminal) task", () => {
+    const next = reduce(base({ state: "done" }), { type: "crew.takeover.started", id: "t1" }, 5000);
+    expect(next.state).toBe("done");
+    expect(next.operatorHold?.since).toBe(5000);
+  });
+
+  it("handback clears the hold and leaves state untouched", () => {
+    const held = reduce(base({ state: "done" }), { type: "crew.takeover.started", id: "t1" }, 5000);
+    const next = reduce(held, { type: "crew.takeover.ended", id: "t1" }, 9000);
+    expect(next.state).toBe("done");
+    expect(next.operatorHold).toBeUndefined();
+  });
+
+  it("a second takeover is idempotent — `since` does not drift", () => {
+    const a = reduce(base(), { type: "crew.takeover.started", id: "t1" }, 5000);
+    const b = reduce(a, { type: "crew.takeover.started", id: "t1" }, 8000);
+    expect(b.operatorHold?.since).toBe(5000);
+  });
+
+  it("handback with no hold is a no-op, not a throw", () => {
+    expect(() => reduce(base(), { type: "crew.takeover.ended", id: "t1" }, 5000)).not.toThrow();
+  });
+});

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -592,13 +592,11 @@ const CLOSE_LOOKUP_RETRY_DELAY_MS = 150;
 
 function buildRecoveryHint(sessId: string | undefined, provider: string | undefined, worktreeCwd: string | undefined): string {
   if (!sessId || !worktreeCwd) return "";
-  // #649: opencode is a fork of Claude Code and shares the transcript layout
-  // (`~/.opencode/projects/...`) and the `--resume` CLI flag.
-  if (provider === "claude" || provider === "opencode") {
-    const baseDir = provider === "opencode" ? ".opencode" : ".claude";
+  // opencode keeps sessions in a sqlite db so there is no transcript file path to print.
+  if (provider === "claude") {
     const escaped = worktreeCwd.replace(/[^a-zA-Z0-9]/g, "-");
-    const transcriptPath = path.join(os.homedir(), baseDir, "projects", escaped, `${sessId}.jsonl`);
-    return `\ntranscript: ${transcriptPath}\nresume:     ${provider} --resume ${sessId}   (run from the worktree path above)\n`;
+    const transcriptPath = path.join(os.homedir(), ".claude", "projects", escaped, `${sessId}.jsonl`);
+    return `\ntranscript: ${transcriptPath}\nresume:     claude --resume ${sessId}   (run from the worktree path above)\n`;
   }
   return "";
 }

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -590,6 +590,19 @@ export async function runCrewRead(
 const CLOSE_LOOKUP_RETRIES = 3;
 const CLOSE_LOOKUP_RETRY_DELAY_MS = 150;
 
+function buildRecoveryHint(sessId: string | undefined, provider: string | undefined, worktreeCwd: string | undefined): string {
+  if (!sessId || !worktreeCwd) return "";
+  // #649: opencode is a fork of Claude Code and shares the transcript layout
+  // (`~/.opencode/projects/...`) and the `--resume` CLI flag.
+  if (provider === "claude" || provider === "opencode") {
+    const baseDir = provider === "opencode" ? ".opencode" : ".claude";
+    const escaped = worktreeCwd.replace(/[^a-zA-Z0-9]/g, "-");
+    const transcriptPath = path.join(os.homedir(), baseDir, "projects", escaped, `${sessId}.jsonl`);
+    return `\ntranscript: ${transcriptPath}\nresume:     ${provider} --resume ${sessId}   (run from the worktree path above)\n`;
+  }
+  return "";
+}
+
 export async function runCrewClose(
   project: string,
   name: string,
@@ -608,6 +621,62 @@ export async function runCrewClose(
   // resolveCaptainWorkspace already validated the project exists; reload for its
   // root path so we can tell a worktree crew (cwd != root) from a root crew.
   const projRoot = loadConfig().projects[project]?.path;
+
+  let matches: TaskRecord[] = [];
+  try {
+    matches = (await deps.listTasks(project)).filter((t) => t.name === name);
+    // #513: the record may not be registered yet (close raced spawn's own
+    // dispatch). Retry briefly before concluding this crew has no daemon task.
+    for (let attempt = 0; attempt < CLOSE_LOOKUP_RETRIES && matches.length === 0; attempt++) {
+      await sleep(CLOSE_LOOKUP_RETRY_DELAY_MS);
+      matches = (await deps.listTasks(project)).filter((t) => t.name === name);
+    }
+  } catch {
+    // Swallow daemon errors — a crew without a daemon must still close.
+  }
+
+  let taskId: string | undefined;
+  let worktreeCwd: string | undefined;
+  let sessId: string | undefined;
+  let provider: string | undefined;
+
+  if (matches.length > 0) {
+    // #513: a name can match more than one record (e.g. an orphaned record
+    // left by a prior close that raced dispatch, followed by a same-name
+    // respawn). Terminalize every non-terminal match so none linger to fire
+    // a phantom CREW STALLED/IDLE later. Reap/worktree cleanup below anchors
+    // on the most-recently-dispatched match — the one the live pane belongs to.
+    const primary = pickMostRecentTask(matches);
+    taskId = primary.id;
+    sessId = primary.sessionId;
+    provider = primary.provider;
+    if (primary.cwd && projRoot && primary.cwd !== projRoot) {
+      worktreeCwd = primary.cwd;
+    }
+
+    if (primary.operatorHold && !opts?.force) {
+      const heldForMin = Math.round((Date.now() - primary.operatorHold.since) / 60000);
+      throw new Error(
+        `Crew '${name}' is under operator takeover (held ${heldForMin}m` +
+          `${primary.operatorHold.note ? `: ${primary.operatorHold.note}` : ""}). ` +
+          `The operator is working in that tab — closing it kills their session and prunes the worktree. ` +
+          `Ask them to run 'squadrant crew handback ${project} ${name}', or pass --force if they told you to.`,
+      );
+    }
+  }
+
+  // Pre-check dirty worktree before ANY mutation (#649)
+  if (worktreeCwd && projRoot) {
+    const dirty = worktreeDirtyFiles(worktreeCwd);
+    if (dirty.length > 0 && !opts?.force) {
+      const transcriptStr = buildRecoveryHint(sessId, provider, worktreeCwd);
+      throw new Error(
+        `Worktree '${worktreeCwd}' has uncommitted files:\n${dirty.map(f => `  ${f}`).join("\n")}\n` +
+        `Why are they uncommitted? Commit them, or pass --force to destroy them.\n${transcriptStr}`
+      );
+    }
+  }
+
   // Terminalize the daemon task FIRST — before (and independent of) finding the
   // cmux pane (#184, hardened for #139). Without this, non-terminal tasks
   // (blocked/working/awaiting-input) linger in the daemon ledger and keep firing
@@ -615,40 +684,8 @@ export async function runCrewClose(
   // so gating terminalization on findCrew (the old order) left zombie records
   // dangling forever. 'cancelled' is terminal but NOT in ATTENTION_STATES, so
   // firePush stays silent — captain initiated the close.
-  let taskId: string | undefined;
-  let worktreeCwd: string | undefined;
-  let sessId: string | undefined;
-  let provider: string | undefined;
-  try {
-    let matches = (await deps.listTasks(project)).filter((t) => t.name === name);
-    // #513: the record may not be registered yet (close raced spawn's own
-    // dispatch). Retry briefly before concluding this crew has no daemon task.
-    for (let attempt = 0; attempt < CLOSE_LOOKUP_RETRIES && matches.length === 0; attempt++) {
-      await sleep(CLOSE_LOOKUP_RETRY_DELAY_MS);
-      matches = (await deps.listTasks(project)).filter((t) => t.name === name);
-    }
-    if (matches.length > 0) {
-      // #513: a name can match more than one record (e.g. an orphaned record
-      // left by a prior close that raced dispatch, followed by a same-name
-      // respawn). Terminalize every non-terminal match so none linger to fire
-      // a phantom CREW STALLED/IDLE later. Reap/worktree cleanup below anchors
-      // on the most-recently-dispatched match — the one the live pane belongs to.
-      const primary = pickMostRecentTask(matches);
-      if (primary.operatorHold && !opts?.force) {
-        const heldForMin = Math.round((Date.now() - primary.operatorHold.since) / 60000);
-        throw new Error(
-          `Crew '${name}' is under operator takeover (held ${heldForMin}m` +
-            `${primary.operatorHold.note ? `: ${primary.operatorHold.note}` : ""}). ` +
-            `The operator is working in that tab — closing it kills their session and prunes the worktree. ` +
-            `Ask them to run 'squadrant crew handback ${project} ${name}', or pass --force if they told you to.`,
-        );
-      }
-      taskId = primary.id;
-      sessId = primary.sessionId;
-      provider = primary.provider;
-      if (primary.cwd && projRoot && primary.cwd !== projRoot) {
-        worktreeCwd = primary.cwd;
-      }
+  if (matches.length > 0) {
+    try {
       for (const task of matches) {
         if (!TERMINAL_STATES.has(task.state)) {
           await deps.emitEvent(project, { type: "task.cancelled", id: task.id, reason: "closed by captain" });
@@ -660,11 +697,11 @@ export async function runCrewClose(
           await deps.closeCodexThread(task.id);
         }
       }
+    } catch {
+      // Swallow daemon errors — a crew without a daemon must still close.
     }
-  } catch (e) {
-    if (e instanceof Error && e.message.includes("operator takeover")) throw e;
-    // Swallow daemon errors — a crew without a daemon must still close.
   }
+
   // Close the cmux pane if it still exists. A dead crew's pane is already gone —
   // that is not an error (the record is terminalized above); proceed to reap
   // children / clean the worktree. Only a genuine miss (no pane AND no daemon
@@ -675,25 +712,17 @@ export async function runCrewClose(
   } else if (taskId === undefined) {
     throw new Error(`Crew '${name}' not found for ${project}. Run 'squadrant crew list ${project}'.`);
   }
+
   // Reap any surviving child processes (vitest workers, node subprocs, etc.)
   // that the cmux pane-close cascade may have missed.
   if (taskId !== undefined) {
     await reapCrewChildren(taskId);
   }
+
   // Auto-clean the crew's worktree AFTER its processes are gone, so we don't
   // yank a dir out from under a live shell. Best-effort: a failed removal must
   // not break close (the branch is preserved regardless).
   if (worktreeCwd && projRoot) {
-    const dirty = worktreeDirtyFiles(worktreeCwd);
-    if (dirty.length > 0 && !opts?.force) {
-      const transcriptStr = sessId && provider === "claude" 
-        ? `\ntranscript: ${path.join(os.homedir(), ".claude", "projects", worktreeCwd.replace(/[^a-zA-Z0-9]/g, "-"), `${sessId}.jsonl`)}\nresume:     claude --resume ${sessId}   (run from the worktree path above)\n` 
-        : "";
-      throw new Error(
-        `Worktree '${worktreeCwd}' has uncommitted files:\n${dirty.map(f => `  ${f}`).join("\n")}\n` +
-        `Why are they uncommitted? Commit them, or pass --force to destroy them.\n${transcriptStr}`
-      );
-    }
     try {
       removeWorktree(projRoot, worktreeCwd, opts);
     } catch (e) {
@@ -701,13 +730,9 @@ export async function runCrewClose(
     }
   }
 
-  if (sessId && provider === "claude" && worktreeCwd) {
-    const escaped = worktreeCwd.replace(/[^a-zA-Z0-9]/g, "-");
-    const transcriptPath = path.join(os.homedir(), ".claude", "projects", escaped, `${sessId}.jsonl`);
-    process.stdout.write(
-      `\ntranscript: ${transcriptPath}\n` +
-      `resume:     claude --resume ${sessId}   (run from the worktree path above)\n`
-    );
+  const hint = buildRecoveryHint(sessId, provider, worktreeCwd);
+  if (hint) {
+    process.stdout.write(hint);
   }
 }
 

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -492,6 +492,7 @@ export async function runCrewSend(
     // emit block must never run for a message that never reached the crew.
     isBlockedByModal?: (pane: PaneRef) => Promise<boolean>;
   },
+  opts?: { force?: boolean }
 ): Promise<void> {
   const crew = await findCrewPane(runtime, workspaceId, project, name);
   if (!crew) {
@@ -502,13 +503,31 @@ export async function runCrewSend(
   if (deps.isBlockedByModal && (await deps.isBlockedByModal(crew))) {
     throw new Error(blockedByModalMessage());
   }
+
+  let task: TaskRecord | undefined;
+  try {
+    const matches = (await deps.listTasks(project)).filter((t) => t.name === name);
+    task = matches.length > 0 ? pickMostRecentTask(matches) : undefined;
+  } catch {
+    // Swallow daemon errors so crews without a daemon or offline daemon
+    // still receive the sent message.
+  }
+
+  if (task && task.operatorHold && !opts?.force) {
+    const heldForMin = Math.round((Date.now() - task.operatorHold.since) / 60000);
+    throw new Error(
+      `Crew '${name}' is under operator takeover (held ${heldForMin}m` +
+        `${task.operatorHold.note ? `: ${task.operatorHold.note}` : ""}). ` +
+        `The operator is working in that tab — sending a message disrupts their conversation. ` +
+        `Ask them to run 'squadrant crew handback ${project} ${name}', or pass --force if they told you to.`,
+    );
+  }
+
   // Best-effort attention-state handling before delivering the captain's answer.
   // Terminal task (done/failed): reopen so the next signal done fires CREW DONE (#148).
   // Blocked task: emit task.started to clear blocked→working so a subsequent real
   // permission prompt re-fires CREW BLOCKED (#182).
   try {
-    const matches = (await deps.listTasks(project)).filter((t) => t.name === name);
-    const task = matches.length > 0 ? pickMostRecentTask(matches) : undefined;
     if (task) {
       if (TERMINAL_STATES.has(task.state)) {
         await deps.emitEvent(project, { type: "task.reopened", id: task.id });
@@ -574,6 +593,7 @@ export async function runCrewClose(
     /** Injectable for tests; defaults to a real delay. */
     sleep?: (ms: number) => Promise<void>;
   },
+  opts?: { force?: boolean }
 ): Promise<void> {
   const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
   // resolveCaptainWorkspace already validated the project exists; reload for its
@@ -605,6 +625,15 @@ export async function runCrewClose(
       // a phantom CREW STALLED/IDLE later. Reap/worktree cleanup below anchors
       // on the most-recently-dispatched match — the one the live pane belongs to.
       const primary = pickMostRecentTask(matches);
+      if (primary.operatorHold && !opts?.force) {
+        const heldForMin = Math.round((Date.now() - primary.operatorHold.since) / 60000);
+        throw new Error(
+          `Crew '${name}' is under operator takeover (held ${heldForMin}m` +
+            `${primary.operatorHold.note ? `: ${primary.operatorHold.note}` : ""}). ` +
+            `The operator is working in that tab — closing it kills their session and prunes the worktree. ` +
+            `Ask them to run 'squadrant crew handback ${project} ${name}', or pass --force if they told you to.`,
+        );
+      }
       taskId = primary.id;
       if (primary.cwd && projRoot && primary.cwd !== projRoot) {
         worktreeCwd = primary.cwd;
@@ -621,7 +650,8 @@ export async function runCrewClose(
         }
       }
     }
-  } catch {
+  } catch (e) {
+    if (e instanceof Error && e.message.includes("operator takeover")) throw e;
     // Swallow daemon errors — a crew without a daemon must still close.
   }
   // Close the cmux pane if it still exists. A dead crew's pane is already gone —

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -133,6 +133,8 @@ export interface CrewSpawnDeps {
   /** #466: optional — when provided, called with task.first-turn.confirmed after
    *  positively confirmed delivery so the daemon can stamp firstTurnConfirmedAt. */
   emitEvent?(project: string, event: ControlEvent): Promise<void>;
+  /** Optional: called when worktree base is resolved. */
+  onBaseResolved?(base: string): void;
 }
 
 // ─── Private helpers ──────────────────────────────────────────────────────────
@@ -236,13 +238,19 @@ export async function runCrewSpawn(
   // Crews run in an isolated worktree+branch by default so multiple parallel
   // crews never collide on a shared HEAD (#296). Pass shared:true (CLI: --shared)
   // for small/one-off tasks that should run on the root checkout.
+  let base = "";
+  if (!input.shared) {
+    base = resolveWorktreeBase(proj.path);
+    deps.onBaseResolved?.(base);
+  }
+
   const spawnCwd = !input.shared
     ? addWorktree({
         repoRoot: proj.path,
         worktreeDir: config.defaults.worktreeDir ?? ".worktrees",
         project: input.project,
         name,
-        base: resolveWorktreeBase(proj.path),
+        base,
       })
     : proj.path;
 

--- a/packages/core/src/crew-spawn.ts
+++ b/packages/core/src/crew-spawn.ts
@@ -19,6 +19,7 @@ import {
   addWorktree,
   resolveWorktreeBase,
   removeWorktree,
+  worktreeDirtyFiles,
   TERMINAL_STATES,
 } from "@squadrant/shared";
 import { resolveCrewRoute, type CrewRouteResult } from "./crew-routing.js";
@@ -607,9 +608,9 @@ export async function runCrewClose(
   // dangling forever. 'cancelled' is terminal but NOT in ATTENTION_STATES, so
   // firePush stays silent — captain initiated the close.
   let taskId: string | undefined;
-  // Worktree to clean up after the pane closes — set only when this crew ran in
-  // its own worktree (cwd recorded by the daemon differs from the root checkout).
   let worktreeCwd: string | undefined;
+  let sessId: string | undefined;
+  let provider: string | undefined;
   try {
     let matches = (await deps.listTasks(project)).filter((t) => t.name === name);
     // #513: the record may not be registered yet (close raced spawn's own
@@ -635,6 +636,8 @@ export async function runCrewClose(
         );
       }
       taskId = primary.id;
+      sessId = primary.sessionId;
+      provider = primary.provider;
       if (primary.cwd && projRoot && primary.cwd !== projRoot) {
         worktreeCwd = primary.cwd;
       }
@@ -673,11 +676,30 @@ export async function runCrewClose(
   // yank a dir out from under a live shell. Best-effort: a failed removal must
   // not break close (the branch is preserved regardless).
   if (worktreeCwd && projRoot) {
+    const dirty = worktreeDirtyFiles(worktreeCwd);
+    if (dirty.length > 0 && !opts?.force) {
+      const transcriptStr = sessId && provider === "claude" 
+        ? `\ntranscript: ${path.join(os.homedir(), ".claude", "projects", worktreeCwd.replace(/[^a-zA-Z0-9]/g, "-"), `${sessId}.jsonl`)}\nresume:     claude --resume ${sessId}   (run from the worktree path above)\n` 
+        : "";
+      throw new Error(
+        `Worktree '${worktreeCwd}' has uncommitted files:\n${dirty.map(f => `  ${f}`).join("\n")}\n` +
+        `Why are they uncommitted? Commit them, or pass --force to destroy them.\n${transcriptStr}`
+      );
+    }
     try {
-      removeWorktree(projRoot, worktreeCwd);
+      removeWorktree(projRoot, worktreeCwd, opts);
     } catch (e) {
       process.stderr.write(`(worktree remove failed: ${(e as Error).message})\n`);
     }
+  }
+
+  if (sessId && provider === "claude" && worktreeCwd) {
+    const escaped = worktreeCwd.replace(/[^a-zA-Z0-9]/g, "-");
+    const transcriptPath = path.join(os.homedir(), ".claude", "projects", escaped, `${sessId}.jsonl`);
+    process.stdout.write(
+      `\ntranscript: ${transcriptPath}\n` +
+      `resume:     claude --resume ${sessId}   (run from the worktree path above)\n`
+    );
   }
 }
 

--- a/packages/core/src/daemon/context.ts
+++ b/packages/core/src/daemon/context.ts
@@ -107,6 +107,7 @@ export interface DaemonContext {
   /** Mutable box so sweep timer can update lastSweepAt without a closure rebind. */
   lastSweepAt: { value: number | null };
   taskTimeoutMs: number | undefined;
+  takeoverNudgeHours: number | undefined;
   isPidAlive: (pid: number) => boolean;
   spawn: typeof realSpawn;
   resultsDir: string;
@@ -166,7 +167,9 @@ export function buildContext(opts: SquadrantdOpts): DaemonContext {
   const sockPath = opts.sockPath ?? join(homedir(), ".config", "squadrant", "squadrant.sock");
   const store = createStore(stateRoot);
   const bootedAt = Date.now();
-  const taskTimeoutMs = loadConfig().defaults.taskTimeoutMs;
+  const config = loadConfig();
+  const taskTimeoutMs = config.defaults.taskTimeoutMs;
+  const takeoverNudgeHours = config.defaults.takeoverNudgeHours;
   const isPidAlive = opts.isPidAlive ?? defaultIsPidAlive;
   const spawn = opts.spawn ?? realSpawn;
   const resultsDir = join(stateRoot, "_results");
@@ -187,6 +190,7 @@ export function buildContext(opts: SquadrantdOpts): DaemonContext {
     bootedAt,
     lastSweepAt: { value: null },
     taskTimeoutMs,
+    takeoverNudgeHours,
     isPidAlive,
     spawn,
     resultsDir,

--- a/packages/core/src/daemon/reduce.ts
+++ b/packages/core/src/daemon/reduce.ts
@@ -72,6 +72,10 @@ export interface DaemonDeps {
    * tests, non-cmux deployments).
    */
   resendFirstTurn?: (rec: TaskRecord) => Promise<{ delivered: boolean }>;
+  /**
+   * #649: Notify the captain when a crew has been held by the operator longer than this.
+   */
+  takeoverNudgeHours?: number;
   /** Override for testing; production default is DEFAULT_FIRST_TURN_UNDELIVERED_BUDGET_MS. */
   firstTurnUndeliveredBudgetMs?: number;
   /** Override for testing; production default is DEFAULT_FIRST_TURN_RESEND_COOLDOWN_MS. */
@@ -503,6 +507,29 @@ export function createDaemon(deps: DaemonDeps) {
           store.delete(r.project, r.id);
           continue;
         }
+
+        // #649: CREW HELD-LONG nudge. Never auto-releases.
+        if (r.operatorHold) {
+          const threshold = (deps.takeoverNudgeHours ?? 6) * 3600000;
+          const holdAge = t - r.operatorHold.since;
+          if (holdAge > threshold) {
+            const timeSinceLastNudge = t - (r.operatorHold.lastNudgeAt ?? 0);
+            if (timeSinceLastNudge > threshold) {
+              const hrs = Math.round(holdAge / 3600000);
+              const tag = crewTag(r);
+              const message = `CREW HELD-LONG ${tag} — held ${hrs}h. Ask the operator whether it is still in use. Do not release it yourself.`;
+              store.put({ ...r, operatorHold: { ...r.operatorHold, lastNudgeAt: t } });
+              if (deps.notify) {
+                try {
+                  const p = deps.notify({ project: r.project, message, record: r, event: { type: "task.progress", id: r.id } as any });
+                  if (p && typeof (p as Promise<void>).catch === "function") (p as Promise<void>).catch(() => {});
+                } catch {}
+              }
+            }
+          }
+          // Fall through: a held crew can still be GC'd (if terminal) or timeout (if not).
+        }
+
         // #225 root-fix: terminate non-terminal tasks that exceeded the wall-clock
         // ceiling. Terminalization is the persistent dedup — a daemon restart sees
         // the cancelled record and the TERMINAL_STATES gate above blocks re-fire.

--- a/packages/core/src/daemon/reduce.ts
+++ b/packages/core/src/daemon/reduce.ts
@@ -295,6 +295,7 @@ const KNOWN_EVENT_TYPES: ReadonlySet<string> = new Set([
   "task.stalled", "task.idle", "task.quiet", "task.timeout", "task.reconcile-failed",
   "task.cancelled", "task.session.ended",
   "task.first-turn.confirmed",  // #466: delivery confirmation
+  "crew.takeover.started", "crew.takeover.ended", // #649: operator takeover
 ]);
 
 export function createDaemon(deps: DaemonDeps) {

--- a/packages/core/src/daemon/reduce.ts
+++ b/packages/core/src/daemon/reduce.ts
@@ -225,6 +225,12 @@ function firePush(
   if (!deps.notify) return;
   if (prev === next.state) return;
   if (!ATTENTION_STATES.has(next.state)) return;
+
+  // #649: the operator is driving this tab. Any attention state now reflects
+  // THEIR work, not the captain's delegated task — pushing it invites the
+  // captain to act on a conversation it cannot see. Handback re-enables pushes.
+  if (next.operatorHold) return;
+
   // #210 idle debounce: a turn-end (awaiting-input) within IDLE_DEBOUNCE_MS of
   // the captain's last turn is part of an active back-and-forth — suppress the
   // CREW IDLE. All other attention states are never debounced.

--- a/packages/core/src/daemon/start.ts
+++ b/packages/core/src/daemon/start.ts
@@ -59,7 +59,7 @@ export function startDaemon(ctx: DaemonContext, opts: SquadrantdOpts, pkgVersion
     void ctx.d.handle({ kind: "event", project, event: e });
 
   const d = createDaemon({
-    store, now: () => Date.now(), isPidAlive, notify, taskTimeoutMs,
+    store, now: () => Date.now(), isPidAlive, notify, taskTimeoutMs, takeoverNudgeHours: ctx.takeoverNudgeHours,
     isSurfaceAlive: surfaceProbe,
     resendFirstTurn: ctx.resendFirstTurn,
     launchHeadless: opts.launchHeadless!,

--- a/packages/core/src/state-machine.ts
+++ b/packages/core/src/state-machine.ts
@@ -82,6 +82,24 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
     return { ...rec, state: "working", question: undefined, error: undefined, lastHeartbeat: now, lastEvent: ev.type };
   }
 
+  if (ev.type === "crew.takeover.started") {
+    // Idempotent: keep the original `since` so a repeat does not reset the
+    // clock the HELD-LONG nudge measures from.
+    if (rec.operatorHold) return { ...rec, lastHeartbeat: now, lastEvent: ev.type };
+    return {
+      ...rec,
+      operatorHold: { since: now, ...(ev.note !== undefined ? { note: ev.note } : {}) },
+      lastHeartbeat: now,
+      lastEvent: ev.type,
+    };
+  }
+
+  if (ev.type === "crew.takeover.ended") {
+    // Over-releasing must never be punished — a no-op, not an error.
+    const { operatorHold: _dropped, ...rest } = rec;
+    return { ...rest, lastHeartbeat: now, lastEvent: ev.type };
+  }
+
   // Terminal states are absorbing: ignore any late/duplicate event idempotently.
   if (TERMINAL_STATES.has(rec.state)) return rec;
 

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -103,6 +103,8 @@ export interface SquadrantConfig {
     roles?: RoleConfig;
     /** #225 hard crew task-timeout ceiling (ms). Default: 8h. */
     taskTimeoutMs?: number;
+    /** #649: notify the captain when a crew has been held by the operator longer than this. Default: 6h. */
+    takeoverNudgeHours?: number;
     /** #275 rule-based crew routing: keyword rules map task text to {agent, model}. Optional — absent = fall through to defaults.roles.crew. */
     crewRouting?: CrewRoutingConfig;
     /** B1: consume cmux's native event stream for crew turn-end (idle) detection

--- a/packages/shared/src/lib/__tests__/git-worktree.test.ts
+++ b/packages/shared/src/lib/__tests__/git-worktree.test.ts
@@ -318,31 +318,43 @@ describe("addWorktree — Spotlight exclusion (#387)", () => {
 describe("resolveWorktreeBase", () => {
   beforeEach(() => execFileSyncMock.mockReset());
 
-  it("returns the branch name from origin/HEAD when set", () => {
-    execFileSyncMock.mockReturnValue(Buffer.from("refs/remotes/origin/main\n"));
-    expect(resolveWorktreeBase("/tmp/repo")).toBe("main");
+  it("returns the checked-out branch if it is not detached", () => {
+    execFileSyncMock.mockReturnValueOnce(Buffer.from("feature-branch\n"));
+    expect(resolveWorktreeBase("/tmp/repo")).toBe("feature-branch");
     expect(execFileSyncMock).toHaveBeenCalledWith(
       "git",
-      ["-C", "/tmp/repo", "symbolic-ref", "refs/remotes/origin/HEAD"],
+      ["-C", "/tmp/repo", "rev-parse", "--abbrev-ref", "HEAD"],
       expect.objectContaining({ stdio: ["ignore", "pipe", "ignore"] }),
     );
   });
 
+  it("falls back to origin/HEAD if HEAD is detached", () => {
+    execFileSyncMock.mockReturnValueOnce(Buffer.from("HEAD\n"));
+    execFileSyncMock.mockReturnValueOnce(Buffer.from("refs/remotes/origin/main\n"));
+    expect(resolveWorktreeBase("/tmp/repo")).toBe("main");
+  });
+
+  it("returns the branch name from origin/HEAD when rev-parse fails", () => {
+    execFileSyncMock.mockImplementationOnce(() => { throw new Error("git error"); });
+    execFileSyncMock.mockReturnValueOnce(Buffer.from("refs/remotes/origin/main\n"));
+    expect(resolveWorktreeBase("/tmp/repo")).toBe("main");
+  });
+
   it("returns a non-main default branch when origin/HEAD points to it", () => {
-    execFileSyncMock.mockReturnValue(Buffer.from("refs/remotes/origin/develop\n"));
+    execFileSyncMock.mockReturnValueOnce(Buffer.from("HEAD\n"));
+    execFileSyncMock.mockReturnValueOnce(Buffer.from("refs/remotes/origin/develop\n"));
     expect(resolveWorktreeBase("/tmp/repo")).toBe("develop");
   });
 
   it("falls back to 'develop' when git returns undefined (no origin/HEAD)", () => {
-    // vitest v3 re-reports errors thrown from mockImplementation even when caught
-    // by production code. Instead, return undefined so .toString() throws a
-    // TypeError inside the try block — same branch, correctly caught by catch{}.
-    execFileSyncMock.mockReturnValue(undefined);
+    execFileSyncMock.mockReturnValueOnce(Buffer.from("HEAD\n"));
+    execFileSyncMock.mockReturnValueOnce(undefined);
     expect(resolveWorktreeBase("/tmp/repo")).toBe("develop");
   });
 
   it("uses a custom fallback when provided and git fails", () => {
-    execFileSyncMock.mockReturnValue(undefined);
+    execFileSyncMock.mockReturnValueOnce(Buffer.from("HEAD\n"));
+    execFileSyncMock.mockReturnValueOnce(undefined);
     expect(resolveWorktreeBase("/tmp/repo", "trunk")).toBe("trunk");
   });
 });

--- a/packages/shared/src/lib/__tests__/git-worktree.test.ts
+++ b/packages/shared/src/lib/__tests__/git-worktree.test.ts
@@ -25,7 +25,7 @@ vi.mock("node:fs", async (importOriginal) => {
   return { ...merged, default: merged };
 });
 
-import { worktreePath, crewBranch, addWorktree, removeWorktree, resolveWorktreeBase } from "../git-worktree.js";
+import { worktreePath, crewBranch, addWorktree, removeWorktree, resolveWorktreeBase, worktreeDirtyFiles } from "../git-worktree.js";
 
 // #387: addWorktree() runs for every registered project, not just pnpm ones —
 // stub existsSync per project "kind" so installWorktreeDependencies sees the
@@ -347,6 +347,25 @@ describe("resolveWorktreeBase", () => {
   });
 });
 
+describe("worktreeDirtyFiles", () => {
+  beforeEach(() => execFileSyncMock.mockReset());
+
+  it("returns files from porcelain status", () => {
+    execFileSyncMock.mockReturnValue(Buffer.from(" M modified.txt\n?? untracked.js\n"));
+    expect(worktreeDirtyFiles("/tmp/wt")).toEqual(["modified.txt", "untracked.js"]);
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      "git",
+      ["-C", "/tmp/wt", "status", "--porcelain", "--untracked-files=all"],
+      expect.anything()
+    );
+  });
+
+  it("returns empty array when git fails", () => {
+    execFileSyncMock.mockReturnValue(undefined);
+    expect(worktreeDirtyFiles("/tmp/wt")).toEqual([]);
+  });
+});
+
 describe("removeWorktree", () => {
   beforeEach(() => execFileSyncMock.mockReset());
 
@@ -361,18 +380,11 @@ describe("removeWorktree", () => {
     );
   });
 
-  it("retries with --force when a plain remove fails (dirty/locked worktree)", () => {
-    let calls = 0;
-    execFileSyncMock.mockImplementation(() => {
-      calls++;
-      if (calls === 1) throw new Error("contains modified or untracked files");
-      return "";
-    });
+  it("runs with --force when opts.force is true", () => {
+    removeWorktree("/tmp/brove", "/tmp/brove/.worktrees/brove-crew-1", { force: true });
 
-    removeWorktree("/tmp/brove", "/tmp/brove/.worktrees/brove-crew-1");
-
-    expect(execFileSyncMock).toHaveBeenCalledTimes(2);
-    expect(execFileSyncMock).toHaveBeenLastCalledWith(
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+    expect(execFileSyncMock).toHaveBeenCalledWith(
       "git",
       ["-C", "/tmp/brove", "worktree", "remove", "--force", "/tmp/brove/.worktrees/brove-crew-1"],
       expect.objectContaining({ stdio: "pipe" }),

--- a/packages/shared/src/lib/__tests__/runtime-sync.test.ts
+++ b/packages/shared/src/lib/__tests__/runtime-sync.test.ts
@@ -149,6 +149,8 @@ describe("ensureRuntimeSynced", () => {
     // plugin: tree target
     write(path.join(sourceRoot, "plugin", "skills", "captain-ops", "SKILL.md"), "captain");
     write(path.join(sourceRoot, "plugin", "skills", "karpathy-principles", "SKILL.md"), "karpathy");
+    write(path.join(sourceRoot, "plugin", "skills", "takeover", "SKILL.md"), "takeover content");
+    write(path.join(sourceRoot, "plugin", "skills", "handback", "SKILL.md"), "handback content");
     write(path.join(sourceRoot, "plugin", ".claude-plugin", "plugin.json"), '{"name":"squadrant"}');
     // templates: flat target sourced from templates/, filtered by extension
     write(path.join(sourceRoot, "templates", "captain.claude.md"), "tmpl");

--- a/packages/shared/src/lib/git-worktree.ts
+++ b/packages/shared/src/lib/git-worktree.ts
@@ -59,13 +59,25 @@ function ensureSpotlightExcluded(repoRoot: string, worktreeDir: string): void {
 // #359: derive the branch a new worktree should be based on. Reads origin/HEAD
 // so main-based repos work without a hand-created `develop`. Falls back to
 // `fallback` (default "develop") when origin/HEAD is unset.
+/**
+ * #359: derive the branch a new worktree should be based on.
+ * #661: prefer the captain's CHECKED-OUT branch. Reading origin/HEAD first meant
+ * every spawn on a repo whose integration branch is not the GitHub default
+ * branch started stale — 155 commits at prism-app — silently, with the damage
+ * only surfacing at PR time as a diff full of unrelated reverts.
+ * Order: checked-out branch → origin/HEAD → fallback.
+ */
 export function resolveWorktreeBase(repoRoot: string, fallback = "develop"): string {
   try {
-    const ref = execFileSync(
-      "git",
-      ["-C", repoRoot, "symbolic-ref", "refs/remotes/origin/HEAD"],
-      { stdio: ["ignore", "pipe", "ignore"] },
-    ).toString().trim();
+    const head = execFileSync("git", ["-C", repoRoot, "rev-parse", "--abbrev-ref", "HEAD"],
+      { stdio: ["ignore", "pipe", "ignore"] }).toString().trim();
+    if (head && head !== "HEAD") return head;   // "HEAD" means detached
+  } catch {
+    // fall through to origin/HEAD
+  }
+  try {
+    const ref = execFileSync("git", ["-C", repoRoot, "symbolic-ref", "refs/remotes/origin/HEAD"],
+      { stdio: ["ignore", "pipe", "ignore"] }).toString().trim();
     const m = ref.match(/^refs\/remotes\/origin\/(.+)$/);
     if (m) return m[1];
   } catch {

--- a/packages/shared/src/lib/git-worktree.ts
+++ b/packages/shared/src/lib/git-worktree.ts
@@ -56,9 +56,6 @@ function ensureSpotlightExcluded(repoRoot: string, worktreeDir: string): void {
   }
 }
 
-// #359: derive the branch a new worktree should be based on. Reads origin/HEAD
-// so main-based repos work without a hand-created `develop`. Falls back to
-// `fallback` (default "develop") when origin/HEAD is unset.
 /**
  * #359: derive the branch a new worktree should be based on.
  * #661: prefer the captain's CHECKED-OUT branch. Reading origin/HEAD first meant

--- a/packages/shared/src/lib/git-worktree.ts
+++ b/packages/shared/src/lib/git-worktree.ts
@@ -198,15 +198,26 @@ function installWorktreeDependencies(wt: string): void {
   }
 }
 
-/**
- * Remove a crew's worktree (auto-clean on close). Tries a plain remove first;
- * a dirty/locked worktree makes git refuse, so we retry with --force. The
- * branch is left intact so the crew's commits survive the close.
- */
-export function removeWorktree(repoRoot: string, wtPath: string): void {
+/** #649: files that would be destroyed by removing this worktree. */
+export function worktreeDirtyFiles(wtPath: string): string[] {
   try {
-    execFileSync("git", ["-C", repoRoot, "worktree", "remove", wtPath], { stdio: "pipe" });
+    return execFileSync("git", ["-C", wtPath, "status", "--porcelain", "--untracked-files=all"],
+      { stdio: ["ignore", "pipe", "ignore"] })
+      .toString().split("\n").map((l) => l.slice(3).trim()).filter(Boolean);
   } catch {
-    execFileSync("git", ["-C", repoRoot, "worktree", "remove", "--force", wtPath], { stdio: "pipe" });
+    return [];
   }
+}
+
+/**
+ * Remove a crew's worktree. The branch is left intact so commits survive.
+ *
+ * #649: this used to catch git's refusal and retry with --force. Git refuses to
+ * remove a dirty worktree precisely to protect uncommitted work; catching that
+ * and forcing past it destroyed an operator's uncommitted .env files at
+ * prism-app. The refusal now stands — callers pass force explicitly.
+ */
+export function removeWorktree(repoRoot: string, wtPath: string, opts?: { force?: boolean }): void {
+  const args = ["-C", repoRoot, "worktree", "remove", ...(opts?.force ? ["--force"] : []), wtPath];
+  execFileSync("git", args, { stdio: "pipe" });
 }

--- a/packages/shared/src/lib/runtime-sync.ts
+++ b/packages/shared/src/lib/runtime-sync.ts
@@ -124,7 +124,7 @@ export type ManagedTarget =
 // (see templates/crew.claude.md, templates/crew.generic.md) — captain-ops,
 // telegram, wiki-ops, etc. are captain/command-only. Keep this list in sync
 // with what the crew templates actually reference.
-export const CREW_SKILLS = ["karpathy-principles"];
+export const CREW_SKILLS = ["karpathy-principles", "takeover", "handback"];
 
 export const MANAGED_TARGETS: ManagedTarget[] = [
   { name: "plugin", srcRel: "plugin", mode: "tree" },

--- a/packages/shared/src/types/control.ts
+++ b/packages/shared/src/types/control.ts
@@ -62,16 +62,6 @@ export interface TaskRecord {
   resultRef?: string;      // filesystem path to captured output/artifact
   parseWarning?: boolean;  // headless exit 0 but unparseable result
   createdAt: number;       // epoch ms
-
-  /** #649: set while the OPERATOR is driving this crew's tab directly rather
-   *  than the captain. Deliberately orthogonal to `state`, not a TaskState:
-   *  a takeover must be recordable on a terminal record (at prism-app the crew
-   *  was `done` when the operator adopted it), and modelling it as a state
-   *  would force a reopen on takeover plus prior-state restoration on handback.
-   *  While set, the CLI refuses `crew close` and `crew send` without --force,
-   *  and the daemon suppresses actionable captain pushes for this task. */
-  operatorHold?: { since: number; note?: string; lastNudgeAt?: number };
-
   lastHeartbeat: number;   // epoch ms
   lastEvent: string;       // last event type applied
   heartbeatBudgetMs: number; // per-task stall threshold
@@ -178,12 +168,6 @@ export type ControlEvent =
   // task to the absorbing 'cancelled' state. Silent: captain initiated the close
   // so no CREW CANCELLED push is fired (not in ATTENTION_STATES).
   | { type: "task.cancelled"; id: string; reason?: string }
-  // #649: the operator has taken over / handed back this crew's tab. Neither
-  // event mutates `state`, so both are valid on a terminal record — that is the
-  // whole point (see TaskRecord.operatorHold).
-  | { type: "crew.takeover.started"; id: string; note?: string }
-  | { type: "crew.takeover.ended"; id: string; note?: string };
-
   // #466: emitted by runCrewSpawn after positively confirming the first turn was
   // delivered. Stamps firstTurnConfirmedAt on the record so the watchdog can
   // distinguish a quiet-thinking crew from one that never received its task.

--- a/packages/shared/src/types/control.ts
+++ b/packages/shared/src/types/control.ts
@@ -62,6 +62,16 @@ export interface TaskRecord {
   resultRef?: string;      // filesystem path to captured output/artifact
   parseWarning?: boolean;  // headless exit 0 but unparseable result
   createdAt: number;       // epoch ms
+
+  /** #649: set while the OPERATOR is driving this crew's tab directly rather
+   *  than the captain. Deliberately orthogonal to `state`, not a TaskState:
+   *  a takeover must be recordable on a terminal record (at prism-app the crew
+   *  was `done` when the operator adopted it), and modelling it as a state
+   *  would force a reopen on takeover plus prior-state restoration on handback.
+   *  While set, the CLI refuses `crew close` and `crew send` without --force,
+   *  and the daemon suppresses actionable captain pushes for this task. */
+  operatorHold?: { since: number; note?: string; lastNudgeAt?: number };
+
   lastHeartbeat: number;   // epoch ms
   lastEvent: string;       // last event type applied
   heartbeatBudgetMs: number; // per-task stall threshold
@@ -177,7 +187,13 @@ export type ControlEvent =
   // session must NOT resume 'working' (nothing heartbeats → false CREW STALLED
   // ~budget later). Terminalizes the record to the absorbing 'cancelled' state.
   // Silent (not in ATTENTION_STATES), like task.cancelled.
-  | { type: "task.session.ended"; id: string };
+  | { type: "task.session.ended"; id: string }
+  // #649: the operator has taken over / handed back this crew's tab. Neither
+  // event mutates `state`, so both are valid on a terminal record — that is the
+  // whole point (see TaskRecord.operatorHold).
+  | { type: "crew.takeover.started"; id: string; note?: string }
+  | { type: "crew.takeover.ended"; id: string; note?: string };
+
 
 // 'stalled' is intentionally excluded — recoverable by the watchdog.
 // 'cancelled' is terminal and silent (captain-initiated close).

--- a/packages/shared/src/types/control.ts
+++ b/packages/shared/src/types/control.ts
@@ -62,6 +62,16 @@ export interface TaskRecord {
   resultRef?: string;      // filesystem path to captured output/artifact
   parseWarning?: boolean;  // headless exit 0 but unparseable result
   createdAt: number;       // epoch ms
+
+  /** #649: set while the OPERATOR is driving this crew's tab directly rather
+   *  than the captain. Deliberately orthogonal to `state`, not a TaskState:
+   *  a takeover must be recordable on a terminal record (at prism-app the crew
+   *  was `done` when the operator adopted it), and modelling it as a state
+   *  would force a reopen on takeover plus prior-state restoration on handback.
+   *  While set, the CLI refuses `crew close` and `crew send` without --force,
+   *  and the daemon suppresses actionable captain pushes for this task. */
+  operatorHold?: { since: number; note?: string; lastNudgeAt?: number };
+
   lastHeartbeat: number;   // epoch ms
   lastEvent: string;       // last event type applied
   heartbeatBudgetMs: number; // per-task stall threshold
@@ -168,6 +178,12 @@ export type ControlEvent =
   // task to the absorbing 'cancelled' state. Silent: captain initiated the close
   // so no CREW CANCELLED push is fired (not in ATTENTION_STATES).
   | { type: "task.cancelled"; id: string; reason?: string }
+  // #649: the operator has taken over / handed back this crew's tab. Neither
+  // event mutates `state`, so both are valid on a terminal record — that is the
+  // whole point (see TaskRecord.operatorHold).
+  | { type: "crew.takeover.started"; id: string; note?: string }
+  | { type: "crew.takeover.ended"; id: string; note?: string };
+
   // #466: emitted by runCrewSpawn after positively confirming the first turn was
   // delivered. Stamps firstTurnConfirmedAt on the record so the watchdog can
   // distinguish a quiet-thinking crew from one that never received its task.

--- a/plugin/skills/captain-ops/SKILL.md
+++ b/plugin/skills/captain-ops/SKILL.md
@@ -194,7 +194,7 @@ To change the effort dial: `squadrant effort <max|balance|low>` or use the `squa
 - **Close crews you're done with** (`squadrant crew close ...`) so they don't accumulate.
 - Crews run in **isolated worktrees by default** (parallel-safe, branch per crew). Pass `--shared` only for tiny/one-off tasks that don't need branch isolation. Never hand-run `git worktree add` — `squadrant crew spawn` handles it.
 - Do NOT edit source code yourself — always delegate to crew.
-- Respect `maxCrew` — don't exceed the configured concurrent crew count.
+- Respect `maxCrew` — don't exceed the configured concurrent crew count. Held crews do not count toward the limit, and at the limit you must ask the operator rather than choosing a crew to close.
 - **For complex multi-step tasks** (3+ steps, multiple files), tell the crew to use GSD inside the task prompt: *"This is a complex task. Use `/gsd:plan-phase` and `/gsd:execute-phase` for wave-based execution with fresh context per step."*
 - **For simple tasks**, don't mention GSD — the crew will handle it directly.
 

--- a/plugin/skills/handback/SKILL.md
+++ b/plugin/skills/handback/SKILL.md
@@ -1,0 +1,8 @@
+# /handback
+
+Runs when the operator is finished driving this tab and wants to return control to the captain.
+
+1. First, you MUST run this command to clear the takeover in the control plane:
+   `squadrant crew handback --task-id "$SQUADRANT_CREW_TASK_ID"`
+
+2. Acknowledge to the user: you have returned control to the captain. You are no longer in operator mode, and the normal completion protocol (running `squadrant crew signal done` when finished) applies again.

--- a/plugin/skills/takeover/SKILL.md
+++ b/plugin/skills/takeover/SKILL.md
@@ -1,0 +1,11 @@
+# /takeover
+
+Runs when the operator wants to take direct control of this crew tab.
+
+1. First, you MUST run this command to record the takeover in the control plane:
+   `squadrant crew takeover --task-id "$SQUADRANT_CREW_TASK_ID"`
+
+2. Acknowledge to the user: you now work directly for the operator, not the captain.
+   **Do not run `squadrant crew signal done`** when you finish what the operator asked — wait for `/handback`.
+
+You are now in operator mode.

--- a/templates/captain.claude.md
+++ b/templates/captain.claude.md
@@ -37,6 +37,7 @@ You are a **project captain** for Squadrant. You lead ONE project. You are a **c
    squadrant crew read <project> <name>          # read its screen
    squadrant crew close <project> <name>         # shutdown when done
    ```
+   **Operator Takeover:** A crew under operator takeover is off-limits — no `send`, no `close`, and its lifecycle signals are not yours to act on. If you are at your crew limit, **ask the operator**; never pick a held crew to close. `--force` exists only for when the operator explicitly tells you to use it.
 3. **Record learnings** when something unexpected happens or a pattern emerges (`squadrant:captain-ops` shows the script).
 4. **Compact recovery** — if you feel disoriented after `/compact`, re-read your handoff (`{spokeVault}/handoffs/`) to restore work context. Role itself survives compact via `--append-system-prompt-file`.
 

--- a/templates/captain.generic.md
+++ b/templates/captain.generic.md
@@ -16,6 +16,7 @@ You are a project captain coordinating work via cmux workspaces. You are a coord
    squadrant crew close <project> <name>         # shutdown when done
    squadrant crew list <project>                 # all live crews
    ```
+   **Operator Takeover:** A crew under operator takeover is off-limits — no `send`, no `close`, and its lifecycle signals are not yours to act on. If you are at your crew limit, **ask the operator**; never pick a held crew to close. `--force` exists only for when the operator explicitly tells you to use it.
 4. Communicate with the project's captain workspace via:
    ```bash
    squadrant runtime send <project> "<message>"


### PR DESCRIPTION
Closes #649. Closes #661.

Spec: `docs/specs/2026-08-06-crew-operator-takeover.md`
Plan: `docs/plans/2026-08-06-crew-operator-takeover.md`

## Why

When the operator works **directly inside a crew's tab**, squadrant records nothing. Two incidents:

- **oneplan** — operator pasted screenshots into a crew tab; the crew came back `CREW BLOCKED` with a question that made no sense against the captain's own message.
- **prism-app** — the operator adopted a finished crew's tab for ~3h. Eight minutes after they typed "Authorize", the captain ran `crew close` to free a `maxCrew` slot. It killed the session mid-turn and pruned the worktree. `.env.local` and a generated admin key were lost.

`CREW DONE` means *the delegated task* is finished. It says nothing about whether a human has since adopted the tab.

## What

**`operatorHold` on `TaskRecord`** — an orthogonal field, not a new `TaskState`. At prism-app the crew was `done` (terminal) when adopted; a state would need reopen-on-takeover plus prior-state restoration on handback. Persisted with the record, so it survives `/compact`, daemon restart, and shows up in `handoff facts`.

**CLI is the source of truth** — `squadrant crew takeover|handback`. `/takeover` and `/handback` are thin crew-side wrappers that shell out to it and also tell the crew not to self-signal `done` while held.

**Enforcement is mechanical, not advisory** (per the #653 lesson — a rule in a template is voluntary):

| Surface | Behaviour when held |
|---|---|
| `crew close` | refuse, `--force` required |
| `crew send` | refuse, `--force` required |
| `firePush` | actionable captain pushes suppressed |
| `crew list` / `tasks` / `handoff facts` | grouped under `HELD`, excluded from the active count |

Both guards run **before** `task.cancelled` and `closePane`, so a refusal destroys nothing.

**Second, independent layer** — catches a forgotten takeover:
- `removeWorktree` no longer catches git's dirty-worktree refusal and retries with `--force`. Git refuses in order to protect uncommitted work; forcing past it is what destroyed the prism-app files.
- `crew close` inspects the worktree first and refuses when dirty, naming the files.
- Prints the transcript path + `claude --resume <id>` on close so recovery is discoverable rather than folklore.

**#661** — `resolveWorktreeBase` now prefers the captain's checked-out branch over `origin/HEAD`. On prism-app (default `main`, integration `staging`, 155 commits apart) every spawn was silently 155 commits stale. The resolved base is printed at spawn.

## Not built (deliberate)

- **`maxCrew` enforcement** — does not exist in code. The only non-config reference in the repo is one line of prose in `captain-ops`. Nothing counts crews; nothing refuses a spawn. Out of scope.
- **Daemon-side detection of operator keystrokes** — operator input is indistinguishable from a crew self-prompt at the pane level. Open question stays on #649.
- **`crew tell`** — superseded by takeover/handback.

## Verification

`pnpm build` · **2453 tests / 185 files** · `node dist/index.js --help`

**Live smoke test on a throwaway project**, real daemon, opencode crew — all steps passed: takeover writes `operatorHold`; `close` and `send` refuse; the pane stays alive and the state is not terminalized; `crew list` shows the HELD group; handback clears it; the dirty-worktree guard fires independently; `--force` overrides.

The smoke test caught a blocker the 2453 unit tests missed: `crew.takeover.*` was absent from the `KNOWN_EVENT_TYPES` allowlist in `daemon/reduce.ts`, so the daemon rejected every takeover event. Every takeover test called `reduce()` directly and bypassed `applyEvent`'s validation. A test at that layer was added.

## Follow-up

The task record for this work was killed mid-review by the wall-clock timeout sweep (age 15.9h vs an 8h ceiling), which permanently closed its `crew approve` path — so this PR was pushed by hand. #629 exempted `blocked`/`review` from the sweep but the clock still measures `now - createdAt` and never resets, so a task that survives several review rounds is cancelled the moment it returns to `working`. Filing separately.