### PR TITLE
fix(config): tighten file modes for config writes (#668)

### DIFF
--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import chalk from "chalk";
-import { DEFAULT_CONFIG_PATH, getDefaultConfig, loadConfig, saveConfig, type SquadrantConfig, isDaemonCachedKey } from "@squadrant/shared";
+import { DEFAULT_CONFIG_PATH, getDefaultConfig, loadConfig, saveConfig, type SquadrantConfig, isDaemonCachedKey, writeConfigFileSync } from "@squadrant/shared";
 import { detectDrift, applySafeFixes, type DriftItem } from "@squadrant/shared";
 import { withStamp } from "@squadrant/shared";
 import { restartDaemonIfRunning, type RestartOutcome } from "@squadrant/core";
@@ -45,7 +45,7 @@ export function runConfigCheck(opts: ConfigCheckOptions): ConfigCheckResult {
   }
 
   if (opts.fix || opts.accept || stamped) {
-    fs.writeFileSync(opts.configPath, JSON.stringify(working, null, 2) + "\n");
+    writeConfigFileSync(opts.configPath, JSON.stringify(working, null, 2) + "\n");
   }
 
   return { items, applied, remaining, stamped };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
 import { Command } from "commander";
-import { readFileSync, existsSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
-import { ensureRuntimeSynced } from "@squadrant/shared";
+import { ensureRuntimeSynced, readConfigFileSync, writeConfigFileSync } from "@squadrant/shared";
 import { ensureDaemon, isOperatorInitiatedCommand } from "@squadrant/core";
 import { doctorCommand } from "./commands/doctor.js";
 import { initCommand } from "./commands/init.js";
@@ -62,11 +62,11 @@ if (process.argv[2] !== "config") {
   try {
     const cfgPath = join(homedir(), ".config", "squadrant", "config.json");
     if (existsSync(cfgPath)) {
-      const cfg = JSON.parse(readFileSync(cfgPath, "utf-8"));
+      const cfg = JSON.parse(readConfigFileSync(cfgPath));
       if (needsCheck(cfg, pkg.version)) {
         const items = detectDrift(cfg, getDefaultConfig());
         if (items.length === 0) {
-          writeFileSync(cfgPath, JSON.stringify(withStamp(cfg, pkg.version), null, 2) + "\n");
+          writeConfigFileSync(cfgPath, JSON.stringify(withStamp(cfg, pkg.version), null, 2) + "\n");
         } else {
           const from = cfg._squadrantVersion ?? "an earlier version";
           process.stderr.write(

--- a/packages/cli/src/lib/daemon-restart-broadcast.ts
+++ b/packages/cli/src/lib/daemon-restart-broadcast.ts
@@ -6,7 +6,7 @@
 // (#529).
 import fs from "node:fs";
 import path from "node:path";
-import type { SquadrantConfig } from "@squadrant/shared";
+import { type SquadrantConfig, readConfigFileSync, writeConfigFileSync } from "@squadrant/shared";
 
 /** Minimal slice of RuntimeDriver used to resolve captain status. */
 export interface DaemonRestartNotifyDriver {
@@ -29,7 +29,7 @@ export function computeRestartSignature(version: string, buildMtimeMs: number): 
 
 export function readPersistedRestartSignature(stateRoot: string): string | null {
   try {
-    const raw = fs.readFileSync(statePath(stateRoot), "utf-8");
+    const raw = readConfigFileSync(statePath(stateRoot));
     const data = JSON.parse(raw) as { signature?: string };
     return typeof data.signature === "string" ? data.signature : null;
   } catch {
@@ -38,8 +38,7 @@ export function readPersistedRestartSignature(stateRoot: string): string | null 
 }
 
 export function writePersistedRestartSignature(stateRoot: string, signature: string): void {
-  fs.mkdirSync(stateRoot, { recursive: true });
-  fs.writeFileSync(statePath(stateRoot), JSON.stringify({ signature }, null, 2) + "\n");
+  writeConfigFileSync(statePath(stateRoot), JSON.stringify({ signature }, null, 2) + "\n");
 }
 
 function restartNotice(version: string, isDevRebuild: boolean): string {

--- a/packages/core/src/protocol.ts
+++ b/packages/core/src/protocol.ts
@@ -1,6 +1,6 @@
 // src/control/protocol.ts
 import { createServer, createConnection, type Server, type Socket } from "node:net";
-import { existsSync, unlinkSync } from "node:fs";
+import { existsSync, unlinkSync, chmodSync } from "node:fs";
 
 // Bump this on any change to the request/reply wire shape.
 // v1 is the first versioned release. Clients treat an absent _v as compatible
@@ -171,6 +171,9 @@ export function startServer(
     });
   });
   server.on("error", onListenError); // never let a server error become uncaughtException
+  server.on("listening", () => {
+    try { chmodSync(sockPath, 0o600); } catch { /* ignore */ }
+  });
   server.listen(sockPath);
   return server;
 }

--- a/packages/core/src/session-freshness.ts
+++ b/packages/core/src/session-freshness.ts
@@ -5,6 +5,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { readConfigFileSync, writeConfigFileSync } from "@squadrant/shared";
 
 export interface SessionRecord {
   lastLaunched: string; // YYYY-MM-DD
@@ -17,16 +18,14 @@ export interface SessionsFile {
 
 export function loadSessions(sessionsPath: string): SessionsFile {
   try {
-    return JSON.parse(fs.readFileSync(sessionsPath, "utf-8")) as SessionsFile;
+    return JSON.parse(readConfigFileSync(sessionsPath)) as SessionsFile;
   } catch {
     return { workspaces: {} };
   }
 }
 
 export function saveSessions(sessionsPath: string, sessions: SessionsFile): void {
-  const dir = path.dirname(sessionsPath);
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(sessionsPath, JSON.stringify(sessions, null, 2) + "\n");
+  writeConfigFileSync(sessionsPath, JSON.stringify(sessions, null, 2) + "\n");
 }
 
 export function computeTemplateHash(role: string, templatesDir: string): string {

--- a/packages/core/src/telegram/setup.ts
+++ b/packages/core/src/telegram/setup.ts
@@ -2,6 +2,7 @@
 // These are exported for testing with injected dependencies.
 // getUpdates is single-consumer — setup runs before the daemon starts polling (#321).
 import fs from "node:fs";
+import { writeConfigFileSync } from "@squadrant/shared";
 import type { TelegramClient } from "./client.js";
 import { loadState } from "./state.js";
 import { BOT_COMMANDS } from "./bot-commands.js";
@@ -137,5 +138,5 @@ export function writeTelegramConfig(
   if (remoteControl !== undefined) next.remoteControl = remoteControl;
   config.telegram = next;
 
-  fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  writeConfigFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
 }

--- a/packages/core/src/telegram/state.ts
+++ b/packages/core/src/telegram/state.ts
@@ -2,6 +2,7 @@
 // registry. Synchronous JSON in stateRoot/telegram-state.json.
 import fs from "node:fs";
 import path from "node:path";
+import { readConfigFileSync, writeConfigFileSync } from "@squadrant/shared";
 
 export interface TelegramState {
   offset: number;
@@ -25,7 +26,7 @@ export function topicKey(project: string, scope = "project"): string {
 
 export function loadState(stateRoot: string): TelegramState {
   try {
-    const raw = fs.readFileSync(statePath(stateRoot), "utf-8");
+    const raw = readConfigFileSync(statePath(stateRoot));
     const data = JSON.parse(raw) as Partial<TelegramState>;
     const result: TelegramState = {
       offset: typeof data.offset === "number" ? data.offset : 0,
@@ -40,8 +41,7 @@ export function loadState(stateRoot: string): TelegramState {
 }
 
 export function saveState(stateRoot: string, s: TelegramState): void {
-  fs.mkdirSync(stateRoot, { recursive: true });
-  fs.writeFileSync(statePath(stateRoot), JSON.stringify(s, null, 2) + "\n");
+  writeConfigFileSync(statePath(stateRoot), JSON.stringify(s, null, 2) + "\n");
 }
 
 export function setTopic(

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import chalk from "chalk";
+import { readConfigFileSync, writeConfigFileSync, migrateConfigPermsSync } from "./lib/config-io.js";
 
 export interface ProjectConfig {
   path: string;
@@ -138,8 +139,8 @@ export interface SquadrantConfig {
   };
 }
 
-const CONFIG_DIR = path.join(os.homedir(), ".config", "squadrant");
-export const DEFAULT_CONFIG_PATH = path.join(CONFIG_DIR, "config.json");
+export const DEFAULT_CONFIG_PATH = process.env.SQUADRANT_CONFIG || path.join(os.homedir(), ".config", "squadrant", "config.json");
+export const CONFIG_DIR = path.dirname(DEFAULT_CONFIG_PATH);
 
 export function getDefaultConfig(): SquadrantConfig {
   return {
@@ -194,8 +195,9 @@ export function getDefaultConfig(): SquadrantConfig {
 }
 
 export function loadConfig(configPath = DEFAULT_CONFIG_PATH): SquadrantConfig {
+  migrateConfigPermsSync();
   try {
-    const raw = fs.readFileSync(configPath, "utf-8");
+    const raw = readConfigFileSync(configPath);
     const config = JSON.parse(raw) as SquadrantConfig;
 
     // Backward compat: migrate models → roles if roles not set
@@ -236,9 +238,7 @@ export function saveConfig(
   config: SquadrantConfig,
   configPath = DEFAULT_CONFIG_PATH,
 ): void {
-  const dir = path.dirname(configPath);
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  writeConfigFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
 }
 
 export function resolveHome(p: string): string {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -16,6 +16,7 @@ export * from "./lib/compat-manifest.js";
 export * from "./lib/config-drift.js";
 export * from "./lib/config-version.js";
 export * from "./lib/update-check.js";
+export * from "./lib/config-io.js";
 export * from "./lib/git-worktree.js";
 export * from "./lib/resolve-text-input.js";
 export * from "./lib/runtime-sync.js";

--- a/packages/shared/src/lib/__tests__/config-io.test.ts
+++ b/packages/shared/src/lib/__tests__/config-io.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+describe("config-io", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "squadrant-config-io-"));
+  const configBase = path.join(tmpDir, ".config", "squadrant");
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it.skipIf(process.platform !== "darwin")("tightens permissions correctly via migration", async () => {
+    vi.doMock("../../config.js", () => ({
+      CONFIG_DIR: configBase,
+      DEFAULT_CONFIG_PATH: path.join(configBase, "config.json")
+    }));
+
+    const { migrateConfigPermsSync } = await import("../config-io.js");
+
+    fs.mkdirSync(configBase, { recursive: true, mode: 0o755 });
+    const file = path.join(configBase, "config.json");
+    fs.writeFileSync(file, "{}", { mode: 0o644 });
+    
+    migrateConfigPermsSync();
+    
+    expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+    expect(fs.statSync(configBase).mode & 0o777).toBe(0o700);
+    vi.doUnmock("../../config.js");
+  });
+
+  it.skipIf(process.platform !== "darwin")("writeConfigFileSync sets strict modes and tightens parents", async () => {
+    vi.doMock("../../config.js", () => ({
+      CONFIG_DIR: configBase,
+      DEFAULT_CONFIG_PATH: path.join(configBase, "config.json")
+    }));
+
+    const { writeConfigFileSync } = await import("../config-io.js");
+
+    const file2 = path.join(configBase, "projects", "proj.json");
+    writeConfigFileSync(file2, "{}");
+    
+    expect(fs.statSync(file2).mode & 0o777).toBe(0o600);
+    expect(fs.statSync(path.dirname(file2)).mode & 0o777).toBe(0o700);
+    expect(fs.statSync(configBase).mode & 0o777).toBe(0o700);
+    vi.doUnmock("../../config.js");
+  });
+});

--- a/packages/shared/src/lib/cmux-autoconfig.ts
+++ b/packages/shared/src/lib/cmux-autoconfig.ts
@@ -10,11 +10,12 @@
 // prompt); it does not print or log. The caller — the `squadrant cmux autoconfig`
 // CLI or the daemon-start re-check — renders the result. squadrant NEVER restarts
 // cmux for the user (that disrupts live sessions); we write config and prompt.
-import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { ensureSocketAutomation } from "./cmux-config.js";
 import { probeCmuxDaemonDirect, type ProbeVerdict } from "./cmux-probe.js";
+import { readConfigFileSync, writeConfigFileSync } from "./config-io.js";
 
 /** One-time prompt marker, alongside the daemon state. */
 export function defaultStatePath(): string {
@@ -51,7 +52,7 @@ interface PromptState {
 
 function readState(path: string): PromptState {
   try {
-    return JSON.parse(readFileSync(path, "utf-8")) as PromptState;
+    return JSON.parse(readConfigFileSync(path)) as { promptedRestart?: boolean };
   } catch {
     return {};
   }
@@ -78,8 +79,7 @@ export async function ensureCmuxAutoConfig(opts: AutoConfigOpts = {}): Promise<A
   if (needsRestart) {
     const already = readState(statePath).promptedRestart === true;
     if (!already) {
-      mkdirSync(dirname(statePath), { recursive: true });
-      writeFileSync(statePath, JSON.stringify({ promptedRestart: true }));
+      writeConfigFileSync(statePath, JSON.stringify({ promptedRestart: true }));
       promptedThisRun = true;
     }
   } else if (verdict === "reachable") {

--- a/packages/shared/src/lib/config-io.ts
+++ b/packages/shared/src/lib/config-io.ts
@@ -1,0 +1,75 @@
+import fs from "node:fs";
+import path from "node:path";
+import { CONFIG_DIR } from "../config.js";
+
+let didLogMigration = false;
+let migrationRun = false;
+
+function tightenModeSync(p: string, expectedMode: number): void {
+  try {
+    if (!fs.existsSync(p)) return;
+    const stat = fs.statSync(p);
+    const currentMode = stat.mode & 0o7777;
+    if ((currentMode & ~expectedMode) !== 0) {
+      fs.chmodSync(p, expectedMode);
+      if (!didLogMigration) {
+        console.warn(`\x1b[33m\u26A0\x1b[0m squadrant: tightened config file permissions (security fix #668)`);
+        didLogMigration = true;
+      }
+    }
+  } catch {
+    // Ignore errors (e.g., EPERM)
+  }
+}
+
+export function writeConfigFileSync(filePath: string, content: string): void {
+  ensureDirSync(path.dirname(filePath));
+  fs.writeFileSync(filePath, content, { mode: 0o600 });
+  tightenModeSync(filePath, 0o600);
+}
+
+export function ensureDirSync(dirPath: string): void {
+  if (dirPath !== CONFIG_DIR && !dirPath.startsWith(CONFIG_DIR + path.sep)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+    return;
+  }
+  
+  fs.mkdirSync(dirPath, { recursive: true, mode: 0o700 });
+  
+  let current = dirPath;
+  while (current === CONFIG_DIR || current.startsWith(CONFIG_DIR + path.sep)) {
+    tightenModeSync(current, 0o700);
+    if (current === CONFIG_DIR) break;
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+}
+
+export function readConfigFileSync(filePath: string): string {
+  return fs.readFileSync(filePath, "utf-8");
+}
+
+export function migrateConfigPermsSync(): void {
+  if (migrationRun) return;
+  migrationRun = true;
+
+  tightenModeSync(CONFIG_DIR, 0o700);
+  tightenModeSync(path.join(CONFIG_DIR, "config.json"), 0o600);
+
+  const projectsDir = path.join(CONFIG_DIR, "projects");
+  tightenModeSync(projectsDir, 0o700);
+
+  try {
+    if (fs.existsSync(projectsDir)) {
+      const files = fs.readdirSync(projectsDir);
+      for (const file of files) {
+        if (file.endsWith(".json")) {
+          tightenModeSync(path.join(projectsDir, file), 0o600);
+        }
+      }
+    }
+  } catch {
+    // Ignore
+  }
+}

--- a/packages/shared/src/project-config.ts
+++ b/packages/shared/src/project-config.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { ModelRoutingConfig } from "./config.js";
+import { readConfigFileSync, writeConfigFileSync } from "./lib/config-io.js";
 
 export type CrewTier = "all" | "alert_only" | "done_only" | "none";
 
@@ -32,7 +33,7 @@ export function projectConfigPath(name: string, root = defaultRoot()): string {
 
 export function loadProjectOverride(name: string, root = defaultRoot()): ProjectOverrideConfig {
   try {
-    return JSON.parse(fs.readFileSync(projectConfigPath(name, root), "utf-8")) as ProjectOverrideConfig;
+    return JSON.parse(readConfigFileSync(projectConfigPath(name, root))) as ProjectOverrideConfig;
   } catch {
     return {};
   }
@@ -51,8 +52,7 @@ export function deepMerge<T>(base: T, patch: unknown): T {
 export function saveProjectOverride(name: string, patch: ProjectOverrideConfig, root = defaultRoot()): void {
   const merged = deepMerge(loadProjectOverride(name, root), patch);
   const file = projectConfigPath(name, root);
-  fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, JSON.stringify(merged, null, 2) + "\n");
+  writeConfigFileSync(file, JSON.stringify(merged, null, 2) + "\n");
 }
 
 export const DEFAULT_NOTIFY: NotifyConfig = { active: false, cap: true, crew: "alert_only" };


### PR DESCRIPTION
Fix #668 — tighten file modes on everything squadrant writes under ~/.config/squadrant. Read the issue first: `gh issue view 668`.

PROBLEM: nothing squadrant writes sets an explicit mode, so every path inherits the process umask (022). Result: `config.json` is 0644 while holding `telegram.botToken` — a live credential readable by any process on the machine. The config dir is 0755 and the daemon socket 0755.

SCOPE:
1. `~/.config/squadrant/config.json` and `projects/*.json` — write with mode 0600. This is the one that actually matters (live secret).
2. `~/.config/squadrant/` directory — create with mode 0700.
3. `squadrant.sock` — chmod 0600 after bind (Claude Code's own peer sockets are srw------- inside a 0700 dir; match that).
4. Migration: existing files on disk already have the loose modes. On startup or config load, if the mode is looser than intended, tighten it in place and log once. Do not fail if the chmod is not permitted.

Find every write path — grep for writeFile/writeFileSync/mkdir on the config dir, don't assume there is only one. If several call sites write config, funnel them through a single helper rather than sprinkling mode options.

OUT OF SCOPE: rotating or moving the telegram token out of config.json. Mode hardening only.

APPROACH: TDD, one commit per logical step, conventional commits referencing (#668). Keep it surgical — no drive-by refactors beyond the shared-helper consolidation above if it is genuinely needed.

GATES before you signal review — ALL must pass: `pnpm build`, `pnpm test`, and `node dist/index.js --help`.

NOTE: this is macOS-only territory; mode assertions in tests should follow the repo's existing `it.skipIf` darwin guard convention. Do NOT chmod the operator's real live ~/.config/squadrant during testing — use temp dirs. When done: `squadrant crew signal review`.