### PR TITLE
fix: measure sweep ceiling from the current working stretch (#664)

### DIFF
--- a/packages/core/src/__tests__/daemon.test.ts
+++ b/packages/core/src/__tests__/daemon.test.ts
@@ -1025,6 +1025,42 @@ describe("sweep: task-timeout (#225)", () => {
     expect(calls[0].message).toMatch(/CREW TIMEOUT/);
   });
 
+  it("#664: a task 20h old whose working stretch just started is NOT cancelled", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    const age20h = 20 * 3_600_000;
+    const now = age20h;
+    // createdAt is 0 (20h ago)
+    // ceiling is 8h (8 * 3_600_000)
+    // workingStretchStartedAt is now - 1h (just started 1h ago)
+    store.put(rec("t664a", {
+      state: "working", createdAt: 0, workingStretchStartedAt: now - 3_600_000,
+      lastHeartbeat: now - 1000, heartbeatBudgetMs: 86_400_000,
+    }));
+    const d = createDaemon({ store, now: () => now, taskTimeoutMs: 8 * 3_600_000, notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    expect(calls.filter((c) => c.message.includes("CREW TIMEOUT"))).toHaveLength(0);
+    expect(store.get("p", "t664a")?.state).toBe("working");
+  });
+
+  it("#664: a task wedged past the ceiling in one stretch IS still cancelled", async () => {
+    const store = createStore(dir);
+    const calls: any[] = [];
+    const age20h = 20 * 3_600_000;
+    const now = age20h;
+    // createdAt is 0 (20h ago)
+    // ceiling is 8h
+    // workingStretchStartedAt is now - 10h (stuck for 10h)
+    store.put(rec("t664b", {
+      state: "working", createdAt: 0, workingStretchStartedAt: now - 10 * 3_600_000,
+      lastHeartbeat: now - 1000, heartbeatBudgetMs: 86_400_000,
+    }));
+    const d = createDaemon({ store, now: () => now, taskTimeoutMs: 8 * 3_600_000, notify: async (a) => { calls.push(a); } });
+    await d.sweep();
+    expect(calls.filter((c) => c.message.includes("CREW TIMEOUT"))).toHaveLength(1);
+    expect(store.get("p", "t664b")?.state).toBe("cancelled");
+  });
+
   it("escalation message names the crew and the full task id", async () => {
     const store = createStore(dir);
     const calls: any[] = [];

--- a/packages/core/src/daemon/reduce.ts
+++ b/packages/core/src/daemon/reduce.ts
@@ -544,7 +544,8 @@ export function createDaemon(deps: DaemonDeps) {
         // a dead one is still caught by the surface-gone reap right below.
         if (!TERMINAL_STATES.has(r.state) && !isStickyAttention(r.state)) {
           const ceiling = deps.taskTimeoutMs ?? DEFAULT_TASK_TIMEOUT_MS;
-          if (t - r.createdAt > ceiling) {
+          const refTime = r.workingStretchStartedAt ?? r.createdAt;
+          if (t - refTime > ceiling) {
             const prevState = r.state; // capture BEFORE terminalization (shown in message)
             const tag = crewTag(r);
             const hrs = Math.round(ceiling / 3_600_000);

--- a/packages/core/src/state-machine.ts
+++ b/packages/core/src/state-machine.ts
@@ -79,7 +79,7 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
   // From ANY state (done/failed/stalled/awaiting-input/working) → working.
   // Clears question and error so the revived task looks fresh.
   if (ev.type === "task.reopened") {
-    return { ...rec, state: "working", question: undefined, error: undefined, lastHeartbeat: now, lastEvent: ev.type };
+    return { ...rec, state: "working", question: undefined, error: undefined, lastHeartbeat: now, lastEvent: ev.type, workingStretchStartedAt: now };
   }
 
   if (ev.type === "crew.takeover.started") {
@@ -115,6 +115,7 @@ export function reduce(rec: TaskRecord, ev: ControlEvent, now: number): TaskReco
         question: undefined, // resuming after a blocked→reply clears the question
         pendingTool: undefined, // #354: a new turn closes any prior tool window
         pendingMonitor: undefined, // #594a: same reset — a new turn moots any prior watch
+        workingStretchStartedAt: now,
       };
     case "task.progress": {
       // task.progress is a real-activity signal (stdout chunk for headless,

--- a/packages/shared/src/types/control.ts
+++ b/packages/shared/src/types/control.ts
@@ -62,6 +62,7 @@ export interface TaskRecord {
   resultRef?: string;      // filesystem path to captured output/artifact
   parseWarning?: boolean;  // headless exit 0 but unparseable result
   createdAt: number;       // epoch ms
+  workingStretchStartedAt?: number; // epoch ms (reset on task.started/reopened to measure ceiling)
 
   /** #649: set while the OPERATOR is driving this crew's tab directly rather
    *  than the captain. Deliberately orthogonal to `state`, not a TaskState:


### PR DESCRIPTION
Closes #664.

## Why

The sweep's wall-clock ceiling measured `now - r.createdAt`, and `createdAt` never resets. A task that survived several captain review rounds exceeded the 8h ceiling permanently, so every return to `working` was cancelled instantly — which closes `crew approve` forever, since approve requires `state === "review"`.

Hit live while shipping #649: task `a7d52925` reached 15.9h across four review rounds, was cancelled by `sweep.task-timeout`, and could not be revived — `crew send` reopened it and the next sweep tick re-cancelled it. PR #663 had to be pushed by hand.

#629 already described this exact outcome in its comment ("permanently closing that path") and exempted `blocked`/`review`. But that fix was **state-based**, while the root cause is that the **clock never resets**. A review round runs `crew works → review (exempt) → captain feedback → working (NOT exempt)`, and the sweep measures task age at that last step.

The ceiling's stated purpose is to catch "a crew stuck actually WORKING". `now - createdAt` cannot distinguish a crew wedged 8h on one turn from a crew that did six productive turns across 16h with human review in between. The human review gate (#599/#656) actively encourages the latter, so the two features pulled against each other: the more carefully the captain reviewed, the more likely the task self-destructed before it could be approved.

## What

`workingStretchStartedAt?: number` on `TaskRecord`, set on `task.started` and `task.reopened`. The sweep now measures `t - (r.workingStretchStartedAt ?? r.createdAt)`. The fallback keeps pre-existing records behaving exactly as before.

Three lines of logic; 4 files, +41/−2.

## Reset points are all human-initiated — audited

`task.started` has six emitters. Each was checked to confirm none fires automatically, which would reset the ceiling forever and silently defeat #225:

| Emitter | Trigger |
|---|---|
| `crew-spawn.ts:546` | `crew send` — a captain turn |
| `daemon/reduce.ts:453` | captain replying to a blocked task |
| `opencode/sse-bridge.ts:107` | after a permission approve/reject — a human decision |
| `daemon/start.ts:73,77` | `launchInteractive` — new task dispatch, `createdAt ≈ now` |
| `codex/driver.ts:119`, `headless-launcher.ts:42` | dispatch, same |

No automatic or liveness-driven emitter. The ceiling still fires on a crew wedged within a single stretch.

## Verification

`pnpm build` · **2455 tests / 185 files** (+2) · `node dist/index.js --help`

The two new tests are the ones that matter:
- a task 20h old whose working stretch started 1h ago is **not** cancelled and stays `working`
- a task 20h old wedged 10h in a single stretch **is** still cancelled, with one `CREW TIMEOUT`

The second is the regression guard for #225 — without it this change would look correct while quietly disabling the ceiling.

No live smoke test for this one, unlike #649: that bug slipped through because a validation allowlist actively rejected the new event type. This change adds no event and no CLI surface — only a record field. `store.put` serialises the whole record with no field filtering, and the sweep reads from the store in-process without crossing the socket, so there is no layer that can silently drop it.